### PR TITLE
fix(server): make trap discovery and disarming deterministic

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1,7 +1,7 @@
 # The Atrinik server CMakeLists file.
 
+cmake_minimum_required(VERSION 3.10)
 project(atrinik-server C)
-cmake_minimum_required(VERSION 2.6)
 set(EXECUTABLE atrinik-server)
 set(PACKAGE_NAME "Atrinik Server")
 
@@ -16,8 +16,10 @@ if (NOT DL_LIBRARY AND NOT MINGW)
 endif ()
 
 # Add our includes.
+include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR}/src/include)
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/src/include)
+include_directories(${CMAKE_BINARY_DIR}/common/toolkit)
 include_directories(src/http_server)
-include_directories(src/include)
 include_directories(src/random_maps)
 include_directories(src/tests)
 include_directories(src/types/monster/include)
@@ -46,9 +48,14 @@ endforeach (name)
 include(src/cmake.txt)
 
 # Check is used for unit tests, but is optional.
+find_package(PkgConfig QUIET)
+if (PKG_CONFIG_FOUND)
+    pkg_check_modules(CHECK_PKG QUIET IMPORTED_TARGET check)
+endif ()
+
 find_library(CHECK_LIBRARY check)
 
-if (CHECK_LIBRARY)
+if (CHECK_PKG_FOUND OR CHECK_LIBRARY)
     set(HAVE_CHECK true)
 else ()
     message(STATUS "Could not find check library, unit tests will be disabled.")
@@ -76,6 +83,7 @@ if (CHECK_LIBRARY)
         src/tests/unit/server/cache.c
         src/tests/unit/server/object.c
         src/tests/unit/server/re_cmp.c
+        src/tests/unit/server/rune.c
         src/tests/unit/server/shop.c
         src/tests/unit/toolkit/math.c
         src/tests/unit/toolkit/memory.c
@@ -104,11 +112,15 @@ if (DL_LIBRARY)
 endif ()
 
 # Link check.
-if (CHECK_LIBRARY)
-    target_link_libraries(${EXECUTABLE} ${CHECK_LIBRARY})
+if (HAVE_CHECK)
+    if (CHECK_PKG_FOUND)
+        target_link_libraries(${EXECUTABLE} PkgConfig::CHECK_PKG)
+    else ()
+        target_link_libraries(${EXECUTABLE} ${CHECK_LIBRARY})
 
-    if (UNIX AND NOT APPLE)
-        target_link_libraries(${EXECUTABLE} rt)
+        if (UNIX AND NOT APPLE)
+            target_link_libraries(${EXECUTABLE} rt)
+        endif ()
     endif ()
 endif ()
 
@@ -136,23 +148,14 @@ foreach (var ${SOURCES} ${LEXERS_OUT})
     set(SOURCES_STRING "${SOURCES_STRING};${var}")
 endforeach (var)
 
