### PR TITLE
fix(client): resolve SDL3 sprite and chat regressions

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -88,6 +88,19 @@ if (BUILD_TESTING AND NOT MINGW)
         ${CMAKE_CURRENT_SOURCE_DIR}/src/include)
     target_link_libraries(client-packet-payload-tests PRIVATE atrinik-toolkit)
     add_test(NAME client-packet-payload COMMAND client-packet-payload-tests)
+
+    add_executable(client-surface-primitives-tests
+        src/tests/surface_primitives.c
+        src/gui/toolkit/surface_primitives.c)
+    atrinik_configure_target(client-surface-primitives-tests)
+    target_compile_definitions(client-surface-primitives-tests PRIVATE SDL_DISABLE_OLD_NAMES)
+    target_include_directories(client-surface-primitives-tests BEFORE PRIVATE
+        ${CMAKE_CURRENT_BINARY_DIR}/src/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/gui/toolkit/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/src)
+    target_link_libraries(client-surface-primitives-tests PRIVATE atrinik-toolkit SDL3::SDL3)
+    add_test(NAME client-surface-primitives COMMAND client-surface-primitives-tests)
 endif ()
 
 # Installer.

--- a/client/src/client/sprite.c
+++ b/client/src/client/sprite.c
@@ -55,6 +55,49 @@ static int dark_alpha[DARK_LEVELS] = {0, 44, 80, 117, 153, 190, 226};
  */
 static sprite_cache_t *sprites_cache = NULL;
 
+/** Calculate the transparent padding around a sprite's visible pixels. */
+static bool sprite_borders_get(SDL_Surface *surface, sprite_struct *sprite) {
+    int minimum_x = surface->w;
+    int minimum_y = surface->h;
+    int maximum_x = -1;
+    int maximum_y = -1;
+    bool locked = false;
+
+    if (SDL_MUSTLOCK(surface)) {
+        if (!SDL_LockSurface(surface)) {
+            return false;
+        }
+        locked = true;
+    }
+
+    for (int y = 0; y < surface->h; y++) {
+        for (int x = 0; x < surface->w; x++) {
+            if (!surface_pixel_visible(surface, x, y)) {
+                continue;
+            }
+
+            minimum_x = MIN(minimum_x, x);
+            minimum_y = MIN(minimum_y, y);
+            maximum_x = MAX(maximum_x, x);
+            maximum_y = MAX(maximum_y, y);
+        }
+    }
+
+    if (locked) {
+        SDL_UnlockSurface(surface);
+    }
+
+    if (maximum_x < 0) {
+        return false;
+    }
+
+    sprite->border_up = minimum_y;
+    sprite->border_down = surface->h - maximum_y - 1;
+    sprite->border_left = minimum_x;
+    sprite->border_right = surface->w - maximum_x - 1;
+    return true;
+}
+
 /**
  * Initialize the sprite system.
  */
@@ -115,24 +158,21 @@ sprite_struct *sprite_tryload_file(char *fname, uint32_t flag, SDL_IOStream *rwo
         return NULL;
     }
 
-    uint32_t ckey = 0;
+    SDL_Palette *palette = SDL_GetSurfacePalette(bitmap);
 
