### PR TITLE
feat: orchestrate concurrent development topologies

### DIFF
--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -73,6 +73,12 @@ manually copy dependencies between repositories. Build a single dependency
 closure with `./atrinik build COMPONENT --profile REVIEW --test` when a full
 system build is unnecessary.
 
+The resources repository owns its runtime distribution boundary in
+`runtime-paths.txt`. Add a new tracked asset collection to that allowlist in
+the same resources change; do not stage repository-wide files or alter the
+wrapper to special-case individual metadata filenames. The coordinator serves
+only tracked regular files selected by the manifest.
+
 For runtime testing, register persistent server state once and reuse it across
 profiles:
 
@@ -86,6 +92,26 @@ profiles:
 Remove `--dry-run` only when an actual launch is intended. Verify display
 forwarding before opening the client. Do not run two servers against one state
 directory outside the coordinator's locking model.
+
+For a persistent client/server review session, treat the profile as a source
+topology and use the supervised lifecycle:
+
+```sh
+./atrinik topology show REVIEW --json
+./atrinik up --name RUNTIME --profile REVIEW --state NAME [--port UDP_PORT]
+./atrinik ps [RUNTIME] --json
+./atrinik logs RUNTIME server --follow
+./atrinik down RUNTIME
+```
+
+Select one service with `up --service server` or `--service client`. Use a
+distinct `--name` and state for every concurrent server topology; omit `--port`
+for automatic allocation or choose a distinct explicit port. The supervisor
+waits for completed server initialization and its fingerprint, pins the paired
+client to it, and isolates each runtime's client configuration. Do not signal
+recorded PIDs directly or tail internal files by reconstructed paths: the
+coordinator verifies process start identity, rotates logs, performs graceful
+shutdown, and holds the server-state lock through its supervisor.
 
 ## Coordinate releases and GitHub changes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,13 @@
   external path.
 - Never replace a dirty checkout, remove a dirty worktree, or overwrite an
   existing mutable server-data directory.
+- Use profiles to declare mixed component sources. Use `topology show` to audit
+  their exact resolution and `up`/`ps`/`logs`/`down` for persistent supervised
+  client/server testing; do not reconstruct internal build, runtime, PID, log,
+  or state-lock paths in ad hoc scripts.
+- Give concurrent topologies distinct names and server states. Let `up` choose
+  ports or assign distinct `--port` values; do not manually assemble a client
+  endpoint or share client configuration directories between topology names.
 - Use precise component and protocol names; do not use vague age-based labels.
 - Do not mention confidential or unreleased Atrinik work in committed files or
   public project surfaces.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ the ignored `workspace/` directory.
 
 ## Requirements
 
-- Python 3.11 or newer
+- Python 3.11 or newer; supervised topologies require Linux process identity
+  and pidfd support
 - Git and the authenticated GitHub CLI (`gh`)
 - CMake, Ninja, and the dependencies required by the selected component
 - Node.js 20 or newer when building `metaserver-worker`
@@ -88,7 +89,7 @@ Choose another start point or attach an existing local branch:
 
 ~~~sh
 ./atrinik worktree create client release-fix \
-  --branch fix/release --from origin/master
+  --branch fix/release --from origin/main
 ./atrinik worktree create content maps-pr \
   --branch review/maps-pr --existing
 ~~~
@@ -147,8 +148,246 @@ cd "$(./atrinik path server --profile maps-review)"
 
 Before every server build or launch, the coordinator collects the selected
 content checkout into an isolated runtime tree and stages the selected resource
-repository. Client builds similarly expose the selected sound checkout. These
-operations never write generated files into a component checkout.
+repository. Only tracked files below the resource repository's
+`runtime-paths.txt` allowlist are staged; development metadata and untracked
+files cannot become server assets. Client builds similarly expose the selected
+sound checkout. These operations never write generated files into a component
+checkout.
+
+## Supervised topologies and practical workflows
+
+A profile is a declarative source topology. The `topology` and process-lifecycle
+commands turn that selection into a Compose-like native development stack:
+
+~~~sh
+./atrinik topology show PROFILE
+./atrinik up --name TOPOLOGY --profile PROFILE --state STATE [--port UDP_PORT]
+./atrinik ps [TOPOLOGY]
+./atrinik logs TOPOLOGY [server|client] [--follow]
+./atrinik down TOPOLOGY
+~~~
+
+`up` resolves the selected client, server, content, protocol, library, sound,
+and resources automatically. It builds the required closure, collects content,
+stages resources/sound, prepares an isolated runtime, and starts both game
+processes under one supervisor. A server gets an available UDP port by default;
+use `--port` when a stable port is useful. The supervisor waits for both the
+QUIC certificate fingerprint and completed server initialization, then gives
+the paired client an authenticated loopback endpoint before declaring the
+topology ready. Use `--service server` or
+`--service client` for a single service. Client startup requires a live
+forwarded display socket.
+
+The supervisor records exact source commits, build and state paths, and process
+start identities. `ps` without a name lists every recorded topology; a name
+selects one. It distinguishes a live process from a reused PID, `down` signals
+only the matching supervisor, and the server state remains locked for the
+complete supervised lifetime. Each topology also has a persistent isolated
+client configuration/cache root and its own collected content and resource
+snapshot, so a subsequent build cannot replace files underneath a running
+topology. Logs live below `workspace/topologies/` and rotate at 10 MiB with
+three backups.
+
+### Use case: run the latest main branches
+
+Use this after first cloning the wrapper, or when returning to development and
+wanting a known-current baseline:
+
+~~~sh
+cd ~/atrinik
+./atrinik init
+./atrinik sync
+./atrinik topology show default
+./atrinik up
+./atrinik ps
+./atrinik logs default server --follow
+# Press Ctrl-C to stop following logs; the services keep running.
+./atrinik down
+~~~
+
+This is useful for ordinary playtesting and for proving that a problem also
+exists without any feature worktree. `sync` refuses dirty primary repositories,
+so it cannot silently overwrite in-progress component work.
+
+### Use case: develop one component without copying the whole project
+
+Create the branch and worktree in its owning repository, then select it in a
+profile. Everything else stays on its primary checkout:
+
+~~~sh
+./atrinik worktree create server socket-fix \
+  --branch fix/socket-timeout
+./atrinik profile create socket-fix
+./atrinik profile set socket-fix server --worktree socket-fix
+./atrinik topology show socket-fix
+./atrinik up --profile socket-fix --state default
+
+cd "$(./atrinik path server --profile socket-fix)"
+git status
+# Edit, test, commit, and push here as in any normal Git repository.
+
+cd ~/atrinik
+./atrinik logs socket-fix server --follow
+./atrinik down socket-fix
+~~~
+
+This is useful for a client- or server-only pull request: the wrapper rebuilds
+only the affected dependency closure and supplies all unchanged repositories
+without nesting their histories into the feature branch.
+
+### Use case: combine client, server, and content pull requests
+
+Fetch each pull request into a local review branch, attach its worktree, then
+compose the three labels. Substitute the actual pull-request numbers:
+
+~~~sh
+git -C client fetch origin pull/CLIENT_PR/head:review/client-ui
+git -C server fetch origin pull/SERVER_PR/head:review/server-combat
+git -C content fetch origin pull/CONTENT_PR/head:review/content-maps
+
+./atrinik worktree create client ui-review \
+  --branch review/client-ui --existing
+./atrinik worktree create server combat-review \
+  --branch review/server-combat --existing
+./atrinik worktree create content maps-review \
+  --branch review/content-maps --existing
+
+./atrinik profile create combined-review
+./atrinik profile set combined-review client --worktree ui-review
+./atrinik profile set combined-review server --worktree combat-review
+./atrinik profile set combined-review content --worktree maps-review
+./atrinik topology show combined-review --json
+./atrinik up --profile combined-review --state review
+./atrinik ps combined-review --json
+./atrinik logs combined-review --follow
+./atrinik down combined-review
+~~~
+
+This is the main cross-repository review workflow. Content is collected from
+the selected content worktree before launch, while client/server sources use
+their selected protocol, library, sound, and resource inputs. The JSON topology
+output is an exact bill of materials for review notes or agent automation.
+
+### Use case: review new maps with unchanged binaries
+
+Keep client and server on their synchronized primary checkouts and select only
+the content worktree:
+
+~~~sh
+./atrinik profile create map-check
+./atrinik profile set map-check content --worktree maps-review
+./atrinik topology show map-check
+./atrinik up --profile map-check --state review
+./atrinik logs map-check server --follow
+./atrinik down map-check
+~~~
+
+This is useful when a map/content pull request needs a real server and client
+but should not be tested against unrelated native branches. Automatic
+collection means there is no manual copy step and no generated output is
+written into the content worktree.
+
+### Use case: reuse one persistent server world across worktrees
+
+Register an existing server-data directory once, then select it by name from
+any topology:
+
+~~~sh
+./atrinik state add shared --path /workspaces/atrinik/server-data
+./atrinik up --profile combined-review --state shared
+./atrinik down combined-review
+./atrinik up --profile default --state shared
+./atrinik down default
+~~~
+
+This is useful for comparing a feature topology with main using the same
+accounts and world state. Run them sequentially: the coordinator deliberately
+refuses to start two servers against the same state directory at once.
+
+### Use case: compare two source combinations safely
+
+Clone a profile, change one selector, inspect both bills of materials, and run
+them one after the other against the same named state:
+
+~~~sh
+./atrinik profile create candidate-b --from combined-review
+./atrinik profile set candidate-b client --primary
+
+./atrinik topology show combined-review --json
+./atrinik topology show candidate-b --json
+
+./atrinik up --profile combined-review --state shared
+# Exercise the first combination.
+./atrinik down combined-review
+
+./atrinik up --profile candidate-b --state shared
+# Repeat the same exercise with the alternate client.
+./atrinik down candidate-b
+~~~
+
+Separate path-keyed build trees prevent the two combinations from overwriting
+one another, while the common state makes the comparison repeatable.
+
+### Use case: run two topologies at the same time
+
+Use distinct topology names, server states, and ports to run a baseline beside
+a candidate. The profile selects source code; `--name` selects the runtime
+instance, so the same profile can also be launched more than once:
+
+~~~sh
+./atrinik state add baseline
+./atrinik state add candidate
+
+./atrinik up --name baseline --profile default \
+  --state baseline --port 17300
+./atrinik up --name candidate --profile candidate-b \
+  --state candidate --port 17301
+
+./atrinik ps
+./atrinik logs baseline server --follow
+./atrinik logs candidate client --follow
+
+./atrinik down baseline
+./atrinik down candidate
+~~~
+
+This is useful for side-by-side regression checks, protocol experiments, and
+reviewing two pull-request combinations without stopping either one. Each
+client is pinned to its own server fingerprint and has separate settings and
+caches. Omit both `--port` options to have the coordinator choose two available
+ports. Two live servers may not use the same state directory; the state lock
+turns that mistake into an immediate error instead of mutable-data corruption.
+
+### Use case: run only a headless server
+
+In a terminal without display forwarding, start only the server and inspect it
+from another shell:
+
+~~~sh
+./atrinik up --profile combined-review --state review --service server
+./atrinik ps combined-review
+./atrinik logs combined-review server --follow
+./atrinik down combined-review
+~~~
+
+This is useful for protocol, content, runtime, and server work where opening a
+graphical client would be distracting or impossible.
+
+### Use case: clean up after a completed review
+
+Stop the topology before removing component worktrees. Removal refuses dirty
+worktrees, so commit, stash, or otherwise preserve intentional edits first:
+
+~~~sh
+./atrinik down combined-review
+./atrinik worktree remove client ui-review
+./atrinik worktree remove server combat-review
+./atrinik worktree remove content maps-review
+~~~
+
+Profiles and rotated logs are small ignored metadata and may remain as a review
+record. Component commits and branches remain owned by their standalone Git
+repositories.
 
 ## Persistent server state
 

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -82,6 +82,46 @@ def parser() -> argparse.ArgumentParser:
     build.add_argument("--profile", default="default")
     build.add_argument("--test", action="store_true")
 
