### PR TITLE
feat: add deterministic test scenarios

### DIFF
--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -124,6 +124,37 @@ recorded PIDs directly or tail internal files by reconstructed paths: the
 coordinator verifies process start identity, rotates logs, performs graceful
 shutdown, and holds the server-state lock through its supervisor.
 
+## Provide manual verification handoffs
+
+End every implementation or change handoff with copy-pasteable manual
+verification commands using `./atrinik` wherever the coordinator supports the
+workflow. Use the concrete names created for the task rather than placeholders.
+Include the narrow automated build/test command and, when runtime behavior is
+relevant, the complete supervised lifecycle:
+
+```sh
+./atrinik profile show PROFILE
+./atrinik build COMPONENT --profile PROFILE --test
+./atrinik topology show PROFILE --json
+./atrinik up --name TOPOLOGY --profile PROFILE --state STATE
+./atrinik ps TOPOLOGY --json
+./atrinik logs TOPOLOGY [server|client] --follow
+./atrinik down TOPOLOGY
+```
+
+State display forwarding or other prerequisites, describe the exact manual
+actions and expected results between `up` and `down`, and always include the
+cleanup command. Do not substitute reconstructed internal build/runtime paths
+or direct executable invocations for a supported wrapper command. If runtime
+verification is not applicable, say so and provide the wrapper build/test and
+inspection commands that are applicable.
+
+When the reviewer needs a ready login, also use the
+`atrinik-test-scenario` skill. Provision with `./atrinik scenario create`,
+retrieve the secret only through `scenario credentials`, and use the scenario's
+dedicated state in the lifecycle above. Never construct account or player save
+files directly.
+
 ## Coordinate releases and GitHub changes
 
 - Keep each repository independently releasable. A component squash commit

--- a/.agents/skills/atrinik-test-scenario/SKILL.md
+++ b/.agents/skills/atrinik-test-scenario/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: atrinik-test-scenario
+description: Provision, inspect, reset, and hand off deterministic local Atrinik account-and-character scenarios through the ./atrinik wrapper. Use when an issue, pull request, gameplay change, client/server fix, or manual reproduction needs a ready-to-login test player, isolated mutable server state, repeatable credentials, or exact wrapper-native runtime verification commands.
+---
+
+# Atrinik Test Scenario
+
+Use the workspace scenario lifecycle to give a reviewer the smallest safe,
+repeatable local player setup for a manual reproduction. Keep account creation
+inside the server API and orchestration inside `./atrinik`; never construct or
+edit account or player save files directly.
+
+## Select the scenario
+
+1. Read the workspace `AGENTS.md` and the `atrinik-multi-repo-workspace` skill.
+2. Identify the exact mixed-component profile for the change. Create or update
+   that profile with `./atrinik profile` when the task already authorizes
+   workspace setup.
+3. Choose a lowercase scenario name tied to the issue or feature, such as
+   `issue-42` or `inventory-filter`.
+4. Use `basic-player` unless the reproduction truly needs another server-owned
+   preset. It provides a normal `human_male` first-login character, including
+   the configured starting map, standard skills, and initial items.
+5. If the required state cannot be reached cheaply from `basic-player`, extend
+   the server provisioner and wrapper preset contract with tests. Do not bypass
+   validation by writing a handcrafted player file.
+
+## Provision and inspect
+
+Create the scenario once:
+
+```sh
+./atrinik scenario create NAME --profile PROFILE --preset basic-player
+```
+
+The command builds the selected server, creates a dedicated registered state
+named `scenario-NAME`, writes mode-0600 credentials below the ignored workspace
+directory, provisions the account through the server's normal password and
+account persistence APIs, and prints the complete manual lifecycle.
+
+Inspect it without revealing the password:
+
+```sh
+./atrinik scenario show NAME --json
+./atrinik scenario list --json
+```
+
+Retrieve credentials only when login is about to be tested:
+
+```sh
+./atrinik scenario credentials NAME
+```
+
+Do not copy the password into commits, review documents, issue comments, logs,
+shell arguments, or final responses. Give reviewers the credentials command.
+
+## Run the reproduction
+
+Use the scenario's recorded profile and state. A client/server check normally
+uses:
+
+```sh
+./atrinik profile show PROFILE
+./atrinik build all --profile PROFILE --test
+./atrinik topology show PROFILE --state scenario-NAME --json
+./atrinik up --name NAME --profile PROFILE --state scenario-NAME
+./atrinik ps NAME --json
+./atrinik logs NAME server --follow
+./atrinik logs NAME client --follow
+./atrinik down NAME
+```
+
+Confirm display forwarding before `up` when the client is included. Between
+`up` and `down`, state the exact login steps, feature actions, and expected
+results for the issue. Use `ps` and wrapper-managed logs instead of reading
+internal PID, build, runtime, or log paths.
+
+## Reset safely
+
+After stopping the topology, restore the scenario to its pristine provisioned
+state with:
+
+```sh
+./atrinik down NAME
+./atrinik scenario reset NAME
+```
+
+Reset is intentionally destructive only to the scenario-owned state. It keeps
+the same account, character, password, profile, preset, and state name. It
+refuses a running or otherwise locked server state and never replaces an
+external, shared, symlinked, malformed, or unregistered directory.
+
+## Hand off
+
+Every final handoff must include copy-pasteable commands with concrete profile,
+scenario, topology, and state names; the credentials lookup; prerequisites;
+the exact manual actions and expected outcome; and `down` for cleanup. Mention
+`scenario reset` as the repeat-test command when appropriate. Never replace a
+supported wrapper command with a reconstructed internal path or direct binary.

