### PR TITLE
feat(server): add standalone region-map generation

### DIFF
--- a/generate-region-maps.sh
+++ b/generate-region-maps.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+BUILD_DIR=${BUILD_DIR:-${ROOT_DIR}/build/server-debug}
+JOBS=${JOBS:-$(nproc)}
+
+if [[ "${BUILD_DIR}" != /* ]]; then
+    BUILD_DIR="${ROOT_DIR}/${BUILD_DIR}"
+fi
+
+cmake -S "${ROOT_DIR}" -B "${BUILD_DIR}" \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DPACKAGE_TYPE=none \
+    -DBUILD_CLIENT=OFF \
+    -DBUILD_SERVER=ON
+cmake --build "${BUILD_DIR}" --target atrinik-server --parallel "${JOBS}"
+
+mkdir -p "${ROOT_DIR}/server/lib"
+python3 "${ROOT_DIR}/tools/collect.py" \
+    --dir "${ROOT_DIR}" \
+    --out "${ROOT_DIR}/server/lib"
+
+if [[ ! -d "${ROOT_DIR}/server/data" ]]; then
+    cp -R "${ROOT_DIR}/server/install_data" "${ROOT_DIR}/server/data"
+fi
+mkdir -p "${ROOT_DIR}/server/data/tmp"
+
+(
+    cd "${ROOT_DIR}/server"
+    "${BUILD_DIR}/server/atrinik-server" --worldmaker
+)
+
+map_count=$(find "${ROOT_DIR}/server/data/http/client-maps" \
+    -maxdepth 1 -type f -name '*.png' | wc -l)
+echo "Generated ${map_count} region maps in server/data/http/client-maps."

--- a/server/README
+++ b/server/README
@@ -74,6 +74,14 @@
  to use the --worldmaker switch, eg, run this prior to starting up your server:
   $ ./server.sh --worldmaker
 
+ From a repository build, the root-level helper performs the complete build,
+ resource collection, runtime setup, and generation sequence:
+  $ ./generate-region-maps.sh
+
+ The generator does not open the game or HTTP listening sockets, so it can be
+ run while another server instance is using the configured ports. Generated
+ PNG and definition files are written to server/data/http/client-maps/.
+
  The region maps are not mandatory to play the game, however, some features may
  not work (specifically, the client will only be able to work with dynamic area
  maps and not the full region maps).

--- a/server/src/server/init.c
+++ b/server/src/server/init.c
@@ -1084,11 +1084,16 @@ static void init_library(int argc, char *argv[])
     curl_set_data_dir(settings.datapath);
     socket_crypto_set_path(settings.datapath);
 
-    /* Import game APIs that need settings */
+    /* Import game APIs that need settings. The world maker only reads game
+     * data and writes files; starting listeners here makes generation fail if
+     * another server instance is already using the configured ports. */
     toolkit_import(ban);
     toolkit_import(faction);
-    toolkit_import(socket_server);
-    toolkit_import(http_server);
+
+    if (!settings.world_maker) {
+        toolkit_import(socket_server);
+        toolkit_import(http_server);
+    }
 
     map_init();
     init_globals();


### PR DESCRIPTION
## Summary

Add a root-level workflow for building the server and generating client region maps.

## Changes

- Add `generate-region-maps.sh`.
- Build the required server target automatically.
- Collect server runtime resources.
- Initialize runtime data when necessary.
- Run the server in world-maker mode.
- Prevent world-maker mode from opening game or HTTP listeners.
- Document the generation workflow and output location.

## Testing

- [x] Run `./generate-region-maps.sh` from a clean build.
- [x] Confirm PNG and definition files appear under `server/data/http/client-maps/`.
- [x] Run generation while another server owns the configured ports.
- [x] Verify the running server is unaffected.
- [x] Verify generated maps are usable by the client.

## Notes

World-maker mode only reads game resources and writes generated files, so it should not require network listeners.