### PR TITLE
fix(python): support current Python runtimes

### DIFF
--- a/maps/python/Interface.py
+++ b/maps/python/Interface.py
@@ -68,7 +68,7 @@ class Interface:
         :param newline: If True, will add a blank line before the message (if
                         any was added previously).
         :type newline: bool
-        :param \**keywds: Rest of the keyword arguments will be formatted into
+        :param \\**keywds: Rest of the keyword arguments will be formatted into
                           the message using msg.format().
         """
 

--- a/maps/python/Language.py
+++ b/maps/python/Language.py
@@ -124,7 +124,7 @@ def time2seconds(s):
 
     total = 0
 
-    for (num, unit) in re.findall("(\d+)\s?([a-zA-Z]+)", s):
+    for (num, unit) in re.findall(r"(\d+)\s?([a-zA-Z]+)", s):
         num = int(num)
         unit = unit.lower()
 

--- a/maps/python/tests/Atrinik_tests/Map.py
+++ b/maps/python/tests/Atrinik_tests/Map.py
@@ -329,8 +329,8 @@ class MapFieldsSuite(TestSuite):
         self.map.msg = "hello world"
         self.field_compare("msg", "hello world")
 
-        self.map.msg = "this\n\is\na\nmulti\nline\nmessage"
-        self.field_compare("msg", "this\n\is\na\nmulti\nline\nmessage")
+        self.map.msg = "this\n\\is\na\nmulti\nline\nmessage"
+        self.field_compare("msg", "this\n\\is\na\nmulti\nline\nmessage")
 
     def test_reset_timeout(self):
         self.field_test_int("reset_timeout", 32, True)

--- a/maps/python/tests/Atrinik_tests/Object.py
+++ b/maps/python/tests/Atrinik_tests/Object.py
@@ -302,7 +302,7 @@ class ObjectMethodsSuite(unittest.TestCase):
         force = self.obj.CreateForce("test-create-force", expiration=1)
         self.assertEqual(force.name, "test-create-force")
         self.assertAlmostEqual(force.speed, 0.02)
-        self.assertEquals(force.food, 1)
+        self.assertEqual(force.food, 1)
         self.assertTrue(force.f_is_used_up)
         self.assertEqual(self.obj.FindObject(type=Atrinik.Type.FORCE), force)
         self.assertTrue(force)
@@ -327,7 +327,7 @@ class ObjectMethodsSuite(unittest.TestCase):
         self.assertEqual(force.name, "test-create-force")
         self.assertGreater(force.speed, 0.0)
         self.assertTrue(force.f_is_used_up)
-        self.assertEquals(force.food, 1)
+        self.assertEqual(force.food, 1)
         self.assertEqual(self.obj.FindObject(type=Atrinik.Type.FORCE), force)
         self.assertTrue(force)
         verify = lambda obj: self.assertTrue(force)
@@ -341,7 +341,7 @@ class ObjectMethodsSuite(unittest.TestCase):
         self.assertEqual(force.name, "test-create-force")
         self.assertGreater(force.speed, 0.0)
         self.assertTrue(force.f_is_used_up)
-        self.assertEquals(force.food, 2)
+        self.assertEqual(force.food, 2)
         self.assertEqual(self.obj.FindObject(type=Atrinik.Type.FORCE), force)
         self.assertTrue(force)
         verify = lambda obj: self.assertTrue(force)
@@ -1483,8 +1483,8 @@ class ObjectFieldsSuite(TestSuite):
         self.obj.msg = "hello world"
         self.field_compare("msg", "hello world")
 
-        self.obj.msg = "this\n\is\na\nmulti\nline\nmessage"
-        self.field_compare("msg", "this\n\is\na\nmulti\nline\nmessage")
+        self.obj.msg = "this\n\\is\na\nmulti\nline\nmessage"
+        self.field_compare("msg", "this\n\\is\na\nmulti\nline\nmessage")
 
     def test_artifact(self):
         with self.assertRaises(TypeError):

--- a/maps/python/tests/__init__.py
+++ b/maps/python/tests/__init__.py
@@ -107,7 +107,7 @@ def simulate_server(seconds=None, count=None, wait=True, before_cb=None,
     :param after_cb: Optional function to after before calling
                      :func:`Atrinik.Process`.
     :type after_cb: collections.Callable
-    :param \**kwargs: Rest of keyword arguments are passed to *before_cb* and
+    :param \\**kwargs: Rest of keyword arguments are passed to *before_cb* and
                       *after_cb*.
     :return: How many times the loop was iterated.
     :rtype: int

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -177,31 +177,41 @@ set(SOURCES_PLUGIN_ARENA
     src/plugins/plugin_arena/plugin_arena.c)
 add_library(plugin_arena MODULE ${SOURCES_PLUGIN_ARENA})
 
-# Set the preferred order of Python versions to find.
-set(Python_ADDITIONAL_VERSIONS 3.5 3.4 3.3 3.2 3.1 3.0 2.7)
-set(CMAKE_USE_PYTHON_VERSION ${Python_ADDITIONAL_VERSIONS})
-# And try to find Python.
-find_package(PythonLibs)
+# Create the Python plugin, if requested and Python was found.
+if (ENABLE_PYTHON_PLUGIN)
+    find_package(Python QUIET COMPONENTS Development)
 
-# Create the Python plugin, if Python was found.
-if (PYTHONLIBS_FOUND)
-    include_directories(${PYTHON_INCLUDE_DIRS})
-    include_directories(src/plugins/plugin_python/include)
-    set(HAVE_PYTHON true)
+    if (Python_Development_FOUND)
+        set(PYTHONLIBS_FOUND true)
+        set(PYTHON_INCLUDE_DIRS ${Python_INCLUDE_DIRS})
+        set(PYTHON_LIBRARIES Python::Python)
+    else ()
+        # Older CMake versions do not provide FindPython.
+        find_package(PythonLibs)
+    endif ()
 
-    set(SOURCES_PLUGIN_PYTHON
-        src/plugins/plugin_python/atrinik_archetype.c
-        src/plugins/plugin_python/atrinik_map.c
-        src/plugins/plugin_python/atrinik_object.c
-        src/plugins/plugin_python/atrinik_party.c
-        src/plugins/plugin_python/atrinik_player.c
-        src/plugins/plugin_python/atrinik_region.c
-        src/plugins/plugin_python/attr_list.c
-        src/plugins/plugin_python/plugin_python.c)
-    add_library(plugin_python MODULE ${SOURCES_PLUGIN_PYTHON})
-    target_link_libraries(plugin_python ${PYTHON_LIBRARIES})
+    if (PYTHONLIBS_FOUND)
+        include_directories(${PYTHON_INCLUDE_DIRS})
+        include_directories(src/plugins/plugin_python/include)
+        set(HAVE_PYTHON true)
+
+        set(SOURCES_PLUGIN_PYTHON
+            src/plugins/plugin_python/atrinik_archetype.c
+            src/plugins/plugin_python/atrinik_map.c
+            src/plugins/plugin_python/atrinik_object.c
+            src/plugins/plugin_python/atrinik_party.c
+            src/plugins/plugin_python/atrinik_player.c
+            src/plugins/plugin_python/atrinik_region.c
+            src/plugins/plugin_python/attr_list.c
+            src/plugins/plugin_python/plugin_python.c)
+        add_library(plugin_python MODULE ${SOURCES_PLUGIN_PYTHON})
+        target_link_libraries(plugin_python ${PYTHON_LIBRARIES})
+        add_dependencies(${EXECUTABLE} plugin_python)
+    else ()
+        message(FATAL_ERROR "Python development files are required for the Python plugin.")
+    endif ()
 else ()
-    message(STATUS "Python libs not found, Python plugin will not be built.")
+    message(STATUS "Python plugin disabled by ENABLE_PYTHON_PLUGIN=false.")
 endif ()
 
 # Configure the .h file with the configuration options (size of long,

--- a/server/src/plugins/plugin_python/atrinik_archetype.c
+++ b/server/src/plugins/plugin_python/atrinik_archetype.c
@@ -139,42 +139,16 @@ static PyGetSetDef getseters[NUM_FIELDS + 1];
 
 /** Our actual Python ArchetypeType. */
 PyTypeObject Atrinik_ArchetypeType = {
-#ifdef IS_PY3K
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(NULL)
-    0,
-#endif
-    "Atrinik.Archetype",
-    sizeof(Atrinik_Archetype),
-    0,
-    (destructor) Atrinik_Archetype_dealloc,
-    NULL, NULL, NULL,
-#ifdef IS_PY3K
-    NULL,
-#else
-    (cmpfunc) Atrinik_Archetype_InternalCompare,
-#endif
-    0, 0, 0, 0, 0, 0,
-    (reprfunc) Atrinik_Archetype_str,
-    0, 0, 0,
-    Py_TPFLAGS_DEFAULT,
-    "Atrinik archetypes",
-    NULL, NULL,
-    (richcmpfunc) Atrinik_Archetype_RichCompare,
-    0, 0, 0,
-    NULL,
-    0,
-    getseters,
-    0, 0, 0, 0, 0, 0, 0,
-    Atrinik_Archetype_new,
-    0, 0, 0, 0, 0, 0, 0, 0
-#ifndef IS_PY_LEGACY
-    , 0
-#endif
-#ifdef Py_TPFLAGS_HAVE_FINALIZE
-    , NULL
-#endif
+    .tp_name = "Atrinik.Archetype",
+    .tp_basicsize = sizeof(Atrinik_Archetype),
+    .tp_dealloc = (destructor) Atrinik_Archetype_dealloc,
+    .tp_str = (reprfunc) Atrinik_Archetype_str,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_doc = "Atrinik archetypes",
+    .tp_richcompare = (richcmpfunc) Atrinik_Archetype_RichCompare,
+    .tp_getset = getseters,
+    .tp_new = Atrinik_Archetype_new,
 };
 
 /**

--- a/server/src/plugins/plugin_python/atrinik_map.c
+++ b/server/src/plugins/plugin_python/atrinik_map.c
@@ -1038,42 +1038,17 @@ static PyGetSetDef getseters[NUM_FIELDS + NUM_MAPFLAGS + 1];
 
 /** Our actual Python MapType. */
 PyTypeObject Atrinik_MapType = {
-#ifdef IS_PY3K
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(NULL)
-    0,
-#endif
-    "Atrinik.Map",
-    sizeof(Atrinik_Map),
-    0,
-    (destructor) Atrinik_Map_dealloc,
-    NULL, NULL, NULL,
-#ifdef IS_PY3K
-    NULL,
-#else
-    (cmpfunc) Atrinik_Map_InternalCompare,
-#endif
-    0, 0, 0, 0, 0, 0,
-    (reprfunc) Atrinik_Map_str,
-    0, 0, 0,
-    Py_TPFLAGS_DEFAULT,
-    "Atrinik maps",
-    NULL, NULL,
-    (richcmpfunc) Atrinik_Map_RichCompare,
-    0, 0, 0,
-    MapMethods,
-    0,
-    getseters,
-    0, 0, 0, 0, 0, 0, 0,
-    Atrinik_Map_new,
-    0, 0, 0, 0, 0, 0, 0, 0
-#ifndef IS_PY_LEGACY
-    , 0
-#endif
-#ifdef Py_TPFLAGS_HAVE_FINALIZE
-    , NULL
-#endif
+    .tp_name = "Atrinik.Map",
+    .tp_basicsize = sizeof(Atrinik_Map),
+    .tp_dealloc = (destructor) Atrinik_Map_dealloc,
+    .tp_str = (reprfunc) Atrinik_Map_str,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_doc = "Atrinik maps",
+    .tp_richcompare = (richcmpfunc) Atrinik_Map_RichCompare,
+    .tp_methods = MapMethods,
+    .tp_getset = getseters,
+    .tp_new = Atrinik_Map_new,
 };
 
 /**

--- a/server/src/plugins/plugin_python/atrinik_object.c
+++ b/server/src/plugins/plugin_python/atrinik_object.c
@@ -2693,46 +2693,18 @@ static PyNumberMethods AtrinikObjectNumber = {
  * Our actual Python ObjectType.
  */
 PyTypeObject Atrinik_ObjectType = {
-#ifdef IS_PY3K
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(NULL)
-    0,
-#endif
-    "Atrinik.Object",
-    sizeof(Atrinik_Object),
-    0,
-    (destructor) Atrinik_Object_dealloc,
-    NULL, NULL, NULL,
-#ifdef IS_PY3K
-    NULL,
-#else
-    (cmpfunc) Atrinik_Object_InternalCompare,
-#endif
-    NULL,
-    &AtrinikObjectNumber,
-    0, 0, 0, 0,
-    (reprfunc) Atrinik_Object_str,
-    0, 0, 0,
-    Py_TPFLAGS_DEFAULT,
-    "Atrinik objects",
-    NULL, NULL,
-    (richcmpfunc) Atrinik_Object_RichCompare,
-    0,
-    NULL,
-    NULL,
-    methods,
-    0,
-    getseters,
-    0, 0, 0, 0, 0, 0, 0,
-    Atrinik_Object_new,
-    0, 0, 0, 0, 0, 0, 0, 0
-#ifndef IS_PY_LEGACY
-    , 0
-#endif
-#ifdef Py_TPFLAGS_HAVE_FINALIZE
-    , NULL
-#endif
+    .tp_name = "Atrinik.Object",
+    .tp_basicsize = sizeof(Atrinik_Object),
+    .tp_dealloc = (destructor) Atrinik_Object_dealloc,
+    .tp_as_number = &AtrinikObjectNumber,
+    .tp_str = (reprfunc) Atrinik_Object_str,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_doc = "Atrinik objects",
+    .tp_richcompare = (richcmpfunc) Atrinik_Object_RichCompare,
+    .tp_methods = methods,
+    .tp_getset = getseters,
+    .tp_new = Atrinik_Object_new,
 };
 
 /**
@@ -2994,34 +2966,17 @@ static PySequenceMethods Atrinik_ObjectIteratorSequence = {
  */
 PyTypeObject Atrinik_ObjectIteratorType = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "Atrinik.ObjectIterator",
-    sizeof(Atrinik_ObjectIterator),
-    0,
-    (destructor) Atrinik_ObjectIterator_dealloc,
-    NULL, NULL, NULL,
-    NULL,
-    NULL,
-    &Atrinik_ObjectIteratorNumber,
-    &Atrinik_ObjectIteratorSequence,
-    0, 0, 0,
-    (reprfunc) Atrinik_ObjectIterator_str,
-    0, 0, 0,
-    Py_TPFLAGS_DEFAULT,
-    "Used for iterating object inventories.",
-    NULL, NULL,
-    NULL,
-    0,
-    (getiterfunc) Atrinik_ObjectIterator_iter,
-    (iternextfunc) Atrinik_ObjectIterator_iternext,
-    NULL,
-    0,
-    NULL,
-    0, 0, 0, 0, 0, 0, 0,
-    PyType_GenericNew,
-    0, 0, 0, 0, 0, 0, 0, 0, 0
-#ifdef Py_TPFLAGS_HAVE_FINALIZE
-    , NULL
-#endif
+    .tp_name = "Atrinik.ObjectIterator",
+    .tp_basicsize = sizeof(Atrinik_ObjectIterator),
+    .tp_dealloc = (destructor) Atrinik_ObjectIterator_dealloc,
+    .tp_as_number = &Atrinik_ObjectIteratorNumber,
+    .tp_as_sequence = &Atrinik_ObjectIteratorSequence,
+    .tp_str = (reprfunc) Atrinik_ObjectIterator_str,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_doc = "Used for iterating object inventories.",
+    .tp_iter = (getiterfunc) Atrinik_ObjectIterator_iter,
+    .tp_iternext = (iternextfunc) Atrinik_ObjectIterator_iternext,
+    .tp_new = PyType_GenericNew,
 };
 
 /**

--- a/server/src/plugins/plugin_python/atrinik_party.c
+++ b/server/src/plugins/plugin_python/atrinik_party.c
@@ -312,42 +312,17 @@ static PyGetSetDef getseters[NUM_FIELDS + 1];
 
 /** Our actual Python PartyType. */
 PyTypeObject Atrinik_PartyType = {
-#ifdef IS_PY3K
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(NULL)
-    0,
-#endif
-    "Atrinik.Party",
-    sizeof(Atrinik_Party),
-    0,
-    (destructor) Atrinik_Party_dealloc,
-    NULL, NULL, NULL,
-#ifdef IS_PY3K
-    NULL,
-#else
-    (cmpfunc) Atrinik_Party_InternalCompare,
-#endif
-    0, 0, 0, 0, 0, 0,
-    (reprfunc) Atrinik_Party_str,
-    0, 0, 0,
-    Py_TPFLAGS_DEFAULT,
-    "Atrinik parties",
-    NULL, NULL,
-    (richcmpfunc) Atrinik_Party_RichCompare,
-    0, 0, 0,
-    PartyMethods,
-    0,
-    getseters,
-    0, 0, 0, 0, 0, 0, 0,
-    Atrinik_Party_new,
-    0, 0, 0, 0, 0, 0, 0, 0
-#ifndef IS_PY_LEGACY
-    , 0
-#endif
-#ifdef Py_TPFLAGS_HAVE_FINALIZE
-    , NULL
-#endif
+    .tp_name = "Atrinik.Party",
+    .tp_basicsize = sizeof(Atrinik_Party),
+    .tp_dealloc = (destructor) Atrinik_Party_dealloc,
+    .tp_str = (reprfunc) Atrinik_Party_str,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_doc = "Atrinik parties",
+    .tp_richcompare = (richcmpfunc) Atrinik_Party_RichCompare,
+    .tp_methods = PartyMethods,
+    .tp_getset = getseters,
+    .tp_new = Atrinik_Party_new,
 };
 
 /**

--- a/server/src/plugins/plugin_python/atrinik_player.c
+++ b/server/src/plugins/plugin_python/atrinik_player.c
@@ -1127,50 +1127,25 @@ static PyGetSetDef getseters[NUM_FIELDS + 1];
  * Our actual Python PlayerType.
  */
 PyTypeObject Atrinik_PlayerType = {
-#ifdef IS_PY3K
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(NULL)
-    0,
-#endif
-    "Atrinik.Player",
-    sizeof(Atrinik_Player),
-    0,
-    (destructor) Atrinik_Player_dealloc,
-    NULL, NULL, NULL,
-#ifdef IS_PY3K
-    NULL,
-#else
-    (cmpfunc) Atrinik_Player_InternalCompare,
-#endif
-    0, 0, 0, 0, 0, 0,
-    (reprfunc) Atrinik_Player_str,
-    0, 0, 0,
-    Py_TPFLAGS_DEFAULT,
-    "Atrinik Player class.\n\n"
-    "To access object's player controller, you can use something like::\n\n"
-    "    activator = Atrinik.WhoIsActivator()\n"
-    "    player = activator.Controller()\n\n"
-    "In the above example, player points to the player structure (which Python "
-    "is wrapping) that is controlling the object *activator*. In this way, you "
-    "can, for example, use something like this to get player's save bed, among "
-    "other things::\n\n"
-    "    print(Atrinik.WhoIsActivator().Controller().savebed_map)\n\n",
-    NULL, NULL,
-    (richcmpfunc) Atrinik_Player_RichCompare,
-    0, 0, 0,
-    methods,
-    0,
-    getseters,
-    0, 0, 0, 0, 0, 0, 0,
-    Atrinik_Player_new,
-    0, 0, 0, 0, 0, 0, 0, 0
-#ifndef IS_PY_LEGACY
-    , 0
-#endif
-#ifdef Py_TPFLAGS_HAVE_FINALIZE
-    , NULL
-#endif
+    .tp_name = "Atrinik.Player",
+    .tp_basicsize = sizeof(Atrinik_Player),
+    .tp_dealloc = (destructor) Atrinik_Player_dealloc,
+    .tp_str = (reprfunc) Atrinik_Player_str,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_doc = "Atrinik Player class.\n\n"
+        "To access object's player controller, you can use something like::\n\n"
+        "    activator = Atrinik.WhoIsActivator()\n"
+        "    player = activator.Controller()\n\n"
+        "In the above example, player points to the player structure (which "
+        "Python is wrapping) that is controlling the object *activator*. In "
+        "this way, you can, for example, use something like this to get "
+        "player's save bed, among other things::\n\n"
+        "    print(Atrinik.WhoIsActivator().Controller().savebed_map)\n\n",
+    .tp_richcompare = (richcmpfunc) Atrinik_Player_RichCompare,
+    .tp_methods = methods,
+    .tp_getset = getseters,
+    .tp_new = Atrinik_Player_new,
 };
 
 /**

--- a/server/src/plugins/plugin_python/atrinik_region.c
+++ b/server/src/plugins/plugin_python/atrinik_region.c
@@ -148,42 +148,16 @@ static PyGetSetDef getseters[NUM_FIELDS + 1];
 
 /** Our actual Python RegionType. */
 PyTypeObject Atrinik_RegionType = {
-#ifdef IS_PY3K
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(NULL)
-    0,
-#endif
-    "Atrinik.Region",
-    sizeof(Atrinik_Region),
-    0,
-    (destructor) Atrinik_Region_dealloc,
-    NULL, NULL, NULL,
-#ifdef IS_PY3K
-    NULL,
-#else
-    (cmpfunc) Atrinik_Region_InternalCompare,
-#endif
-    0, 0, 0, 0, 0, 0,
-    (reprfunc) Atrinik_Region_str,
-    0, 0, 0,
-    Py_TPFLAGS_DEFAULT,
-    "Atrinik regions",
-    NULL, NULL,
-    (richcmpfunc) Atrinik_Region_RichCompare,
-    0, 0, 0,
-    NULL,
-    0,
-    getseters,
-    0, 0, 0, 0, 0, 0, 0,
-    Atrinik_Region_new,
-    0, 0, 0, 0, 0, 0, 0, 0
-#ifndef IS_PY_LEGACY
-    , 0
-#endif
-#ifdef Py_TPFLAGS_HAVE_FINALIZE
-    , NULL
-#endif
+    .tp_name = "Atrinik.Region",
+    .tp_basicsize = sizeof(Atrinik_Region),
+    .tp_dealloc = (destructor) Atrinik_Region_dealloc,
+    .tp_str = (reprfunc) Atrinik_Region_str,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_doc = "Atrinik regions",
+    .tp_richcompare = (richcmpfunc) Atrinik_Region_RichCompare,
+    .tp_getset = getseters,
+    .tp_new = Atrinik_Region_new,
 };
 
 /**

--- a/server/src/plugins/plugin_python/attr_list.c
+++ b/server/src/plugins/plugin_python/attr_list.c
@@ -735,43 +735,16 @@ static PyMappingMethods MappingMethods = {
 
 /** AttrListType definition. */
 PyTypeObject Atrinik_AttrListType = {
-#ifdef IS_PY3K
     PyVarObject_HEAD_INIT(NULL, 0)
-#else
-    PyObject_HEAD_INIT(NULL)
-    0,
-#endif
-    "Atrinik.AttrList",
-    sizeof(Atrinik_AttrList),
-    0,
-    NULL,
-    NULL, NULL, NULL,
-    NULL,
-    NULL,
-    0,
-    &SequenceMethods,
-    &MappingMethods,
-    0, 0,
-    NULL,
-    0, 0, 0,
-    Py_TPFLAGS_DEFAULT,
-    "Atrinik attr lists",
-    NULL, NULL, NULL,
-    0,
-    (getiterfunc) iter,
-    (iternextfunc) iternext,
-    methods,
-    0,
-    NULL,
-    0, 0, 0, 0, 0, 0, 0,
-    NULL,
-    0, 0, 0, 0, 0, 0, 0, 0
-#ifndef IS_PY_LEGACY
-    , 0
-#endif
-#ifdef Py_TPFLAGS_HAVE_FINALIZE
-    , NULL
-#endif
+    .tp_name = "Atrinik.AttrList",
+    .tp_basicsize = sizeof(Atrinik_AttrList),
+    .tp_as_sequence = &SequenceMethods,
+    .tp_as_mapping = &MappingMethods,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_doc = "Atrinik attr lists",
+    .tp_iter = (getiterfunc) iter,
+    .tp_iternext = (iternextfunc) iternext,
+    .tp_methods = methods,
 };
 
 /**

--- a/server/src/plugins/plugin_python/include/plugin_python.h
+++ b/server/src/plugins/plugin_python/include/plugin_python.h
@@ -62,7 +62,7 @@
 /* Fake some Python 2.x functions for Python 3.x. */
 #ifdef IS_PY3K
 #define PyString_Check PyUnicode_Check
-#define PyString_AsString _PyUnicode_AsString
+#define PyString_AsString PyUnicode_AsUTF8
 #define PyInt_Check PyLong_Check
 #define PyInt_AsLong PyLong_AsLong
 extern PyTypeObject PyIOBase_Type;

--- a/server/src/plugins/plugin_python/plugin_python.c
+++ b/server/src/plugins/plugin_python/plugin_python.c
@@ -41,12 +41,6 @@
 #include <object_methods.h>
 
 #include <compile.h>
-#include <eval.h>
-#ifdef STR
-/* STR is redefined in node.h. Since this file doesn't use STR, we remove it */
-#undef STR
-#endif
-#include <node.h>
 
 /** Hooks. */
 struct plugin_hooklist *hooks;
@@ -659,6 +653,39 @@ static void PyErr_LOG(void)
 }
 
 /**
+ * Reads a Python source file into a NUL-terminated buffer.
+ */
+static char *read_script_file(const char *filename)
+{
+    FILE *fp = fopen(filename, "rb");
+    long size;
+    char *source;
+
+    if (fp == NULL) {
+        return NULL;
+    }
+
+    if (fseek(fp, 0, SEEK_END) != 0 || (size = ftell(fp)) < 0) {
+        fclose(fp);
+        return NULL;
+    }
+
+    rewind(fp);
+    source = malloc((size_t) size + 1);
+
+    if (source == NULL || fread(source, 1, (size_t) size, fp) !=
+            (size_t) size) {
+        free(source);
+        fclose(fp);
+        return NULL;
+    }
+
+    source[size] = '\0';
+    fclose(fp);
+    return source;
+}
+
+/**
  * Outputs the compiled bytecode for a given python file, using in-memory
  * caching of bytecode.
  */
@@ -675,8 +702,7 @@ static PyCodeObject *compilePython(char *filename)
     HASH_FIND_STR(python_cache, filename, cache);
 
     if (!cache || cache->cached_time < stat_buf.st_mtime) {
-        FILE *fp;
-        struct _node *n;
+        char *source;
         PyCodeObject *code = NULL;
 
         if (cache) {
@@ -686,39 +712,16 @@ static PyCodeObject *compilePython(char *filename)
             free(cache);
         }
 
-        fp = fopen(filename, "r");
+        source = read_script_file(filename);
 
-        if (!fp) {
-            LOG(BUG, "Python: The script file %s can't be opened.", filename);
+        if (source == NULL) {
+            LOG(BUG, "Python: The script file %s cannot be opened.", filename);
             return NULL;
         }
 
-#ifdef WIN32
-        {
-            char buf[HUGE_BUF], *pystr = NULL;
-            size_t buf_len = 0, pystr_len = 0;
-
-            while (fgets(buf, sizeof(buf), fp)) {
-                buf_len = strlen(buf);
-                pystr_len += buf_len;
-                pystr = realloc(pystr, sizeof(char) * (pystr_len + 1));
-                strcpy(pystr + pystr_len - buf_len, buf);
-                pystr[pystr_len] = '\0';
-            }
-
-            n = PyParser_SimpleParseString(pystr, Py_file_input);
-            free(pystr);
-        }
-#else
-        n = PyParser_SimpleParseFile(fp, filename, Py_file_input);
-#endif
-
-        if (n) {
-            code = PyNode_Compile(n, filename);
-            PyNode_Free(n);
-        }
-
-        fclose(fp);
+        code = (PyCodeObject *) Py_CompileString(source, filename,
+                Py_file_input);
+        free(source);
 
         if (PyErr_Occurred()) {
             PyErr_LOG();
@@ -1872,19 +1875,14 @@ static PyObject *Atrinik_Eval(PyObject *self, PyObject *args)
 {
     double seconds = 0.0f;
     const char *s;
-    struct _node *n;
     PyCodeObject *code = NULL;
 
     if (!PyArg_ParseTuple(args, "s|d", &s, &seconds)) {
         return NULL;
     }
 
-    n = PyParser_SimpleParseString(s, Py_file_input);
-
-    if (n != NULL) {
-        code = PyNode_Compile(n, "eval'd code");
-        PyNode_Free(n);
-    }
+    code = (PyCodeObject *) Py_CompileString(s, "eval'd code",
+            Py_file_input);
 
     if (PyErr_Occurred()) {
         PyErr_LOG();
@@ -1893,7 +1891,6 @@ static PyObject *Atrinik_Eval(PyObject *self, PyObject *args)
 
     if (code != NULL) {
         python_eval_struct *tmp;
-        PyGILState_STATE gilstate;
         struct timeval tv;
 
         gettimeofday(&tv, NULL);
@@ -1906,10 +1903,6 @@ static PyObject *Atrinik_Eval(PyObject *self, PyObject *args)
         tmp->code = code;
         tmp->seconds = tv.tv_sec + tv.tv_usec / 1000000. + seconds;
         DL_APPEND(python_eval, tmp);
-
-        gilstate = PyGILState_Ensure();
-        DL_APPEND(python_eval, tmp);
-        PyGILState_Release(gilstate);
     }
 
     Py_INCREF(Py_None);
@@ -2530,7 +2523,6 @@ MODULEAPI void initPlugin(struct plugin_hooklist *hooklist)
 #endif
 
     Py_Initialize();
-    PyEval_InitThreads();
 
 #ifdef IS_PY3K
     m = PyImport_ImportModule("Atrinik");
@@ -3301,7 +3293,7 @@ PyObject *generic_rich_compare(int op, int result)
 int python_call_int(PyObject *callable, PyObject *arglist)
 {
     /* Call the Python function. */
-    PyObject *result = PyEval_CallObject(callable, arglist);
+    PyObject *result = PyObject_CallObject(callable, arglist);
 
     int retval = 0;
     /* Check the result. */


### PR DESCRIPTION
## Summary

Modernize the server's Python plugin and map scripts for compatibility with current Python 3 releases.

## Changes

- Use designated initializers for Python extension types.
- Replace removed or private CPython APIs with supported public APIs.
- Compile scripts using `Py_CompileString`.
- Remove obsolete parser-node and thread-initialization APIs.
- Fix duplicate deferred-evaluation queue insertion.
- Modernize Python discovery in CMake.
- Resolve invalid escape sequences and deprecated test assertions.

## Testing

- [x] Build the Python server plugin.
- [x] Run the server plugin unit tests.
- [x] Run the map Python test suite.
- [x] Verify representative NPC and map scripts load successfully.

## Notes

This is intended as a compatibility change. It should not alter the public Atrinik Python scripting API.