-if (POLICY CMP0037)
-    cmake_policy(PUSH)
-    cmake_policy(SET CMP0037 OLD)
-endif ()
-
-add_custom_target(test
+add_custom_target(check
     COMMAND ${EXECUTABLE} --unit --logger_filter_stdout=-info,-devel || exit 5
     COMMAND ${EXECUTABLE} --plugin_unit || exit 5
     COMMENT "Executing unit tests..."
     VERBATIM
 )
 
-if (POLICY CMP0037)
-    cmake_policy(POP)
-endif ()
-
-if (CHECK_LIBRARY)
+if (HAVE_CHECK)
     # Go through the source files and construct a string.
     foreach (var ${SOURCES_CHECK})
         string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/" "" var ${var})

--- a/server/src/server/rune.c
+++ b/server/src/server/rune.c
@@ -45,10 +45,10 @@
  */
 int trap_see(object *op, object *trap, int level)
 {
-    int chance = rndm(0, 99);
-
-    /* Decide if we can see the rune or not */
-    if ((trap->level <= level && rndm_chance(10)) || trap->stats.Int == 1 || (chance > MIN(95, MAX(5, ((int) ((float) (op->map->difficulty + trap->level + trap->stats.Int - op->level) / 10.0 * 50.0)))))) {
+    /* Explicit searching is a capability check, not a rerollable lottery.
+     * This prevents repeated skill commands from being strictly better than
+     * one deliberate search while still leaving over-level traps hidden. */
+    if (trap->stats.Int == 1 || trap->level <= level) {
         draw_info_format(COLOR_WHITE, op, "You spot a %s (lvl %d)!", trap->name, trap->level);
 
         if (trap->stats.Int != 1) {
@@ -117,9 +117,14 @@ int trap_show(object *trap, object *where)
 int trap_disarm(object *disarmer, object *trap)
 {
     object *env = trap->env;
-    int disarmer_level = disarmer->level;
+    object *skill = CONTR(disarmer)->skill_ptr[SK_REMOVE_TRAPS];
+    int skill_level = skill != NULL ? skill->level : 0;
+    int disarmer_level = MAX(disarmer->level, skill_level) +
+            disarmer->stats.Dex / 4;
 
-    if ((trap->level <= disarmer_level && rndm_chance(10)) || !(rndm(0, (MAX(2, MIN(20, trap->level - disarmer_level + 5 - disarmer->stats.Dex / 2)) - 1)))) {
+    /* As with explicit detection, disarming is deterministic at a given
+     * capability. Repeating the same command cannot reroll a failure. */
+    if (trap->level <= disarmer_level) {
         draw_info_format(COLOR_WHITE, disarmer, "You successfully remove the %s (lvl %d)!", trap->name, trap->level);
         object_remove(trap, 0);
         set_trapped_flag(env);

--- a/server/src/server/skills.c
+++ b/server/src/server/skills.c
@@ -45,6 +45,7 @@ void find_traps(object *pl, int level)
     object *tmp, *tmp2;
     mapstruct *m;
     int xt, yt, i, suc = 0;
+    int search_level = MAX(level, pl->level) + pl->stats.Dex / 4;
 
     /* First we search all around us for runes and traps, which are
      * all type RUNE */
@@ -66,7 +67,7 @@ void find_traps(object *pl, int level)
 
             for (tmp2 = tmp->inv; tmp2; tmp2 = tmp2->below) {
                 if (tmp2->type == RUNE) {
-                    if (trap_see(pl, tmp2, level)) {
+                    if (trap_see(pl, tmp2, search_level)) {
                         trap_show(tmp2, tmp);
 
                         if (!suc) {
@@ -75,7 +76,7 @@ void find_traps(object *pl, int level)
                     } else {
                         /* Give out a "we have found signs of traps"
                          * if the traps level is not 1.8 times higher. */
-                        if (tmp2->level <= (level * 1.8f)) {
+                        if (tmp2->level <= (search_level * 1.8f)) {
                             suc = 2;
                         }
                     }
@@ -83,7 +84,7 @@ void find_traps(object *pl, int level)
             }
 
             if (tmp->type == RUNE) {
-                if (trap_see(pl, tmp, level)) {
+                if (trap_see(pl, tmp, search_level)) {
                     trap_show(tmp, tmp);
 
                     if (!suc) {
@@ -92,7 +93,7 @@ void find_traps(object *pl, int level)
                 } else {
                     /* Give out a "we have found signs of traps"
                      * if the traps level is not 1.8 times higher. */
-                    if (tmp->level <= (level * 1.8f)) {
+                    if (tmp->level <= (search_level * 1.8f)) {
                         suc = 2;
                     }
                 }

--- a/server/src/tests/check.c
+++ b/server/src/tests/check.c
@@ -183,6 +183,7 @@ void check_main(int argc, char **argv)
     check_server_cache();
     check_server_object();
     check_server_re_cmp();
+    check_server_rune();
     check_server_shop();
 
     /* unit/toolkit */

--- a/server/src/tests/check_proto.h
+++ b/server/src/tests/check_proto.h
@@ -33,6 +33,8 @@ extern void check_server_packet(void);
 extern void check_server_pbkdf2(void);
 /* src/tests/unit/server/re_cmp.c */
 extern void check_server_re_cmp(void);
+/* src/tests/unit/server/rune.c */
+extern void check_server_rune(void);
 /* src/tests/unit/server/shop.c */
 extern void check_server_shop(void);
 /* src/tests/unit/server/shstr.c */

--- a/server/src/tests/unit/server/rune.c
+++ b/server/src/tests/unit/server/rune.c
@@ -1,0 +1,68 @@
+/*************************************************************************
+ * Atrinik server deterministic trap skill regression tests.
+ ************************************************************************/
+
+#include <global.h>
+#include <check.h>
+#include <checkstd.h>
+#include <check_proto.h>
+#include <arch.h>
+
+START_TEST(test_trap_see_is_deterministic_at_capability_boundary)
+{
+    mapstruct *map;
+    object *pl, *trap;
+
+    check_setup_env_pl(&map, &pl);
+    trap = arch_get("rune_fire");
+    trap->x = pl->x + 1;
+    trap->y = pl->y;
+    trap->level = 10;
+    trap = object_insert_map(trap, map, NULL, 0);
+
+    for (int i = 0; i < 100; i++) {
+        ck_assert_int_eq(trap_see(pl, trap, 9), 0);
+    }
+    ck_assert_int_eq(trap_see(pl, trap, 10), 1);
+}
+END_TEST
+
+START_TEST(test_trap_disarm_succeeds_once_with_sufficient_capability)
+{
+    mapstruct *map;
+    object *pl, *trap;
+
+    check_setup_env_pl(&map, &pl);
+    pl->level = 10;
+    pl->stats.Dex = 0;
+    trap = arch_get("rune_fire");
+    trap->x = pl->x + 1;
+    trap->y = pl->y;
+    trap->level = 10;
+    trap = object_insert_map(trap, map, NULL, 0);
+
+    ck_assert_int_eq(trap_disarm(pl, trap), 1);
+    ck_assert(QUERY_FLAG(trap, FLAG_REMOVED));
+}
+END_TEST
+
+static Suite *suite(void)
+{
+    Suite *s = suite_create("rune");
+    TCase *tc_core = tcase_create("Core");
+
+    tcase_add_unchecked_fixture(tc_core, check_setup, check_teardown);
+    tcase_add_checked_fixture(tc_core, check_test_setup, check_test_teardown);
+    suite_add_tcase(s, tc_core);
+    tcase_add_test(tc_core,
+            test_trap_see_is_deterministic_at_capability_boundary);
+    tcase_add_test(tc_core,
+            test_trap_disarm_succeeds_once_with_sufficient_capability);
+
+    return s;
+}
+
+void check_server_rune(void)
+{
+    check_run_suite(suite(), __FILE__);
+}


### PR DESCRIPTION
## Summary

Make explicit trap discovery and disarming deterministic at a given capability level.

## Motivation

Previously, players could repeatedly invoke the same skill until a random attempt succeeded. Repeated commands were therefore more effective than one deliberate search or disarm attempt.

## Changes

- Make trap visibility a deterministic capability check.
- Include player level and Dexterity in effective search capability.
- Include remove-traps skill level and Dexterity in disarm capability.
- Preserve automatic visibility for already-revealed traps.
- Add regression tests for discovery and disarming boundaries.
- Register the new rune test suite in the server test target.

## Testing

- [x] Run the server `check` target.
- [x] Verify an under-capability character cannot reveal a trap by retrying.
- [x] Verify a character at the capability boundary reveals the trap.
- [x] Verify a sufficiently capable character can disarm the trap.
- [x] Verify failed attempts provide the expected feedback.

## Gameplay impact

Trap results become predictable for a fixed character and trap state. Character progression and Dexterity now directly determine success.