### PR TITLE
feat(server): rebalance combat XP, traps, and status effects

### DIFF
--- a/arch/forces/depletion.arc
+++ b/arch/forces/depletion.arc
@@ -5,7 +5,7 @@ layer 3
 type 114
 no_drop 1
 msg
-Temporary depletion of stats; use the restoration spell or see a priest to remove this condition.
+Temporary depletion of stats; use the remove depletion spell or see a priest to remove this condition.
 endmsg
 glow ff0000
 glow_speed 7

--- a/server/src/include/object.h
+++ b/server/src/include/object.h
@@ -88,6 +88,24 @@ typedef struct key_value {
     struct key_value *next;
 } key_value_t;
 
+/** Damage dealt to a living object by one player's skill. */
+typedef struct combat_contribution {
+    /** Player responsible for the damage. */
+    struct obj *player;
+
+    /** Player tag used to reject stale object pointers. */
+    tag_t player_count;
+
+    /** Skill that dealt the damage. */
+    uint8_t skill_nr;
+
+    /** Actual, overkill-capped damage dealt. */
+    double damage;
+
+    /** Next contribution. */
+    struct combat_contribution *next;
+} combat_contribution_t;
+
 /**
  * Object structure.
  */
@@ -158,6 +176,9 @@ struct obj {
 
     /** Type-dependant extra data. */
     void *custom_attrset;
+
+    /** Per-player, per-skill damage participation for kill experience. */
+    combat_contribution_t *combat_contributions;
 
     /* These get an extra add_refcount(), after having been copied by memcpy().
      * All fields below this point are automatically copied by memcpy. If

--- a/server/src/include/proto.h
+++ b/server/src/include/proto.h
@@ -335,6 +335,7 @@ extern const char *const lose_msg[5];
 extern const char *const statname[5];
 extern const char *const short_stat_name[5];
 extern StringBuffer *depletion_get_tooltip(const object *depletion, StringBuffer *sb);
+extern object *depletion_get_or_create(object *op);
 extern void set_attr_value(living *stats, int attr, int8_t value);
 extern void change_attr_value(living *stats, int attr, int8_t value);
 extern int8_t get_attr_value(const living *stats, int attr);
@@ -505,7 +506,7 @@ extern object *SK_skill(object *op);
 extern skill_struct skills[NROFSKILLS];
 extern void find_traps(object *pl);
 extern void remove_trap(object *op);
-extern void traps_auto_disarm(object *pl, object *container);
+extern tag_t traps_auto_disarm(object *pl, object *container);
 /* src/server/spell_effect.c */
 extern void cast_magic_storm(object *op, object *tmp, int lvl);
 extern int recharge(object *op);

--- a/server/src/server/attack.c
+++ b/server/src/server/attack.c
@@ -56,6 +56,53 @@ const char *const attack_name[NROFATTACKS] = {
     "electricity", "poison",   "acid",   "magic",  "lifesteal",    "blind",     "paralyze",
     "force",       "godpower", "chaos",  "drain",  "slow",         "confusion", "internal"};
 
+/** Bound participation metadata retained by any one victim. */
+#define MAX_COMBAT_CONTRIBUTIONS 128
+
+/** Record actual damage participation for later skill-aware kill XP. */
+static void attack_record_combat_contribution(object *victim,
+                                              object *contributor,
+                                              object *skill,
+                                              double damage) {
+    if (victim->type == PLAYER || contributor->type != PLAYER || skill == NULL || damage <= 0.0 ||
+        !isfinite(damage) || skill->stats.sp < 0 || skill->stats.sp >= NROFSKILLS ||
+        CONTR(contributor)->skill_ptr[skill->stats.sp] == NULL) {
+        return;
+    }
+
+    size_t count = 0;
+    combat_contribution_t **link = &victim->combat_contributions;
+    while (*link != NULL) {
+        combat_contribution_t *entry = *link;
+        if (!OBJECT_VALID(entry->player, entry->player_count)) {
+            *link = entry->next;
+            free(entry);
+            continue;
+        }
+
+        if (entry->player == contributor && entry->player_count == contributor->count &&
+            entry->skill_nr == skill->stats.sp) {
+            entry->damage = DBL_MAX - entry->damage < damage ? DBL_MAX : entry->damage + damage;
+            return;
+        }
+
+        count++;
+        link = &entry->next;
+    }
+
+    if (count >= MAX_COMBAT_CONTRIBUTIONS) {
+        return;
+    }
+
+    combat_contribution_t *entry = xcalloc(1, sizeof(*entry));
+    entry->player = contributor;
+    entry->player_count = contributor->count;
+    entry->skill_nr = skill->stats.sp;
+    entry->damage = damage;
+    entry->next = victim->combat_contributions;
+    victim->combat_contributions = entry;
+}
+
 /**
  * Perform sanity checks to make sure the attacker can actually attack the
  * target.
@@ -828,6 +875,12 @@ int attack_hit(object *op, object *hitter, int dam) {
         maxdam = op->stats.hp;
     }
 
+    object *damage_skill = hitter->chosen_skill;
+    if (damage_skill == NULL) {
+        damage_skill = hitter_owner->chosen_skill;
+    }
+    attack_record_combat_contribution(op, hitter_owner, damage_skill, maxdam);
+
     /* Damage the target got */
     op->stats.hp -= maxdam;
 
@@ -912,18 +965,18 @@ void attack_hit_map(object *op, int dir, bool multi_reduce) {
  * Player. This should be the killer.
  * @param exp_gain
  * Experience to gain.
- * @param skill
- * Skill that was used to kill the monster.
+ * @param skill_nr
+ * Skill that receives the experience.
  */
-static inline void share_kill_exp_one(object *op, int64_t exp_gain, object *skill) {
+static void share_kill_exp_one(object *op, int64_t exp_gain, int skill_nr) {
     HARD_ASSERT(op != NULL);
-    HARD_ASSERT(skill != NULL);
 
-    if (exp_gain != 0) {
-        add_exp(op, exp_gain, skill->stats.sp, 0);
-    } else {
-        draw_info(COLOR_WHITE, op, "Your enemy wasn't worth any experience to you.");
+    if (exp_gain <= 0 || skill_nr < 0 || skill_nr >= NROFSKILLS ||
+        CONTR(op)->skill_ptr[skill_nr] == NULL) {
+        return;
     }
+
+    add_exp(op, exp_gain, skill_nr, 0);
 }
 
 /**
@@ -935,18 +988,20 @@ static inline void share_kill_exp_one(object *op, int64_t exp_gain, object *skil
  * Player that killed the monster.
  * @param exp_gain
  * Experience to share.
- * @param skill
- * Skill that was used to kill the monster.
+ * @param skill_nr
+ * Participating skill that receives the experience.
+ * @param preferred
+ * Participating player who receives indivisible remainder XP.
  */
-static void share_kill_exp(object *op, int64_t exp_gain, object *skill) {
+static void share_kill_exp(object *op, int64_t exp_gain, int skill_nr, object *preferred) {
     HARD_ASSERT(op != NULL);
-    HARD_ASSERT(skill != NULL);
+    HARD_ASSERT(preferred != NULL);
 
     int shares = 0, count = 0;
 
     /* No party, no sharing. */
     if (CONTR(op)->party == NULL) {
-        share_kill_exp_one(op, exp_gain, skill);
+        share_kill_exp_one(preferred, exp_gain, skill_nr);
         return;
     }
 
@@ -956,7 +1011,7 @@ static void share_kill_exp(object *op, int64_t exp_gain, object *skill) {
             continue;
         }
 
-        object *player_skill = CONTR(ol->objlink.ob)->skill_ptr[skill->stats.sp];
+        object *player_skill = CONTR(ol->objlink.ob)->skill_ptr[skill_nr];
         if (player_skill == NULL) {
             continue;
         }
@@ -966,26 +1021,111 @@ static void share_kill_exp(object *op, int64_t exp_gain, object *skill) {
     }
 
     if (count <= 1 || shares > exp_gain) {
-        share_kill_exp_one(op, exp_gain, skill);
-    } else {
-        int64_t share = exp_gain / shares;
-        int64_t given = 0;
-        for (objectlink *ol = party->members; ol != NULL; ol = ol->next) {
-            if (ol->objlink.ob == op || !on_same_map(ol->objlink.ob, op)) {
-                continue;
-            }
+        share_kill_exp_one(preferred, exp_gain, skill_nr);
+        return;
+    }
 
-            object *player_skill = CONTR(ol->objlink.ob)->skill_ptr[skill->stats.sp];
-            if (player_skill == NULL) {
-                continue;
-            }
-
-            given += add_exp(ol->objlink.ob, (player_skill->level + 4) * share, skill->stats.sp, 0);
+    int64_t share = exp_gain / shares;
+    int64_t given = 0;
+    for (objectlink *ol = party->members; ol != NULL; ol = ol->next) {
+        if (!on_same_map(ol->objlink.ob, op)) {
+            continue;
         }
 
-        exp_gain -= given;
-        share_kill_exp_one(op, exp_gain, skill);
+        object *player_skill = CONTR(ol->objlink.ob)->skill_ptr[skill_nr];
+        if (player_skill == NULL) {
+            continue;
+        }
+
+        given += add_exp(ol->objlink.ob, (player_skill->level + 4) * share, skill_nr, 0);
     }
+
+    share_kill_exp_one(preferred, MAX(0, exp_gain - given), skill_nr);
+}
+
+/** Whether a contributor belongs to the killer's XP-sharing group. */
+static bool kill_exp_group_member(object *killer, object *contributor) {
+    if (killer == contributor) {
+        return true;
+    }
+
+    return CONTR(killer)->party != NULL && CONTR(contributor)->party == CONTR(killer)->party &&
+           on_same_map(killer, contributor);
+}
+
+/** Award kill XP proportionally across every skill that dealt damage. */
+static int64_t award_kill_exp(object *killer, object *victim, object *fatal_skill) {
+    HARD_ASSERT(killer != NULL);
+    HARD_ASSERT(victim != NULL);
+    HARD_ASSERT(fatal_skill != NULL);
+
+    double skill_damage[NROFSKILLS] = {0};
+    double preferred_damage[NROFSKILLS] = {0};
+    object *preferred[NROFSKILLS] = {0};
+    double total_damage = 0.0;
+
+    for (combat_contribution_t *entry = victim->combat_contributions; entry != NULL;
+         entry = entry->next) {
+        if (!OBJECT_VALID(entry->player, entry->player_count) || entry->player->type != PLAYER ||
+            entry->skill_nr >= NROFSKILLS || !isfinite(entry->damage) || entry->damage <= 0.0 ||
+            CONTR(entry->player)->skill_ptr[entry->skill_nr] == NULL ||
+            !kill_exp_group_member(killer, entry->player)) {
+            continue;
+        }
+
+        skill_damage[entry->skill_nr] += entry->damage;
+        total_damage += entry->damage;
+        if (preferred[entry->skill_nr] == NULL ||
+            entry->damage > preferred_damage[entry->skill_nr]) {
+            preferred[entry->skill_nr] = entry->player;
+            preferred_damage[entry->skill_nr] = entry->damage;
+        }
+    }
+
+    if (total_damage <= 0.0 || !isfinite(total_damage)) {
+        int skill_nr = fatal_skill->stats.sp;
+        if (skill_nr < 0 || skill_nr >= NROFSKILLS || CONTR(killer)->skill_ptr[skill_nr] == NULL) {
+            return 0;
+        }
+
+        int64_t exp = calc_skill_exp(killer, victim, fatal_skill->level);
+        if (exp == 0) {
+            draw_info(COLOR_WHITE, killer, "Your enemy wasn't worth any experience to you.");
+            return 0;
+        }
+
+        share_kill_exp(killer, exp, skill_nr, killer);
+        return exp;
+    }
+
+    int64_t total_exp = 0;
+    for (int skill_nr = 0; skill_nr < NROFSKILLS; skill_nr++) {
+        if (preferred[skill_nr] == NULL || skill_damage[skill_nr] <= 0.0) {
+            continue;
+        }
+
+        object *skill = CONTR(preferred[skill_nr])->skill_ptr[skill_nr];
+        int64_t full_exp = calc_skill_exp(preferred[skill_nr], victim, skill->level);
+        long double weighted =
+            (long double)full_exp * (long double)skill_damage[skill_nr] / total_damage;
+        int64_t exp = (int64_t)(weighted + 0.5L);
+        if (exp <= 0) {
+            continue;
+        }
+
+        share_kill_exp(killer, exp, skill_nr, preferred[skill_nr]);
+        if (INT64_MAX - total_exp < exp) {
+            total_exp = INT64_MAX;
+        } else {
+            total_exp += exp;
+        }
+    }
+
+    if (total_exp == 0) {
+        draw_info(COLOR_WHITE, killer, "Your enemy wasn't worth any experience to you.");
+    }
+
+    return total_exp;
 }
 
 /**
@@ -1077,11 +1217,7 @@ bool attack_kill(object *op, object *hitter) {
         }
 
         if (skill != NULL) {
-            /* Calculate how much experience to gain. */
-            exp_gain = calc_skill_exp(owner, op, skill->level);
-            /* Give the experience, sharing it with party members if
-             * applicable. */
-            share_kill_exp(owner, exp_gain, skill);
+            exp_gain = award_kill_exp(owner, op, skill);
         }
     }
 

--- a/server/src/server/living.c
+++ b/server/src/server/living.c
@@ -250,6 +250,35 @@ StringBuffer *depletion_get_tooltip(const object *depletion, StringBuffer *sb) {
     return sb;
 }
 
+/** Find or create the applied depletion force for a living object. */
+object *depletion_get_or_create(object *op) {
+    HARD_ASSERT(op != NULL);
+
+    static archetype_t *at = NULL;
+    if (at == NULL) {
+        at = arch_find("depletion");
+        SOFT_ASSERT_RC(at != NULL, NULL, "Couldn't find archetype depletion");
+    }
+
+    object *depletion = object_find_arch(op, at);
+    if (depletion == NULL) {
+        depletion = arch_to_object(at);
+        /* The complete item packet emitted by insertion must already identify
+         * this as an active effect; a later partial update cannot create the
+         * missing active-effect icon. */
+        SET_FLAG(depletion, FLAG_APPLIED);
+        depletion = object_insert_into(depletion, op, 0);
+        SOFT_ASSERT_RC(depletion != NULL,
+                       NULL,
+                       "Failed to insert depletion into %s",
+                       object_get_str(op));
+    }
+
+    SET_FLAG(depletion, FLAG_APPLIED);
+
+    return depletion;
+}
+
 /**
  * Sets Str/Dex/con/Wis/Cha/Int/Pow in stats to value, depending on what
  * attr is (STR to POW).
@@ -382,25 +411,14 @@ void drain_stat(object *op) {
  * Statistic to drain.
  */
 void drain_specific_stat(object *op, int deplete_stats) {
-    object *tmp;
-    archetype_t *at = arch_find("depletion");
-
-    if (!at) {
-        LOG(BUG, "Couldn't find archetype depletion.");
+    object *tmp = depletion_get_or_create(op);
+    if (tmp == NULL) {
         return;
-    } else {
-        tmp = object_find_arch(op, at);
-
-        if (!tmp) {
-            tmp = arch_to_object(at);
-            tmp = object_insert_into(tmp, op, 0);
-            SET_FLAG(tmp, FLAG_APPLIED);
-        }
     }
 
     draw_info(COLOR_GRAY, op, drain_msg[deplete_stats]);
     change_attr_value(&tmp->stats, deplete_stats, -1);
-    esrv_update_item(UPD_EXTRA, tmp);
+    esrv_update_item(UPD_FLAGS | UPD_EXTRA, tmp);
     living_update_player(op);
 }
 

--- a/server/src/server/object.c
+++ b/server/src/server/object.c
@@ -1072,6 +1072,18 @@ object *object_owner(object *op) {
     return op->owner;
 }
 
+/** Free combat participation state that must not survive object reuse/copy. */
+static void object_combat_contributions_free(object *op) {
+    combat_contribution_t *contribution = op->combat_contributions;
+    while (contribution != NULL) {
+        combat_contribution_t *next = contribution->next;
+        free(contribution);
+        contribution = next;
+    }
+
+    op->combat_contributions = NULL;
+}
+
 /**
  * Copy object first frees everything allocated by the second object,
  * and then copies the contents of the first object into the second
@@ -1089,6 +1101,8 @@ void object_copy(object *op, const object *src, bool no_speed) {
     HARD_ASSERT(src != NULL);
 
     bool is_removed = QUERY_FLAG(op, FLAG_REMOVED);
+
+    object_combat_contributions_free(op);
 
     FREE_ONLY_HASH(op->name);
     FREE_ONLY_HASH(op->title);
@@ -1621,6 +1635,7 @@ void object_destroy(object *op) {
     }
 
     object_free_key_values(op);
+    object_combat_contributions_free(op);
 
     if (QUERY_FLAG(op, FLAG_IS_LINKED)) {
         connection_object_remove(op);

--- a/server/src/server/rune.c
+++ b/server/src/server/rune.c
@@ -52,14 +52,34 @@ static void trap_award_exp(object *pl, object *trap, int skill_nr) {
         return;
     }
 
-    int64_t exp = trap->stats.exp;
-    if (exp > INT64_MAX / trap->level) {
-        exp = INT64_MAX;
-    } else {
-        exp *= trap->level;
-    }
-
+    object *skill = CONTR(pl)->skill_ptr[skill_nr];
+    HARD_ASSERT(skill != NULL);
+    int64_t exp = calc_skill_exp(pl, trap, skill->level);
     add_exp(pl, exp, skill_nr, 0);
+}
+
+/** Stable per-player/per-trap roll, preventing command-spam rerolls. */
+static int trap_skill_roll(const object *pl, const object *trap, int skill_nr, uint64_t salt) {
+    uint64_t value = (uint64_t)pl->count * UINT64_C(0x9e3779b185ebca87) ^
+                     (uint64_t)trap->count * UINT64_C(0xc2b2ae3d27d4eb4f) ^
+                     (uint64_t)skill_nr * UINT64_C(0x165667b19e3779f9) ^ salt;
+    value ^= value >> 33;
+    value *= UINT64_C(0xff51afd7ed558ccd);
+    value ^= value >> 33;
+    value *= UINT64_C(0xc4ceb9fe1a85ec53);
+    value ^= value >> 33;
+    return (int)(value % 100) + 1;
+}
+
+/** Chance to find a still-hidden trap. */
+static int trap_find_chance(const object *trap, int rating) {
+    int difficulty = MAX(trap->level, trap->stats.Int);
+    return MAX(15, MIN(95, 70 + (rating - difficulty) * 4));
+}
+
+/** Chance to disarm a discovered trap without triggering failure handling. */
+static int trap_disarm_chance(const object *trap, int rating) {
+    return MAX(10, MIN(90, 65 + (rating - trap->level) * 5));
 }
 
 /**
@@ -74,10 +94,10 @@ static void trap_award_exp(object *pl, object *trap, int skill_nr) {
  * @retval 1 Trap was spotted.
  */
 int trap_see(object *op, object *trap, int level) {
-    /* Explicit searching is a capability check, not a rerollable lottery.
-     * This prevents repeated skill commands from being strictly better than
-     * one deliberate search while still leaving over-level traps hidden. */
-    if (trap->stats.Int == 1 || trap->level <= level) {
+    /* A stable roll makes individual traps uncertain without making repeated
+     * skill-command spam better than one deliberate attempt. */
+    if (trap->stats.Int == 1 || trap_skill_roll(op, trap, SK_FIND_TRAPS, UINT64_C(0x21f0aaad)) <=
+                                    trap_find_chance(trap, level)) {
         draw_info_format(COLOR_WHITE, op, "You spot a %s (lvl %d)!", trap->name, trap->level);
 
         if (trap->stats.Int != 1) {
@@ -144,15 +164,14 @@ int trap_show(object *trap, object *where) {
  * @param trap
  * Trap to disarm.
  * @return
- * 1 if trap was disarmed, 0 otherwise.
+ * One of @ref trap_disarm_result_t.
  */
 int trap_disarm(object *disarmer, object *trap) {
     object *env = trap->env;
     int disarmer_level = trap_skill_rating(disarmer, SK_REMOVE_TRAPS);
 
-    /* As with explicit detection, disarming is deterministic at a given
-     * capability. Repeating the same command cannot reroll a failure. */
-    if (trap->level <= disarmer_level) {
+    if (trap_skill_roll(disarmer, trap, SK_REMOVE_TRAPS, UINT64_C(0x8b8b8b8b)) <=
+        trap_disarm_chance(trap, disarmer_level)) {
         draw_info_format(COLOR_WHITE,
                          disarmer,
                          "You successfully remove the %s (lvl %d)!",
@@ -162,7 +181,7 @@ int trap_disarm(object *disarmer, object *trap) {
         set_trapped_flag(env);
         CONTR(disarmer)->stat_traps_disarmed++;
         trap_award_exp(disarmer, trap, SK_REMOVE_TRAPS);
-        return 1;
+        return TRAP_DISARM_SUCCESS;
     } else {
         draw_info_format(COLOR_WHITE,
                          disarmer,
@@ -170,14 +189,13 @@ int trap_disarm(object *disarmer, object *trap) {
                          trap->name,
                          trap->level);
 
-        if (trap->level > disarmer_level * 1.4f || rndm(0, 2)) {
-            if (!(rndm(0,
-                       (MAX(2, disarmer_level - trap->level + disarmer->stats.Dex / 2 - 6)) - 1))) {
-                draw_info(COLOR_WHITE, disarmer, "In fact, you set it off!");
-                rune_spring(trap, disarmer);
-            }
+        int trip_chance = MAX(50, MIN(90, 55 + (trap->level - disarmer_level) * 5));
+        if (trap_skill_roll(disarmer, trap, SK_REMOVE_TRAPS, UINT64_C(0xf00dcafe)) <= trip_chance) {
+            draw_info(COLOR_WHITE, disarmer, "In fact, you set it off!");
+            rune_spring(trap, disarmer);
+            return TRAP_DISARM_TRIPPED;
         }
 
-        return 0;
+        return TRAP_DISARM_FAILED;
     }
 }

--- a/server/src/server/skills.c
+++ b/server/src/server/skills.c
@@ -63,7 +63,8 @@ static trap_search_result find_traps_in_object(object *pl, object *where, int se
         if (trap_see(pl, trap, search_level)) {
             trap_show(trap, where);
             result = TRAP_SEARCH_FOUND;
-        } else if (result == TRAP_SEARCH_NONE && trap->level <= search_level * 1.8f) {
+        } else if (result == TRAP_SEARCH_NONE &&
+                   MAX(trap->level, trap->stats.Int) <= search_level * 1.8f) {
             result = TRAP_SEARCH_SIGNS;
         }
     }
@@ -80,7 +81,7 @@ static trap_search_result find_traps_in_object(object *pl, object *where, int se
  * @param where
  * Object whose inventory is checked.
  */
-static void remove_traps_from_object(object *pl, object *where) {
+static tag_t remove_traps_from_object(object *pl, object *where) {
     FOR_INV_PREPARE(where, trap) {
         if (trap->type != RUNE || trap->stats.Int > 1) {
             continue;
@@ -90,11 +91,14 @@ static void remove_traps_from_object(object *pl, object *where) {
             trap_show(trap, where);
         }
 
-        if (!trap_disarm(pl, trap)) {
-            return;
+        int result = trap_disarm(pl, trap);
+        if (result != TRAP_DISARM_SUCCESS) {
+            return result == TRAP_DISARM_TRIPPED ? trap->count : 0;
         }
     }
     FOR_INV_FINISH();
+
+    return 0;
 }
 
 /**
@@ -109,19 +113,21 @@ static void remove_traps_from_object(object *pl, object *where) {
  * @param container
  * Container about to be opened.
  */
-void traps_auto_disarm(object *pl, object *container) {
+tag_t traps_auto_disarm(object *pl, object *container) {
     HARD_ASSERT(pl != NULL);
     HARD_ASSERT(container != NULL);
 
     if (pl->type != PLAYER || CONTR(pl)->skill_ptr[SK_FIND_TRAPS] == NULL ||
         CONTR(pl)->skill_ptr[SK_REMOVE_TRAPS] == NULL) {
-        return;
+        return 0;
     }
 
     int search_level = trap_skill_rating(pl, SK_FIND_TRAPS);
     if (find_traps_in_object(pl, container, search_level) == TRAP_SEARCH_FOUND) {
-        remove_traps_from_object(pl, container);
+        return remove_traps_from_object(pl, container);
     }
+
+    return 0;
 }
 
 /**
@@ -167,7 +173,8 @@ void find_traps(object *pl) {
                 } else {
                     /* Give out a "we have found signs of traps"
                      * if the traps level is not 1.8 times higher. */
-                    if (suc == TRAP_SEARCH_NONE && tmp->level <= search_level * 1.8f) {
+                    if (suc == TRAP_SEARCH_NONE &&
+                        MAX(tmp->level, tmp->stats.Int) <= search_level * 1.8f) {
                         suc = TRAP_SEARCH_SIGNS;
                     }
                 }

--- a/server/src/tests/unit/server/attack.c
+++ b/server/src/tests/unit/server/attack.c
@@ -28,6 +28,7 @@
 #include <check_proto.h>
 #include <arch.h>
 #include <monster_data.h>
+#include <player.h>
 
 START_TEST(test_attack_is_melee_range) {
     mapstruct *map;
@@ -142,6 +143,66 @@ START_TEST(test_attack_roll_adjust_describes_positional_bonuses) {
 }
 END_TEST
 
+START_TEST(test_kill_experience_follows_damage_skill_participation) {
+    mapstruct *map;
+    object *pl, *monster;
+
+    check_setup_env_pl(&map, &pl);
+    monster = arch_get("goblin");
+    monster->x = pl->x + 1;
+    monster->y = pl->y;
+    monster->level = 1;
+    monster->stats.hp = 100;
+    monster->stats.maxhp = 100;
+    monster->stats.exp = 1000;
+    memset(monster->protection, 0, sizeof(monster->protection));
+    monster = object_insert_map(monster, map, NULL, 0);
+    monster_data_init(monster);
+    monster->enemy = pl;
+    monster->enemy_count = pl->count;
+
+    memset(pl->attack, 0, sizeof(pl->attack));
+    pl->attack[ATNR_IMPACT] = 100;
+    object *saved_chosen_skill = pl->chosen_skill;
+    object *saved_unarmed = CONTR(pl)->skill_ptr[SK_UNARMED];
+    object *saved_find_traps = CONTR(pl)->skill_ptr[SK_FIND_TRAPS];
+    object *unarmed = arch_get("skill_unarmed");
+    unarmed->stats.sp = SK_UNARMED;
+    object *other_skill = arch_get("skill_find_traps");
+    other_skill->stats.sp = SK_FIND_TRAPS;
+    CONTR(pl)->skill_ptr[SK_UNARMED] = unarmed;
+    CONTR(pl)->skill_ptr[SK_FIND_TRAPS] = other_skill;
+
+    int64_t unarmed_before = unarmed->stats.exp;
+    int64_t other_before = other_skill->stats.exp;
+    int64_t unarmed_full = calc_skill_exp(pl, monster, unarmed->level);
+    int64_t other_full = calc_skill_exp(pl, monster, other_skill->level);
+
+    pl->chosen_skill = unarmed;
+    int unarmed_damage = attack_hit(monster, pl, 25);
+    ck_assert_int_gt(unarmed_damage, 0);
+    ck_assert_int_gt(monster->stats.hp, 0);
+
+    pl->chosen_skill = other_skill;
+    int other_damage = attack_hit(monster, pl, 100);
+    ck_assert_int_gt(other_damage, unarmed_damage);
+
+    int total_damage = unarmed_damage + other_damage;
+    int64_t expected_unarmed =
+        (int64_t)((long double)unarmed_full * unarmed_damage / total_damage + 0.5L);
+    int64_t expected_other =
+        (int64_t)((long double)other_full * other_damage / total_damage + 0.5L);
+    ck_assert_int_eq(unarmed->stats.exp - unarmed_before, expected_unarmed);
+    ck_assert_int_eq(other_skill->stats.exp - other_before, expected_other);
+    ck_assert_int_gt(other_skill->stats.exp - other_before, unarmed->stats.exp - unarmed_before);
+    pl->chosen_skill = saved_chosen_skill;
+    CONTR(pl)->skill_ptr[SK_UNARMED] = saved_unarmed;
+    CONTR(pl)->skill_ptr[SK_FIND_TRAPS] = saved_find_traps;
+    object_destroy(unarmed);
+    object_destroy(other_skill);
+}
+END_TEST
+
 static Suite *suite(void) {
     Suite *s = suite_create("attack");
     TCase *tc_core = tcase_create("Core");
@@ -153,6 +214,7 @@ static Suite *suite(void) {
     tcase_add_test(tc_core, test_attack_is_melee_range);
     tcase_add_test(tc_core, test_attack_roll_adjust_describes_positional_bonuses);
     tcase_add_test(tc_core, test_attack_roll_adjust_describes_moved_target_penalty);
+    tcase_add_test(tc_core, test_kill_experience_follows_damage_skill_participation);
 
     return s;
 }

--- a/server/src/tests/unit/server/living.c
+++ b/server/src/tests/unit/server/living.c
@@ -7,6 +7,7 @@
 #include <checkstd.h>
 #include <check_proto.h>
 #include <arch.h>
+#include <disease.h>
 
 START_TEST(test_depletion_tooltip_lists_current_stats) {
     object *depletion = arch_get("depletion");
@@ -14,10 +15,59 @@ START_TEST(test_depletion_tooltip_lists_current_stats) {
     set_attr_value(&depletion->stats, 2, -3);
 
     char *tooltip = stringbuffer_finish(depletion_get_tooltip(depletion, NULL));
+    ck_assert_ptr_nonnull(strstr(tooltip, "use the remove depletion spell"));
+    ck_assert_ptr_null(strstr(tooltip, "restoration"));
+    ck_assert_ptr_nonnull(strstr(tooltip, "or see a priest"));
     ck_assert_ptr_nonnull(strstr(tooltip, "Currently depleted: strength (1), constitution (3)."));
 
     free(tooltip);
     object_destroy(depletion);
+}
+END_TEST
+
+START_TEST(test_depletion_force_is_applied_before_stat_updates) {
+    mapstruct *map;
+    object *pl;
+
+    check_setup_env_pl(&map, &pl);
+    drain_specific_stat(pl, 0);
+
+    object *depletion = object_find_arch(pl, arch_find("depletion"));
+    ck_assert_ptr_nonnull(depletion);
+    ck_assert(QUERY_FLAG(depletion, FLAG_APPLIED));
+    ck_assert_int_eq(get_attr_value(&depletion->stats, 0), -1);
+}
+END_TEST
+
+START_TEST(test_reduce_symptoms_ignores_non_progressive_symptoms) {
+    mapstruct *map;
+    object *pl;
+
+    check_setup_env_pl(&map, &pl);
+    object *symptom = arch_get("symptom");
+    symptom->value = 0;
+    symptom->speed_left = 7.0;
+    symptom = object_insert_into(symptom, pl, 0);
+
+    ck_assert(!disease_reduce_symptoms(pl, 5));
+    ck_assert_int_eq(symptom->value, 0);
+    ck_assert_double_eq(symptom->speed_left, 7.0);
+}
+END_TEST
+
+START_TEST(test_reduce_symptoms_reduces_and_reschedules_progressive_symptoms) {
+    mapstruct *map;
+    object *pl;
+
+    check_setup_env_pl(&map, &pl);
+    object *symptom = arch_get("symptom");
+    symptom->value = 30;
+    symptom->speed_left = 7.0;
+    symptom = object_insert_into(symptom, pl, 0);
+
+    ck_assert(disease_reduce_symptoms(pl, 5));
+    ck_assert_int_eq(symptom->value, 20);
+    ck_assert_double_eq(symptom->speed_left, 0.0);
 }
 END_TEST
 
@@ -29,6 +79,9 @@ static Suite *suite(void) {
     tcase_add_checked_fixture(tc_core, check_test_setup, check_test_teardown);
     suite_add_tcase(s, tc_core);
     tcase_add_test(tc_core, test_depletion_tooltip_lists_current_stats);
+    tcase_add_test(tc_core, test_depletion_force_is_applied_before_stat_updates);
+    tcase_add_test(tc_core, test_reduce_symptoms_ignores_non_progressive_symptoms);
+    tcase_add_test(tc_core, test_reduce_symptoms_reduces_and_reschedules_progressive_symptoms);
 
     return s;
 }

--- a/server/src/tests/unit/server/rune.c
+++ b/server/src/tests/unit/server/rune.c
@@ -10,6 +10,7 @@
 #include <object_methods.h>
 #include <player.h>
 #include <rune.h>
+#include <container.h>
 
 START_TEST(test_trap_skill_ratings_scale_with_character_skill_and_stat) {
     mapstruct *map;
@@ -89,28 +90,68 @@ START_TEST(test_trap_see_is_deterministic_at_capability_boundary) {
     trap->level = 10;
     trap = object_insert_map(trap, map, NULL, 0);
 
+    int result = trap_see(pl, trap, 9);
     for (int i = 0; i < 100; i++) {
-        ck_assert_int_eq(trap_see(pl, trap, 9), 0);
+        ck_assert_int_eq(trap_see(pl, trap, 9), result);
     }
-    ck_assert_int_eq(trap_see(pl, trap, 10), 1);
 }
 END_TEST
 
-START_TEST(test_trap_disarm_succeeds_once_with_sufficient_capability) {
+START_TEST(test_trap_find_can_succeed_or_fail_at_equal_rating) {
     mapstruct *map;
-    object *pl, *trap;
+    object *pl;
+    int successes = 0;
 
     check_setup_env_pl(&map, &pl);
-    pl->level = 10;
-    pl->stats.Dex = 10;
-    trap = arch_get("rune_fire");
-    trap->x = pl->x + 1;
-    trap->y = pl->y;
-    trap->level = 10;
-    trap = object_insert_map(trap, map, NULL, 0);
+    for (int i = 0; i < 1000; i++) {
+        object *trap = arch_get("rune_fire");
+        trap->level = 10;
+        trap->stats.Int = 10;
+        successes += trap_see(pl, trap, 10);
+        object_destroy(trap);
+    }
 
-    ck_assert_int_eq(trap_disarm(pl, trap), 1);
-    ck_assert(QUERY_FLAG(trap, FLAG_REMOVED));
+    ck_assert_int_gt(successes, 600);
+    ck_assert_int_lt(successes, 800);
+}
+END_TEST
+
+START_TEST(test_trap_disarm_always_retains_failure_and_trip_risk) {
+    mapstruct *map;
+    object *pl;
+    int successes = 0;
+    int tripped = 0;
+
+    check_setup_env_pl(&map, &pl);
+    pl->level = MAXLEVEL;
+    pl->stats.Dex = MAX_STAT;
+
+    for (int i = 0; i < 1000; i++) {
+        object *trap = arch_get("rune_fire");
+        trap->x = pl->x + 1;
+        trap->y = pl->y;
+        trap->level = 1;
+        trap->stats.Int = 1;
+        trap->stats.dam = 0;
+        trap = object_insert_map(trap, map, NULL, 0);
+
+        int result = trap_disarm(pl, trap);
+        if (result == TRAP_DISARM_SUCCESS) {
+            successes++;
+        } else if (result == TRAP_DISARM_TRIPPED) {
+            tripped++;
+        }
+
+        if (!QUERY_FLAG(trap, FLAG_REMOVED)) {
+            object_remove(trap, 0);
+        }
+        object_destroy(trap);
+    }
+
+    ck_assert_int_gt(successes, 850);
+    ck_assert_int_lt(successes, 950);
+    ck_assert_int_gt(tripped, 20);
+    ck_assert_int_lt(tripped, 90);
 }
 END_TEST
 
@@ -133,26 +174,58 @@ START_TEST(test_trap_successes_award_skill_and_character_experience_once) {
     int64_t find_exp = find_skill->stats.exp;
     int64_t remove_exp = remove_skill->stats.exp;
 
-    trap = arch_get("rune_fire");
-    trap->x = pl->x + 1;
-    trap->y = pl->y;
-    trap->level = 1;
-    trap->stats.Int = 20;
-    trap->stats.exp = 100;
-    trap = object_insert_map(trap, map, NULL, 0);
+    int64_t expected_find_gain = 0;
+    for (int i = 0; i < 100 && expected_find_gain == 0; i++) {
+        trap = arch_get("rune_fire");
+        trap->level = 1;
+        trap->stats.Int = 2;
+        trap->stats.exp = 100;
+        int64_t expected = calc_skill_exp(pl, trap, find_skill->level);
+        if (trap_see(pl, trap, trap_skill_rating(pl, SK_FIND_TRAPS))) {
+            expected_find_gain = expected;
+        } else {
+            object_destroy(trap);
+            trap = NULL;
+        }
+    }
 
-    ck_assert_int_eq(trap_see(pl, trap, trap_skill_rating(pl, SK_FIND_TRAPS)), 1);
+    ck_assert_ptr_nonnull(trap);
     int64_t find_gain = find_skill->stats.exp - find_exp;
-    ck_assert_int_gt(find_gain, 0);
+    ck_assert_int_eq(find_gain, expected_find_gain);
     ck_assert_int_eq(pl->stats.exp - character_exp, find_gain / 5);
 
     ck_assert_int_eq(trap_see(pl, trap, trap_skill_rating(pl, SK_FIND_TRAPS)), 1);
     ck_assert_int_eq(find_skill->stats.exp - find_exp, find_gain);
+    object_destroy(trap);
 
-    ck_assert_int_eq(trap_disarm(pl, trap), 1);
+    int64_t expected_remove_gain = 0;
+    trap = NULL;
+    for (int i = 0; i < 100 && expected_remove_gain == 0; i++) {
+        trap = arch_get("rune_fire");
+        trap->x = pl->x + 1;
+        trap->y = pl->y;
+        trap->level = 1;
+        trap->stats.Int = 1;
+        trap->stats.dam = 0;
+        trap->stats.exp = 100;
+        trap = object_insert_map(trap, map, NULL, 0);
+        int64_t expected = calc_skill_exp(pl, trap, remove_skill->level);
+        if (trap_disarm(pl, trap) == TRAP_DISARM_SUCCESS) {
+            expected_remove_gain = expected;
+        } else {
+            if (!QUERY_FLAG(trap, FLAG_REMOVED)) {
+                object_remove(trap, 0);
+            }
+            object_destroy(trap);
+            trap = NULL;
+        }
+    }
+
+    ck_assert_ptr_nonnull(trap);
     int64_t remove_gain = remove_skill->stats.exp - remove_exp;
-    ck_assert_int_gt(remove_gain, 0);
+    ck_assert_int_eq(remove_gain, expected_remove_gain);
     ck_assert_int_eq(pl->stats.exp - character_exp, find_gain / 5 + remove_gain / 5);
+    object_destroy(trap);
 
     link_player_skills(pl);
     ck_assert_int_eq(pl->stats.exp, find_skill->stats.exp / 5 + remove_skill->stats.exp / 5);
@@ -179,9 +252,49 @@ START_TEST(test_traps_auto_disarm_container) {
 
     object_apply(container, pl, 0);
 
-    ck_assert(QUERY_FLAG(trap, FLAG_REMOVED));
-    ck_assert_ptr_null(container->inv);
+    if (container->inv != NULL) {
+        ck_assert_int_ne(container->inv->type, RUNE);
+        ck_assert(QUERY_FLAG(container->inv, FLAG_IS_USED_UP));
+    }
     ck_assert_ptr_eq(CONTR(pl)->container, container);
+}
+END_TEST
+
+START_TEST(test_auto_disarm_trip_does_not_spring_reusable_trap_twice) {
+    mapstruct *map;
+    object *pl;
+    int remaining = 0;
+
+    check_setup_env_pl(&map, &pl);
+    pl->level = MAXLEVEL;
+
+    for (int i = 0; i < 250; i++) {
+        object *container = arch_get("sack");
+        container->x = pl->x + 1;
+        container->y = pl->y;
+        container = object_insert_map(container, map, NULL, 0);
+
+        object *trap = arch_get("rune_fire");
+        trap->level = 1;
+        trap->stats.Int = 1;
+        trap->stats.hp = 2;
+        trap->stats.dam = 0;
+        trap = object_insert_into(trap, container, 0);
+
+        object_apply(container, pl, 0);
+        if (container->inv != NULL) {
+            remaining++;
+            ck_assert_int_eq(container->inv->type, RUNE);
+            ck_assert_int_eq(container->inv->stats.hp, 1);
+            ck_assert(!QUERY_FLAG(container->inv, FLAG_IS_USED_UP));
+        }
+
+        container_close(pl, container);
+        object_remove(container, 0);
+        object_destroy(container);
+    }
+
+    ck_assert_int_gt(remaining, 5);
 }
 END_TEST
 
@@ -196,9 +309,11 @@ static Suite *suite(void) {
     tcase_add_test(tc_core, test_generated_trap_level_distribution);
     tcase_add_test(tc_core, test_generated_trap_inherits_monster_base_experience);
     tcase_add_test(tc_core, test_trap_see_is_deterministic_at_capability_boundary);
-    tcase_add_test(tc_core, test_trap_disarm_succeeds_once_with_sufficient_capability);
+    tcase_add_test(tc_core, test_trap_find_can_succeed_or_fail_at_equal_rating);
+    tcase_add_test(tc_core, test_trap_disarm_always_retains_failure_and_trip_risk);
     tcase_add_test(tc_core, test_trap_successes_award_skill_and_character_experience_once);
     tcase_add_test(tc_core, test_traps_auto_disarm_container);
+    tcase_add_test(tc_core, test_auto_disarm_trip_does_not_spring_reusable_trap_twice);
 
     return s;
 }

--- a/server/src/types/container.c
+++ b/server/src/types/container.c
@@ -101,7 +101,7 @@ static void container_open(object *applier, object *op) {
         CONTR(op->attacked_by)->container_below = applier;
     } else {
         /* Not open yet. */
-        traps_auto_disarm(applier, op);
+        tag_t tripped_trap = traps_auto_disarm(applier, op);
         SET_FLAG(op, FLAG_APPLIED);
 
         if (op->other_arch != NULL) {
@@ -116,7 +116,7 @@ static void container_open(object *applier, object *op) {
         object_update(op, UP_OBJ_FACE);
 
         FOR_INV_PREPARE(op, tmp) {
-            if (tmp->type == RUNE) {
+            if (tmp->type == RUNE && tmp->count != tripped_trap) {
                 rune_spring(tmp, applier);
             } else if (tmp->type == MONSTER) {
                 object_remove(tmp, 0);

--- a/server/src/types/disease.c
+++ b/server/src/types/disease.c
@@ -572,7 +572,10 @@ bool disease_reduce_symptoms(object *op, int reduction) {
 
     bool success = false;
     FOR_INV_PREPARE(op, tmp) {
-        if (tmp->type != SYMPTOM) {
+        /* Non-progressive symptoms (value == 0), such as warts, have no
+         * severity to reduce. Rescheduling them here makes healing trigger
+         * their damage immediately. */
+        if (tmp->type != SYMPTOM || tmp->value <= 0) {
             continue;
         }
 

--- a/server/src/types/include/rune.h
+++ b/server/src/types/include/rune.h
@@ -30,6 +30,13 @@
 #ifndef RUNE_H
 #define RUNE_H
 
+/** Outcomes from attempting to disarm a trap. */
+typedef enum trap_disarm_result {
+    TRAP_DISARM_TRIPPED = -1,
+    TRAP_DISARM_FAILED,
+    TRAP_DISARM_SUCCESS
+} trap_disarm_result_t;
+
 /* Prototypes */
 
 int trap_skill_rating(object *pl, int skill_nr);

--- a/server/src/types/player.c
+++ b/server/src/types/player.c
@@ -675,26 +675,23 @@ static void player_death_deplete_stats(object *op) {
     }
 
     object *depletion = NULL;
-    for (int i = 0; i < num_lose; i++) {
+    if (num_lose > 0) {
         static archetype_t *at = NULL;
         if (at == NULL) {
             at = arch_find("depletion");
             SOFT_ASSERT(at != NULL, "Could not find depletion archetype");
         }
 
-        if (depletion == NULL) {
+        if (at != NULL) {
             depletion = object_find_arch(op, at);
-            if (depletion == NULL) {
-                depletion = arch_to_object(at);
-                depletion = object_insert_into(depletion, op, 0);
-                SOFT_ASSERT(depletion != NULL, "Could not insert depletion");
-            }
         }
+    }
 
+    for (int i = 0; i < num_lose; i++) {
         int stat = rndm(0, NUM_STATS - 1);
         bool lose = true;
 
-        int8_t value = get_attr_value(&depletion->stats, stat);
+        int8_t value = depletion != NULL ? get_attr_value(&depletion->stats, stat) : 0;
         if (value < 0) {
             int loss_chance = 1 + op->level / BALSL_LOSS_CHANCE_RATIO;
             int keep_chance = value * value;
@@ -711,6 +708,13 @@ static void player_death_deplete_stats(object *op) {
             continue;
         }
 
+        if (depletion == NULL) {
+            depletion = depletion_get_or_create(op);
+            if (depletion == NULL) {
+                continue;
+            }
+        }
+
         change_attr_value(&depletion->stats, stat, -1);
         SET_FLAG(depletion, FLAG_APPLIED);
         lost_stat = true;
@@ -718,7 +722,7 @@ static void player_death_deplete_stats(object *op) {
     }
 
     if (lost_stat) {
-        esrv_update_item(UPD_EXTRA, depletion);
+        esrv_update_item(UPD_FLAGS | UPD_EXTRA, depletion);
         living_update_player(op);
     } else {
         draw_info(COLOR_WHITE,

--- a/server/src/types/rune.c
+++ b/server/src/types/rune.c
@@ -36,6 +36,9 @@
 #include <disease.h>
 #include <rune.h>
 
+/** Direct traps deliberately hit harder than an equivalent basic attack. */
+#define TRAP_DIRECT_DAMAGE_MULTIPLIER 1.5f
+
 /**
  * Calculate a player's effective rating for a trap skill.
  *
@@ -134,7 +137,8 @@ void rune_spring(object *op, object *victim) {
     /* Direct damage. */
     if (op->stats.sp == -1) {
         OBJECTS_DESTROYED_BEGIN(op, victim) {
-            int dam = op->stats.dam * (LEVEL_DAMAGE(op->level) * 0.925f);
+            int dam =
+                (int)(op->stats.dam * (LEVEL_DAMAGE(op->level) * TRAP_DIRECT_DAMAGE_MULTIPLIER));
             attack_hit(victim, op, dam);
 
             if (!OBJECTS_DESTROYED(victim)) {


### PR DESCRIPTION
## Base update

#170 and #171 are merged. This branch is rebased directly onto merged #171 (`66a3f0c53`), so the PR now contains only its gameplay/server changes. It contains no inherited #171 client/protocol files or metaserver Worker files; the Worker implementation is owned by its separate repository.

## Summary

- distribute kill XP across the skills that actually contributed damage, while preserving party sharing, anti-kill-steal boundaries, XP caps, and loot eligibility
- make trap finding/disarming probabilistic and anti-reroll, retain a meaningful trip risk, increase direct trap damage, prevent double-triggering reusable traps, and calculate trap XP like level-relative kill XP
- send depletion as applied in its first item update and refresh flags/tooltips immediately after death/stat drain
- recommend the implemented `remove depletion` spell in authored content
- ignore zero-value/non-progressive disease symptoms during symptom reduction

Closes #121.
Closes #144.

## Validation

- full warning-as-error Linux client/server build after realignment
- all 25 CTest targets, including QUIC network integration and Python plugin runtime
- focused attack, living, and rune regression suites
- narrow archetype collection confirming the corrected depletion tooltip
- targeted clang-tidy review, repository formatting, and `git diff --check`
- audited the complete `master...HEAD` file list to confirm the separately owned Worker implementation is absent

## Review attention

The branch includes bounded/tag-validated per-victim contribution state and deterministic per-player/trap probability hashing. Live balance attention should focus on mixed-skill boss fights, party members changing maps at death, corpse-heavy level 10-30 areas, high-skill disarmers, and reusable/multi-payload runes.
