### PR TITLE
fix(server): allow CLEAR to interrupt queued movement

### DIFF
--- a/server/src/socket/request.c
+++ b/server/src/socket/request.c
@@ -1966,7 +1966,16 @@ void socket_command_quest_list(socket_struct *ns, player *pl, uint8_t *data, siz
 
 void socket_command_clear(socket_struct *ns, player *pl, uint8_t *data, size_t len, size_t pos)
 {
+    /* The graphical client sends CLEAR for its Stay action. Besides dropping
+     * commands which have not been dispatched yet, cancel movement already
+     * expanded into the player's persistent server-side path queue and stop
+     * directional run mode. This lets combat or other urgent input reliably
+    * interrupt click-to-move. */
     ns->packet_recv_cmd->len = 0;
+    if (pl != NULL) {
+        player_path_clear(pl);
+        pl->run_on = 0;
+    }
 }
 
 void socket_command_move_path(socket_struct *ns, player *pl, uint8_t *data, size_t len, size_t pos)


### PR DESCRIPTION
## Summary

Ensure the client's Stay/CLEAR action fully interrupts server-side movement.

## Changes

- Clear commands that have not yet been dispatched.
- Clear the player's persistent path queue.
- Disable directional run mode.

## Motivation

Click-to-move paths are expanded into a server-side queue. Clearing only the current packet did not stop movement already stored in that queue, which made combat and urgent input feel unresponsive.

## Testing

- [x] Begin a multi-tile click-to-move path.
- [x] Trigger Stay/CLEAR while moving.
- [x] Verify movement stops immediately.
- [x] Verify directional run mode is cancelled.
- [x] Verify normal movement can resume afterward.