### PR TITLE
feat(client): add gameplay telemetry and combat feedback

### DIFF
--- a/client/data/interface.cfg
+++ b/client/data/interface.cfg
@@ -31,6 +31,15 @@ y = 28
 w = 70
 h = 22
 
+[game_time]
+moveable = yes
+shown = yes
+texture_type = 1
+x = 872
+y = 28
+w = 140
+h = 22
+
 [input]
 moveable = yes
 shown = no
@@ -135,6 +144,15 @@ x = 0
 y = 290
 w = 300
 h = 145
+
+[xp_tracker]
+moveable = yes
+shown = yes
+texture_type = 1
+x = 812
+y = 50
+w = 200
+h = 22
 
 [notification]
 moveable = no

--- a/client/data/settings.txt
+++ b/client/data/settings.txt
@@ -151,14 +151,14 @@ category Client
 end
 
 category Map
-	setting Player names
+	setting Living names
 		type select
 		option No names
 		option All names
-		option Only other
-		option Only yours
+		option Others only
+		option Yours only
 		default 1
-		desc Show names of players above their heads.
+		desc Show names of players and creatures above their heads.
 	end
 	setting Map zoom
 		type range

--- a/client/settings/interface.cfg
+++ b/client/settings/interface.cfg
@@ -5,6 +5,7 @@ id = buddy
 id = ignore
 
 [fps]
+[game_time]
 [input]
 [map]
 [menu_buttons]
@@ -12,6 +13,7 @@ id = ignore
 [mplayer]
 [network_graph]
 [render_profiler]
+[xp_tracker]
 [party]
 [protections]
 [skills]

--- a/client/src/client/commands.c
+++ b/client/src/client/commands.c
@@ -323,6 +323,7 @@ void socket_command_stats(uint8_t *data, size_t len, size_t pos) {
 
                 case CS_STAT_EXP:
                     cpl.stats.exp = packet_to_uint64(data, len, &pos);
+                    telemetry_exp_update(cpl.stats.exp);
                     widget_redraw_type_id(STAT_ID, "exp");
                     break;
 
@@ -717,6 +718,11 @@ void socket_command_mapstats(uint8_t *data, size_t len, size_t pos) {
             packet_to_string(data, len, &pos, msg_anim.color, sizeof(msg_anim.color));
             packet_to_string(data, len, &pos, msg_anim.message, sizeof(msg_anim.message));
             msg_anim.tick = LastTick;
+        } else if (type == CMD_MAPSTATS_TIME) {
+            uint64_t game_seconds = packet_to_uint64(data, len, &pos);
+            uint32_t millis_per_game_minute = packet_to_uint32(data, len, &pos);
+            telemetry_game_time_sync(game_seconds, millis_per_game_minute);
+            WIDGET_REDRAW_ALL(GAME_TIME_ID);
         }
     }
 }
