### PR TITLE
fix(toolkit): safely manage background thread lifecycles

### DIFF
--- a/common/toolkit/console.c
+++ b/common/toolkit/console.c
@@ -72,6 +72,9 @@ static pthread_mutex_t command_process_queue_mutex;
  */
 static pthread_t thread_id;
 
+/** Whether the console thread was successfully started. */
+static bool thread_started;
+
 #ifdef HAVE_READLINE
 /**
  * Prompt for readline.
@@ -109,7 +112,11 @@ TOOLKIT_DEINIT_FUNC(console)
 {
     size_t i;
 
-    pthread_cancel(thread_id);
+    if (thread_started) {
+        pthread_cancel(thread_id);
+        pthread_join(thread_id, NULL);
+        thread_started = false;
+    }
 
     for (i = 0; i < console_commands_num; i++) {
         efree(console_commands[i].command);
@@ -385,6 +392,7 @@ console_start_thread (void)
         return 0;
     }
 
+    thread_started = true;
     return 1;
 }
 

--- a/common/toolkit/curl.c
+++ b/common/toolkit/curl.c
@@ -161,6 +161,11 @@ struct curl_request {
     bool finished:1;
 
     /**
+     * Whether the request was started in its own thread.
+     */
+    bool threaded:1;
+
+    /**
      * Whether the peer certificate is untrusted.
      */
     bool untrusted:1;
@@ -987,8 +992,9 @@ curl_request_free (curl_request_t *request)
         pthread_mutex_unlock(&request->mutex);
     }
 
-    pthread_join(request->thread_id, NULL);
-    pthread_detach(request->thread_id);
+    if (request->threaded) {
+        pthread_join(request->thread_id, NULL);
+    }
 
     if (request->body != NULL) {
         efree(request->body);
@@ -1539,6 +1545,8 @@ curl_request_start_get (curl_request_t *request)
         /* coverity[missing_lock] */
         LOG(ERROR, "Failed to create thread: %s (%d)", strerror(rc), rc);
         request->state = CURL_STATE_ERROR;
+    } else {
+        request->threaded = true;
     }
 }
 


### PR DESCRIPTION
## Summary

Prevent invalid thread joins and ensure toolkit background threads are shut down cleanly.

## Changes

- Track whether the console thread was successfully started.
- Cancel and join the console thread during shutdown.
- Track whether a cURL request started a worker thread.
- Join cURL worker threads only when they exist.
- Remove the invalid detach-after-join sequence.

## Testing

- [x] Start and stop the client with the interactive console enabled.
- [x] Start and stop the server with the interactive console enabled.
- [x] Exercise successful and failed asynchronous cURL requests.
- [x] Verify shutdown completes without hangs or thread-related errors.

## Risk

This changes shutdown and request-cleanup behavior. Testing should cover startup failures as well as normal operation.