### PR TITLE
feat(server): improve corpse trap lifecycle

### DIFF
--- a/server/src/include/proto.h
+++ b/server/src/include/proto.h
@@ -506,6 +506,7 @@ extern object *SK_skill(object *op);
 extern skill_struct skills[NROFSKILLS];
 extern void find_traps(object *pl);
 extern void remove_trap(object *op);
+extern bool traps_detect_in_container(object *pl, object *container);
 extern tag_t traps_auto_disarm(object *pl, object *container);
 /* src/server/spell_effect.c */
 extern void cast_magic_storm(object *op, object *tmp, int lvl);

--- a/server/src/server/item.c
+++ b/server/src/server/item.c
@@ -172,6 +172,10 @@ StringBuffer *object_get_title(const object *op, const object *caller, StringBuf
                 }
             }
 
+            if (QUERY_FLAG(op, FLAG_IS_TRAPPED)) {
+                stringbuffer_append_string(sb, " (trapped)");
+            }
+
             break;
 
         case SCROLL:
@@ -1335,13 +1339,13 @@ void set_trapped_flag(object *op) {
         /* Must be a rune AND visible */
         if (tmp->type == RUNE && tmp->stats.Int <= 1) {
             SET_FLAG(op, FLAG_IS_TRAPPED);
-            return;
+            break;
         }
     }
 
     if (QUERY_FLAG(op, FLAG_IS_TRAPPED) != flag) {
         if (op->env) {
-            esrv_update_item(UPD_FLAGS, op);
+            esrv_update_item(UPD_FLAGS | UPD_NAME, op);
         } else {
             object_update(op, UP_OBJ_FACE);
         }

--- a/server/src/server/skills.c
+++ b/server/src/server/skills.c
@@ -102,6 +102,28 @@ static tag_t remove_traps_from_object(object *pl, object *where) {
 }
 
 /**
+ * Search a container for a trap without disarming it.
+ *
+ * @param pl
+ * Player searching the container.
+ * @param container
+ * Container to search.
+ * @return
+ * True if at least one trap was discovered.
+ */
+bool traps_detect_in_container(object *pl, object *container) {
+    HARD_ASSERT(pl != NULL);
+    HARD_ASSERT(container != NULL);
+
+    if (pl->type != PLAYER || CONTR(pl)->skill_ptr[SK_FIND_TRAPS] == NULL) {
+        return false;
+    }
+
+    return find_traps_in_object(pl, container, trap_skill_rating(pl, SK_FIND_TRAPS)) ==
+           TRAP_SEARCH_FOUND;
+}
+
+/**
  * Automatically search for and disarm traps before a player opens a container.
  *
  * The attempt is made only when the player knows both required skills. Failed
@@ -122,8 +144,11 @@ tag_t traps_auto_disarm(object *pl, object *container) {
         return 0;
     }
 
-    int search_level = trap_skill_rating(pl, SK_FIND_TRAPS);
-    if (find_traps_in_object(pl, container, search_level) == TRAP_SEARCH_FOUND) {
+    if (QUERY_FLAG(container, FLAG_IS_TRAPPED)) {
+        return remove_traps_from_object(pl, container);
+    }
+
+    if (traps_detect_in_container(pl, container)) {
         return remove_traps_from_object(pl, container);
     }
 

--- a/server/src/tests/suites.cmake
+++ b/server/src/tests/suites.cmake
@@ -21,5 +21,6 @@ set(ATRINIK_SERVER_TEST_SUITES
     "toolkit.socket_asset|check_server_socket_asset|src/tests/unit/toolkit/socket_asset.c"
     "toolkit.string|check_server_string|src/tests/unit/toolkit/string.c"
     "toolkit.stringbuffer|check_server_stringbuffer|src/tests/unit/toolkit/stringbuffer.c"
+    "types.container|check_types_container|src/tests/unit/types/container.c"
     "types.light_apply|check_types_light_apply|src/tests/unit/types/light_apply.c"
     "types.sound_ambient|check_types_sound_ambient|src/tests/unit/types/sound_ambient.c")

--- a/server/src/tests/unit/server/rune.c
+++ b/server/src/tests/unit/server/rune.c
@@ -260,6 +260,40 @@ START_TEST(test_traps_auto_disarm_container) {
 }
 END_TEST
 
+START_TEST(test_corpse_trap_discovery_cancels_first_open) {
+    mapstruct *map;
+    object *pl, *corpse, *trap;
+
+    check_setup_env_pl(&map, &pl);
+    corpse = arch_get("corpse_default");
+    corpse->x = pl->x + 1;
+    corpse->y = pl->y;
+    corpse = object_insert_map(corpse, map, NULL, 0);
+
+    trap = arch_get("rune_fire");
+    trap->level = 1;
+    trap->stats.Int = 1;
+    trap->stats.dam = 0;
+    object_insert_into(trap, corpse, 0);
+
+    object_apply(corpse, pl, 0);
+
+    ck_assert_ptr_null(CONTR(pl)->container);
+    ck_assert(!QUERY_FLAG(corpse, FLAG_APPLIED));
+    ck_assert(!QUERY_FLAG(corpse, FLAG_BEEN_APPLIED));
+    ck_assert(QUERY_FLAG(corpse, FLAG_IS_TRAPPED));
+    char *name = object_get_base_name_s(corpse, pl);
+    ck_assert_ptr_nonnull(strstr(name, "(trapped)"));
+    free(name);
+
+    object_apply(corpse, pl, 0);
+
+    ck_assert_ptr_eq(CONTR(pl)->container, corpse);
+    ck_assert(QUERY_FLAG(corpse, FLAG_APPLIED));
+    ck_assert(QUERY_FLAG(corpse, FLAG_BEEN_APPLIED));
+}
+END_TEST
+
 START_TEST(test_auto_disarm_trip_does_not_spring_reusable_trap_twice) {
     mapstruct *map;
     object *pl;
@@ -313,6 +347,7 @@ static Suite *suite(void) {
     tcase_add_test(tc_core, test_trap_disarm_always_retains_failure_and_trip_risk);
     tcase_add_test(tc_core, test_trap_successes_award_skill_and_character_experience_once);
     tcase_add_test(tc_core, test_traps_auto_disarm_container);
+    tcase_add_test(tc_core, test_corpse_trap_discovery_cancels_first_open);
     tcase_add_test(tc_core, test_auto_disarm_trip_does_not_spring_reusable_trap_twice);
 
     return s;

--- a/server/src/tests/unit/types/container.c
+++ b/server/src/tests/unit/types/container.c
@@ -1,0 +1,100 @@
+/*************************************************************************
+ * Atrinik server corpse lifecycle regression tests.
+ ************************************************************************/
+
+#include <global.h>
+#include <check.h>
+#include <checkstd.h>
+#include <check_proto.h>
+#include <arch.h>
+#include <container.h>
+#include <object.h>
+
+START_TEST(test_corpse_decay_windows_shorten_with_search_and_empty_state) {
+    object *corpse = arch_get("corpse_default");
+    ck_assert(container_is_corpse(corpse));
+
+    corpse->last_eat = corpse->stats.food;
+    container_update_corpse_decay(corpse);
+    ck_assert_int_eq(corpse->stats.food, CORPSE_DECAY_FRESH);
+    ck_assert_int_eq(corpse->last_eat, CORPSE_DECAY_FRESH);
+
+    object *loot = object_insert_into(arch_get("ambercoin"), corpse, 0);
+    SET_FLAG(corpse, FLAG_BEEN_APPLIED);
+    container_update_corpse_decay(corpse);
+    ck_assert_int_eq(corpse->stats.food, CORPSE_DECAY_SEARCHED);
+    ck_assert_int_eq(corpse->last_eat, CORPSE_DECAY_SEARCHED);
+
+    object_remove(loot, 0);
+    object_destroy(loot);
+    container_update_corpse_decay(corpse);
+    ck_assert_int_eq(corpse->stats.food, CORPSE_DECAY_EMPTY);
+    ck_assert_int_eq(corpse->last_eat, CORPSE_DECAY_EMPTY);
+
+    object_destroy(corpse);
+}
+END_TEST
+
+START_TEST(test_empty_personalized_corpse_skips_unlock_decay_phase) {
+    mapstruct *map;
+    object *pl;
+
+    check_setup_env_pl(&map, &pl);
+    object *corpse = arch_get("corpse_default");
+    corpse->x = pl->x + 1;
+    corpse->y = pl->y;
+    corpse->sub_type = ST1_CONTAINER_CORPSE_player;
+    FREE_AND_ADD_REF_HASH(corpse->slaying, pl->name);
+    SET_FLAG(corpse, FLAG_BEEN_APPLIED);
+    corpse->stats.food = 1;
+    corpse->last_eat = 1;
+    corpse = object_insert_map(corpse, map, NULL, 0);
+    tag_t tag = corpse->count;
+
+    ck_assert_int_eq(common_object_process_pre(corpse), 1);
+    ck_assert(OBJECT_DESTROYED(corpse, tag));
+}
+END_TEST
+
+START_TEST(test_searched_corpse_with_loot_retains_unlock_phase) {
+    mapstruct *map;
+    object *pl;
+
+    check_setup_env_pl(&map, &pl);
+    object *corpse = arch_get("corpse_default");
+    corpse->x = pl->x + 1;
+    corpse->y = pl->y;
+    corpse->sub_type = ST1_CONTAINER_CORPSE_player;
+    FREE_AND_ADD_REF_HASH(corpse->slaying, pl->name);
+    SET_FLAG(corpse, FLAG_BEEN_APPLIED);
+    corpse->stats.food = 1;
+    corpse->last_eat = 1;
+    object_insert_into(arch_get("ambercoin"), corpse, 0);
+    corpse = object_insert_map(corpse, map, NULL, 0);
+    tag_t tag = corpse->count;
+
+    ck_assert_int_eq(common_object_process_pre(corpse), 1);
+    ck_assert(!OBJECT_DESTROYED(corpse, tag));
+    ck_assert_ptr_null(corpse->slaying);
+    ck_assert_int_eq(corpse->stats.food, CORPSE_DECAY_SEARCHED);
+    ck_assert_int_eq(corpse->last_eat, CORPSE_DECAY_SEARCHED);
+}
+END_TEST
+
+static Suite *suite(void) {
+    Suite *s = suite_create("container");
+    TCase *tc_core = tcase_create("Core");
+
+    tcase_add_unchecked_fixture(tc_core, check_setup, check_teardown);
+    tcase_add_checked_fixture(tc_core, check_test_setup, check_test_teardown);
+    suite_add_tcase(s, tc_core);
+    tcase_add_test(tc_core, test_corpse_decay_windows_shorten_with_search_and_empty_state);
+    tcase_add_test(tc_core, test_empty_personalized_corpse_skips_unlock_decay_phase);
+    tcase_add_test(tc_core, test_searched_corpse_with_loot_retains_unlock_phase);
+
+    return s;
+}
+
+void check_types_container(void) {
+    check_run_suite(suite(), __FILE__);
+}

--- a/server/src/types/common/process.c
+++ b/server/src/types/common/process.c
@@ -31,6 +31,7 @@
 
 #include <global.h>
 #include <arch.h>
+#include <container.h>
 
 /**
  * Process a changing object.
@@ -125,9 +126,13 @@ int common_object_process_pre(object *op) {
         return 1;
     }
 
+    if (QUERY_FLAG(op, FLAG_IS_USED_UP)) {
+        container_update_corpse_decay(op);
+    }
+
     if (QUERY_FLAG(op, FLAG_IS_USED_UP) && --op->stats.food <= 0) {
         /* Handle corpses specially. */
-        if (op->type == CONTAINER && op->sub_type == ST1_CONTAINER_CORPSE) {
+        if (container_is_corpse(op)) {
             /* If the corpse is currently open by someone, delay the
              * corpse removal for a bit longer. */
             if (op->attacked_by) {
@@ -136,16 +141,17 @@ int common_object_process_pre(object *op) {
                 return 1;
             }
 
-            /* If the corpse was locked, remove the lock, making it
-             * available available for all players, and reset the decay
-             * counter. */
-            if (op->slaying || op->stats.maxhp) {
+            /* If the corpse was locked, remove the lock, making it available
+             * for all players, and reset the decay counter. */
+            if (op->inv != NULL && (op->slaying || op->stats.maxhp)) {
                 if (op->slaying) {
                     FREE_AND_CLEAR_HASH2(op->slaying);
                 }
 
                 op->stats.maxhp = 0;
                 op->stats.food = op->arch->clone.stats.food;
+                op->last_eat = op->stats.food;
+                container_update_corpse_decay(op);
                 return 1;
             }
         }

--- a/server/src/types/container.c
+++ b/server/src/types/container.c
@@ -59,6 +59,48 @@ bool container_check_magical(object *op, object *container) {
 }
 
 /**
+ * Check whether an object is any kind of monster corpse container.
+ *
+ * Corpse ownership is encoded in the high bits of the subtype, so all three
+ * current variants must participate in the same lifecycle handling.
+ *
+ * @param op
+ * Object to inspect.
+ * @return
+ * True if the object is a monster corpse container.
+ */
+bool container_is_corpse(const object *op) {
+    return op != NULL && op->type == CONTAINER &&
+           (op->sub_type == ST1_CONTAINER_CORPSE || op->sub_type == ST1_CONTAINER_CORPSE_player ||
+            op->sub_type == ST1_CONTAINER_CORPSE_party);
+}
+
+/**
+ * Shorten a corpse's remaining decay window according to its state.
+ *
+ * This function only caps an existing timer; it never extends a corpse's
+ * lifetime.
+ *
+ * @param op
+ * Object whose decay timer should be updated.
+ */
+void container_update_corpse_decay(object *op) {
+    if (!container_is_corpse(op) || !QUERY_FLAG(op, FLAG_IS_USED_UP)) {
+        return;
+    }
+
+    int16_t limit = CORPSE_DECAY_FRESH;
+    if (QUERY_FLAG(op, FLAG_BEEN_APPLIED)) {
+        limit = op->inv != NULL ? CORPSE_DECAY_SEARCHED : CORPSE_DECAY_EMPTY;
+    }
+
+    op->stats.food = MIN(op->stats.food, limit);
+    if (op->last_eat <= 0 || op->last_eat > limit) {
+        op->last_eat = limit;
+    }
+}
+
+/**
  * Actually open a container, springing traps/monsters, and doing the
  * linked list linking.
  *
@@ -66,19 +108,32 @@ bool container_check_magical(object *op, object *container) {
  * Player that is opening the container.
  * @param op
  * The container.
+ * @return
+ * True if the container was opened, false if opening was canceled.
  */
-static void container_open(object *applier, object *op) {
+static bool container_open(object *applier, object *op) {
     HARD_ASSERT(applier != NULL);
     HARD_ASSERT(op != NULL);
 
     /* Safety. */
     if (applier->type != PLAYER) {
-        return;
+        return false;
     }
 
     /* Safety. */
     if (op->attacked_by && op->attacked_by->type != PLAYER) {
         op->attacked_by = NULL;
+    }
+
+    if (op->attacked_by == NULL && container_is_corpse(op) && !QUERY_FLAG(op, FLAG_IS_TRAPPED) &&
+        traps_detect_in_container(applier, op)) {
+        char *name = object_get_base_name_s(op, applier);
+        draw_info_format(COLOR_WHITE,
+                         applier,
+                         "You stop before opening %s. Apply it again to try to disarm the trap.",
+                         name);
+        free(name);
+        return false;
     }
 
     /* Check for quest containers. */
@@ -151,6 +206,7 @@ static void container_open(object *applier, object *op) {
     pl->container_below = NULL;
     op->attacked_by = applier;
     op->attacked_by_count = applier->count;
+    return true;
 }
 
 /**
@@ -357,8 +413,12 @@ static int apply_func(object *op, object *applier, int aflags) {
             return OBJECT_METHOD_OK;
         }
 
+        if (!container_open(applier, op)) {
+            free(name);
+            return OBJECT_METHOD_OK;
+        }
+
         draw_info_format(COLOR_WHITE, applier, "You open %s.", name);
-        container_open(applier, op);
 
         /* Handle party corpses. */
         if (op->slaying != NULL && op->sub_type == ST1_CONTAINER_CORPSE_party) {
@@ -367,8 +427,12 @@ static int apply_func(object *op, object *applier, int aflags) {
     } else {
         /* If it's readied, open it, otherwise ready it. */
         if (QUERY_FLAG(op, FLAG_APPLIED)) {
+            if (!container_open(applier, op)) {
+                free(name);
+                return OBJECT_METHOD_OK;
+            }
+
             draw_info_format(COLOR_WHITE, applier, "You open %s.", name);
-            container_open(applier, op);
         } else {
             if (OBJECT_IS_AMMO(op)) {
                 object_apply_item(op, applier, aflags);
@@ -395,6 +459,7 @@ static int apply_func(object *op, object *applier, int aflags) {
     /* Only after actually readying/opening the container we know more
      * about it. */
     SET_FLAG(op, FLAG_BEEN_APPLIED);
+    container_update_corpse_decay(op);
 
     return OBJECT_METHOD_OK;
 }

--- a/server/src/types/include/container.h
+++ b/server/src/types/include/container.h
@@ -32,7 +32,14 @@
 
 /* Prototypes */
 
+/** Maximum decay process intervals for fresh, searched, and empty corpses. */
+#define CORPSE_DECAY_FRESH 10
+#define CORPSE_DECAY_SEARCHED 5
+#define CORPSE_DECAY_EMPTY 2
+
 bool container_check_magical(object *op, object *container);
 bool container_close(object *applier, object *op);
+bool container_is_corpse(const object *op);
+void container_update_corpse_decay(object *op);
 
 #endif


### PR DESCRIPTION
## Summary

- cancel the first corpse-open attempt when a trap is discovered
- mark the corpse name and existing client overlay as trapped, with an explicit retry/disarm message
- use the next apply attempt to auto-disarm known traps before opening
- shorten fresh, searched, and empty corpse decay windows to 10, 5, and 2 process intervals
- remove empty personalized/party corpses without an unnecessary unlock phase while preserving that phase when loot remains

## Review findings addressed

- fixed newly set trapped flags skipping their own client update
- centralized recognition of normal, personalized, and party corpse subtypes
- preserved quest, party-loot, search-stat, and container linked-list state on canceled opens
- preserved existing trap failure and reusable-trap semantics
- added deterministic trap and corpse lifecycle regression coverage

## Validation

- `./build.sh atrinik-server`
- `./build.sh check` (25/25 passed)
- `bash tools/clang-format.sh --check`
- `git diff --check`
- targeted clang-tidy; no source diagnostics for changed logic

The targeted and full suites ran in the approved host context because the repository's documented sandbox restriction blocks their isolated loopback fixture sockets.
