### PR TITLE
feat(server): centralize deterministic clock domains

### DIFF
--- a/doc/SERVER_CLOCKS.md
+++ b/doc/SERVER_CLOCKS.md
@@ -1,0 +1,95 @@
+# Legacy server clock domains
+
+The legacy server has three explicit clock domains. New code must store typed
+absolute deadlines from `server/src/include/server_clock.h` and must not compare
+values from different domains.
+
+## Domain contract
+
+### Simulation ticks
+
+`server_tick_t` is authoritative gameplay time. It advances once in
+`main_process()` and therefore advances only when the simulation advances.
+Gameplay delays, spell durations, AI schedules, action wind-ups, encounter
+expiry, and other deterministic mechanics belong here. The current main-loop
+cadence and catch-up behavior remain owned by `reset_sleep()` and
+`sleep_delta()`; the clock service observes that cadence but does not change it.
+
+`global_round_tag` is a same-round generation marker for damage and map-update
+deduplication. It is not a duration clock. The authored world time-of-day in
+`server/src/server/time.c` is also separate: it maps simulation progress to the
+game world's calendar and persists `todtick` in `clockdata`.
+
+### Monotonic process time
+
+`server_monotonic_t` is backed by `datetime_monotonic_us()` in production. Use
+it for socket and handshake deadlines, rate windows, retry/backoff, process
+metrics, watchdogs, session elapsed time, and bounded worker waits. Its absolute
+value is process-local: never persist it, log it as a calendar fact, or send it
+as a meaningful protocol timestamp.
+
+### UTC wall time
+
+`server_wall_utc_t` is a Unix timestamp. Use it only for durable calendar facts
+and operator/audit output such as account creation, last login, save metadata,
+certificate validity, and heartbeat file timestamps. Do not use it for an
+in-process elapsed-time decision. When a deadline must survive restart, persist
+a UTC target and convert it with `server_wall_utc_remaining()`, which rejects
+expired targets and clamps unreasonable remaining durations before creating a
+new monotonic or simulation deadline.
+
+## Arithmetic and testing rules
+
+- Deadline addition and duration constructors saturate at `UINT64_MAX`, so the
+  clock never wraps into the past. Expiry is inclusive: `now == deadline` is
+  expired. Elapsed/difference helpers clamp a backward observation to zero.
+- Tick conversion uses the configured simulation tick period. Duration-to-tick
+  conversion rounds up so a deadline cannot expire early; tick-to-duration
+  conversion reports overflow instead of truncating.
+- Server startup installs the production clock from `reset_sleep()`. Only the
+  main loop advances simulation time. A deliberate `/speed` change updates the
+  conversion period without changing existing absolute tick deadlines.
+- Unit tests may include `server/src/tests/server_clock_fake.h`, install a fake
+  clock, and advance simulation and monotonic time independently without
+  sleeping. Teardown must call `server_clock_fake_uninstall()`.
+
+The first consumer migration stores pre-login deadlines as typed monotonic
+values. Join-password rate windows are also monotonic, so wall-clock jumps can
+neither reset nor extend those admission controls.
+
+## Raw-clock audit and migration path
+
+This audit covers remaining direct clock access under `server/src` as of
+2026-08-06. Direct calls are retained only where listed; new call sites should
+use the typed service.
+
+| Location | Current purpose and classification | Migration |
+| --- | --- | --- |
+| `server/server_clock.c` | The sole production adapters for monotonic and UTC wall time. | Keep. |
+| `server/time.c`, `server/main.c` (`GETTIMEOFDAY`) | Legacy loop cadence, spare pathfinding budget, and the legacy `seconds()` accessor. Cadence is a separate scheduling mechanism; `seconds()` is ambiguous. | Preserve cadence for now; later replace its wall-based measurement with monotonic scheduling in a dedicated behavior review and remove or retag `seconds()` callers. |
+| `server/main.c` (`datetime_monotonic_us`) | Game-loop performance metric. Correct domain, but bypasses the server type. | Replace with typed monotonic elapsed helpers. |
+| `server/plugins.c`, `plugins/plugin_python/plugin_python.c` | Plugin performance measurements using `gettimeofday()`. Wrong domain because wall jumps can corrupt durations. | Replace with typed monotonic elapsed helpers. |
+| `socket/assets.c` | Transfer budget windows and response performance metrics using toolkit monotonic values. Correct domain, untyped. | Migrate to typed monotonic deadlines and durations. |
+| `socket/port_mapping.c` | Router-mapping renewal deadline using toolkit monotonic milliseconds and unchecked addition. Correct domain, overflow-prone. | Migrate to typed saturating monotonic deadlines. |
+| `socket/metaserver.c` (`datetime_monotonic_ms`) | Rendezvous pacing. Correct domain, untyped. | Migrate to typed monotonic durations. |
+| `socket/metaserver.c` (`GETTIMEOFDAY`) | Absolute deadline for a default realtime `pthread_cond_timedwait`. Wall jumps can alter the wait. | Initialize a monotonic condition variable where supported, with a portable fallback, then construct its deadline from a monotonic clock. |
+| `socket/metaserver.c` (`time(NULL)`) | Human-readable last-success and last-failure operator timestamps. Correct wall domain. | Route through `server_wall_utc_now()` while retaining wall semantics. |
+| `socket/server.c` (`time(NULL)`) | UTC heartbeat file consumed by an external container health check. Correct durable/operator wall timestamp. | Route timestamp acquisition through the wall accessor; use a separate monotonic deadline to rate-limit writes. |
+| `server/account.c` (`datetime_getutc`) | Persisted account timestamps are correct wall facts; authentication-work refill is an in-process duration and is in the wrong domain. | Keep persisted facts as typed wall time and migrate work refill to monotonic time. |
+| `server/swap.c` (`time(NULL)`) | Converts persisted map reset targets into remaining time during shutdown. Correct persistence boundary, but negative and unreasonable values are not clamped here. | Route through wall time and `server_wall_utc_remaining()` with a map-reset-specific maximum. |
+| `types/player.c` gravestone timestamp | Authored calendar text. Correct wall domain. | Route through wall accessor before formatting. |
+| `types/player.c` save throttling and session counters | In-process durations use wall time and can be distorted by clock changes. | Store monotonic session/save deadlines; persist only validated UTC facts that must survive restart. This is the session/autosave stage needed by issue #123. |
+
+The gameplay migration order is: monster-dialog and encounter expiry; named
+spawn cooldowns; target-dummy measurement windows; then action wind-ups and
+other action timers. Each field should change from raw `pticks` or
+`global_round_tag` arithmetic to a `server_tick_t` deadline together with its
+producers, consumers, tests, and persistence behavior. Performance and network
+call sites in the table can migrate independently because they do not change
+simulation cadence.
+
+Shared toolkit raw clocks are outside the server provider boundary. Logger
+timestamps and certificate creation facts are wall time; toolkit QUIC/direct
+socket deadlines are monotonic; `porting.c` owns platform clock/sleep fallbacks.
+The fallback random seed in `toolkit/math.c` and signal-throttling wall timer in
+`toolkit/signals.c` deserve separate security and monotonic-domain cleanup.