-    if (SDL_GetSurfacePalette(bitmap) != NULL) {
-        SDL_GetSurfaceColorKey(bitmap, &ckey);
-        SDL_SetSurfaceColorKey(bitmap, true, ckey);
-        SDL_SetSurfaceRLE(bitmap, true);
-    } else if (flag & SURFACE_FLAG_COLKEY_16M) {
+    if (palette == NULL && (flag & SURFACE_FLAG_COLKEY_16M)) {
         /* Force a true color png to colorkey. Default ckey is black (0). */
         SDL_SetSurfaceColorKey(bitmap, true, 0);
-        SDL_SetSurfaceRLE(bitmap, true);
     }
 
-    surface_borders_get(bitmap,
-                        &sprite->border_up,
-                        &sprite->border_down,
-                        &sprite->border_left,
-                        &sprite->border_right,
-                        ckey);
+    if (!surface_ensure_blittable(&bitmap)) {
+        SDL_DestroySurface(bitmap);
+        free(sprite);
+        return NULL;
+    }
+
+    sprite_borders_get(bitmap, sprite);
+    SDL_SetSurfaceRLE(bitmap, true);
     sprite->bitmap = bitmap;
 
     if (flag & (SURFACE_FLAG_DISPLAYFORMATALPHA | SURFACE_FLAG_DISPLAYFORMAT)) {
@@ -696,12 +736,11 @@ static SDL_Surface *sprite_effects_create(SDL_Surface *surface, const sprite_eff
             goto done;
         }
 
-        char buf[MAX_BUF];
-        snprintf(VS(buf), "rectangle:500,500,%d", dark_alpha[effects->dark_level]);
-        SDL_BlitSurface(texture_surface(texture_get(TEXTURE_TYPE_SOFTWARE, buf)),
-                        NULL,
-                        surface,
-                        NULL);
+        if (!surface_darken_preserve_alpha(surface, dark_alpha[effects->dark_level])) {
+            SDL_DestroySurface(surface);
+            surface = NULL;
+            goto done;
+        }
         FREE_TMP_SURFACE();
     } else if (BIT_QUERY(effects->flags, SPRITE_FLAG_FOW)) {
         surface = sprite_effect_fow(surface);

--- a/client/src/gui/toolkit/surface_primitives.c
+++ b/client/src/gui/toolkit/surface_primitives.c
@@ -77,6 +77,81 @@ SDL_Surface *surface_to_display_alpha(SDL_Surface *surface) {
     return SDL_ConvertSurface(surface, SDL_PIXELFORMAT_RGBA32);
 }
 
+/**
+ * Convert packed indexed surfaces to a format supported by SDL's blitters.
+ *
+ * SDL3 can load 1-, 2-, and 4-bit indexed PNGs, but its software blitters and
+ * scaling functions do not support those packed formats. The majority of
+ * Atrinik's game sprites use them, so normalize only those surfaces while
+ * retaining the more compact, supported 8-bit indexed format.
+ */
+bool surface_ensure_blittable(SDL_Surface **surface) {
+    HARD_ASSERT(surface != NULL);
+    HARD_ASSERT(*surface != NULL);
+
+    const SDL_PixelFormatDetails *details = SDL_GetPixelFormatDetails((*surface)->format);
+    if (details == NULL) {
+        return false;
+    }
+
+    if (details->bits_per_pixel >= 8) {
+        return true;
+    }
+
+    SDL_Surface *converted = surface_to_display_alpha(*surface);
+    if (converted == NULL) {
+        return false;
+    }
+
+    SDL_DestroySurface(*surface);
+    *surface = converted;
+    return true;
+}
+
+/**
+ * Darken RGB channels without changing any pixel's alpha.
+ *
+ * Blending a translucent black rectangle onto an RGBA sprite also increases
+ * the alpha of transparent pixels under SDL3. That turns sprite backgrounds
+ * into visible rectangles. Applying the equivalent RGB modulation directly
+ * preserves the sprite silhouette.
+ */
+bool surface_darken_preserve_alpha(SDL_Surface *surface, Uint8 alpha) {
+    HARD_ASSERT(surface != NULL);
+
+    if (alpha == SDL_ALPHA_TRANSPARENT) {
+        return true;
+    }
+
+    if (!SDL_LockSurface(surface)) {
+        return false;
+    }
+
+    const SDL_PixelFormatDetails *details = SDL_GetPixelFormatDetails(surface->format);
+    SDL_Palette *palette = SDL_GetSurfacePalette(surface);
+    if (details == NULL || details->bytes_per_pixel != sizeof(Uint32)) {
+        SDL_UnlockSurface(surface);
+        SDL_SetError("Darkening requires a 32-bit surface");
+        return false;
+    }
+
+    const unsigned int factor = SDL_ALPHA_OPAQUE - alpha;
+    for (int y = 0; y < surface->h; y++) {
+        Uint32 *row = (Uint32 *)((Uint8 *)surface->pixels + y * surface->pitch);
+        for (int x = 0; x < surface->w; x++) {
+            Uint8 red, green, blue, pixel_alpha;
+            SDL_GetRGBA(row[x], details, palette, &red, &green, &blue, &pixel_alpha);
+            red = (Uint8)((red * factor + 127) / SDL_ALPHA_OPAQUE);
+            green = (Uint8)((green * factor + 127) / SDL_ALPHA_OPAQUE);
+            blue = (Uint8)((blue * factor + 127) / SDL_ALPHA_OPAQUE);
+            row[x] = SDL_MapRGBA(details, palette, red, green, blue, pixel_alpha);
+        }
+    }
+
+    SDL_UnlockSurface(surface);
+    return true;
+}
+
 Uint32 surface_map_rgb(SDL_Surface *surface, Uint8 red, Uint8 green, Uint8 blue) {
     return SDL_MapRGB(SDL_GetPixelFormatDetails(surface->format),
                       SDL_GetSurfacePalette(surface),

--- a/client/src/gui/widgets/input.c
+++ b/client/src/gui/widgets/input.c
@@ -92,6 +92,10 @@ static int widget_event(widgetdata *widget, SDL_Event *event) {
         return text_input_event(&WIDGET_INPUT(widget)->text_input, event);
     }
 
+    if (widget->show && event->type == SDL_EVENT_KEY_UP) {
+        return 1;
+    }
+
     if (widget->show && event->type == SDL_EVENT_KEY_DOWN) {
         input = WIDGET_INPUT(widget);
 
@@ -119,6 +123,11 @@ static int widget_event(widgetdata *widget, SDL_Event *event) {
         } else if (text_input_event(text_input, event)) {
             return 1;
         }
+
+        /* SDL3 emits printable text through SDL_EVENT_TEXT_INPUT. Consume the
+         * corresponding physical key event so it cannot also activate a
+         * gameplay key binding while chat has keyboard focus. */
+        return 1;
     }
 
     return 0;

--- a/client/src/include/surface_primitives.h
+++ b/client/src/include/surface_primitives.h
@@ -33,6 +33,8 @@ extern void pixel_format_get_rgba(Uint32 pixel,
                                   Uint8 *alpha);
 extern SDL_Surface *surface_to_display(SDL_Surface *surface);
 extern SDL_Surface *surface_to_display_alpha(SDL_Surface *surface);
+extern bool surface_ensure_blittable(SDL_Surface **surface);
+extern bool surface_darken_preserve_alpha(SDL_Surface *surface, Uint8 alpha);
 extern Uint32 surface_map_rgb(SDL_Surface *surface, Uint8 red, Uint8 green, Uint8 blue);
 extern Uint32
 surface_map_rgba(SDL_Surface *surface, Uint8 red, Uint8 green, Uint8 blue, Uint8 alpha);

--- a/client/src/tests/surface_primitives.c
+++ b/client/src/tests/surface_primitives.c
@@ -1,0 +1,82 @@
+/*************************************************************************
+ *           Atrinik, a Multiplayer Online Role Playing Game             *
+ *                                                                       *
+ *   Copyright (C) 2026 Atrinik Development Team                         *
+ *                                                                       *
+ * This program is free software; you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation; either version 2 of the License, or     *
+ * (at your option) any later version.                                   *
+ ************************************************************************/
+
+#include <global.h>
+
+SDL_Surface *ScreenSurface = NULL;
+
+#define TEST_CHECK(condition) \
+    do {                      \
+        if (!(condition)) {   \
+            abort();          \
+        }                     \
+    } while (0)
+
+static void test_packed_indexed_conversion(void) {
+    SDL_Surface *surface = SDL_CreateSurface(2, 1, SDL_PIXELFORMAT_INDEX4MSB);
+    TEST_CHECK(surface != NULL);
+
+    SDL_Color colors[16] = {{0}};
+    colors[0] = (SDL_Color){255, 0, 255, SDL_ALPHA_TRANSPARENT};
+    colors[1] = (SDL_Color){240, 10, 20, SDL_ALPHA_OPAQUE};
+    SDL_Palette *palette = SDL_CreatePalette(arraysize(colors));
+    TEST_CHECK(palette != NULL);
+    TEST_CHECK(SDL_SetPaletteColors(palette, colors, 0, arraysize(colors)));
+    TEST_CHECK(SDL_SetSurfacePalette(surface, palette));
+    SDL_DestroyPalette(palette);
+    ((Uint8 *)surface->pixels)[0] = 0x10;
+
+    TEST_CHECK(surface_ensure_blittable(&surface));
+    const SDL_PixelFormatDetails *details = SDL_GetPixelFormatDetails(surface->format);
+    TEST_CHECK(details != NULL);
+    TEST_CHECK(details->bits_per_pixel == sizeof(Uint32) * 8);
+
+    Uint8 red, green, blue, alpha;
+    TEST_CHECK(SDL_ReadSurfacePixel(surface, 0, 0, &red, &green, &blue, &alpha));
+    TEST_CHECK(red == 240 && green == 10 && blue == 20 && alpha == SDL_ALPHA_OPAQUE);
+    TEST_CHECK(SDL_ReadSurfacePixel(surface, 1, 0, &red, &green, &blue, &alpha));
+    TEST_CHECK(alpha == SDL_ALPHA_TRANSPARENT);
+
+    SDL_Surface *destination = SDL_CreateSurface(2, 1, SDL_PIXELFORMAT_XRGB8888);
+    TEST_CHECK(destination != NULL);
+    TEST_CHECK(SDL_FillSurfaceRect(destination, NULL, surface_map_rgb(destination, 1, 2, 3)));
+    TEST_CHECK(SDL_BlitSurface(surface, NULL, destination, NULL));
+    TEST_CHECK(SDL_ReadSurfacePixel(destination, 0, 0, &red, &green, &blue, &alpha));
+    TEST_CHECK(red == 240 && green == 10 && blue == 20);
+    TEST_CHECK(SDL_ReadSurfacePixel(destination, 1, 0, &red, &green, &blue, &alpha));
+    TEST_CHECK(red == 1 && green == 2 && blue == 3);
+
+    SDL_DestroySurface(destination);
+    SDL_DestroySurface(surface);
+}
+
+static void test_darken_preserves_alpha(void) {
+    SDL_Surface *surface = SDL_CreateSurface(2, 1, SDL_PIXELFORMAT_RGBA32);
+    TEST_CHECK(surface != NULL);
+    TEST_CHECK(SDL_WriteSurfacePixel(surface, 0, 0, 100, 150, 200, SDL_ALPHA_TRANSPARENT));
+    TEST_CHECK(SDL_WriteSurfacePixel(surface, 1, 0, 100, 150, 200, 200));
+
+    TEST_CHECK(surface_darken_preserve_alpha(surface, 128));
+
+    Uint8 red, green, blue, alpha;
+    TEST_CHECK(SDL_ReadSurfacePixel(surface, 0, 0, &red, &green, &blue, &alpha));
+    TEST_CHECK(red == 50 && green == 75 && blue == 100 && alpha == SDL_ALPHA_TRANSPARENT);
+    TEST_CHECK(SDL_ReadSurfacePixel(surface, 1, 0, &red, &green, &blue, &alpha));
+    TEST_CHECK(red == 50 && green == 75 && blue == 100 && alpha == 200);
+
+    SDL_DestroySurface(surface);
+}
+
+int main(void) {
+    test_packed_indexed_conversion();
+    test_darken_preserves_alpha();
+    return 0;
+}


### PR DESCRIPTION
## Summary

- normalize packed 1/2/4-bit indexed sprite surfaces before SDL3 blitting and scaling, restoring inventory, below-inventory, and player-doll item art
- calculate sprite padding from the normalized visible silhouette
- darken sprite RGB without changing transparent-pixel alpha, removing nighttime rectangles
- keep focused chat key-down/key-up events from falling through to gameplay commands
- add focused packed-surface and alpha-preservation regression tests

## Validation

- warning-as-error GCC client build
- warning-as-error Clang ASan/UBSan client build
- client packet and surface CTests
- focused surface CTest under ASan/UBSan/LSan outside the sandbox
- focused clang-format and clang-tidy review
- `git diff --check`

## Manual acceptance

Representative live-map, inventory, player-doll, below-inventory, and IME checks are called out for maintainer testing.