### PR TITLE
build(windows): add reproducible MXE cross-build packaging

### DIFF
--- a/.devcontainer/asound.conf
+++ b/.devcontainer/asound.conf
@@ -1,0 +1,9 @@
+# Route ALSA applications through the PulseAudio server exposed by WSLg.
+# PULSE_SERVER is configured in devcontainer.json.
+pcm.!default {
+    type pulse
+}
+
+ctl.!default {
+    type pulse
+}

--- a/.devcontainer/windows-cross/Dockerfile
+++ b/.devcontainer/windows-cross/Dockerfile
@@ -1,0 +1,75 @@
+FROM mcr.microsoft.com/devcontainers/base:bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
+        autopoint \
+        bison \
+        bzip2 \
+        ca-certificates \
+        cmake \
+        flex \
+        g++ \
+        g++-multilib \
+        gettext \
+        git \
+        gperf \
+        intltool \
+        libc6-dev-i386 \
+        libclang-dev \
+        libgdk-pixbuf-2.0-dev \
+        libgl-dev \
+        libltdl-dev \
+        libpcre2-dev \
+        libssl-dev \
+        libtool-bin \
+        libxml-parser-perl \
+        lzip \
+        make \
+        ninja-build \
+        openssl \
+        p7zip-full \
+        patch \
+        perl \
+        python-is-python3 \
+        python3 \
+        python3-mako \
+        python3-packaging \
+        python3-pkg-resources \
+        python3-setuptools \
+        ruby \
+        sqlite3 \
+        unzip \
+        wget \
+        xz-utils \
+        zip \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG MXE_REF=master
+ARG MXE_BUILD_JOBS=2
+RUN git clone https://github.com/mxe/mxe.git /opt/mxe \
+    && git -C /opt/mxe checkout "${MXE_REF}"
+
+COPY .devcontainer/windows-cross/curl-openssl.patch /tmp/curl-openssl.patch
+RUN git -C /opt/mxe apply /tmp/curl-openssl.patch \
+    && chown -R vscode:vscode /opt/mxe
+
+USER vscode
+RUN make -C /opt/mxe --jobs="${MXE_BUILD_JOBS}" JOBS="${MXE_BUILD_JOBS}" \
+        MXE_TARGETS=x86_64-w64-mingw32.shared \
+        openssl
+RUN make -C /opt/mxe --jobs="${MXE_BUILD_JOBS}" JOBS="${MXE_BUILD_JOBS}" \
+        MXE_TARGETS=x86_64-w64-mingw32.shared \
+        cc cmake curl openssl zlib libxml2 sdl sdl_image sdl_mixer sdl_ttf
+RUN test "$(/opt/mxe/usr/x86_64-w64-mingw32.shared/bin/curl-config --ssl-backends)" \
+        = "OpenSSL"
+USER root
+
+ENV MXE_ROOT=/opt/mxe \
+    MXE_TARGET=x86_64-w64-mingw32.shared \
+    MXE_TOOLCHAIN_FILE=/opt/mxe/usr/x86_64-w64-mingw32.shared/share/cmake/mxe-conf.cmake \
+    MXE_RUNTIME_DIR=/opt/mxe/usr/x86_64-w64-mingw32.shared/bin \
+    PATH=/opt/mxe/usr/bin:${PATH}

--- a/.devcontainer/windows-cross/curl-openssl.patch
+++ b/.devcontainer/windows-cross/curl-openssl.patch
@@ -1,0 +1,12 @@
+diff --git a/src/curl.mk b/src/curl.mk
+--- a/src/curl.mk
++++ b/src/curl.mk
+@@ -21,6 +21,7 @@
+ define $(PKG)_BUILD
+     cd '$(BUILD_DIR)' && $(SOURCE_DIR)/configure \
+         $(MXE_CONFIGURE_OPTS) \
+-        --with-schannel \
++        --with-openssl='$(PREFIX)/$(TARGET)' \
++        --without-schannel \
+         --with-libidn2 \
+         --enable-sspi \

--- a/.devcontainer/windows-cross/devcontainer.json
+++ b/.devcontainer/windows-cross/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "Atrinik Windows cross-build (MXE)",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "../..",
+    "args": {
+      "MXE_BUILD_JOBS": "2"
+    }
+  },
+  "workspaceFolder": "/workspaces/atrinik",
+  "remoteUser": "vscode",
+  "postCreateCommand": "git submodule update --init --recursive || true",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cmake-tools",
+        "ms-vscode.cpptools"
+      ],
+      "settings": {
+        "cmake.configurePreset": "windows-mxe-release",
+        "cmake.buildPreset": "windows-mxe-release"
+      }
+    }
+  }
+}