--- a/doc/SERVER_CLOCKS.md
+++ b/doc/SERVER_CLOCKS.md
@@ -67,6 +67,7 @@ use the typed service.
 | --- | --- | --- |
 | `server/server_clock.c` | The sole production adapters for monotonic and UTC wall time. | Keep. |
 | `server/time.c`, `server/main.c` (`GETTIMEOFDAY`) | Legacy loop cadence, spare pathfinding budget, and the legacy `seconds()` accessor. Cadence is a separate scheduling mechanism; `seconds()` is ambiguous. | Preserve cadence for now; later replace its wall-based measurement with monotonic scheduling in a dedicated behavior review and remove or retag `seconds()` callers. |
+| `server/main.c` (`pticks` periodic work) | Gameplay/world updates are correctly simulation-based, but metaserver publication is process I/O and currently shares that schedule. | Keep gameplay periodic work on typed simulation deadlines; move metaserver retry/backoff and publication cadence to typed monotonic deadlines. |
 | `server/main.c` (`datetime_monotonic_us`) | Game-loop performance metric. Correct domain, but bypasses the server type. | Replace with typed monotonic elapsed helpers. |
 | `server/plugins.c`, `plugins/plugin_python/plugin_python.c` | Plugin performance measurements using `gettimeofday()`. Wrong domain because wall jumps can corrupt durations. | Replace with typed monotonic elapsed helpers. |
 | `socket/assets.c` | Transfer budget windows and response performance metrics using toolkit monotonic values. Correct domain, untyped. | Migrate to typed monotonic deadlines and durations. |

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -156,7 +156,8 @@ if (BUILD_TESTING AND NOT MINGW)
         include(src/tests/suites.cmake)
         set(SOURCES_CHECK
             src/tests/main.c
-            src/tests/check.c)
+            src/tests/check.c
+            src/tests/server_clock_fake.c)
         set(ATRINIK_SERVER_UNIT_SUITES)
         set(ATRINIK_SERVER_TEST_SUITE_DECLARATIONS)
         set(ATRINIK_SERVER_TEST_SUITE_ENTRIES)

--- a/server/README
+++ b/server/README
@@ -30,6 +30,10 @@
   $ ctest --test-dir build/gcc-debug --output-on-failure \
       -R '^server-unit-toolkit.packet$'
 
+ The server's simulation, monotonic, UTC wall, round-generation, and authored
+ world-time domains are documented in ../doc/SERVER_CLOCKS.md. New deadlines
+ must use the typed server clock API described there.
+
  The `check` build target remains available for compatibility and prepares the
  same build-owned runtime automatically.
 

