### PR TITLE
fix(python): qualify NPC interface command constant

### DIFF
--- a/maps/python/Interface.py
+++ b/maps/python/Interface.py
@@ -335,7 +335,7 @@ class Interface:
         Closes any previously opened interface dialog.
         """
 
-        self._activator.Controller().SendPacket(CLIENT_CMD_INTERFACE, "", None)
+        self._activator.Controller().SendPacket(Atrinik.CLIENT_CMD_INTERFACE, "", None)
 
     def send(self):
         """
@@ -410,7 +410,7 @@ class Interface:
             data += [14] + obj_data
 
         # Send the data.
-        pl.SendPacket(CLIENT_CMD_INTERFACE, fmt, *data)
+        pl.SendPacket(Atrinik.CLIENT_CMD_INTERFACE, fmt, *data)
 
 
 IB_CHECKS_STATE1 = frozenset(["need_complete_before_start", "need_start",

--- a/maps/python/tests/Interface.py
+++ b/maps/python/tests/Interface.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 import Atrinik
 from tests import TestSuite, ib_wrapper
 from QuestManager import QuestManager
-from Interface import InterfaceBuilder
+from Interface import Interface, InterfaceBuilder
 
 
 class InterfaceBuilderSuite(TestSuite):
@@ -470,6 +470,19 @@ class InterfaceBuilderSuite(TestSuite):
         qm.complete("special")
         ib.finish(locals(), "hello")
         self.IB_test("InterfaceDialog_completed.dialog_hello")
+
+    def test_08_send_and_close(self):
+        packets = activator.Controller().s_packets
+        packets.clear()
+
+        interface = Interface(activator, self.npc)
+        interface.add_msg("Hello")
+        interface.send()
+        self.assertTrue(packets)
+
+        packets.clear()
+        interface.dialog_close()
+        self.assertTrue(packets)
 
 
 activator = Atrinik.WhoIsActivator()


### PR DESCRIPTION
## Summary

- qualify the interface packet command as `Atrinik.CLIENT_CMD_INTERFACE` in
  both dialog send and close paths
- add an embedded-plugin regression test that sends and closes a real interface
  packet

## Root cause

`Interface.py` imports the plugin with `import Atrinik`, but the previous fix
referenced `CLIENT_CMD_INTERFACE` as an unqualified global. Imported modules do
not inherit the wildcard-populated globals used for event scripts, so every NPC
dialog that reached `Interface.send()` raised `NameError` in packaged servers.

The plugin already exports the authoritative command constant; this change uses
that existing module attribute directly. No command ID or packet layout changes.

## Validation

- `python3 -m py_compile maps/python/Interface.py maps/python/tests/Interface.py`
- warning-as-error server and Python-plugin build
- isolated `server-plugin-python` runtime test, including the new send/close
  coverage
- `bash tools/clang-format.sh --check`
- `git diff --check`

## Windows packaging

The Windows server packaging workflow copies the authored `maps/` tree into its
content-addressed package root before collection, so the corrected module is
included directly in the portable ZIP.
