### PR TITLE
fix(protocol): consume raw client packet payloads

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -123,6 +123,17 @@ if (HAVE_SDL_MIXER)
     endif ()
 endif ()
 
+if (BUILD_TESTING AND NOT MINGW)
+    add_executable(client-packet-payload-tests
+        src/tests/packet_payload.c
+        src/client/packet_payload.c)
+    atrinik_configure_target(client-packet-payload-tests)
+    target_include_directories(client-packet-payload-tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/include)
+    target_link_libraries(client-packet-payload-tests PRIVATE atrinik-toolkit)
+    add_test(NAME client-packet-payload COMMAND client-packet-payload-tests)
+endif ()
+
 # Installer.
 if (WIN32 AND NOT UNIX)
     set(INSTALL_SUBDIR_BIN ".")

--- a/client/src/client/commands.c
+++ b/client/src/client/commands.c
@@ -32,7 +32,9 @@
 #include <video.h>
 #include <client_socket.h>
 #include <openssl/crypto.h>
+#include <packet_payload.h>
 #include <region_map.h>
+#include <wrapper.h>
 #include <toolkit/map_protocol.h>
 #include <toolkit/packet.h>
 #include <toolkit/path.h>
@@ -151,39 +153,26 @@ void socket_command_anim(uint8_t *data, size_t len, size_t pos) {
 
 /** @copydoc socket_command_struct::handle_func */
 void socket_command_image(uint8_t *data, size_t len, size_t pos) {
-    packet_reader_t reader;
-    packet_reader_init_cursor(&reader, data, len, &pos);
-    uint32_t facenum, filesize;
+    uint32_t facenum;
+    packet_view_t image;
     char buf[HUGE_BUF];
-    FILE *fp;
 
-    if (pos > len || len - pos < 8) {
-        LOG(ERROR, "Ignoring truncated image packet");
+    if (!client_packet_parse_image(data, len, pos, &facenum, &image)) {
         return;
     }
-
-    facenum = packet_reader_read_uint32(&reader);
-    filesize = packet_reader_read_uint32(&reader);
-
-    if (!image_face_valid(facenum) || image_get_face_name(facenum) == NULL ||
-        filesize > len - pos) {
-        LOG(ERROR,
-            "Ignoring invalid image packet (face: %" PRIu32 ", size: %" PRIu32
-            ", remaining: %" PRIu64 ")",
-            facenum,
-            filesize,
-            (uint64_t)(len - pos));
+    if (!image_face_valid(facenum) || image_get_face_name(facenum) == NULL) {
+        LOG(ERROR, "Ignoring image packet with invalid face ID %" PRIu32, facenum);
         return;
     }
 
     /* Save picture to cache and load it to FaceList. */
     snprintf(buf, sizeof(buf), DIRECTORY_CACHE "/%s", image_get_face_name(facenum));
-
-    fp = path_fopen(buf, "wb+");
-
-    if (fp) {
-        fwrite(data + pos, 1, filesize, fp);
-        fclose(fp);
+    char *path = file_path(buf, "wb");
+    bool saved = path_write_atomic(path, image.data, image.len, 0600);
+    free(path);
+    if (!saved) {
+        LOG(ERROR, "Could not atomically write image cache file '%s'.", buf);
+        return;
     }
 
     FaceList[facenum].sprite = sprite_tryload_file(buf, 0, NULL);

--- a/client/src/client/packet_payload.c
+++ b/client/src/client/packet_payload.c
@@ -1,0 +1,79 @@
+/*************************************************************************
+ *           Atrinik, a Multiplayer Online Role Playing Game             *
+ *                                                                       *
+ *   Copyright (C) 2009-2014 Zoey Rose and Atrinik Development Team      *
+ *                                                                       *
+ * This program is free software; you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation; either version 2 of the License, or     *
+ * (at your option) any later version.                                   *
+ ************************************************************************/
+
+#include <packet_payload.h>
+
+bool client_packet_parse_image(const uint8_t *data,
+                               size_t len,
+                               size_t pos,
+                               uint32_t *face_id,
+                               packet_view_t *image) {
+    packet_reader_t reader;
+    packet_reader_init_at(&reader, data, len, pos);
+
+    uint32_t parsed_face_id = packet_reader_read_uint32(&reader);
+    uint32_t image_size = packet_reader_read_uint32(&reader);
+    packet_view_t parsed_image = packet_reader_read_view(&reader, image_size);
+    if (!packet_reader_finish(&reader)) {
+        return false;
+    }
+
+    *face_id = parsed_face_id;
+    *image = parsed_image;
+    return true;
+}
+
+bool client_packet_parse_file_update(const uint8_t *data,
+                                     size_t len,
+                                     size_t pos,
+                                     char *filename,
+                                     size_t filename_size,
+                                     uint32_t *uncompressed_size,
+                                     packet_view_t *compressed) {
+    packet_reader_t reader;
+    packet_reader_init_at(&reader, data, len, pos);
+
+    if (!packet_reader_read_string(&reader, filename, filename_size)) {
+        return false;
+    }
+    uint32_t parsed_size = packet_reader_read_uint32(&reader);
+    packet_view_t parsed_compressed =
+        packet_reader_read_view(&reader, packet_reader_remaining(&reader));
+    if (!packet_reader_finish(&reader)) {
+        return false;
+    }
+
+    *uncompressed_size = parsed_size;
+    *compressed = parsed_compressed;
+    return true;
+}
+
+bool client_packet_parse_resource(const uint8_t *data,
+                                  size_t len,
+                                  size_t pos,
+                                  char *name,
+                                  size_t name_size,
+                                  size_t digest_size,
+                                  packet_view_t *digest) {
+    packet_reader_t reader;
+    packet_reader_init_at(&reader, data, len, pos);
+
+    if (!packet_reader_read_string(&reader, name, name_size)) {
+        return false;
+    }
+    packet_view_t parsed_digest = packet_reader_read_view(&reader, digest_size);
+    if (!packet_reader_finish(&reader)) {
+        return false;
+    }
+
+    *digest = parsed_digest;
+    return true;
+}

--- a/client/src/client/resources.c
+++ b/client/src/client/resources.c
@@ -30,6 +30,7 @@
  */
 
 #include <global.h>
+#include <packet_payload.h>
 #include <wrapper.h>
 #include <resources.h>
 #include <toolkit/string.h>
@@ -85,10 +86,16 @@ resource_t *resources_find(const char *name) {
 
 /** @copydoc socket_command_struct::handle_func */
 void socket_command_resource(uint8_t *data, size_t len, size_t pos) {
-    packet_reader_t reader;
-    packet_reader_init_cursor(&reader, data, len, &pos);
     char resource_name[HUGE_BUF];
-    packet_reader_read_string(&reader, VS(resource_name));
+    packet_view_t md;
+    if (!client_packet_parse_resource(data,
+                                      len,
+                                      pos,
+                                      VS(resource_name),
+                                      sizeof(((resource_t *)NULL)->md),
+                                      &md)) {
+        return;
+    }
     if (string_isempty(resource_name)) {
         LOG(PACKET, "Received empty resource name");
         return;
@@ -98,20 +105,14 @@ void socket_command_resource(uint8_t *data, size_t len, size_t pos) {
         return;
     }
 
-    const unsigned char *md = data + pos;
-    if (len - pos != sizeof(((resource_t *)NULL)->md)) {
-        LOG(PACKET, "Invalid remaining packet size");
-        return;
-    }
-
     char digest[sizeof(((resource_t *)NULL)->digest)];
-    SOFT_ASSERT(string_tohex(md, len - pos, VS(digest), false) == sizeof(digest) - 1,
+    SOFT_ASSERT(string_tohex(md.data, md.len, VS(digest), false) == sizeof(digest) - 1,
                 "string_tohex failed");
     string_tolower(digest);
 
     resource_t *resource = xcalloc(1, sizeof(*resource));
     resource->name = xstrdup(resource_name);
-    memcpy(resource->md, md, sizeof(resource->md));
+    memcpy(resource->md, md.data, sizeof(resource->md));
     memcpy(resource->digest, digest, sizeof(resource->digest));
     HASH_ADD_KEYPTR(hh, resources, resource->name, strlen(resource->name), resource);
 

--- a/client/src/client/updates.c
+++ b/client/src/client/updates.c
@@ -31,8 +31,13 @@
 
 #include <global.h>
 #include <client_socket.h>
+#include <packet_payload.h>
 #include <toolkit/packet.h>
 #include <toolkit/path.h>
+#include <wrapper.h>
+
+/** Bound server-directed allocations and decompression work. */
+#define FILE_UPDATE_UNCOMPRESSED_MAX (64U * 1024U * 1024U)
 
 /**
  * How many file updates have been requested. This is used to block the
@@ -58,39 +63,63 @@ static void file_updates_request(char *filename) {
 
 /** @copydoc socket_command_struct::handle_func */
 void socket_command_file_update(uint8_t *data, size_t len, size_t pos) {
-    packet_reader_t reader;
-    packet_reader_init_cursor(&reader, data, len, &pos);
     char filename[MAX_BUF];
-    unsigned long ucomp_len;
-    unsigned char *dest;
-    FILE *fp;
+    uint32_t expected_size;
+    packet_view_t compressed;
 
-    if (file_updates_requested != 0) {
-        file_updates_requested--;
+    if (file_updates_requested == 0) {
+        LOG(ERROR, "Ignoring unsolicited file update.");
+        return;
     }
 
-    packet_reader_read_string(&reader, filename, sizeof(filename));
-    ucomp_len = packet_reader_read_uint32(&reader);
-    len -= pos;
+    if (!client_packet_parse_file_update(data,
+                                         len,
+                                         pos,
+                                         VS(filename),
+                                         &expected_size,
+                                         &compressed)) {
+        return;
+    }
+    if (!path_is_safe_relative(filename)) {
+        LOG(ERROR, "Refusing unsafe file update path '%s'.", filename);
+        return;
+    }
+    if (expected_size == 0 || expected_size > FILE_UPDATE_UNCOMPRESSED_MAX) {
+        LOG(ERROR,
+            "Refusing file update '%s' with invalid uncompressed size %" PRIu32 ".",
+            filename,
+            expected_size);
+        return;
+    }
 
     /* Uncompress it. */
-    dest = xmalloc(ucomp_len);
-    uncompress((Bytef *)dest, (uLongf *)&ucomp_len, (const Bytef *)data + pos, (uLong)len);
-    data = dest;
-    len = ucomp_len;
-
-    fp = path_fopen(filename, "wb");
-
-    if (!fp) {
-        LOG(BUG, "Could not open file '%s' for writing.", filename);
+    unsigned char *dest = xmalloc(expected_size);
+    uLongf actual_size = expected_size;
+    uLong consumed_size = compressed.len;
+    int status = uncompress2(dest, &actual_size, compressed.data, &consumed_size);
+    if (status != Z_OK || actual_size != expected_size || consumed_size != compressed.len) {
+        LOG(ERROR,
+            "Could not decompress file update '%s' (zlib status: %d, expected: %" PRIu32
+            ", actual: %lu, compressed: %" PRIu64 ", consumed: %lu).",
+            filename,
+            status,
+            expected_size,
+            (unsigned long)actual_size,
+            (uint64_t)compressed.len,
+            consumed_size);
         free(dest);
         return;
     }
 
-    /* Update the file. */
-    fwrite(data, 1, len, fp);
-    fclose(fp);
+    char *path = file_path(filename, "wb");
+    bool saved = path_write_atomic(path, dest, actual_size, 0600);
+    free(path);
     free(dest);
+    if (!saved) {
+        LOG(ERROR, "Could not atomically write file update '%s'.", filename);
+        return;
+    }
+    file_updates_requested--;
 }
 
 /**

--- a/client/src/cmake.txt
+++ b/client/src/cmake.txt
@@ -15,6 +15,7 @@ set(SOURCES
 	src/client/metaserver.c
 	src/client/metaserver_direct.c
 	src/client/misc.c
+	src/client/packet_payload.c
 	src/client/player.c
 	src/client/region_map.c
 	src/client/resources.c

--- a/client/src/include/packet_payload.h
+++ b/client/src/include/packet_payload.h
@@ -1,0 +1,37 @@
+/*************************************************************************
+ *           Atrinik, a Multiplayer Online Role Playing Game             *
+ *                                                                       *
+ *   Copyright (C) 2009-2014 Zoey Rose and Atrinik Development Team      *
+ *                                                                       *
+ * This program is free software; you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation; either version 2 of the License, or     *
+ * (at your option) any later version.                                   *
+ ************************************************************************/
+
+#ifndef PACKET_PAYLOAD_H
+#define PACKET_PAYLOAD_H
+
+#include <toolkit/packet.h>
+
+bool client_packet_parse_image(const uint8_t *data,
+                               size_t len,
+                               size_t pos,
+                               uint32_t *face_id,
+                               packet_view_t *image);
+bool client_packet_parse_file_update(const uint8_t *data,
+                                     size_t len,
+                                     size_t pos,
+                                     char *filename,
+                                     size_t filename_size,
+                                     uint32_t *uncompressed_size,
+                                     packet_view_t *compressed);
+bool client_packet_parse_resource(const uint8_t *data,
+                                  size_t len,
+                                  size_t pos,
+                                  char *name,
+                                  size_t name_size,
+                                  size_t digest_size,
+                                  packet_view_t *digest);
+
+#endif

--- a/client/src/tests/packet_payload.c
+++ b/client/src/tests/packet_payload.c
@@ -1,0 +1,126 @@
+/*************************************************************************
+ *           Atrinik, a Multiplayer Online Role Playing Game             *
+ *                                                                       *
+ *   Copyright (C) 2009-2014 Zoey Rose and Atrinik Development Team      *
+ *                                                                       *
+ * This program is free software; you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation; either version 2 of the License, or     *
+ * (at your option) any later version.                                   *
+ ************************************************************************/
+
+#include <packet_payload.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+#define TEST_CHECK(condition) \
+    do {                      \
+        if (!(condition)) {   \
+            abort();          \
+        }                     \
+    } while (0)
+
+static void test_image(void) {
+    packet_struct *packet = packet_new(0, 16, 16);
+    const uint8_t bytes[] = {1, 2, 3};
+    packet_writer_write_uint32(packet, 42);
+    packet_writer_write_uint32(packet, sizeof(bytes));
+    packet_writer_write_bytes(packet, bytes, sizeof(bytes));
+
+    uint32_t face_id = 0;
+    packet_view_t image = {0};
+    TEST_CHECK(client_packet_parse_image(packet->data, packet->len, 0, &face_id, &image));
+    TEST_CHECK(face_id == 42);
+    TEST_CHECK(image.len == sizeof(bytes));
+    TEST_CHECK(memcmp(image.data, bytes, sizeof(bytes)) == 0);
+
+    packet_writer_write_uint8(packet, 0xff);
+    TEST_CHECK(!client_packet_parse_image(packet->data, packet->len, 0, &face_id, &image));
+    packet_free(packet);
+
+    const uint8_t truncated[] = {0, 0, 0, 42, 0, 0, 0, 4, 1, 2, 3};
+    TEST_CHECK(!client_packet_parse_image(truncated, sizeof(truncated), 0, &face_id, &image));
+}
+
+static void test_file_update(void) {
+    packet_struct *packet = packet_new(0, 32, 16);
+    const uint8_t bytes[] = {4, 5, 6};
+    packet_writer_write_cstring(packet, "sound/effect.ogg");
+    packet_writer_write_uint32(packet, 1234);
+    packet_writer_write_bytes(packet, bytes, sizeof(bytes));
+
+    char filename[64];
+    uint32_t uncompressed_size = 0;
+    packet_view_t compressed = {0};
+    TEST_CHECK(client_packet_parse_file_update(packet->data,
+                                               packet->len,
+                                               0,
+                                               filename,
+                                               sizeof(filename),
+                                               &uncompressed_size,
+                                               &compressed));
+    TEST_CHECK(strcmp(filename, "sound/effect.ogg") == 0);
+    TEST_CHECK(uncompressed_size == 1234);
+    TEST_CHECK(compressed.len == sizeof(bytes));
+    TEST_CHECK(memcmp(compressed.data, bytes, sizeof(bytes)) == 0);
+    packet_free(packet);
+
+    const uint8_t unterminated[] = {'b', 'a', 'd'};
+    TEST_CHECK(!client_packet_parse_file_update(unterminated,
+                                                sizeof(unterminated),
+                                                0,
+                                                filename,
+                                                sizeof(filename),
+                                                &uncompressed_size,
+                                                &compressed));
+}
+
+static void test_resource(void) {
+    packet_struct *packet = packet_new(0, 80, 16);
+    uint8_t digest_bytes[64];
+    memset(digest_bytes, 0xab, sizeof(digest_bytes));
+    packet_writer_write_cstring(packet, "painting.xml");
+    packet_writer_write_bytes(packet, digest_bytes, sizeof(digest_bytes));
+
+    char name[64];
+    packet_view_t digest = {0};
+    TEST_CHECK(client_packet_parse_resource(packet->data,
+                                            packet->len,
+                                            0,
+                                            name,
+                                            sizeof(name),
+                                            sizeof(digest_bytes),
+                                            &digest));
+    TEST_CHECK(strcmp(name, "painting.xml") == 0);
+    TEST_CHECK(digest.len == sizeof(digest_bytes));
+    TEST_CHECK(memcmp(digest.data, digest_bytes, sizeof(digest_bytes)) == 0);
+
+    packet_writer_write_uint8(packet, 0xff);
+    TEST_CHECK(!client_packet_parse_resource(packet->data,
+                                             packet->len,
+                                             0,
+                                             name,
+                                             sizeof(name),
+                                             sizeof(digest_bytes),
+                                             &digest));
+    packet_free(packet);
+
+    const uint8_t truncated[] = {'x', '\0', 1, 2, 3};
+    TEST_CHECK(!client_packet_parse_resource(truncated,
+                                             sizeof(truncated),
+                                             0,
+                                             name,
+                                             sizeof(name),
+                                             sizeof(digest_bytes),
+                                             &digest));
+}
+
+int main(void) {
+    toolkit_import(packet);
+    test_image();
+    test_file_update();
+    test_resource();
+    toolkit_deinit();
+    return 0;
+}


### PR DESCRIPTION
## Summary

- parse IMAGE, FILE_UPDATE, and RESOURCE raw tails through bounded packet readers
- reject truncated/trailing payloads before cache or file side effects
- validate and bound file-update decompression, safe paths, solicitation, and atomic persistence
- add focused client packet-layout regression coverage

This fixes the repeated `Rejected malformed image command: trailing data` errors introduced by the bounded packet cursor migration and the corresponding resource/update cursor mismatches. The server wire format is unchanged.

## Validation

- `cmake --build --preset gcc-debug`
- `ctest --preset gcc-debug --output-on-failure` (29/29 passed outside the restricted socket sandbox)
- Clang ASan/UBSan client and `client-packet-payload` test
- targeted `clang-tidy`
- `git diff --check`