### PR TITLE
fix(client): prevent crashes in rendering and audio handling

### DIFF
--- a/client/src/client/animations.c
+++ b/client/src/client/animations.c
@@ -149,3 +149,62 @@ void anims_reset(void)
         }
     }
 }
+Animations *
+animation_get (uint16_t animation_id)
+{
+    if (!check_animation_status(animation_id)) {
+        return NULL;
+    }
+
+    Animations *animation = &animations[animation_id];
+    if (animation->faces == NULL || animation->num_animations == 0 ||
+            animation->facings == 0 || animation->frame == 0 ||
+            animation->frame != animation->num_animations /
+            animation->facings) {
+        LOG(ERROR, "Animation %u has inconsistent frame data", animation_id);
+        return NULL;
+    }
+
+    return animation;
+}
+
+/**
+ * Resolve one animation frame without allowing an out-of-bounds access.
+ */
+bool
+animation_get_face (uint16_t animation_id, uint8_t direction, size_t state,
+                    uint16_t *face)
+{
+    HARD_ASSERT(face != NULL);
+
+    Animations *animation = animation_get(animation_id);
+    if (animation == NULL) {
+        return false;
+    }
+
+    size_t facing = direction < animation->facings ? direction : 0;
+    if (state >= animation->frame) {
+        LOG(ERROR, "Invalid animation state (animation: %u, direction: %u, "
+            "state: %" PRIu64 ", frames: %" PRIu64 ")", animation_id,
+            direction, (uint64_t) state, (uint64_t) animation->frame);
+        return false;
+    }
+
+    size_t index = facing * animation->frame + state;
+    if (index >= animation->num_animations) {
+        LOG(ERROR, "Invalid animation frame index (animation: %u, index: %"
+            PRIu64 ", count: %" PRIu64 ")", animation_id, (uint64_t) index,
+            (uint64_t) animation->num_animations);
+        return false;
+    }
+
+    uint16_t candidate = animation->faces[index] & FACE_ID_MASK;
+    if (!image_face_valid(candidate)) {
+        LOG(ERROR, "Animation %u resolved to invalid face ID %u",
+            animation_id, candidate);
+        return false;
+    }
+
+    *face = candidate;
+    return true;
+}

--- a/client/src/client/client.c
+++ b/client/src/client/client.c
@@ -147,16 +147,26 @@ void DoClient(void)
  * @param anum
  * Animation ID.
  */
