### PR TITLE
fix(ci): restore generated release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,5 +33,5 @@ jobs:
           npx --yes
           --package=semantic-release@25.0.9
           --package=@semantic-release/exec@7.1.0
-          --package=conventional-changelog-conventionalcommits@10.2.1
+          --package=conventional-changelog-conventionalcommits@9.3.1
           semantic-release


### PR DESCRIPTION
## Summary

- pin conventional-changelog-conventionalcommits to the writer-v8-compatible 9.3.1 release
- restore Features and Bug Fixes sections in semantic-release GitHub release descriptions
- avoid the silent header-only output caused by preset v10 with conventional-changelog-writer v8

## Validation

- actionlint .github/workflows/release.yml
- git diff --check

Upstream: https://github.com/semantic-release/release-notes-generator/issues/992