--- a/server/src/cmake.txt
+++ b/server/src/cmake.txt
@@ -101,6 +101,7 @@ set(SERVER_CORE_SOURCES
 	src/server/region.c
 	src/server/resources.c
 	src/server/rune.c
+	src/server/server_clock.c
 	src/server/shop.c
 	src/server/skill_util.c
 	src/server/skills.c

--- a/server/src/include/newserver.h
+++ b/server/src/include/newserver.h
@@ -32,6 +32,10 @@
 #define NEWSERVER_H
 
 #include "map.h"
+#include "server_clock.h"
+
+/** Maximum time a connection may remain in the pre-login state. */
+#define SOCKET_PRELOGIN_TIMEOUT 30
 
 /** How many items to show in the below window. Used in esrv_draw_look(). */
 #define NUM_LOOK_OBJECTS 15
@@ -139,8 +143,8 @@ typedef struct socket_struct {
      */
     int login_count;
 
-    /** Wall-clock admission time used by the pre-login deadline. */
-    time_t accepted_at;
+    /** Monotonic pre-login deadline. Never persisted or sent to clients. */
+    server_monotonic_t prelogin_deadline;
 
     /** X size of the map the client wants. */
     int mapx;

--- a/server/src/include/proto.h
+++ b/server/src/include/proto.h
@@ -671,6 +671,7 @@ extern void draw_info_map(uint8_t type,
 extern Socket_Info socket_info;
 extern socket_struct *init_sockets;
 extern bool init_connection(socket_struct *ns);
+extern bool socket_prelogin_expired(const socket_struct *ns);
 extern void free_all_newserver(void);
 extern void free_newsocket(socket_struct *ns);
 extern void init_srv_files(void);

--- a/server/src/include/server_clock.h
+++ b/server/src/include/server_clock.h
@@ -1,0 +1,102 @@
+/*************************************************************************
+ *           Atrinik, a Multiplayer Online Role Playing Game             *
+ *                                                                       *
+ *   Copyright (C) 2009-2014 Zoey Rose and Atrinik Development Team      *
+ *                                                                       *
+ * This program is free software; you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation; either version 2 of the License, or     *
+ * (at your option) any later version.                                   *
+ ************************************************************************/
+
+/**
+ * @file
+ * Typed server clock domains and overflow-safe deadline helpers.
+ */
+
+#ifndef SERVER_CLOCK_H
+#define SERVER_CLOCK_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/** Authoritative simulation time. It advances only from the game loop. */
+typedef struct server_tick {
+    uint64_t value;
+} server_tick_t;
+
+/** Number of authoritative simulation ticks. */
+typedef struct server_tick_duration {
+    uint64_t value;
+} server_tick_duration_t;
+
+/** Monotonic process timestamp. It has no wall-clock or persistent meaning. */
+typedef struct server_monotonic {
+    uint64_t microseconds;
+} server_monotonic_t;
+
+/** Elapsed real time, represented in microseconds. */
+typedef struct server_duration {
+    uint64_t microseconds;
+} server_duration_t;
+
+/** UTC Unix timestamp, used only for durable calendar facts and operator output. */
+typedef struct server_wall_utc {
+    int64_t seconds;
+} server_wall_utc_t;
+
+/**
+ * Initialize the production clock.
+ *
+ * @param tick_period_us
+ * Duration of one authoritative simulation tick. Must be non-zero.
+ * @param initial_tick
+ * Initial simulation tick.
+ */
+void server_clock_init(uint64_t tick_period_us, server_tick_t initial_tick);
+
+/** Update the configured simulation tick period after an intentional speed change. */
+void server_clock_set_tick_period(uint64_t tick_period_us);
+
+/** Advance simulation time by one tick. This is owned by the authoritative main loop. */
+void server_clock_advance_tick(void);
+
+server_tick_t server_tick_now(void);
+server_tick_t server_tick_deadline_after(server_tick_duration_t duration);
+bool server_tick_expired(server_tick_t deadline);
+server_tick_duration_t server_tick_elapsed(server_tick_t since);
+server_tick_duration_t server_tick_difference(server_tick_t later, server_tick_t earlier);
+
+server_monotonic_t server_monotonic_now(void);
+server_monotonic_t server_monotonic_deadline_after(server_duration_t duration);
+bool server_monotonic_expired(server_monotonic_t deadline);
+bool server_monotonic_reached(server_monotonic_t now, server_monotonic_t deadline);
+bool server_monotonic_before(server_monotonic_t lhs, server_monotonic_t rhs);
+bool server_monotonic_is_set(server_monotonic_t timestamp);
+server_duration_t server_monotonic_elapsed(server_monotonic_t since);
+server_duration_t server_monotonic_difference(server_monotonic_t later, server_monotonic_t earlier);
+
+server_wall_utc_t server_wall_utc_now(void);
+
+/**
+ * Convert a persisted UTC deadline to a bounded in-process remaining duration.
+ *
+ * Expired deadlines produce zero and false. Future deadlines are clamped to
+ * maximum so corrupt or unreasonable persisted values cannot create an
+ * unbounded deadline.
+ */
+bool server_wall_utc_remaining(server_wall_utc_t deadline,
+                               server_wall_utc_t now,
+                               server_duration_t maximum,
+                               server_duration_t *remaining);
+
+server_duration_t server_duration_from_milliseconds(uint64_t milliseconds);
+server_duration_t server_duration_from_seconds(uint64_t seconds);
+
+/** Convert a duration to ticks, rounding up so deadlines never expire early. */
+bool server_duration_to_ticks(server_duration_t duration, server_tick_duration_t *ticks);
+
+/** Convert ticks to a duration, failing if the exact result is not representable. */
+bool server_ticks_to_duration(server_tick_duration_t ticks, server_duration_t *duration);
+
+#endif

--- a/server/src/include/server_clock.h
+++ b/server/src/include/server_clock.h
@@ -46,7 +46,8 @@ typedef struct server_wall_utc {
 } server_wall_utc_t;
 
 /**
- * Initialize the production clock.
+ * Initialize the production clock. Startup owns this operation; it must run
+ * before worker threads or clock consumers start.
  *
  * @param tick_period_us
  * Duration of one authoritative simulation tick. Must be non-zero.
@@ -55,7 +56,7 @@ typedef struct server_wall_utc {
  */
 void server_clock_init(uint64_t tick_period_us, server_tick_t initial_tick);
 
-/** Update the configured simulation tick period after an intentional speed change. */
+/** Main-thread-only update after an intentional simulation speed change. */
 void server_clock_set_tick_period(uint64_t tick_period_us);
 
 /** Advance simulation time by one tick. This is owned by the authoritative main loop. */
@@ -75,6 +76,9 @@ bool server_monotonic_before(server_monotonic_t lhs, server_monotonic_t rhs);
 bool server_monotonic_is_set(server_monotonic_t timestamp);
 server_duration_t server_monotonic_elapsed(server_monotonic_t since);
 server_duration_t server_monotonic_difference(server_monotonic_t later, server_monotonic_t earlier);
+bool server_monotonic_elapsed_at_least(server_monotonic_t now,
+                                       server_monotonic_t since,
+                                       server_duration_t duration);
 
 server_wall_utc_t server_wall_utc_now(void);
 

--- a/server/src/server/main.c
+++ b/server/src/server/main.c
@@ -549,6 +549,7 @@ void main_process(void) {
     /* Global round ticker. */
     global_round_tag++;
     pticks++;
+    server_clock_advance_tick();
 
     /* "do" something with objects with speed */
     process_events();

--- a/server/src/server/server_clock.c
+++ b/server/src/server/server_clock.c
@@ -14,6 +14,7 @@
 #include <global.h>
 #include <server_clock.h>
 #include <toolkit/datetime.h>
+#include "server_clock_internal.h"
 
 typedef struct server_clock_state {
     uint64_t production_tick_period_us;
@@ -118,6 +119,12 @@ server_duration_t server_monotonic_elapsed(server_monotonic_t since) {
     return server_monotonic_difference(server_monotonic_now(), since);
 }
 
+bool server_monotonic_elapsed_at_least(server_monotonic_t now,
+                                       server_monotonic_t since,
+                                       server_duration_t duration) {
+    return server_monotonic_difference(now, since).microseconds >= duration.microseconds;
+}
+
 server_wall_utc_t server_wall_utc_now(void) {
     if (clock_state.fake) {
         return clock_state.fake_wall;
@@ -138,6 +145,8 @@ bool server_wall_utc_remaining(server_wall_utc_t deadline,
         return false;
     }
 
+    /* Unsigned subtraction represents the complete ordered int64_t distance,
+     * including INT64_MIN to INT64_MAX, without signed overflow. */
     uint64_t seconds = (uint64_t)deadline.seconds - (uint64_t)now.seconds;
     *remaining = server_duration_from_seconds(seconds);
     if (remaining->microseconds > maximum.microseconds) {
@@ -185,7 +194,7 @@ bool server_ticks_to_duration(server_tick_duration_t ticks, server_duration_t *d
     return true;
 }
 
-void server_clock_fake_install(uint64_t tick_period_us,
+void server_clock_test_install(uint64_t tick_period_us,
                                server_tick_t tick,
                                server_monotonic_t monotonic,
                                server_wall_utc_t wall) {
@@ -198,22 +207,22 @@ void server_clock_fake_install(uint64_t tick_period_us,
     clock_state.fake = true;
 }
 
-void server_clock_fake_advance_ticks(server_tick_duration_t duration) {
+void server_clock_test_advance_ticks(server_tick_duration_t duration) {
     HARD_ASSERT(clock_state.fake);
     clock_state.fake_tick.value = saturating_add(clock_state.fake_tick.value, duration.value);
 }
 
-void server_clock_fake_advance_monotonic(server_duration_t duration) {
+void server_clock_test_advance_monotonic(server_duration_t duration) {
     HARD_ASSERT(clock_state.fake);
     clock_state.fake_monotonic.microseconds =
         saturating_add(clock_state.fake_monotonic.microseconds, duration.microseconds);
 }
 
-void server_clock_fake_set_wall(server_wall_utc_t wall) {
+void server_clock_test_set_wall(server_wall_utc_t wall) {
     HARD_ASSERT(clock_state.fake);
     clock_state.fake_wall = wall;
 }
 
-void server_clock_fake_uninstall(void) {
+void server_clock_test_uninstall(void) {
     clock_state.fake = false;
 }

--- a/server/src/server/server_clock.c
+++ b/server/src/server/server_clock.c
@@ -1,0 +1,219 @@
+/*************************************************************************
+ *           Atrinik, a Multiplayer Online Role Playing Game             *
+ *                                                                       *
+ *   Copyright (C) 2009-2014 Zoey Rose and Atrinik Development Team      *
+ *                                                                       *
+ * This program is free software; you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation; either version 2 of the License, or     *
+ * (at your option) any later version.                                   *
+ ************************************************************************/
+
+/** @file Typed server clock implementation. */
+
+#include <global.h>
+#include <server_clock.h>
+#include <toolkit/datetime.h>
+
+typedef struct server_clock_state {
+    uint64_t production_tick_period_us;
+    server_tick_t production_tick;
+    bool fake;
+    uint64_t fake_tick_period_us;
+    server_tick_t fake_tick;
+    server_monotonic_t fake_monotonic;
+    server_wall_utc_t fake_wall;
+} server_clock_state_t;
+
+static server_clock_state_t clock_state;
+
+static uint64_t saturating_add(uint64_t lhs, uint64_t rhs) {
+    return UINT64_MAX - lhs < rhs ? UINT64_MAX : lhs + rhs;
+}
+
+static uint64_t saturating_multiply(uint64_t lhs, uint64_t rhs) {
+    return rhs != 0 && lhs > UINT64_MAX / rhs ? UINT64_MAX : lhs * rhs;
+}
+
+void server_clock_init(uint64_t tick_period_us, server_tick_t initial_tick) {
+    HARD_ASSERT(tick_period_us != 0);
+
+    clock_state.production_tick_period_us = tick_period_us;
+    clock_state.production_tick = initial_tick;
+    clock_state.fake = false;
+}
+
+void server_clock_set_tick_period(uint64_t tick_period_us) {
+    HARD_ASSERT(tick_period_us != 0);
+    clock_state.production_tick_period_us = tick_period_us;
+}
+
+void server_clock_advance_tick(void) {
+    server_tick_t *tick = clock_state.fake ? &clock_state.fake_tick : &clock_state.production_tick;
+    tick->value = saturating_add(tick->value, 1);
+}
+
+server_tick_t server_tick_now(void) {
+    return clock_state.fake ? clock_state.fake_tick : clock_state.production_tick;
+}
+
+server_tick_t server_tick_deadline_after(server_tick_duration_t duration) {
+    server_tick_t deadline = {saturating_add(server_tick_now().value, duration.value)};
+    return deadline;
+}
+
+bool server_tick_expired(server_tick_t deadline) {
+    return server_tick_now().value >= deadline.value;
+}
+
+server_tick_duration_t server_tick_difference(server_tick_t later, server_tick_t earlier) {
+    server_tick_duration_t elapsed = {later.value >= earlier.value ? later.value - earlier.value
+                                                                   : 0};
+    return elapsed;
+}
+
+server_tick_duration_t server_tick_elapsed(server_tick_t since) {
+    return server_tick_difference(server_tick_now(), since);
+}
+
+server_monotonic_t server_monotonic_now(void) {
+    if (clock_state.fake) {
+        return clock_state.fake_monotonic;
+    }
+
+    server_monotonic_t now = {datetime_monotonic_us()};
+    return now;
+}
+
+server_monotonic_t server_monotonic_deadline_after(server_duration_t duration) {
+    server_monotonic_t deadline = {
+        saturating_add(server_monotonic_now().microseconds, duration.microseconds)};
+    return deadline;
+}
+
+bool server_monotonic_reached(server_monotonic_t now, server_monotonic_t deadline) {
+    return now.microseconds >= deadline.microseconds;
+}
+
+bool server_monotonic_expired(server_monotonic_t deadline) {
+    return server_monotonic_reached(server_monotonic_now(), deadline);
+}
+
+bool server_monotonic_before(server_monotonic_t lhs, server_monotonic_t rhs) {
+    return lhs.microseconds < rhs.microseconds;
+}
+
+bool server_monotonic_is_set(server_monotonic_t timestamp) {
+    return timestamp.microseconds != 0;
+}
+
+server_duration_t server_monotonic_difference(server_monotonic_t later,
+                                              server_monotonic_t earlier) {
+    server_duration_t elapsed = {
+        later.microseconds >= earlier.microseconds ? later.microseconds - earlier.microseconds : 0};
+    return elapsed;
+}
+
+server_duration_t server_monotonic_elapsed(server_monotonic_t since) {
+    return server_monotonic_difference(server_monotonic_now(), since);
+}
+
+server_wall_utc_t server_wall_utc_now(void) {
+    if (clock_state.fake) {
+        return clock_state.fake_wall;
+    }
+
+    server_wall_utc_t now = {(int64_t)time(NULL)};
+    return now;
+}
+
+bool server_wall_utc_remaining(server_wall_utc_t deadline,
+                               server_wall_utc_t now,
+                               server_duration_t maximum,
+                               server_duration_t *remaining) {
+    HARD_ASSERT(remaining != NULL);
+
+    if (deadline.seconds <= now.seconds) {
+        remaining->microseconds = 0;
+        return false;
+    }
+
+    uint64_t seconds = (uint64_t)deadline.seconds - (uint64_t)now.seconds;
+    *remaining = server_duration_from_seconds(seconds);
+    if (remaining->microseconds > maximum.microseconds) {
+        *remaining = maximum;
+    }
+    return true;
+}
+
+server_duration_t server_duration_from_milliseconds(uint64_t milliseconds) {
+    server_duration_t duration = {saturating_multiply(milliseconds, UINT64_C(1000))};
+    return duration;
+}
+
+server_duration_t server_duration_from_seconds(uint64_t seconds) {
+    server_duration_t duration = {saturating_multiply(seconds, UINT64_C(1000000))};
+    return duration;
+}
+
+bool server_duration_to_ticks(server_duration_t duration, server_tick_duration_t *ticks) {
+    HARD_ASSERT(ticks != NULL);
+
+    uint64_t tick_period_us =
+        clock_state.fake ? clock_state.fake_tick_period_us : clock_state.production_tick_period_us;
+    if (tick_period_us == 0) {
+        return false;
+    }
+
+    ticks->value = duration.microseconds / tick_period_us;
+    if (duration.microseconds % tick_period_us != 0) {
+        ticks->value++;
+    }
+    return true;
+}
+
+bool server_ticks_to_duration(server_tick_duration_t ticks, server_duration_t *duration) {
+    HARD_ASSERT(duration != NULL);
+
+    uint64_t tick_period_us =
+        clock_state.fake ? clock_state.fake_tick_period_us : clock_state.production_tick_period_us;
+    if (tick_period_us == 0 || (ticks.value != 0 && tick_period_us > UINT64_MAX / ticks.value)) {
+        return false;
+    }
+
+    duration->microseconds = ticks.value * tick_period_us;
+    return true;
+}
+
+void server_clock_fake_install(uint64_t tick_period_us,
+                               server_tick_t tick,
+                               server_monotonic_t monotonic,
+                               server_wall_utc_t wall) {
+    HARD_ASSERT(tick_period_us != 0);
+
+    clock_state.fake_tick_period_us = tick_period_us;
+    clock_state.fake_tick = tick;
+    clock_state.fake_monotonic = monotonic;
+    clock_state.fake_wall = wall;
+    clock_state.fake = true;
+}
+
+void server_clock_fake_advance_ticks(server_tick_duration_t duration) {
+    HARD_ASSERT(clock_state.fake);
+    clock_state.fake_tick.value = saturating_add(clock_state.fake_tick.value, duration.value);
+}
+
+void server_clock_fake_advance_monotonic(server_duration_t duration) {
+    HARD_ASSERT(clock_state.fake);
+    clock_state.fake_monotonic.microseconds =
+        saturating_add(clock_state.fake_monotonic.microseconds, duration.microseconds);
+}
+
+void server_clock_fake_set_wall(server_wall_utc_t wall) {
+    HARD_ASSERT(clock_state.fake);
+    clock_state.fake_wall = wall;
+}
+
+void server_clock_fake_uninstall(void) {
+    clock_state.fake = false;
+}

--- a/server/src/server/server_clock_internal.h
+++ b/server/src/server/server_clock_internal.h
@@ -9,25 +9,23 @@
  * (at your option) any later version.                                   *
  ************************************************************************/
 
-/**
- * @file
- * Test-only control surface for the server clock.
- *
- * Install and uninstall fakes only while no server worker thread is running.
- */
+/** @file Private clock controls used only by the fake-clock test adapter. */
 
-#ifndef SERVER_CLOCK_FAKE_H
-#define SERVER_CLOCK_FAKE_H
+#ifndef SERVER_CLOCK_INTERNAL_H
+#define SERVER_CLOCK_INTERNAL_H
 
 #include <server_clock.h>
 
-void server_clock_fake_install(uint64_t tick_period_us,
+/* These hooks are deliberately absent from the public include directory.
+ * Tests call them before worker threads exist and restore production mode
+ * during teardown. */
+void server_clock_test_install(uint64_t tick_period_us,
                                server_tick_t tick,
                                server_monotonic_t monotonic,
                                server_wall_utc_t wall);
-void server_clock_fake_advance_ticks(server_tick_duration_t duration);
-void server_clock_fake_advance_monotonic(server_duration_t duration);
-void server_clock_fake_set_wall(server_wall_utc_t wall);
-void server_clock_fake_uninstall(void);
+void server_clock_test_advance_ticks(server_tick_duration_t duration);
+void server_clock_test_advance_monotonic(server_duration_t duration);
+void server_clock_test_set_wall(server_wall_utc_t wall);
+void server_clock_test_uninstall(void);
 
 #endif

--- a/server/src/server/time.c
+++ b/server/src/server/time.c
@@ -148,6 +148,7 @@ void reset_sleep(void) {
     process_min_utime = 999999999;
     process_tot_mtime = 0;
     pticks = 1;
+    server_clock_init((uint64_t)max_time, (server_tick_t){(uint64_t)pticks});
 
     (void)GETTIMEOFDAY(&last_time);
 }
@@ -254,6 +255,7 @@ void set_max_time(long t) {
               "You feel a sudden and inexplicable change in the fabric of "
               "time and space...");
     max_time = t;
+    server_clock_set_tick_period((uint64_t)max_time);
     send_game_time(NULL);
 }
 

--- a/server/src/socket/init.c
+++ b/server/src/socket/init.c
@@ -58,7 +58,8 @@ bool init_connection(socket_struct *ns) {
     }
 
     ns->login_count = 0;
-    ns->accepted_at = time(NULL);
+    ns->prelogin_deadline =
+        server_monotonic_deadline_after(server_duration_from_seconds(SOCKET_PRELOGIN_TIMEOUT));
     ns->keepalive = 0;
     ns->addme = 0;
     ns->faceset = 0;
@@ -81,6 +82,12 @@ bool init_connection(socket_struct *ns) {
     ns->packets = NULL;
 
     return true;
+}
+
+bool socket_prelogin_expired(const socket_struct *ns) {
+    HARD_ASSERT(ns != NULL);
+    return server_monotonic_is_set(ns->prelogin_deadline) &&
+           server_monotonic_expired(ns->prelogin_deadline);
 }
 
 /**

--- a/server/src/socket/request.c
+++ b/server/src/socket/request.c
@@ -70,8 +70,8 @@ static unsigned int join_failure_global_count;
 static bool join_password_allowed(socket_struct *ns) {
     server_monotonic_t now = server_monotonic_now();
     server_duration_t minute = server_duration_from_seconds(60);
-    if (server_monotonic_difference(now, join_failure_global_window).microseconds >=
-        minute.microseconds) {
+    server_duration_t stale = server_duration_from_seconds(120);
+    if (server_monotonic_elapsed_at_least(now, join_failure_global_window, minute)) {
         join_failure_global_window = now;
         join_failure_global_count = 0;
     }
@@ -85,8 +85,7 @@ static bool join_password_allowed(socket_struct *ns) {
     if (entry == NULL) {
         join_failure_entry_t *old, *next;
         HASH_ITER(hh, join_failures, old, next) {
-            if (server_monotonic_difference(now, old->window_started).microseconds >=
-                server_duration_from_seconds(120).microseconds) {
+            if (server_monotonic_elapsed_at_least(now, old->window_started, stale)) {
                 HASH_DEL(join_failures, old);
                 free(old);
             }
@@ -110,8 +109,7 @@ static bool join_password_allowed(socket_struct *ns) {
         HASH_ADD_STR(join_failures, address, entry);
     }
 
-    if (server_monotonic_difference(now, entry->window_started).microseconds >=
-        minute.microseconds) {
+    if (server_monotonic_elapsed_at_least(now, entry->window_started, minute)) {
         entry->window_started = now;
         entry->failures = 0;
     }

--- a/server/src/socket/request.c
+++ b/server/src/socket/request.c
@@ -59,17 +59,19 @@
 typedef struct join_failure_entry {
     UT_hash_handle hh;
     char address[MAX_BUF];
-    time_t window_started;
+    server_monotonic_t window_started;
     unsigned int failures;
 } join_failure_entry_t;
 
 static join_failure_entry_t *join_failures;
-static time_t join_failure_global_window;
+static server_monotonic_t join_failure_global_window;
 static unsigned int join_failure_global_count;
 
 static bool join_password_allowed(socket_struct *ns) {
-    time_t now = time(NULL);
-    if (now - join_failure_global_window >= 60) {
+    server_monotonic_t now = server_monotonic_now();
+    server_duration_t minute = server_duration_from_seconds(60);
+    if (server_monotonic_difference(now, join_failure_global_window).microseconds >=
+        minute.microseconds) {
         join_failure_global_window = now;
         join_failure_global_count = 0;
     }
@@ -83,7 +85,8 @@ static bool join_password_allowed(socket_struct *ns) {
     if (entry == NULL) {
         join_failure_entry_t *old, *next;
         HASH_ITER(hh, join_failures, old, next) {
-            if (now - old->window_started >= 120) {
+            if (server_monotonic_difference(now, old->window_started).microseconds >=
+                server_duration_from_seconds(120).microseconds) {
                 HASH_DEL(join_failures, old);
                 free(old);
             }
@@ -91,7 +94,8 @@ static bool join_password_allowed(socket_struct *ns) {
         if (HASH_COUNT(join_failures) >= JOIN_FAILURE_ENTRY_MAX) {
             join_failure_entry_t *oldest = NULL;
             HASH_ITER(hh, join_failures, old, next) {
-                if (oldest == NULL || old->window_started < oldest->window_started) {
+                if (oldest == NULL ||
+                    server_monotonic_before(old->window_started, oldest->window_started)) {
                     oldest = old;
                 }
             }
@@ -106,7 +110,8 @@ static bool join_password_allowed(socket_struct *ns) {
         HASH_ADD_STR(join_failures, address, entry);
     }
 
-    if (now - entry->window_started >= 60) {
+    if (server_monotonic_difference(now, entry->window_started).microseconds >=
+        minute.microseconds) {
         entry->window_started = now;
         entry->failures = 0;
     }

--- a/server/src/socket/server.c
+++ b/server/src/socket/server.c
@@ -103,7 +103,6 @@ static csocket_entry_t *client_sockets;
 static size_t client_sockets_count;
 
 #define SOCKET_PENDING_CONNECTIONS_MAX 128U
-#define SOCKET_PRELOGIN_TIMEOUT 30
 
 /**
  * Defines all the possible socket commands.
@@ -724,8 +723,7 @@ void socket_server_process(void) {
 
     csocket_entry_t *entry, *entry_tmp;
     DL_FOREACH_SAFE(client_sockets, entry, entry_tmp) {
-        if (entry->cs->accepted_at != 0 &&
-            time(NULL) - entry->cs->accepted_at >= SOCKET_PRELOGIN_TIMEOUT) {
+        if (socket_prelogin_expired(entry->cs)) {
             LOG(SYSTEM,
                 "Connection %s exceeded the pre-login deadline",
                 socket_get_id(entry->cs->sc));

--- a/server/src/tests/server_clock_fake.c
+++ b/server/src/tests/server_clock_fake.c
@@ -9,25 +9,30 @@
  * (at your option) any later version.                                   *
  ************************************************************************/
 
-/**
- * @file
- * Test-only control surface for the server clock.
- *
- * Install and uninstall fakes only while no server worker thread is running.
- */
+/** @file Test-only fake-clock adapter. */
 
-#ifndef SERVER_CLOCK_FAKE_H
-#define SERVER_CLOCK_FAKE_H
-
-#include <server_clock.h>
+#include <server_clock_fake.h>
+#include "server/server_clock_internal.h"
 
 void server_clock_fake_install(uint64_t tick_period_us,
                                server_tick_t tick,
                                server_monotonic_t monotonic,
-                               server_wall_utc_t wall);
-void server_clock_fake_advance_ticks(server_tick_duration_t duration);
-void server_clock_fake_advance_monotonic(server_duration_t duration);
-void server_clock_fake_set_wall(server_wall_utc_t wall);
-void server_clock_fake_uninstall(void);
+                               server_wall_utc_t wall) {
+    server_clock_test_install(tick_period_us, tick, monotonic, wall);
+}
 
-#endif
+void server_clock_fake_advance_ticks(server_tick_duration_t duration) {
+    server_clock_test_advance_ticks(duration);
+}
+
+void server_clock_fake_advance_monotonic(server_duration_t duration) {
+    server_clock_test_advance_monotonic(duration);
+}
+
+void server_clock_fake_set_wall(server_wall_utc_t wall) {
+    server_clock_test_set_wall(wall);
+}
+
+void server_clock_fake_uninstall(void) {
+    server_clock_test_uninstall();
+}

--- a/server/src/tests/server_clock_fake.h
+++ b/server/src/tests/server_clock_fake.h
@@ -1,0 +1,28 @@
+/*************************************************************************
+ *           Atrinik, a Multiplayer Online Role Playing Game             *
+ *                                                                       *
+ *   Copyright (C) 2009-2014 Zoey Rose and Atrinik Development Team      *
+ *                                                                       *
+ * This program is free software; you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation; either version 2 of the License, or     *
+ * (at your option) any later version.                                   *
+ ************************************************************************/
+
+/** @file Test-only control surface for the server clock. */
+
+#ifndef SERVER_CLOCK_FAKE_H
+#define SERVER_CLOCK_FAKE_H
+
+#include <server_clock.h>
+
+void server_clock_fake_install(uint64_t tick_period_us,
+                               server_tick_t tick,
+                               server_monotonic_t monotonic,
+                               server_wall_utc_t wall);
+void server_clock_fake_advance_ticks(server_tick_duration_t duration);
+void server_clock_fake_advance_monotonic(server_duration_t duration);
+void server_clock_fake_set_wall(server_wall_utc_t wall);
+void server_clock_fake_uninstall(void);
+
+#endif

--- a/server/src/tests/suites.cmake
+++ b/server/src/tests/suites.cmake
@@ -13,6 +13,7 @@ set(ATRINIK_SERVER_TEST_SUITES
     "server.re_cmp|check_server_re_cmp|src/tests/unit/server/re_cmp.c"
     "server.request|check_server_request|src/tests/unit/server/request.c"
     "server.rune|check_server_rune|src/tests/unit/server/rune.c"
+    "server.server_clock|check_server_server_clock|src/tests/unit/server/server_clock.c"
     "server.shop|check_server_shop|src/tests/unit/server/shop.c"
     "toolkit.math|check_server_math|src/tests/unit/toolkit/math.c"
     "toolkit.memory|check_server_memory|src/tests/unit/toolkit/memory.c"

--- a/server/src/tests/unit/server/server_clock.c
+++ b/server/src/tests/unit/server/server_clock.c
@@ -1,0 +1,183 @@
+/*************************************************************************
+ *           Atrinik, a Multiplayer Online Role Playing Game             *
+ *                                                                       *
+ *   Copyright (C) 2009-2014 Zoey Rose and Atrinik Development Team      *
+ *                                                                       *
+ * This program is free software; you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation; either version 2 of the License, or     *
+ * (at your option) any later version.                                   *
+ ************************************************************************/
+
+#include <global.h>
+#include <check.h>
+#include <checkstd.h>
+#include <check_proto.h>
+#include <server_clock_fake.h>
+
+static void clock_test_setup(void) {
+    server_clock_fake_install(UINT64_C(125000),
+                              (server_tick_t){10},
+                              (server_monotonic_t){UINT64_C(1000000)},
+                              (server_wall_utc_t){INT64_C(1700000000)});
+}
+
+static void clock_test_teardown(void) {
+    server_clock_fake_uninstall();
+}
+
+START_TEST(test_domains_advance_independently) {
+    server_tick_t tick = server_tick_now();
+    server_monotonic_t monotonic = server_monotonic_now();
+
+    server_clock_fake_advance_ticks((server_tick_duration_t){3});
+    ck_assert_uint_eq(server_tick_now().value, tick.value + 3);
+    ck_assert_uint_eq(server_monotonic_now().microseconds, monotonic.microseconds);
+
+    server_clock_fake_advance_monotonic(server_duration_from_milliseconds(25));
+    ck_assert_uint_eq(server_tick_now().value, tick.value + 3);
+    ck_assert_uint_eq(server_monotonic_now().microseconds,
+                      monotonic.microseconds + UINT64_C(25000));
+}
+END_TEST
+
+START_TEST(test_deadlines_expire_at_exact_boundary) {
+    server_tick_t tick_deadline = server_tick_deadline_after((server_tick_duration_t){2});
+    server_monotonic_t monotonic_deadline =
+        server_monotonic_deadline_after(server_duration_from_milliseconds(10));
+
+    server_clock_fake_advance_ticks((server_tick_duration_t){1});
+    server_clock_fake_advance_monotonic(server_duration_from_milliseconds(9));
+    ck_assert(!server_tick_expired(tick_deadline));
+    ck_assert(!server_monotonic_expired(monotonic_deadline));
+
+    server_clock_fake_advance_ticks((server_tick_duration_t){1});
+    server_clock_fake_advance_monotonic(server_duration_from_milliseconds(1));
+    ck_assert(server_tick_expired(tick_deadline));
+    ck_assert(server_monotonic_expired(monotonic_deadline));
+}
+END_TEST
+
+START_TEST(test_wall_clock_jumps_do_not_change_deadlines) {
+    server_monotonic_t deadline = server_monotonic_deadline_after(server_duration_from_seconds(5));
+
+    server_clock_fake_set_wall((server_wall_utc_t){INT64_C(1)});
+    ck_assert(!server_monotonic_expired(deadline));
+    server_clock_fake_set_wall((server_wall_utc_t){INT64_MAX});
+    ck_assert(!server_monotonic_expired(deadline));
+
+    server_clock_fake_advance_monotonic(server_duration_from_seconds(5));
+    ck_assert(server_monotonic_expired(deadline));
+}
+END_TEST
+
+START_TEST(test_prelogin_deadline_ignores_wall_clock_jumps) {
+    socket_struct socket = {0};
+    socket.prelogin_deadline =
+        server_monotonic_deadline_after(server_duration_from_seconds(SOCKET_PRELOGIN_TIMEOUT));
+
+    server_clock_fake_set_wall((server_wall_utc_t){INT64_MAX});
+    ck_assert(!socket_prelogin_expired(&socket));
+    server_clock_fake_advance_monotonic(server_duration_from_seconds(SOCKET_PRELOGIN_TIMEOUT));
+    ck_assert(socket_prelogin_expired(&socket));
+}
+END_TEST
+
+START_TEST(test_persisted_wall_deadlines_are_validated_and_clamped) {
+    server_duration_t remaining;
+    server_duration_t maximum = server_duration_from_seconds(60);
+
+    ck_assert(!server_wall_utc_remaining((server_wall_utc_t){99},
+                                         (server_wall_utc_t){100},
+                                         maximum,
+                                         &remaining));
+    ck_assert_uint_eq(remaining.microseconds, 0);
+
+    ck_assert(server_wall_utc_remaining((server_wall_utc_t){130},
+                                        (server_wall_utc_t){100},
+                                        maximum,
+                                        &remaining));
+    ck_assert_uint_eq(remaining.microseconds, server_duration_from_seconds(30).microseconds);
+
+    ck_assert(server_wall_utc_remaining((server_wall_utc_t){INT64_MAX},
+                                        (server_wall_utc_t){INT64_MIN},
+                                        maximum,
+                                        &remaining));
+    ck_assert_uint_eq(remaining.microseconds, maximum.microseconds);
+}
+END_TEST
+
+START_TEST(test_arithmetic_saturates_and_elapsed_clamps) {
+    server_clock_fake_install(UINT64_C(125000),
+                              (server_tick_t){UINT64_MAX - 2},
+                              (server_monotonic_t){UINT64_MAX - 2},
+                              (server_wall_utc_t){0});
+
+    ck_assert_uint_eq(server_tick_deadline_after((server_tick_duration_t){10}).value, UINT64_MAX);
+    ck_assert_uint_eq(server_monotonic_deadline_after((server_duration_t){10}).microseconds,
+                      UINT64_MAX);
+
+    server_clock_fake_advance_ticks((server_tick_duration_t){10});
+    server_clock_fake_advance_monotonic((server_duration_t){10});
+    ck_assert_uint_eq(server_tick_now().value, UINT64_MAX);
+    ck_assert_uint_eq(server_monotonic_now().microseconds, UINT64_MAX);
+
+    ck_assert_uint_eq(server_tick_difference((server_tick_t){1}, (server_tick_t){2}).value, 0);
+    ck_assert_uint_eq(
+        server_monotonic_difference((server_monotonic_t){1}, (server_monotonic_t){2}).microseconds,
+        0);
+}
+END_TEST
+
+START_TEST(test_tick_duration_conversions_are_checked) {
+    server_tick_duration_t ticks;
+    server_duration_t duration;
+
+    ck_assert(server_duration_to_ticks(server_duration_from_seconds(1), &ticks));
+    ck_assert_uint_eq(ticks.value, 8);
+    ck_assert(server_duration_to_ticks((server_duration_t){UINT64_C(125001)}, &ticks));
+    ck_assert_uint_eq(ticks.value, 2);
+    ck_assert(server_ticks_to_duration((server_tick_duration_t){8}, &duration));
+    ck_assert_uint_eq(duration.microseconds, UINT64_C(1000000));
+    ck_assert(!server_ticks_to_duration((server_tick_duration_t){UINT64_MAX}, &duration));
+}
+END_TEST
+
+START_TEST(test_fake_cleanup_restores_production_clock) {
+    server_clock_fake_uninstall();
+    server_clock_init(UINT64_C(500000), (server_tick_t){77});
+    server_clock_fake_install(UINT64_C(1),
+                              (server_tick_t){1},
+                              (server_monotonic_t){1},
+                              (server_wall_utc_t){1});
+    server_clock_fake_uninstall();
+
+    ck_assert_uint_eq(server_tick_now().value, 77);
+    server_tick_duration_t ticks;
+    ck_assert(server_duration_to_ticks(server_duration_from_seconds(1), &ticks));
+    ck_assert_uint_eq(ticks.value, 2);
+}
+END_TEST
+
+static Suite *suite(void) {
+    Suite *s = suite_create("server_clock");
+    TCase *tc_core = tcase_create("Core");
+
+    tcase_add_unchecked_fixture(tc_core, check_setup, check_teardown);
+    tcase_add_checked_fixture(tc_core, clock_test_setup, clock_test_teardown);
+    tcase_add_test(tc_core, test_domains_advance_independently);
+    tcase_add_test(tc_core, test_deadlines_expire_at_exact_boundary);
+    tcase_add_test(tc_core, test_wall_clock_jumps_do_not_change_deadlines);
+    tcase_add_test(tc_core, test_prelogin_deadline_ignores_wall_clock_jumps);
+    tcase_add_test(tc_core, test_persisted_wall_deadlines_are_validated_and_clamped);
+    tcase_add_test(tc_core, test_arithmetic_saturates_and_elapsed_clamps);
+    tcase_add_test(tc_core, test_tick_duration_conversions_are_checked);
+    tcase_add_test(tc_core, test_fake_cleanup_restores_production_clock);
+    suite_add_tcase(s, tc_core);
+
+    return s;
+}
+
+void check_server_server_clock(void) {
+    check_run_suite(suite(), __FILE__);
+}

--- a/server/src/tests/unit/server/server_clock.c
+++ b/server/src/tests/unit/server/server_clock.c
@@ -133,6 +133,11 @@ START_TEST(test_tick_duration_conversions_are_checked) {
     server_tick_duration_t ticks;
     server_duration_t duration;
 
+    ck_assert_uint_eq(server_duration_from_seconds(0).microseconds, 0);
+    ck_assert_uint_eq(server_duration_from_milliseconds(UINT64_MAX).microseconds, UINT64_MAX);
+    ck_assert_uint_eq(server_duration_from_seconds(UINT64_MAX).microseconds, UINT64_MAX);
+    ck_assert(server_duration_to_ticks((server_duration_t){0}, &ticks));
+    ck_assert_uint_eq(ticks.value, 0);
     ck_assert(server_duration_to_ticks(server_duration_from_seconds(1), &ticks));
     ck_assert_uint_eq(ticks.value, 8);
     ck_assert(server_duration_to_ticks((server_duration_t){UINT64_C(125001)}, &ticks));

--- a/server/src/types/player.c
+++ b/server/src/types/player.c
@@ -2656,7 +2656,8 @@ char *player_make_path(const char *name, const char *ext) {
     name_lower = xstrdup(name);
     string_tolower(name_lower);
 
-    for (i = 0; i < settings.limits[ALLOWED_CHARS_CHARNAME][0] - 1; i++) {
+    for (i = 0; name_lower[i] != '\0' && i + 1 < (size_t)settings.limits[ALLOWED_CHARS_CHARNAME][0];
+         i++) {
         stringbuffer_append_string_len(sb, name_lower, i + 1);
         stringbuffer_append_string(sb, "/");
     }


### PR DESCRIPTION
Closes #155.

## Summary

- add distinct typed simulation-tick, monotonic-process, duration, and UTC wall-clock APIs with saturating deadlines and checked tick conversions
- initialize and advance simulation time from the existing authoritative loop without changing cadence or world time
- provide a test-only fake clock with independent tick, monotonic, and wall controls plus boundary, wall-jump, persistence-clamp, and cleanup coverage
- migrate pre-login deadlines and join-password rate windows away from wall time
- document domain ownership, persistence rules, the raw-clock audit, and the staged migration path
- fix a short-name heap over-read in player path construction exposed by the full sanitizer review

## Validation

- complete GCC build passed
- ctest --preset gcc-debug: 28/28 passed, including network E2E and Python plugin runtime
- bash tools/clang-format.sh --check passed
- targeted clang-tidy completed and targeted cppcheck reported no findings
- Clang ASan/UBSan/LSan build passed; 28/29 sanitizer tests passed, including the clock suite and dedicated lifecycle leak smoke. The Python plugin test confirms the player path over-read is fixed, then reaches unrelated existing LOS signed-shift UB and embedded-Python shutdown leaks documented by the branch review.