### PR TITLE
fix(client): align tile hit-testing with map projection

### DIFF
--- a/client/src/client/main.c
+++ b/client/src/client/main.c
@@ -43,9 +43,6 @@
 #include <cmake.h>
 #include <openssl/crypto.h>
 
-/** Y coordinate of the default arrow's click tip within its texture. */
-#define CURSOR_DEFAULT_HOTSPOT_Y 5
-
 /** The main screen surface. */
 SDL_Surface *ScreenSurface;
 /** Server's attributes */
@@ -861,23 +858,11 @@ int main(int argc, char *argv[]) {
 
         if (!setting_get_int(OPT_CAT_CLIENT, OPT_SYSTEM_CURSOR) && cursor_x != -1 &&
             cursor_y != -1 && SDL_GetAppState() & SDL_APPMOUSEFOCUS) {
-            SDL_Surface *cursor_surface = texture_surface(cursor_texture);
-            int hotspot_x = cursor_surface->w / 2;
-            int hotspot_y = cursor_surface->h / 2;
-
-            /* The default arrow is centered horizontally in its padded asset,
-             * but its actionable tip is near the top. Keep the rendered tip
-             * on SDL's actual mouse coordinate so map clicks match the tile
-             * indicated by the cursor. */
-            if (cursor_texture == texture_get(TEXTURE_TYPE_CLIENT, "cursor_default")) {
-                hotspot_y = CURSOR_DEFAULT_HOTSPOT_Y;
-            }
-
             surface_show(ScreenSurface,
-                         cursor_x - hotspot_x,
-                         cursor_y - hotspot_y,
+                         cursor_x - texture_surface(cursor_texture)->w / 2,
+                         cursor_y - texture_surface(cursor_texture)->h / 2,
                          NULL,
-                         cursor_surface);
+                         texture_surface(cursor_texture));
         }
         render_profiler_end(RENDER_PROFILE_OVERLAYS, profile_overlays_started);
 

--- a/client/src/gui/widgets/map.c
+++ b/client/src/gui/widgets/map.c
@@ -2829,7 +2829,7 @@ void map_draw_map(SDL_Surface *surface) {
  * What to draw.
  */
 void map_draw_one(int x, int y, SDL_Surface *surface) {
-    map_render_data_t data = {0};
+    map_render_data_t data = {.world_surface = true};
 
     map_setup_render_data(cur_widget[MAP_ID]->surface, &data, NULL, NULL, NULL, NULL);
 
@@ -3043,7 +3043,7 @@ void map_target_handle(uint8_t is_friend) {
  * True on success, false on failure.
  */
 bool mouse_to_tile_coords(int mx, int my, int *tx, int *ty) {
-    map_render_data_t data = {0};
+    map_render_data_t data = {.world_surface = true};
     int x, y, w, h;
     map_setup_render_data(cur_widget[MAP_ID]->surface, &data, &x, &y, &w, &h);
 


### PR DESCRIPTION
## Summary

- use the playable-world projection when resolving mouse coordinates to the
  48x24 isometric tile grid
- use that same projection when drawing the green selected-tile highlight
- remove the unrelated custom cursor hotspot workaround

## Root cause

The multi-level map renderer introduced an explicit `world_surface` render-data
flag. The main map painter and map animations set it, but mouse hit-testing and
`map_draw_one()` did not. Those paths therefore applied the non-world/minimap
projection offsets even though they operated on the playable map surface.

## Validation

- confirmed by live devcontainer playtesting
- warning-as-error client build
- `bash tools/clang-format.sh --check`
- focused `clang-tidy` with no changed-line diagnostics
- `git diff --check`

## Playtest coverage

- hover highlight and left-click path destination agree on the same tile
- targeting and movement use the tile under the pointer
- custom cursor rendering no longer compensates for map-coordinate errors