--- a/build-windows.sh
+++ b/build-windows.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${MXE_TOOLCHAIN_FILE:-}" || ! -f "${MXE_TOOLCHAIN_FILE}" ]]; then
+    echo "MXE_TOOLCHAIN_FILE does not point to an MXE toolchain." >&2
+    echo "Run this script in the 'Atrinik Windows cross-build (MXE)' devcontainer." >&2
+    exit 1
+fi
+
+if [[ -z "${MXE_RUNTIME_DIR:-}" || ! -d "${MXE_RUNTIME_DIR}" ]]; then
+    echo "MXE_RUNTIME_DIR does not point to the shared MXE runtime directory." >&2
+    exit 1
+fi
+
+JOBS=${JOBS:-$(nproc)}
+PACKAGE_DIR=${PACKAGE_DIR:-build/packages}
+
+cmake --preset windows-mxe-release
+cmake --build --preset windows-mxe-release --parallel "${JOBS}"
+mkdir -p "${PACKAGE_DIR}"
+cpack --config build/windows-mxe-release/CPackConfig.cmake \
+    -G ZIP \
+    -B "${PACKAGE_DIR}"
+
+echo "Windows package written to ${PACKAGE_DIR}"

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -126,12 +126,39 @@ if (WIN32 AND NOT UNIX)
     set(INSTALL_SUBDIR_SHARE ".")
     set(INSTALL_SUBDIR_DOC ".")
 
-    file(GLOB DLLS "${CMAKE_CURRENT_SOURCE_DIR}/*.dll")
-    set(EXES gunzip.exe tar.exe atrinik.bat ca-bundle.crt timidity.cfg)
-    install(FILES ${DLLS} DESTINATION ${INSTALL_SUBDIR_BIN})
-    install(TARGETS atrinik2 DESTINATION ${INSTALL_SUBDIR_BIN})
-    install(FILES ${EXES} DESTINATION ${INSTALL_SUBDIR_BIN})
-    install(DIRECTORY timidity DESTINATION ${INSTALL_SUBDIR_BIN})
+    set(ATRINIK_WINDOWS_RUNTIME_DIR "" CACHE PATH
+        "Directory containing MinGW runtime DLLs for portable packages")
+    set(ATRINIK_CA_BUNDLE "${CMAKE_CURRENT_SOURCE_DIR}/ca-bundle.crt" CACHE FILEPATH
+        "CA certificate bundle to install with the client")
+
+    install(TARGETS atrinik atrinik2
+        RUNTIME DESTINATION ${INSTALL_SUBDIR_BIN})
+
+    if (ATRINIK_WINDOWS_RUNTIME_DIR)
+        file(GLOB ATRINIK_WINDOWS_RUNTIME_DLLS
+            "${ATRINIK_WINDOWS_RUNTIME_DIR}/*.dll")
+
+        if (ATRINIK_WINDOWS_RUNTIME_DLLS)
+            install(FILES ${ATRINIK_WINDOWS_RUNTIME_DLLS}
+                DESTINATION ${INSTALL_SUBDIR_BIN})
+        else ()
+            message(FATAL_ERROR
+                "No DLLs found in ATRINIK_WINDOWS_RUNTIME_DIR: ${ATRINIK_WINDOWS_RUNTIME_DIR}")
+        endif ()
+    else ()
+        message(WARNING "ATRINIK_WINDOWS_RUNTIME_DIR is empty; portable packages will not include dependency DLLs")
+    endif ()
+
+    install(FILES atrinik.bat DESTINATION ${INSTALL_SUBDIR_BIN})
+    install(FILES "${ATRINIK_CA_BUNDLE}" DESTINATION ${INSTALL_SUBDIR_BIN}
+        RENAME ca-bundle.crt)
+
+    if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/timidity.cfg")
+        install(FILES timidity.cfg DESTINATION ${INSTALL_SUBDIR_BIN})
+    endif ()
+    if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/timidity")
+        install(DIRECTORY timidity DESTINATION ${INSTALL_SUBDIR_BIN})
+    endif ()
 else ()
     set(INSTALL_SUBDIR_BIN "games")
     set(INSTALL_SUBDIR_SHARE "share/games/atrinik")

