### PR TITLE
balance(content): reduce book weights

### DIFF
--- a/arch/items/readable/books/book.arc
+++ b/arch/items/readable/books/book.arc
@@ -8,7 +8,7 @@ material 1
 item_condition 100
 item_quality 100
 value 45
-weight 1200
+weight 450
 level 1
 exp 10
 no_pick 0
@@ -24,7 +24,7 @@ material 1
 item_condition 100
 item_quality 100
 value 45
-weight 1200
+weight 450
 level 1
 exp 10
 no_pick 0
@@ -40,7 +40,7 @@ material 1
 item_condition 100
 item_quality 100
 value 45
-weight 1200
+weight 450
 level 1
 exp 10
 no_pick 0
@@ -56,7 +56,7 @@ material 1
 item_condition 100
 item_quality 100
 value 45
-weight 1200
+weight 450
 level 1
 exp 10
 no_pick 0
@@ -72,7 +72,7 @@ material 1
 item_condition 100
 item_quality 100
 value 45
-weight 1200
+weight 450
 level 1
 exp 10
 no_pick 0

--- a/arch/items/readable/books/tome.arc
+++ b/arch/items/readable/books/tome.arc
@@ -7,7 +7,7 @@ type 8
 material 1
 material_real 1
 value 50
-weight 1250
+weight 750
 level 1
 exp 10
 no_pick 0
@@ -23,7 +23,7 @@ material 1
 item_condition 100
 item_quality 100
 value 50
-weight 1250
+weight 750
 level 1
 exp 10
 no_pick 0
@@ -39,7 +39,7 @@ material 1
 item_condition 100
 item_quality 100
 value 50
-weight 1250
+weight 750
 level 1
 exp 10
 no_pick 0
@@ -55,7 +55,7 @@ material 1
 item_condition 100
 item_quality 100
 value 50
-weight 1250
+weight 750
 level 1
 exp 10
 no_pick 0
@@ -71,7 +71,7 @@ material 1
 item_condition 100
 item_quality 100
 value 50
-weight 1250
+weight 750
 level 1
 exp 10
 no_pick 0

--- a/arch/items/spells/book_cleric.arc
+++ b/arch/items/spells/book_cleric.arc
@@ -9,6 +9,6 @@ material 1
 item_condition 100
 item_quality 100
 value 150
-weight 950
+weight 500
 nrof 1
 end

--- a/arch/items/spells/book_spell.arc
+++ b/arch/items/spells/book_spell.arc
@@ -10,6 +10,6 @@ material 1
 item_condition 100
 item_quality 100
 value 1150
-weight 950
+weight 500
 can_stack 1
 end


### PR DESCRIPTION
## Summary

- reduce ordinary books from 1.2 kg to 0.45 kg
- reduce large tomes from 1.25 kg to 0.75 kg
- reduce spell and prayer books from 0.95 kg to 0.5 kg
- preserve a useful weight distinction between ordinary books and tomes

## Validation

- `python3 tools/collect.py -c archetypes -d .`
- verified all type-8 readable archetypes and map-level overrides
- `git diff --check`