### PR TITLE
fix(server): modernize the bundled HTTP helper

### DIFF
--- a/server/src/http_server/http_server.c
+++ b/server/src/http_server/http_server.c
@@ -85,7 +85,7 @@ http_curl_cb (curl_request_t *request, void *user_data)
 TOOLKIT_INIT_FUNC(http_server)
 {
     if (settings.http_server) {
-        process_t *process = process_create("python");
+        process_t *process = process_create("python3");
         process_add_arg(process, "tools/http_server.py");
         process_set_data_out_cb(process, http_data_cb);
         process_set_data_err_cb(process, http_data_cb);
@@ -112,7 +112,7 @@ TOOLKIT_INIT_FUNC(http_server)
     current_request = curl_request_create(settings.http_url,
                                           CURL_PKEY_TRUST_APPLICATION);
     curl_request_set_cb(current_request, http_curl_cb, NULL);
-    curl_request_set_delay(current_request, 100000);
+    curl_request_set_delay(current_request, 1000000);
     curl_request_start_get(current_request);
     pthread_mutex_unlock(&request_lock);
 }

--- a/server/tools/http_server.py
+++ b/server/tools/http_server.py
@@ -31,7 +31,11 @@ else:
 
 os.chdir(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-config.readfp(open("server.cfg"))
+with open("server.cfg") as fp:
+    if hasattr(config, "read_file"):
+        config.read_file(fp)
+    else:
+        config.readfp(fp)
 config.read(["server-custom.cfg"])
 
 path_translations = {
@@ -182,7 +186,9 @@ class ForkingHTTPServer(SocketServerMixIn, HTTPServer):
         HTTPServer.finish_request(self, request, client_address)
 
 if __name__ == '__main__':
-    with LockFile(__file__) as _:
+    lock_path = os.path.join(config.get("general", "datapath"),
+                             ".http_server.py")
+    with LockFile(lock_path) as _:
         o = urlparse(config.get("general", "http_url"))
         server = ForkingHTTPServer(("", o.port), HTTPRequestHandler)
         server.serve_forever()


### PR DESCRIPTION
## Summary

Update the server's bundled HTTP helper for Python 3 and improve its runtime behavior.

## Changes

- Start the helper using `python3`.
- Use the modern `ConfigParser.read_file` API when available.
- Retain compatibility with older Python versions.
- Store the HTTP helper lock in the configured data directory.
- Reduce excessive HTTP polling frequency.

## Testing

- [x] Start the server with `http_server=on`.
- [x] Verify the helper serves files from the configured HTTP path.
- [x] Verify a second helper process is rejected by the lock.
- [x] Verify separate server data directories can run independently.
- [x] Confirm the server shuts down cleanly.

## Notes

Moving the lock into the data directory avoids treating the source checkout as mutable runtime state.