### PR TITLE
fix(ci): set repository for release publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,6 +176,9 @@ jobs:
 
       - name: Publish GitHub release
         env:
+          # This job intentionally has no checkout, so gh cannot infer the
+          # repository from local Git metadata.
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
         run: |


### PR DESCRIPTION
## Summary

- give the checkout-free Windows release publisher explicit GitHub repository context
- preserve the split build, validation, and publication jobs introduced by the release acceleration work
- leave job names, permissions, required checks, and central governance mappings unchanged

## Root cause

The Windows packages build and artifact upload succeeded for v5.0.16, but the later publisher job intentionally has no source checkout. GitHub CLI therefore could not infer a repository from local Git metadata and failed during gh release view with fatal: not a git repository.

Setting GH_REPO from github.repository lets every gh release command address atrinik/atrinik without adding an unnecessary checkout.

## Validation

- actionlint .github/workflows/release.yml
- git diff --check
- from /tmp outside any Git checkout, GH_REPO=atrinik/atrinik gh release view v5.0.14 succeeded
- confirmed atrinik/github-settings required-check mapping is unaffected