### PR TITLE
feat: add shared server worktree tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ components through standard CMake `FetchContent` overrides, runs both CTest
 suites, prepares the server runtime from the pinned content/resources, and
 executes the server's non-listening version smoke check. See
 [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for release and data-flow
-details.
+details. [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) covers editable component
+worktrees, devcontainer launch commands, and safely sharing one mutable server
+data directory across server worktrees.
 
 ## Releases
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,105 @@
+# Development after the repository split
+
+The integration repository assembles released component snapshots. Edit a
+component in its own repository and use this repository when validating a set
+of released versions together.
+
+## Build and run the pinned integration snapshot
+
+From the integration repository root inside the Linux devcontainer:
+
+```sh
+python3 scripts/components.py sync
+scripts/build.sh
+```
+
+The build verifies all component locks, builds and tests both native programs,
+and prepares the server runtime. Run the client from its component working
+directory:
+
+```sh
+cd build/components/client
+../../integration/client/atrinik
+```
+
+Run the server through its prepared launcher:
+
+```sh
+cd build/components/server
+./server.sh --port_mapping=off --stun_server=off
+```
+
+The client command opens a graphical window and may enable audio. The server
+command starts the game service; the shown flags disable automatic port mapping
+and STUN discovery. `./server.sh --version` is the bounded smoke check used by
+the integration build.
+
+## Editable component worktrees
+
+Keep one primary clone for each component and add feature worktrees beside it.
+For example:
+
+```sh
+mkdir -p /workspaces/atrinik-dev/repos /workspaces/atrinik-dev/worktrees
+gh repo clone atrinik/client /workspaces/atrinik-dev/repos/client
+gh repo clone atrinik/server /workspaces/atrinik-dev/repos/server
+
+git -C /workspaces/atrinik-dev/repos/client fetch origin
+git -C /workspaces/atrinik-dev/repos/client worktree add \
+  /workspaces/atrinik-dev/worktrees/client-ui -b feat/client-ui origin/master
+
+git -C /workspaces/atrinik-dev/repos/server fetch origin
+git -C /workspaces/atrinik-dev/repos/server worktree add \
+  /workspaces/atrinik-dev/worktrees/server-rules -b feat/server-rules origin/master
+```
+
+Each component worktree owns its build directory and dependency checkout. This
+avoids CMake cache collisions while ccache still shares compiled objects. Use
+the component README for its exact build and test commands.
+
+List and remove worktrees through the primary clone:
+
+```sh
+git -C /workspaces/atrinik-dev/repos/server worktree list
+git -C /workspaces/atrinik-dev/repos/server worktree remove \
+  /workspaces/atrinik-dev/worktrees/server-rules
+git -C /workspaces/atrinik-dev/repos/server worktree prune
+git -C /workspaces/atrinik-dev/repos/server branch -d feat/server-rules
+```
+
+Inspect `git status --short` before removal. Avoid `--force` unless the
+worktree's uncommitted and ignored files have been deliberately preserved or
+discarded.
+
+## One mutable server data directory
+
+Never copy live accounts, identities, generated maps, or other mutable server
+state into every worktree. The integration helper initializes one external
+directory, links a server worktree's ignored `data` path to it, prepares that
+worktree's executable/plugins/content links, and takes an exclusive lock while
+the server runs:
+
+```sh
+scripts/server-worktree.sh prepare \
+  --worktree /workspaces/atrinik-dev/worktrees/server-rules
+
+scripts/server-worktree.sh run \
+  --worktree /workspaces/atrinik-dev/worktrees/server-rules \
+  -- --port_mapping=off --stun_server=off
+```
+
+By default, linked integration worktrees share
+`<primary-integration-clone>/build/shared/server-data`. To keep state elsewhere,
+set one absolute path consistently:
+
+```sh
+export ATRINIK_SHARED_SERVER_DATA=/workspaces/atrinik-state/server-data
+```
+
+The helper refuses to replace an existing real `data` directory or a symlink
+to a different location. Back up and deliberately migrate existing state
+before linking it. It also refuses a shared directory inside the server
+worktree and prevents concurrent server processes from writing the same data.
+Removing a component worktree removes only its symlink; the external data and
+lock file remain. Back up the shared directory independently before testing a
+change that can rewrite accounts, identities, or persistent world state.

--- a/scripts/server-worktree.sh
+++ b/scripts/server-worktree.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+usage: server-worktree.sh prepare --worktree PATH [--build-dir PATH]
+       server-worktree.sh run --worktree PATH [--build-dir PATH] [-- SERVER_ARGS...]
+
+Prepare or run an atrinik/server Git worktree while keeping mutable server data
+in one shared directory. Set ATRINIK_SHARED_SERVER_DATA to override the default
+shared directory.
+EOF
+}
+
+if [[ $# -eq 0 ]]; then
+  usage >&2
+  exit 2
+fi
+
+action=$1
+shift
+server_worktree=
+build_directory=build/linux-debug
+server_args=()
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --worktree)
+      [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+      server_worktree=$2
+      shift 2
+      ;;
+    --build-dir)
+      [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+      build_directory=$2
+      shift 2
+      ;;
+    --)
+      shift
+      server_args=("$@")
+      break
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ${action} != prepare && ${action} != run ]]; then
+  echo "unknown action: ${action}" >&2
+  usage >&2
+  exit 2
+fi
+if [[ -z ${server_worktree} ]]; then
+  echo "--worktree is required" >&2
+  usage >&2
+  exit 2
+fi
+if [[ ${action} == prepare && ${#server_args[@]} -ne 0 ]]; then
+  echo "server arguments are only valid with the run action" >&2
+  exit 2
+fi
+
+script_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+server_worktree=$(cd "${server_worktree}" && pwd -P)
+for required_path in install_data server.sh tools/prepare-runtime.sh; do
+  if [[ ! -e ${server_worktree}/${required_path} ]]; then
+    echo "not an atrinik/server worktree; missing ${required_path}: ${server_worktree}" >&2
+    exit 1
+  fi
+done
+
+if [[ -n ${ATRINIK_SHARED_SERVER_DATA:-} ]]; then
+  if [[ ${ATRINIK_SHARED_SERVER_DATA} != /* ]]; then
+    echo "ATRINIK_SHARED_SERVER_DATA must be an absolute path" >&2
+    exit 1
+  fi
+  configured_data=${ATRINIK_SHARED_SERVER_DATA%/}
+else
+  git_common_dir=$(git -C "${script_root}" rev-parse --path-format=absolute --git-common-dir)
+  configured_data=$(dirname "${git_common_dir}")/build/shared/server-data
+fi
+if [[ -z ${configured_data} || ${configured_data} == / ]]; then
+  echo "refusing unsafe shared server data path: ${configured_data:-<empty>}" >&2
+  exit 1
+fi
+
+data_link=${server_worktree}/data
+if [[ -e ${data_link} && ! -L ${data_link} ]]; then
+  echo "refusing to replace existing server worktree data: ${data_link}" >&2
+  echo "Back it up and move it to ${configured_data}, then rerun this command." >&2
+  exit 1
+fi
+
+configured_parent=$(dirname "${configured_data}")
+configured_name=$(basename "${configured_data}")
+if [[ ${configured_name} == . || ${configured_name} == .. ]]; then
+  echo "refusing unsafe shared server data path: ${configured_data}" >&2
+  exit 1
+fi
+mkdir -p "${configured_parent}"
+configured_parent=$(cd "${configured_parent}" && pwd -P)
+configured_data=${configured_parent}/${configured_name}
+
+case ${configured_data}/ in
+  "${server_worktree}/"*)
+    echo "shared server data must be outside the server worktree: ${configured_data}" >&2
+    exit 1
+    ;;
+esac
+if [[ -L ${data_link} ]]; then
+  linked_data=$(readlink -m "${data_link}")
+  intended_data=$(readlink -m "${configured_data}")
+  if [[ ${linked_data} != "${intended_data}" ]]; then
+    echo "server worktree data points elsewhere: ${data_link} -> ${linked_data}" >&2
+    exit 1
+  fi
+fi
+
+if ! command -v flock >/dev/null 2>&1; then
+  echo "flock is required to protect shared server data" >&2
+  exit 1
+fi
+lock_file=${configured_data}.lock
+exec {lock_fd}>"${lock_file}"
+if ! flock --exclusive --nonblock "${lock_fd}"; then
+  echo "another server worktree is already using ${configured_data}" >&2
+  exit 1
+fi
+
+staging=
+cleanup() {
+  if [[ -n ${staging} && -d ${staging} ]]; then
+    rm -rf -- "${staging}"
+  fi
+}
+trap cleanup EXIT
+if [[ -e ${configured_data} && ! -d ${configured_data} ]]; then
+  echo "shared server data path is not a directory: ${configured_data}" >&2
+  exit 1
+fi
+if [[ ! -e ${configured_data} ]]; then
+  staging=$(mktemp -d "${configured_parent}/.${configured_name}.init.XXXXXX")
+  cp -a "${server_worktree}/install_data/." "${staging}/"
+  mkdir -p "${staging}/tmp"
+  if [[ -e ${configured_data} ]]; then
+    echo "shared server data appeared during initialization: ${configured_data}" >&2
+    exit 1
+  fi
+  mv "${staging}" "${configured_data}"
+  staging=
+fi
+shared_data=$(cd "${configured_data}" && pwd -P)
+case ${shared_data}/ in
+  "${server_worktree}/"*)
+    echo "shared server data must be outside the server worktree: ${shared_data}" >&2
+    exit 1
+    ;;
+esac
+for required_data_file in bans motd; do
+  if [[ ! -f ${shared_data}/${required_data_file} ]]; then
+    echo "shared path does not look like Atrinik server data; missing file ${required_data_file}: ${shared_data}" >&2
+    exit 1
+  fi
+done
+for required_data_directory in keys unique-items; do
+  if [[ ! -d ${shared_data}/${required_data_directory} ]]; then
+    echo "shared path does not look like Atrinik server data; missing directory ${required_data_directory}: ${shared_data}" >&2
+    exit 1
+  fi
+done
+mkdir -p "${shared_data}/tmp"
+
+if [[ -L ${data_link} ]]; then
+  linked_data=$(readlink -f "${data_link}" || true)
+  if [[ ${linked_data} != "${shared_data}" ]]; then
+    echo "server worktree data points elsewhere: ${data_link} -> ${linked_data}" >&2
+    exit 1
+  fi
+elif [[ -e ${data_link} ]]; then
+  echo "refusing to replace existing server worktree data: ${data_link}" >&2
+  echo "Back it up and move it to ${shared_data}, then rerun this command." >&2
+  exit 1
+else
+  ln -s "${shared_data}" "${data_link}"
+fi
+
+"${server_worktree}/tools/prepare-runtime.sh" "${build_directory}"
+printf 'Shared server data: %s\n' "${shared_data}"
+
+if [[ ${action} == prepare ]]; then
+  exit 0
+fi
+(
+  cd "${server_worktree}"
+  exec ./server.sh "${server_args[@]}"
+)

--- a/tests/test_server_worktree.py
+++ b/tests/test_server_worktree.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "server-worktree.sh"
+
+
+class ServerWorktreeTests(unittest.TestCase):
+    def make_server(self, root: Path) -> Path:
+        server = root / "server"
+        (server / "install_data" / "keys").mkdir(parents=True)
+        (server / "install_data" / "unique-items").mkdir()
+        (server / "install_data" / "bans").write_text("")
+        (server / "install_data" / "motd").write_text("Welcome\n")
+        (server / "install_data" / "seed.txt").write_text("seed\n")
+        (server / "tools").mkdir()
+        (server / "tools" / "prepare-runtime.sh").write_text(
+            "#!/usr/bin/env bash\n"
+            "set -eu\n"
+            "root=$(cd \"$(dirname \"${BASH_SOURCE[0]}\")/..\" && pwd)\n"
+            "printf '%s\\n' \"$1\" > \"${root}/prepared-build-dir\"\n"
+        )
+        (server / "tools" / "prepare-runtime.sh").chmod(0o755)
+        (server / "server.sh").write_text(
+            "#!/usr/bin/env bash\nset -eu\nprintf '%s\\n' \"$@\"\n"
+        )
+        (server / "server.sh").chmod(0o755)
+        return server
+
+    def run_helper(
+        self, action: str, server: Path, state: Path, *arguments: str
+    ) -> subprocess.CompletedProcess[str]:
+        environment = os.environ.copy()
+        environment["ATRINIK_SHARED_SERVER_DATA"] = str(state)
+        return subprocess.run(
+            [
+                str(SCRIPT),
+                action,
+                "--worktree",
+                str(server),
+                "--build-dir",
+                "build/test",
+                *arguments,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=environment,
+            timeout=10,
+        )
+
+    def test_prepare_initializes_and_links_shared_data(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            server = self.make_server(root)
+            state = root / "state" / "server-data"
+
+            result = self.run_helper("prepare", server, state)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue((state / "seed.txt").is_file())
+            self.assertTrue((state / "tmp").is_dir())
+            self.assertTrue((server / "data").is_symlink())
+            self.assertEqual((server / "data").resolve(), state.resolve())
+            self.assertEqual(
+                (server / "prepared-build-dir").read_text(), "build/test\n"
+            )
+
+    def test_prepare_refuses_existing_worktree_data(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            server = self.make_server(root)
+            (server / "data").mkdir()
+            state = root / "state" / "server-data"
+
+            result = self.run_helper("prepare", server, state)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("refusing to replace existing", result.stderr)
+            self.assertFalse(state.exists())
+
+    def test_prepare_refuses_state_inside_worktree(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            server = self.make_server(root)
+            state = server / "shared" / "server-data"
+
+            result = self.run_helper("prepare", server, state)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("must be outside", result.stderr)
+            self.assertFalse(state.exists())
+
+    def test_prepare_refuses_another_data_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            server = self.make_server(root)
+            other_state = root / "other-data"
+            other_state.mkdir()
+            (server / "data").symlink_to(other_state, target_is_directory=True)
+            state = root / "state" / "server-data"
+
+            result = self.run_helper("prepare", server, state)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("points elsewhere", result.stderr)
+
+    def test_run_forwards_arguments(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            server = self.make_server(root)
+            state = root / "state" / "server-data"
+
+            result = self.run_helper(
+                "run", server, state, "--", "--port_mapping=off", "--version"
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("--port_mapping=off\n--version\n", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- document pinned integration and editable component build/run workflows
- add a helper that links server worktrees to one external mutable data directory
- protect shared state with canonical-path checks, refusal semantics, atomic initialization, and an exclusive runtime lock

## Validation
- 24 Python tests
- ShellCheck
- actionlint
- Python compileall
- JSON validation
- git diff --check
- exact local/remote Git tree equality

GitHub Actions remains affected by the ongoing service incident. This exact tree was reviewed and validated manually before the authorized administrative merge.