### PR TITLE
fix: restore workspace devcontainer configuration

### DIFF
--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -20,6 +20,9 @@ description: Coordinate changes, reviews, builds, releases, and Git worktrees ac
   as `./client` and `./server`. Generated worktrees, profiles, builds, and
   default state remain under `./workspace`; `ATRINIK_WORKSPACE_DIR` relocates
   only that generated and mutable data.
+- Keep workspace-specific VS Code launch configurations in the wrapper's
+  `.devcontainer/` directory. The standalone `devcontainer` component owns the
+  reusable images; use `./atrinik init` for post-create repository setup.
 - Preserve dirty checkouts and worktrees. Never move component source into the
   wrapper or replace persistent state.
 

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:4": {
+      "version": "4.0.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5",
+      "integrity": "sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,53 @@
+{
+  "name": "Atrinik 2026 Linux Build",
+  "image": "ghcr.io/atrinik/linux-build:1.0.3",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:4": {
+      "moby": false
+    }
+  },
+  "remoteUser": "ubuntu",
+  "updateRemoteUserUID": true,
+  "runArgs": [
+    "--network", "host",
+    "--security-opt", "seccomp=unconfined",
+    "--security-opt", "no-new-privileges=false"
+  ],
+  "initializeCommand": "install -d -m 700 \"${localEnv:HOME}/.codex-atrinik\" && if [ ! -e \"${localEnv:HOME}/.gitconfig\" ]; then install -m 600 /dev/null \"${localEnv:HOME}/.gitconfig\"; fi",
+  "workspaceFolder": "/workspaces/atrinik",
+  "mounts": [
+    "source=${localEnv:HOME}/.codex-atrinik,target=/home/ubuntu/.codex,type=bind",
+    "source=${localEnv:HOME}/.gitconfig,target=/home/ubuntu/.gitconfig,type=bind,readonly",
+    "source=/mnt/wslg/PulseServer,target=/mnt/wslg/PulseServer,type=bind"
+  ],
+  "containerEnv": {
+    "CODEX_HOME": "/home/ubuntu/.codex",
+    "PULSE_SERVER": "unix:/mnt/wslg/PulseServer",
+    "SDL_AUDIODRIVER": "pulse"
+  },
+  "postCreateCommand": "./atrinik init",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cmake-tools",
+        "llvm-vs-code-extensions.vscode-clangd",
+        "ms-python.python",
+        "dbaeumer.vscode-eslint",
+        "timonwong.shellcheck",
+        "EditorConfig.EditorConfig"
+      ],
+      "settings": {
+        "[c]": {
+          "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
+        },
+        "[cpp]": {
+          "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
+        },
+        "clangd.arguments": [
+          "--background-index",
+          "--clang-tidy"
+        ]
+      }
+    }
+  }
+}

--- a/.devcontainer/windows-cross/devcontainer.json
+++ b/.devcontainer/windows-cross/devcontainer.json
@@ -1,0 +1,28 @@
+{
+  "name": "Atrinik Windows cross-build (MXE)",
+  "image": "ghcr.io/atrinik/windows-build:1.0.3",
+  "workspaceFolder": "/workspaces/atrinik",
+  "remoteUser": "vscode",
+  "initializeCommand": "if [ ! -e \"${localEnv:HOME}/.gitconfig\" ]; then install -m 600 /dev/null \"${localEnv:HOME}/.gitconfig\"; fi",
+  "mounts": [
+    "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,readonly"
+  ],
+  "remoteEnv": {
+    "PATH": "/opt/mxe/usr/bin:${containerEnv:PATH}"
+  },
+  "postCreateCommand": "./atrinik manifest validate",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cmake-tools",
+        "ms-vscode.cpptools"
+      ],
+      "settings": {
+        "cmake.cmakePath": "/opt/mxe/usr/bin/x86_64-w64-mingw32.shared-cmake",
+        "cmake.configureArgs": [
+          "--no-warn-unused-cli"
+        ]
+      }
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,9 @@
   below the wrapper root. Component worktrees, builds, profiles, and default
   mutable state belong below the ignored workspace directory or an explicit
   external path.