+    topology = commands.add_parser(
+        "topology", help="inspect a resolved multi-component topology"
+    )
+    topology_commands = topology.add_subparsers(
+        dest="topology_command", required=True
+    )
+    topology_show = topology_commands.add_parser("show")
+    topology_show.add_argument("profile", nargs="?", default="default")
+    topology_show.add_argument("--state", default="default")
+    topology_show.add_argument(
+        "--service", choices=["server", "client"], action="append"
+    )
+    topology_show.add_argument("--json", action="store_true")
+
+    up = commands.add_parser("up", help="build and start a supervised topology")
+    up.add_argument("--name")
+    up.add_argument("--profile", default="default")
+    up.add_argument("--state", default="default")
+    up.add_argument(
+        "--port",
+        type=int,
+        help="server UDP port (default: choose an available port)",
+    )
+    up.add_argument("--service", choices=["server", "client"], action="append")
+    up.add_argument("--json", action="store_true")
+
+    ps = commands.add_parser("ps", help="show supervised topology processes")
+    ps.add_argument("name", nargs="?")
+    ps.add_argument("--json", action="store_true")
+
+    logs = commands.add_parser("logs", help="show supervised topology logs")
+    logs.add_argument("name", nargs="?", default="default")
+    logs.add_argument("service", nargs="?", choices=["server", "client"])
+    logs.add_argument("--tail", type=int, default=100)
+    logs.add_argument("--follow", "-f", action="store_true")
+
+    down = commands.add_parser("down", help="stop a supervised topology")
+    down.add_argument("name", nargs="?", default="default")
+    down.add_argument("--json", action="store_true")
+
     state = commands.add_parser("state", help="register persistent server state")
     state_commands = state.add_subparsers(dest="state_command", required=True)
     state_add = state_commands.add_parser("add")
@@ -210,6 +250,83 @@ def main(arguments: list[str] | None = None) -> int:
             print(workspace.component_path(options.component, options.profile))
         elif options.command == "build":
             print(workspace.build(options.target, options.profile, options.test))
+        elif options.command == "topology":
+            summary = workspace.topology_summary(
+                options.profile, options.state, options.service
+            )
+            if options.json:
+                print(json.dumps(summary, indent=2, sort_keys=True))
+            else:
+                print(f"profile\t{summary['profile']}")
+                print(f"services\t{','.join(summary['services'])}")
+                print(f"dependencies\t{','.join(summary['dependencies'])}")
+                print(f"state\t{summary['state'] or '-'}")
+                print(f"build\t{summary['build_root']}")
+                for component, row in summary["components"].items():
+                    cleanliness = "dirty" if row["dirty"] else "clean"
+                    print(
+                        f"{component}\t{row['head'][:12]}\t{cleanliness}\t"
+                        f"{row['path']}"
+                    )
+        elif options.command == "up":
+            name = options.name or options.profile
+            status = workspace.topology_up(
+                name, options.profile, options.state, options.service, options.port
+            )
+            if options.json:
+                print(json.dumps(status, indent=2, sort_keys=True))
+            else:
+                endpoint = status.get("endpoint")
+                suffix = (
+                    f" at {endpoint['host']}:{endpoint['port']}"
+                    if endpoint
+                    else ""
+                )
+                print(f"topology {name}: started{suffix}")
+        elif options.command == "ps":
+            statuses = (
+                [workspace.topology_status(options.name)]
+                if options.name
+                else workspace.topology_statuses()
+            )
+            if options.json:
+                value = statuses[0] if options.name else statuses
+                print(json.dumps(value, indent=2, sort_keys=True))
+            else:
+                for index, status in enumerate(statuses):
+                    if len(statuses) > 1:
+                        if index:
+                            print()
+                        print(f"==> {status['name']} <==")
+                    supervisor = status["supervisor"]
+                    supervisor_state = (
+                        "running" if supervisor["running"] else "stopped"
+                    )
+                    print(
+                        f"supervisor\t{supervisor_state}\t{supervisor['pid']}\t"
+                        f"{status['profile']}"
+                    )
+                    if status["endpoint"]:
+                        endpoint = status["endpoint"]
+                        print(
+                            f"endpoint\t{endpoint['host']}:{endpoint['port']}\t"
+                            f"{endpoint['fingerprint']}"
+                        )
+                    for service, row in status["services"].items():
+                        print(
+                            f"{service}\t{row['status']}\t{row['pid']}\t"
+                            f"{row['log']}"
+                        )
+        elif options.command == "logs":
+            workspace.topology_logs(
+                options.name, options.service, options.tail, options.follow
+            )
+        elif options.command == "down":
+            status = workspace.topology_down(options.name)
+            if options.json:
+                print(json.dumps(status, indent=2, sort_keys=True))
+            else:
+                print(f"topology {options.name}: stopped")
         elif options.command == "state":
             if options.state_command == "add":
                 workspace.state_add(options.name, options.path)

--- a/atrinik_workspace/model.py
+++ b/atrinik_workspace/model.py
@@ -160,6 +160,7 @@ class Paths:
     worktrees: Path
     profiles: Path
     builds: Path
+    topologies: Path
     state: Path
     marker: Path
     states_file: Path
@@ -183,6 +184,7 @@ class Paths:
             worktrees=workspace / "worktrees",
             profiles=workspace / "profiles",
             builds=workspace / "build",
+            topologies=workspace / "topologies",
             state=workspace / "state",
             marker=workspace / ".atrinik-workspace.json",
             states_file=workspace / "states.json",
@@ -208,6 +210,7 @@ class Paths:
             self.worktrees,
             self.profiles,
             self.builds,
+            self.topologies,
             self.state,
         ):
             directory.mkdir(parents=True, exist_ok=True)
@@ -216,8 +219,10 @@ class Paths:
 
 
 def managed_reset(path: Path, workspace_builds: Path, purpose: str) -> None:
-    path = path.resolve(strict=False)
     builds = workspace_builds.resolve()
+    if path.is_symlink():
+        raise WorkspaceError(f"refusing symlinked managed build path: {path}")
+    path = path.parent.resolve() / path.name
     if builds not in path.parents:
         raise WorkspaceError(f"refusing to replace path outside workspace builds: {path}")
     marker = path / MANAGED_MARKER
@@ -233,8 +238,10 @@ def managed_reset(path: Path, workspace_builds: Path, purpose: str) -> None:
 
 
 def managed_directory(path: Path, workspace_builds: Path, purpose: str) -> None:
-    path = path.resolve(strict=False)
     builds = workspace_builds.resolve()
