### PR TITLE
fix(protocol): synchronize gameplay information

### DIFF
--- a/client/src/client/commands.c
+++ b/client/src/client/commands.c
@@ -214,6 +214,7 @@ void socket_command_target(uint8_t *data, size_t len, size_t pos) {
     cpl.target_code = packet_to_uint8(data, len, &pos);
     packet_to_string(data, len, &pos, cpl.target_color, sizeof(cpl.target_color));
     packet_to_string(data, len, &pos, cpl.target_name, sizeof(cpl.target_name));
+    cpl.target_level = packet_to_uint8(data, len, &pos);
     cpl.combat = packet_to_uint8(data, len, &pos);
     cpl.combat_force = packet_to_uint8(data, len, &pos);
     WIDGET_REDRAW_ALL(TARGET_ID);

--- a/client/src/gui/widgets/target.c
+++ b/client/src/gui/widgets/target.c
@@ -148,8 +148,9 @@ static void widget_draw(widgetdata *widget) {
                          cpl.target_color,
                          TEXT_MARKUP | TEXT_VALIGN_CENTER,
                          &box,
-                         "%s\n[c=#%s]HP: %d%%[/c] %s",
+                         "%s (level %u)\n[c=#%s]HP: %d%%[/c] %s",
                          cpl.target_name,
+                         cpl.target_level,
                          hp_color,
                          hp,
                          str);

--- a/client/src/include/config.h
+++ b/client/src/include/config.h
@@ -31,7 +31,7 @@
 #define CONFIG_H
 
 /** Socket version. */
-#define SOCKET_VERSION 1070
+#define SOCKET_VERSION 1071
 
 /** File the the arch definitions. */
 #define ARCHDEF_FILE "data/archdef.dat"

--- a/client/src/include/player.h
+++ b/client/src/include/player.h
@@ -137,6 +137,9 @@ typedef struct Player_Struct {
     /** Target name. */
     char target_name[MAX_BUF];
 
+    /** Target level. */
+    uint8_t target_level;
+
     int warn_hp;
 
     /** Currently marked item. */

--- a/doc/ADS/ADS-2
+++ b/doc/ADS/ADS-2
@@ -939,6 +939,24 @@ ASSET:
  without partially applying an earlier block.
 
 ===============================================================================
+= 3.6. Client command TARGET                                                  =
+===============================================================================
+ This command replaces the client's active-target state. The packet contains
+ these fields in order:
+
+  - target_type (uint8): SELF (0), ENEMY (1), NEUTRAL (2), or FRIEND (3).
+  - color (string): display color in hexadecimal RRGGBB notation.
+  - name (string): the target's unadorned object name.
+  - level (uint8): the target's current level.
+  - combat (uint8): zero to hold attacks or one to attack valid targets.
+  - combat_force (uint8): zero to protect friendly targets or one to permit
+    attacking them.
+
+ TARGET includes level beginning with socket protocol version 1071. Clients
+ and servers using different versions MUST reject each other before gameplay
+ state is exchanged.
+
+===============================================================================
 = 3.4 and 3.7. Shared ITEM flag semantics                                     =
 ===============================================================================
  The ITEM command's item records and the ITEM_UPDATE command when its

--- a/server/src/commands/player/who.c
+++ b/server/src/commands/player/who.c
@@ -55,11 +55,11 @@ void command_who(object *op, const char *command, char *params) {
                  pl->ob->level);
 
         if (pl->afk) {
-            strncat(buf, " [AFK]", sizeof(buf) - strlen(buf) - 1);
+            snprintfcat(buf, sizeof(buf), " [AFK]");
         }
 
         if (pl->cs->is_bot) {
-            strncat(buf, " [BOT]", sizeof(buf) - strlen(buf) - 1);
+            snprintfcat(buf, sizeof(buf), " &lsqb;BOT&rsqb;");
         }
 
         if (show_connection) {

--- a/server/src/include/config.h
+++ b/server/src/include/config.h
@@ -176,7 +176,7 @@
 #define AUTOSAVE 5000
 
 /** Socket version. */
-#define SOCKET_VERSION 1070
+#define SOCKET_VERSION 1071
 
 /**
  * If 1, all data packets that are longer than @ref COMPRESS_DATA_PACKETS_SIZE

--- a/server/src/include/player.h
+++ b/server/src/include/player.h
@@ -465,6 +465,13 @@ struct pl_player {
      */
     uint32_t last_path_denied;
 
+    /** Wizardry level used for the last spell-cost update. */
+    int16_t last_spell_cost_level;
+
+    /** Target and viewer levels used for the last target update. */
+    int16_t last_target_level;
+    int16_t last_target_viewer_level;
+
     /**
      * Last sent UIDs of player's equipment.
      */

--- a/server/src/socket/request.c
+++ b/server/src/socket/request.c
@@ -332,6 +332,32 @@ void esrv_update_stats(player *pl) {
 
     packet_struct *packet = NULL;
 
+    int spell_cost_level = 0;
+    if (pl->skill_ptr[SK_WIZARDRY_SPELLS] != NULL) {
+        spell_cost_level = pl->skill_ptr[SK_WIZARDRY_SPELLS]->level;
+    }
+
+    if (pl->last_spell_cost_level != spell_cost_level) {
+        pl->last_spell_cost_level = spell_cost_level;
+
+        FOR_INV_PREPARE(pl->ob, tmp) {
+            if (tmp->type == SPELL) {
+                esrv_update_item(UPD_EXTRA, tmp);
+            }
+        }
+        FOR_INV_FINISH();
+    }
+
+    int target_level = pl->ob->level;
+    if (pl->target_object != NULL &&
+        (pl->target_object == pl->ob || OBJECT_VALID(pl->target_object, pl->target_object_count))) {
+        target_level = pl->target_object->level;
+    }
+
+    if (pl->last_target_level != target_level || pl->last_target_viewer_level != pl->ob->level) {
+        send_target_command(pl);
+    }
+
     if (pl->target_object && pl->target_object != pl->ob) {
         uint8_t hp =
             MAX(1,
@@ -2445,6 +2471,8 @@ void send_target_command(player *pl) {
         packet_append_string_terminated(packet, COLOR_YELLOW);
         packet_debug_data(packet, 0, "Target name");
         packet_append_string_terminated(packet, pl->ob->name);
+        packet_debug_data(packet, 0, "Target level");
+        packet_append_uint8(packet, pl->ob->level);
 
         pl->target_object = pl->ob;
         pl->target_object_count = 0;
@@ -2470,24 +2498,18 @@ void send_target_command(player *pl) {
 
         packet_debug_data(packet, 0, "Target name");
 
-        if (pl->tgm) {
-            char buf[MAX_BUF];
-
-            snprintf(buf,
-                     sizeof(buf),
-                     "%s (lvl %d)",
-                     pl->target_object->name,
-                     pl->target_object->level);
-            packet_append_string_terminated(packet, buf);
-        } else {
-            packet_append_string_terminated(packet, pl->target_object->name);
-        }
+        packet_append_string_terminated(packet, pl->target_object->name);
+        packet_debug_data(packet, 0, "Target level");
+        packet_append_uint8(packet, pl->target_object->level);
     }
 
     packet_debug_data(packet, 0, "Combat mode");
     packet_append_uint8(packet, pl->combat);
     packet_debug_data(packet, 0, "Combat force mode");
     packet_append_uint8(packet, pl->combat_force);
+
+    pl->last_target_level = pl->target_object->level;
+    pl->last_target_viewer_level = pl->ob->level;
 
     socket_send_packet(pl->cs, packet);
 }

--- a/server/src/tests/suites.cmake
+++ b/server/src/tests/suites.cmake
@@ -11,6 +11,7 @@ set(ATRINIK_SERVER_TEST_SUITES
     "server.light|check_server_light|src/tests/unit/server/light.c"
     "server.object|check_server_object|src/tests/unit/server/object.c"
     "server.re_cmp|check_server_re_cmp|src/tests/unit/server/re_cmp.c"
+    "server.request|check_server_request|src/tests/unit/server/request.c"
     "server.rune|check_server_rune|src/tests/unit/server/rune.c"
     "server.shop|check_server_shop|src/tests/unit/server/shop.c"
     "toolkit.math|check_server_math|src/tests/unit/toolkit/math.c"

--- a/server/src/tests/unit/server/request.c
+++ b/server/src/tests/unit/server/request.c
@@ -1,0 +1,125 @@
+/*************************************************************************
+ * Atrinik server presentation synchronization regression tests.
+ ************************************************************************/
+
+#include <global.h>
+#include <check.h>
+#include <checkstd.h>
+#include <check_proto.h>
+#include <toolkit/packet.h>
+#include <arch.h>
+#include <object.h>
+#include <player.h>
+
+static size_t queued_command_count(socket_struct *cs, uint8_t type) {
+    size_t count = 0;
+
+    for (packet_struct *packet = cs->packets; packet != NULL; packet = packet->next) {
+        if (packet->type == type) {
+            count++;
+        }
+    }
+
+    return count;
+}
+
+START_TEST(test_target_packet_includes_current_level_and_plain_name) {
+    mapstruct *map;
+    object *pl;
+
+    check_setup_env_pl(&map, &pl);
+    pl->level = 42;
+    CONTR(pl)->tgm = 1;
+    socket_buffer_clear(CONTR(pl)->cs);
+
+    send_target_command(CONTR(pl));
+
+    packet_struct *packet = CONTR(pl)->cs->packets;
+    while (packet != NULL && packet->type != CLIENT_CMD_TARGET) {
+        packet = packet->next;
+    }
+    ck_assert_ptr_nonnull(packet);
+
+    size_t pos = 0;
+    char color[MAX_BUF];
+    char name[MAX_BUF];
+    ck_assert_uint_eq(packet_to_uint8(packet->data, packet->len, &pos), CMD_TARGET_SELF);
+    packet_to_string(packet->data, packet->len, &pos, VS(color));
+    packet_to_string(packet->data, packet->len, &pos, VS(name));
+    ck_assert_str_eq(name, pl->name);
+    ck_assert_uint_eq(packet_to_uint8(packet->data, packet->len, &pos), 42);
+    ck_assert_uint_eq(packet_to_uint8(packet->data, packet->len, &pos), CONTR(pl)->combat);
+    ck_assert_uint_eq(packet_to_uint8(packet->data, packet->len, &pos), CONTR(pl)->combat_force);
+    ck_assert_uint_eq(pos, packet->len);
+}
+END_TEST
+
+START_TEST(test_wizardry_level_change_refreshes_spell_cost_once) {
+    mapstruct *map;
+    object *pl;
+
+    check_setup_env_pl(&map, &pl);
+    object *spell = object_insert_into(arch_get("spell_frostbolt"), pl, 0);
+    ck_assert_ptr_nonnull(spell);
+    ck_assert_int_eq(spell->type, SPELL);
+
+    CONTR(pl)->last_spell_cost_level = CONTR(pl)->skill_ptr[SK_WIZARDRY_SPELLS]->level;
+    socket_buffer_clear(CONTR(pl)->cs);
+    CONTR(pl)->skill_ptr[SK_WIZARDRY_SPELLS]->level++;
+
+    esrv_update_stats(CONTR(pl));
+    ck_assert_uint_eq(queued_command_count(CONTR(pl)->cs, CLIENT_CMD_ITEM_UPDATE), 1);
+
+    socket_buffer_clear(CONTR(pl)->cs);
+    esrv_update_stats(CONTR(pl));
+    ck_assert_uint_eq(queued_command_count(CONTR(pl)->cs, CLIENT_CMD_ITEM_UPDATE), 0);
+}
+END_TEST
+
+START_TEST(test_who_escapes_bot_marker_for_client_markup) {
+    mapstruct *map;
+    object *pl;
+
+    check_setup_env_pl(&map, &pl);
+    CONTR(pl)->cs->is_bot = 1;
+    socket_buffer_clear(CONTR(pl)->cs);
+
+    command_who(pl, "who", NULL);
+
+    bool found_marker = false;
+    for (packet_struct *packet = CONTR(pl)->cs->packets; packet != NULL; packet = packet->next) {
+        if (packet->type != CLIENT_CMD_DRAWINFO) {
+            continue;
+        }
+
+        size_t pos = 0;
+        char color[MAX_BUF];
+        char message[MAX_BUF];
+        packet_to_uint8(packet->data, packet->len, &pos);
+        packet_to_string(packet->data, packet->len, &pos, VS(color));
+        packet_to_string(packet->data, packet->len, &pos, VS(message));
+        ck_assert_ptr_null(strstr(message, " [BOT]"));
+        found_marker |= strstr(message, " &lsqb;BOT&rsqb;") != NULL;
+    }
+
+    ck_assert(found_marker);
+}
+END_TEST
+
+static Suite *suite(void) {
+    Suite *s = suite_create("request");
+    TCase *tc_core = tcase_create("Core");
+
+    tcase_add_unchecked_fixture(tc_core, check_setup, check_teardown);
+    tcase_add_checked_fixture(tc_core, check_test_setup, check_test_teardown);
+    suite_add_tcase(s, tc_core);
+    tcase_add_test(tc_core, test_target_packet_includes_current_level_and_plain_name);
+    tcase_add_test(tc_core, test_wizardry_level_change_refreshes_spell_cost_once);
+    tcase_add_test(tc_core, test_who_escapes_bot_marker_for_client_markup);
+
+    return s;
+}
+
+void check_server_request(void) {
+    check_run_suite(suite(), __FILE__);
+}

--- a/server/src/types/player.c
+++ b/server/src/types/player.c
@@ -196,6 +196,9 @@ static player *get_player(player *p) {
     p->target_hp = -1;
     p->gen_sp_armour = 0;
     p->last_speed = -1;
+    p->last_spell_cost_level = -1;
+    p->last_target_level = -1;
+    p->last_target_viewer_level = -1;
     p->update_los = 1;
 
     p->last_stats.exp = -1;


### PR DESCRIPTION
## Summary

- carry target level as an explicit TARGET field and show it for every active target
- refresh target level/color when either the target or viewer levels without retargeting
- escape the bot marker emitted by `/who` so the client renders `[BOT]` literally
- refresh serialized spell costs whenever the player's wizardry level changes
- document and gate the TARGET layout as socket protocol 1071

## Review findings addressed

- removed TGM-only level decoration from target identity
- added current-level cache invalidation for target state
- replaced duplicated `strncat` capacity arithmetic with `snprintfcat`
- added a dedicated request regression suite for TARGET layout, bot markup, and spell refresh frequency

## Validation

- `./build.sh atrinik`
- `./build.sh atrinik-server`
- `./build.sh check` (25/25 passed)
- `bash tools/clang-format.sh --check`
- `git diff --check`
- targeted clang-tidy; no diagnostics attributable to changed logic

The sandboxed targeted test initially hit the repository's documented loopback-socket restriction; the unchanged targeted test and full suite passed in the approved host context.

## Breaking impact

TARGET adds a `uint8` level field after the name. Client and server both advance to socket protocol 1071 and reject mismatched peers before gameplay state.
