### PR TITLE
feat(server): add containerized server deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+build
+server/data
+server-data
+server/lib
+server/libplugin_*.so
+server-custom.cfg
+server/server-custom.cfg
+*.log

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,0 +1,94 @@
+FROM ubuntu:26.04 AS build
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        check \
+        cmake \
+        flex \
+        libcurl4-openssl-dev \
+        libgd-dev \
+        libreadline-dev \
+        libsubunit-dev \
+        libssl-dev \
+        pkgconf \
+        python3-dev \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . .
+
+RUN cmake -S . -B build/server-release \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DPACKAGE_TYPE=none \
+        -DBUILD_CLIENT=OFF \
+        -DBUILD_SERVER=ON \
+    && cmake --build build/server-release \
+        --target atrinik-server plugin_arena \
+        --parallel
+
+RUN mkdir -p server/lib \
+    && python3 tools/collect.py --dir /src --out /src/server/lib \
+    && cp build/server-release/server/libplugin_arena.so server/ \
+    && cp build/server-release/server/libplugin_python.so server/ \
+    && cp -R server/install_data /tmp/atrinik-data \
+    && mkdir -p /tmp/atrinik-data/tmp /tmp/atrinik-data/http \
+    && cd server \
+    && ../build/server-release/server/atrinik-server \
+        --worldmaker \
+        --datapath=/tmp/atrinik-data \
+        --httppath=/tmp/atrinik-data/http \
+        --http_server=off \
+    && mkdir -p install_data/http \
+    && cp -R /tmp/atrinik-data/http/client-maps install_data/http/
+
+FROM ubuntu:26.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    ATRINIK_HTTP_URL=http://localhost:8080
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libcrypt1 \
+        libcurl4t64 \
+        libgd3 \
+        libpython3.14 \
+        libreadline8t64 \
+        libssl3t64 \
+        libsubunit0 \
+        python3 \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --uid 10001 atrinik
+
+WORKDIR /opt/atrinik
+
+COPY --from=build /src/maps ./maps
+RUN rm ./maps/python/events/init/documentation.py
+COPY --from=build /src/server/atrinikloop.sh ./server/atrinikloop.sh
+COPY --from=build /src/server/ca-bundle.crt ./server/ca-bundle.crt
+COPY --from=build /src/server/install_data ./server/install_data
+COPY --from=build /src/server/lib ./server/lib
+COPY --from=build /src/server/permissions.cfg ./server/permissions.cfg
+COPY --from=build /src/server/resources ./server/resources
+COPY --from=build /src/server/server.cfg ./server/server.cfg
+COPY --from=build /src/server/tools ./server/tools
+COPY --from=build /src/build/server-release/server/atrinik-server ./server/atrinik-server
+COPY --from=build /src/build/server-release/server/libplugin_arena.so ./server/libplugin_arena.so
+COPY --from=build /src/build/server-release/server/libplugin_python.so ./server/libplugin_python.so
+COPY docker/server-entrypoint.sh /usr/local/bin/atrinik-server-entrypoint
+
+RUN mkdir -p server/data \
+    && chown -R atrinik:atrinik /opt/atrinik
+
+USER atrinik
+WORKDIR /opt/atrinik/server
+
+EXPOSE 1728 1729 8080
+
+ENTRYPOINT ["atrinik-server-entrypoint"]

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -1,0 +1,25 @@
+services:
+  server:
+    image: atrinik-server
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+    environment:
+      ATRINIK_HTTP_URL: ${ATRINIK_HTTP_URL:-http://localhost:8080}
+      HOME: /tmp
+    user: "${LOCAL_UID:-1000}:${LOCAL_GID:-1000}"
+    ports:
+      - "${ATRINIK_PORT:-1728}:1728"
+      - "${ATRINIK_CRYPTO_PORT:-1729}:1729"
+      - "${ATRINIK_HTTP_PORT:-8080}:8080"
+    volumes:
+      - ./server-data:/opt/atrinik/server/data
+      - ./server-custom.cfg:/opt/atrinik/server/server-custom.cfg:ro
+    restart: unless-stopped
+    stop_grace_period: 30s
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/', timeout=2)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s

--- a/docker/server-entrypoint.sh
+++ b/docker/server-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -eu
+
+# Initialize a new host data folder from the image defaults.
+if [ ! -e data/.atrinik-initialized ]; then
+    cp -R install_data/. data/
+    touch data/.atrinik-initialized
+fi
+
+# Refresh image-owned HTTP assets (including region maps) while preserving
+# player saves and other mutable server data in the mounted folder.
+mkdir -p data/http data/tmp
+cp -R install_data/http/. data/http/
+
+exec ./atrinik-server \
+    --network_stack=ipv4 \
+    --no_console \
+    --http_url="${ATRINIK_HTTP_URL:-http://localhost:8080}" \
+    "$@"

--- a/server/README
+++ b/server/README
@@ -128,6 +128,36 @@
   - http://localhost:8080/resources            -> server/resources/
 
 =================================================
+= 2.3. Running with Docker Compose               =
+=================================================
+
+ A standalone Linux server image can be built and run without VS Code. From
+ the repository root:
+  $ cp server-custom.cfg.example server-custom.cfg
+  $ mkdir -p server-data
+  $ LOCAL_UID=$(id -u) LOCAL_GID=$(id -g) \
+      docker compose -f compose.server.yaml up --build -d
+
+ The game server is exposed on TCP ports 1728 (normal) and 1729 (optional
+ crypto), and its bundled HTTP server on port 8080. Player data and other
+ mutable state are kept directly in the host's server-data/ folder. Region maps
+ are generated while building the image and refreshed into that folder when
+ the container starts. On Linux, LOCAL_UID and LOCAL_GID keep those files owned
+ by the user running Docker.
+
+ To follow logs or stop the service:
+  $ docker compose -f compose.server.yaml logs -f
+  $ docker compose -f compose.server.yaml down
+
+ The server-data/ folder is preserved by 'down' and can be backed up with
+ ordinary filesystem tools.
+
+ For a public server, set ATRINIK_HTTP_URL to the externally reachable HTTP
+ URL and review section 3 below. For example:
+  $ ATRINIK_HTTP_URL=http://atrinik.example.com:8080 \
+      docker compose -f compose.server.yaml up -d
+
+=================================================
 = 3. Running a public server                    =
 =================================================
 


### PR DESCRIPTION
## Summary

Add a standalone Docker Compose deployment for running a persistent Atrinik server independently of the development environment.

## Changes

- Add a multi-stage server image.
- Build the server and Python plugin in the image.
- Collect runtime resources and generate region maps.
- Add an entrypoint that initializes persistent data.
- Refresh image-owned HTTP assets without overwriting player state.
- Add a Compose service with ports, health checks, and restart policy.
- Support host UID/GID mapping on Linux.
- Add an example production-oriented server override file.
- Document startup, logs, shutdown, persistence, and public HTTP configuration.

## Testing

- [x] Copy `server-custom.cfg.example` to `server-custom.cfg`.
- [x] Start the service with `docker compose -f compose.server.yaml up --build`.
- [x] Confirm ports 1728 and 8080 are reachable.
- [x] Confirm the health check becomes healthy.
- [x] Create test player data and restart the container.
- [x] Verify mutable data survives `docker compose down`.
- [x] Verify generated region maps are served over HTTP.

## Security

The example configuration does not grant development permissions by default. Public operators must review permissions, exposed ports, and `ATRINIK_HTTP_URL` before deployment.