--- a/.agents/skills/atrinik-test-scenario/SKILL.md
+++ b/.agents/skills/atrinik-test-scenario/SKILL.md
@@ -61,7 +61,7 @@ uses:
 
 ```sh
 ./atrinik profile show PROFILE
-./atrinik build all --profile PROFILE --test
+./atrinik build server --profile PROFILE --test
 ./atrinik topology show PROFILE --state scenario-NAME --json
 ./atrinik up --name NAME --profile PROFILE --state scenario-NAME
 ./atrinik ps NAME --json

--- a/.agents/skills/atrinik-test-scenario/agents/openai.yaml
+++ b/.agents/skills/atrinik-test-scenario/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Atrinik Test Scenario"
+  short_description: "Provision deterministic local Atrinik test players"
+  default_prompt: "Set up the smallest deterministic local Atrinik account and character scenario for this manual reproduction, then provide exact ./atrinik verification and cleanup commands."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,17 @@
   merge is released by semantic-release.
 - Run the complete Python test suite, compileall, ShellCheck for shell changes,
   actionlint for workflow changes, and `git diff --check` before finishing.
+- Every implementation or change handoff must include copy-pasteable manual
+  verification commands that use the thin `./atrinik` wrapper whenever it
+  supports the workflow. Use exact profile, worktree, topology, service, and
+  state names; include the automated build/test command, the complete
+  `topology show`/`up`/`ps`/`logs`/`down` lifecycle when runtime verification
+  is relevant, feature-specific actions and expected results, display or other
+  prerequisites, and the cleanup command. Do not replace supported wrapper
+  commands with reconstructed build paths or direct executable invocations.
+- Use `.agents/skills/atrinik-test-scenario/SKILL.md` when manual verification
+  benefits from a ready local account and character. Keep scenario credentials
+  and state ignored and isolated; never handcraft account or player files.
 - Deep-review reports are ignored local artifacts under `build/`; do not commit
   them.
 - Keep this guide, the multi-repository skill, `README.md`, and

--- a/README.md
+++ b/README.md
@@ -220,7 +220,8 @@ the password; request it explicitly with `credentials` immediately before
 login.
 
 Scenarios live below ignored `workspace/scenarios/`. Their metadata records the
-profile and exact provisioning server commit. Account files contain the normal
+profile plus every resolved provisioning dependency's path, commit, and dirty
+status. Account files contain the normal
 Argon2id password record, and the reserved empty player file deliberately
 causes the first client login to use normal character initialization. The
 offline provisioner starts no listener, plugin, metaserver, or console and

--- a/README.md
+++ b/README.md
@@ -66,6 +66,29 @@ The client command opens a graphical application. Verify that the devcontainer
 display forwarding socket is live before launching it. Use `--dry-run` to
 build and print either launch command without starting the process.
 
+### Manual verification handoffs
+
+Change handoffs should end with a copy-pasteable verification recipe that uses
+the thin wrapper instead of internal build paths or direct component binaries.
+Use the actual profile, topology, and state names for the change. A runtime
+client/server review normally follows this shape:
+
+~~~sh
+./atrinik profile show PROFILE
+./atrinik build COMPONENT --profile PROFILE --test
+./atrinik topology show PROFILE --json
+./atrinik up --name TOPOLOGY --profile PROFILE --state STATE
+./atrinik ps TOPOLOGY --json
+./atrinik logs TOPOLOGY client --follow
+# Perform the feature-specific checks described in the handoff.
+./atrinik down TOPOLOGY
+~~~
+
+The handoff should name any display or runtime prerequisite, list the exact
+manual actions and expected results, and include `down` for cleanup. When no
+runtime check applies, it should say so and still provide the relevant wrapper
+build/test and topology-inspection commands.
+
 ## Synchronizing repositories
 
 Inspect the local primary checkouts before changing them:
@@ -174,6 +197,48 @@ repository. Only tracked files below the resource repository's
 files cannot become server assets. Client builds similarly expose the selected
 sound checkout. These operations never write generated files into a component
 checkout.
+
+## Deterministic test scenarios
+
+A scenario is a local, ready-to-login account and character plus its own
+registered server state. It is useful for handing off an issue reproduction
+without asking every reviewer to register another account and character.
+
+~~~sh
+./atrinik scenario create issue-42 --profile maps-review --preset basic-player
+./atrinik scenario show issue-42 --json
+./atrinik scenario credentials issue-42
+~~~
+
+`basic-player` provisions a normal `human_male` first-login character through
+the selected server's own account API. On first login the server supplies its
+configured starting map, standard skills, and initial items. The wrapper builds
+the selected server, creates the dedicated `scenario-issue-42` state, stores a
+generated password in a mode-0600 ignored file, and prints exact
+`topology show`/`up`/`ps`/`logs`/`down` commands. `show` and `list` never reveal
+the password; request it explicitly with `credentials` immediately before
+login.
+
+Scenarios live below ignored `workspace/scenarios/`. Their metadata records the
+profile and exact provisioning server commit. Account files contain the normal
+Argon2id password record, and the reserved empty player file deliberately
+causes the first client login to use normal character initialization. The
+offline provisioner starts no listener, plugin, metaserver, or console and
+refuses existing account or character identities.
+
+After stopping the topology, reset only the scenario-owned mutable state while
+keeping its login and source profile stable:
+
+~~~sh
+./atrinik down issue-42
+./atrinik scenario reset issue-42
+~~~
+
+Reset refuses a running or otherwise locked state and validates the ownership
+marker, state registration, state shape, and credential permissions before it
+replaces anything. External and shared states are never scenario reset targets.
+Do not create static account or player fixtures; add a tested server-owned
+preset if a future reproduction needs more than `basic-player`.
 
 ## Supervised topologies and practical workflows
 

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -130,6 +130,28 @@ def parser() -> argparse.ArgumentParser:
     state_list = state_commands.add_parser("list")
     state_list.add_argument("--json", action="store_true")
 
+    scenario = commands.add_parser(
+        "scenario", help="manage deterministic local test scenarios"
+    )
+    scenario_commands = scenario.add_subparsers(
+        dest="scenario_command", required=True
+    )
+    scenario_create = scenario_commands.add_parser("create")
+    scenario_create.add_argument("name")
+    scenario_create.add_argument("--profile", default="default")
+    scenario_create.add_argument("--preset", default="basic-player")
+    scenario_create.add_argument("--json", action="store_true")
+    scenario_list = scenario_commands.add_parser("list")
+    scenario_list.add_argument("--json", action="store_true")
+    scenario_show = scenario_commands.add_parser("show")
+    scenario_show.add_argument("name")
+    scenario_show.add_argument("--json", action="store_true")
+    scenario_credentials = scenario_commands.add_parser("credentials")
+    scenario_credentials.add_argument("name")
+    scenario_reset = scenario_commands.add_parser("reset")
+    scenario_reset.add_argument("name")
+    scenario_reset.add_argument("--json", action="store_true")
+
     launch = commands.add_parser("run", help="build and run client or server")
     launch_commands = launch.add_subparsers(dest="target", required=True)
     for target in ("client", "server"):
@@ -146,6 +168,32 @@ def parser() -> argparse.ArgumentParser:
 
 def _forwarded_arguments(arguments: list[str]) -> list[str]:
     return arguments[1:] if arguments and arguments[0] == "--" else arguments
+
+
+def _print_scenario(summary: dict[str, object]) -> None:
+    print(f"scenario\t{summary['name']}")
+    print(f"profile\t{summary['profile']}")
+    print(f"preset\t{summary['preset']}")
+    print(f"state\t{summary['state']}")
+    print(f"account\t{summary['account']}")
+    print(f"character\t{summary['character']}")
+    print(f"path\t{summary['path']}")
+
+
+def _print_scenario_handoff(summary: dict[str, object]) -> None:
+    name = summary["name"]
+    profile = summary["profile"]
+    state = summary["state"]
+    print("manual verification:")
+    print(f"  ./atrinik profile show {profile}")
+    print(f"  ./atrinik build all --profile {profile} --test")
+    print(f"  ./atrinik scenario credentials {name}")
+    print(f"  ./atrinik topology show {profile} --state {state} --json")
+    print(f"  ./atrinik up --name {name} --profile {profile} --state {state}")
+    print(f"  ./atrinik ps {name} --json")
+    print(f"  ./atrinik logs {name} server --follow")
+    print(f"  ./atrinik logs {name} client --follow")
+    print(f"  ./atrinik down {name}")
 
 
 def main(arguments: list[str] | None = None) -> int:
@@ -345,6 +393,45 @@ def main(arguments: list[str] | None = None) -> int:
                 else:
                     for name, path in sorted(states.items()):
                         print(f"{name}\t{path}")
+        elif options.command == "scenario":
+            if options.scenario_command == "create":
+                summary = workspace.scenario_create(
+                    options.name, options.profile, options.preset
+                )
+                if options.json:
+                    print(json.dumps(summary, indent=2, sort_keys=True))
+                else:
+                    _print_scenario(summary)
+                    _print_scenario_handoff(summary)
+            elif options.scenario_command == "list":
+                summaries = workspace.scenario_list()
+                if options.json:
+                    print(json.dumps(summaries, indent=2, sort_keys=True))
+                else:
+                    for summary in summaries:
+                        print(
+                            f"{summary['name']}\t{summary['profile']}\t"
+                            f"{summary['preset']}\t{summary['state']}"
+                        )
+            elif options.scenario_command == "show":
+                summary = workspace.scenario_show(options.name)
+                if options.json:
+                    print(json.dumps(summary, indent=2, sort_keys=True))
+                else:
+                    _print_scenario(summary)
+                    _print_scenario_handoff(summary)
+            elif options.scenario_command == "credentials":
+                credentials = workspace.scenario_credentials(options.name)
+                for key in ("account", "character", "password"):
+                    print(f"{key}\t{credentials[key]}")
+            else:
+                summary = workspace.scenario_reset(options.name)
+                if options.json:
+                    print(json.dumps(summary, indent=2, sort_keys=True))
+                else:
+                    print(f"scenario {options.name}: reset")
+                    _print_scenario(summary)
+                    _print_scenario_handoff(summary)
         elif options.command == "run":
             forwarded = _forwarded_arguments(options.arguments)
             if options.target == "client":

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -186,7 +186,7 @@ def _print_scenario_handoff(summary: dict[str, object]) -> None:
     state = summary["state"]
     print("manual verification:")
     print(f"  ./atrinik profile show {profile}")
-    print(f"  ./atrinik build all --profile {profile} --test")
+    print(f"  ./atrinik build server --profile {profile} --test")
     print(f"  ./atrinik scenario credentials {name}")
     print(f"  ./atrinik topology show {profile} --state {state} --json")
     print(f"  ./atrinik up --name {name} --profile {profile} --state {state}")

--- a/atrinik_workspace/model.py
+++ b/atrinik_workspace/model.py
@@ -161,6 +161,7 @@ class Paths:
     profiles: Path
     builds: Path
     topologies: Path
+    scenarios: Path
     state: Path
     marker: Path
     states_file: Path
@@ -185,6 +186,7 @@ class Paths:
             profiles=workspace / "profiles",
             builds=workspace / "build",
             topologies=workspace / "topologies",
+            scenarios=workspace / "scenarios",
             state=workspace / "state",
             marker=workspace / ".atrinik-workspace.json",
             states_file=workspace / "states.json",
@@ -211,6 +213,7 @@ class Paths:
             self.profiles,
             self.builds,
             self.topologies,
+            self.scenarios,
             self.state,
         ):
             directory.mkdir(parents=True, exist_ok=True)

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -4,11 +4,13 @@ import binascii
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import ExitStack, contextmanager
+from datetime import datetime, timezone
 import fcntl
 import hashlib
 import os
 from pathlib import Path, PurePosixPath
 import re
+import secrets
 import shlex
 import shutil
 import signal
@@ -71,6 +73,20 @@ PREFERRED_BUILD_COMPONENTS = set().union(
 TOPOLOGY_SERVICES = ("server", "client")
 RESOURCE_PATHS_MANIFEST = "runtime-paths.txt"
 SERVER_IDENTITY_MAX_SIZE = 64 * 1024
+SCENARIO_KEYS = {
+    "schema_version",
+    "name",
+    "profile",
+    "preset",
+    "state",
+    "account",
+    "character",
+    "archetype",
+    "server",
+    "provisioned_at",
+}
+SCENARIO_PRESETS = {"basic-player": {"archetype": "human_male"}}
+SCENARIO_PASSWORD_MAX_SIZE = 128
 
 
 def display_arguments(arguments: list[str]) -> str:
@@ -1055,9 +1071,6 @@ class Workspace:
     def state_add(self, name: str, path: Path | None) -> Path:
         self.paths.ensure()
         validate_name(name, "state name")
-        states = self._load_states()
-        if name in states:
-            raise WorkspaceError(f"state already exists: {name}")
         if path is None:
             resolved = (self.paths.state / "server" / name).resolve(strict=False)
         else:
@@ -1070,10 +1083,269 @@ class Workspace:
             raise WorkspaceError(f"state path is not a directory: {resolved}")
         if resolved.exists():
             self._validate_state(resolved)
-        states[name] = str(resolved)
-        atomic_json(self.paths.states_file, {"schema_version": SCHEMA_VERSION, "states": states})
+        with exclusive_lock(self.paths.workspace / "states.lock", "states registry"):
+            states = self._load_states()
+            if name in states:
+                raise WorkspaceError(f"state already exists: {name}")
+            states[name] = str(resolved)
+            atomic_json(
+                self.paths.states_file,
+                {"schema_version": SCHEMA_VERSION, "states": states},
+            )
         print(resolved)
         return resolved
+
+    def _scenario_directory(self, name: str) -> Path:
+        validate_name(name, "scenario name")
+        directory = (self.paths.scenarios / name).resolve(strict=False)
+        if directory.parent != self.paths.scenarios.resolve():
+            raise WorkspaceError(f"invalid scenario path: {directory}")
+        return directory
+
+    @staticmethod
+    def _write_scenario_password(path: Path, password: str) -> None:
+        descriptor = open_regular_file(
+            path,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            "scenario password",
+            0o600,
+        )
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+                stream.write(password)
+                stream.flush()
+                os.fsync(stream.fileno())
+        except BaseException:
+            path.unlink(missing_ok=True)
+            raise
+
+    @staticmethod
+    def _open_scenario_password(path: Path) -> int:
+        descriptor = open_regular_file(path, os.O_RDONLY, "scenario password")
+        metadata = os.fstat(descriptor)
+        mode = stat.S_IMODE(metadata.st_mode)
+        if mode != 0o600:
+            os.close(descriptor)
+            raise WorkspaceError(
+                f"scenario password must have mode 0600, not {mode:04o}: {path}"
+            )
+        if not 0 < metadata.st_size <= SCENARIO_PASSWORD_MAX_SIZE:
+            os.close(descriptor)
+            raise WorkspaceError(f"scenario password file is invalid: {path}")
+        return descriptor
+
+    @classmethod
+    def _read_scenario_password(cls, path: Path) -> str:
+        descriptor = cls._open_scenario_password(path)
+        try:
+            with os.fdopen(descriptor, encoding="utf-8") as stream:
+                password = stream.read(SCENARIO_PASSWORD_MAX_SIZE + 1)
+                descriptor = -1
+        except UnicodeError as error:
+            raise WorkspaceError(
+                f"scenario password file is not UTF-8: {path}"
+            ) from error
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+        if not password or len(password) > SCENARIO_PASSWORD_MAX_SIZE or "\n" in password:
+            raise WorkspaceError(f"scenario password file is invalid: {path}")
+        return password
+
+    def _load_scenario(self, name: str) -> dict[str, Any]:
+        self.paths.ensure()
+        root = self._scenario_directory(name)
+        if not root.is_dir() or root.is_symlink():
+            raise WorkspaceError(f"scenario does not exist: {name}")
+        marker = root / MANAGED_MARKER
+        if marker.is_symlink() or load_json(marker) != {
+            "schema_version": SCHEMA_VERSION,
+            "purpose": "test-scenario",
+        }:
+            raise WorkspaceError(f"scenario ownership marker is invalid: {name}")
+        metadata_path = root / "scenario.json"
+        if metadata_path.is_symlink():
+            raise WorkspaceError(f"scenario metadata is invalid: {name}")
+        metadata = load_json(metadata_path)
+        if not isinstance(metadata, dict):
+            raise WorkspaceError(f"scenario metadata must be an object: {name}")
+        require_keys(metadata, SCENARIO_KEYS, f"scenario {name}")
+        server = metadata.get("server")
+        if (
+            metadata.get("schema_version") != SCHEMA_VERSION
+            or metadata.get("name") != name
+            or not isinstance(metadata.get("profile"), str)
+            or metadata.get("preset") not in SCENARIO_PRESETS
+            or metadata.get("state") != f"scenario-{name}"
+            or not isinstance(metadata.get("account"), str)
+            or not isinstance(metadata.get("character"), str)
+            or not isinstance(metadata.get("archetype"), str)
+            or not isinstance(metadata.get("provisioned_at"), str)
+            or not metadata["provisioned_at"]
+            or not isinstance(server, dict)
+            or set(server) != {"path", "head"}
+            or not isinstance(server.get("path"), str)
+            or not Path(server["path"]).is_absolute()
+            or not isinstance(server.get("head"), str)
+            or not re.fullmatch(r"[0-9a-f]{40,64}", server["head"])
+        ):
+            raise WorkspaceError(f"scenario metadata is invalid: {name}")
+        state = root / "state"
+        if state.is_symlink():
+            raise WorkspaceError(f"scenario state is invalid: {name}")
+        self._validate_state(state)
+        registered = self._load_states().get(metadata["state"])
+        if registered is None or Path(registered).resolve(strict=False) != state.resolve():
+            raise WorkspaceError(f"scenario state registration is invalid: {name}")
+        os.close(self._open_scenario_password(root / "password"))
+        return metadata
+
+    def _scenario_provision_state(
+        self,
+        metadata: dict[str, Any],
+        state: Path,
+        password_file: Path,
+    ) -> dict[str, str]:
+        required = TARGET_DEPENDENCIES["server"]
+        selected = self._resolve_build_profile(metadata["profile"], required)
+        root = self._build_resolved(
+            "server", metadata["profile"], False, ["server"], selected
+        )
+        runtime = self._prepare_server_runtime(
+            root, selected, state, metadata["state"]
+        )
+        executable = runtime / "atrinik-server"
+        run(
+            [
+                str(executable),
+                "--provision_scenario",
+                f"--provision_account={metadata['account']}",
+                f"--provision_character={metadata['character']}",
+                f"--provision_archetype={metadata['archetype']}",
+                f"--provision_password_file={password_file}",
+            ],
+            cwd=runtime,
+        )
+        server = selected["server"]
+        return {
+            "path": str(server),
+            "head": git(server, "rev-parse", "HEAD", capture=True, trace=False),
+        }
+
+    def scenario_create(
+        self, name: str, profile: str, preset: str = "basic-player"
+    ) -> dict[str, Any]:
+        self.paths.ensure()
+        validate_name(name, "scenario name")
+        if preset not in SCENARIO_PRESETS:
+            raise WorkspaceError(f"unknown scenario preset: {preset}")
+        root = self._scenario_directory(name)
+        state_name = f"scenario-{name}"
+        digest = hashlib.sha256(name.encode()).hexdigest()[:8]
+        metadata: dict[str, Any] = {
+            "schema_version": SCHEMA_VERSION,
+            "name": name,
+            "profile": profile,
+            "preset": preset,
+            "state": state_name,
+            "account": f"scenario{digest}",
+            "character": f"Scenario {digest}",
+            "archetype": SCENARIO_PRESETS[preset]["archetype"],
+            "server": {"path": "/", "head": "0" * 40},
+            "provisioned_at": "pending",
+        }
+        operation_lock = self.paths.scenarios / "operation.lock"
+        with exclusive_lock(operation_lock, "scenario operation"):
+            if root.exists() or root.is_symlink():
+                raise WorkspaceError(f"scenario already exists: {name}")
+            if state_name in self._load_states():
+                raise WorkspaceError(f"state already exists: {state_name}")
+            staging = Path(
+                tempfile.mkdtemp(prefix=f".{name}-", dir=self.paths.scenarios)
+            )
+            try:
+                atomic_json(
+                    staging / MANAGED_MARKER,
+                    {"schema_version": SCHEMA_VERSION, "purpose": "test-scenario"},
+                )
+                password = secrets.token_urlsafe(12)
+                password_file = staging / "password"
+                self._write_scenario_password(password_file, password)
+                server_source = self.component_path("server", profile)
+                state = self.state_path(
+                    state_name, server_source, resolved_path=staging / "state"
+                )
+                metadata["server"] = self._scenario_provision_state(
+                    metadata, state, password_file
+                )
+                metadata["provisioned_at"] = datetime.now(timezone.utc).isoformat()
+                atomic_json(staging / "scenario.json", metadata)
+                staging.replace(root)
+                try:
+                    self.state_add(state_name, (root / "state").resolve())
+                except BaseException:
+                    shutil.rmtree(root)
+                    raise
+            except BaseException:
+                if staging.exists():
+                    shutil.rmtree(staging)
+                raise
+        return self.scenario_show(name)
+
+    def scenario_show(self, name: str) -> dict[str, Any]:
+        metadata = self._load_scenario(name)
+        return {**metadata, "path": str(self._scenario_directory(name))}
+
+    def scenario_list(self) -> list[dict[str, Any]]:
+        self.paths.ensure()
+        scenarios: list[dict[str, Any]] = []
+        for path in sorted(self.paths.scenarios.iterdir()):
+            if path.is_dir() and not path.name.startswith("."):
+                scenarios.append(self.scenario_show(path.name))
+        return scenarios
+
+    def scenario_credentials(self, name: str) -> dict[str, str]:
+        metadata = self._load_scenario(name)
+        return {
+            "account": metadata["account"],
+            "character": metadata["character"],
+            "password": self._read_scenario_password(
+                self._scenario_directory(name) / "password"
+            ),
+        }
+
+    def scenario_reset(self, name: str) -> dict[str, Any]:
+        self.paths.ensure()
+        root = self._scenario_directory(name)
+        operation_lock = self.paths.scenarios / "operation.lock"
+        with exclusive_lock(operation_lock, "scenario operation"):
+            metadata = self._load_scenario(name)
+            state = root / "state"
+            with exclusive_lock(
+                Path(f"{state}.lock"),
+                f"server state {state}",
+                nonblocking=True,
+            ):
+                staging_root = Path(
+                    tempfile.mkdtemp(prefix=f".{name}-reset-", dir=self.paths.scenarios)
+                )
+                try:
+                    server_source = self.component_path("server", metadata["profile"])
+                    staging_state = self.state_path(
+                        metadata["state"],
+                        server_source,
+                        resolved_path=staging_root / "state",
+                    )
+                    metadata["server"] = self._scenario_provision_state(
+                        metadata, staging_state, root / "password"
+                    )
+                    metadata["provisioned_at"] = datetime.now(timezone.utc).isoformat()
+                    replace_directory(state, staging_state, f".{name}-state-previous-")
+                    atomic_json(root / "scenario.json", metadata)
+                finally:
+                    if staging_root.exists():
+                        shutil.rmtree(staging_root)
+        return self.scenario_show(name)
 
     def _load_states(self) -> dict[str, str]:
         if not self.paths.states_file.exists():

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -82,7 +82,7 @@ SCENARIO_KEYS = {
     "account",
     "character",
     "archetype",
-    "server",
+    "resolved",
     "provisioned_at",
 }
 SCENARIO_PRESETS = {"basic-player": {"archetype": "human_male"}}
@@ -1083,6 +1083,11 @@ class Workspace:
             raise WorkspaceError(f"state path is not a directory: {resolved}")
         if resolved.exists():
             self._validate_state(resolved)
+        self._register_state(name, resolved)
+        print(resolved)
+        return resolved
+
+    def _register_state(self, name: str, resolved: Path) -> None:
         with exclusive_lock(self.paths.workspace / "states.lock", "states registry"):
             states = self._load_states()
             if name in states:
@@ -1092,8 +1097,6 @@ class Workspace:
                 self.paths.states_file,
                 {"schema_version": SCHEMA_VERSION, "states": states},
             )
-        print(resolved)
-        return resolved
 
     def _scenario_directory(self, name: str) -> Path:
         validate_name(name, "scenario name")
@@ -1124,10 +1127,11 @@ class Workspace:
         descriptor = open_regular_file(path, os.O_RDONLY, "scenario password")
         metadata = os.fstat(descriptor)
         mode = stat.S_IMODE(metadata.st_mode)
-        if mode != 0o600:
+        wrong_owner = hasattr(os, "geteuid") and metadata.st_uid != os.geteuid()
+        if wrong_owner or mode != 0o600:
             os.close(descriptor)
             raise WorkspaceError(
-                f"scenario password must have mode 0600, not {mode:04o}: {path}"
+                f"scenario password must be owned by this user and mode 0600: {path}"
             )
         if not 0 < metadata.st_size <= SCENARIO_PASSWORD_MAX_SIZE:
             os.close(descriptor)
@@ -1148,7 +1152,12 @@ class Workspace:
         finally:
             if descriptor >= 0:
                 os.close(descriptor)
-        if not password or len(password) > SCENARIO_PASSWORD_MAX_SIZE or "\n" in password:
+        if (
+            not password
+            or len(password) > SCENARIO_PASSWORD_MAX_SIZE
+            or "\n" in password
+            or "\r" in password
+        ):
             raise WorkspaceError(f"scenario password file is invalid: {path}")
         return password
 
@@ -1170,7 +1179,7 @@ class Workspace:
         if not isinstance(metadata, dict):
             raise WorkspaceError(f"scenario metadata must be an object: {name}")
         require_keys(metadata, SCENARIO_KEYS, f"scenario {name}")
-        server = metadata.get("server")
+        resolved = metadata.get("resolved")
         if (
             metadata.get("schema_version") != SCHEMA_VERSION
             or metadata.get("name") != name
@@ -1182,14 +1191,23 @@ class Workspace:
             or not isinstance(metadata.get("archetype"), str)
             or not isinstance(metadata.get("provisioned_at"), str)
             or not metadata["provisioned_at"]
-            or not isinstance(server, dict)
-            or set(server) != {"path", "head"}
-            or not isinstance(server.get("path"), str)
-            or not Path(server["path"]).is_absolute()
-            or not isinstance(server.get("head"), str)
-            or not re.fullmatch(r"[0-9a-f]{40,64}", server["head"])
+            or not isinstance(resolved, dict)
+            or set(resolved) != TARGET_DEPENDENCIES["server"]
         ):
             raise WorkspaceError(f"scenario metadata is invalid: {name}")
+        for component, record in resolved.items():
+            if (
+                not isinstance(record, dict)
+                or set(record) != {"path", "head", "dirty"}
+                or not isinstance(record.get("path"), str)
+                or not Path(record["path"]).is_absolute()
+                or not isinstance(record.get("head"), str)
+                or not re.fullmatch(r"[0-9a-f]{40,64}", record["head"])
+                or not isinstance(record.get("dirty"), bool)
+            ):
+                raise WorkspaceError(
+                    f"scenario component metadata is invalid: {name}/{component}"
+                )
         state = root / "state"
         if state.is_symlink():
             raise WorkspaceError(f"scenario state is invalid: {name}")
@@ -1205,7 +1223,7 @@ class Workspace:
         metadata: dict[str, Any],
         state: Path,
         password_file: Path,
-    ) -> dict[str, str]:
+    ) -> dict[str, dict[str, Any]]:
         required = TARGET_DEPENDENCIES["server"]
         selected = self._resolve_build_profile(metadata["profile"], required)
         root = self._build_resolved(
@@ -1226,10 +1244,15 @@ class Workspace:
             ],
             cwd=runtime,
         )
-        server = selected["server"]
         return {
-            "path": str(server),
-            "head": git(server, "rev-parse", "HEAD", capture=True, trace=False),
+            component: {
+                "path": str(path),
+                "head": git(path, "rev-parse", "HEAD", capture=True, trace=False),
+                "dirty": not _is_clean(path, trace=False),
+            }
+            for component, path in sorted(
+                (component, selected[component]) for component in required
+            )
         }
 
     def scenario_create(
@@ -1251,7 +1274,7 @@ class Workspace:
             "account": f"scenario{digest}",
             "character": f"Scenario {digest}",
             "archetype": SCENARIO_PRESETS[preset]["archetype"],
-            "server": {"path": "/", "head": "0" * 40},
+            "resolved": {},
             "provisioned_at": "pending",
         }
         operation_lock = self.paths.scenarios / "operation.lock"
@@ -1275,14 +1298,14 @@ class Workspace:
                 state = self.state_path(
                     state_name, server_source, resolved_path=staging / "state"
                 )
-                metadata["server"] = self._scenario_provision_state(
+                metadata["resolved"] = self._scenario_provision_state(
                     metadata, state, password_file
                 )
                 metadata["provisioned_at"] = datetime.now(timezone.utc).isoformat()
                 atomic_json(staging / "scenario.json", metadata)
                 staging.replace(root)
                 try:
-                    self.state_add(state_name, (root / "state").resolve())
+                    self._register_state(state_name, (root / "state").resolve())
                 except BaseException:
                     shutil.rmtree(root)
                     raise
@@ -1336,7 +1359,7 @@ class Workspace:
                         server_source,
                         resolved_path=staging_root / "state",
                     )
-                    metadata["server"] = self._scenario_provision_state(
+                    metadata["resolved"] = self._scenario_provision_state(
                         metadata, staging_state, root / "password"
                     )
                     metadata["provisioned_at"] = datetime.now(timezone.utc).isoformat()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -137,6 +137,9 @@ server in offline provisioning mode. The server uses its normal validation,
 Argon2id password, atomic account-save, and exclusive player-reservation paths;
 the empty player record causes first login to follow normal character creation.
 No scenario secret is stored in metadata or passed as a process argument.
+The metadata records path, commit, and dirty status for the selected server,
+content, resources, protocol, and library inputs so an audit does not imply
+that a scenario provisioned from local edits came from a clean commit.
 
 Creation and reset serialize on a scenario-operation lock. State registry
 writes also serialize independently, preventing concurrent state additions

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -129,6 +129,33 @@ A topology may select one service, and distinct runtime names permit concurrent
 combinations as long as their server ports and mutable state directories do not
 conflict.
 
+Test scenarios are owned directories below `workspace/scenarios/`, each with a
+strict metadata record, ownership marker, mode-0600 password file, and dedicated
+registered server state. Creation resolves and builds the scenario profile,
+initializes state from the selected server's `install_data`, and invokes that
+server in offline provisioning mode. The server uses its normal validation,
+Argon2id password, atomic account-save, and exclusive player-reservation paths;
+the empty player record causes first login to follow normal character creation.
+No scenario secret is stored in metadata or passed as a process argument.
+
+Creation and reset serialize on a scenario-operation lock. State registry
+writes also serialize independently, preventing concurrent state additions
+from losing entries. Reset validates that the scenario marker, metadata,
+credentials, registered path, and server-state shape still match, then takes
+the same nonblocking state lock used by server launches. It provisions a fresh
+staging state before atomically replacing only the scenario-owned state, so a
+running topology, external state, symlink, malformed directory, or failed
+provision cannot be overwritten.
+
+Verification handoffs are wrapper-native operating procedures. They identify
+the exact profile, topology, and state selected for a change; use `build
+--test` for automated validation; use `topology show`, `up`, `ps`, and `logs`
+for runtime inspection; describe the feature-specific actions and expected
+results; and finish with `down`. When a ready player is useful, the handoff
+adds `scenario credentials` without copying its password. This keeps manual
+review on the same resolved source topology, isolated client configuration,
+supervised processes, logs, and state locks as automated workspace validation.
+
 The two-terminal foreground launch path uses the same named state and explicit
 UDP port for both commands. Its client reads only the certificate block from
 the state's persistent QUIC identity and hashes the DER certificate to produce

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -183,6 +183,66 @@ class ParserTests(unittest.TestCase):
             "review", "content", "path", "relative"
         )
 
+    def test_scenario_create_prints_complete_manual_handoff(self) -> None:
+        summary = {
+            "name": "issue-42",
+            "profile": "issue-42",
+            "preset": "basic-player",
+            "state": "scenario-issue-42",
+            "account": "scenario12345678",
+            "character": "Scenario 12345678",
+            "path": "/workspace/scenarios/issue-42",
+        }
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.scenario_create.return_value = summary
+            with mock.patch("builtins.print") as output:
+                result = main(
+                    [
+                        "scenario",
+                        "create",
+                        "issue-42",
+                        "--profile",
+                        "issue-42",
+                    ]
+                )
+
+        self.assertEqual(result, 0)
+        workspace_type.return_value.scenario_create.assert_called_once_with(
+            "issue-42", "issue-42", "basic-player"
+        )
+        rendered = "\n".join(str(call.args[0]) for call in output.call_args_list)
+        self.assertIn("./atrinik profile show issue-42", rendered)
+        self.assertIn("./atrinik build all --profile issue-42 --test", rendered)
+        self.assertIn("./atrinik scenario credentials issue-42", rendered)
+        self.assertIn(
+            "./atrinik up --name issue-42 --profile issue-42 "
+            "--state scenario-issue-42",
+            rendered,
+        )
+        self.assertIn("./atrinik ps issue-42 --json", rendered)
+        self.assertIn("./atrinik logs issue-42 client --follow", rendered)
+        self.assertIn("./atrinik down issue-42", rendered)
+
+    def test_scenario_credentials_are_explicitly_requested(self) -> None:
+        credentials = {
+            "account": "scenario12345678",
+            "character": "Scenario 12345678",
+            "password": "secret-value",
+        }
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.scenario_credentials.return_value = credentials
+            with mock.patch("builtins.print") as output:
+                result = main(["scenario", "credentials", "issue-42"])
+
+        self.assertEqual(result, 0)
+        rendered = "\n".join(str(call.args[0]) for call in output.call_args_list)
+        self.assertEqual(
+            rendered,
+            "account\tscenario12345678\n"
+            "character\tScenario 12345678\n"
+            "password\tsecret-value",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -212,7 +212,7 @@ class ParserTests(unittest.TestCase):
         )
         rendered = "\n".join(str(call.args[0]) for call in output.call_args_list)
         self.assertIn("./atrinik profile show issue-42", rendered)
-        self.assertIn("./atrinik build all --profile issue-42 --test", rendered)
+        self.assertIn("./atrinik build server --profile issue-42 --test", rendered)
         self.assertIn("./atrinik scenario credentials issue-42", rendered)
         self.assertIn(
             "./atrinik up --name issue-42 --profile issue-42 "
@@ -242,6 +242,33 @@ class ParserTests(unittest.TestCase):
             "character\tScenario 12345678\n"
             "password\tsecret-value",
         )
+
+    def test_scenario_create_json_is_machine_readable(self) -> None:
+        summary = {
+            "name": "issue-42",
+            "profile": "issue-42",
+            "preset": "basic-player",
+            "state": "scenario-issue-42",
+            "account": "scenario12345678",
+            "character": "Scenario 12345678",
+            "path": "/workspace/scenarios/issue-42",
+        }
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.scenario_create.return_value = summary
+            with mock.patch("builtins.print") as output:
+                result = main(
+                    [
+                        "scenario",
+                        "create",
+                        "issue-42",
+                        "--profile",
+                        "issue-42",
+                        "--json",
+                    ]
+                )
+
+        self.assertEqual(result, 0)
+        self.assertEqual(json.loads(output.call_args.args[0]), summary)
 
 
 if __name__ == "__main__":

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 import shutil
 import signal
+import stat
 import subprocess
 import tempfile
 import time
@@ -850,6 +851,86 @@ class WorkspaceTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "lacks required file"):
             self.workspace.state_add("bad", malformed)
         self.assertEqual((malformed / "unrelated").read_text(), "keep\n")
+
+    def test_scenario_lifecycle_owns_isolated_state_and_credentials(self) -> None:
+        server = self.workspace.paths.repositories / "server"
+        server_record = {
+            "path": str(server),
+            "head": command("git", "rev-parse", "HEAD", cwd=server),
+        }
+        with mock.patch.object(
+            self.workspace, "_scenario_provision_state", return_value=server_record
+        ) as provision:
+            created = self.workspace.scenario_create(
+                "issue-42", "default", "basic-player"
+            )
+
+            self.assertEqual(created["state"], "scenario-issue-42")
+            self.assertEqual(created["account"], "scenario1dd9ee81")
+            self.assertEqual(created["character"], "Scenario 1dd9ee81")
+            scenario_root = self.workspace.paths.scenarios / "issue-42"
+            state = scenario_root / "state"
+            self.assertEqual(
+                Path(self.workspace.list_states()["scenario-issue-42"]), state
+            )
+            self.assertEqual(
+                stat.S_IMODE((scenario_root / "password").stat().st_mode), 0o600
+            )
+            credentials = self.workspace.scenario_credentials("issue-42")
+            self.assertEqual(credentials["account"], created["account"])
+            self.assertEqual(credentials["character"], created["character"])
+            self.assertTrue(credentials["password"])
+
+            (state / "accounts").mkdir()
+            reset = self.workspace.scenario_reset("issue-42")
+            self.assertFalse((state / "accounts").exists())
+            self.assertGreater(reset["provisioned_at"], created["provisioned_at"])
+
+        self.assertEqual(provision.call_count, 2)
+
+    def test_scenario_create_rolls_back_failed_provisioning(self) -> None:
+        with mock.patch.object(
+            self.workspace,
+            "_scenario_provision_state",
+            side_effect=WorkspaceError("provision failed"),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "provision failed"):
+                self.workspace.scenario_create("failed", "default")
+
+        self.assertFalse((self.workspace.paths.scenarios / "failed").exists())
+        self.assertNotIn("scenario-failed", self.workspace.list_states())
+
+    def test_scenario_rejects_insecure_password_permissions(self) -> None:
+        server = self.workspace.paths.repositories / "server"
+        server_record = {
+            "path": str(server),
+            "head": command("git", "rev-parse", "HEAD", cwd=server),
+        }
+        with mock.patch.object(
+            self.workspace, "_scenario_provision_state", return_value=server_record
+        ):
+            self.workspace.scenario_create("permissions", "default")
+
+        password = self.workspace.paths.scenarios / "permissions" / "password"
+        password.chmod(0o644)
+        with self.assertRaisesRegex(WorkspaceError, "mode 0600"):
+            self.workspace.scenario_show("permissions")
+
+    def test_scenario_reset_refuses_locked_state(self) -> None:
+        server = self.workspace.paths.repositories / "server"
+        server_record = {
+            "path": str(server),
+            "head": command("git", "rev-parse", "HEAD", cwd=server),
+        }
+        with mock.patch.object(
+            self.workspace, "_scenario_provision_state", return_value=server_record
+        ):
+            self.workspace.scenario_create("locked", "default")
+
+        state = self.workspace.paths.scenarios / "locked" / "state"
+        with exclusive_lock(Path(f"{state}.lock"), "test state"):
+            with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                self.workspace.scenario_reset("locked")
 
     def test_foreground_client_pins_matching_server_state(self) -> None:
         server = self.workspace.paths.repositories / "server"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -139,6 +139,17 @@ class WorkspaceTests(unittest.TestCase):
         self.seeds[name] = seed
         self.origins[name] = origin
 
+    def scenario_resolved_fixture(self) -> dict[str, dict[str, object]]:
+        resolved: dict[str, dict[str, object]] = {}
+        for component in ("server", "content", "resources", "libatrinik", "protocol"):
+            path = self.workspace.paths.repositories / component
+            resolved[component] = {
+                "path": str(path),
+                "head": command("git", "rev-parse", "HEAD", cwd=path),
+                "dirty": False,
+            }
+        return resolved
+
     def advance_origin(self, name: str, filename: str) -> str:
         seed = self.seeds[name]
         command("git", "pull", "--ff-only", cwd=seed)
@@ -853,17 +864,15 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual((malformed / "unrelated").read_text(), "keep\n")
 
     def test_scenario_lifecycle_owns_isolated_state_and_credentials(self) -> None:
-        server = self.workspace.paths.repositories / "server"
-        server_record = {
-            "path": str(server),
-            "head": command("git", "rev-parse", "HEAD", cwd=server),
-        }
+        resolved = self.scenario_resolved_fixture()
         with mock.patch.object(
-            self.workspace, "_scenario_provision_state", return_value=server_record
+            self.workspace, "_scenario_provision_state", return_value=resolved
         ) as provision:
-            created = self.workspace.scenario_create(
-                "issue-42", "default", "basic-player"
-            )
+            with mock.patch("builtins.print") as output:
+                created = self.workspace.scenario_create(
+                    "issue-42", "default", "basic-player"
+                )
+            output.assert_not_called()
 
             self.assertEqual(created["state"], "scenario-issue-42")
             self.assertEqual(created["account"], "scenario1dd9ee81")
@@ -900,14 +909,50 @@ class WorkspaceTests(unittest.TestCase):
         self.assertFalse((self.workspace.paths.scenarios / "failed").exists())
         self.assertNotIn("scenario-failed", self.workspace.list_states())
 
-    def test_scenario_rejects_insecure_password_permissions(self) -> None:
-        server = self.workspace.paths.repositories / "server"
-        server_record = {
-            "path": str(server),
-            "head": command("git", "rev-parse", "HEAD", cwd=server),
+    def test_scenario_audit_records_only_server_dependency_closure(self) -> None:
+        required = {"server", "content", "resources", "libatrinik", "protocol"}
+        selected = {
+            component: self.workspace.paths.repositories / component
+            for component in (*sorted(required), "client")
         }
+        metadata = {
+            "profile": "default",
+            "state": "scenario-audit",
+            "account": "scenarioaudit",
+            "character": "Scenario Audit",
+            "archetype": "human_male",
+        }
+        runtime = self.root / "scenario-runtime"
+        runtime.mkdir()
+        with (
+            mock.patch.object(
+                self.workspace, "_resolve_build_profile", return_value=selected
+            ),
+            mock.patch.object(
+                self.workspace, "_build_resolved", return_value=self.root / "build"
+            ),
+            mock.patch.object(
+                self.workspace, "_prepare_server_runtime", return_value=runtime
+            ),
+            mock.patch("atrinik_workspace.workspace.run"),
+            mock.patch(
+                "atrinik_workspace.workspace.git", return_value="a" * 40
+            ),
+            mock.patch(
+                "atrinik_workspace.workspace._is_clean", return_value=True
+            ),
+        ):
+            resolved = self.workspace._scenario_provision_state(
+                metadata, self.root / "state", self.root / "password"
+            )
+
+        self.assertEqual(set(resolved), required)
+        self.assertNotIn("client", resolved)
+
+    def test_scenario_rejects_insecure_password_permissions(self) -> None:
+        resolved = self.scenario_resolved_fixture()
         with mock.patch.object(
-            self.workspace, "_scenario_provision_state", return_value=server_record
+            self.workspace, "_scenario_provision_state", return_value=resolved
         ):
             self.workspace.scenario_create("permissions", "default")
 
@@ -917,13 +962,9 @@ class WorkspaceTests(unittest.TestCase):
             self.workspace.scenario_show("permissions")
 
     def test_scenario_reset_refuses_locked_state(self) -> None:
-        server = self.workspace.paths.repositories / "server"
-        server_record = {
-            "path": str(server),
-            "head": command("git", "rev-parse", "HEAD", cwd=server),
-        }
+        resolved = self.scenario_resolved_fixture()
         with mock.patch.object(
-            self.workspace, "_scenario_provision_state", return_value=server_record
+            self.workspace, "_scenario_provision_state", return_value=resolved
         ):
             self.workspace.scenario_create("locked", "default")
 


### PR DESCRIPTION
## Summary

- add `scenario create`, `list`, `show`, `credentials`, and `reset` lifecycle commands
- own an isolated registered state and mode-0600 generated password for each ready-to-login local player
- provision through the selected server from atrinik/server#46 instead of handcrafted save files
- audit the complete provisioning dependency closure, including dirty worktrees
- print exact wrapper-native build, credentials, topology, status, logs, and cleanup commands
- add the `atrinik-test-scenario` repository skill and synchronize AGENTS, workspace guidance, README, and architecture docs

## Safety

- failed creates remain unpublished and unregistered
- resets stage a complete replacement while holding the normal server-state lock
- ownership markers, state registration, file shape, credential ownership/mode, and symlinks are validated before use
- machine-readable create/show/list/reset output remains valid JSON on stdout

## Validation

- `python3 -m unittest discover -s tests` (79/79 passed)
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- scenario skill quick validation
- `git diff --check`
- real create/show/reset, JSON audit, file-mode inspection, and supervised server readiness smoke test

Depends on atrinik/server#46.