@@ -1168,7 +1174,7 @@ void socket_command_version(uint8_t *data, size_t len, size_t pos) {
     cpl.server_socket_version = packet_to_uint32(data, len, &pos);
     if (cpl.server_socket_version < SOCKET_VERSION) {
         draw_info(COLOR_RED,
-                  "The server uses an incompatible map lighting protocol. Please update the "
+                  "The server uses an incompatible gameplay protocol. Please update the "
                   "server.");
         cpl.state = ST_START;
         return;

--- a/client/src/client/player.c
+++ b/client/src/client/player.c
@@ -71,6 +71,7 @@ void clear_player(void) {
     spells_deinit();
 
     memset(&cpl, 0, sizeof(cpl));
+    telemetry_reset();
     cpl.stats.Str = cpl.stats.Dex = cpl.stats.Con = cpl.stats.Int = cpl.stats.Pow = -1;
     objects_init();
     quickslots_init();

--- a/client/src/client/sound.c
+++ b/client/src/client/sound.c
@@ -74,6 +74,8 @@ static int sound_background_loop;
  * Volume the background music was started at.
  */
 static int sound_background_volume;
+/** Per-track adjustment supplied by the current map. */
+static int sound_background_volume_adjustment;
 /**
  * Loaded sounds.
  */
@@ -82,6 +84,33 @@ static sound_data_struct *sound_data;
  * Hook function calle whenever ::sound_background changes its value.
  */
 static void (*sound_background_hook)(void);
+
+static int sound_percent_to_mixer(int64_t percent) {
+    percent = MAX(INT64_C(0), MIN(INT64_C(100), percent));
+    return (int)((percent * MIX_MAX_VOLUME + 50) / 100);
+}
+
+static void sound_apply_music_volume(int64_t percent) {
+    sound_background_volume = (int)MAX(INT64_C(0), MIN(INT64_C(100), percent));
+    Mix_VolumeMusic(sound_percent_to_mixer(sound_background_volume));
+
+    if (sound_background == NULL) {
+        return;
+    }
+
+    if (sound_background_volume == 0) {
+        if (!Mix_PausedMusic()) {
+            sound_pause_music();
+        }
+    } else if (Mix_PausedMusic()) {
+        sound_resume_music();
+    }
+}
+
+static void sound_start_bg_music_internal(const char *filename,
+                                          int64_t volume,
+                                          int loop,
+                                          int volume_adjustment);
 
 /**
  * Execute the ::sound_background_hook callback.
@@ -230,7 +259,10 @@ static void sound_music_finished_process(void) {
             sound_background_loop--;
         }
 
-        sound_start_bg_music(bg_music, sound_background_volume, sound_background_loop);
+        sound_start_bg_music_internal(bg_music,
+                                      sound_background_volume,
+                                      sound_background_loop,
+                                      sound_background_volume_adjustment);
     }
 
     free(tmp);
@@ -379,9 +411,9 @@ static int sound_add_effect(const char *filename, int volume, int loop) {
         return -1;
     }
 
-    Mix_Volume(channel,
-               (int)((setting_get_int(OPT_CAT_SOUND, OPT_VOLUME_SOUND) / 100.0) *
-                     ((double)volume * (MIX_MAX_VOLUME / 100.0))));
+    int64_t effective_percent =
+        setting_get_int(OPT_CAT_SOUND, OPT_VOLUME_SOUND) * MAX(0, volume) / 100;
+    Mix_Volume(channel, sound_percent_to_mixer(effective_percent));
 
     return channel;
 #else
@@ -439,7 +471,10 @@ int sound_play_effect_loop(const char *filename, int volume, int loop) {
  * @param loop
  * How many times to loop, -1 for infinite number.
  */
-void sound_start_bg_music(const char *filename, int volume, int loop) {
+static void sound_start_bg_music_internal(const char *filename,
+                                          int64_t volume,
+                                          int loop,
+                                          int volume_adjustment) {
 #ifdef HAVE_SDL_MIXER
     char path[HUGE_BUF];
     sound_data_struct *tmp;
@@ -457,6 +492,9 @@ void sound_start_bg_music(const char *filename, int volume, int loop) {
 
     /* Same background music, nothing to do. */
     if (sound_background && !strcmp(sound_background, path)) {
+        sound_background_loop = loop;
+        sound_background_volume_adjustment = volume_adjustment;
+        sound_apply_music_volume(volume);
         return;
     }
 
@@ -485,12 +523,12 @@ void sound_start_bg_music(const char *filename, int volume, int loop) {
     sound_background = xstrdup(path);
     sound_background_hook_execute();
     sound_background_loop = loop;
-    sound_background_volume = volume;
+    sound_background_volume_adjustment = volume_adjustment;
     sound_background_duration = sound_music_file_get_duration(filename);
     sound_background_update_duration = 1;
 
-    Mix_VolumeMusic(volume);
     Mix_PlayMusic(tmp->data, 0);
+    sound_apply_music_volume(volume);
 
     sound_background_started = SDL_GetTicks();
 
@@ -498,10 +536,11 @@ void sound_start_bg_music(const char *filename, int volume, int loop) {
      * others) will continue playing even when the volume has been set to
      * 0, which means we need to manually pause the music if volume is 0,
      * and unpause it in sound_update_volume(), if the volume changes. */
-    if (volume == 0) {
-        sound_pause_music();
-    }
 #endif
+}
+
+void sound_start_bg_music(const char *filename, int volume, int loop) {
+    sound_start_bg_music_internal(filename, volume, loop, 0);
 }
 
 /**
@@ -562,9 +601,10 @@ void update_map_bg_music(const char *bg_music) {
             return;
         }
 
-        sound_start_bg_music(filename,
-                             setting_get_int(OPT_CAT_SOUND, OPT_VOLUME_MUSIC) + vol,
-                             loop);
+        sound_start_bg_music_internal(filename,
+                                      setting_get_int(OPT_CAT_SOUND, OPT_VOLUME_MUSIC) + vol,
+                                      loop,
+                                      vol);
     }
 }
 
@@ -577,21 +617,9 @@ void sound_update_volume(void) {
     }
 
 #ifdef HAVE_SDL_MIXER
-    Mix_VolumeMusic(setting_get_int(OPT_CAT_SOUND, OPT_VOLUME_MUSIC));
-
-    /* If there is any background music, due to a bug in SDL_mixer, we
-     * may need to pause or unpause the music. */
-    if (sound_background) {
-        /* If the new volume is 0, pause the music. */
-        if (setting_get_int(OPT_CAT_SOUND, OPT_VOLUME_MUSIC) == 0) {
-            if (!Mix_PausedMusic()) {
-                sound_pause_music();
-            }
-        } else if (Mix_PausedMusic()) {
-            /* Non-zero and already paused, so resume the music. */
-            sound_resume_music();
-        }
-    }
+    int64_t volume =
+        setting_get_int(OPT_CAT_SOUND, OPT_VOLUME_MUSIC) + sound_background_volume_adjustment;
+    sound_apply_music_volume(volume);
 #endif
 }
 
@@ -734,7 +762,12 @@ void socket_command_sound(uint8_t *data, size_t len, size_t pos) {
         x = packet_to_uint8(data, len, &pos);
         y = packet_to_uint8(data, len, &pos);
 
-        channel = sound_play_effect_loop(filename, 100 + volume, loop);
+        const char *effect = filename;
+        if (strcmp(filename, "player_hurt.ogg") == 0) {
+            effect = cpl.gender == GENDER_FEMALE ? "doh_female.ogg" : "doh.ogg";
+        }
+
+        channel = sound_play_effect_loop(effect, 100 + volume, loop);
 
         if (channel != -1) {
             int angle, distance;
@@ -754,9 +787,10 @@ void socket_command_sound(uint8_t *data, size_t len, size_t pos) {
         }
     } else if (type == CMD_SOUND_BACKGROUND) {
         if (!sound_map_background_disabled) {
-            sound_start_bg_music(filename,
-                                 setting_get_int(OPT_CAT_SOUND, OPT_VOLUME_MUSIC) + volume,
-                                 loop);
+            sound_start_bg_music_internal(filename,
+                                          setting_get_int(OPT_CAT_SOUND, OPT_VOLUME_MUSIC) + volume,
+                                          loop,
+                                          volume);
         }
     } else if (type == CMD_SOUND_ABSOLUTE) {
         sound_add_effect(filename, (uint8_t)volume, loop);

--- a/client/src/client/sound.c
+++ b/client/src/client/sound.c
@@ -51,6 +51,17 @@ static uint8_t enabled = 0;
  */
 static sound_ambient_struct *sound_ambient_head = NULL;
 
+/** Female player-hurt variants supplied by the sound submodule. */
+static const char *const sound_female_hurt_effects[] = {
+    "doh_female_1.ogg",
+    "doh_female_2.ogg",
+    "doh_female_3.ogg",
+    "doh_female_4.ogg",
+    "doh_female_5.ogg",
+    "doh_female_6.ogg",
+    "doh_female_7.ogg",
+};
+
 #ifdef HAVE_SDL_MIXER
 
 /**
@@ -764,7 +775,12 @@ void socket_command_sound(uint8_t *data, size_t len, size_t pos) {
 
         const char *effect = filename;
         if (strcmp(filename, "player_hurt.ogg") == 0) {
-            effect = cpl.gender == GENDER_FEMALE ? "doh_female.ogg" : "doh.ogg";
+            if (cpl.gender == GENDER_FEMALE) {
+                effect =
+                    sound_female_hurt_effects[rndm(0, arraysize(sound_female_hurt_effects) - 1)];
+            } else {
+                effect = "doh.ogg";
+            }
         }
 
         channel = sound_play_effect_loop(effect, 100 + volume, loop);

--- a/client/src/client/telemetry.c
+++ b/client/src/client/telemetry.c
@@ -1,0 +1,117 @@
+/*************************************************************************
+ *           Atrinik, a Multiplayer Online Role Playing Game             *
+ *                                                                       *
+ *   Copyright (C) 2009-2026 Atrinik Development Team                    *
+ *                                                                       *
+ * This program is free software; you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation; either version 2 of the License, or     *
+ * (at your option) any later version.                                   *
+ ************************************************************************/
+
+/** @file Client-side session telemetry. */
+
+#include <global.h>
+#include <toolkit/datetime.h>
+
+typedef struct telemetry_state {
+    bool exp_initialized;
+    uint64_t exp_last;
+    uint64_t exp_gained;
+    uint64_t exp_started_us;
+    bool game_time_valid;
+    uint64_t game_seconds;
+    uint64_t game_time_synced_us;
+    uint32_t millis_per_game_minute;
+} telemetry_state_t;
+
+static telemetry_state_t telemetry;
+
+void telemetry_reset(void) {
+    telemetry = (telemetry_state_t){0};
+    telemetry.exp_started_us = datetime_monotonic_us();
+    WIDGET_REDRAW_ALL(XP_TRACKER_ID);
+    WIDGET_REDRAW_ALL(GAME_TIME_ID);
+}
+
+void telemetry_exp_update(uint64_t exp) {
+    if (!telemetry.exp_initialized) {
+        telemetry.exp_initialized = true;
+        telemetry.exp_last = exp;
+        telemetry.exp_started_us = datetime_monotonic_us();
+        return;
+    }
+
+    if (exp > telemetry.exp_last) {
+        uint64_t gained = exp - telemetry.exp_last;
+        if (UINT64_MAX - telemetry.exp_gained < gained) {
+            telemetry.exp_gained = UINT64_MAX;
+        } else {
+            telemetry.exp_gained += gained;
+        }
+    }
+
+    telemetry.exp_last = exp;
+    WIDGET_REDRAW_ALL(XP_TRACKER_ID);
+}
+
+void telemetry_exp_tracker_reset(void) {
+    telemetry.exp_initialized = true;
+    telemetry.exp_last = cpl.stats.exp;
+    telemetry.exp_gained = 0;
+    telemetry.exp_started_us = datetime_monotonic_us();
+    WIDGET_REDRAW_ALL(XP_TRACKER_ID);
+    draw_info(COLOR_GREEN, "Experience tracker reset.");
+}
+
+uint64_t telemetry_exp_gained(void) {
+    return telemetry.exp_gained;
+}
+
+uint64_t telemetry_exp_elapsed_seconds(void) {
+    uint64_t elapsed_us = datetime_monotonic_us() - telemetry.exp_started_us;
+    return elapsed_us / 1000000;
+}
+
+uint64_t telemetry_exp_per_hour(void) {
+    uint64_t elapsed_us = datetime_monotonic_us() - telemetry.exp_started_us;
+    if (elapsed_us == 0 || telemetry.exp_gained == 0) {
+        return 0;
+    }
+
+    long double hourly = (long double)telemetry.exp_gained * 3600000000.0L / elapsed_us;
+    return hourly >= UINT64_MAX ? UINT64_MAX : (uint64_t)hourly;
+}
+
+void telemetry_game_time_sync(uint64_t game_seconds, uint32_t millis_per_game_minute) {
+    if (millis_per_game_minute == 0) {
+        LOG(PACKET, "Ignoring game-time synchronization with a zero rate");
+        return;
+    }
+
+    telemetry.game_time_valid = true;
+    telemetry.game_seconds = game_seconds;
+    telemetry.game_time_synced_us = datetime_monotonic_us();
+    telemetry.millis_per_game_minute = millis_per_game_minute;
+}
+
+bool telemetry_game_time_get(uint64_t *game_minutes, uint32_t *millis_per_game_minute) {
+    if (!telemetry.game_time_valid) {
+        return false;
+    }
+
+    uint64_t elapsed_us = datetime_monotonic_us() - telemetry.game_time_synced_us;
+    uint64_t minute_us = (uint64_t)telemetry.millis_per_game_minute * 1000;
+    uint64_t elapsed_minutes = elapsed_us / minute_us;
+    uint64_t elapsed_seconds = elapsed_minutes * 60 + elapsed_us % minute_us * 60 / minute_us;
+    uint64_t current_seconds = telemetry.game_seconds;
+    if (UINT64_MAX - current_seconds < elapsed_seconds) {
+        current_seconds = UINT64_MAX;
+    } else {
+        current_seconds += elapsed_seconds;
+    }
+
+    *game_minutes = current_seconds / 60;
+    *millis_per_game_minute = telemetry.millis_per_game_minute;
+    return true;
+}

--- a/client/src/cmake.txt
+++ b/client/src/cmake.txt
@@ -20,6 +20,7 @@ set(SOURCES
 	src/client/resources.c
 	src/client/server_files.c
 	src/client/server_settings.c
+	src/client/telemetry.c
 	src/client/settings.c
 	src/client/socket.c
 	src/client/sound.c
@@ -68,6 +69,7 @@ set(SOURCES
 	src/gui/widgets/buddy.c
 	src/gui/widgets/container.c
 	src/gui/widgets/fps.c
+	src/gui/widgets/game_time.c
 	src/gui/widgets/input.c
 	src/gui/widgets/inventory.c
 	src/gui/widgets/label.c
@@ -91,4 +93,5 @@ set(SOURCES
 	src/gui/widgets/target.c
 	src/gui/widgets/texture.c
 	src/gui/widgets/textwin.c
+	src/gui/widgets/xp_tracker.c
 	${SOURCES_TOOLKIT})

--- a/client/src/gui/toolkit/include/widget.h
+++ b/client/src/gui/toolkit/include/widget.h
@@ -295,6 +295,7 @@ typedef enum WidgetID {
     MAPNAME_ID,
     INPUT_ID,
     FPS_ID,
+    GAME_TIME_ID,
     MPLAYER_ID,
     SPELLS_ID,
     SKILLS_ID,
@@ -311,6 +312,7 @@ typedef enum WidgetID {
     INVENTORY_ID,
     NETWORK_GRAPH_ID,
     RENDER_PROFILER_ID,
+    XP_TRACKER_ID,
 
     /** The total number of widgets. */
     TOTAL_WIDGETS

--- a/client/src/gui/toolkit/widget.c
+++ b/client/src/gui/toolkit/widget.c
@@ -57,6 +57,7 @@ static const char *const widget_names[TOTAL_SUBWIDGETS] = {"map",
                                                            "mapname",
                                                            "input",
                                                            "fps",
+                                                           "game_time",
                                                            "mplayer",
                                                            "spells",
                                                            "skills",
@@ -73,6 +74,7 @@ static const char *const widget_names[TOTAL_SUBWIDGETS] = {"map",
                                                            "inventory",
                                                            "network_graph",
                                                            "render_profiler",
+                                                           "xp_tracker",
 
                                                            "container_strip",
                                                            "menu",
@@ -260,6 +262,7 @@ void toolkit_widget_init(void) {
     widget_initializers[BUDDY_ID] = widget_buddy_init;
     widget_initializers[CONTAINER_ID] = widget_container_init;
     widget_initializers[FPS_ID] = widget_fps_init;
+    widget_initializers[GAME_TIME_ID] = widget_game_time_init;
     widget_initializers[INPUT_ID] = widget_input_init;
     widget_initializers[INVENTORY_ID] = widget_inventory_init;
     widget_initializers[LABEL_ID] = widget_label_init;
@@ -270,6 +273,7 @@ void toolkit_widget_init(void) {
     widget_initializers[MPLAYER_ID] = widget_mplayer_init;
     widget_initializers[NETWORK_GRAPH_ID] = widget_network_graph_init;
     widget_initializers[RENDER_PROFILER_ID] = widget_render_profiler_init;
+    widget_initializers[XP_TRACKER_ID] = widget_xp_tracker_init;
     widget_initializers[NOTIFICATION_ID] = widget_notification_init;
     widget_initializers[PARTY_ID] = widget_party_init;
     widget_initializers[PDOLL_ID] = widget_playerdoll_init;
@@ -290,11 +294,18 @@ void toolkit_widget_init(void) {
 
     widget_load("settings/interface.cfg", 0, widgets);
 
-    /* Older saved layouts predate the profiler widget. Ensure the singleton
-     * exists so enabling its setting works without resetting the interface. */
-    if (cur_widget[RENDER_PROFILER_ID] == NULL) {
-        widgetdata *profiler = create_widget_object(RENDER_PROFILER_ID);
-        SOFT_ASSERT(profiler != NULL, "Could not create render profiler widget");
+    /* Older saved layouts predate these singleton widgets. Create missing
+     * entries from their defaults without requiring an interface reset. */
+    static const int ensured_widgets[] = {
+        RENDER_PROFILER_ID,
+        GAME_TIME_ID,
+        XP_TRACKER_ID,
+    };
+    for (size_t i = 0; i < arraysize(ensured_widgets); i++) {
+        if (cur_widget[ensured_widgets[i]] == NULL) {
+            widgetdata *widget = create_widget_object(ensured_widgets[i]);
+            SOFT_ASSERT(widget != NULL, "Could not create ensured widget");
+        }
     }
 
     widgets_ensure_onscreen();

--- a/client/src/gui/widgets/game_time.c
+++ b/client/src/gui/widgets/game_time.c
@@ -1,0 +1,80 @@
+/*************************************************************************
+ *           Atrinik, a Multiplayer Online Role Playing Game             *
+ *                                                                       *
+ *   Copyright (C) 2009-2026 Atrinik Development Team                    *
+ *                                                                       *
+ * This program is free software; you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation; either version 2 of the License, or     *
+ * (at your option) any later version.                                   *
+ ************************************************************************/
+
+/** @file Synchronized in-game clock widget. */
+
+#include <global.h>
+
+static void widget_draw(widgetdata *widget) {
+    if (!widget->redraw) {
+        return;
+    }
+
+    SDL_Rect box = {.w = widget->w, .h = widget->h};
+    uint64_t game_minutes;
+    uint32_t millis_per_game_minute;
+    char text[32] = "Game time: --:--";
+
+    if (telemetry_game_time_get(&game_minutes, &millis_per_game_minute)) {
+        unsigned hour = game_minutes / 60 % 24;
+        unsigned minute = game_minutes % 60;
+        snprintf(VS(text), "Game time: %02u:%02u", hour, minute);
+    }
+
+    text_show(widget->surface,
+              FONT_ARIAL11,
+              text,
+              4,
+              0,
+              COLOR_WHITE,
+              TEXT_VALIGN_CENTER | TEXT_OUTLINE,
+              &box);
+}
+
+static void widget_background(widgetdata *widget, int draw) {
+    static uint64_t displayed_minute = UINT64_MAX;
+    uint64_t game_minutes;
+    uint32_t millis_per_game_minute;
+    if (telemetry_game_time_get(&game_minutes, &millis_per_game_minute) &&
+        game_minutes != displayed_minute) {
+        displayed_minute = game_minutes;
+        WIDGET_REDRAW_ALL(GAME_TIME_ID);
+    }
+}
+
+static int widget_event(widgetdata *widget, SDL_Event *event) {
+    if (event->type == SDL_MOUSEMOTION) {
+        uint64_t game_minutes;
+        uint32_t millis_per_game_minute;
+        if (telemetry_game_time_get(&game_minutes, &millis_per_game_minute)) {
+            char buf[160];
+            snprintf(VS(buf),
+                     "Day %" PRIu64 ", %02" PRIu64 ":%02" PRIu64
+                     "\nOne game minute passes every %.2f real seconds.",
+                     game_minutes / (UINT64_C(24) * 60) + 1,
+                     game_minutes / 60 % 24,
+                     game_minutes % 60,
+                     millis_per_game_minute / 1000.0);
+            tooltip_create(event->motion.x, event->motion.y, FONT_ARIAL11, buf);
+            tooltip_multiline(260);
+            tooltip_enable_delay(100);
+        }
+        return 1;
+    }
+
+    return 0;
+}
+
+void widget_game_time_init(widgetdata *widget) {
+    widget->draw_func = widget_draw;
+    widget->background_func = widget_background;
+    widget->event_func = widget_event;
+}

--- a/client/src/gui/widgets/map.c
+++ b/client/src/gui/widgets/map.c
@@ -1674,9 +1674,9 @@ static void map_draw_annotations(SDL_Surface *surface, map_render_context_t *con
             if (setting_get_int(OPT_CAT_MAP, OPT_PLAYER_NAMES) == 1) {
                 draw_name = true;
             } else if (setting_get_int(OPT_CAT_MAP, OPT_PLAYER_NAMES) == 2) {
-                draw_name = strncasecmp(name, cpl.name, strlen(name)) != 0;
+                draw_name = cell->target_object_count[sub_layer] != 0;
             } else if (setting_get_int(OPT_CAT_MAP, OPT_PLAYER_NAMES) == 3) {
-                draw_name = strncasecmp(name, cpl.name, strlen(name)) == 0;
+                draw_name = cell->target_object_count[sub_layer] == 0;
             }
 
             if (draw_name) {

--- a/client/src/gui/widgets/xp_tracker.c
+++ b/client/src/gui/widgets/xp_tracker.c
@@ -1,0 +1,86 @@
+/*************************************************************************
+ *           Atrinik, a Multiplayer Online Role Playing Game             *
+ *                                                                       *
+ *   Copyright (C) 2009-2026 Atrinik Development Team                    *
+ *                                                                       *
+ * This program is free software; you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation; either version 2 of the License, or     *
+ * (at your option) any later version.                                   *
+ ************************************************************************/
+
+/** @file Experience-per-hour widget. */
+
+#include <global.h>
+#include <toolkit/datetime.h>
+#include <toolkit/string.h>
+
+static void widget_draw(widgetdata *widget) {
+    if (!widget->redraw) {
+        return;
+    }
+
+    SDL_Rect box = {.w = widget->w, .h = widget->h};
+    char hourly[64];
+    snprintf(VS(hourly), "%s", string_format_number_comma(telemetry_exp_per_hour()));
+
+    text_show_format(widget->surface,
+                     FONT_ARIAL11,
+                     4,
+                     0,
+                     COLOR_WHITE,
+                     TEXT_VALIGN_CENTER | TEXT_OUTLINE,
+                     &box,
+                     "XP/h: %s",
+                     hourly);
+}
+
+static void widget_background(widgetdata *widget, int draw) {
+    static uint64_t last_redraw_second;
+    uint64_t now = datetime_monotonic_us() / 1000000;
+    if (now != last_redraw_second) {
+        last_redraw_second = now;
+        WIDGET_REDRAW_ALL(XP_TRACKER_ID);
+    }
+}
+
+static int widget_event(widgetdata *widget, SDL_Event *event) {
+    if (event->type == SDL_MOUSEMOTION) {
+        char gained[64];
+        snprintf(VS(gained), "%s", string_format_number_comma(telemetry_exp_gained()));
+        uint64_t elapsed = telemetry_exp_elapsed_seconds();
+        char buf[256];
+        snprintf(VS(buf),
+                 "Experience gained: %s\nElapsed: %02" PRIu64 ":%02" PRIu64 ":%02" PRIu64
+                 "\nRight-click to reset.",
+                 gained,
+                 elapsed / 3600,
+                 elapsed / 60 % 60,
+                 elapsed % 60);
+        tooltip_create(event->motion.x, event->motion.y, FONT_ARIAL11, buf);
+        tooltip_multiline(220);
+        tooltip_enable_delay(100);
+        return 1;
+    }
+
+    return 0;
+}
+
+static void menu_reset(widgetdata *widget, widgetdata *menuitem, SDL_Event *event) {
+    telemetry_exp_tracker_reset();
+}
+
+static int widget_menu_handle(widgetdata *widget, SDL_Event *event) {
+    widgetdata *menu = create_menu(event->motion.x, event->motion.y, widget);
+    widget_menu_standard_items(widget, menu);
+    add_menuitem(menu, "Reset XP tracker", &menu_reset, MENU_NORMAL, 0);
+    menu_finalize(menu);
+    return 1;
+}
+
+void widget_xp_tracker_init(widgetdata *widget) {
+    widget->draw_func = widget_draw;
+    widget->background_func = widget_background;
+    widget->event_func = widget_event;
+    widget->menu_handle_func = widget_menu_handle;
+}

--- a/client/src/include/config.h
+++ b/client/src/include/config.h
@@ -31,7 +31,7 @@
 #define CONFIG_H
 
 /** Socket version. */
-#define SOCKET_VERSION 1069
+#define SOCKET_VERSION 1070
 
 /** File the the arch definitions. */
 #define ARCHDEF_FILE "data/archdef.dat"

--- a/client/src/include/proto.h
+++ b/client/src/include/proto.h
@@ -143,6 +143,14 @@ extern void client_send_move(tag_t loc, tag_t tag, uint32_t nrof);
 extern void send_command(const char *command);
 extern void init_player_data(void);
 extern int gender_to_id(const char *gender);
+extern void telemetry_reset(void);
+extern void telemetry_exp_update(uint64_t exp);
+extern void telemetry_exp_tracker_reset(void);
+extern uint64_t telemetry_exp_gained(void);
+extern uint64_t telemetry_exp_per_hour(void);
+extern uint64_t telemetry_exp_elapsed_seconds(void);
+extern void telemetry_game_time_sync(uint64_t game_seconds, uint32_t millis_per_game_minute);
+extern bool telemetry_game_time_get(uint64_t *game_minutes, uint32_t *millis_per_game_minute);
 extern void player_draw_exp_progress(SDL_Surface *surface, int x, int y, int64_t xp, uint8_t level);
 /* src/client/region_map.c */
 /* src/client/server_files.c */
@@ -1099,6 +1107,7 @@ extern void widget_buddy_init(widgetdata *widget);
 extern void widget_container_init(widgetdata *widget);
 /* src/gui/widgets/fps.c */
 extern void widget_fps_init(widgetdata *widget);
+extern void widget_game_time_init(widgetdata *widget);
 /* src/gui/widgets/input.c */
 extern void widget_input_init(widgetdata *widget);
 /* src/gui/widgets/inventory.c */
@@ -1274,5 +1283,6 @@ extern void textwin_show(SDL_Surface *surface, int x, int y, int w, int h);
 extern int textwin_tabs_height(widgetdata *widget);
 extern void textwin_create_scrollbar(widgetdata *widget);
 extern void widget_textwin_init(widgetdata *widget);
+extern void widget_xp_tracker_init(widgetdata *widget);
 extern void widget_textwin_handle_console(const char *text);
 #endif

--- a/client/src/include/settings.h
+++ b/client/src/include/settings.h
@@ -109,7 +109,7 @@ enum {
  * Options in the ::OPT_CAT_MAP category.
  */
 enum {
-    /** Which player names to show. */
+    /** Which living-object names to show. */
     OPT_PLAYER_NAMES,
     /** How much to zoom the map. */
     OPT_MAP_ZOOM,

--- a/common/toolkit/socket.h
+++ b/common/toolkit/socket.h
@@ -436,6 +436,8 @@ typedef struct socket_asset_response {
 #define CMD_MAPSTATS_WEATHER 3
 /** Text animation. */
 #define CMD_MAPSTATS_TEXT_ANIM 4
+/** Synchronize the in-game clock and its real-time rate. */
+#define CMD_MAPSTATS_TIME 5
 /*@}*/
 
 /**

--- a/doc/ADS/ADS-2
+++ b/doc/ADS/ADS-2
@@ -963,6 +963,33 @@ ASSET:
  item UIDs are connection-local and MUST NOT be used as durable read identity.
 
 ===============================================================================
+= 3.13. Client command MAPSTATS                                               =
+===============================================================================
+ This server-to-client command contains one or more map-state records. Records
+ are concatenated without a count; the packet boundary terminates the final
+ record. Each record begins with type (uint8), followed by the fields defined
+ for that type:
+
+  - 1 (NAME): map_name (string).
+  - 2 (MUSIC): background_music (string).
+  - 3 (WEATHER): weather (string).
+  - 4 (TEXT_ANIM): color (string), then message (string).
+  - 5 (TIME): game_seconds (uint64), then
+    milliseconds_per_game_minute (uint32).
+
+ Multi-byte values use network byte order. game_seconds is the authoritative
+ absolute in-game time in seconds. milliseconds_per_game_minute is nonzero and
+ gives the nominal real-time duration of one in-game minute, including the
+ server's configured time multiplier. A client may extrapolate between TIME
+ records using a monotonic local clock, but each new record replaces that
+ estimate so server scheduling delay cannot accumulate as permanent drift.
+
+ TIME is part of socket protocol version 1070. MAPSTATS records are not
+ length-delimited, so a new record type or a changed record layout requires a
+ socket-version increment and clients and servers using different versions
+ MUST reject each other before gameplay state is exchanged.
+
+===============================================================================
 = 3.19. Client command CHARACTERS                                             =
 ===============================================================================
  This command reports account metadata and the account's available characters

--- a/server/src/commands/permission/settime.c
+++ b/server/src/commands/permission/settime.c
@@ -46,4 +46,6 @@ void command_settime(object *op, const char *command, char *params) {
         tick_the_clock();
         get_tod(&tod);
     }
+
+    send_game_time(NULL);
 }

--- a/server/src/include/config.h
+++ b/server/src/include/config.h
@@ -176,7 +176,7 @@
 #define AUTOSAVE 5000
 
 /** Socket version. */
-#define SOCKET_VERSION 1069
+#define SOCKET_VERSION 1070
 
 /**
  * If 1, all data packets that are longer than @ref COMPRESS_DATA_PACKETS_SIZE

--- a/server/src/include/proto.h
+++ b/server/src/include/proto.h
@@ -731,6 +731,7 @@ extern void packet_append_map_name(struct packet_struct *packet, object *op, obj
 extern void packet_append_map_music(struct packet_struct *packet, object *op, object *map_info);
 extern void packet_append_map_weather(struct packet_struct *packet, object *op, object *map_info);
 extern void draw_client_map2(object *pl);
+extern void send_game_time(player *recipient);
 extern void
 socket_command_quest_list(socket_struct *ns, player *pl, uint8_t *data, size_t len, size_t pos);
 extern void

--- a/server/src/server/attack.c
+++ b/server/src/server/attack.c
@@ -530,10 +530,11 @@ send_attack_msg(object *op, object *hitter, atnr_t atnr, double dam_done, double
     if (op->type == PLAYER) {
         draw_info_format(COLOR_PURPLE,
                          op,
-                         "%s hit you for %d (%d) damage.",
+                         "%s hit you for %d (%d) %s damage.",
                          hitter->name,
                          (int)(dam_done + 0.5),
-                         (int)(dam_done - dam_orig + 0.5));
+                         (int)(dam_done - dam_orig + 0.5),
+                         attack_name[atnr]);
     }
 
     const char *hitter_name = atnr == ATNR_INTERNAL ? hitter->name : attack_name[atnr];
@@ -812,6 +813,9 @@ int attack_hit(object *op, object *hitter, int dam) {
     if (op->type == PLAYER) {
         CONTR(op)->last_combat = pticks;
         CONTR(op)->stat_damage_taken += maxdam;
+        if (maxdam > 0.0) {
+            play_sound_player_only(CONTR(op), CMD_SOUND_EFFECT, "player_hurt.ogg", 0, 0, 0, 0);
+        }
     }
 
     op->last_damage += maxdam;

--- a/server/src/server/main.c
+++ b/server/src/server/main.c
@@ -491,6 +491,10 @@ static void do_specials(void) {
         tick_the_clock();
     }
 
+    if (!(pticks % (PTICKS_PER_CLOCK / 6))) {
+        send_game_time(NULL);
+    }
+
     /* Clears the tmp-files of maps which have reset */
     if (!(pticks % 509)) {
         flush_old_maps();

--- a/server/src/server/time.c
+++ b/server/src/server/time.c
@@ -254,6 +254,7 @@ void set_max_time(long t) {
               "You feel a sudden and inexplicable change in the fabric of "
               "time and space...");
     max_time = t;
+    send_game_time(NULL);
 }
 
 /**
@@ -272,6 +273,7 @@ void set_max_time_multiplier(int t) {
               "You feel a sudden and inexplicable change in the fabric of "
               "time and space...");
     max_time_multiplier = t;
+    send_game_time(NULL);
 }
 
 /**

--- a/server/src/socket/request.c
+++ b/server/src/socket/request.c
@@ -262,7 +262,7 @@ void socket_command_version(socket_struct *ns, player *pl, uint8_t *data, size_t
                        NULL,
                        COLOR_RED,
                        ns,
-                       "Your client uses an incompatible map lighting protocol.\n"
+                       "Your client uses an incompatible gameplay protocol.\n"
                        "Please update to the latest Atrinik client.");
         ns->state = ST_ZOMBIE;
         return;
@@ -769,6 +769,29 @@ static const char *get_playername_color(object *pl, object *op) {
     return COLOR_WHITE;
 }
 
+/** Return the target-difficulty color used for non-player living names. */
+static const char *get_living_level_color(const object *pl, const object *op) {
+    if (op->level < level_color[pl->level].yellow) {
+        if (op->level < level_color[pl->level].green) {
+            return COLOR_GRAY;
+        }
+        if (op->level < level_color[pl->level].blue) {
+            return COLOR_GREEN;
+        }
+        return COLOR_BLUE;
+    }
+    if (op->level >= level_color[pl->level].purple) {
+        return COLOR_PURPLE;
+    }
+    if (op->level >= level_color[pl->level].red) {
+        return COLOR_RED;
+    }
+    if (op->level >= level_color[pl->level].orange) {
+        return COLOR_ORANGE;
+    }
+    return COLOR_YELLOW;
+}
+
 void packet_append_map_name(struct packet_struct *packet, object *op, object *map_info) {
     packet_debug_data(packet, 0, "Map name");
     packet_append_string(packet, "[b][o=#000000]");
@@ -790,6 +813,41 @@ void packet_append_map_weather(struct packet_struct *packet, object *op, object 
                                     map_info && map_info->title
                                         ? map_info->title
                                         : (op->map->weather ? op->map->weather : "none"));
+}
+
+/**
+ * Synchronize the in-game clock with one client or every connected player.
+ *
+ * The client receives an absolute game-second value and the number of real
+ * milliseconds per game minute, allowing it to advance the display without
+ * receiving a packet every minute. Seconds preserve the partial minute at
+ * login so the first locally advanced minute does not start late.
+ *
+ * @param recipient
+ * Player to synchronize, or NULL to synchronize every player.
+ */
+void send_game_time(player *recipient) {
+    uint64_t game_seconds = (uint64_t)todtick * 60 * 60 +
+                            (uint64_t)(pticks % PTICKS_PER_CLOCK) * 60 * 60 / PTICKS_PER_CLOCK;
+    uint64_t rate = max_time > 0 && max_time_multiplier > 0
+                        ? (uint64_t)PTICKS_PER_CLOCK * (uint64_t)max_time /
+                              (UINT64_C(60) * 1000 * (uint64_t)max_time_multiplier)
+                        : 1;
+    rate = MAX(rate, UINT64_C(1));
+    uint32_t millis_per_game_minute = (uint32_t)MIN(UINT32_MAX, MAX(1, rate));
+
+    for (player *pl = recipient != NULL ? recipient : first_player; pl != NULL;
+         pl = recipient != NULL ? NULL : pl->next) {
+        if (pl->ob == NULL || pl->ob->map == NULL) {
+            continue;
+        }
+
+        packet_struct *packet = packet_new(CLIENT_CMD_MAPSTATS, 16, 0);
+        packet_append_uint8(packet, CMD_MAPSTATS_TIME);
+        packet_append_uint64(packet, game_seconds);
+        packet_append_uint32(packet, millis_per_game_minute);
+        socket_send_packet(pl->cs, packet);
+    }
 }
 
 /** Clear a map cell. */
@@ -1635,8 +1693,8 @@ void draw_client_map2(object *pl) {
 
                             client_flags = GET_CLIENT_FLAGS(head);
 
-                            /* Player? So we want to send their name. */
-                            if (tmp->type == PLAYER) {
+                            /* Keep every visible living creature identified. */
+                            if (head->type == PLAYER || (layer == LAYER_LIVING && IS_LIVE(head))) {
                                 flags |= MAP2_FLAG_NAME;
                             }
 
@@ -1745,7 +1803,8 @@ void draw_client_map2(object *pl) {
                                 (layer != LAYER_LIVING ||
                                  (mp->anim_flags[sub_layer] == anim_flags &&
                                   mp->client_flags[sub_layer] == client_flags)) &&
-                                (!(flags & MAP2_FLAG_NAME) || !CONTR(tmp)->cs->ext_title_flag) &&
+                                (!(flags & MAP2_FLAG_NAME) || head->type != PLAYER ||
+                                 !CONTR(head)->cs->ext_title_flag) &&
                                 (!(flags2 & MAP2_FLAG2_TARGET) ||
                                  ((mp->is_friend & (1 << sub_layer)) != 0) == is_friend)) {
                                 continue;
@@ -1818,15 +1877,29 @@ void draw_client_map2(object *pl) {
                                 packet_append_uint8(packet_layer, quick_pos);
                             }
 
-                            /* Player name? Add the player's name, and their player
-                             * name color. */
+                            /* Add a visible living object's name and display color. */
                             if (flags & MAP2_FLAG_NAME) {
-                                packet_debug_data(packet_layer, 2, "Player name");
-                                packet_append_string_terminated(packet_layer,
-                                                                CONTR(tmp)->quick_name);
-                                packet_debug_data(packet_layer, 2, "Player name color");
-                                packet_append_string_terminated(packet_layer,
-                                                                get_playername_color(pl, tmp));
+                                const char *name_color;
+                                char *living_name = NULL;
+                                const char *name;
+
+                                if (head->type == PLAYER) {
+                                    name = CONTR(head)->quick_name;
+                                    name_color = get_playername_color(pl, head);
+                                } else {
+                                    living_name = object_get_short_name_s(head, pl);
+                                    name = living_name;
+                                    /* A stable color keeps cached map labels valid when
+                                     * the viewer levels up. The target UI separately
+                                     * communicates relative difficulty. */
+                                    name_color = COLOR_WHITE;
+                                }
+
+                                packet_debug_data(packet_layer, 2, "Living object name");
+                                packet_append_string_terminated(packet_layer, name);
+                                packet_debug_data(packet_layer, 2, "Living object name color");
+                                packet_append_string_terminated(packet_layer, name_color);
+                                free(living_name);
                             }
 
                             if (flags & MAP2_FLAG_ANIMATION) {
@@ -2054,7 +2127,12 @@ void draw_client_map2(object *pl) {
     packet_append_uint8(packet_header, level_count);
     packet_append_packet(packet_header, packet_levels);
     packet_free(packet_levels);
+    bool connected = CONTR(pl)->map_update_cmd == MAP_UPDATE_CMD_CONNECTED;
     socket_send_packet(CONTR(pl)->cs, packet_header);
+
+    if (connected) {
+        send_game_time(CONTR(pl));
+    }
 
     if (packet_sound->len >= 1) {
         socket_send_packet(CONTR(pl)->cs, packet_sound);
@@ -2381,27 +2459,7 @@ void send_target_command(player *pl) {
 
         packet_debug_data(packet, 0, "Color");
 
-        if (pl->target_object->level < level_color[pl->ob->level].yellow) {
-            if (pl->target_object->level < level_color[pl->ob->level].green) {
-                packet_append_string_terminated(packet, COLOR_GRAY);
-            } else {
-                if (pl->target_object->level < level_color[pl->ob->level].blue) {
-                    packet_append_string_terminated(packet, COLOR_GREEN);
-                } else {
-                    packet_append_string_terminated(packet, COLOR_BLUE);
-                }
-            }
-        } else {
-            if (pl->target_object->level >= level_color[pl->ob->level].purple) {
-                packet_append_string_terminated(packet, COLOR_PURPLE);
-            } else if (pl->target_object->level >= level_color[pl->ob->level].red) {
-                packet_append_string_terminated(packet, COLOR_RED);
-            } else if (pl->target_object->level >= level_color[pl->ob->level].orange) {
-                packet_append_string_terminated(packet, COLOR_ORANGE);
-            } else {
-                packet_append_string_terminated(packet, COLOR_YELLOW);
-            }
-        }
+        packet_append_string_terminated(packet, get_living_level_color(pl->ob, pl->target_object));
 
         packet_debug_data(packet, 0, "Target name");
 


### PR DESCRIPTION
## Base update

Rebased directly onto merged #170 (`bf5e99463`). The metaserver Worker implementation was intentionally moved to its separate repository; this PR contains no `metaserver/worker` files, Worker workflow, or related `.gitignore` changes.

The female audio assets referenced here were published and merged through atrinik/atrinik-sound#1.

## Summary

- add a resettable XP/hour widget based on positive character-XP deltas and monotonic elapsed time
- synchronize authoritative game time and time speed at login and periodically, then extrapolate a client time widget locally
- apply configured sound/music volume correctly during login and track changes
- map the generic player-hurt cue to the existing male sound or one of seven normalized professional female hurt takes
- include damage type names in incoming-hit messages
- render living creature names above their heads without requiring targeting

## Validation

- full warning-as-error Linux client/server build
- all 25 CTest targets, including QUIC network integration and Python plugin runtime
- every female vocal independently decoded with libvorbis and SDL_mixer 1.2
- five-second headless SDL startup reached the initialized client loop with no widget or settings parse errors
- targeted clang-tidy, repository formatting, and `git diff --check`
- audited the complete `master...HEAD` file list to confirm the separately owned Worker implementation is absent

The client currently has no headless widget/audio unit-test harness; the local deep-review artifact calls out focused runtime checks for saved layouts, reset interaction, mixer edge volumes, map transitions, multipart monster labels, mixed-damage attacks, and subjective vocal balance.

## Protocol

Advances the legacy socket protocol to carry absolute game time plus milliseconds per game minute. Client and server are updated together, and ADS-2 now documents the complete `MAPSTATS` record contract and compatibility constraint.
