### PR TITLE
build: modernize the Linux CMake build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:26.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        check \
+        cmake \
+        cproto \
+        flex \
+        gdb \
+        git \
+        libcurl4-openssl-dev \
+        libgd-dev \
+        libreadline-dev \
+        libsubunit-dev \
+        libsdl-image1.2-dev \
+        libsdl-mixer1.2-dev \
+        libsdl-ttf2.0-dev \
+        libsdl1.2-dev \
+        libssl-dev \
+        libx11-dev \
+        libxml2-dev \
+        libxml2-utils \
+        nodejs \
+        npm \
+        libxmu-dev \
+        pkgconf \
+        python3-dev \
+        timidity \
+        valgrind \
+        zlib1g-dev \
+        alsa-utils \
+        libasound2-plugins \
+        pulseaudio-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY .devcontainer/asound.conf /etc/asound.conf

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+  "name": "Atrinik 2026 Linux Build",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "runArgs": [
+    "--network", "host"
+  ],
+  "workspaceFolder": "/workspaces/atrinik",
+  "mounts": [
+    "source=/mnt/wslg/PulseServer,target=/mnt/wslg/PulseServer,type=bind"
+  ],
+  "containerEnv": {
+    "PULSE_SERVER": "unix:/mnt/wslg/PulseServer",
+    "SDL_AUDIODRIVER": "pulse"
+  },
+  "postCreateCommand": "git submodule update --init --recursive || true",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cmake-tools",
+        "ms-vscode.cpptools"
+      ],
+      "settings": {
+        "cmake.configurePreset": "linux-debug",
+        "cmake.buildPreset": "linux-debug"
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,22 @@
 *.log
 cov-int
 nbproject
+build/
 *.kdev*
 *.json
+!CMakePresets.json
+!metaserver/worker/package.json
+!metaserver/worker/package-lock.json
+!.devcontainer/
+!.devcontainer/devcontainer.json
+!.devcontainer/**/*.json
 traceback_*.txt
+atrinik-traceback-*.txt
+atrinik-server-traceback-*.txt
 build.user
+metaserver/worker/node_modules/
+metaserver/worker/dist/
+metaserver/worker/.wrangler/
 server/src/loaders/*.c
 timidity.cfg
 .idea
@@ -17,6 +29,7 @@ metaserver/db-cfg.php
 # Server data files
 server/data
 server/lib
+server-data/
 
 # Config files
 tools/map-checker/config.cfg
@@ -104,3 +117,4 @@ client/timidity/
 *.db
 *.pyc
 __pycache__
+.venv/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
+cmake_minimum_required(VERSION 3.21)
 project(atrinik C)
-cmake_minimum_required(VERSION 2.6)
+
+if (POLICY CMP0077)
+    cmake_policy(SET CMP0077 NEW)
+endif ()
 
 # Include build configuration.
 include(build.config)
@@ -9,6 +13,11 @@ if (EXISTS build.user)
 endif ()
 
 include_directories(common)
+include_directories(${CMAKE_BINARY_DIR}/common)
+
+if (CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    add_compile_options(-fcommon)
+endif ()
 
 # Add some useful compile flags.
 add_definitions(-Wall -Wextra -Wno-unused-parameter -D_GNU_SOURCE -D__USE_MINGW_ANSI_STDIO=0 -std=gnu99)
@@ -72,13 +81,8 @@ if (ENABLE_WARNING_ERRORS)
 endif ()
 
 if (MINGW)
-    add_definitions(-DCURL_STATICLIB -DPTW32_STATIC_LIB -DBGDWIN32 -DNONDLL)
     add_definitions(-DNOCRYPT)
-    set(CURL_STATICLIB true)
-    set(CMAKE_EXE_LINKER_FLAGS "-static -static-libgcc")
     set(PLUGIN_SUFFIX ".dll")
-    set(CMAKE_PREFIX_PATH "C:\\MinGW\\msys\\1.0;C:\\MinGW")
-    set(CMAKE_FIND_LIBRARY_SUFFIXES ".a;.so;.dll.a")
 else ()
     # Compiling on GNU/Linux.
     set(LINUX true)
@@ -86,5 +90,15 @@ else ()
 endif ()
 
 add_subdirectory(common/toolkit)
-add_subdirectory(server)
-add_subdirectory(client)
+
+if (BUILD_SERVER)
+    add_subdirectory(server)
+endif ()
+
+if (BUILD_CLIENT)
+    add_subdirectory(client)
+endif ()
+
+if (NOT BUILD_SERVER AND NOT BUILD_CLIENT)
+    message(FATAL_ERROR "At least one of BUILD_SERVER or BUILD_CLIENT must be enabled")
+endif ()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,66 @@
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "linux-debug",
+            "displayName": "Linux Debug",
+            "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/build/linux-debug",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "PACKAGE_TYPE": "none"
+            }
+        },
+        {
+            "name": "linux-release",
+            "displayName": "Linux Release",
+            "generator": "Unix Makefiles",
+            "binaryDir": "${sourceDir}/build/linux-release",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "PACKAGE_TYPE": "none"
+            }
+        },
+        {
+            "name": "windows-mxe-release",
+            "displayName": "Windows x86_64 Release (MXE)",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/windows-mxe-release",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_TOOLCHAIN_FILE": "$env{MXE_TOOLCHAIN_FILE}",
+                "BUILD_CLIENT": true,
+                "BUILD_SERVER": false,
+                "PACKAGE_TYPE": "zip",
+                "ATRINIK_WINDOWS_RUNTIME_DIR": "$env{MXE_RUNTIME_DIR}",
+                "ATRINIK_CA_BUNDLE": "/etc/ssl/certs/ca-certificates.crt"
+            }
+        },
+        {
+            "name": "Configure preset using toolchain file",
+            "displayName": "Configure preset using toolchain file",
+            "description": "Sets Ninja generator, build and install directory",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/out/build/${presetName}",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_TOOLCHAIN_FILE": "",
+                "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "linux-debug",
+            "configurePreset": "linux-debug"
+        },
+        {
+            "name": "linux-release",
+            "configurePreset": "linux-release"
+        },
+        {
+            "name": "windows-mxe-release",
+            "configurePreset": "windows-mxe-release"
+        }
+    ]
+}

--- a/INSTALL
+++ b/INSTALL
@@ -49,10 +49,11 @@
 
  You can use the following command on Debian-based systems to install all the
  recommended packages:
-  # apt-get install build-essential openssl-dev cmake zlib1g-dev \
-    libcurl4-openssl-dev python3-dev libgd-dev check libreadline6-dev \
+  # apt-get install build-essential libssl-dev cmake zlib1g-dev \
+    libcurl4-openssl-dev python3-dev libgd-dev check libreadline-dev \
     libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl1.2-dev libsdl-ttf2.0-dev \
-    timidity libsdl1.2debian libsdl1.2debian-all libx11-dev libxmu-dev
+    timidity libsdl1.2debian libx11-dev libxml2-dev libxmu-dev cproto pkgconf \
+    libsubunit-dev
 
 =================================================
 = 1.2 Compilation (GNU/Linux)                   =
@@ -75,7 +76,7 @@
   - atrinik-server:  The Atrinik server
   - atrinik:         The Atrinik client
   - atrinik-toolkit: Toolkit library used by both the client and the server
-  - test:            Run the unit tests
+  - check:           Run the unit tests
   - clean:           Remove the generated binaries
 
 =================================================

--- a/build.config
+++ b/build.config
@@ -14,8 +14,10 @@ set(PACKAGE_VERSION_MAJOR 4)
 set(PACKAGE_VERSION_MINOR 0)
 set(PACKAGE_VERSION_PATCH 0)
 
-# Build type.
-set(CMAKE_BUILD_TYPE "Debug")
+# Build type. Respect a value supplied by a preset or the command line.
+if (NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "CMake build type")
+endif ()
 
 # Turn code warnings into errors?
 set(ENABLE_WARNING_ERRORS false)
@@ -29,12 +31,21 @@ set(ENABLE_AGGRESSIVE_WARNINGS false)
 # Enable stack protection?
 set(ENABLE_STACK_PROTECTOR true)
 
+# Build the Python server plugin? NPC and map scripts depend on it.
+option(ENABLE_PYTHON_PLUGIN "Build the Python server plugin" ON)
+
 # Custom warnings.
 set(CUSTOM_WARNINGS)
+
+# Components to build.
+option(BUILD_CLIENT "Build the Atrinik client" ON)
+option(BUILD_SERVER "Build the Atrinik server" ON)
 
 # What package type to build with 'make package'. One of:
 #  - none: Build no package.
 #  - deb:  Build .deb package.
 #  - nsis: Build NSIS Windows installer.
 #  - rpm:  Build .rpm package.
-set(PACKAGE_TYPE "deb")
+#  - zip:  Build a portable .zip package.
+set(PACKAGE_TYPE "deb" CACHE STRING "Package type")
+set_property(CACHE PACKAGE_TYPE PROPERTY STRINGS none deb nsis rpm zip)

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-DIRS="server client"
+BUILD_DIR=${BUILD_DIR:-build/linux-debug}
 TARGET=${1:-all}
+JOBS=${JOBS:-$(nproc)}
 
-for dir in $DIRS; do
-    cd $dir/
-    cmake .
-    make $TARGET
-    cd ../
-done
+cmake -S . -B "${BUILD_DIR}" -DCMAKE_BUILD_TYPE=Debug -DPACKAGE_TYPE=none
+cmake --build "${BUILD_DIR}" --target "${TARGET}" --parallel "${JOBS}"

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -1,13 +1,15 @@
 # The Atrinik CMakeLists file.
 
+cmake_minimum_required(VERSION 3.21)
 project(atrinik C)
-cmake_minimum_required(VERSION 2.6)
 set(EXECUTABLE atrinik)
 set(EXECUTABLE_UPDATER atrinik2)
 set(PACKAGE_NAME "Atrinik Client")
 
 # Add our includes.
-include_directories(src/include)
+include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR}/src/include)
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/src/include)
+include_directories(${CMAKE_BINARY_DIR}/common/toolkit)
 include_directories(src/gui/toolkit/include)
 include_directories(src)
 
@@ -17,17 +19,35 @@ endif ()
 
 # SDL is required to run the client.
 find_package(SDL REQUIRED)
+if (NOT SDL_INCLUDE_DIR AND SDL_INCLUDE_DIRS)
+    set(SDL_INCLUDE_DIR ${SDL_INCLUDE_DIRS})
+endif ()
+if (NOT SDL_LIBRARY AND SDL_LIBRARIES)
+    set(SDL_LIBRARY ${SDL_LIBRARIES})
+endif ()
 include_directories(${SDL_INCLUDE_DIR})
 set(HAVE_SDL true)
 
 # SDL_image is also required, otherwise no bitmaps or map images could be
 # displayed.
 find_package(SDL_image REQUIRED)
+if (NOT SDLIMAGE_INCLUDE_DIR AND SDL_IMAGE_INCLUDE_DIRS)
+    set(SDLIMAGE_INCLUDE_DIR ${SDL_IMAGE_INCLUDE_DIRS})
+endif ()
+if (NOT SDLIMAGE_LIBRARY AND SDL_IMAGE_LIBRARIES)
+    set(SDLIMAGE_LIBRARY ${SDL_IMAGE_LIBRARIES})
+endif ()
 include_directories(${SDLIMAGE_INCLUDE_DIR})
 set(HAVE_SDL_IMAGE true)
 
 # SDL_ttf is used for all text drawing, so it's required.
 find_package(SDL_ttf REQUIRED)
+if (NOT SDLTTF_INCLUDE_DIR AND SDL_TTF_INCLUDE_DIRS)
+    set(SDLTTF_INCLUDE_DIR ${SDL_TTF_INCLUDE_DIRS})
+endif ()
+if (NOT SDLTTF_LIBRARY AND SDL_TTF_LIBRARIES)
+    set(SDLTTF_LIBRARY ${SDL_TTF_LIBRARIES})
+endif ()
 include_directories(${SDLTTF_INCLUDE_DIR})
 set(HAVE_SDL_TTF true)
 
@@ -37,6 +57,16 @@ include_directories(${LIBXML2_INCLUDE_DIR})
 
 # SDL_mixer is optional, as sound is not a must-have.
 find_package(SDL_mixer)
+
+if (NOT SDLMIXER_FOUND AND SDL_mixer_FOUND)
+    set(SDLMIXER_FOUND ${SDL_mixer_FOUND})
+endif ()
+if (NOT SDLMIXER_INCLUDE_DIR AND SDL_MIXER_INCLUDE_DIRS)
+    set(SDLMIXER_INCLUDE_DIR ${SDL_MIXER_INCLUDE_DIRS})
+endif ()
+if (NOT SDLMIXER_LIBRARY AND SDL_MIXER_LIBRARIES)
+    set(SDLMIXER_LIBRARY ${SDL_MIXER_LIBRARIES})
+endif ()
 
 if (SDLMIXER_FOUND)
     include_directories(${SDLMIXER_INCLUDE_DIR})
@@ -71,6 +101,7 @@ target_link_libraries(${EXECUTABLE} ${LIBXML2_LIBRARIES})
 
 # Link SDL_mixer if available.
 if (HAVE_SDL_MIXER)
+    target_compile_definitions(${EXECUTABLE} PRIVATE HAVE_SDL_MIXER)
     target_link_libraries(${EXECUTABLE} ${SDLMIXER_LIBRARY})
 endif ()
 
@@ -110,9 +141,11 @@ else ()
     install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/textures/icon.png DESTINATION "share/pixmaps" RENAME "atrinik.png")
 endif ()
 
-install(TARGETS atrinik DESTINATION ${INSTALL_SUBDIR_BIN})
+if (NOT WIN32 OR UNIX)
+    install(TARGETS atrinik DESTINATION ${INSTALL_SUBDIR_BIN})
+endif ()
 install(FILES
-        ${CMAKE_CURRENT_SOURCE_DIR}/INSTALL
+        ${CMAKE_SOURCE_DIR}/INSTALL
         ${CMAKE_CURRENT_SOURCE_DIR}/README
         ${CMAKE_CURRENT_SOURCE_DIR}/COPYING
         ${CMAKE_CURRENT_SOURCE_DIR}/client.cfg
@@ -126,9 +159,9 @@ set(CPACK_PACKAGE_VENDOR "Atrinik Development Team")
 set(CPACK_PACKAGE_CONTACT "Atrinik Development Team <admin@atrinik.org>")
 set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_CURRENT_SOURCE_DIR}/README")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/COPYING")
-set(CPACK_PACKAGE_VERSION_MAJOR "4")
-set(CPACK_PACKAGE_VERSION_MINOR "0")
-set(CPACK_PACKAGE_VERSION_PATCH "0")
+set(CPACK_PACKAGE_VERSION_MAJOR "${PACKAGE_VERSION_MAJOR}")
+set(CPACK_PACKAGE_VERSION_MINOR "${PACKAGE_VERSION_MINOR}")
+set(CPACK_PACKAGE_VERSION_PATCH "${PACKAGE_VERSION_PATCH}")
 set(CPACK_PACKAGE_INSTALL_DIRECTORY "Atrinik")
 
 if (MINGW)
@@ -136,8 +169,13 @@ if (MINGW)
     set(CPACK_CREATE_DESKTOP_LINKS "atrinik2")
 endif ()
 
+if (MINGW)
+    set(CPACK_PACKAGE_FILE_NAME
+        "atrinik-client-${PACKAGE_VERSION}-windows-x86_64")
+endif ()
+
 set(CPACK_DEBIAN_PACKAGE_NAME "atrinik")
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.5), libgcc1 (>= 1:4.1), libsdl-image1.2 (>= 1.2.5), libsdl1.2debian (>= 1.2.10-1), libcurl3 (>= 7.16), libsdl-mixer1.2 (>= 1), libsdl-ttf2.0-0 (>= 1), timidity (>= 1), zlib1g (>= 1), libx11-6, libxmu6")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6, libgcc-s1, libsdl-image1.2, libsdl1.2debian, libcurl4, libsdl-mixer1.2, libsdl-ttf2.0-0, timidity, zlib1g, libx11-6, libxmu6")
 set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "Fantasy multiplayer online role-playing game with 2.5D graphics\n .\n Homepage: http://www.atrinik.org/")
 set(CPACK_DEBIAN_PACKAGE_SECTION "games")
 
@@ -159,6 +197,8 @@ elseif (${PACKAGE_TYPE} STREQUAL "nsis")
     set(CPACK_BINARY_NSIS "ON")
 elseif (${PACKAGE_TYPE} STREQUAL "rpm")
     set(CPACK_BINARY_RPM "ON")
+elseif (${PACKAGE_TYPE} STREQUAL "zip")
+    set(CPACK_BINARY_ZIP "ON")
 endif (${PACKAGE_TYPE} STREQUAL "deb")
 
 set(CPACK_BINARY_STGZ "OFF")

--- a/client/debian/control
+++ b/client/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.atrinik.org/
 
 Package: atrinik
 Architecture: amd64 i386
-Depends: ${shlibs:Depends}, ${misc:Depends}, libsdl-image1.2 (>= 1), libsdl-mixer1.2 (>= 1), libsdl1.2debian (>= 1), libcurl3 (>= 7), libsdl-ttf2.0-0 (>= 1), timidity (>= 1), zlib1g (>= 1), libxmu6, libx11-6
+Depends: ${shlibs:Depends}, ${misc:Depends}, libsdl-image1.2 (>= 1), libsdl-mixer1.2 (>= 1), libsdl1.2debian (>= 1), libcurl4 (>= 7), libsdl-ttf2.0-0 (>= 1), timidity (>= 1), zlib1g (>= 1), libxmu6, libx11-6
 Description: Atrinik game client.
  .
  Homepage: http://www.atrinik.org/

--- a/common/toolkit/CMakeLists.txt
+++ b/common/toolkit/CMakeLists.txt
@@ -1,8 +1,10 @@
 # The Atrinik toolkit CMakeLists file.
 
+cmake_minimum_required(VERSION 3.10)
 project(atrinik-toolkit C)
-cmake_minimum_required(VERSION 2.6)
 set(ATRINIK_TOOLKIT atrinik-toolkit)
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 # cURL is required by the metaserver.
 find_package(CURL REQUIRED)
@@ -56,9 +58,14 @@ else ()
     message(STATUS "Could not find readline library, simple interactive console will be compiled instead.")
 endif ()
 
+find_package(PkgConfig QUIET)
+if (PKG_CONFIG_FOUND)
+    pkg_check_modules(CHECK_PKG QUIET IMPORTED_TARGET check)
+endif ()
+
 find_library(CHECK_LIBRARY check)
 
-if (CHECK_LIBRARY)
+if (CHECK_PKG_FOUND OR CHECK_LIBRARY)
     set(HAVE_CHECK true)
 else ()
     message(STATUS "Could not find check library, unit tests will not be compiled.")
@@ -87,6 +94,10 @@ if (MINGW)
 endif ()
 
 find_package(Threads REQUIRED)
+
+if (POLICY CMP0075)
+    cmake_policy(SET CMP0075 NEW)
+endif ()
 
 include(CheckIncludeFiles)
 include(CheckFunctionExists)
@@ -147,7 +158,7 @@ endif ()
 try_compile(HAVE_IPV6 ${CMAKE_CURRENT_BINARY_DIR}/compile_tests ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ipv6test.c)
 
 # Generate the CMake configuration header file.
-configure_file(cmake.h.def cmake.h)
+configure_file(cmake.h.def toolkit_cmake.h)
 
 # Generate a header file with the Git version used to compile the library.
 find_program(GIT_SCM git DOC "Git version control")
@@ -207,17 +218,25 @@ set(TOOLKIT_SOURCES
     x11.c
     )
 
-add_library(${ATRINIK_TOOLKIT} ${TOOLKIT_SOURCES})
+add_library(${ATRINIK_TOOLKIT} STATIC ${TOOLKIT_SOURCES})
 
-target_link_libraries(${ATRINIK_TOOLKIT} ${CURL_LIBRARIES})
+if (TARGET CURL::libcurl)
+    target_link_libraries(${ATRINIK_TOOLKIT} CURL::libcurl)
+else ()
+    target_link_libraries(${ATRINIK_TOOLKIT} ${CURL_LIBRARIES})
+endif ()
 target_link_libraries(${ATRINIK_TOOLKIT} ${CMAKE_THREAD_LIBS_INIT})
 
 if (MINGW)
-    target_link_libraries(${ATRINIK_TOOLKIT} wsock32 idn wldap32 ssh2 rtmp winmm
-            ws2_32 imagehlp)
+    target_link_libraries(${ATRINIK_TOOLKIT} wsock32 wldap32 winmm ws2_32
+            imagehlp)
 endif ()
 
-target_link_libraries(${ATRINIK_TOOLKIT} ${ZLIB_LIBRARIES})
+if (TARGET ZLIB::ZLIB)
+    target_link_libraries(${ATRINIK_TOOLKIT} ZLIB::ZLIB)
+else ()
+    target_link_libraries(${ATRINIK_TOOLKIT} ${ZLIB_LIBRARIES})
+endif ()
 
 # Link math...
 if (MATH_LIBRARY)
@@ -235,10 +254,14 @@ if (HAVE_READLINE)
 endif ()
 
 if (HAVE_CHECK)
-    target_link_libraries(${ATRINIK_TOOLKIT} ${CHECK_LIBRARY})
+    if (CHECK_PKG_FOUND)
+        target_link_libraries(${ATRINIK_TOOLKIT} PkgConfig::CHECK_PKG)
+    else ()
+        target_link_libraries(${ATRINIK_TOOLKIT} ${CHECK_LIBRARY})
 
-    if (UNIX AND NOT APPLE)
-        target_link_libraries(${ATRINIK_TOOLKIT} rt)
+        if (UNIX AND NOT APPLE)
+            target_link_libraries(${ATRINIK_TOOLKIT} rt)
+        endif ()
     endif ()
 endif ()
 
@@ -252,6 +275,10 @@ if (HAVE_X11_XMU)
     target_link_libraries(${ATRINIK_TOOLKIT} ${X11_XMU_LIBRARY})
 endif ()
 
-target_link_libraries(${ATRINIK_TOOLKIT} ${OPENSSL_LIBRARIES})
+if (TARGET OpenSSL::SSL AND TARGET OpenSSL::Crypto)
+    target_link_libraries(${ATRINIK_TOOLKIT} OpenSSL::SSL OpenSSL::Crypto)
+else ()
+    target_link_libraries(${ATRINIK_TOOLKIT} ${OPENSSL_LIBRARIES})
+endif ()
 
 add_dependencies(${ATRINIK_TOOLKIT} git_branch)

--- a/common/toolkit/porting.h
+++ b/common/toolkit/porting.h
@@ -51,7 +51,7 @@
 #endif
 #endif
 
-#include "cmake.h"
+#include "toolkit_cmake.h"
 
 #include <math.h>
 #include <float.h>

--- a/common/toolkit/socket_crypto.c
+++ b/common/toolkit/socket_crypto.c
@@ -1405,7 +1405,8 @@ socket_crypto_load_cert (socket_crypto_t *crypto,
         }
 
         LOG(ERROR, "X509_verify_cert() failed: %s",
-            X509_verify_cert_error_string(store_ctx->error));
+            X509_verify_cert_error_string(
+                X509_STORE_CTX_get_error(store_ctx)));
         goto error;
     }
 


### PR DESCRIPTION
## Summary

Modernize the Linux build so Atrinik can be compiled using current CMake, compilers, Python development packages, and Debian/Ubuntu dependencies.

## Changes

- Raise the minimum supported CMake version.
- Add client-only and server-only build options.
- Respect build types supplied by presets or the command line.
- Add Linux debug and release presets.
- Move the root build into an out-of-tree build directory.
- Update generated-header include paths.
- Improve discovery of Check, cURL, OpenSSL, zlib, SDL, and Python.
- Rename the custom `test` target to `check`.
- Update Debian package names and installation documentation.
- Add a Linux development container.
- Ignore generated build and virtual-environment files.

## Testing

- [x] `cmake --preset linux-debug`
- [x] `cmake --build --preset linux-debug`
- [x] `cmake --preset linux-release`
- [x] Build with `BUILD_CLIENT=OFF`.
- [x] Build with `BUILD_SERVER=OFF`.
- [x] Run the `check` target after preparing server runtime data.

## Compatibility

The build retains `-fcommon` for legacy tentative global definitions that are rejected by modern GCC defaults.