--- a/client/atrinik.bat
+++ b/client/atrinik.bat
@@ -12,22 +12,20 @@ timeout /NOBREAK 2
 rem Make sure no Atrinik clients are running.
 taskkill /f /t /im atrinik.exe >nul 2>&1
 
-rem Store the current working directory.
-set old_dir=%CD%
+rem Store the directory containing the portable client.
+set "old_dir=%~dp0"
 rem Go to the patches directory.
-cd "%AppData%\.atrinik\temp"
+cd /d "%AppData%\.atrinik\temp"
 
-rem Extract all patches.
+rem Extract all patches using tar included with supported Windows versions.
 for %%f in (*.tar.gz) do (
 	echo Extracting %%f
-	"%old_dir%\gunzip.exe" -c %%f > %%~nf
-	"%old_dir%\tar.exe" xvf %%~nf
-	del /q %%f
-	del /q %%~nf
+	tar -xzf "%%f"
+	del /q "%%f"
 )
 
 rem Go back to the old directory.
-cd "%old_dir%"
+cd /d "%old_dir%"
 rem Copy over the extracted files.
 xcopy /s/e/y "%AppData%"\.atrinik\temp\*.* .\
 rem Remove the temporary directory.

--- a/common/toolkit/logger.c
+++ b/common/toolkit/logger.c
@@ -312,6 +312,7 @@ void logger_print(logger_level level, const char *function, uint64_t line,
     char formatted[HUGE_BUF], timebuf[HUGE_BUF], buf[sizeof(formatted) * 2];
     va_list ap;
     struct timeval tv;
+    time_t timestamp;
     struct tm *tm;
 
     TOOLKIT_PROTECT();
@@ -332,7 +333,8 @@ void logger_print(logger_level level, const char *function, uint64_t line,
     va_end(ap);
 
     gettimeofday(&tv, NULL);
-    tm = localtime(&tv.tv_sec);
+    timestamp = (time_t) tv.tv_sec;
+    tm = localtime(&timestamp);
 
     if (tm != NULL) {
         char timebuf2[MAX_BUF];

--- a/common/toolkit/signals.c
+++ b/common/toolkit/signals.c
@@ -280,33 +280,49 @@ static void signal_handler(int sig, siginfo_t *siginfo, void *context)
 #ifdef WIN32
     fputs("Stack trace:\n", fp);
 
+    DWORD machine_type;
+    DWORD64 program_counter;
+#ifdef _WIN64
+    machine_type = IMAGE_FILE_MACHINE_AMD64;
+    program_counter = ExceptionInfo->ContextRecord->Rip;
+#else
+    machine_type = IMAGE_FILE_MACHINE_I386;
+    program_counter = ExceptionInfo->ContextRecord->Eip;
+#endif
+
     if (EXCEPTION_STACK_OVERFLOW !=
             ExceptionInfo->ExceptionRecord->ExceptionCode) {
-        STACKFRAME frame;
+        STACKFRAME64 frame;
         int i;
 
         SymInitialize(GetCurrentProcess(), 0, 1);
 
         memset(&frame, 0, sizeof(frame));
-        frame.AddrPC.Offset = ExceptionInfo->ContextRecord->Eip;
+        frame.AddrPC.Offset = program_counter;
         frame.AddrPC.Mode = AddrModeFlat;
+#ifdef _WIN64
+        frame.AddrStack.Offset = ExceptionInfo->ContextRecord->Rsp;
+        frame.AddrFrame.Offset = ExceptionInfo->ContextRecord->Rbp;
+#else
         frame.AddrStack.Offset = ExceptionInfo->ContextRecord->Esp;
-        frame.AddrStack.Mode = AddrModeFlat;
         frame.AddrFrame.Offset = ExceptionInfo->ContextRecord->Ebp;
+#endif
+        frame.AddrStack.Mode = AddrModeFlat;
         frame.AddrFrame.Mode = AddrModeFlat;
 
         i = 0;
 
-        while (StackWalk(IMAGE_FILE_MACHINE_I386, GetCurrentProcess(),
+        while (StackWalk64(machine_type, GetCurrentProcess(),
                 GetCurrentThread(), &frame, ExceptionInfo->ContextRecord, 0,
-                SymFunctionTableAccess, SymGetModuleBase, 0)) {
-            fprintf(fp, "%d: %p\n", i, (void *) frame.AddrPC.Offset);
+                SymFunctionTableAccess64, SymGetModuleBase64, 0)) {
+            fprintf(fp, "%d: %p\n", i,
+                    (void *) (uintptr_t) frame.AddrPC.Offset);
             i++;
         }
 
         SymCleanup(GetCurrentProcess());
     } else {
-        fprintf(fp, "%p\n", (void *) ExceptionInfo->ContextRecord->Eip);
+        fprintf(fp, "%p\n", (void *) (uintptr_t) program_counter);
     }
 #else
     {

--- a/common/toolkit/socket.c
+++ b/common/toolkit/socket.c
@@ -944,7 +944,8 @@ bool socket_host2addr(const char *host, struct sockaddr_storage *addr)
 
 #ifdef WIN32
 /** @cond */
-static const char *inet_ntop(int af, const void *src, char *dst, size_t size)
+static const char *socket_inet_ntop(int af, const void *src, char *dst,
+        size_t size)
 {
 #ifdef HAVE_IPV6
     struct sockaddr_storage ss;
@@ -985,7 +986,9 @@ static const char *inet_ntop(int af, const void *src, char *dst, size_t size)
     return NULL;
 }
 /** @endcond */
-#endif
+#else
+#define socket_inet_ntop inet_ntop
+#endif /* WIN32 */
 
 /**
  * Convert a binary representation of an IP (either IPv4 or IPv6) address into
@@ -1009,13 +1012,13 @@ const char *socket_addr2host(const struct sockaddr_storage *addr, char *buf,
 #ifdef HAVE_IPV6
     if (saddr->sin_family == AF_INET6) {
         const struct sockaddr_in6 *saddr6 = (const struct sockaddr_in6 *) addr;
-        return inet_ntop(saddr6->sin6_family, &saddr6->sin6_addr, buf,
+        return socket_inet_ntop(saddr6->sin6_family, &saddr6->sin6_addr, buf,
                 bufsize);
     }
-    return inet_ntop(saddr->sin_family, &saddr->sin_addr, buf, bufsize);
+    return socket_inet_ntop(saddr->sin_family, &saddr->sin_addr, buf, bufsize);
 #else
 #ifdef WIN32
-    return inet_ntop(saddr->sin_family, &saddr->sin_addr, buf, bufsize);
+    return socket_inet_ntop(saddr->sin_family, &saddr->sin_addr, buf, bufsize);
 #else
     return inet_ntoa_r(saddr->sin_addr, buf, bufsize);
 #endif

--- a/compose.windows.yaml
+++ b/compose.windows.yaml
@@ -1,0 +1,16 @@
+services:
+  windows-build:
+    image: atrinik-windows-mxe
+    build:
+      context: .
+      dockerfile: .devcontainer/windows-cross/Dockerfile
+      args:
+        MXE_BUILD_JOBS: ${MXE_BUILD_JOBS:-2}
+    working_dir: /workspaces/atrinik
+    user: "${LOCAL_UID:-1000}:${LOCAL_GID:-1000}"
+    environment:
+      HOME: /tmp
+    volumes:
+      - .:/workspaces/atrinik
+    command:
+      - ./build-windows.sh


### PR DESCRIPTION
## Summary

Add a reproducible Linux-hosted workflow for producing a portable 64-bit Windows client with MXE.

## Changes

- Add an isolated Windows cross-build development container.
- Add an MXE CMake preset and packaging script.
- Add a Docker Compose entry point for command-line builds.
- Package runtime DLLs and CA certificates into a portable ZIP.
- Update the Windows updater to use the operating system's `tar`.
- Add 64-bit Windows stack-trace support.
- Resolve Windows socket and timestamp portability issues.
- Document the supported cross-build workflow.

## Testing

- [x] Build the Windows cross-build container.
- [x] Run `./build-windows.sh` inside the container.
- [x] Confirm the portable ZIP is created under `build/packages/`.
- [x] Start the packaged client on Windows 10 or newer.
- [x] Verify the updater can extract a test patch.
- [x] Verify required DLLs and CA certificates are included.

## Notes

The initial MXE image build is expected to take some time, but Docker should cache the toolchain layer for later builds.