+    if path.is_symlink():
+        raise WorkspaceError(f"refusing symlinked managed build path: {path}")
+    path = path.parent.resolve() / path.name
     if builds != path and builds not in path.parents:
         raise WorkspaceError(f"refusing build path outside workspace builds: {path}")
     marker = path / MANAGED_MARKER

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import re
+import signal
+import stat
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from typing import Any, BinaryIO
+
+
+LOG_LIMIT = 10 * 1024 * 1024
+LOG_BACKUPS = 3
+SERVER_READY_TIMEOUT = 30
+FINGERPRINT_PATTERN = re.compile(
+    rb"QUIC certificate SHA-256:\s*([0-9a-fA-F]{64})"
+)
+SERVER_READY_PATTERN = re.compile(rb"Server ready\. Waiting for connections\.\.\.")
+
+
+def process_start_time(pid: int) -> str | None:
+    """Return Linux's stable process start tick for PID-reuse protection."""
+    try:
+        fields = (Path("/proc") / str(pid) / "stat").read_text().rsplit(")", 1)[1]
+        return fields.split()[19]
+    except (IndexError, OSError):
+        return None
+
+
+def process_matches(pid: int, start_time: str) -> bool:
+    try:
+        fields = (Path("/proc") / str(pid) / "stat").read_text().rsplit(")", 1)[1]
+        values = fields.split()
+        return values[0] != "Z" and values[19] == start_time
+    except (IndexError, OSError):
+        return False
+
+
+def atomic_status(path: Path, value: dict[str, Any]) -> None:
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(value, stream, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        temporary.replace(path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def open_log(path: Path) -> BinaryIO:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags, 0o600)
+    if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+        os.close(descriptor)
+        raise RuntimeError(f"service log is not a regular file: {path}")
+    return os.fdopen(descriptor, "ab", buffering=0)
+
+
+def terminate(processes: dict[str, subprocess.Popen[bytes]]) -> None:
+    for process in processes.values():
+        if process.poll() is None:
+            try:
+                os.killpg(process.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline and any(
+        process.poll() is None for process in processes.values()
+    ):
+        time.sleep(0.1)
+    for process in processes.values():
+        if process.poll() is None:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+    for process in processes.values():
+        try:
+            process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            pass
+
+
+class RotatingLog:
+    def __init__(self, path: Path):
+        self.path = path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self.stream = open_log(path)
+
+    def write(self, content: bytes) -> None:
+        if self.stream.tell() + len(content) > LOG_LIMIT:
+            self.stream.close()
+            oldest = self.path.with_name(f"{self.path.name}.{LOG_BACKUPS}")
+            oldest.unlink(missing_ok=True)
+            for index in range(LOG_BACKUPS - 1, 0, -1):
+                source = self.path.with_name(f"{self.path.name}.{index}")
+                if source.exists() or source.is_symlink():
+                    source.replace(
+                        self.path.with_name(f"{self.path.name}.{index + 1}")
+                    )
+            if self.path.exists() or self.path.is_symlink():
+                self.path.replace(self.path.with_name(f"{self.path.name}.1"))
+            self.stream = open_log(self.path)
+        self.stream.write(content)
+
+    def close(self) -> None:
+        self.stream.close()
+
+
+class ServerReadinessCapture:
+    def __init__(self) -> None:
+        self.event = threading.Event()
+        self.fingerprint: str | None = None
+        self.server_ready = False
+        self.buffer = b""
+
+    def feed(self, content: bytes) -> None:
+        if self.event.is_set():
+            return
+        self.buffer = (self.buffer + content)[-4096:]
+        if self.fingerprint is None:
+            match = FINGERPRINT_PATTERN.search(self.buffer)
+            if match is not None:
+                self.fingerprint = match.group(1).decode("ascii").lower()
+        self.server_ready = self.server_ready or bool(
+            SERVER_READY_PATTERN.search(self.buffer)
+        )
+        if self.fingerprint is not None and self.server_ready:
+            self.event.set()
+
+
+def pump_output(
+    process: subprocess.Popen[bytes],
+    output: RotatingLog,
+    capture: ServerReadinessCapture | None = None,
+) -> None:
+    assert process.stdout is not None
+    writable = True
+    while content := process.stdout.read1(65536):
+        if capture is not None:
+            capture.feed(content)
+        if writable:
+            try:
+                output.write(content)
+            except (OSError, RuntimeError) as error:
+                writable = False
+                print(f"service log write failed: {error}", file=sys.stderr)
+    process.stdout.close()
+
+
+def supervise(spec_path: Path, lock_fd: int | None) -> int:
+    with spec_path.open(encoding="utf-8") as stream:
+        spec = json.load(stream)
+    status_path = spec_path.parent / "status.json"
+    stop = False
+
+    def request_stop(_signum: int, _frame: object) -> None:
+        nonlocal stop
+        stop = True
+
+    signal.signal(signal.SIGINT, request_stop)
+    signal.signal(signal.SIGTERM, request_stop)
+
+    supervisor_start_time = process_start_time(os.getpid())
+    if supervisor_start_time is None:
+        raise RuntimeError("cannot identify topology supervisor process")
+    status: dict[str, Any] = {
+        "schema_version": 1,
+        "name": spec["name"],
+        "profile": spec["profile"],
+        "dependencies": spec["dependencies"],
+        "state": spec["state"],
+        "build_root": spec["build_root"],
+        "resolved": spec["resolved"],
+        "endpoint": (
+            {**spec["endpoint"], "fingerprint": None}
+            if spec["endpoint"] is not None
+            else None
+        ),
+        "ready": False,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "stopped_at": None,
+        "supervisor": {
+            "pid": os.getpid(),
+            "start_time": supervisor_start_time,
+        },
+        "services": {},
+    }
+    processes: dict[str, subprocess.Popen[bytes]] = {}
+    logs: list[RotatingLog] = []
+    pumps: list[threading.Thread] = []
+
+    def start_service(
+        name: str,
+        extra_arguments: list[str] | None = None,
+        capture: ServerReadinessCapture | None = None,
+    ) -> subprocess.Popen[bytes]:
+        service = spec["services"][name]
+        log = Path(service["log"])
+        log.parent.mkdir(parents=True, exist_ok=True)
+        output = RotatingLog(log)
+        logs.append(output)
+        output.write(
+            f"\n[{datetime.now(timezone.utc).isoformat()}] starting {name}\n".encode()
+        )
+        command = list(service["command"])
+        command.extend(extra_arguments or [])
+        environment = os.environ.copy()
+        environment.update(service.get("environment", {}))
+        process = subprocess.Popen(
+            command,
+            cwd=service["cwd"],
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+            pass_fds=(lock_fd,) if name == "server" and lock_fd is not None else (),
+        )
+        start_time = process_start_time(process.pid)
+        if start_time is None:
+            process.terminate()
+            raise RuntimeError(f"cannot identify {name} process")
+        processes[name] = process
+        pump = threading.Thread(
+            target=pump_output,
+            args=(process, output, capture),
+            name=f"{name}-log",
+            daemon=True,
+        )
+        pump.start()
+        pumps.append(pump)
+        status["services"][name] = {
+            "pid": process.pid,
+            "start_time": start_time,
+            "status": "starting" if capture is not None else "running",
+            "exit_code": None,
+            "log": str(log),
+            "cwd": service["cwd"],
+        }
+        atomic_status(status_path, status)
+        return process
+
+    try:
+        if "server" in spec["services"]:
+            capture = ServerReadinessCapture()
+            server = start_service("server", capture=capture)
+            deadline = time.monotonic() + SERVER_READY_TIMEOUT
+            while not capture.event.wait(timeout=0.1):
+                if server.poll() is not None:
+                    raise RuntimeError(
+                        f"server exited before becoming ready with code {server.returncode}"
+                    )
+                if stop:
+                    raise RuntimeError("topology stopped before the server became ready")
+                if time.monotonic() >= deadline:
+                    raise RuntimeError(
+                        f"server did not become ready within {SERVER_READY_TIMEOUT} seconds"
+                    )
+            assert capture.fingerprint is not None
+            status["endpoint"]["fingerprint"] = capture.fingerprint
+            status["services"]["server"]["status"] = "running"
+            atomic_status(status_path, status)
+
+        if "client" in spec["services"]:
+            client_arguments: list[str] = []
+            endpoint = status["endpoint"]
+            if endpoint is not None:
+                client_arguments = [
+                    f"--server={endpoint['host']} {endpoint['port']} "
+                    f"{endpoint['fingerprint']}",
+                    f"--connect={endpoint['host']}",
+                    "--stun_server=off",
+                    "--nometa",
+                ]
+            start_service("client", client_arguments)
+
+        status["ready"] = True
+        atomic_status(status_path, status)
+
+        while not stop and all(
+            process.poll() is None for process in processes.values()
+        ):
+            changed = False
+            for name, process in processes.items():
+                code = process.poll()
+                service_status = status["services"][name]
+                if code is not None and service_status["status"] == "running":
+                    service_status["status"] = "exited"
+                    service_status["exit_code"] = code
+                    changed = True
+            if changed:
+                atomic_status(status_path, status)
+            time.sleep(0.2)
+    except BaseException as error:
+        status["error"] = f"{type(error).__name__}: {error}"
+        atomic_status(status_path, status)
+        return 1
+    finally:
+        terminate(processes)
+        for pump in pumps:
+            pump.join(timeout=2)
+        for name, process in processes.items():
+            code = process.poll()
+            service_status = status["services"][name]
+            service_status["status"] = "exited"
+            service_status["exit_code"] = code
+        status["stopped_at"] = datetime.now(timezone.utc).isoformat()
+        status["ready"] = False
+        atomic_status(status_path, status)
+        for output in logs:
+            output.close()
+        if lock_fd is not None:
+            os.close(lock_fd)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--spec", type=Path, required=True)
+    parser.add_argument("--lock-fd", type=int)
+    parser.add_argument("--daemonize", action="store_true")
+    options = parser.parse_args()
+    if options.daemonize and os.fork() != 0:
+        return 0
+    try:
+        return supervise(options.spec, options.lock_fd)
+    except BaseException as error:
+        message = f"{type(error).__name__}: {error}"
+        print(f"topology supervisor failed during startup: {message}", file=sys.stderr)
+        try:
+            atomic_status(options.spec.parent / "startup-error.json", {"error": message})
+        except OSError as status_error:
+            print(f"cannot record topology startup failure: {status_error}", file=sys.stderr)
+        if options.lock_fd is not None:
+            try:
+                os.close(options.lock_fd)
+            except OSError:
+                pass
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -1,16 +1,22 @@
 from __future__ import annotations
 
+from collections import deque
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 import fcntl
 import os
-from pathlib import Path
+from pathlib import Path, PurePosixPath
+import re
 import shlex
 import shutil
+import signal
+import socket
+import stat
 import subprocess
 import sys
 import tempfile
-from typing import Any, Iterator
+import time
+from typing import Any, Iterator, TextIO
 
 from .model import (
     MANAGED_MARKER,
@@ -27,6 +33,7 @@ from .model import (
     require_keys,
     validate_name,
 )
+from .supervisor import process_matches
 
 
 PROFILE_KEYS = {"schema_version", "name", "components"}
@@ -58,6 +65,8 @@ TARGET_DEPENDENCIES = {
 PREFERRED_BUILD_COMPONENTS = set().union(
     *(TARGET_DEPENDENCIES[target] for target in ALL_BUILD_TARGETS)
 )
+TOPOLOGY_SERVICES = ("server", "client")
+RESOURCE_PATHS_MANIFEST = "runtime-paths.txt"
 
 
 def display_arguments(arguments: list[str]) -> str:
@@ -84,6 +93,7 @@ def run(
     capture: bool = False,
     env: dict[str, str] | None = None,
     trace: bool = True,
+    diagnostics_to_stderr: bool = True,
 ) -> str:
     if trace:
         print(f"+ {display_arguments(arguments)}", file=sys.stderr)
@@ -95,6 +105,7 @@ def run(
             text=True,
             capture_output=capture,
             env=env,
+            stdout=sys.stderr if diagnostics_to_stderr and not capture else None,
         )
     except FileNotFoundError as error:
         raise WorkspaceError(f"required command not found: {arguments[0]}") from error
@@ -111,6 +122,21 @@ def git(
     path: Path, *arguments: str, capture: bool = False, trace: bool = True
 ) -> str:
     return run(["git", "-C", str(path), *arguments], capture=capture, trace=trace)
+
+
+def replace_directory(output: Path, staging: Path, backup_prefix: str) -> None:
+    if output.exists():
+        backup = Path(tempfile.mkdtemp(prefix=backup_prefix, dir=output.parent))
+        backup.rmdir()
+        output.replace(backup)
+        try:
+            staging.replace(output)
+        except BaseException:
+            backup.replace(output)
+            raise
+        shutil.rmtree(backup)
+    else:
+        staging.replace(output)
 
 
 def _remote_matches(url: str, repository: str) -> bool:
@@ -155,16 +181,37 @@ def _worktree_records(
     return records
 
 
+def open_regular_file(
+    path: Path, flags: int, description: str, mode: int = 0o600
+) -> int:
+    flags |= os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags, mode)
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            os.close(descriptor)
+            raise WorkspaceError(f"{description} is not a regular file: {path}")
+        return descriptor
+    except OSError as error:
+        raise WorkspaceError(f"cannot open {description} {path}: {error}") from error
+
+
 @contextmanager
-def exclusive_lock(path: Path, description: str, nonblocking: bool = False) -> Iterator[None]:
+def exclusive_lock(
+    path: Path, description: str, nonblocking: bool = False
+) -> Iterator[TextIO]:
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a+") as lock:
+    descriptor = open_regular_file(
+        path, os.O_RDWR | os.O_CREAT, f"{description} lock"
+    )
+    with os.fdopen(descriptor, "a+") as lock:
         operation = fcntl.LOCK_EX | (fcntl.LOCK_NB if nonblocking else 0)
         try:
             fcntl.flock(lock, operation)
         except BlockingIOError as error:
             raise WorkspaceError(f"{description} is already in use") from error
-        yield
+        yield lock
 
 
 class Workspace:
@@ -738,36 +785,114 @@ class Workspace:
             if staging.exists():
                 shutil.rmtree(staging)
             raise
-        if output.exists():
-            backup = Path(tempfile.mkdtemp(prefix=".content-previous-", dir=output.parent))
-            backup.rmdir()
-            output.replace(backup)
-            try:
-                staging.replace(output)
-            except BaseException:
-                backup.replace(output)
-                raise
-            shutil.rmtree(backup)
-        else:
-            staging.replace(output)
+        replace_directory(output, staging, ".content-previous-")
         return output
 
     def _stage_resources(self, root: Path, selected: dict[str, Path]) -> Path:
         output = root / "runtime" / "resources"
         source = selected["resources"]
-        managed_reset(output, self.paths.builds, "resource-view")
-        for entry in source.iterdir():
-            if entry.name in {".git", MANAGED_MARKER, ".atrinik-dependency.json"}:
-                continue
-            (output / entry.name).symlink_to(entry, target_is_directory=entry.is_dir())
-        atomic_json(
-            output / ".atrinik-dependency.json",
-            {
-                "schema_version": SCHEMA_VERSION,
-                "workspace_source": str(source),
-                "commit": git(source, "rev-parse", "HEAD", capture=True),
-            },
-        )
+        output.parent.mkdir(parents=True, exist_ok=True)
+        if output.exists() or output.is_symlink():
+            managed_directory(output, self.paths.builds, "resource-view")
+        manifest = source / RESOURCE_PATHS_MANIFEST
+        try:
+            lines = manifest.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeError) as error:
+            raise WorkspaceError(
+                f"cannot read resource runtime manifest: {manifest}: {error}"
+            ) from error
+        if not lines:
+            raise WorkspaceError(f"resource runtime manifest is empty: {manifest}")
+        runtime_paths: list[str] = []
+        for line in lines:
+            path = PurePosixPath(line)
+            if (
+                not line
+                or path.is_absolute()
+                or line != path.as_posix()
+                or any(part in {"", ".", ".."} for part in path.parts)
+                or line in runtime_paths
+            ):
+                raise WorkspaceError(
+                    f"invalid resource runtime path in {manifest}: {line!r}"
+                )
+            runtime_paths.append(line)
+
+        try:
+            result = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(source),
+                    "ls-files",
+                    "-z",
+                    "--cached",
+                    "--",
+                    *runtime_paths,
+                ],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        except FileNotFoundError as error:
+            raise WorkspaceError("required command not found: git") from error
+        except subprocess.CalledProcessError as error:
+            detail = error.stderr.decode("utf-8", errors="replace").strip()
+            suffix = f": {detail}" if detail else ""
+            raise WorkspaceError(f"cannot list tracked runtime resources{suffix}") from error
+
+        try:
+            tracked = [
+                item.decode("utf-8")
+                for item in result.stdout.split(b"\0")
+                if item
+            ]
+        except UnicodeDecodeError as error:
+            raise WorkspaceError("runtime resource paths must use UTF-8 names") from error
+        if not tracked:
+            raise WorkspaceError(
+                f"resource runtime manifest selects no tracked files: {manifest}"
+            )
+        staging = Path(tempfile.mkdtemp(prefix=".resources-", dir=output.parent))
+        selected_roots = tuple(PurePosixPath(path) for path in runtime_paths)
+        try:
+            atomic_json(
+                staging / MANAGED_MARKER,
+                {"schema_version": SCHEMA_VERSION, "purpose": "resource-view"},
+            )
+            for relative in tracked:
+                path = PurePosixPath(relative)
+                if not any(
+                    path == root_path or root_path in path.parents
+                    for root_path in selected_roots
+                ):
+                    raise WorkspaceError(
+                        f"Git returned an unexpected resource path: {relative}"
+                    )
+                source_path = source.joinpath(*path.parts)
+                try:
+                    mode = source_path.lstat().st_mode
+                except FileNotFoundError:
+                    continue
+                if not stat.S_ISREG(mode):
+                    raise WorkspaceError(
+                        f"tracked runtime resource is not a regular file: {source_path}"
+                    )
+                destination = staging.joinpath(*path.parts)
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source_path, destination, follow_symlinks=False)
+            atomic_json(
+                staging / ".atrinik-dependency.json",
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "workspace_source": str(source),
+                    "commit": git(source, "rev-parse", "HEAD", capture=True),
+                },
+            )
+        except BaseException:
+            shutil.rmtree(staging)
+            raise
+        replace_directory(output, staging, ".resources-previous-")
         return output
 
     def _cmake(
@@ -978,6 +1103,712 @@ class Workspace:
             if not (path / name).is_dir():
                 raise WorkspaceError(f"server state lacks required directory {name}: {path}")
 
+    def _topology_services(self, services: list[str] | None) -> list[str]:
+        requested = set(services or TOPOLOGY_SERVICES)
+        unknown = sorted(requested - set(TOPOLOGY_SERVICES))
+        if unknown:
+            raise WorkspaceError(f"unknown topology services: {', '.join(unknown)}")
+        if not requested:
+            raise WorkspaceError("a topology must contain at least one service")
+        return [service for service in TOPOLOGY_SERVICES if service in requested]
+
+    def topology_summary(
+        self,
+        profile_name: str,
+        state_name: str,
+        services: list[str] | None = None,
+    ) -> dict[str, Any]:
+        selected_services = self._topology_services(services)
+        required = set().union(
+            *(TARGET_DEPENDENCIES[service] for service in selected_services)
+        )
+        resolved = self._resolve_build_profile(profile_name, required)
+        key = profile_key(resolved)
+        state = (
+            str(self._state_location(state_name))
+            if "server" in selected_services
+            else None
+        )
+        return {
+            "profile": profile_name,
+            "services": selected_services,
+            "dependencies": sorted(required),
+            "state": state,
+            "build_root": str(
+                self.paths.builds / "profiles" / f"{profile_name}-{key}"
+            ),
+            "components": {
+                name: {
+                    "path": str(path),
+                    "head": git(
+                        path,
+                        "rev-parse",
+                        "HEAD",
+                        capture=True,
+                        trace=False,
+                    ),
+                    "dirty": not _is_clean(path, trace=False),
+                }
+                for name, path in sorted(resolved.items())
+            },
+        }
+
+    def _topology_directory(self, name: str, create: bool = False) -> Path:
+        validate_name(name, "topology name")
+        self.paths.ensure()
+        path = self.paths.topologies / name
+        marker = path / MANAGED_MARKER
+        metadata = {"schema_version": SCHEMA_VERSION, "purpose": f"topology:{name}"}
+        if path.exists() or path.is_symlink():
+            if not path.is_dir() or path.is_symlink():
+                raise WorkspaceError(f"topology path is not a managed directory: {path}")
+            if not marker.is_file() or marker.is_symlink() or load_json(marker) != metadata:
+                raise WorkspaceError(f"topology ownership marker is invalid: {path}")
+        elif create:
+            path.mkdir()
+            atomic_json(marker, metadata)
+        else:
+            raise WorkspaceError(f"topology does not exist: {name}")
+        return path
+
+    def _reset_topology_subdirectory(
+        self, topology_root: Path, name: str, purpose: str
+    ) -> Path:
+        path = topology_root / name
+        metadata = {"schema_version": SCHEMA_VERSION, "purpose": purpose}
+        if path.exists() or path.is_symlink():
+            marker = path / MANAGED_MARKER
+            if (
+                not path.is_dir()
+                or path.is_symlink()
+                or not marker.is_file()
+                or marker.is_symlink()
+                or load_json(marker) != metadata
+            ):
+                raise WorkspaceError(
+                    f"topology runtime path is not managed for {purpose}: {path}"
+                )
+            shutil.rmtree(path)
+        path.mkdir()
+        atomic_json(path / MANAGED_MARKER, metadata)
+        return path
+
+    def _take_topology_runtime_input(
+        self,
+        topology_root: Path,
+        source: Path,
+        name: str,
+        purpose: str,
+    ) -> Path:
+        expected = {"schema_version": SCHEMA_VERSION, "purpose": purpose}
+        marker = source / MANAGED_MARKER
+        if (
+            not source.is_dir()
+            or source.is_symlink()
+            or not marker.is_file()
+            or marker.is_symlink()
+            or load_json(marker) != expected
+        ):
+            raise WorkspaceError(
+                f"topology runtime input is not managed for {purpose}: {source}"
+            )
+        container = topology_root / "runtime"
+        if container.exists() or container.is_symlink():
+            if not container.is_dir() or container.is_symlink():
+                raise WorkspaceError(
+                    f"topology runtime container is invalid: {container}"
+                )
+        else:
+            container.mkdir()
+        destination = container / name
+        if destination.exists() or destination.is_symlink():
+            destination_marker = destination / MANAGED_MARKER
+            if (
+                not destination.is_dir()
+                or destination.is_symlink()
+                or not destination_marker.is_file()
+                or destination_marker.is_symlink()
+                or load_json(destination_marker) != expected
+            ):
+                raise WorkspaceError(
+                    f"topology runtime destination is not managed: {destination}"
+                )
+            shutil.rmtree(destination)
+        source.replace(destination)
+        return destination
+
+    def _prepare_topology_client_runtime(
+        self, topology_root: Path, selected: dict[str, Path]
+    ) -> Path:
+        runtime = self._reset_topology_subdirectory(
+            topology_root, "client-runtime", "topology-client-runtime"
+        )
+        source = selected["client"]
+        for entry in source.iterdir():
+            if entry.name in {".git", "build", "sound", MANAGED_MARKER}:
+                continue
+            (runtime / entry.name).symlink_to(
+                entry, target_is_directory=entry.is_dir()
+            )
+        (runtime / "sound").symlink_to(
+            selected["sound"], target_is_directory=True
+        )
+        return runtime
+
+    @staticmethod
+    def _recorded_process_running(record: Any) -> bool:
+        if not isinstance(record, dict):
+            return False
+        pid = record.get("pid")
+        start_time = record.get("start_time")
+        return (
+            isinstance(pid, int)
+            and not isinstance(pid, bool)
+            and isinstance(start_time, str)
+            and process_matches(pid, start_time)
+        )
+
+    def topology_status(self, name: str) -> dict[str, Any]:
+        root = self._topology_directory(name)
+        status_path = root / "status.json"
+        if not status_path.is_file() or status_path.is_symlink():
+            raise WorkspaceError(f"topology has not been started: {name}")
+        status = load_json(status_path)
+        required = {
+            "schema_version",
+            "name",
+            "profile",
+            "dependencies",
+            "state",
+            "build_root",
+            "resolved",
+            "endpoint",
+            "ready",
+            "started_at",
+            "stopped_at",
+            "supervisor",
+            "services",
+        }
+        if (
+            not isinstance(status, dict)
+            or status.get("schema_version") != SCHEMA_VERSION
+            or status.get("name") != name
+            or not required <= set(status) <= required | {"error"}
+            or not isinstance(status.get("dependencies"), list)
+            or not isinstance(status.get("resolved"), dict)
+            or not isinstance(status.get("ready"), bool)
+            or not isinstance(status.get("profile"), str)
+            or not status["profile"]
+            or not all(
+                isinstance(dependency, str)
+                and dependency in PREFERRED_BUILD_COMPONENTS
+                for dependency in status["dependencies"]
+            )
+            or len(status["dependencies"]) != len(set(status["dependencies"]))
+            or status.get("state") is not None
+            and (
+                not isinstance(status.get("state"), str)
+                or not Path(status["state"]).is_absolute()
+            )
+            or not isinstance(status.get("build_root"), str)
+            or not Path(status["build_root"]).is_absolute()
+            or not isinstance(status.get("started_at"), str)
+            or not status["started_at"]
+            or status.get("stopped_at") is not None
+            and not isinstance(status.get("stopped_at"), str)
+            or "error" in status
+            and not isinstance(status.get("error"), str)
+        ):
+            raise WorkspaceError(f"topology status is invalid: {name}")
+        for component, resolved in status["resolved"].items():
+            if (
+                component not in self.manifest.by_name
+                or not isinstance(resolved, dict)
+                or set(resolved) != {"path", "head", "dirty"}
+                or not isinstance(resolved.get("path"), str)
+                or not Path(resolved["path"]).is_absolute()
+                or not isinstance(resolved.get("head"), str)
+                or not re.fullmatch(r"[0-9a-f]{40,64}", resolved["head"])
+                or not isinstance(resolved.get("dirty"), bool)
+            ):
+                raise WorkspaceError(f"topology resolution status is invalid: {name}")
+        supervisor = status.get("supervisor")
+        if (
+            not isinstance(supervisor, dict)
+            or set(supervisor) != {"pid", "start_time"}
+            or not isinstance(supervisor.get("pid"), int)
+            or isinstance(supervisor.get("pid"), bool)
+            or supervisor["pid"] <= 0
+            or not isinstance(supervisor.get("start_time"), str)
+            or not supervisor["start_time"].isdigit()
+        ):
+            raise WorkspaceError(f"topology supervisor status is invalid: {name}")
+        supervisor_running = self._recorded_process_running(supervisor)
+        supervisor["running"] = supervisor_running
+        endpoint = status.get("endpoint")
+        if endpoint is not None:
+            fingerprint = endpoint.get("fingerprint") if isinstance(endpoint, dict) else None
+            if (
+                not isinstance(endpoint, dict)
+                or set(endpoint) != {"host", "port", "fingerprint"}
+                or endpoint.get("host") != "127.0.0.1"
+                or not isinstance(endpoint.get("port"), int)
+                or isinstance(endpoint.get("port"), bool)
+                or not 1 <= endpoint["port"] <= 65535
+                or (
+                    fingerprint is not None
+                    and (
+                        not isinstance(fingerprint, str)
+                        or len(fingerprint) != 64
+                        or any(character not in "0123456789abcdef" for character in fingerprint)
+                    )
+                )
+            ):
+                raise WorkspaceError(f"topology endpoint status is invalid: {name}")
+        services = status.get("services")
+        if (
+            not isinstance(services, dict)
+            or (not services and not status.get("error"))
+            or not set(services) <= set(TOPOLOGY_SERVICES)
+        ):
+            raise WorkspaceError(f"topology service status is invalid: {name}")
+        for service in services.values():
+            if (
+                not isinstance(service, dict)
+                or set(service)
+                != {"pid", "start_time", "status", "exit_code", "log", "cwd"}
+                or not isinstance(service.get("pid"), int)
+                or isinstance(service.get("pid"), bool)
+                or service["pid"] <= 0
+                or not isinstance(service.get("start_time"), str)
+                or not service["start_time"].isdigit()
+                or service.get("status") not in {"starting", "running", "exited"}
+                or (
+                    service.get("exit_code") is not None
+                    and (
+                        not isinstance(service.get("exit_code"), int)
+                        or isinstance(service.get("exit_code"), bool)
+                    )
+                )
+                or not isinstance(service.get("log"), str)
+                or not Path(service["log"]).is_absolute()
+                or not isinstance(service.get("cwd"), str)
+                or not Path(service["cwd"]).is_absolute()
+            ):
+                raise WorkspaceError(f"topology service status is invalid: {name}")
+            service["running"] = self._recorded_process_running(service)
+            if (
+                service.get("status") in {"starting", "running"}
+                and not service["running"]
+            ):
+                service["status"] = "stale"
+        if (
+            ("server" in services) != (endpoint is not None)
+            or (
+                status["ready"]
+                and endpoint is not None
+                and endpoint["fingerprint"] is None
+            )
+        ):
+            raise WorkspaceError(f"topology endpoint status is invalid: {name}")
+        if not supervisor_running:
+            status["ready"] = False
+        return status
+
+    def topology_statuses(self) -> list[dict[str, Any]]:
+        self.paths.ensure()
+        statuses: list[dict[str, Any]] = []
+        for path in sorted(self.paths.topologies.iterdir()):
+            if path.is_dir() and not path.is_symlink() and (path / "status.json").is_file():
+                statuses.append(self.topology_status(path.name))
+        return statuses
+
+    @staticmethod
+    def _select_topology_port(requested: int | None) -> int:
+        if requested is not None and (
+            not isinstance(requested, int)
+            or isinstance(requested, bool)
+            or not 0 <= requested <= 65535
+        ):
+            raise WorkspaceError("topology port must be between 0 and 65535")
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as candidate:
+                candidate.bind(("0.0.0.0", requested or 0))
+                return int(candidate.getsockname()[1])
+        except OSError as error:
+            if requested:
+                raise WorkspaceError(
+                    f"topology UDP port {requested} is unavailable: {error}"
+                ) from error
+            raise WorkspaceError(f"cannot allocate a topology UDP port: {error}") from error
+
+    @staticmethod
+    def _require_client_display() -> None:
+        wayland = os.environ.get("WAYLAND_DISPLAY")
+        runtime = os.environ.get("XDG_RUNTIME_DIR")
+        if wayland and runtime and (Path(runtime) / wayland).is_socket():
+            return
+        display = os.environ.get("DISPLAY", "")
+        if display.startswith(":"):
+            display_number = display[1:].split(".", 1)[0]
+            if display_number.isdigit() and Path(
+                f"/tmp/.X11-unix/X{display_number}"
+            ).is_socket():
+                return
+        raise WorkspaceError(
+            "client display forwarding is unavailable; reload or reopen the "
+            "devcontainer before starting the client"
+        )
+
+    def topology_up(
+        self,
+        name: str,
+        profile_name: str,
+        state_name: str,
+        services: list[str] | None = None,
+        port: int | None = None,
+    ) -> dict[str, Any]:
+        selected_services = self._topology_services(services)
+        if "server" not in selected_services and port is not None:
+            raise WorkspaceError("--port requires the server service")
+        topology_root = self._topology_directory(name, create=True)
+        operation_lock = topology_root / "operation.lock"
+        with exclusive_lock(
+            operation_lock, f"topology {name} operation", nonblocking=True
+        ):
+            status_path = topology_root / "status.json"
+            startup_error_path = topology_root / "startup-error.json"
+            if status_path.is_file():
+                if status_path.is_symlink():
+                    raise WorkspaceError(f"topology status is invalid: {name}")
+                previous = self.topology_status(name)
+                if previous["supervisor"]["running"] or any(
+                    service["running"] for service in previous["services"].values()
+                ):
+                    raise WorkspaceError(f"topology is already running: {name}")
+
+            if "client" in selected_services:
+                self._require_client_display()
+
+            required = set().union(
+                *(TARGET_DEPENDENCIES[service] for service in selected_services)
+            )
+            selected = self._resolve_build_profile(profile_name, required)
+            targets = [service for service in ("client", "server") if service in selected_services]
+
+            with ExitStack() as stack:
+                state_location: Path | None = None
+                state_lock: TextIO | None = None
+                if "server" in selected_services:
+                    state_location = self._state_location(state_name)
+                    state_lock = stack.enter_context(
+                        exclusive_lock(
+                            Path(f"{state_location}.lock"),
+                            f"server state {state_location}",
+                            nonblocking=True,
+                        )
+                    )
+
+                root = self._build_resolved(
+                    "topology", profile_name, False, targets, selected
+                )
+                endpoint: dict[str, Any] | None = None
+                if "server" in selected_services:
+                    stack.enter_context(
+                        exclusive_lock(
+                            self.paths.topologies / "ports.lock",
+                            "topology port allocation",
+                        )
+                    )
+                    endpoint = {
+                        "host": "127.0.0.1",
+                        "port": self._select_topology_port(port),
+                    }
+                service_specs: dict[str, dict[str, Any]] = {}
+                if "server" in selected_services:
+                    assert state_location is not None
+                    state = self.state_path(
+                        state_name,
+                        selected["server"],
+                        resolved_path=state_location,
+                    )
+                    content = self._take_topology_runtime_input(
+                        topology_root,
+                        root / "runtime" / "content",
+                        "content",
+                        "collected-content",
+                    )
+                    resources = self._take_topology_runtime_input(
+                        topology_root,
+                        root / "runtime" / "resources",
+                        "resources",
+                        "resource-view",
+                    )
+                    runtime = self._prepare_server_runtime(
+                        root,
+                        selected,
+                        state,
+                        state_name,
+                        content,
+                        resources,
+                    )
+                    executable = runtime / "atrinik-server"
+                    service_specs["server"] = {
+                        "command": [
+                            str(executable),
+                            f"--port_quic={endpoint['port']}",
+                            "--port_mapping=off",
+                            "--stun_server=off",
+                            "--no_console",
+                        ],
+                        "cwd": str(runtime),
+                        "log": str(topology_root / "server.log"),
+                    }
+                if "client" in selected_services:
+                    executable = root / "build" / "client" / "atrinik"
+                    working = self._prepare_topology_client_runtime(
+                        topology_root, selected
+                    )
+                    if not executable.is_file():
+                        raise WorkspaceError(f"client executable is missing: {executable}")
+                    client_config = topology_root / "client-config"
+                    if client_config.exists() or client_config.is_symlink():
+                        if not client_config.is_dir() or client_config.is_symlink():
+                            raise WorkspaceError(
+                                f"client configuration path is invalid: {client_config}"
+                            )
+                    else:
+                        client_config.mkdir()
+                    service_specs["client"] = {
+                        "command": [str(executable)],
+                        "cwd": str(working),
+                        "log": str(topology_root / "client.log"),
+                        "environment": {
+                            "ATRINIK_CONFIG_DIR": str(client_config.resolve())
+                        },
+                    }
+
+                resolved_status = {
+                    component: {
+                        "path": str(path),
+                        "head": git(
+                            path,
+                            "rev-parse",
+                            "HEAD",
+                            capture=True,
+                            trace=False,
+                        ),
+                        "dirty": not _is_clean(path, trace=False),
+                    }
+                    for component, path in sorted(selected.items())
+                }
+                spec = {
+                    "schema_version": SCHEMA_VERSION,
+                    "name": name,
+                    "profile": profile_name,
+                    "dependencies": sorted(required),
+                    "state": str(state_location) if state_location else None,
+                    "build_root": str(root),
+                    "resolved": resolved_status,
+                    "endpoint": endpoint,
+                    "services": service_specs,
+                }
+                spec_path = topology_root / "spec.json"
+                atomic_json(spec_path, spec)
+                status_path.unlink(missing_ok=True)
+                startup_error_path.unlink(missing_ok=True)
+
+                supervisor_log_path = topology_root / "supervisor.log"
+                supervisor_log = os.fdopen(
+                    open_regular_file(
+                        supervisor_log_path,
+                        os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+                        "topology supervisor log",
+                    ),
+                    "ab",
+                    buffering=0,
+                )
+                try:
+                    command = [
+                        sys.executable,
+                        "-m",
+                        "atrinik_workspace.supervisor",
+                        "--daemonize",
+                        "--spec",
+                        str(spec_path),
+                    ]
+                    pass_fds: tuple[int, ...] = ()
+                    if state_lock is not None:
+                        command.extend(["--lock-fd", str(state_lock.fileno())])
+                        pass_fds = (state_lock.fileno(),)
+                    environment = os.environ.copy()
+                    source_root = str(Path(__file__).resolve().parents[1])
+                    python_path = environment.get("PYTHONPATH")
+                    environment["PYTHONPATH"] = (
+                        source_root
+                        if not python_path
+                        else source_root + os.pathsep + python_path
+                    )
+                    process = subprocess.Popen(
+                        command,
+                        cwd=self.paths.repository,
+                        env=environment,
+                        stdin=subprocess.DEVNULL,
+                        stdout=supervisor_log,
+                        stderr=subprocess.STDOUT,
+                        start_new_session=True,
+                        pass_fds=pass_fds,
+                    )
+                except OSError as error:
+                    raise WorkspaceError(f"cannot start topology supervisor: {error}") from error
+                finally:
+                    supervisor_log.close()
+
+                deadline = time.monotonic() + 45
+                while time.monotonic() < deadline:
+                    if startup_error_path.is_file():
+                        if startup_error_path.is_symlink():
+                            raise WorkspaceError(
+                                f"topology startup error is invalid: {name}"
+                            )
+                        failure = load_json(startup_error_path)
+                        if (
+                            not isinstance(failure, dict)
+                            or set(failure) != {"error"}
+                            or not isinstance(failure.get("error"), str)
+                        ):
+                            raise WorkspaceError(
+                                f"topology startup error is invalid: {name}"
+                            )
+                        raise WorkspaceError(
+                            f"topology supervisor failed: {failure['error']}"
+                        )
+                    if status_path.is_file():
+                        status = self.topology_status(name)
+                        if status.get("error"):
+                            raise WorkspaceError(
+                                f"topology supervisor failed: {status['error']}"
+                            )
+                        if status["supervisor"]["running"] and status["ready"]:
+                            process.wait(timeout=2)
+                            return status
+                    if process.poll() not in (None, 0):
+                        break
+                    time.sleep(0.1)
+                raise WorkspaceError(
+                    f"topology supervisor failed to start; inspect "
+                    f"{topology_root / 'supervisor.log'}"
+                )
+
+    def topology_down(self, name: str, timeout: float = 15) -> dict[str, Any]:
+        root = self._topology_directory(name)
+        with exclusive_lock(
+            root / "operation.lock", f"topology {name} operation", nonblocking=True
+        ):
+            status = self.topology_status(name)
+            supervisor = status["supervisor"]
+            orphaned = [
+                service
+                for service in status["services"].values()
+                if service["running"]
+            ]
+            targets = [supervisor] if supervisor["running"] else orphaned
+            if not targets:
+                return status
+            for record in targets:
+                pid = record["pid"]
+                start_time = record["start_time"]
+                try:
+                    pidfd = os.pidfd_open(pid)
+                except ProcessLookupError:
+                    continue
+                try:
+                    if process_matches(pid, start_time):
+                        signal.pidfd_send_signal(pidfd, signal.SIGTERM)
+                finally:
+                    os.close(pidfd)
+            deadline = time.monotonic() + timeout
+            while time.monotonic() < deadline:
+                if not any(self._recorded_process_running(record) for record in targets):
+                    status = self.topology_status(name)
+                    return status
+                time.sleep(0.1)
+            raise WorkspaceError(
+                f"topology did not stop within {timeout:g} seconds: {name}"
+            )
+
+    def topology_logs(
+        self,
+        name: str,
+        service: str | None,
+        tail: int,
+        follow: bool,
+    ) -> None:
+        if tail < 0:
+            raise WorkspaceError("log tail must not be negative")
+        root = self._topology_directory(name)
+        services = [service] if service else list(TOPOLOGY_SERVICES)
+        unknown = sorted(set(services) - set(TOPOLOGY_SERVICES))
+        if unknown:
+            raise WorkspaceError(f"unknown topology services: {', '.join(unknown)}")
+        paths = [(item, root / f"{item}.log") for item in services]
+        paths = [(item, path) for item, path in paths if path.is_file()]
+        if not paths:
+            raise WorkspaceError(f"topology has no matching logs: {name}")
+        positions: dict[Path, tuple[int, int, int]] = {}
+        for item, path in paths:
+            with os.fdopen(
+                open_regular_file(path, os.O_RDONLY, "topology log"),
+                encoding="utf-8",
+                errors="replace",
+            ) as stream:
+                lines = deque(stream, maxlen=tail) if tail else ()
+                if len(paths) > 1:
+                    print(f"==> {item} <==")
+                for line in lines:
+                    print(line, end="")
+                metadata = os.fstat(stream.fileno())
+                positions[path] = (metadata.st_dev, metadata.st_ino, stream.tell())
+        while follow:
+            changed = False
+            for item, path in paths:
+                try:
+                    descriptor = open_regular_file(
+                        path, os.O_RDONLY, "topology log"
+                    )
+                except WorkspaceError:
+                    continue
+                with os.fdopen(
+                    descriptor, encoding="utf-8", errors="replace"
+                ) as stream:
+                    metadata = os.fstat(stream.fileno())
+                    device, inode, offset = positions[path]
+                    if (
+                        (metadata.st_dev, metadata.st_ino) != (device, inode)
+                        or metadata.st_size < offset
+                    ):
+                        offset = 0
+                    stream.seek(offset)
+                    content = stream.read()
+                    positions[path] = (
+                        metadata.st_dev,
+                        metadata.st_ino,
+                        stream.tell(),
+                    )
+                if content:
+                    if len(paths) > 1:
+                        print(f"==> {item} <==")
+                    print(content, end="", flush=True)
+                    changed = True
+            try:
+                status = self.topology_status(name)
+                running = status["supervisor"]["running"]
+            except WorkspaceError:
+                running = False
+            if not running and not changed:
+                break
+            time.sleep(0.25)
+
     def run_client(
         self, profile_name: str, arguments: list[str], dry_run: bool
     ) -> Path:
@@ -990,7 +1821,8 @@ class Workspace:
         print(f"cwd: {working}")
         print(f"command: {display_arguments(command)}")
         if not dry_run:
-            run(command, cwd=working)
+            self._require_client_display()
+            run(command, cwd=working, diagnostics_to_stderr=False)
         return executable
 
     def run_server(
@@ -1020,7 +1852,7 @@ class Workspace:
             print(f"cwd: {runtime}")
             print(f"command: {display_arguments(command)}")
             if not dry_run:
-                run(command, cwd=runtime)
+                run(command, cwd=runtime, diagnostics_to_stderr=False)
             return executable
 
     def _prepare_server_runtime(
@@ -1029,19 +1861,23 @@ class Workspace:
         selected: dict[str, Path],
         state: Path,
         state_name: str,
+        content: Path | None = None,
+        resources: Path | None = None,
     ) -> Path:
         state_key = profile_key({"state": state})
         runtime = root / "run" / "server" / f"{state_name}-{state_key}"
         managed_reset(runtime, self.paths.builds, f"server-runtime:{state_key}")
         source = selected["server"]
         binary = root / "build" / "server"
+        content = content or root / "runtime" / "content"
+        resources = resources or root / "runtime" / "resources"
         links = {
             "atrinik-server": binary / "atrinik-server",
             "libplugin_arena.so": binary / "libplugin_arena.so",
             "libplugin_python.so": binary / "libplugin_python.so",
-            "lib": root / "runtime" / "content" / "lib",
-            "maps": root / "runtime" / "content" / "maps",
-            "resources": root / "runtime" / "resources",
+            "lib": content / "lib",
+            "maps": content / "maps",
+            "resources": resources,
             "data": state,
             "tools": source / "tools",
         }

--- a/components.json
+++ b/components.json
@@ -1,16 +1,16 @@
 {
   "schema_version": 1,
   "components": [
-    {"name": "client", "repository": "atrinik/client", "branch": "master", "build": "client"},
-    {"name": "server", "repository": "atrinik/server", "branch": "master", "build": "server"},
-    {"name": "protocol", "repository": "atrinik/protocol", "branch": "master", "build": "protocol"},
-    {"name": "libatrinik", "repository": "atrinik/libatrinik", "branch": "master", "build": "library"},
-    {"name": "content", "repository": "atrinik/content", "branch": "master", "build": "content"},
-    {"name": "sound", "repository": "atrinik/sound", "branch": "master", "build": "assets"},
-    {"name": "resources", "repository": "atrinik/resources", "branch": "master", "build": "assets"},
-    {"name": "tools", "repository": "atrinik/tools", "branch": "master", "build": "none"},
-    {"name": "editor", "repository": "atrinik/editor", "branch": "master", "build": "none"},
-    {"name": "metaserver-worker", "repository": "atrinik/metaserver-worker", "branch": "master", "build": "worker"},
+    {"name": "client", "repository": "atrinik/client", "branch": "main", "build": "client"},
+    {"name": "server", "repository": "atrinik/server", "branch": "main", "build": "server"},
+    {"name": "protocol", "repository": "atrinik/protocol", "branch": "main", "build": "protocol"},
+    {"name": "libatrinik", "repository": "atrinik/libatrinik", "branch": "main", "build": "library"},
+    {"name": "content", "repository": "atrinik/content", "branch": "main", "build": "content"},
+    {"name": "sound", "repository": "atrinik/sound", "branch": "main", "build": "assets"},
+    {"name": "resources", "repository": "atrinik/resources", "branch": "main", "build": "assets"},
+    {"name": "tools", "repository": "atrinik/tools", "branch": "main", "build": "none"},
+    {"name": "editor", "repository": "atrinik/editor", "branch": "main", "build": "none"},
+    {"name": "metaserver-worker", "repository": "atrinik/metaserver-worker", "branch": "main", "build": "worker"},
     {"name": "devcontainer", "repository": "atrinik/devcontainer", "branch": "main", "build": "none"},
     {"name": "github-settings", "repository": "atrinik/github-settings", "branch": "main", "build": "none"}
   ]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,6 +28,7 @@ workspace/
   profiles/<name>.json               checkout selectors
   build/profiles/<name>-<key>/       isolated sources, builds, and runtime
   build/npm-cache/                   shared package download cache
+  topologies/<name>/                 supervised process state and rotated logs
   state/server/<name>/               persistent mutable server data
   states.json                        named external-state registry
 ~~~
@@ -60,7 +61,7 @@ The playable build flow is:
 
 ~~~text
 selected content -> build_runtime.py -> isolated content/lib + content/maps
-selected resources -----------------> isolated resource view
+selected tracked resource allowlist -> isolated resource view
 selected protocol + library + sound -> client source view -> CMake/Ninja
 selected protocol + library --------> server source view -> CMake/Ninja
 selected Worker --------------------> npm source view -> npm run check
@@ -72,6 +73,10 @@ links to their selected worktrees. The Worker view is copied because Node's
 module resolver follows configuration-file links and would otherwise search the
 component checkout instead of the isolated dependency directory. Collected
 content and resource dependency metadata identify the selected path and commit.
+The resources repository's `runtime-paths.txt` is the distribution boundary:
+only tracked regular files below those paths enter the runtime view. This keeps
+repository metadata, local untracked files, and symlinks out of the asset
+protocol.
 
 ## Runtime and state
 
@@ -87,6 +92,30 @@ server. Profile builds have their own blocking lock, and server launch views are
 keyed by state path. Processes started outside the coordinator do not
 participate in the state lock, so operators must not point those processes at
 the same state concurrently.
+
+Profiles are source-topology definitions for supervised runtime as well as
+builds. `up` resolves the requested service dependency closure once, records
+the exact paths/commits and build root, prepares the same isolated views used by
+foreground launches, and hands the state-lock file descriptor through a short
+forking bootstrap to a detached native supervisor and its server child. The
+lock remains held for the server lifetime without a long-lived invoking CLI
+process.
+
+The supervisor owns child lifetimes and size-bounded rotating logs. Status
+records include Linux process start ticks in addition to PIDs; `ps` and `down`
+require both to match, preventing an old status file from targeting an
+unrelated reused PID. Shutdown signals the supervisor, which gracefully stops
+children before releasing state. For a paired topology it starts the server
+first, waits for its fingerprint and final ready signal, and then pins the
+client to that authenticated loopback endpoint. Available UDP ports are
+allocated under a workspace-wide lock, or callers may request an explicit
+port. Each runtime name owns an isolated persistent client configuration base.
+A server topology takes ownership of its collected content and staged resource
+directories after the shared incremental build, so later builds cannot mutate
+the filesystem seen by a running process.
+A topology may select one service, and distinct runtime names permit concurrent
+combinations as long as their server ports and mutable state directories do not
+conflict.
 
 ## Trust and command execution
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,10 +15,10 @@ class ParserTests(unittest.TestCase):
             {
                 "component": "client",
                 "repository": "atrinik/client",
-                "default_branch": "master",
+                "default_branch": "main",
                 "path": "/workspace/repos/client",
                 "initialized": True,
-                "branch": "master",
+                "branch": "main",
                 "head": "0123456789ab",
                 "dirty": False,
                 "remote": "origin",
@@ -78,6 +78,71 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(options.state, "shared")
         self.assertTrue(options.dry_run)
         self.assertEqual(options.arguments, ["--", "--version"])
+
+    def test_up_defaults_runtime_name_to_profile(self) -> None:
+        status = {
+            "supervisor": {"running": True},
+            "endpoint": {
+                "host": "127.0.0.1",
+                "port": 17300,
+                "fingerprint": "a" * 64,
+            },
+        }
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.topology_up.return_value = status
+            with mock.patch("builtins.print") as output:
+                result = main(
+                    [
+                        "up",
+                        "--profile",
+                        "review",
+                        "--state",
+                        "shared",
+                        "--service",
+                        "server",
+                        "--port",
+                        "17300",
+                    ]
+                )
+
+        self.assertEqual(result, 0)
+        workspace_type.return_value.topology_up.assert_called_once_with(
+            "review", "review", "shared", ["server"], 17300
+        )
+        output.assert_called_once_with("topology review: started at 127.0.0.1:17300")
+
+    def test_topology_show_supports_json(self) -> None:
+        summary = {
+            "profile": "review",
+            "services": ["server"],
+            "dependencies": ["server"],
+            "state": "/state",
+            "build_root": "/build",
+            "components": {},
+        }
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.topology_summary.return_value = summary
+            with mock.patch("builtins.print") as output:
+                result = main(
+                    ["topology", "show", "review", "--service", "server", "--json"]
+                )
+
+        self.assertEqual(result, 0)
+        workspace_type.return_value.topology_summary.assert_called_once_with(
+            "review", "default", ["server"]
+        )
+        self.assertEqual(json.loads(output.call_args.args[0]), summary)
+
+    def test_ps_without_name_lists_all_topologies_as_json(self) -> None:
+        statuses = [{"name": "baseline"}, {"name": "candidate"}]
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.topology_statuses.return_value = statuses
+            with mock.patch("builtins.print") as output:
+                result = main(["ps", "--json"])
+
+        self.assertEqual(result, 0)
+        workspace_type.return_value.topology_statuses.assert_called_once_with()
+        self.assertEqual(json.loads(output.call_args.args[0]), statuses)
 
     def test_relative_external_profile_path_is_not_silently_absolutized(self) -> None:
         with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -12,6 +12,7 @@ from atrinik_workspace.model import (
     Paths,
     WorkspaceError,
     atomic_json,
+    managed_directory,
     managed_reset,
     profile_key,
 )
@@ -25,7 +26,7 @@ class ManifestTests(unittest.TestCase):
 
     def valid_components(self) -> list[dict[str, str]]:
         return [
-            {"name": name, "repository": f"atrinik/{name}", "branch": "master", "build": build}
+            {"name": name, "repository": f"atrinik/{name}", "branch": "main", "build": build}
             for name, build in (
                 ("client", "client"),
                 ("server", "server"),
@@ -141,6 +142,21 @@ class PathSafetyTests(unittest.TestCase):
             with self.assertRaisesRegex(WorkspaceError, "unmanaged build path"):
                 managed_reset(target, builds, "test")
             self.assertTrue((target / "valuable").is_file())
+
+    def test_managed_reset_refuses_symlinked_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            builds = Path(temporary) / "build"
+            real = builds / "real"
+            target = builds / "profile"
+            managed_directory(real, builds, "test")
+            target.symlink_to(real, target_is_directory=True)
+
+            with self.assertRaisesRegex(
+                WorkspaceError, "symlinked managed build path"
+            ):
+                managed_reset(target, builds, "test")
+
+            self.assertTrue(real.is_dir())
 
     def test_refuses_malformed_workspace_marker(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import unittest
+
+from atrinik_workspace.supervisor import ServerReadinessCapture
+
+
+class ServerReadinessCaptureTests(unittest.TestCase):
+    def test_requires_fingerprint_and_finished_server_startup(self) -> None:
+        capture = ServerReadinessCapture()
+
+        capture.feed(b"QUIC certificate SHA-256: " + b"A" * 64 + b"\n")
+
+        self.assertEqual(capture.fingerprint, "a" * 64)
+        self.assertFalse(capture.event.is_set())
+
+        capture.feed(b"Server ready. Waiting for connections...\n")
+
+        self.assertTrue(capture.event.is_set())
+
+    def test_recognizes_readiness_messages_split_across_chunks(self) -> None:
+        capture = ServerReadinessCapture()
+
+        capture.feed(b"Server ready. Waiting for connec")
+        capture.feed(b"tions...\nQUIC certificate SHA-256: " + b"b" * 31)
+        capture.feed(b"b" * 33 + b"\n")
+
+        self.assertEqual(capture.fingerprint, "b" * 64)
+        self.assertTrue(capture.event.is_set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -4,14 +4,17 @@ import json
 import os
 from pathlib import Path
 import shutil
+import signal
 import subprocess
 import tempfile
+import time
 import unittest
 from unittest import mock
 
 from atrinik_workspace.model import (
     MANAGED_MARKER,
     WorkspaceError,
+    atomic_json,
     load_json,
     managed_directory,
     managed_reset,
@@ -55,7 +58,7 @@ class WorkspaceTests(unittest.TestCase):
                 {
                     "name": name,
                     "repository": f"atrinik/{name}",
-                    "branch": "master",
+                    "branch": "main",
                     "build": build,
                 }
                 for name, build in COMPONENTS
@@ -93,10 +96,16 @@ class WorkspaceTests(unittest.TestCase):
         command("git", "init", "--bare", str(origin), cwd=self.root)
         seed = self.root / "seeds" / name
         seed.mkdir(parents=True)
-        command("git", "init", "-b", "master", cwd=seed)
+        command("git", "init", "-b", "main", cwd=seed)
         command("git", "config", "user.name", "Tests", cwd=seed)
         command("git", "config", "user.email", "tests@example.invalid", cwd=seed)
         (seed / "README").write_text(f"{name}\n", encoding="utf-8")
+        if name == "resources":
+            (seed / "runtime-paths.txt").write_text("paintings\n", encoding="utf-8")
+            (seed / "paintings").mkdir()
+            (seed / "paintings" / "scene.jpg").write_text(
+                "resource\n", encoding="utf-8"
+            )
         if name == "server":
             (seed / "install_data" / "keys").mkdir(parents=True)
             (seed / "install_data" / "unique-items").mkdir()
@@ -111,7 +120,8 @@ class WorkspaceTests(unittest.TestCase):
         command("git", "add", ".", cwd=seed)
         command("git", "commit", "-m", "feat: seed", cwd=seed)
         command("git", "remote", "add", "origin", str(origin), cwd=seed)
-        command("git", "push", "-u", "origin", "master", cwd=seed)
+        command("git", "push", "-u", "origin", "main", cwd=seed)
+        command("git", "symbolic-ref", "HEAD", "refs/heads/main", cwd=origin)
         checkout = self.workspace.paths.repositories / name
         checkout.parent.mkdir(parents=True, exist_ok=True)
         command("git", "clone", str(origin), str(checkout), cwd=self.root)
@@ -371,6 +381,49 @@ class WorkspaceTests(unittest.TestCase):
             (source / ".atrinik-dependency.json").read_text(encoding="utf-8"),
             "component metadata\n",
         )
+        self.assertTrue((output / "paintings" / "scene.jpg").is_file())
+        self.assertFalse((output / "paintings" / "scene.jpg").is_symlink())
+        self.assertEqual(
+            (output / "paintings" / "scene.jpg").read_text(encoding="utf-8"),
+            "resource\n",
+        )
+        self.assertFalse((output / "README").exists())
+
+    def test_resource_view_ignores_untracked_files(self) -> None:
+        source = self.workspace.paths.repositories / "resources"
+        (source / "paintings" / "private.txt").write_text(
+            "do not serve\n", encoding="utf-8"
+        )
+        root = self.workspace.paths.builds / "profiles" / "test"
+        managed_directory(root, self.workspace.paths.builds, "test-profile")
+
+        output = self.workspace._stage_resources(root, {"resources": source})
+
+        self.assertFalse((output / "paintings" / "private.txt").exists())
+
+    def test_resource_view_rejects_unsafe_manifest_path(self) -> None:
+        source = self.workspace.paths.repositories / "resources"
+        (source / "runtime-paths.txt").write_text("../outside\n", encoding="utf-8")
+        root = self.workspace.paths.builds / "profiles" / "test"
+        managed_directory(root, self.workspace.paths.builds, "test-profile")
+
+        with self.assertRaisesRegex(WorkspaceError, "invalid resource runtime path"):
+            self.workspace._stage_resources(root, {"resources": source})
+
+    def test_resource_view_failure_preserves_previous_output(self) -> None:
+        source = self.workspace.paths.repositories / "resources"
+        root = self.workspace.paths.builds / "profiles" / "test"
+        managed_directory(root, self.workspace.paths.builds, "test-profile")
+        output = self.workspace._stage_resources(root, {"resources": source})
+        (source / "runtime-paths.txt").write_text("../outside\n", encoding="utf-8")
+
+        with self.assertRaisesRegex(WorkspaceError, "invalid resource runtime path"):
+            self.workspace._stage_resources(root, {"resources": source})
+
+        self.assertEqual(
+            (output / "paintings" / "scene.jpg").read_text(encoding="utf-8"),
+            "resource\n",
+        )
 
     def test_content_collection_failure_preserves_previous_output(self) -> None:
         root = self.workspace.paths.builds / "profiles" / "test"
@@ -399,6 +452,19 @@ class WorkspaceTests(unittest.TestCase):
             with self.assertRaisesRegex(WorkspaceError, "already in use"):
                 with exclusive_lock(lock, "test resource", nonblocking=True):
                     self.fail("concurrent lock unexpectedly succeeded")
+
+    def test_exclusive_lock_refuses_symlink(self) -> None:
+        target = self.root / "valuable"
+        target.write_text("preserve\n", encoding="utf-8")
+        lock = self.workspace.paths.builds / "locks" / "test.lock"
+        lock.parent.mkdir(parents=True)
+        lock.symlink_to(target)
+
+        with self.assertRaisesRegex(WorkspaceError, "cannot open test resource lock"):
+            with exclusive_lock(lock, "test resource"):
+                self.fail("symlinked lock unexpectedly opened")
+
+        self.assertEqual(target.read_text(encoding="utf-8"), "preserve\n")
 
     def test_server_runtime_paths_are_isolated_by_state(self) -> None:
         source = self.workspace.paths.repositories / "server"
@@ -433,6 +499,320 @@ class WorkspaceTests(unittest.TestCase):
         self.assertTrue((first / "data").is_symlink())
         self.assertEqual((second / "data").resolve(), state_two)
 
+    def test_topology_summary_resolves_service_dependency_closure(self) -> None:
+        summary = self.workspace.topology_summary(
+            "default", "default", ["client"]
+        )
+
+        self.assertEqual(summary["services"], ["client"])
+        self.assertIsNone(summary["state"])
+        self.assertEqual(
+            set(summary["dependencies"]),
+            {"client", "sound", "libatrinik", "protocol"},
+        )
+        self.assertEqual(
+            set(summary["components"]),
+            {
+                "client",
+                "server",
+                "content",
+                "resources",
+                "sound",
+                "libatrinik",
+                "protocol",
+            },
+        )
+        self.assertIn("default-", summary["build_root"])
+
+    def test_supervised_topology_lifecycle_and_logs(self) -> None:
+        build_root = self.workspace.paths.builds / "fake-topology"
+        executable = build_root / "build" / "client" / "atrinik"
+        executable.parent.mkdir(parents=True)
+        (build_root / "sources" / "client").mkdir(parents=True)
+        executable.write_text(
+            "#!/usr/bin/env python3\n"
+            "import os, time\n"
+            "print('client ready', flush=True)\n"
+            "print('config=' + os.environ['ATRINIK_CONFIG_DIR'], flush=True)\n"
+            "while True:\n"
+            "    time.sleep(0.1)\n",
+            encoding="utf-8",
+        )
+        executable.chmod(0o755)
+
+        with (
+            mock.patch.object(
+                self.workspace, "_build_resolved", return_value=build_root
+            ),
+            mock.patch.object(self.workspace, "_require_client_display"),
+        ):
+            status = self.workspace.topology_up(
+                "review", "default", "default", ["client"]
+            )
+        try:
+            self.assertTrue(status["supervisor"]["running"])
+            self.assertTrue(status["services"]["client"]["running"])
+            self.assertEqual(
+                Path(status["services"]["client"]["cwd"]),
+                self.workspace.paths.topologies / "review" / "client-runtime",
+            )
+            with (
+                mock.patch.object(
+                    self.workspace, "_build_resolved", return_value=build_root
+                ),
+                mock.patch.object(self.workspace, "_require_client_display"),
+            ):
+                second = self.workspace.topology_up(
+                    "review-two", "default", "default", ["client"]
+                )
+            self.assertNotEqual(
+                status["services"]["client"]["cwd"],
+                second["services"]["client"]["cwd"],
+            )
+            with self.assertRaisesRegex(WorkspaceError, "already running"):
+                with (
+                    mock.patch.object(
+                        self.workspace, "_build_resolved", return_value=build_root
+                    ),
+                    mock.patch.object(self.workspace, "_require_client_display"),
+                ):
+                    self.workspace.topology_up(
+                        "review", "default", "default", ["client"]
+                    )
+
+            deadline = time.monotonic() + 5
+            log = self.workspace.paths.topologies / "review" / "client.log"
+            while time.monotonic() < deadline and (
+                not log.is_file() or "client ready" not in log.read_text()
+            ):
+                time.sleep(0.05)
+            self.assertIn("client ready", log.read_text())
+            self.assertIn(
+                str(self.workspace.paths.topologies / "review" / "client-config"),
+                log.read_text(),
+            )
+
+            with mock.patch("builtins.print") as output:
+                self.workspace.topology_logs("review", "client", 10, False)
+            self.assertIn("client ready", "".join(call.args[0] for call in output.call_args_list))
+        finally:
+            try:
+                if self.workspace.topology_status("review-two")["supervisor"][
+                    "running"
+                ]:
+                    self.workspace.topology_down("review-two", timeout=5)
+            except WorkspaceError:
+                pass
+            if self.workspace.topology_status("review")["supervisor"]["running"]:
+                self.workspace.topology_down("review", timeout=5)
+
+        stopped = self.workspace.topology_status("review")
+        self.assertFalse(stopped["supervisor"]["running"])
+        self.assertFalse(stopped["services"]["client"]["running"])
+
+    def test_supervised_pair_pins_client_and_holds_state_lock_until_down(self) -> None:
+        source = self.workspace.paths.repositories / "server"
+        (source / "tools").mkdir()
+        for name in ("ca-bundle.crt", "permissions.cfg", "server.cfg"):
+            (source / name).write_text("test\n", encoding="utf-8")
+        build_root = self.workspace.paths.builds / "fake-server-topology"
+        binary = build_root / "build" / "server"
+        binary.mkdir(parents=True)
+        executable = binary / "atrinik-server"
+        executable.write_text(
+            "#!/usr/bin/env python3\n"
+            "import sys, time\n"
+            f"print('QUIC certificate SHA-256: {'a' * 64}', flush=True)\n"
+            "print('Server ready. Waiting for connections...', flush=True)\n"
+            "print(repr(sys.argv[1:]), flush=True)\n"
+            "while True:\n"
+            "    time.sleep(0.1)\n",
+            encoding="utf-8",
+        )
+        executable.chmod(0o755)
+        for name in ("libplugin_arena.so", "libplugin_python.so"):
+            (binary / name).write_text("test\n", encoding="utf-8")
+        for path in (
+            build_root / "runtime" / "content" / "lib",
+            build_root / "runtime" / "content" / "maps",
+            build_root / "runtime" / "resources",
+        ):
+            path.mkdir(parents=True, exist_ok=True)
+        atomic_json(
+            build_root / "runtime" / "content" / MANAGED_MARKER,
+            {"schema_version": 1, "purpose": "collected-content"},
+        )
+        atomic_json(
+            build_root / "runtime" / "resources" / MANAGED_MARKER,
+            {"schema_version": 1, "purpose": "resource-view"},
+        )
+        client = build_root / "build" / "client" / "atrinik"
+        client.parent.mkdir(parents=True)
+        (build_root / "sources" / "client").mkdir(parents=True)
+        client.write_text(
+            "#!/usr/bin/env python3\n"
+            "import os, sys, time\n"
+            "print(repr(sys.argv[1:]), flush=True)\n"
+            "print('config=' + os.environ['ATRINIK_CONFIG_DIR'], flush=True)\n"
+            "while True:\n"
+            "    time.sleep(0.1)\n",
+            encoding="utf-8",
+        )
+        client.chmod(0o755)
+
+        with (
+            mock.patch.object(
+                self.workspace, "_build_resolved", return_value=build_root
+            ),
+            mock.patch.object(
+                self.workspace, "_select_topology_port", return_value=17300
+            ),
+            mock.patch.object(self.workspace, "_require_client_display"),
+        ):
+            status = self.workspace.topology_up(
+                "server-review", "default", "default", None, 17300
+            )
+        self.assertTrue(status["ready"])
+        self.assertEqual(status["endpoint"]["port"], 17300)
+        self.assertEqual(status["endpoint"]["fingerprint"], "a" * 64)
+        server_runtime = Path(status["services"]["server"]["cwd"])
+        self.assertEqual(
+            (server_runtime / "maps").resolve(),
+            self.workspace.paths.topologies
+            / "server-review"
+            / "runtime"
+            / "content"
+            / "maps",
+        )
+        self.assertEqual(
+            Path(status["services"]["client"]["cwd"]),
+            self.workspace.paths.topologies
+            / "server-review"
+            / "client-runtime",
+        )
+        client_log = self.workspace.paths.topologies / "server-review" / "client.log"
+        server_log = self.workspace.paths.topologies / "server-review" / "server.log"
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and (
+            not client_log.is_file() or "--server=" not in client_log.read_text()
+        ):
+            time.sleep(0.05)
+        self.assertIn("'--port_quic=17300'", server_log.read_text())
+        self.assertIn(
+            f"'--server=127.0.0.1 17300 {'a' * 64}'", client_log.read_text()
+        )
+        self.assertIn("'--connect=127.0.0.1'", client_log.read_text())
+        self.assertIn("'--stun_server=off'", client_log.read_text())
+        self.assertIn("'--nometa'", client_log.read_text())
+        self.assertIn(
+            str(
+                self.workspace.paths.topologies
+                / "server-review"
+                / "client-config"
+            ),
+            client_log.read_text(),
+        )
+        state = self.workspace._state_location("default")
+        try:
+            with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                with exclusive_lock(
+                    Path(f"{state}.lock"), "server state", nonblocking=True
+                ):
+                    self.fail("supervised state lock unexpectedly became available")
+
+            supervisor = status["supervisor"]
+            pidfd = os.pidfd_open(supervisor["pid"])
+            try:
+                signal.pidfd_send_signal(pidfd, signal.SIGKILL)
+            finally:
+                os.close(pidfd)
+            deadline = time.monotonic() + 5
+            while (
+                time.monotonic() < deadline
+                and self.workspace.topology_status("server-review")["supervisor"][
+                    "running"
+                ]
+            ):
+                time.sleep(0.05)
+            orphaned = self.workspace.topology_status("server-review")
+            self.assertFalse(orphaned["supervisor"]["running"])
+            self.assertFalse(orphaned["ready"])
+            self.assertTrue(orphaned["services"]["server"]["running"])
+            with self.assertRaisesRegex(WorkspaceError, "already running"):
+                self.workspace.topology_up(
+                    "server-review", "default", "default", None, 17300
+                )
+            with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                with exclusive_lock(
+                    Path(f"{state}.lock"), "server state", nonblocking=True
+                ):
+                    self.fail("orphaned server released its state lock")
+            recovered = self.workspace.topology_down("server-review", timeout=5)
+            self.assertFalse(
+                any(service["running"] for service in recovered["services"].values())
+            )
+        finally:
+            remaining = self.workspace.topology_status("server-review")
+            if remaining["supervisor"]["running"] or any(
+                service["running"] for service in remaining["services"].values()
+            ):
+                self.workspace.topology_down("server-review", timeout=5)
+
+        with exclusive_lock(Path(f"{state}.lock"), "server state", nonblocking=True):
+            pass
+
+    def test_topology_port_selection_rejects_unavailable_port(self) -> None:
+        candidate = mock.MagicMock()
+        candidate.__enter__.return_value = candidate
+        candidate.bind.side_effect = OSError("address in use")
+        with mock.patch(
+            "atrinik_workspace.workspace.socket.socket", return_value=candidate
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "is unavailable"):
+                self.workspace._select_topology_port(17300)
+
+        candidate.reset_mock()
+        candidate.bind.side_effect = None
+        candidate.getsockname.return_value = ("0.0.0.0", 49152)
+        with mock.patch(
+            "atrinik_workspace.workspace.socket.socket", return_value=candidate
+        ):
+            self.assertEqual(self.workspace._select_topology_port(None), 49152)
+
+        with self.assertRaisesRegex(WorkspaceError, "between 0 and 65535"):
+            self.workspace._select_topology_port(True)
+
+    def test_topology_status_rejects_boolean_process_id(self) -> None:
+        root = self.workspace._topology_directory("invalid", create=True)
+        atomic_json(
+            root / "status.json",
+            {
+                "schema_version": 1,
+                "name": "invalid",
+                "profile": "default",
+                "dependencies": [],
+                "state": None,
+                "build_root": "/tmp/build",
+                "resolved": {},
+                "endpoint": None,
+                "ready": False,
+                "started_at": "2026-08-06T00:00:00+00:00",
+                "stopped_at": None,
+                "supervisor": {"pid": True, "start_time": "1"},
+                "services": {},
+                "error": "test fixture",
+            },
+        )
+
+        with self.assertRaisesRegex(WorkspaceError, "supervisor status is invalid"):
+            self.workspace.topology_status("invalid")
+
+    def test_client_only_topology_rejects_server_port(self) -> None:
+        with self.assertRaisesRegex(WorkspaceError, "requires the server"):
+            self.workspace.topology_up(
+                "client-only", "default", "default", ["client"], 17300
+            )
+
     def test_state_initializes_once_and_reuses_it(self) -> None:
         server = self.workspace.paths.repositories / "server"
         first = self.workspace.state_path("default", server)
@@ -455,6 +835,15 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertNotIn("secret", displayed)
         self.assertIn("<redacted>", displayed)
+
+    def test_operational_subprocess_output_uses_stderr(self) -> None:
+        completed = mock.MagicMock(stdout="")
+        with mock.patch(
+            "atrinik_workspace.workspace.subprocess.run", return_value=completed
+        ) as invoke:
+            workspace_run(["tool"])
+
+        self.assertIs(invoke.call_args.kwargs["stdout"], os.sys.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add Compose-like supervised client/server topologies with independent profiles, states, ports, logs, and lifecycle commands
- isolate collected content, tracked resources, client configuration, process identity, and server state for concurrent reviews
- move every component contract to `main` and document practical multi-worktree development scenarios
- harden managed paths, PID signaling, atomic runtime replacement, and machine-readable output

## Validation

- 60/60 Python tests
- Python byte compilation
- actionlint
- component manifest validation
- multi-repository skill validation
- forbidden-reference and whitespace scans
- two simultaneous real server topologies on distinct ports/states
- final real server topology with regular-file-only resource snapshot, clean asset cache, and graceful exit 0

The detailed iterative review is retained locally under ignored `build/` output.