-void check_animation_status(int anum)
+bool check_animation_status(int anum)
 {
-    /* Check if it has been loaded. */
-    if (animations[anum].loaded) {
-        return;
+    if (anum < 0 || (size_t) anum >= animations_num || animations == NULL ||
+            anim_table == NULL) {
+        LOG(ERROR, "Ignoring invalid animation ID %d (count: %" PRIu64 ")",
+            anum, (uint64_t) animations_num);
+        return false;
     }
 
-    /* Mark this animation as loaded. */
-    animations[anum].loaded = 1;
+    if (animations[anum].loaded) {
+        return true;
+    }
 
-    /* Same as server sends it */
+    if (anim_table[anum].anim_cmd == NULL || anim_table[anum].len < 4) {
+        LOG(ERROR, "Animation %d has no valid command data", anum);
+        return false;
+    }
+
+    /* Same as server sends it. */
     socket_command_anim(anim_table[anum].anim_cmd, anim_table[anum].len, 0);
+
+    return animations[anum].loaded;
 }

--- a/client/src/client/commands.c
+++ b/client/src/client/commands.c
@@ -75,26 +75,51 @@ void socket_command_setup(uint8_t *data, size_t len, size_t pos)
 /** @copydoc socket_command_struct::handle_func */
 void socket_command_anim(uint8_t *data, size_t len, size_t pos)
 {
-    uint16_t anim_id;
-    int i;
-
-    anim_id = packet_to_uint16(data, len, &pos);
-    animations[anim_id].flags = packet_to_uint8(data, len, &pos);
-    animations[anim_id].facings = packet_to_uint8(data, len, &pos);
-    animations[anim_id].num_animations = (len - pos) / 2;
-
-    if (animations[anim_id].facings > 1) {
-        animations[anim_id].frame = animations[anim_id].num_animations / animations[anim_id].facings;
-    } else {
-        animations[anim_id].frame = animations[anim_id].num_animations;
+    if (pos > len || len - pos < 4) {
+        LOG(ERROR, "Ignoring truncated animation packet");
+        return;
     }
 
-    animations[anim_id].faces = emalloc(sizeof(uint16_t) * animations[anim_id].num_animations);
+    uint16_t anim_id = packet_to_uint16(data, len, &pos);
+    uint8_t flags = packet_to_uint8(data, len, &pos);
+    uint8_t facings = packet_to_uint8(data, len, &pos);
 
-    for (i = 0; pos < len; i++) {
-        animations[anim_id].faces[i] = packet_to_uint16(data, len, &pos);
-        image_request_face(animations[anim_id].faces[i]);
+    if (anim_id >= animations_num || animations == NULL) {
+        LOG(ERROR, "Ignoring invalid animation ID %u (count: %" PRIu64 ")",
+            anim_id, (uint64_t) animations_num);
+        return;
     }
+
+    size_t num_animations = (len - pos) / 2;
+    if ((len - pos) % 2 != 0 || num_animations == 0 || facings == 0 ||
+            num_animations % facings != 0) {
+        LOG(ERROR, "Ignoring malformed animation %u (%" PRIu64
+            " faces, %u facings)", anim_id, (uint64_t) num_animations,
+            facings);
+        return;
+    }
+
+    Animations *animation = &animations[anim_id];
+    efree(animation->faces);
+    animation->faces = emalloc(sizeof(*animation->faces) * num_animations);
+    animation->flags = flags;
+    animation->facings = facings;
+    animation->num_animations = num_animations;
+    animation->frame = num_animations / facings;
+
+    for (size_t i = 0; i < num_animations; i++) {
+        uint16_t face = packet_to_uint16(data, len, &pos) & FACE_ID_MASK;
+        if (!image_face_valid(face)) {
+            LOG(ERROR, "Animation %u contains invalid face ID %u", anim_id,
+                face);
+            face = 0;
+        }
+
+        animation->faces[i] = face;
+        image_request_face(face);
+    }
+
+    animation->loaded = 1;
 }
 
 /** @copydoc socket_command_struct::handle_func */
@@ -104,11 +129,25 @@ void socket_command_image(uint8_t *data, size_t len, size_t pos)
     char buf[HUGE_BUF];
     FILE *fp;
 
+    if (pos > len || len - pos < 8) {
+        LOG(ERROR, "Ignoring truncated image packet");
+        return;
+    }
+
     facenum = packet_to_uint32(data, len, &pos);
     filesize = packet_to_uint32(data, len, &pos);
 
+    if (!image_face_valid(facenum) || image_get_face_name(facenum) == NULL ||
+            filesize > len - pos) {
+        LOG(ERROR, "Ignoring invalid image packet (face: %" PRIu32
+            ", size: %" PRIu32 ", remaining: %" PRIu64 ")",
+            facenum, filesize, (uint64_t) (len - pos));
+        return;
+    }
+
     /* Save picture to cache and load it to FaceList. */
-    snprintf(buf, sizeof(buf), DIRECTORY_CACHE "/%s", FaceList[facenum].name);
+    snprintf(buf, sizeof(buf), DIRECTORY_CACHE "/%s",
+            image_get_face_name(facenum));
 
     fp = path_fopen(buf, "wb+");
 
@@ -345,11 +384,18 @@ void socket_command_stats(uint8_t *data, size_t len, size_t pos)
 /** @copydoc socket_command_struct::handle_func */
 void socket_command_player(uint8_t *data, size_t len, size_t pos)
 {
-    int tag, weight, face;
+    int tag, weight;
 
     tag = packet_to_uint32(data, len, &pos);
     weight = packet_to_uint32(data, len, &pos);
-    face = packet_to_uint32(data, len, &pos);
+    uint32_t raw_face = packet_to_uint32(data, len, &pos);
+    uint16_t face = raw_face & FACE_ID_MASK;
+    if (!image_face_valid(face)) {
+        LOG(ERROR, "Player %d received invalid face ID %" PRIu32, tag,
+            raw_face);
+        face = 0;
+    }
+
     image_request_face(face);
     packet_to_string(data, len, &pos, cpl.name, sizeof(cpl.name));
 
@@ -383,8 +429,17 @@ void command_item_update(uint8_t *data, size_t len, size_t *pos, uint32_t flags,
     }
 
     if (flags & UPD_FACE) {
-        tmp->face = packet_to_uint16(data, len, pos);
-        image_request_face(tmp->face);
+        uint16_t raw_face = packet_to_uint16(data, len, pos);
+        uint16_t face = raw_face & FACE_ID_MASK;
+        if (!image_face_valid(face)) {
+            LOG(ERROR, "Object %" PRIu32 " received invalid face ID %u "
+                "(animation: %u, direction: %u)", tmp->tag, raw_face,
+                tmp->animation_id, tmp->direction);
+            face = 0;
+        }
+
+        tmp->face = face;
+        image_request_face(face);
     }
 
     if (flags & UPD_DIRECTION) {
@@ -408,9 +463,14 @@ void command_item_update(uint8_t *data, size_t len, size_t *pos, uint32_t flags,
     }
 
     if (flags & UPD_ANIM) {
-        uint16_t animation_id;
+        uint16_t animation_id = packet_to_uint16(data, len, pos);
 
-        animation_id = packet_to_uint16(data, len, pos);
+        if (animation_id >= animations_num) {
+            LOG(ERROR, "Object %" PRIu32 " received invalid animation ID %u "
+                "(face: %u, direction: %u)", tmp->tag, animation_id,
+                tmp->face, tmp->direction);
+            animation_id = 0;
+        }
 
         /* Changing animation ID, force animation. */
         if (tmp->animation_id != animation_id) {

--- a/client/src/client/image.c
+++ b/client/src/client/image.c
@@ -46,6 +46,34 @@ static bmap_t *image_bmaps = NULL;
 static size_t image_bmaps_size = 0;
 
 /**
+ * Check whether a face ID can be used to index ::FaceList.
+ */
+bool
+image_face_valid (int face)
+{
+    return face >= 0 && face < MAX_FACE_TILES;
+}
+
+/**
+ * Get a loaded sprite without allowing an invalid face array access.
+ */
+sprite_struct *
+image_get_sprite (int face)
+{
+    sprite_struct *sprite = image_face_valid(face) ? FaceList[face].sprite : NULL;
+
+    return sprite != NULL && sprite->bitmap != NULL ? sprite : NULL;
+}
+
+/**
+ * Get a face name without allowing an invalid face array access.
+ */
+const char *
+image_get_face_name (int face)
+{
+    return image_face_valid(face) ? FaceList[face].name : NULL;
+}
+/**
  * Free data associated with a bmap_t structure.
  */
 static void
@@ -227,8 +255,13 @@ image_bmaps_deinit (void)
 void
 finish_face_cmd (int facenum, uint32_t checksum, const char *face)
 {
-    HARD_ASSERT(facenum >= 0);
     HARD_ASSERT(face != NULL);
+
+    if (!image_face_valid(facenum) || (size_t) facenum >= image_bmaps_size) {
+        LOG(ERROR, "Ignoring invalid face data ID %d (catalog size: %" PRIu64 ")",
+            facenum, (uint64_t) image_bmaps_size);
+        return;
+    }
 
     /* Loaded or requested. */
     if (FaceList[facenum].name != NULL) {
@@ -402,7 +435,13 @@ void
 image_request_face (int pnum)
 {
     char buf[MAX_BUF];
-    uint16_t num = (uint16_t) (pnum &~0x8000);
+    uint16_t num = (uint16_t) (pnum & FACE_ID_MASK);
+
+    if (!image_face_valid(num) || num >= image_bmaps_size) {
+        LOG(ERROR, "Ignoring invalid face ID %d (normalized: %u, catalog size: %" PRIu64 ")",
+            pnum, num, (uint64_t) image_bmaps_size);
+        return;
+    }
 
     if (setting_get_int(OPT_CAT_DEVEL, OPT_RELOAD_GFX) &&
         load_gfx_user_face(num)) {
@@ -414,11 +453,6 @@ image_request_face (int pnum)
         return;
     }
 
-    if (num >= image_bmaps_size) {
-        LOG(ERROR, "Server sent picture ID too loarge (%d, max: %" PRIu64 ")",
-            num, (uint64_t) image_bmaps_size);
-        return;
-    }
 
     if (load_gfx_user_face(num)) {
         return;

--- a/client/src/client/item.c
+++ b/client/src/client/item.c
@@ -453,26 +453,37 @@ int object_animate(object *ob)
         ret = true;
     }
 
-    if (ob->animation_id > 0) {
-        check_animation_status(ob->animation_id);
-    }
-
     if (ob->animation_id > 0 && ob->anim_speed) {
+        Animations *animation = animation_get(ob->animation_id);
+        if (animation == NULL) {
+            LOG(ERROR, "Disabling invalid object animation (tag: %" PRIu32
+                ", face: %u, animation: %u, direction: %u)", ob->tag,
+                ob->face, ob->animation_id, ob->direction);
+            ob->animation_id = 0;
+            return ret;
+        }
+
         ob->last_anim++;
 
         if (ob->last_anim >= ob->anim_speed) {
-            if (++ob->anim_state >= animations[ob->animation_id].frame) {
+            ob->anim_state++;
+            if (ob->anim_state >= animation->frame) {
                 ob->anim_state = 0;
             }
 
-            if (ob->direction > animations[ob->animation_id].facings) {
-                ob->face = animations[ob->animation_id].faces[ob->anim_state];
-            } else {
-                ob->face = animations[ob->animation_id].faces[animations[ob->animation_id].frame * ob->direction + ob->anim_state];
+            uint16_t face;
+            if (!animation_get_face(ob->animation_id, ob->direction,
+                    ob->anim_state, &face)) {
+                LOG(ERROR, "Disabling invalid object animation frame (tag: %"
+                    PRIu32 ", face: %u, animation: %u, direction: %u, state: %u)",
+                    ob->tag, ob->face, ob->animation_id, ob->direction,
+                    ob->anim_state);
+                ob->animation_id = 0;
+                return ret;
             }
 
+            ob->face = face;
             ob->last_anim = 0;
-
             ret = true;
         }
     }
@@ -553,45 +564,45 @@ void object_show_centered (SDL_Surface *surface,
     HARD_ASSERT(surface != NULL);
     HARD_ASSERT(tmp != NULL);
 
-    if (FaceList[tmp->face].sprite == NULL) {
+    sprite_struct *sprite = image_get_sprite(tmp->face);
+    if (sprite == NULL || sprite->bitmap == NULL) {
         return;
     }
 
-    /* Will be used for coordinate calculations. */
-    uint16_t face = tmp->face;
+    sprite_struct *layout_sprite = sprite;
 
     /* If the item is animated, try to use the first animation face for
      * coordinate calculations to prevent 'jumping' of the animation. */
     if (tmp->animation_id > 0) {
-        check_animation_status(tmp->animation_id);
-
-        if (animations[tmp->animation_id].num_animations) {
-            uint16_t face_id;
-
-            face_id = animations[tmp->animation_id].frame * tmp->direction;
-
-            if (FaceList[animations[tmp->animation_id].faces[face_id]].sprite) {
-                face = animations[tmp->animation_id].faces[face_id];
+        uint16_t layout_face;
+        if (animation_get_face(tmp->animation_id, tmp->direction, 0,
+                &layout_face)) {
+            sprite_struct *candidate = image_get_sprite(layout_face);
+            if (candidate != NULL && candidate->bitmap != NULL) {
+                layout_sprite = candidate;
             }
         }
     }
 
-    int border_left = FaceList[face].sprite->border_left;
-    int border_up = FaceList[face].sprite->border_up;
+    int border_left = layout_sprite->border_left;
+    int border_up = layout_sprite->border_up;
     if (tmp->glow[0] != '\0') {
         border_left -= SPRITE_GLOW_SIZE * 2;
         border_up -= SPRITE_GLOW_SIZE * 2;
     }
 
-    int xlen = FaceList[face].sprite->bitmap->w - border_left -
-               FaceList[face].sprite->border_right;
-    int ylen = FaceList[face].sprite->bitmap->h - border_up -
-               FaceList[face].sprite->border_down;
+    int xlen = layout_sprite->bitmap->w - border_left -
+               layout_sprite->border_right;
+    int ylen = layout_sprite->bitmap->h - border_up -
+               layout_sprite->border_down;
     if (tmp->glow[0] != '\0') {
         xlen += SPRITE_GLOW_SIZE * 2;
         ylen += SPRITE_GLOW_SIZE * 2;
     }
 
+    if (xlen <= 0 || ylen <= 0) {
+        return;
+    }
     double zoom_x = 1.0, zoom_y = 1.0;
     if (fit) {
         int xlen2 = xlen, ylen2 = ylen;
@@ -644,23 +655,22 @@ void object_show_centered (SDL_Surface *surface,
         border_up = (h - ylen) / 2;
     }
 
-    if (face != tmp->face) {
+    if (layout_sprite != sprite) {
         int temp = border_left - box.x;
 
         box.x = 0;
-        box.w = FaceList[tmp->face].sprite->bitmap->w * zoom_x;
+        box.w = sprite->bitmap->w * zoom_x;
         border_left = temp;
 
-        temp = border_up - box.y + (FaceList[face].sprite->bitmap->h * zoom_y -
-                                    FaceList[tmp->face].sprite->bitmap->h *
-                                    zoom_y);
+        temp = border_up - box.y + (layout_sprite->bitmap->h * zoom_y -
+                                    sprite->bitmap->h * zoom_y);
         box.y = 0;
-        box.h = FaceList[tmp->face].sprite->bitmap->h * zoom_y;
+        box.h = sprite->bitmap->h * zoom_y;
         border_up = temp;
 
         if (border_left < 0) {
             box.x = -border_left;
-            box.w = FaceList[tmp->face].sprite->bitmap->w * zoom_x +
+            box.w = sprite->bitmap->w * zoom_x +
                     border_left;
 
             if (box.w > w) {
@@ -676,7 +686,7 @@ void object_show_centered (SDL_Surface *surface,
 
         if (border_up < 0) {
             box.y = -border_up;
-            box.h = FaceList[tmp->face].sprite->bitmap->h * zoom_y + border_up;
+            box.h = sprite->bitmap->h * zoom_y + border_up;
 
             if (box.h > h) {
                 box.h = h;
@@ -704,5 +714,5 @@ void object_show_centered (SDL_Surface *surface,
     }
 
     surface_show_effects(surface, x + border_left, y + border_up, &box,
-                         FaceList[tmp->face].sprite->bitmap, &effects);
+                         sprite->bitmap, &effects);
 }

--- a/client/src/client/metaserver.c
+++ b/client/src/client/metaserver.c
@@ -770,7 +770,7 @@ int metaserver_thread(void *dummy)
         /* Send a GET request to the metaserver */
         curl_request_t *request =
             curl_request_create(clioption_settings.metaservers[i - 1],
-                                CURL_PKEY_TRUST_ULTIMATE);
+                                CURL_PKEY_TRUST_SYSTEM);
         curl_request_do_get(request);
 
         /* If the request succeeded, parse the metaserver data and break out. */

--- a/client/src/client/player.c
+++ b/client/src/client/player.c
@@ -104,7 +104,7 @@ void clear_player(void)
  * @param face
  * Face ID.
  */
-void new_player(tag_t tag, long weight, short face)
+void new_player(tag_t tag, long weight, uint16_t face)
 {
     cpl.ob->tag = tag;
     cpl.ob->weight = (float) weight / 1000;

--- a/client/src/client/sound.c
+++ b/client/src/client/sound.c
@@ -194,9 +194,23 @@ static void sound_music_file_set_duration(const char *filename, uint32_t duratio
 }
 
 /**
- * Hook called when music has finished playing.
+ * SDL_mixer callback. This can run on the audio thread, so only enqueue an
+ * event; the main thread owns all music state and cached resources.
  */
 static void sound_music_finished(void)
+{
+    SDL_Event event;
+
+    memset(&event, 0, sizeof(event));
+    event.type = SDL_USEREVENT;
+    event.user.code = EVENT_SOUND_MUSIC_FINISHED;
+    SDL_PushEvent(&event);
+}
+
+/**
+ * Handle completed music on the main thread.
+ */
+static void sound_music_finished_process(void)
 {
     uint32_t duration;
     char *tmp;
@@ -231,6 +245,18 @@ static void sound_music_finished(void)
 #endif
 
 /**
+ * Handle the music-finished event posted by SDL_mixer.
+ */
+void sound_music_finished_handle(void)
+{
+#ifdef HAVE_SDL_MIXER
+    if (enabled && !Mix_PlayingMusic()) {
+        sound_music_finished_process();
+    }
+#endif
+}
+
+/**
  * Register a new ::sound_background_hook callback.
  * @param ptr
  * New callback to register.
@@ -259,7 +285,9 @@ void sound_init(void)
         enabled = 0;
     }
 
-    Mix_HookMusicFinished(sound_music_finished);
+    if (enabled) {
+        Mix_HookMusicFinished(sound_music_finished);
+    }
 #else
     enabled = 0;
 #endif
@@ -286,17 +314,23 @@ static void sound_cache_free(void)
  */
 void sound_deinit(void)
 {
-    sound_cache_free();
+    enabled = 0;
 #ifdef HAVE_SDL_MIXER
-    Mix_CloseAudio();
+    Mix_HookMusicFinished(NULL);
+    Mix_HaltMusic();
+    Mix_HaltChannel(-1);
 #endif
 
-    enabled = 0;
-
+    sound_ambient_clear();
     if (sound_background != NULL) {
         efree(sound_background);
         sound_background = NULL;
     }
+
+#ifdef HAVE_SDL_MIXER
+    sound_cache_free();
+    Mix_CloseAudio();
+#endif
 }
 
 /**
@@ -304,6 +338,16 @@ void sound_deinit(void)
  */
 void sound_clear_cache(void)
 {
+#ifdef HAVE_SDL_MIXER
+    if (enabled) {
+        sound_stop_bg_music();
+        sound_ambient_clear();
+        Mix_HaltChannel(-1);
+    }
+#else
+    sound_ambient_clear();
+#endif
+
     sound_cache_free();
 }
 

--- a/client/src/client/video.c
+++ b/client/src/client/video.c
@@ -308,8 +308,10 @@ video_set_icon (SDL_Surface *icon)
     HARD_ASSERT(icon != NULL);
 
 #if defined(HAVE_X11)
-    Atom net_wm_icon = XInternAtom(SDL_display, "_NET_WM_ICON", False);
-    if (net_wm_icon) {
+    Atom net_wm_icon = SDL_display != NULL ?
+        XInternAtom(SDL_display, "_NET_WM_ICON", False) :
+        None;
+    if (net_wm_icon && SDL_window) {
         video_set_icon_x11(icon,
                            SDL_display,
                            x11_window_get_parent(SDL_display, SDL_window),

--- a/client/src/events/event.c
+++ b/client/src/events/event.c
@@ -220,6 +220,12 @@ int Event_PollInputDevice(void)
             done = 1;
             break;
 
+        case SDL_USEREVENT:
+            if (event.user.code == EVENT_SOUND_MUSIC_FINISHED) {
+                sound_music_finished_handle();
+            }
+            break;
+
         default:
             break;
         }

--- a/client/src/gui/misc/effects.c
+++ b/client/src/gui/misc/effects.c
@@ -461,7 +461,7 @@ void effect_sprites_play(void)
     for (tmp = current_effect->sprites; tmp; tmp = next) {
         next = tmp->next;
 
-        if (!FaceList[tmp->def->id].sprite) {
+        if (!image_get_sprite(tmp->def->id)) {
             continue;
         }
 
@@ -474,11 +474,11 @@ void effect_sprites_play(void)
         x_check = y_check = 0;
 
         if (tmp->def->x_check_mod) {
-            x_check = FaceList[tmp->def->id].sprite->bitmap->w;
+            x_check = image_get_sprite(tmp->def->id)->bitmap->w;
         }
 
         if (tmp->def->y_check_mod) {
-            y_check = FaceList[tmp->def->id].sprite->bitmap->h;
+            y_check = image_get_sprite(tmp->def->id)->bitmap->h;
         }
 
         if (tmp->def->warp_sides) {
@@ -500,7 +500,7 @@ void effect_sprites_play(void)
         /* Show the sprite. */
         sprite_effects.zoom_x = sprite_effects.zoom_y = tmp->def->zoom;
         surface_show_effects(cur_widget[MAP_ID]->surface, tmp->x, tmp->y, NULL,
-                FaceList[tmp->def->id].sprite->bitmap, &sprite_effects);
+                image_get_sprite(tmp->def->id)->bitmap, &sprite_effects);
         num_sprites++;
 
         /* Move it if there is no delay configured or if enough time has passed.
@@ -556,7 +556,7 @@ void effect_sprites_play(void)
             }
 
             /* Invalid sprite. */
-            if (sprite->def->id == -1 || !FaceList[sprite->def->id].sprite) {
+            if (sprite->def->id == -1 || !image_get_sprite(sprite->def->id)) {
                 LOG(INFO, "Invalid sprite ID %d", sprite->def->id);
                 effect_sprite_remove(sprite);
                 return;
@@ -570,7 +570,7 @@ void effect_sprites_play(void)
             }
 
             if (sprite->def->reverse) {
-                sprite->y = cur_widget[MAP_ID]->h - FaceList[sprite->def->id].sprite->bitmap->h;
+                sprite->y = cur_widget[MAP_ID]->h - image_get_sprite(sprite->def->id)->bitmap->h;
             } else if (sprite->def->y != -1) {
                 sprite->y = sprite->def->y;
             }

--- a/client/src/gui/popups/characters.c
+++ b/client/src/gui/popups/characters.c
@@ -135,9 +135,14 @@ static void list_post_column(list_struct *list, uint32_t row, uint32_t col)
         static uint8_t state[2] = {0, 0};
         uint16_t anim_id, face;
         size_t idx;
+        Animations *animation;
+        const char *face_name;
 
         anim_id = atoi(list->text[row][col]);
-        check_animation_status(anim_id);
+        animation = animation_get(anim_id);
+        if (animation == NULL) {
+            return;
+        }
         idx = list->row_selected - 1 == row ? 1 : 0;
 
         if (SDL_GetTicks() - ticks[idx] > 500) {
@@ -145,22 +150,22 @@ static void list_post_column(list_struct *list, uint32_t row, uint32_t col)
             state[idx]++;
         }
 
-        if (state[idx] >= (animations[anim_id].num_animations / animations[anim_id].facings)) {
+        if (state[idx] >= animation->frame) {
             state[idx] = 0;
         }
 
-        if (list->row_selected - 1 == row) {
-            face = animations[anim_id].faces[(animations[anim_id].num_animations / animations[anim_id].facings) * (5 + 8) + state[idx]];
-        } else {
-            face = animations[anim_id].faces[(animations[anim_id].num_animations / animations[anim_id].facings) * 5 + state[idx]];
+        uint8_t direction = list->row_selected - 1 == row ? 13 : 5;
+        if (!animation_get_face(anim_id, direction, state[idx], &face)) {
+            return;
         }
 
         image_request_face(face);
 
-        if (FaceList[face].name) {
+        face_name = image_get_face_name(face);
+        if (face_name != NULL) {
             char *facename;
 
-            facename = string_sub(FaceList[face].name, 0, -4);
+            facename = string_sub(face_name, 0, -4);
             text_show_format(list->surface, FONT_ARIAL10, list->x, LIST_ROWS_START(list) + (LIST_ROW_OFFSET(row, list) * LIST_ROW_HEIGHT(list)), COLOR_WHITE, TEXT_MARKUP, NULL, "[img=%s 0 10 0 0 0 0 0 0 0 0 0 50 45]", facename);
             efree(facename);
         }

--- a/client/src/gui/toolkit/text.c
+++ b/client/src/gui/toolkit/text.c
@@ -1035,12 +1035,12 @@ int text_show_character(font_struct **font, font_struct *orig_font, SDL_Surface 
                     sprite_effects.dark_level = dark_level;
                     sprite_effects.alpha = alpha;
 
-                    if (id != -1 && FaceList[id].sprite) {
+                    if (id != -1 && image_get_sprite(id)) {
                         int w, h;
                         SDL_Rect srcrect;
 
-                        w = FaceList[id].sprite->bitmap->w;
-                        h = FaceList[id].sprite->bitmap->h;
+                        w = image_get_sprite(id)->bitmap->w;
+                        h = image_get_sprite(id)->bitmap->h;
 
                         if (sprite_effects.rotate) {
                             rotozoomSurfaceSizeXY(w, h, sprite_effects.rotate,
@@ -1101,7 +1101,7 @@ int text_show_character(font_struct **font, font_struct *orig_font, SDL_Surface 
 
                         surface_show_effects(surface, dest->x + x, dest->y + y,
                                 wd || ht ? &srcrect : NULL,
-                                FaceList[id].sprite->bitmap, &sprite_effects);
+                                image_get_sprite(id)->bitmap, &sprite_effects);
                     }
                 }
             }
@@ -1293,8 +1293,8 @@ int text_show_character(font_struct **font, font_struct *orig_font, SDL_Surface 
                     icon_sprite = NULL;
                     icon_surface = NULL;
 
-                    if (id != -1 && FaceList[id].sprite) {
-                        icon_sprite = FaceList[id].sprite;
+                    if (id != -1 && image_get_sprite(id)) {
+                        icon_sprite = image_get_sprite(id);
                         icon_surface = icon_sprite->bitmap;
                     }
 

--- a/client/src/gui/widgets/active_effects.c
+++ b/client/src/gui/widgets/active_effects.c
@@ -123,7 +123,7 @@ static void widget_draw(widgetdata *widget)
 
         DL_FOREACH(tmp->active_effects, effect)
         {
-            sprite = FaceList[effect->op->face].sprite;
+            sprite = image_get_sprite(effect->op->face);
 
             if (!sprite) {
                 continue;
@@ -139,10 +139,9 @@ static void widget_draw(widgetdata *widget)
                 widget->redraw++;
             }
 
-            if (effect->op->face != -1 &&
-                FaceList[effect->op->face].sprite != NULL) {
+            if (image_get_sprite(effect->op->face) != NULL) {
                 surface_show(widget->surface, x, y, NULL,
-                             FaceList[effect->op->face].sprite->bitmap);
+                             image_get_sprite(effect->op->face)->bitmap);
             }
 
             if (effect->sec != -1) {
@@ -185,7 +184,7 @@ static int widget_event(widgetdata *widget, SDL_Event *event)
 
         DL_FOREACH(tmp->active_effects, effect)
         {
-            sprite = FaceList[effect->op->face].sprite;
+            sprite = image_get_sprite(effect->op->face);
 
             if (!sprite) {
                 continue;

--- a/client/src/gui/widgets/map.c
+++ b/client/src/gui/widgets/map.c
@@ -767,7 +767,10 @@ void map_set_data(int x, int y, int layer, int16_t face,
     }
 
     if (anim_speed != 0) {
-        check_animation_status(face);
+        if (!check_animation_status(face)) {
+            cell->faces[layer] = 0;
+            cell->anim_speed[layer] = 0;
+        }
     } else {
         image_request_face(face);
     }
@@ -845,9 +848,10 @@ static void map_animate_object(struct MapCell *cell, int layer)
         return;
     }
 
-    animation = &animations[cell->faces[layer]];
-
-    if (animation->num_animations == 0) {
+    animation = animation_get(cell->faces[layer]);
+    if (animation == NULL) {
+        cell->faces[layer] = 0;
+        cell->anim_speed[layer] = 0;
         return;
     }
 
@@ -858,8 +862,7 @@ static void map_animate_object(struct MapCell *cell, int layer)
     }
 
     /* If beyond drawable states, reset */
-    if (cell->anim_state[layer] >=
-            animation->num_animations / animation->facings) {
+    if (cell->anim_state[layer] >= animation->frame) {
         cell->anim_state[layer] = 0;
     }
 }
@@ -904,36 +907,32 @@ void map_animate(void)
 
 static uint16_t map_object_get_face(struct MapCell *cell, int layer)
 {
-    int sub_layer, dir, state;
+    int sub_layer, dir;
     Animations *animation;
+    uint16_t face;
 
     if (cell->anim_speed[layer] == 0) {
         return cell->faces[layer];
     }
 
-    animation = &animations[cell->faces[layer]];
-
-    if (animation->num_animations == 0) {
-        return cell->faces[layer];
+    animation = animation_get(cell->faces[layer]);
+    if (animation == NULL || cell->anim_facing[layer] == 0) {
+        return 0;
     }
 
     sub_layer = layer / NUM_LAYERS;
     dir = cell->anim_facing[layer] - 1;
-    state = 0;
 
-    if (animation->facings == 9) {
-        state = dir * (animation->num_animations / 9);
-    } else if (animation->facings >= 25) {
+    if (animation->facings >= 25) {
         if (cell->anim_flags[sub_layer] & ANIM_FLAG_ATTACKING) {
             dir += 16;
         } else if (cell->anim_flags[sub_layer] & ANIM_FLAG_MOVING) {
             dir += 8;
         }
-
-        state = dir * (animation->num_animations / animation->facings);
     }
 
-    return animation->faces[cell->anim_state[layer] + state];
+    return animation_get_face(cell->faces[layer], dir,
+            cell->anim_state[layer], &face) ? face : 0;
 }
 
 /**
@@ -987,8 +986,8 @@ draw_map_object (SDL_Surface *surface, map_render_data_t *data)
         return;
     }
 
-    sprite_struct *face_sprite = FaceList[face].sprite;
-    if (face_sprite == NULL) {
+    sprite_struct *face_sprite = image_get_sprite(face);
+    if (face_sprite == NULL || face_sprite->bitmap == NULL) {
         return;
     }
 

--- a/client/src/gui/widgets/skills.c
+++ b/client/src/gui/widgets/skills.c
@@ -98,7 +98,7 @@ static void list_post_column(list_struct *list, uint32_t row, uint32_t col)
         return;
     }
 
-    if (!FaceList[skill_list[skill_id]->skill->face].sprite) {
+    if (!image_get_sprite(skill_list[skill_id]->skill->face)) {
         return;
     }
 
@@ -107,7 +107,7 @@ static void list_post_column(list_struct *list, uint32_t row, uint32_t col)
     box.w = INVENTORY_ICON_SIZE;
     box.h = INVENTORY_ICON_SIZE;
 
-    surface_show(list->surface, box.x, box.y, NULL, FaceList[skill_list[skill_id]->skill->face].sprite->bitmap);
+    surface_show(list->surface, box.x, box.y, NULL, image_get_sprite(skill_list[skill_id]->skill->face)->bitmap);
 
     if (selected_skill != skill_id) {
         return;

--- a/client/src/gui/widgets/spells.c
+++ b/client/src/gui/widgets/spells.c
@@ -422,6 +422,7 @@ static void widget_draw(widgetdata *widget)
      * icon, spell cost, etc. */
     if (spell != NULL) {
         SDL_Surface *icon;
+        sprite_struct *icon_sprite;
         const char *status;
 
         box.h = 30;
@@ -440,7 +441,8 @@ static void widget_draw(widgetdata *widget)
         text_show(widget->surface, FONT_ARIAL10, spell->msg, 160, 40,
                 COLOR_WHITE, TEXT_WORD_WRAP, &box);
 
-        icon = FaceList[spell->spell->face].sprite->bitmap;
+        icon_sprite = image_get_sprite(spell->spell->face);
+        icon = icon_sprite != NULL ? icon_sprite->bitmap : NULL;
 
         text_show_format(widget->surface, FONT_ARIAL10, 160, widget->h - 30,
                 COLOR_WHITE, TEXT_MARKUP, NULL, "[b]Cost[/b]: %d",
@@ -461,10 +463,12 @@ static void widget_draw(widgetdata *widget)
 
         text_show_format(widget->surface, FONT_ARIAL10, 160, widget->h - 18,
                 COLOR_WHITE, TEXT_MARKUP, NULL, "[b]Status[/b]: %s", status);
-        draw_frame(widget->surface, widget->w - 6 - icon->w,
-                widget->h - 6 - icon->h, icon->w + 1, icon->h + 1);
-        surface_show(widget->surface, widget->w - 5 - icon->w,
-                widget->h - 5 - icon->h, NULL, icon);
+        if (icon != NULL) {
+            draw_frame(widget->surface, widget->w - 6 - icon->w,
+                    widget->h - 6 - icon->h, icon->w + 1, icon->h + 1);
+            surface_show(widget->surface, widget->w - 5 - icon->w,
+                    widget->h - 5 - icon->h, NULL, icon);
+        }
     }
 
     for (i = 0; i < BUTTON_NUM; i++) {
@@ -564,7 +568,10 @@ static int widget_event(widgetdata *widget, SDL_Event *event)
             return 0;
         }
 
-        icon = FaceList[spell->spell->face].sprite;
+        icon = image_get_sprite(spell->spell->face);
+        if (icon == NULL || icon->bitmap == NULL) {
+            return 0;
+        }
         xpos = widget->x + widget->w - 5;
         ypos = widget->y + widget->h - 5;
 

--- a/client/src/include/client.h
+++ b/client/src/include/client.h
@@ -46,7 +46,7 @@ typedef struct Animations {
     int loaded;
 
     /* Length of one a animation frame (num_anim / facings) */
-    int frame;
+    size_t frame;
     uint16_t *faces;
 
     /* Number of frames */
@@ -54,7 +54,7 @@ typedef struct Animations {
 
     /* Number of animations. Value of 2 means
      * only faces[0], [1] have meaningful values. */
-    uint8_t num_animations;
+    size_t num_animations;
     uint8_t flags;
 } Animations;
 

--- a/client/src/include/event.h
+++ b/client/src/include/event.h
@@ -37,6 +37,9 @@ enum {
     DRAG_QUICKSLOT_SPELL
 };
 
+/** SDL user-event code posted when SDL_mixer finishes a music track. */
+#define EVENT_SOUND_MUSIC_FINISHED 1
+
 /**
  * Called when dragged object is not handled, and a handler was specified.
  */

--- a/client/src/include/image.h
+++ b/client/src/include/image.h
@@ -70,6 +70,9 @@ typedef struct bmap_hash {
     UT_hash_handle hh;
 } bmap_hash_t;
 
+/** Mask used to extract a face ID from its protocol representation. */
+#define FACE_ID_MASK 0x7fff
+
 /* Prototypes */
 void image_init(void);
 void image_deinit(void);
@@ -78,5 +81,8 @@ void image_bmaps_deinit(void);
 void finish_face_cmd(int facenum, uint32_t checksum, const char *face);
 void image_request_face(int pnum);
 int image_get_id(const char *name);
+bool image_face_valid(int face);
+struct sprite_struct *image_get_sprite(int face);
+const char *image_get_face_name(int face);
 
 #endif

--- a/client/src/include/item.h
+++ b/client/src/include/item.h
@@ -69,7 +69,7 @@ typedef struct obj {
     double weight;
 
     /** Index for face array. */
-    int16_t face;
+    uint16_t face;
 
     /** Index into animation array. */
     uint16_t animation_id;

--- a/client/src/include/proto.h
+++ b/client/src/include/proto.h
@@ -3,10 +3,13 @@
 extern void read_anims(void);
 extern void anims_deinit(void);
 extern void anims_reset(void);
+extern Animations *animation_get(uint16_t animation_id);
+extern bool animation_get_face(uint16_t animation_id, uint8_t direction,
+        size_t state, uint16_t *face);
 /* src/client/client.c */
 extern Client_Player cpl;
 extern void DoClient(void);
-extern void check_animation_status(int anum);
+extern bool check_animation_status(int anum);
 /* src/client/cmd_aliases.c */
 extern void cmd_aliases_init(void);
 extern void cmd_aliases_deinit(void);
@@ -86,7 +89,7 @@ extern _anim_table *anim_table;
 extern Animations *animations;
 extern size_t animations_num;
 extern struct screensize *Screensize;
-extern _face_struct FaceList[32767];
+extern _face_struct FaceList[MAX_FACE_TILES];
 extern struct msg_anim_struct msg_anim;
 extern clioption_settings_struct clioption_settings;
 extern void keepalive_ping_stats(void);
@@ -123,7 +126,7 @@ extern const char *gender_objective[4];
 extern const char *gender_possessive[4];
 extern const char *gender_reflexive[4];
 extern void clear_player(void);
-extern void new_player(tag_t tag, long weight, short face);
+extern void new_player(tag_t tag, long weight, uint16_t face);
 extern void client_send_apply(object *op);
 extern void client_send_examine(tag_t tag);
 extern void client_send_move(tag_t loc, tag_t tag, uint32_t nrof);
@@ -182,6 +185,7 @@ extern bool client_socket_open(client_socket_t *csock, const char *host, int por
 extern void sound_background_hook_register(void *ptr);
 extern void sound_init(void);
 extern void sound_deinit(void);
+extern void sound_music_finished_handle(void);
 extern void sound_clear_cache(void);
 extern void sound_play_effect(const char *filename, int volume);
 extern int sound_play_effect_loop(const char *filename, int volume, int loop);


### PR DESCRIPTION
## Summary

Hardens the client against invalid face and animation data, unsafe sprite access, and SDL_mixer callback races that could cause intermittent access violations, particularly on Windows.

## Changes

- validate face IDs, image packets, animation IDs, facings, and frame counts
- add bounds-checked helpers for resolving faces, sprites, and animation frames
- replace direct face-table access throughout map, inventory, effects, spell, skill, text, and character rendering
- use unsigned face IDs and appropriately sized animation counters
- disable malformed object and map animations instead of indexing invalid memory
- move music-completion processing from SDL_mixer's audio thread to the main SDL event loop
- stop active playback before freeing cached audio resources
- guard X11 window-icon handling when display or window handles are unavailable
- use the system trust store for metaserver connections
- add contextual logging for rejected face and animation data
