### PR TITLE
feat(content): establish stable content identities

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -73,7 +73,7 @@ jobs:
               client/*)
                 client=true
                 ;;
-              arch/*|maps/*|server/*|Dockerfile.server|generate-region-maps.sh|tools/collect.py|tools/utils.py|tools/compilers/*)
+              arch/*|maps/*|server/*|Dockerfile.server|generate-region-maps.sh|tools/collect.py|tools/utils.py|tools/compilers/*|tools/content_catalog/*|tools/map-checker-qt/*|tools/tests/test_content_catalog.py)
                 server=true
                 ;;
               .devcontainer/*|.github/workflows/linux-ci.yml|.github/workflows/release.yml|CMakeLists.txt|CMakePresets.json|build.config|build.sh|build-windows.sh|cmake/*|common/*|compose.windows.yaml|tests/*)

--- a/arch/artifacts.art
+++ b/arch/artifacts.art
@@ -2594,7 +2594,7 @@ def_arch scroll_generic
 Object
 level 1
 inv_face scroll_fire.101
-sp 0
+spell_id spell_firestorm
 type 111
 is_magical 1
 value 25
@@ -2608,7 +2608,7 @@ affinity cold
 def_arch scroll_generic
 Object
 level 1
-sp 1
+spell_id spell_icestorm
 inv_face scroll_ice.101
 type 111
 is_magical 1
@@ -2623,7 +2623,7 @@ def_arch scroll_generic
 Object
 level 1
 inv_face scroll_heal.101
-sp 2
+spell_id spell_minor_healing
 type 111
 is_magical 1
 value 27
@@ -2637,7 +2637,7 @@ def_arch scroll_generic
 Object
 level 1
 inv_face scroll_str.101
-sp 5
+spell_id spell_strength_self
 type 111
 is_magical 1
 value 23
@@ -2651,7 +2651,7 @@ def_arch scroll_generic
 Object
 level 1
 inv_face scroll_identify.101
-sp 6
+spell_id spell_identify
 type 111
 is_magical 1
 value 28
@@ -2665,7 +2665,7 @@ def_arch scroll_generic
 Object
 level 1
 inv_face scroll_remove.101
-sp 9
+spell_id spell_remove_curse
 type 111
 is_magical 1
 value 27
@@ -2678,7 +2678,7 @@ difficulty 6
 def_arch scroll_generic
 Object
 level 1
-sp 10
+spell_id spell_remove_damnation
 inv_face scroll_remove.101
 type 111
 is_magical 1
@@ -2693,7 +2693,7 @@ def_arch scroll_generic
 Object
 inv_face scroll_wound.101
 level 1
-sp 11
+spell_id spell_cause_light_wounds
 type 111
 is_magical 1
 value 20
@@ -2707,7 +2707,7 @@ def_arch scroll_generic
 Object
 inv_face scroll_recharge.101
 level 1
-sp 20
+spell_id spell_recharge
 type 111
 is_magical 1
 value 36
@@ -2885,7 +2885,7 @@ face potion_golden.101
 level 1
 type 5
 is_magical 1
-sp 15
+spell_id spell_remove_depletion
 value 135
 end
 
@@ -2901,7 +2901,7 @@ level 1
 is_magical 1
 type 5
 value 170
-sp 0
+spell_id spell_firestorm
 end
 
 Allowed potion_generic
@@ -2915,7 +2915,7 @@ face potion_white.101
 level 1
 type 5
 is_magical 1
-sp 1
+spell_id spell_icestorm
 value 170
 end
 
@@ -2931,7 +2931,7 @@ face potion_fizzy.101
 is_magical 1
 level 1
 type 5
-sp 3
+spell_id spell_cure_poison
 value 170
 end
 
@@ -2947,7 +2947,7 @@ stand_still 1
 type 5
 face potion_effervescent.101
 is_magical 1
-sp 4
+spell_id spell_cure_disease
 value 170
 end
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,3 +61,77 @@ after the matching images are published.
 
 See the root `README.md` and `INSTALL`, `client/README`, and `server/README` for
 component-specific setup and validation procedures.
+
+## Authored content identities
+
+`tools/content_catalog/` is the shared identity and cross-reference layer for
+authored gameplay content. It reads authoritative sources directly; it is not
+another source of truth. Run it from the repository root with:
+
+```sh
+python3 -m tools.content_catalog validate --root .
+python3 -m tools.content_catalog emit --root . \
+    --output build/content-catalog.json
+```
+
+The emitted JSON is deterministic, contains repository-relative source
+locations, and belongs under `build/`. Collection runs the same validator
+before writing any aggregate file. CTest exposes `content-catalog-unit` and
+`content-catalog-validate`; the server `check` label includes both.
+
+Stable IDs are domain-qualified at persistence and interchange boundaries,
+for example `quest:lost_memories`, `quest-part:lost_memories::helping_out`,
+`region:incuna`, `map:/shattered_islands/world_1_80`, and
+`archetype:skill_literacy`. A matching string in another domain never satisfies
+a typed reference.
+
+| Domain | Canonical stable key | Authoritative source |
+| --- | --- | --- |
+| `archetype` | Primary `Object` key; multipart continuation objects are not independently addressable | Authored `arch/**/*.arc` files |
+| `artifact` | `artifact` key | Authored `arch/**/*.art` and `maps/**/*.art` files |
+| `treasure` | `treasure` or `treasureone` key; this is also the stable key for a reward backed by a treasure table | Authored `arch/**/*.trs` and `maps/**/*.trs` files |
+| `map` | Leading-slash path relative to `maps/`, without rewriting the filename | Authored map file |
+| `region` | `region` key | `maps/regions.reg` |
+| `faction` | `faction` key | Authored `maps/**/*.factions` files |
+| `quest` | Directory name immediately below `maps/interfaces/quests/` | `maps/interfaces/quests/<quest>/` |
+| `quest-part` | Quest key plus nested part UIDs joined with `::` | The quest XML's `part uid` attributes |
+| `spell` | Spell archetype key, conventionally `spell_<name>` | Type-29 spell archetype in `arch/`; the matching `spellist.h` ID is its runtime mapping |
+| `skill` | Skill archetype key, conventionally `skill_<name>` | Type-43 skill archetype in `arch/`; the matching `skillist.h` ID is its runtime mapping |
+
+Display names, messages, descriptions, translations, filesystem enumeration
+order, C enum values, and array positions are not identities. In particular,
+quest-part UIDs are validated and preserved verbatim; the interface compiler
+must never sanitize one into a different key. Runtime spell and skill indices
+are process-local acceleration values. New durable data must serialize the
+stable archetype key and resolve it to an index after startup.
+The object save format writes these as `spell_id` and `skill_id`; the generic
+numeric `sp` field remains available for unrelated object types. Reserved skill
+table slots without an obtainable skill archetype are internal implementation
+details and are not catalog definitions.
+
+Existing monster variants and bosses retain their archetype identities; do not
+invent parallel variant or boss IDs for them. A monster-family key does not yet
+have an authoritative authored source. The same is true for disciplines,
+techniques, activities, achievements, and named landmark records. The feature
+that introduces one of those concepts must add its explicit key to its owning
+authored schema and teach the catalog loader about that schema in the same
+change. A monster's mutable `name` or broad legacy `race` value is not a safe
+substitute. Alchemical formulae likewise have no current authored entries or
+stable recipe key; the first recipe work must add an explicit recipe key rather
+than deriving one from its result title or ingredient order.
+
+### Rename, removal, and migration policy
+
+Before any ID has a durable consumer, a rename may be made atomically by
+updating its authoritative definition and every in-repository reference. Once
+an ID has been persisted or exchanged externally, its rename or removal must
+include a reviewed migration or tombstone owned beside that domain's source.
+The migration must identify the old domain-qualified key, the replacement (or
+explicit removal), and every durable store that applies it. Tests must cover
+both resolution and repeated application.
+
+Do not add aliases or migrations for hypothetical data. Generated catalogs and
+runtime lookup tables are rebuilt from the post-migration sources and are
+never edited by hand. A migration may be deleted only when every supported
+store has recorded its application and no accepted input can still contain the
+old key.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -115,7 +115,7 @@ have an authoritative authored source. The same is true for disciplines,
 techniques, activities, achievements, and named landmark records. The feature
 that introduces one of those concepts must add its explicit key to its owning
 authored schema and teach the catalog loader about that schema in the same
-change. A monster's mutable `name` or broad legacy `race` value is not a safe
+change. A monster's mutable `name` or broad `race` value is not a safe
 substitute. Alchemical formulae likewise have no current authored entries or
 stable recipe key; the first recipe work must add an explicit recipe key rather
 than deriving one from its result title or ingredient order.

--- a/maps/shattered_islands/strakewood_island/zechna_temple/zechna_temple_0_0_-3
+++ b/maps/shattered_islands/strakewood_island/zechna_temple/zechna_temple_0_0_-3
@@ -2520,7 +2520,7 @@ name Zechna's heavy rod
 no_pick 1
 identified 1
 is_magical 1
-sp 50
+spell_id spell_negative_energy_bolt
 level 115
 end
 end

--- a/maps/shattered_islands/world_4_43
+++ b/maps/shattered_islands/world_4_43
@@ -2266,7 +2266,7 @@ x 11
 y 11
 end
 arch rod_heavy
-sp 19
+spell_id spell_word_of_recall
 x 11
 y 11
 end

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -152,6 +152,22 @@ if (BUILD_TESTING AND NOT MINGW)
     find_package(Python3 REQUIRED COMPONENTS Interpreter)
     pkg_check_modules(CHECK_PKG QUIET IMPORTED_TARGET check)
 
+    add_test(NAME content-catalog-unit
+        COMMAND ${Python3_EXECUTABLE} -m unittest
+            tools.tests.test_content_catalog)
+    set_tests_properties(content-catalog-unit PROPERTIES
+        LABELS "server;content;unit"
+        TIMEOUT 60
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+
+    add_test(NAME content-catalog-validate
+        COMMAND ${Python3_EXECUTABLE} -m tools.content_catalog
+            validate --root "${CMAKE_SOURCE_DIR}")
+    set_tests_properties(content-catalog-validate PROPERTIES
+        LABELS "server;content"
+        TIMEOUT 60
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+
     if (CHECK_PKG_FOUND)
         include(src/tests/suites.cmake)
         set(SOURCES_CHECK
@@ -219,8 +235,10 @@ if (BUILD_TESTING AND NOT MINGW)
             CONFIGURE_DEPENDS
             LIST_DIRECTORIES false
             "${CMAKE_SOURCE_DIR}/arch/*"
+            "${CMAKE_SOURCE_DIR}/maps/*"
             "${CMAKE_SOURCE_DIR}/server/install_data/*"
-            "${CMAKE_SOURCE_DIR}/tools/compilers/*.py")
+            "${CMAKE_SOURCE_DIR}/tools/compilers/*.py"
+            "${CMAKE_SOURCE_DIR}/tools/content_catalog/*.py")
         list(APPEND ATRINIK_SERVER_TEST_RESOURCE_INPUTS
             ${CMAKE_SOURCE_DIR}/server/ca-bundle.crt
             ${CMAKE_SOURCE_DIR}/server/permissions.cfg

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -234,12 +234,28 @@ if (BUILD_TESTING AND NOT MINGW)
         file(GLOB_RECURSE ATRINIK_SERVER_TEST_RESOURCE_INPUTS
             CONFIGURE_DEPENDS
             LIST_DIRECTORIES false
-            "${CMAKE_SOURCE_DIR}/arch/*"
-            "${CMAKE_SOURCE_DIR}/maps/*"
+            "${CMAKE_SOURCE_DIR}/arch/*.anim"
+            "${CMAKE_SOURCE_DIR}/arch/*.arc"
+            "${CMAKE_SOURCE_DIR}/arch/*.art"
+            "${CMAKE_SOURCE_DIR}/arch/*.png"
+            "${CMAKE_SOURCE_DIR}/arch/*.trs"
+            "${CMAKE_SOURCE_DIR}/maps/*.art"
+            "${CMAKE_SOURCE_DIR}/maps/*.dtd"
+            "${CMAKE_SOURCE_DIR}/maps/*.factions"
+            "${CMAKE_SOURCE_DIR}/maps/*.trs"
+            "${CMAKE_SOURCE_DIR}/maps/*.xml"
             "${CMAKE_SOURCE_DIR}/server/install_data/*"
             "${CMAKE_SOURCE_DIR}/tools/compilers/*.py"
             "${CMAKE_SOURCE_DIR}/tools/content_catalog/*.py")
         list(APPEND ATRINIK_SERVER_TEST_RESOURCE_INPUTS
+            ${CMAKE_SOURCE_DIR}/arch/effects
+            ${CMAKE_SOURCE_DIR}/arch/formulae
+            ${CMAKE_SOURCE_DIR}/arch/hfiles
+            ${CMAKE_SOURCE_DIR}/arch/image_info
+            ${CMAKE_SOURCE_DIR}/arch/materials
+            ${CMAKE_SOURCE_DIR}/arch/messages
+            ${CMAKE_SOURCE_DIR}/arch/server_settings
+            ${CMAKE_SOURCE_DIR}/maps/regions.reg
             ${CMAKE_SOURCE_DIR}/server/ca-bundle.crt
             ${CMAKE_SOURCE_DIR}/server/permissions.cfg
             ${CMAKE_SOURCE_DIR}/server/server.cfg

--- a/server/src/include/skillist.h
+++ b/server/src/include/skillist.h
@@ -60,14 +60,28 @@
  * file
  */
 skill_struct skills[NROFSKILLS] = {
-    {"alchemy", NULL, 10},       {"literacy", NULL, 0},         {"bargaining", NULL, 0},
-    {"construction", NULL, 0},   {"unarmed", NULL, 0},          {"karate", NULL, 0},
-    {"throwing", NULL, 1},       {"wizardry spells", NULL, 1},  {"magic devices", NULL, 4},
-    {"meditation", NULL, 0},     {"find traps", NULL, 0},       {"remove traps", NULL, 0},
-    {"bow archery", NULL, 0},    {"crossbow archery", NULL, 0}, {"sling archery", NULL, 0},
-    {"slash weapons", NULL, 0},  {"cleave weapons", NULL, 0},   {"pierce weapons", NULL, 0},
-    {"impact weapons", NULL, 0}, {"two-hand mastery", NULL, 0}, {"polearm mastery", NULL, 0},
-    {"inscription", NULL, 0},
+    {"skill_alchemy", "alchemy", NULL, 10},
+    {"skill_literacy", "literacy", NULL, 0},
+    {"skill_bargaining", "bargaining", NULL, 0},
+    {"skill_construction", "construction", NULL, 0},
+    {"skill_unarmed", "unarmed", NULL, 0},
+    {"skill_karate", "karate", NULL, 0},
+    {"skill_throwing", "throwing", NULL, 1},
+    {"skill_wizardry_spells", "wizardry spells", NULL, 1},
+    {"skill_magic_devices", "magic devices", NULL, 4},
+    {"skill_meditation", "meditation", NULL, 0},
+    {"skill_find_traps", "find traps", NULL, 0},
+    {"skill_remove_traps", "remove traps", NULL, 0},
+    {"skill_bow_archery", "bow archery", NULL, 0},
+    {"skill_crossbow_archery", "crossbow archery", NULL, 0},
+    {"skill_sling_archery", "sling archery", NULL, 0},
+    {"skill_slash_weapons", "slash weapons", NULL, 0},
+    {"skill_cleave_weapons", "cleave weapons", NULL, 0},
+    {"skill_pierce_weapons", "pierce weapons", NULL, 0},
+    {"skill_impact_weapons", "impact weapons", NULL, 0},
+    {"skill_two_hand_mastery", "two-hand mastery", NULL, 0},
+    {"skill_polearm_mastery", "polearm mastery", NULL, 0},
+    {"skill_inscription", "inscription", NULL, 0},
 };
 
 #endif

--- a/server/src/include/skills.h
+++ b/server/src/include/skills.h
@@ -114,6 +114,9 @@ struct archetype;
 
 /** Skill structure for the skills array. */
 typedef struct skill_struct {
+    /** Stable ID used at persistence and interchange boundaries. */
+    const char *id;
+
     /** How to describe it to the player */
     const char *name;
 
@@ -149,6 +152,10 @@ extern object *SK_skill(object *op);
 /** Public API implemented in src/server/skills.c. */
 
 extern skill_struct skills[NROFSKILLS];
+
+extern int skill_index_from_id(const char *id);
+
+extern const char *skill_id_from_index(int skillnr);
 
 extern void find_traps(object *pl);
 

--- a/server/src/include/spellist.h
+++ b/server/src/include/spellist.h
@@ -32,7 +32,8 @@
 
 /** Array of all the spells. */
 spell_struct spells[NROFREALSPELLS] = {
-    {"firestorm",
+    {"spell_firestorm",
+     "firestorm",
      5,
      8,
      3,
@@ -51,7 +52,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "firebreath",
      NULL},
 
-    {"icestorm",
+    {"spell_icestorm",
+     "icestorm",
      5,
      8,
      3,
@@ -70,7 +72,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "icestorm",
      NULL},
 
-    {"minor healing",
+    {"spell_minor_healing",
+     "minor healing",
      4,
      8,
      3,
@@ -89,7 +92,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "meffect_green",
      NULL},
 
-    {"cure poison",
+    {"spell_cure_poison",
+     "cure poison",
      5,
      8,
      3,
@@ -108,7 +112,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "meffect_purple",
      NULL},
 
-    {"cure disease",
+    {"spell_cure_disease",
+     "cure disease",
      5,
      8,
      3,
@@ -127,7 +132,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "meffect_purple",
      NULL},
 
-    {"strength self",
+    {"spell_strength_self",
+     "strength self",
      5,
      8,
      3,
@@ -146,7 +152,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "meffect_yellow",
      NULL},
 
-    {"identify",
+    {"spell_identify",
+     "identify",
      5,
      8,
      3,
@@ -165,7 +172,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "meffect_pink",
      NULL},
 
-    {"asteroid",
+    {"spell_asteroid",
+     "asteroid",
      5,
      32,
      2,
@@ -184,7 +192,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "asteroid",
      NULL},
 
-    {"frost nova",
+    {"spell_frost_nova",
+     "frost nova",
      5,
      42,
      2,
@@ -203,7 +212,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "asteroid",
      NULL},
 
-    {"remove curse",
+    {"spell_remove_curse",
+     "remove curse",
      5,
      8,
      3,
@@ -222,7 +232,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "meffect_blue",
      NULL},
 
-    {"remove damnation",
+    {"spell_remove_damnation",
+     "remove damnation",
      5,
      8,
      3,
@@ -241,7 +252,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "meffect_blue",
      NULL},
 
-    {"cause light wounds",
+    {"spell_cause_light_wounds",
+     "cause light wounds",
      4,
      8,
      3,
@@ -260,7 +272,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "cause_wounds",
      NULL},
 
-    {"confuse",
+    {"spell_confuse",
+     "confuse",
      5,
      8,
      3,
@@ -279,7 +292,8 @@ spell_struct spells[NROFREALSPELLS] = {
      NULL,
      NULL},
 
-    {"magic bullet",
+    {"spell_magic_bullet",
+     "magic bullet",
      4,
      8,
      3,
@@ -298,7 +312,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "bullet",
      NULL},
 
-    {"summon golem",
+    {"spell_summon_golem",
+     "summon golem",
      5,
      8,
      3,
@@ -317,7 +332,8 @@ spell_struct spells[NROFREALSPELLS] = {
      NULL,
      NULL},
 
-    {"remove depletion",
+    {"spell_remove_depletion",
+     "remove depletion",
      5,
      8,
      3,
@@ -336,7 +352,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "meffect_purple",
      NULL},
 
-    {"probe",
+    {"spell_probe",
+     "probe",
      2,
      8,
      3,
@@ -355,7 +372,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "probebullet",
      NULL},
 
-    {"town portal",
+    {"spell_town_portal",
+     "town portal",
      30,
      8,
      1,
@@ -374,7 +392,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "perm_magic_portal",
      NULL},
 
-    {"create food",
+    {"spell_create_food",
+     "create food",
      30,
      8,
      1,
@@ -393,7 +412,8 @@ spell_struct spells[NROFREALSPELLS] = {
      NULL,
      NULL},
 
-    {"word of recall",
+    {"spell_word_of_recall",
+     "word of recall",
      5,
      24,
      1,
@@ -412,7 +432,8 @@ spell_struct spells[NROFREALSPELLS] = {
      NULL,
      NULL},
 
-    {"recharge",
+    {"spell_recharge",
+     "recharge",
      50,
      100,
      2,
@@ -431,7 +452,8 @@ spell_struct spells[NROFREALSPELLS] = {
      NULL,
      NULL},
 
-    {"greater healing",
+    {"spell_greater_healing",
+     "greater healing",
      6,
      8,
      3,
@@ -450,7 +472,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "meffect_green",
      NULL},
 
-    {"restoration",
+    {"spell_restoration",
+     "restoration",
      10,
      12,
      3,
@@ -469,7 +492,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "meffect_green",
      NULL},
 
-    {"protection from cold",
+    {"spell_protection_from_cold",
+     "protection from cold",
      22,
      100,
      2,
@@ -488,7 +512,8 @@ spell_struct spells[NROFREALSPELLS] = {
      NULL,
      NULL},
 
-    {"protection from fire",
+    {"spell_protection_from_fire",
+     "protection from fire",
      22,
      100,
      2,
@@ -507,7 +532,8 @@ spell_struct spells[NROFREALSPELLS] = {
      NULL,
      NULL},
 
-    {"protection from electricity",
+    {"spell_protection_from_electricity",
+     "protection from electricity",
      22,
      100,
      2,
@@ -526,7 +552,8 @@ spell_struct spells[NROFREALSPELLS] = {
      NULL,
      NULL},
 
-    {"protection from poison",
+    {"spell_protection_from_poison",
+     "protection from poison",
      22,
      100,
      2,
@@ -545,7 +572,8 @@ spell_struct spells[NROFREALSPELLS] = {
      NULL,
      NULL},
 
-    {"consecrate",
+    {"spell_consecrate",
+     "consecrate",
      10,
      70,
      2,
@@ -564,7 +592,8 @@ spell_struct spells[NROFREALSPELLS] = {
      NULL,
      NULL},
 
-    {"finger of death",
+    {"spell_finger_of_death",
+     "finger of death",
      7,
      12,
      2,
@@ -583,7 +612,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "spellobject_finger_of_death",
      NULL},
 
-    {"cause cold",
+    {"spell_cause_cold",
+     "cause cold",
      10,
      50,
      2,
@@ -602,7 +632,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "disease_cold",
      NULL},
 
-    {"cause flu",
+    {"spell_cause_flu",
+     "cause flu",
      12,
      50,
      2,
@@ -621,7 +652,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "flu",
      NULL},
 
-    {"cause leprosy",
+    {"spell_cause_leprosy",
+     "cause leprosy",
      14,
      58,
      2,
@@ -640,7 +672,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "leprosy",
      NULL},
 
-    {"cause smallpox",
+    {"spell_cause_smallpox",
+     "cause smallpox",
      16,
      58,
      2,
@@ -659,7 +692,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "smallpox",
      NULL},
 
-    {"cause pneumonic plague",
+    {"spell_cause_pneumonic_plague",
+     "cause pneumonic plague",
      18,
      58,
      2,
@@ -678,7 +712,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "pneumonic_plague",
      NULL},
 
-    {"meteor",
+    {"spell_meteor",
+     "meteor",
      5,
      32,
      2,
@@ -697,7 +732,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "meteor",
      NULL},
 
-    {"meteor swarm",
+    {"spell_meteor_swarm",
+     "meteor swarm",
      5,
      42,
      2,
@@ -716,7 +752,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "meteor",
      NULL},
 
-    {"poison fog",
+    {"spell_poison_fog",
+     "poison fog",
      18,
      86,
      2,
@@ -735,7 +772,8 @@ spell_struct spells[NROFREALSPELLS] = {
      NULL,
      NULL},
 
-    {"bullet swarm",
+    {"spell_bullet_swarm",
+     "bullet swarm",
      5,
      86,
      2,
@@ -754,7 +792,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "bullet",
      NULL},
 
-    {"bullet storm",
+    {"spell_bullet_storm",
+     "bullet storm",
      4,
      86,
      2,
@@ -773,7 +812,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "bullet",
      NULL},
 
-    {"destruction",
+    {"spell_destruction",
+     "destruction",
      20,
      20,
      0,
@@ -792,7 +832,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "spellobject_destruction",
      NULL},
 
-    {"create bomb",
+    {"spell_create_bomb",
+     "create bomb",
      10,
      30,
      2,
@@ -811,7 +852,8 @@ spell_struct spells[NROFREALSPELLS] = {
      NULL,
      NULL},
 
-    {"cure confusion",
+    {"spell_cure_confusion",
+     "cure confusion",
      5,
      8,
      3,
@@ -830,7 +872,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "meffect_purple",
      NULL},
 
-    {"transform wealth",
+    {"spell_transform_wealth",
+     "transform wealth",
      18,
      40,
      2,
@@ -849,7 +892,8 @@ spell_struct spells[NROFREALSPELLS] = {
      NULL,
      NULL},
 
-    {"magic missile",
+    {"spell_magic_missile",
+     "magic missile",
      3,
      8,
      3,
@@ -868,7 +912,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "magic_missile",
      NULL},
 
-    {"rain of healing",
+    {"spell_rain_of_healing",
+     "rain of healing",
      6,
      18,
      0,
@@ -887,7 +932,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "meffect_green",
      NULL},
 
-    {"party heal",
+    {"spell_party_heal",
+     "party heal",
      6,
      16,
      0,
@@ -906,7 +952,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "meffect_green",
      NULL},
 
-    {"frostbolt",
+    {"spell_frostbolt",
+     "frostbolt",
      5,
      8,
      3,
@@ -925,7 +972,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "frostbolt",
      NULL},
 
-    {"firebolt",
+    {"spell_firebolt",
+     "firebolt",
      5,
      8,
      3,
@@ -944,7 +992,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "firebolt",
      NULL},
 
-    {"lightning",
+    {"spell_lightning",
+     "lightning",
      5,
      8,
      3,
@@ -963,7 +1012,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "lightning",
      NULL},
 
-    {"forked lightning",
+    {"spell_forked_lightning",
+     "forked lightning",
      5,
      8,
      3,
@@ -982,7 +1032,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "forked_lightning",
      NULL},
 
-    {"negative energy bolt",
+    {"spell_negative_energy_bolt",
+     "negative energy bolt",
      5,
      8,
      3,
@@ -1001,7 +1052,8 @@ spell_struct spells[NROFREALSPELLS] = {
      "negabolt",
      NULL},
 
-    {"holy word",
+    {"spell_holy_word",
+     "holy word",
      6,
      12,
      0,

--- a/server/src/include/spells.h
+++ b/server/src/include/spells.h
@@ -128,6 +128,9 @@ struct archetype;
 
 /** Spell structure. */
 typedef struct spell_struct {
+    /** Stable ID used at persistence and interchange boundaries. */
+    const char *id;
+
     /** Name of this spell. */
     const char *name;
 
@@ -346,6 +349,10 @@ extern void init_spells(void);
 extern int insert_spell_effect(const char *archname, mapstruct *m, int x, int y);
 
 extern spell_struct *find_spell(int spelltype);
+
+extern int spell_index_from_id(const char *id);
+
+extern const char *spell_id_from_index(int spelltype);
 
 extern int cast_spell(object *op,
                       object *caster,

--- a/server/src/loaders/object.l
+++ b/server/src/loaders/object.l
@@ -412,6 +412,24 @@ lex_error = 0;
 ^hp{S}               op->stats.hp = IVAL;
 ^maxhp{S}            op->stats.maxhp = IVAL;
 ^sp{S}               op->stats.sp = IVAL;
+^spell_id{S}         {
+    int spell = spell_index_from_id(yval());
+    if (spell == SP_NO_SPELL) {
+        LOG(ERROR, "Unknown stable spell ID %s for object %s.", yval(), object_get_str(op));
+        lex_error = 1;
+    } else {
+        op->stats.sp = spell;
+    }
+}
+^skill_id{S}         {
+    int skill = skill_index_from_id(yval());
+    if (skill < 0) {
+        LOG(ERROR, "Unknown stable skill ID %s for object %s.", yval(), object_get_str(op));
+        lex_error = 1;
+    } else {
+        op->stats.sp = skill;
+    }
+}
 ^maxsp{S}            op->stats.maxsp = IVAL;
 ^exp{S}              op->stats.exp = atoll(yval());
 ^food{S}             op->stats.food = IVAL;
@@ -1215,7 +1233,21 @@ get_ob_diff (StringBuffer *sb, const object *op, const object *op2)
     }
 
     if (op->stats.sp != op2->stats.sp) {
-        SAVE_INT(sb, "sp", op->stats.sp);
+        const char *stable_id = NULL;
+        const char *field_name = NULL;
+        if (op->type == SKILL) {
+            stable_id = skill_id_from_index(op->stats.sp);
+            field_name = "skill_id";
+        } else if (op->type == SPELL || OBJECT_IS_SPELL_TOOL(op)) {
+            stable_id = spell_id_from_index(op->stats.sp);
+            field_name = "spell_id";
+        }
+
+        if (stable_id != NULL) {
+            SAVE_STRING(sb, field_name, stable_id);
+        } else {
+            SAVE_INT(sb, "sp", op->stats.sp);
+        }
     }
 
     if (op->stats.maxsp != op2->stats.maxsp) {

--- a/server/src/loaders/object.l
+++ b/server/src/loaders/object.l
@@ -50,10 +50,14 @@ lex_load (int     *depth,       \
 #define MAXDEPTH 10
 
 static const char *yval(void);
+static int validate_stable_identity(const object *op,
+                                    bool saw_numeric_sp,
+                                    int numeric_sp,
+                                    bool saw_spell_id,
+                                    bool saw_skill_id);
 
 /* that's needed to track the used buffers for recursive ccalling */
 static void *cur_buffer;
-static int lex_error;
 static char msgbuf[HUGE_BUF * 4];
 static size_t msgbuf_len;
 static artifact_t *art_amask;
@@ -167,7 +171,11 @@ WS  [ \t]*{NL}
 %{
 int ismore = 0;
 object *op = items[*depth];
-lex_error = 0;
+int lex_error = 0;
+bool saw_numeric_sp = false;
+int numeric_sp = SP_NO_SPELL;
+bool saw_spell_id = false;
+bool saw_skill_id = false;
 %}
 
 ^arch{S}             {
@@ -199,7 +207,9 @@ lex_error = 0;
         items[*depth] = tmp;
 
         if (linemode == 0) {
-            lex_load(depth, items, maxdepth, map_flags, linemode);
+            if (lex_load(depth, items, maxdepth, map_flags, linemode) == LL_ERROR) {
+                lex_error = 1;
+            }
 
             if (tmp->arch != NULL) {
                 tmp = object_insert_into(tmp, op, 0);
@@ -360,6 +370,15 @@ lex_error = 0;
 }
 
 ^end{WS}             {
+    if (validate_stable_identity(
+            op, saw_numeric_sp, numeric_sp, saw_spell_id, saw_skill_id) != 0) {
+        lex_error = 1;
+    }
+
+    if (lex_error != 0) {
+        return LL_ERROR;
+    }
+
     if (linemode) {
         /* Linemode is only set for artifact loading. */
         if ((*depth) > 0) {
@@ -411,8 +430,13 @@ lex_error = 0;
 ^pow{S}              op->stats.Pow = IVAL;
 ^hp{S}               op->stats.hp = IVAL;
 ^maxhp{S}            op->stats.maxhp = IVAL;
-^sp{S}               op->stats.sp = IVAL;
+^sp{S}               {
+    numeric_sp = IVAL;
+    saw_numeric_sp = true;
+    op->stats.sp = numeric_sp;
+}
 ^spell_id{S}         {
+    saw_spell_id = true;
     int spell = spell_index_from_id(yval());
     if (spell == SP_NO_SPELL) {
         LOG(ERROR, "Unknown stable spell ID %s for object %s.", yval(), object_get_str(op));
@@ -422,6 +446,7 @@ lex_error = 0;
     }
 }
 ^skill_id{S}         {
+    saw_skill_id = true;
     int skill = skill_index_from_id(yval());
     if (skill < 0) {
         LOG(ERROR, "Unknown stable skill ID %s for object %s.", yval(), object_get_str(op));
@@ -745,10 +770,15 @@ lex_error = 0;
 #.*{NL}              {}
 
 <<EOF>>              {
+    if (validate_stable_identity(
+            op, saw_numeric_sp, numeric_sp, saw_spell_id, saw_skill_id) != 0) {
+        lex_error = 1;
+    }
+
     /* If we got an error, return the error. Otherwise, return that we got
      * EOF. */
     if (lex_error != 0) {
-        return lex_error;
+        return LL_ERROR;
     }
     else {
         return LL_EOF;
@@ -758,6 +788,45 @@ lex_error = 0;
 %%
 
 #pragma GCC diagnostic pop
+
+/**
+ * Validate fields whose meaning depends on the object's final type.
+ *
+ * Object attributes may appear in any order, so this check must run only
+ * after the complete object has been read.
+ */
+static int
+validate_stable_identity (const object *op,
+                          bool saw_numeric_sp,
+                          int numeric_sp,
+                          bool saw_spell_id,
+                          bool saw_skill_id)
+{
+    HARD_ASSERT(op != NULL);
+
+    int invalid = 0;
+    bool uses_spell_index = op->type == SPELL || OBJECT_IS_SPELL_TOOL(op);
+    if (saw_numeric_sp && numeric_sp != SP_NO_SPELL &&
+            (op->type == SKILL || uses_spell_index)) {
+        LOG(ERROR,
+            "Numeric spell/skill ID %d is not stable for object %s.",
+            numeric_sp,
+            object_get_str(op));
+        invalid = 1;
+    }
+
+    if (saw_spell_id && !uses_spell_index) {
+        LOG(ERROR, "spell_id is invalid for object %s.", object_get_str(op));
+        invalid = 1;
+    }
+
+    if (saw_skill_id && op->type != SKILL) {
+        LOG(ERROR, "skill_id is invalid for object %s.", object_get_str(op));
+        invalid = 1;
+    }
+
+    return invalid;
+}
 
 /**
  * Returns the next token for lex.
@@ -919,6 +988,11 @@ load_object (const char *str, object *op, int map_flags)
 
         if (retval == LL_NORMAL) {
             break;
+        } else if (retval == LL_ERROR) {
+            if (cur_buffer != NULL) {
+                yy_switch_to_buffer(cur_buffer);
+            }
+            return LL_ERROR;
         }
     }
 
@@ -963,6 +1037,13 @@ load_object_fp (FILE *fp, object *op, int map_flags)
         YY_BUFFER_STATE yybufstate = yy_scan_string(buf);
         retval = lex_load(&depth, items, MAXDEPTH, map_flags, 1);
         yy_delete_buffer(yybufstate);
+
+        if (retval == LL_ERROR) {
+            if (cur_buffer != NULL) {
+                yy_switch_to_buffer(cur_buffer);
+            }
+            return LL_ERROR;
+        }
 
         if (retval == LL_NORMAL) {
             /* Be sure we work on the right buffer */
@@ -1020,7 +1101,9 @@ load_object_buffer (void *buffer, object *op, int map_flags)
 
     int depth = 0;
     int retval = lex_load(&depth, items, MAXDEPTH, map_flags, 0);
-    load_object_finish(op, map_flags);
+    if (retval != LL_ERROR) {
+        load_object_finish(op, map_flags);
+    }
     return retval;
 }
 
@@ -1245,6 +1328,14 @@ get_ob_diff (StringBuffer *sb, const object *op, const object *op2)
 
         if (stable_id != NULL) {
             SAVE_STRING(sb, field_name, stable_id);
+        } else if (field_name != NULL && op->stats.sp != SP_NO_SPELL) {
+            LOG(BUG,
+                "Object %s has invalid runtime %s index %d.",
+                object_get_str(op),
+                field_name,
+                op->stats.sp);
+            stringbuffer_append_printf(
+                sb, "%s __invalid_runtime_index_%d\n", field_name, op->stats.sp);
         } else {
             SAVE_INT(sb, "sp", op->stats.sp);
         }

--- a/server/src/server/arch.c
+++ b/server/src/server/arch.c
@@ -191,6 +191,11 @@ static void arch_pass_first(FILE *fp) {
 
                 last_more = at;
                 break;
+
+            case LL_ERROR:
+                LOG(ERROR, "Discarding invalid archetype while loading archetypes.");
+                arch_free(at);
+                break;
         }
 
         at = arch_new();

--- a/server/src/server/map.c
+++ b/server/src/server/map.c
@@ -828,6 +828,14 @@ static void load_objects(mapstruct *m, FILE *fp, int mapflags) {
 
     int rc;
     while ((rc = load_object_buffer(buffer, op, mapflags)) != LL_EOF) {
+        if (rc == LL_ERROR) {
+            LOG(ERROR, "Discarding invalid object while loading map %s.", m->path);
+            object_destroy(op);
+            op = object_get();
+            op->map = m;
+            continue;
+        }
+
         if (rc == LL_MORE) {
             LOG(ERROR, "Encountered tail object: %s", object_get_str(op));
             continue;

--- a/server/src/server/skill_util.c
+++ b/server/src/server/skill_util.c
@@ -205,13 +205,9 @@ int64_t calc_skill_exp(object *who, object *op, int level) {
 void init_new_exp_system(void) {
     int i;
     archetype_t *at;
-    char buf[MAX_BUF];
 
     for (i = 0; i < NROFSKILLS; i++) {
-        snprintf(buf, sizeof(buf), "skill_%s", skills[i].name);
-        string_replace_char(buf, " ", '_');
-
-        at = arch_find(buf);
+        at = arch_find(skills[i].id);
 
         if (!at) {
             continue;

--- a/server/src/server/skills.c
+++ b/server/src/server/skills.c
@@ -36,6 +36,40 @@
 #include <player.h>
 #include <rune.h>
 
+/**
+ * Resolve a stable skill ID to its process-local table index.
+ *
+ * @param id Stable skill key.
+ * @return Skill index, or -1 when the ID is unknown.
+ */
+int skill_index_from_id(const char *id) {
+    if (id == NULL) {
+        return -1;
+    }
+
+    for (int i = 0; i < NROFSKILLS; i++) {
+        if (strcmp(skills[i].id, id) == 0) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+/**
+ * Get the stable ID for a process-local skill table index.
+ *
+ * @param skillnr Skill index.
+ * @return Stable skill ID, or NULL when the index is invalid.
+ */
+const char *skill_id_from_index(int skillnr) {
+    if (skillnr < 0 || skillnr >= NROFSKILLS) {
+        return NULL;
+    }
+
+    return skills[skillnr].id;
+}
+
 typedef enum trap_search_result {
     TRAP_SEARCH_NONE,
     TRAP_SEARCH_FOUND,

--- a/server/src/server/spell_util.c
+++ b/server/src/server/spell_util.c
@@ -73,16 +73,12 @@ void init_spells(void) {
     init_spells_done = 1;
 
     for (i = 0; i < NROFREALSPELLS; i++) {
-        char spellname[HUGE_BUF], tmpresult[MAX_BUF];
         archetype_t *at;
 
-        string_replace(spells[i].name, " ", "_", tmpresult, sizeof(spellname));
-        snprintf(spellname, sizeof(spellname), "spell_%s", tmpresult);
-
-        at = arch_find(spellname);
+        at = arch_find(spells[i].id);
 
         if (!at) {
-            LOG(ERROR, "Could not find required archetype %s.", spellname);
+            LOG(ERROR, "Could not find required archetype %s.", spells[i].id);
             exit(1);
         }
 
@@ -173,6 +169,37 @@ spell_struct *find_spell(int spelltype) {
     }
 
     return &spells[spelltype];
+}
+
+/**
+ * Resolve a stable spell ID to its process-local table index.
+ *
+ * @param id Stable spell archetype key.
+ * @return Spell index, or ::SP_NO_SPELL when the ID is unknown.
+ */
+int spell_index_from_id(const char *id) {
+    if (id == NULL) {
+        return SP_NO_SPELL;
+    }
+
+    for (int i = 0; i < NROFREALSPELLS; i++) {
+        if (strcmp(spells[i].id, id) == 0) {
+            return i;
+        }
+    }
+
+    return SP_NO_SPELL;
+}
+
+/**
+ * Get the stable ID for a process-local spell table index.
+ *
+ * @param spelltype Spell index.
+ * @return Stable spell ID, or NULL when the index is invalid.
+ */
+const char *spell_id_from_index(int spelltype) {
+    spell_struct *spell = find_spell(spelltype);
+    return spell != NULL ? spell->id : NULL;
 }
 
 /**

--- a/server/src/tests/unit/server/object.c
+++ b/server/src/tests/unit/server/object.c
@@ -416,6 +416,33 @@ START_TEST(test_object_stable_spell_and_skill_ids) {
     ck_assert_ptr_eq(strstr(dump, "\nsp "), NULL);
     free(dump);
     object_destroy(ob);
+
+    ck_assert_ptr_eq(object_load_str("arch wand\nsp 19\nend\n"), NULL);
+    ck_assert_ptr_eq(object_load_str("arch wand\nspell_id unknown\nend\n"), NULL);
+    ck_assert_ptr_eq(object_load_str("arch sack\nspell_id spell_firestorm\nend\n"), NULL);
+    ck_assert_ptr_eq(object_load_str("arch sack\nskill_id skill_literacy\nend\n"), NULL);
+    ck_assert_ptr_eq(object_load_str("arch wand\narch wand\nsp 19\nend\nend\n"), NULL);
+
+    ob = object_load_str("arch sack\nspell_id spell_firestorm\ntype 109\nend\n");
+    ck_assert_ptr_nonnull(ob);
+    ck_assert_int_eq(ob->stats.sp, spell_index_from_id("spell_firestorm"));
+    object_destroy(ob);
+
+    ob = object_load_str("arch sack\nskill_id skill_literacy\ntype 43\nend\n");
+    ck_assert_ptr_nonnull(ob);
+    ck_assert_int_eq(ob->stats.sp, skill_index_from_id("skill_literacy"));
+    object_destroy(ob);
+
+    ob = object_load_str("arch wand\nend\n");
+    ck_assert_ptr_nonnull(ob);
+    ob->stats.sp = 9999;
+    sb = stringbuffer_new();
+    object_dump_rec(ob, sb);
+    dump = stringbuffer_finish(sb);
+    ck_assert_ptr_nonnull(strstr(dump, "spell_id __invalid_runtime_index_9999"));
+    ck_assert_ptr_eq(strstr(dump, "\nsp 9999"), NULL);
+    free(dump);
+    object_destroy(ob);
 }
 END_TEST
 

--- a/server/src/tests/unit/server/object.c
+++ b/server/src/tests/unit/server/object.c
@@ -384,6 +384,41 @@ START_TEST(test_object_load_str) {
 }
 END_TEST
 
+START_TEST(test_object_stable_spell_and_skill_ids) {
+    ck_assert_int_eq(spell_index_from_id("spell_firestorm"), SP_FIRESTORM);
+    ck_assert_str_eq(spell_id_from_index(SP_FIRESTORM), "spell_firestorm");
+    ck_assert_int_eq(spell_index_from_id("unknown"), SP_NO_SPELL);
+    ck_assert_ptr_eq(spell_id_from_index(SP_NO_SPELL), NULL);
+
+    ck_assert_int_eq(skill_index_from_id("skill_literacy"), SK_LITERACY);
+    ck_assert_str_eq(skill_id_from_index(SK_LITERACY), "skill_literacy");
+    ck_assert_int_eq(skill_index_from_id("unknown"), -1);
+    ck_assert_ptr_eq(skill_id_from_index(-1), NULL);
+
+    object *ob = object_load_str("arch wand\nspell_id spell_firestorm\nend\n");
+    ck_assert_ptr_ne(ob, NULL);
+    ck_assert_int_eq(ob->stats.sp, SP_FIRESTORM);
+    StringBuffer *sb = stringbuffer_new();
+    object_dump_rec(ob, sb);
+    char *dump = stringbuffer_finish(sb);
+    ck_assert_ptr_ne(strstr(dump, "spell_id spell_firestorm\n"), NULL);
+    ck_assert_ptr_eq(strstr(dump, "\nsp "), NULL);
+    free(dump);
+    object_destroy(ob);
+
+    ob = object_load_str("arch skill_literacy\nskill_id skill_throwing\nend\n");
+    ck_assert_ptr_ne(ob, NULL);
+    ck_assert_int_eq(ob->stats.sp, SK_THROWING);
+    sb = stringbuffer_new();
+    object_dump_rec(ob, sb);
+    dump = stringbuffer_finish(sb);
+    ck_assert_ptr_ne(strstr(dump, "skill_id skill_throwing\n"), NULL);
+    ck_assert_ptr_eq(strstr(dump, "\nsp "), NULL);
+    free(dump);
+    object_destroy(ob);
+}
+END_TEST
+
 START_TEST(test_object_reverse_inventory) {
     char *cp, *cp2;
     object *ob;
@@ -468,6 +503,7 @@ static Suite *suite(void) {
     tcase_add_test(tc_core, test_object_can_pick);
     tcase_add_test(tc_core, test_object_clone);
     tcase_add_test(tc_core, test_object_load_str);
+    tcase_add_test(tc_core, test_object_stable_spell_and_skill_ids);
     tcase_add_test(tc_core, test_object_reverse_inventory);
     tcase_add_test(tc_core, test_object_create_singularity);
     tcase_add_test(tc_core, test_OBJECT_DESTROYED);

--- a/server/src/types/player.c
+++ b/server/src/types/player.c
@@ -2786,10 +2786,12 @@ out:
  *
  * @param pl
  * Player.
- * @param path
- * Path to load the data from.
+ * @param fp
+ * Player data stream.
+ * @return
+ * True on success, false if the object data is invalid.
  */
-static void player_load(player *pl, FILE *fp) {
+static bool player_load(player *pl, FILE *fp) {
     HARD_ASSERT(pl != NULL);
     HARD_ASSERT(fp != NULL);
 
@@ -2843,13 +2845,17 @@ static void player_load(player *pl, FILE *fp) {
 
     SET_FLAG(pl->ob, FLAG_NO_FIX_PLAYER);
     void *buffer = create_loader_buffer(fp);
-    load_object_buffer(buffer, pl->ob, 0);
+    int result = load_object_buffer(buffer, pl->ob, 0);
     delete_loader_buffer(buffer);
     CLEAR_FLAG(pl->ob, FLAG_NO_FIX_PLAYER);
+    if (result == LL_ERROR) {
+        return false;
+    }
 
     /* The inventory of players is loaded in reverse order, so we need to
      * reorder it. */
     object_reverse_inventory(pl->ob);
+    return true;
 }
 
 /**
@@ -3108,8 +3114,15 @@ void player_login(socket_struct *ns, const char *name, struct archetype *at) {
     /* If the file is empty, it's a new character. */
     if (statbuf.st_size == 0) {
         player_create(pl, at, name);
-    } else {
-        player_load(pl, fp);
+    } else if (!player_load(pl, fp)) {
+        LOG(ERROR, "Player data file %s contains invalid object data.", path);
+        draw_info_send(CHAT_TYPE_GAME,
+                       NULL,
+                       COLOR_RED,
+                       ns,
+                       "Could not load your player file; contact an administrator.");
+        free_player(pl);
+        goto out;
     }
 
     pl->ob->custom_attrset = pl;

--- a/tools/collect.py
+++ b/tools/collect.py
@@ -12,8 +12,10 @@ import os
 import getopt
 import shutil
 import platform
+from pathlib import Path
 
 from compilers.interface_compiler import InterfaceCompiler
+from content_catalog import load_catalog
 import compilers
 import utils
 
@@ -172,6 +174,14 @@ def main():
             for entry in dict(globals()):
                 if entry.startswith("collect_"):
                     what_collect.append(entry)
+
+        catalog = load_catalog(Path(paths["root"]))
+        if catalog.has_errors:
+            for diagnostic in catalog.diagnostics:
+                print(diagnostic.format(), file=sys.stderr)
+            print("Content validation failed; collection was not started.",
+                  file=sys.stderr)
+            sys.exit(1)
 
         # Call the collecting functions.
         for collect in what_collect:

--- a/tools/compilers/interface_compiler.py
+++ b/tools/compilers/interface_compiler.py
@@ -180,7 +180,10 @@ class TagCompilerPart(BaseTagCompiler):
         if "parts" not in self.parent.data:
             self.parent.data["parts"] = OrderedDict()
 
-        self.data["uid"] = re.sub(r"\W+", "", elem.get("uid"))
+        # Content validation guarantees that this is already a stable ID.
+        # Never rewrite authored identities: doing so can merge distinct parts
+        # and makes references disagree with the source XML.
+        self.data["uid"] = elem.get("uid")
         self.data["name"] = elem.get("name", self.data["uid"])
         self.parent.data["parts"][self.data["uid"]] = self.data
 

--- a/tools/content_catalog/__init__.py
+++ b/tools/content_catalog/__init__.py
@@ -1,0 +1,14 @@
+"""Atrinik authored-content identity catalog."""
+
+from .loaders import load_catalog
+from .model import ContentCatalog, ContentId, Definition, Diagnostic, Reference, SourceLocation
+
+__all__ = (
+    "ContentCatalog",
+    "ContentId",
+    "Definition",
+    "Diagnostic",
+    "Reference",
+    "SourceLocation",
+    "load_catalog",
+)

--- a/tools/content_catalog/__main__.py
+++ b/tools/content_catalog/__main__.py
@@ -1,0 +1,63 @@
+"""Command-line interface for the Atrinik content catalog."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Optional, Sequence
+
+from .loaders import load_catalog
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate Atrinik content identities and cross-references."
+    )
+    parser.add_argument(
+        "command", choices=("validate", "emit"), nargs="?", default="validate"
+    )
+    parser.add_argument(
+        "--root", type=Path, default=Path.cwd(), help="Atrinik source-tree root"
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="JSON output path (required for emit; relative paths use --root)",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = _parser().parse_args(argv)
+    root = args.root.resolve()
+    catalog = load_catalog(root)
+
+    for diagnostic in catalog.diagnostics:
+        print(diagnostic.format(), file=sys.stderr)
+
+    counts = ", ".join(
+        "{}={}".format(domain, count) for domain, count in catalog.counts().items()
+    )
+    print(
+        "Content catalog: {} definitions, {} references ({})".format(
+            len(catalog.definitions), len(catalog.references), counts
+        )
+    )
+
+    if args.command == "emit":
+        if args.output is None:
+            print("error: emit requires --output", file=sys.stderr)
+            return 2
+        output = args.output if args.output.is_absolute() else root / args.output
+        output.parent.mkdir(parents=True, exist_ok=True)
+        with output.open("w", encoding="utf-8", newline="\n") as destination:
+            json.dump(catalog.to_dict(), destination, indent=2, sort_keys=True)
+            destination.write("\n")
+
+    return 1 if catalog.has_errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/content_catalog/loaders.py
+++ b/tools/content_catalog/loaders.py
@@ -104,6 +104,57 @@ def _load_archetypes(catalog: ContentCatalog, arch_root: Path) -> None:
                 current_type = None
 
 
+def _load_runtime_identity_tables(catalog: ContentCatalog, server_root: Path) -> None:
+    """Validate explicit stable IDs used by process-local C lookup tables."""
+
+    table_specs = (
+        (server_root / "src/include/spellist.h", "spell", "spell table id"),
+        (server_root / "src/include/skillist.h", "skill", "skill table id"),
+    )
+    for path, domain, field in table_specs:
+        if not path.is_file():
+            continue
+        seen: Dict[str, SourceLocation] = {}
+        with path.open(encoding="utf-8") as source:
+            for line_number, line in enumerate(source, 1):
+                for match in re.finditer(r'\{"((?:spell|skill)_[a-z0-9_]+)"\s*,', line):
+                    key = match.group(1)
+                    location = catalog.location(path, line_number, match.start(1) + 1)
+                    previous = seen.get(key)
+                    if previous is not None:
+                        catalog.add_diagnostic(
+                            "duplicate-runtime-id",
+                            "duplicate {} {}; first declared at {}".format(
+                                domain, key, previous.display()
+                            ),
+                            location,
+                            related=previous,
+                        )
+                        continue
+                    seen[key] = location
+                    # Some legacy skill enum slots do not have an obtainable
+                    # skill archetype. Existing authored skills must map to
+                    # stable table IDs; unused slots remain process-local.
+                    if domain == "spell" or any(
+                        definition.content_id == ContentId(domain, key)
+                        for definition in catalog.definitions
+                    ):
+                        catalog.add_reference(key, (domain,), location, field)
+
+        table_ids = set(seen)
+        for definition in catalog.definitions:
+            if definition.content_id.domain != domain:
+                continue
+            if definition.content_id.key not in table_ids:
+                catalog.add_diagnostic(
+                    "missing-runtime-id",
+                    "{} {} has no stable entry in {}".format(
+                        domain, definition.content_id.key, path.name
+                    ),
+                    definition.location,
+                )
+
+
 def _load_artifacts(catalog: ContentCatalog, roots: Sequence[Path]) -> None:
     for root in roots:
         if not root.is_dir():
@@ -429,6 +480,7 @@ def load_catalog(root: Path) -> ContentCatalog:
     arch_root = root / "arch"
     maps_root = root / "maps"
     _load_archetypes(catalog, arch_root)
+    _load_runtime_identity_tables(catalog, root / "server")
     _load_artifacts(catalog, (arch_root, maps_root))
     _load_treasures(catalog, (arch_root, maps_root))
     _load_factions(catalog, maps_root)

--- a/tools/content_catalog/loaders.py
+++ b/tools/content_catalog/loaders.py
@@ -16,10 +16,13 @@ QUEST_PART_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_.-]*$")
 OBJECT_DOMAINS = ("archetype", "artifact")
 
 
-def _iter_source_lines(path: Path) -> Iterator[Tuple[int, str]]:
-    """Yield significant lines while respecting legacy msg/endmsg blocks."""
+def _iter_source_lines(
+    path: Path, catalog: ContentCatalog
+) -> Iterator[Tuple[int, str]]:
+    """Yield significant lines while respecting classic msg/endmsg blocks."""
 
     in_message = False
+    message_line = 0
     with path.open(encoding="utf-8") as source:
         for line_number, raw_line in enumerate(source, 1):
             line = raw_line.strip()
@@ -29,10 +32,17 @@ def _iter_source_lines(path: Path) -> Iterator[Tuple[int, str]]:
                 continue
             if line == "msg":
                 in_message = True
+                message_line = line_number
                 continue
             if not line or line.startswith("#"):
                 continue
             yield line_number, line
+    if in_message:
+        catalog.add_diagnostic(
+            "unterminated-message",
+            "msg block has no endmsg",
+            catalog.location(path, message_line),
+        )
 
 
 def _split(line: str) -> Tuple[str, str]:
@@ -53,7 +63,7 @@ def _load_archetypes(catalog: ContentCatalog, arch_root: Path) -> None:
         multipart_continuation = False
         inside_object = False
 
-        for line_number, line in _iter_source_lines(path):
+        for line_number, line in _iter_source_lines(path, catalog):
             field, value = _split(line)
             if field == "More" and not value:
                 multipart_continuation = True
@@ -102,11 +112,25 @@ def _load_archetypes(catalog: ContentCatalog, arch_root: Path) -> None:
                 inside_object = False
                 current = None
                 current_type = None
+        if inside_object:
+            catalog.add_diagnostic(
+                "unterminated-object",
+                "Object block has no end",
+                current_location or catalog.location(path, 1),
+            )
+        elif multipart_continuation:
+            catalog.add_diagnostic(
+                "dangling-multipart",
+                "More is not followed by an Object block",
+                catalog.location(path, 1),
+            )
 
 
 def _load_runtime_identity_tables(catalog: ContentCatalog, server_root: Path) -> None:
     """Validate explicit stable IDs used by process-local C lookup tables."""
 
+    definitions = tuple(catalog.definitions)
+    definition_ids = {definition.content_id for definition in definitions}
     table_specs = (
         (server_root / "src/include/spellist.h", "spell", "spell table id"),
         (server_root / "src/include/skillist.h", "skill", "skill table id"),
@@ -132,17 +156,14 @@ def _load_runtime_identity_tables(catalog: ContentCatalog, server_root: Path) ->
                         )
                         continue
                     seen[key] = location
-                    # Some legacy skill enum slots do not have an obtainable
+                    # Some reserved skill enum slots do not have an obtainable
                     # skill archetype. Existing authored skills must map to
                     # stable table IDs; unused slots remain process-local.
-                    if domain == "spell" or any(
-                        definition.content_id == ContentId(domain, key)
-                        for definition in catalog.definitions
-                    ):
+                    if domain == "spell" or ContentId(domain, key) in definition_ids:
                         catalog.add_reference(key, (domain,), location, field)
 
         table_ids = set(seen)
-        for definition in catalog.definitions:
+        for definition in definitions:
             if definition.content_id.domain != domain:
                 continue
             if definition.content_id.key not in table_ids:
@@ -161,11 +182,19 @@ def _load_artifacts(catalog: ContentCatalog, roots: Sequence[Path]) -> None:
             continue
         for path in sorted(root.rglob("*.art")):
             current: Optional[ContentId] = None
-            for line_number, line in _iter_source_lines(path):
+            current_location: Optional[SourceLocation] = None
+            for line_number, line in _iter_source_lines(path, catalog):
                 field, value = _split(line)
                 if field == "artifact" and value:
                     location = catalog.location(path, line_number, _column(line, value))
+                    if current is not None:
+                        catalog.add_diagnostic(
+                            "unterminated-artifact",
+                            "artifact block has no end before the next artifact",
+                            current_location or location,
+                        )
                     current = catalog.add_definition("artifact", value, location)
+                    current_location = location
                 elif field == "def_arch" and value:
                     catalog.add_reference(
                         value.split()[0],
@@ -174,8 +203,31 @@ def _load_artifacts(catalog: ContentCatalog, roots: Sequence[Path]) -> None:
                         "def_arch",
                         current,
                     )
+                elif field == "spell_id" and value:
+                    catalog.add_reference(
+                        value,
+                        ("spell",),
+                        catalog.location(path, line_number, _column(line, value)),
+                        "spell_id",
+                        current,
+                    )
+                elif field == "skill_id" and value:
+                    catalog.add_reference(
+                        value,
+                        ("skill",),
+                        catalog.location(path, line_number, _column(line, value)),
+                        "skill_id",
+                        current,
+                    )
                 elif field == "end" and not value:
                     current = None
+                    current_location = None
+            if current is not None:
+                catalog.add_diagnostic(
+                    "unterminated-artifact",
+                    "artifact block has no end",
+                    current_location or catalog.location(path, line_number),
+                )
 
 
 def _load_treasures(catalog: ContentCatalog, roots: Sequence[Path]) -> None:
@@ -184,11 +236,19 @@ def _load_treasures(catalog: ContentCatalog, roots: Sequence[Path]) -> None:
             continue
         for path in sorted(root.rglob("*.trs")):
             current: Optional[ContentId] = None
-            for line_number, line in _iter_source_lines(path):
+            current_location: Optional[SourceLocation] = None
+            for line_number, line in _iter_source_lines(path, catalog):
                 field, value = _split(line)
                 if field in ("treasure", "treasureone") and value:
                     location = catalog.location(path, line_number, _column(line, value))
+                    if current is not None:
+                        catalog.add_diagnostic(
+                            "unterminated-treasure",
+                            "treasure block has no end before the next treasure",
+                            current_location or location,
+                        )
                     current = catalog.add_definition("treasure", value, location)
+                    current_location = location
                 elif field == "arch" and value:
                     catalog.add_reference(
                         value.split()[0],
@@ -205,13 +265,22 @@ def _load_treasures(catalog: ContentCatalog, roots: Sequence[Path]) -> None:
                         "treasure list",
                         current,
                     )
+                elif field == "end" and not value:
+                    current = None
+                    current_location = None
+            if current is not None:
+                catalog.add_diagnostic(
+                    "unterminated-treasure",
+                    "treasure block has no end",
+                    current_location or catalog.location(path, line_number),
+                )
 
 
 def _load_factions(catalog: ContentCatalog, maps_root: Path) -> None:
     parents: Dict[str, Tuple[str, SourceLocation]] = {}
     for path in sorted(maps_root.rglob("*.factions")):
         stack: List[ContentId] = []
-        for line_number, line in _iter_source_lines(path):
+        for line_number, line in _iter_source_lines(path, catalog):
             field, value = _split(line)
             if field == "faction" and value:
                 location = catalog.location(path, line_number, _column(line, value))
@@ -237,6 +306,12 @@ def _load_factions(catalog: ContentCatalog, maps_root: Path) -> None:
                 )
             elif field == "end" and not value and stack:
                 stack.pop()
+        if stack:
+            catalog.add_diagnostic(
+                "unterminated-faction",
+                "faction block has no end",
+                catalog.location(path, line_number),
+            )
     catalog.check_cycles("faction", parents)
 
 
@@ -245,36 +320,76 @@ def _load_regions(catalog: ContentCatalog, maps_root: Path) -> None:
     if not path.is_file():
         return
     current: Optional[ContentId] = None
+    current_location: Optional[SourceLocation] = None
     parents: Dict[str, Tuple[str, SourceLocation]] = {}
-    for line_number, line in _iter_source_lines(path):
+    for line_number, line in _iter_source_lines(path, catalog):
         field, value = _split(line)
         if field == "region" and value:
             location = catalog.location(path, line_number, _column(line, value))
+            if current is not None:
+                catalog.add_diagnostic(
+                    "unterminated-region",
+                    "region block has no end before the next region",
+                    current_location or location,
+                )
             current = catalog.add_definition("region", value, location)
+            current_location = location
         elif field == "parent" and value and current is not None:
             location = catalog.location(path, line_number, _column(line, value))
             catalog.add_reference(value, ("region",), location, "region parent", current)
             parents[current.key] = (value, location)
         elif field in ("map_first", "jail") and value:
             map_key = value.split()[0]
-            catalog.add_reference(
-                _canonical_map_path(map_key),
-                ("map",),
+            _add_map_reference(
+                catalog,
+                map_key,
                 catalog.location(path, line_number, _column(line, map_key)),
                 "region {}".format(field),
                 current,
             )
         elif field == "end" and not value:
             current = None
+            current_location = None
+    if current is not None:
+        catalog.add_diagnostic(
+            "unterminated-region",
+            "region block has no end",
+            current_location or catalog.location(path, line_number),
+        )
     catalog.check_cycles("region", parents)
 
 
 def _canonical_map_path(path: str, base: Optional[str] = None) -> str:
-    if path.startswith("/"):
-        normalized = posixpath.normpath(path)
-    else:
-        normalized = posixpath.normpath(posixpath.join(base or "/", path))
-    return "/" + normalized.lstrip("/")
+    combined = path.lstrip("/") if path.startswith("/") else posixpath.join(
+        (base or "/").lstrip("/"), path
+    )
+    parts: List[str] = []
+    for part in combined.split("/"):
+        if part in ("", "."):
+            continue
+        if part == "..":
+            if not parts:
+                raise ValueError("map path escapes the maps root")
+            parts.pop()
+        else:
+            parts.append(part)
+    return "/" + "/".join(parts)
+
+
+def _add_map_reference(
+    catalog: ContentCatalog,
+    path: str,
+    location: SourceLocation,
+    field: str,
+    source: Optional[ContentId],
+    base: Optional[str] = None,
+) -> None:
+    try:
+        key = _canonical_map_path(path, base)
+    except ValueError as error:
+        catalog.add_diagnostic("invalid-map-path", "{}: {}".format(field, error), location)
+        return
+    catalog.add_reference(key, ("map",), location, field, source)
 
 
 def _is_map_file(path: Path) -> bool:
@@ -322,7 +437,7 @@ def _load_maps(catalog: ContentCatalog, maps_root: Path) -> None:
         # preserves identity validation without turning the catalog artifact
         # into a second, much larger encoding of the map itself.
         seen_archetypes = set()
-        for line_number, line in _iter_source_lines(path):
+        for line_number, line in _iter_source_lines(path, catalog):
             field, value = _split(line)
             if in_header:
                 if field == "region" and value:
@@ -334,13 +449,13 @@ def _load_maps(catalog: ContentCatalog, maps_root: Path) -> None:
                         map_id,
                     )
                 elif field.startswith("tile_path_") and value:
-                    target = _canonical_map_path(value, posixpath.dirname(map_key))
-                    catalog.add_reference(
-                        target,
-                        ("map",),
+                    _add_map_reference(
+                        catalog,
+                        value,
                         catalog.location(path, line_number, _column(line, value)),
                         field,
                         map_id,
+                        posixpath.dirname(map_key),
                     )
                 elif field == "end" and not value:
                     in_header = False
@@ -356,6 +471,28 @@ def _load_maps(catalog: ContentCatalog, maps_root: Path) -> None:
                     "map arch",
                     map_id,
                 )
+            elif field == "spell_id" and value:
+                catalog.add_reference(
+                    value,
+                    ("spell",),
+                    catalog.location(path, line_number, _column(line, value)),
+                    "spell_id",
+                    map_id,
+                )
+            elif field == "skill_id" and value:
+                catalog.add_reference(
+                    value,
+                    ("skill",),
+                    catalog.location(path, line_number, _column(line, value)),
+                    "skill_id",
+                    map_id,
+                )
+        if in_header:
+            catalog.add_diagnostic(
+                "unterminated-map-header",
+                "map header has no end",
+                catalog.location(path, 1),
+            )
 
 
 class _InterfaceLoader:
@@ -424,19 +561,37 @@ class _InterfaceLoader:
         source = self.quest_id
         if name in ("item", "object") and attrs.get("arch"):
             self.catalog.add_reference(
-                attrs["arch"], OBJECT_DOMAINS, self.location(attrs["arch"]), "{} arch".format(name), source
+                attrs["arch"],
+                OBJECT_DOMAINS,
+                self.location(attrs["arch"]),
+                "{} arch".format(name),
+                source,
             )
         if attrs.get("cast"):
             spell_key = "spell_" + re.sub(r"\s+", "_", attrs["cast"].strip().lower())
-            self.catalog.add_reference(spell_key, ("spell",), self.location(attrs["cast"]), "cast", source)
+            self.catalog.add_reference(
+                spell_key,
+                ("spell",),
+                self.location(attrs["cast"]),
+                "cast",
+                source,
+            )
         if attrs.get("teleport"):
             target = attrs["teleport"].split()[0]
-            self.catalog.add_reference(
-                _canonical_map_path(target), ("map",), self.location(target), "teleport", source
+            _add_map_reference(
+                self.catalog,
+                target,
+                self.location(target),
+                "teleport",
+                source,
             )
         if attrs.get("region_map"):
             self.catalog.add_reference(
-                attrs["region_map"], ("region",), self.location(attrs["region_map"]), "region_map", source
+                attrs["region_map"],
+                ("region",),
+                self.location(attrs["region_map"]),
+                "region_map",
+                source,
             )
         for attribute, value in attrs.items():
             if attribute.startswith("faction_"):
@@ -487,5 +642,8 @@ def load_catalog(root: Path) -> ContentCatalog:
     _load_maps(catalog, maps_root)
     _load_regions(catalog, maps_root)
     _load_interfaces(catalog, maps_root)
+    catalog.check_shared_namespace(
+        "server archetype", ("archetype", "artifact")
+    )
     catalog.resolve_references()
     return catalog

--- a/tools/content_catalog/loaders.py
+++ b/tools/content_catalog/loaders.py
@@ -1,0 +1,439 @@
+"""Load Atrinik's authored content into a typed identity graph."""
+
+from __future__ import annotations
+
+import posixpath
+import re
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List, Optional, Sequence, Tuple
+from xml.parsers import expat
+
+from .model import ContentCatalog, ContentId, SourceLocation
+
+
+QUEST_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_.-]*$")
+QUEST_PART_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_.-]*$")
+OBJECT_DOMAINS = ("archetype", "artifact")
+
+
+def _iter_source_lines(path: Path) -> Iterator[Tuple[int, str]]:
+    """Yield significant lines while respecting legacy msg/endmsg blocks."""
+
+    in_message = False
+    with path.open(encoding="utf-8") as source:
+        for line_number, raw_line in enumerate(source, 1):
+            line = raw_line.strip()
+            if in_message:
+                if line == "endmsg":
+                    in_message = False
+                continue
+            if line == "msg":
+                in_message = True
+                continue
+            if not line or line.startswith("#"):
+                continue
+            yield line_number, line
+
+
+def _split(line: str) -> Tuple[str, str]:
+    parts = line.split(None, 1)
+    return parts[0], parts[1] if len(parts) == 2 else ""
+
+
+def _column(line: str, value: str) -> int:
+    position = line.find(value)
+    return position + 1 if position >= 0 else 1
+
+
+def _load_archetypes(catalog: ContentCatalog, arch_root: Path) -> None:
+    for path in sorted(arch_root.rglob("*.arc")):
+        current: Optional[ContentId] = None
+        current_type: Optional[str] = None
+        current_location: Optional[SourceLocation] = None
+        multipart_continuation = False
+        inside_object = False
+
+        for line_number, line in _iter_source_lines(path):
+            field, value = _split(line)
+            if field == "More" and not value:
+                multipart_continuation = True
+                continue
+            if field == "Object" and value:
+                inside_object = True
+                current_type = None
+                current_location = catalog.location(path, line_number, _column(line, value))
+                if multipart_continuation:
+                    current = None
+                else:
+                    current = catalog.add_definition(
+                        "archetype", value, current_location
+                    )
+                multipart_continuation = False
+                continue
+            if not inside_object:
+                continue
+            if field == "type" and value:
+                current_type = value.split()[0]
+            elif field == "other_arch" and value:
+                catalog.add_reference(
+                    value.split()[0],
+                    ("archetype",),
+                    catalog.location(path, line_number, _column(line, value)),
+                    "other_arch",
+                    current,
+                )
+            elif field == "randomitems" and value:
+                catalog.add_reference(
+                    value.split()[0],
+                    ("treasure",),
+                    catalog.location(path, line_number, _column(line, value)),
+                    "randomitems",
+                    current,
+                )
+            elif field == "end" and not value:
+                if current is not None and current_type in ("29", "43"):
+                    domain = "spell" if current_type == "29" else "skill"
+                    catalog.add_definition(
+                        domain,
+                        current.key,
+                        current_location or catalog.location(path, line_number),
+                        {"archetype": current.key},
+                    )
+                inside_object = False
+                current = None
+                current_type = None
+
+
+def _load_artifacts(catalog: ContentCatalog, roots: Sequence[Path]) -> None:
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for path in sorted(root.rglob("*.art")):
+            current: Optional[ContentId] = None
+            for line_number, line in _iter_source_lines(path):
+                field, value = _split(line)
+                if field == "artifact" and value:
+                    location = catalog.location(path, line_number, _column(line, value))
+                    current = catalog.add_definition("artifact", value, location)
+                elif field == "def_arch" and value:
+                    catalog.add_reference(
+                        value.split()[0],
+                        OBJECT_DOMAINS,
+                        catalog.location(path, line_number, _column(line, value)),
+                        "def_arch",
+                        current,
+                    )
+                elif field == "end" and not value:
+                    current = None
+
+
+def _load_treasures(catalog: ContentCatalog, roots: Sequence[Path]) -> None:
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for path in sorted(root.rglob("*.trs")):
+            current: Optional[ContentId] = None
+            for line_number, line in _iter_source_lines(path):
+                field, value = _split(line)
+                if field in ("treasure", "treasureone") and value:
+                    location = catalog.location(path, line_number, _column(line, value))
+                    current = catalog.add_definition("treasure", value, location)
+                elif field == "arch" and value:
+                    catalog.add_reference(
+                        value.split()[0],
+                        OBJECT_DOMAINS,
+                        catalog.location(path, line_number, _column(line, value)),
+                        "treasure arch",
+                        current,
+                    )
+                elif field == "list" and value and value != "NONE":
+                    catalog.add_reference(
+                        value.split()[0],
+                        ("treasure",),
+                        catalog.location(path, line_number, _column(line, value)),
+                        "treasure list",
+                        current,
+                    )
+
+
+def _load_factions(catalog: ContentCatalog, maps_root: Path) -> None:
+    parents: Dict[str, Tuple[str, SourceLocation]] = {}
+    for path in sorted(maps_root.rglob("*.factions")):
+        stack: List[ContentId] = []
+        for line_number, line in _iter_source_lines(path):
+            field, value = _split(line)
+            if field == "faction" and value:
+                location = catalog.location(path, line_number, _column(line, value))
+                content_id = catalog.add_definition("faction", value, location)
+                if stack:
+                    parent = stack[-1]
+                    catalog.add_reference(
+                        parent.key, ("faction",), location, "nested faction parent", content_id
+                    )
+                    parents[content_id.key] = (parent.key, location)
+                stack.append(content_id)
+            elif field == "parent" and value and stack:
+                location = catalog.location(path, line_number, _column(line, value))
+                catalog.add_reference(value, ("faction",), location, "faction parent", stack[-1])
+                parents[stack[-1].key] = (value, location)
+            elif field == "enemy" and value:
+                catalog.add_reference(
+                    value,
+                    ("faction",),
+                    catalog.location(path, line_number, _column(line, value)),
+                    "faction enemy",
+                    stack[-1] if stack else None,
+                )
+            elif field == "end" and not value and stack:
+                stack.pop()
+    catalog.check_cycles("faction", parents)
+
+
+def _load_regions(catalog: ContentCatalog, maps_root: Path) -> None:
+    path = maps_root / "regions.reg"
+    if not path.is_file():
+        return
+    current: Optional[ContentId] = None
+    parents: Dict[str, Tuple[str, SourceLocation]] = {}
+    for line_number, line in _iter_source_lines(path):
+        field, value = _split(line)
+        if field == "region" and value:
+            location = catalog.location(path, line_number, _column(line, value))
+            current = catalog.add_definition("region", value, location)
+        elif field == "parent" and value and current is not None:
+            location = catalog.location(path, line_number, _column(line, value))
+            catalog.add_reference(value, ("region",), location, "region parent", current)
+            parents[current.key] = (value, location)
+        elif field in ("map_first", "jail") and value:
+            map_key = value.split()[0]
+            catalog.add_reference(
+                _canonical_map_path(map_key),
+                ("map",),
+                catalog.location(path, line_number, _column(line, map_key)),
+                "region {}".format(field),
+                current,
+            )
+        elif field == "end" and not value:
+            current = None
+    catalog.check_cycles("region", parents)
+
+
+def _canonical_map_path(path: str, base: Optional[str] = None) -> str:
+    if path.startswith("/"):
+        normalized = posixpath.normpath(path)
+    else:
+        normalized = posixpath.normpath(posixpath.join(base or "/", path))
+    return "/" + normalized.lstrip("/")
+
+
+def _is_map_file(path: Path) -> bool:
+    try:
+        with path.open("rb") as source:
+            prefix = source.read(4096)
+    except OSError:
+        return False
+    if b"\0" in prefix:
+        return False
+    try:
+        text = prefix.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        return line == "arch map"
+    return False
+
+
+def _load_maps(catalog: ContentCatalog, maps_root: Path) -> None:
+    ignored_suffixes = {
+        ".art",
+        ".dtd",
+        ".factions",
+        ".md",
+        ".png",
+        ".py",
+        ".pyc",
+        ".reg",
+        ".rst",
+        ".trs",
+        ".txt",
+        ".xml",
+    }
+    for path in sorted(item for item in maps_root.rglob("*") if item.is_file()):
+        if path.suffix.lower() in ignored_suffixes or not _is_map_file(path):
+            continue
+        map_key = "/" + path.relative_to(maps_root).as_posix()
+        map_id = catalog.add_definition("map", map_key, catalog.location(path, 1))
+        in_header = True
+        # A map may place thousands of identical objects. One edge per target
+        # preserves identity validation without turning the catalog artifact
+        # into a second, much larger encoding of the map itself.
+        seen_archetypes = set()
+        for line_number, line in _iter_source_lines(path):
+            field, value = _split(line)
+            if in_header:
+                if field == "region" and value:
+                    catalog.add_reference(
+                        value,
+                        ("region",),
+                        catalog.location(path, line_number, _column(line, value)),
+                        "map region",
+                        map_id,
+                    )
+                elif field.startswith("tile_path_") and value:
+                    target = _canonical_map_path(value, posixpath.dirname(map_key))
+                    catalog.add_reference(
+                        target,
+                        ("map",),
+                        catalog.location(path, line_number, _column(line, value)),
+                        field,
+                        map_id,
+                    )
+                elif field == "end" and not value:
+                    in_header = False
+            elif field == "arch" and value:
+                target = value.split()[0]
+                if target in seen_archetypes:
+                    continue
+                seen_archetypes.add(target)
+                catalog.add_reference(
+                    target,
+                    OBJECT_DOMAINS,
+                    catalog.location(path, line_number, _column(line, value)),
+                    "map arch",
+                    map_id,
+                )
+
+
+class _InterfaceLoader:
+    QUEST_FIELDS = ("start", "complete", "fail", "started", "finished", "completed", "failed")
+
+    def __init__(self, catalog: ContentCatalog, path: Path, quest_key: Optional[str]):
+        self.catalog = catalog
+        self.path = path
+        self.quest_key = quest_key
+        self.quest_id: Optional[ContentId] = None
+        self.part_stack: List[str] = []
+        self.parser = expat.ParserCreate()
+        self.parser.StartElementHandler = self._start
+        self.parser.EndElementHandler = self._end
+
+    def location(self, attribute_value: Optional[str] = None) -> SourceLocation:
+        column = self.parser.CurrentColumnNumber + 1
+        if attribute_value:
+            column += 1
+        return self.catalog.location(self.path, self.parser.CurrentLineNumber, column)
+
+    def parse(self) -> None:
+        try:
+            with self.path.open("rb") as source:
+                self.parser.ParseFile(source)
+        except expat.ExpatError as error:
+            self.catalog.add_diagnostic(
+                "invalid-xml",
+                str(error),
+                self.catalog.location(self.path, error.lineno, error.offset + 1),
+            )
+
+    def _start(self, name: str, attrs: Dict[str, str]) -> None:
+        if name == "quest":
+            if self.quest_key is None:
+                self.catalog.add_diagnostic(
+                    "quest-location",
+                    "quest definitions must be stored below maps/interfaces/quests/<uid>/",
+                    self.location(),
+                )
+            else:
+                if not QUEST_ID_RE.fullmatch(self.quest_key):
+                    self.catalog.add_diagnostic(
+                        "invalid-quest-id",
+                        "quest directory '{}' is not a stable identifier".format(self.quest_key),
+                        self.location(),
+                    )
+                self.quest_id = self.catalog.add_definition(
+                    "quest", self.quest_key, self.location(), {"name": attrs.get("name", "")}
+                )
+        elif name == "part":
+            uid = attrs.get("uid", "")
+            if not QUEST_PART_ID_RE.fullmatch(uid):
+                self.catalog.add_diagnostic(
+                    "invalid-quest-part-id",
+                    "quest part uid '{}' must match {}".format(uid, QUEST_PART_ID_RE.pattern),
+                    self.location(uid),
+                )
+            self.part_stack.append(uid)
+            if self.quest_key is not None:
+                key = self.quest_key + "::" + "::".join(self.part_stack)
+                self.catalog.add_definition(
+                    "quest-part", key, self.location(uid), {"uid": uid}
+                )
+
+        source = self.quest_id
+        if name in ("item", "object") and attrs.get("arch"):
+            self.catalog.add_reference(
+                attrs["arch"], OBJECT_DOMAINS, self.location(attrs["arch"]), "{} arch".format(name), source
+            )
+        if attrs.get("cast"):
+            spell_key = "spell_" + re.sub(r"\s+", "_", attrs["cast"].strip().lower())
+            self.catalog.add_reference(spell_key, ("spell",), self.location(attrs["cast"]), "cast", source)
+        if attrs.get("teleport"):
+            target = attrs["teleport"].split()[0]
+            self.catalog.add_reference(
+                _canonical_map_path(target), ("map",), self.location(target), "teleport", source
+            )
+        if attrs.get("region_map"):
+            self.catalog.add_reference(
+                attrs["region_map"], ("region",), self.location(attrs["region_map"]), "region_map", source
+            )
+        for attribute, value in attrs.items():
+            if attribute.startswith("faction_"):
+                self.catalog.add_reference(
+                    value, ("faction",), self.location(value), attribute, source
+                )
+        if self.quest_key is not None:
+            for field in self.QUEST_FIELDS:
+                value = attrs.get(field)
+                if value:
+                    key = self.quest_key + "::" + value
+                    self.catalog.add_reference(
+                        key, ("quest-part",), self.location(value), field, source
+                    )
+
+    def _end(self, name: str) -> None:
+        if name == "part" and self.part_stack:
+            self.part_stack.pop()
+
+
+def _load_interfaces(catalog: ContentCatalog, maps_root: Path) -> None:
+    interfaces_root = maps_root / "interfaces"
+    quests_root = interfaces_root / "quests"
+    if not interfaces_root.is_dir():
+        return
+    for path in sorted(interfaces_root.rglob("*.xml")):
+        quest_key = None
+        try:
+            relative = path.relative_to(quests_root)
+            if len(relative.parts) >= 2:
+                quest_key = relative.parts[0]
+        except ValueError:
+            pass
+        _InterfaceLoader(catalog, path, quest_key).parse()
+
+
+def load_catalog(root: Path) -> ContentCatalog:
+    """Build and resolve a catalog from an Atrinik source tree."""
+
+    catalog = ContentCatalog(root)
+    arch_root = root / "arch"
+    maps_root = root / "maps"
+    _load_archetypes(catalog, arch_root)
+    _load_artifacts(catalog, (arch_root, maps_root))
+    _load_treasures(catalog, (arch_root, maps_root))
+    _load_factions(catalog, maps_root)
+    _load_maps(catalog, maps_root)
+    _load_regions(catalog, maps_root)
+    _load_interfaces(catalog, maps_root)
+    catalog.resolve_references()
+    return catalog

--- a/tools/content_catalog/model.py
+++ b/tools/content_catalog/model.py
@@ -1,0 +1,311 @@
+"""Typed content identity graph and deterministic diagnostics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+
+@dataclass(frozen=True, order=True)
+class ContentId:
+    """A canonical identifier qualified by its content domain."""
+
+    domain: str
+    key: str
+
+    def __str__(self) -> str:
+        return "{}:{}".format(self.domain, self.key)
+
+
+@dataclass(frozen=True, order=True)
+class SourceLocation:
+    """A stable, repository-relative source location."""
+
+    path: str
+    line: int
+    column: int = 1
+
+    def display(self) -> str:
+        return "{}:{}:{}".format(self.path, self.line, self.column)
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "path": self.path,
+            "line": self.line,
+            "column": self.column,
+        }
+
+
+@dataclass(frozen=True)
+class Definition:
+    """A canonical content definition."""
+
+    content_id: ContentId
+    location: SourceLocation
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "domain": self.content_id.domain,
+            "key": self.content_id.key,
+            "location": self.location.to_dict(),
+            "metadata": dict(sorted(self.metadata.items())),
+        }
+
+
+@dataclass(frozen=True)
+class Reference:
+    """A typed edge from authored content to a canonical definition."""
+
+    key: str
+    allowed_domains: Tuple[str, ...]
+    location: SourceLocation
+    field: str
+    source: Optional[ContentId] = None
+
+    def to_dict(self) -> Mapping[str, object]:
+        data = {
+            "key": self.key,
+            "allowed_domains": list(self.allowed_domains),
+            "field": self.field,
+            "location": self.location.to_dict(),
+        }
+        if self.source is not None:
+            data["source"] = {
+                "domain": self.source.domain,
+                "key": self.source.key,
+            }
+        return data
+
+
+@dataclass(frozen=True, order=True)
+class Diagnostic:
+    """An actionable catalog problem."""
+
+    location: SourceLocation
+    code: str
+    message: str
+    severity: str = "error"
+    related: Optional[SourceLocation] = field(default=None, compare=True)
+
+    def format(self) -> str:
+        return "{}: {} {}: {}".format(
+            self.location.display(), self.severity, self.code, self.message
+        )
+
+    def to_dict(self) -> Mapping[str, object]:
+        data = {
+            "severity": self.severity,
+            "code": self.code,
+            "message": self.message,
+            "location": self.location.to_dict(),
+        }
+        if self.related is not None:
+            data["related"] = self.related.to_dict()
+        return data
+
+
+class ContentCatalog:
+    """Mutable builder for definitions, references, and diagnostics."""
+
+    SCHEMA_VERSION = 1
+
+    def __init__(self, root: Path):
+        self.root = root.resolve()
+        self._definitions: Dict[ContentId, Definition] = {}
+        self._references: List[Reference] = []
+        self._diagnostics: List[Diagnostic] = []
+
+    @property
+    def definitions(self) -> Sequence[Definition]:
+        return tuple(
+            sorted(
+                self._definitions.values(),
+                key=lambda definition: (
+                    definition.content_id.domain,
+                    definition.content_id.key,
+                    definition.location,
+                ),
+            )
+        )
+
+    @property
+    def references(self) -> Sequence[Reference]:
+        return tuple(
+            sorted(
+                self._references,
+                key=lambda reference: (
+                    reference.location,
+                    reference.field,
+                    reference.allowed_domains,
+                    reference.key,
+                ),
+            )
+        )
+
+    @property
+    def diagnostics(self) -> Sequence[Diagnostic]:
+        return tuple(
+            sorted(
+                self._diagnostics,
+                key=lambda diagnostic: (
+                    diagnostic.location,
+                    diagnostic.severity,
+                    diagnostic.code,
+                    diagnostic.message,
+                    diagnostic.related or SourceLocation("", 0, 0),
+                ),
+            )
+        )
+
+    @property
+    def has_errors(self) -> bool:
+        return any(item.severity == "error" for item in self._diagnostics)
+
+    def location(self, path: Path, line: int, column: int = 1) -> SourceLocation:
+        try:
+            relative = path.resolve().relative_to(self.root)
+        except ValueError:
+            relative = path.resolve()
+        return SourceLocation(relative.as_posix(), line, column)
+
+    def add_definition(
+        self,
+        domain: str,
+        key: str,
+        location: SourceLocation,
+        metadata: Optional[Mapping[str, object]] = None,
+    ) -> ContentId:
+        content_id = ContentId(domain, key)
+        definition = Definition(content_id, location, metadata or {})
+        previous = self._definitions.get(content_id)
+        if previous is not None:
+            self.add_diagnostic(
+                "duplicate-id",
+                "duplicate {}; first defined at {}".format(
+                    content_id, previous.location.display()
+                ),
+                location,
+                related=previous.location,
+            )
+        else:
+            self._definitions[content_id] = definition
+        return content_id
+
+    def add_reference(
+        self,
+        key: str,
+        allowed_domains: Iterable[str],
+        location: SourceLocation,
+        field: str,
+        source: Optional[ContentId] = None,
+    ) -> None:
+        self._references.append(
+            Reference(key, tuple(sorted(set(allowed_domains))), location, field, source)
+        )
+
+    def add_diagnostic(
+        self,
+        code: str,
+        message: str,
+        location: SourceLocation,
+        severity: str = "error",
+        related: Optional[SourceLocation] = None,
+    ) -> None:
+        self._diagnostics.append(
+            Diagnostic(location, code, message, severity, related)
+        )
+
+    def resolve_references(self) -> None:
+        """Resolve all typed edges after every domain has been loaded."""
+
+        keys_by_domain: Dict[str, set] = {}
+        domains_by_key: Dict[str, set] = {}
+        for content_id in self._definitions:
+            keys_by_domain.setdefault(content_id.domain, set()).add(content_id.key)
+            domains_by_key.setdefault(content_id.key, set()).add(content_id.domain)
+
+        for reference in self._references:
+            matches = [
+                domain
+                for domain in reference.allowed_domains
+                if reference.key in keys_by_domain.get(domain, set())
+            ]
+            if len(matches) == 1:
+                continue
+            if len(matches) > 1:
+                self.add_diagnostic(
+                    "ambiguous-reference",
+                    "{} '{}' resolves in multiple allowed domains: {}".format(
+                        reference.field, reference.key, ", ".join(matches)
+                    ),
+                    reference.location,
+                )
+                continue
+
+            actual_domains = sorted(domains_by_key.get(reference.key, set()))
+            if actual_domains:
+                self.add_diagnostic(
+                    "wrong-domain-reference",
+                    "{} '{}' expects {}, but the key exists as {}".format(
+                        reference.field,
+                        reference.key,
+                        ", ".join(reference.allowed_domains),
+                        ", ".join(actual_domains),
+                    ),
+                    reference.location,
+                )
+            else:
+                self.add_diagnostic(
+                    "missing-reference",
+                    "{} '{}' does not resolve in {}".format(
+                        reference.field,
+                        reference.key,
+                        ", ".join(reference.allowed_domains),
+                    ),
+                    reference.location,
+                )
+
+    def check_cycles(self, domain: str, edges: Mapping[str, Tuple[str, SourceLocation]]) -> None:
+        """Report cycles in a single-parent identity hierarchy."""
+
+        visited = set()
+        for start in sorted(edges):
+            if start in visited:
+                continue
+            path: List[str] = []
+            positions = {}
+            current = start
+            while current in edges and current not in visited:
+                if current in positions:
+                    cycle = path[positions[current] :] + [current]
+                    _, location = edges[current]
+                    self.add_diagnostic(
+                        "identity-cycle",
+                        "{} hierarchy contains a cycle: {}".format(
+                            domain, " -> ".join(cycle)
+                        ),
+                        location,
+                    )
+                    break
+                positions[current] = len(path)
+                path.append(current)
+                current = edges[current][0]
+            visited.update(path)
+
+    def counts(self) -> Mapping[str, int]:
+        counts: Dict[str, int] = {}
+        for definition in self._definitions.values():
+            domain = definition.content_id.domain
+            counts[domain] = counts.get(domain, 0) + 1
+        return dict(sorted(counts.items()))
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "counts": self.counts(),
+            "definitions": [definition.to_dict() for definition in self.definitions],
+            "references": [reference.to_dict() for reference in self.references],
+            "diagnostics": [diagnostic.to_dict() for diagnostic in self.diagnostics],
+        }

--- a/tools/content_catalog/model.py
+++ b/tools/content_catalog/model.py
@@ -294,6 +294,35 @@ class ContentCatalog:
                 current = edges[current][0]
             visited.update(path)
 
+    def check_shared_namespace(self, namespace: str, domains: Iterable[str]) -> None:
+        """Reject IDs that collide in a runtime namespace shared by domains."""
+
+        selected_domains = set(domains)
+        definitions_by_key: Dict[str, List[Definition]] = {}
+        for definition in self._definitions.values():
+            if definition.content_id.domain in selected_domains:
+                definitions_by_key.setdefault(definition.content_id.key, []).append(
+                    definition
+                )
+
+        for key, definitions in sorted(definitions_by_key.items()):
+            if len(definitions) < 2:
+                continue
+            definitions.sort(key=lambda definition: definition.content_id.domain)
+            first = definitions[0]
+            for definition in definitions[1:]:
+                self.add_diagnostic(
+                    "shared-namespace-collision",
+                    "{} key '{}' is defined in both {} and {}".format(
+                        namespace,
+                        key,
+                        first.content_id.domain,
+                        definition.content_id.domain,
+                    ),
+                    definition.location,
+                    related=first.location,
+                )
+
     def counts(self) -> Mapping[str, int]:
         counts: Dict[str, int] = {}
         for definition in self._definitions.values():

--- a/tools/map-checker-qt/map-checker.py
+++ b/tools/map-checker-qt/map-checker.py
@@ -11,6 +11,13 @@ import sys
 from threading import Thread
 import logging
 import logging.handlers
+from pathlib import Path
+
+TOOLS_PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+if TOOLS_PATH not in sys.path:
+    sys.path.insert(0, TOOLS_PATH)
+
+from content_catalog import load_catalog
 
 from system.checker import CheckerMap, CheckerObject, CheckerArchetype, \
     AbstractChecker
@@ -88,6 +95,7 @@ class MapChecker:
         self.checker_map.set_map_checker(self)
 
         self.info_add_fnc = None
+        self.last_scan_valid = True
         self._thread = None
 
         self.queue = queue.Queue()
@@ -95,6 +103,30 @@ class MapChecker:
         self._thread_running = False
         self._scan_status = ""
         self._scan_progress = 0
+
+    def validate_content_catalog(self):
+        """Run the repository-wide identity validator used by collection."""
+        source_root = Path(self.get_maps_path()).resolve().parent
+        catalog = load_catalog(source_root)
+        for diagnostic in catalog.diagnostics:
+            self.queue.put({
+                "file": {
+                    "name": diagnostic.location.path,
+                    "path": diagnostic.location.path,
+                    "is_map": diagnostic.location.path.startswith("maps/"),
+                },
+                "severity": ("critical" if diagnostic.severity == "error"
+                             else "warning"),
+                "description": "{}: {}".format(diagnostic.code,
+                                                  diagnostic.message),
+                "explanation": (
+                    "Content identity validation failed at line {}, column "
+                    "{}.".format(diagnostic.location.line,
+                                  diagnostic.location.column)
+                ),
+                "loc": None,
+            })
+        return not catalog.has_errors
 
     @property
     def collections(self):
@@ -165,6 +197,10 @@ class MapChecker:
             path = self.get_maps_path()
 
         self._scan_progress = 0
+        self._scan_status = "Validating content identities..."
+        self.last_scan_valid = self.validate_content_catalog()
+        if not self.last_scan_valid:
+            return
 
         if not files:
             # First scan for possible map files.
@@ -403,7 +439,7 @@ def main():
     else:
         map_checker.scan(path=path, files=files, fix=fix,
                          threading=False, real_map_path=real_map_path)
-        ret = 0
+        ret = 0 if map_checker.last_scan_valid else 1
 
         while map_checker.queue.qsize():
             try:

--- a/tools/tests/test_content_catalog.py
+++ b/tools/tests/test_content_catalog.py
@@ -1,0 +1,223 @@
+"""Tests for the authored-content identity catalog."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools.content_catalog import ContentCatalog, ContentId, load_catalog
+
+
+class ContentCatalogTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        (self.root / "arch").mkdir()
+        (self.root / "maps" / "interfaces" / "quests" / "sample_quest").mkdir(
+            parents=True
+        )
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def write(self, relative_path, contents):
+        path = self.root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(contents, encoding="utf-8")
+        return path
+
+    def create_valid_tree(self):
+        self.write(
+            "arch/objects.arc",
+            """Object base
+type 1
+end
+Object spell_minor_healing
+type 29
+end
+Object skill_literacy
+type 43
+end
+Object multipart_head
+type 1
+end
+More
+Object multipart_tail
+type 1
+end
+""",
+        )
+        self.write(
+            "arch/items.art",
+            """Allowed all
+artifact special_item
+def_arch base
+Object
+end
+""",
+        )
+        self.write(
+            "arch/items.trs",
+            """treasure basic_loot
+  arch special_item
+end
+""",
+        )
+        self.write(
+            "maps/world.factions",
+            """faction world
+  faction citizens
+  end
+end
+""",
+        )
+        self.write(
+            "maps/regions.reg",
+            """region world
+map_first /start
+end
+region town
+parent world
+end
+""",
+        )
+        self.write(
+            "maps/start",
+            """arch map
+region town
+tile_path_1 next
+end
+arch base
+end
+arch base
+end
+arch special_item
+end
+""",
+        )
+        self.write(
+            "maps/next",
+            """arch map
+region town
+end
+arch base
+end
+""",
+        )
+        self.write(
+            "maps/interfaces/quests/sample_quest/quest.xml",
+            """<?xml version="1.0"?>
+<interfaces>
+  <quest name="Sample Quest">
+    <part uid="first_part">
+      <part uid="nested_part"/>
+      <interface>
+        <action start="first_part::nested_part" cast="minor healing"
+                teleport="/start 1 1" region_map="town"/>
+        <object arch="special_item"/>
+      </interface>
+    </part>
+  </quest>
+</interfaces>
+""",
+        )
+
+    def test_loads_domain_qualified_definitions_and_references(self):
+        self.create_valid_tree()
+
+        catalog = load_catalog(self.root)
+
+        self.assertFalse(catalog.has_errors, [item.format() for item in catalog.diagnostics])
+        ids = {definition.content_id for definition in catalog.definitions}
+        self.assertIn(ContentId("archetype", "base"), ids)
+        self.assertIn(ContentId("artifact", "special_item"), ids)
+        self.assertIn(ContentId("spell", "spell_minor_healing"), ids)
+        self.assertIn(ContentId("skill", "skill_literacy"), ids)
+        self.assertIn(ContentId("quest", "sample_quest"), ids)
+        self.assertIn(
+            ContentId("quest-part", "sample_quest::first_part::nested_part"), ids
+        )
+        self.assertNotIn(ContentId("archetype", "multipart_tail"), ids)
+
+        map_arch_references = [
+            reference
+            for reference in catalog.references
+            if reference.source == ContentId("map", "/start")
+            and reference.field == "map arch"
+            and reference.key == "base"
+        ]
+        self.assertEqual(1, len(map_arch_references))
+
+    def test_reports_duplicate_missing_wrong_domain_and_cycles(self):
+        catalog = ContentCatalog(self.root)
+        first = catalog.location(self.root / "one", 1)
+        second = catalog.location(self.root / "two", 2)
+        catalog.add_definition("archetype", "shared", first)
+        catalog.add_definition("archetype", "shared", second)
+        catalog.add_definition("faction", "world", first)
+        catalog.add_definition("faction", "town", second)
+        catalog.add_reference("shared", ("region",), second, "region parent")
+        catalog.add_reference("absent", ("map",), second, "teleport")
+        catalog.check_cycles(
+            "faction", {"world": ("town", first), "town": ("world", second)}
+        )
+        catalog.resolve_references()
+
+        codes = {diagnostic.code for diagnostic in catalog.diagnostics}
+        self.assertEqual(
+            {
+                "duplicate-id",
+                "identity-cycle",
+                "missing-reference",
+                "wrong-domain-reference",
+            },
+            codes,
+        )
+
+    def test_rejects_quest_part_ids_that_would_be_silently_changed(self):
+        self.create_valid_tree()
+        quest = self.root / "maps/interfaces/quests/sample_quest/quest.xml"
+        quest.write_text(
+            """<interfaces><quest name="Sample"><part uid="Not Stable!"/>
+</quest></interfaces>
+""",
+            encoding="utf-8",
+        )
+
+        catalog = load_catalog(self.root)
+
+        self.assertIn(
+            "invalid-quest-part-id",
+            {diagnostic.code for diagnostic in catalog.diagnostics},
+        )
+
+    def test_serialized_catalog_is_deterministic(self):
+        self.create_valid_tree()
+
+        first = json.dumps(load_catalog(self.root).to_dict(), sort_keys=True)
+        second = json.dumps(load_catalog(self.root).to_dict(), sort_keys=True)
+
+        self.assertEqual(first, second)
+
+    def test_display_name_changes_do_not_change_identity(self):
+        self.create_valid_tree()
+        first_ids = {
+            definition.content_id for definition in load_catalog(self.root).definitions
+        }
+        quest = self.root / "maps/interfaces/quests/sample_quest/quest.xml"
+        quest.write_text(
+            quest.read_text(encoding="utf-8").replace(
+                'name="Sample Quest"', 'name="A Translated Display Name"'
+            ),
+            encoding="utf-8",
+        )
+
+        second_ids = {
+            definition.content_id for definition in load_catalog(self.root).definitions
+        }
+
+        self.assertEqual(first_ids, second_ids)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_content_catalog.py
+++ b/tools/tests/test_content_catalog.py
@@ -38,6 +38,9 @@ end
 Object skill_literacy
 type 43
 end
+Object wand
+type 109
+end
 Object sample_monster_variant
 type 80
 race sample_family
@@ -97,6 +100,9 @@ arch base
 end
 arch special_item
 end
+arch wand
+spell_id spell_minor_healing
+end
 """,
         )
         self.write(
@@ -152,6 +158,13 @@ end
             and reference.key == "base"
         ]
         self.assertEqual(1, len(map_arch_references))
+        self.assertTrue(
+            any(
+                reference.field == "spell_id"
+                and reference.key == "spell_minor_healing"
+                for reference in catalog.references
+            )
+        )
 
     def test_reports_duplicate_missing_wrong_domain_and_cycles(self):
         catalog = ContentCatalog(self.root)
@@ -159,12 +172,16 @@ end
         second = catalog.location(self.root / "two", 2)
         catalog.add_definition("archetype", "shared", first)
         catalog.add_definition("archetype", "shared", second)
+        catalog.add_definition("artifact", "shared", second)
         catalog.add_definition("faction", "world", first)
         catalog.add_definition("faction", "town", second)
         catalog.add_reference("shared", ("region",), second, "region parent")
         catalog.add_reference("absent", ("map",), second, "teleport")
         catalog.check_cycles(
             "faction", {"world": ("town", first), "town": ("world", second)}
+        )
+        catalog.check_shared_namespace(
+            "server archetype", ("archetype", "artifact")
         )
         catalog.resolve_references()
 
@@ -174,6 +191,7 @@ end
                 "duplicate-id",
                 "identity-cycle",
                 "missing-reference",
+                "shared-namespace-collision",
                 "wrong-domain-reference",
             },
             codes,
@@ -195,6 +213,44 @@ end
             "invalid-quest-part-id",
             {diagnostic.code for diagnostic in catalog.diagnostics},
         )
+
+    def test_rejects_map_paths_that_escape_the_authored_root(self):
+        self.create_valid_tree()
+        start = self.root / "maps/start"
+        start.write_text(
+            start.read_text(encoding="utf-8").replace(
+                "tile_path_1 next", "tile_path_1 ../../outside"
+            ),
+            encoding="utf-8",
+        )
+
+        catalog = load_catalog(self.root)
+
+        self.assertIn("invalid-map-path", {item.code for item in catalog.diagnostics})
+
+    def test_reports_unterminated_source_blocks(self):
+        self.create_valid_tree()
+        self.write(
+            "arch/broken.arc",
+            """Object broken
+type 1
+msg
+This block never ends.
+""",
+        )
+        self.write(
+            "arch/broken.trs",
+            """treasure broken_reward
+  arch base
+""",
+        )
+
+        catalog = load_catalog(self.root)
+
+        codes = {item.code for item in catalog.diagnostics}
+        self.assertIn("unterminated-message", codes)
+        self.assertIn("unterminated-object", codes)
+        self.assertIn("unterminated-treasure", codes)
 
     def test_serialized_catalog_is_deterministic(self):
         self.create_valid_tree()

--- a/tools/tests/test_content_catalog.py
+++ b/tools/tests/test_content_catalog.py
@@ -38,6 +38,10 @@ end
 Object skill_literacy
 type 43
 end
+Object sample_monster_variant
+type 80
+race sample_family
+end
 Object multipart_head
 type 1
 end
@@ -133,6 +137,7 @@ end
         self.assertIn(ContentId("artifact", "special_item"), ids)
         self.assertIn(ContentId("spell", "spell_minor_healing"), ids)
         self.assertIn(ContentId("skill", "skill_literacy"), ids)
+        self.assertIn(ContentId("archetype", "sample_monster_variant"), ids)
         self.assertIn(ContentId("quest", "sample_quest"), ids)
         self.assertIn(
             ContentId("quest-part", "sample_quest::first_part::nested_part"), ids
@@ -217,6 +222,34 @@ end
         }
 
         self.assertEqual(first_ids, second_ids)
+
+    def test_runtime_table_display_names_do_not_own_spell_or_skill_ids(self):
+        self.create_valid_tree()
+        self.write(
+            "server/src/include/spellist.h",
+            '    {"spell_minor_healing",\n     "Translated Spell Name",\n',
+        )
+        self.write(
+            "server/src/include/skillist.h",
+            '    {"skill_literacy", "Translated Skill Name", NULL, 0},\n',
+        )
+
+        catalog = load_catalog(self.root)
+
+        self.assertFalse(catalog.has_errors, [item.format() for item in catalog.diagnostics])
+        runtime_fields = {reference.field for reference in catalog.references}
+        self.assertIn("spell table id", runtime_fields)
+        self.assertIn("skill table id", runtime_fields)
+
+        spell_table = self.root / "server/src/include/spellist.h"
+        spell_table.write_text(
+            '    {"spell_missing",\n     "Translated Spell Name",\n',
+            encoding="utf-8",
+        )
+        catalog = load_catalog(self.root)
+        self.assertIn(
+            "missing-reference", {item.code for item in catalog.diagnostics}
+        )
 
 
 if __name__ == "__main__":

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -30,7 +30,9 @@ def find_files(where, ext=None, rec=True, ignore_dirs=True, ignore_files=False,
     :rtype list
     """
 
-    nodes = os.listdir(where)
+    # Collection output is committed and consumed as an ordered stream by the
+    # legacy loaders, so filesystem enumeration order must never leak into it.
+    nodes = sorted(os.listdir(where))
     files = []
 
     for node in nodes:

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -31,7 +31,7 @@ def find_files(where, ext=None, rec=True, ignore_dirs=True, ignore_files=False,
     """
 
     # Collection output is committed and consumed as an ordered stream by the
-    # legacy loaders, so filesystem enumeration order must never leak into it.
+    # classic loaders, so filesystem enumeration order must never leak into it.
     nodes = sorted(os.listdir(where))
     files = []
 


### PR DESCRIPTION
Closes atrinik/content#19.

## Summary

- add a deterministic, typed catalog for archetypes, artifacts, treasures,
  maps, regions, factions, quests and quest parts, spells, and skills
- validate duplicate, missing, ambiguous, wrong-domain, cyclic,
  shared-namespace, malformed-block, and root-escaping identities with source
  locations
- make collection, CTest, Linux CI path selection, and the modern map checker
  use the shared catalog
- add explicit spell and skill table keys and persist them as `spell_id` and
  `skill_id` instead of runtime array positions
- migrate every current authored numeric spell reference and fail closed for
  invalid or wrong-type durable identities
- document canonical ownership plus rename, removal, migration, and tombstone
  policy in `docs/ARCHITECTURE.md`

## Review

The implementation went through two full diff-review and remediation passes.
The review covered identity semantics, all persistence/error paths, malformed
input handling, namespace collisions, deterministic output, scale, security,
duplicate-code opportunities, CMake dependency boundaries, and acceptance
criteria. The final source tree contains 8,072 definitions and 65,263
deduplicated typed references; a deterministic JSON emit is 26 MiB and takes
about seven seconds in the development container.

Notable remediations include recursive `LL_ERROR` propagation, validation
after complete order-independent object parsing, fail-closed corrupt-index
serialization, invalid map/player record handling, root-escape rejection,
positive authored CMake input globs, shared artifact/archetype namespace
checking, and malformed source-block diagnostics.

## Validation

- `cmake --build --preset linux-debug --target atrinik-server-tests atrinik-server -j2`
- `ctest --test-dir build/linux-debug --output-on-failure` (31/31 passed)
- `python3 -m unittest tools.tests.test_content_catalog` (8/8 passed)
- `python3 -m tools.content_catalog validate --root .`
- two byte-identical catalog emits (`498d9a8771094fb028e997a121a04ab6e700713a52e3486fa9e3ad2e6c5a04be`)
- focused modern map-checker scan of both migrated maps (zero diagnostics)
- `bash tools/clang-format.sh --check`
- `actionlint .github/workflows/linux-ci.yml`
- targeted `clang-tidy -p build/linux-debug`
- Python compilation and `git diff --check`
