### PR TITLE
fix(build): remove obsolete schema from client package

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -179,7 +179,10 @@ install(FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/COPYING
         ${CMAKE_CURRENT_SOURCE_DIR}/client.cfg
         DESTINATION ${INSTALL_SUBDIR_DOC})
-install(DIRECTORY textures cache data fonts gfx_user schemas settings sound srv_files DESTINATION ${INSTALL_SUBDIR_SHARE} PATTERN ".git" EXCLUDE)
+install(DIRECTORY
+        textures cache data fonts gfx_user settings sound srv_files
+        DESTINATION ${INSTALL_SUBDIR_SHARE}
+        PATTERN ".git" EXCLUDE)
 
 include(InstallRequiredSystemLibraries)
 


### PR DESCRIPTION
## Summary

- remove the deleted ADS-7 schema directory from the client CPack install inputs
- allow portable Windows client packaging to complete after the QUIC-only protocol cleanup

## Root cause

The QUIC-only change removed client/schemas/Atrinik-ADS-7.xsd, leaving the directory absent, but client/CMakeLists.txt still required schemas during installation. CPack therefore failed after the Windows executable built successfully.

## Validation

- Windows client package built with ghcr.io/atrinik/windows-build:0.0.3
- SDL_mixer import verification passed
- CPack generated atrinik-client-5.0.14-windows-x86_64.zip
- ZIP integrity check passed
- git diff --check passed