+- Keep wrapper-specific VS Code launch configuration under `.devcontainer/`.
+  The standalone `devcontainer` component owns reusable toolchain images, not
+  workspace composition; initialize checkouts through `./atrinik init`.
 - Never replace a dirty checkout, remove a dirty worktree, or overwrite an
   existing mutable server-data directory.
 - Use profiles to declare mixed component sources. Use `topology show` to audit

--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ the ignored `workspace/` directory.
 The Atrinik development container supplies the native build dependencies. Run
 all commands below from this repository's root.
 
+### Development container
+
+Open this wrapper repository in VS Code and choose **Dev Containers: Reopen in
+Container** to use the pinned Linux build environment. On first creation, the
+container runs `./atrinik init`; it clones missing component repositories and
+validates existing checkouts without updating or replacing them. The Windows
+cross-build configuration is available at
+`.devcontainer/windows-cross/devcontainer.json` after `./atrinik init` has
+prepared the component checkouts.
+
+The wrapper owns these launch configurations because they compose the complete
+development workspace. The standalone `devcontainer` component owns only the
+published Linux and Windows toolchain images they reference.
+
 ## Quick start
 
 ~~~sh

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,6 +7,13 @@ Implementation, release packaging, and component-specific tests belong to the
 standalone repositories listed in `components.json`. The workspace coordinator
 does not vendor, pin, or commit component source.
 
+The wrapper also owns the VS Code launch configurations that compose this
+multi-repository workspace. The default configuration delegates repository
+setup to `./atrinik init`, preserving existing checkouts while cloning missing
+ones; the specialized Windows cross-build configuration validates the same
+manifest after initialization. The standalone `devcontainer` repository owns
+the versioned toolchain images, not the wrapper-specific launch configuration.
+
 `components.json` is the source of truth for repository identity, default
 branch, and local build contract. Profile and state schemas are intentionally
 strict: duplicate keys, missing fields, unknown fields, invalid names, and

--- a/tests/test_devcontainer.py
+++ b/tests/test_devcontainer.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class DevcontainerTests(unittest.TestCase):
+    def load_config(self, relative_path: str) -> dict[str, object]:
+        with (ROOT / relative_path).open(encoding="utf-8") as config_file:
+            return json.load(config_file)
+
+    def test_default_configuration_initializes_component_checkouts(self) -> None:
+        config = self.load_config(".devcontainer/devcontainer.json")
+
+        self.assertEqual(config["workspaceFolder"], "/workspaces/atrinik")
+        self.assertEqual(config["postCreateCommand"], "./atrinik init")
+        self.assertEqual(config["image"], "ghcr.io/atrinik/linux-build:1.0.3")
+
+    def test_windows_configuration_validates_component_manifest(self) -> None:
+        config = self.load_config(
+            ".devcontainer/windows-cross/devcontainer.json"
+        )
+
+        self.assertEqual(config["workspaceFolder"], "/workspaces/atrinik")
+        self.assertEqual(
+            config["postCreateCommand"], "./atrinik manifest validate"
+        )
+        self.assertEqual(config["image"], "ghcr.io/atrinik/windows-build:1.0.3")
+
+    def test_default_feature_lock_matches_configuration(self) -> None:
+        config = self.load_config(".devcontainer/devcontainer.json")
+        lock = self.load_config(".devcontainer/devcontainer-lock.json")
+
+        self.assertEqual(set(config["features"]), set(lock["features"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- restore the wrapper-owned Linux and Windows cross-build devcontainer configurations removed during the repository split
- pin the published 1.0.3 toolchain images and initialize the multi-repository workspace through the coordinator
- document the ownership boundary and add regression coverage for both configurations

## Validation

- `python3 -m unittest discover -v` (63 tests)
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- Dev Containers CLI 0.88.0 resolved both configurations
- manifest, JSON, skill, and `git diff --check` validation