### PR TITLE
docs: add specialist agent skills

### DIFF
--- a/.agents/skills/atrinik-c-change/SKILL.md
+++ b/.agents/skills/atrinik-c-change/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: atrinik-c-change
+description: Implement and validate Atrinik C17 code, headers, native builds, warnings, formatting, tests, and public APIs. Use when native client, server, libatrinik, CMake, or generated-consumer code is the primary change.
+---
+
+# Atrinik C Change
+
+Use this skill for native implementation work whose primary contract is C or
+C++. Use `atrinik-protocol-change` instead when the wire contract is primary,
+and combine this skill with `atrinik-multi-repo-workspace` when more than one
+standalone repository is involved.
+
+## Establish ownership
+
+1. Read the workspace and selected component `AGENTS.md` files.
+2. Select the owning component through a workspace profile; do not edit a dirty
+   primary checkout or copy implementation into the wrapper repository.
+3. Trace declarations, implementations, generated inputs, callers, and tests
+   before changing an API. `client` and `server` are C17 applications;
+   `libatrinik` owns reusable native libraries; `protocol` owns generated
+   command identifiers.
+4. Preserve component boundaries. Move generally reusable code into
+   `libatrinik` only when its ownership and consumer contract are clear.
+
+## Implement the contract
+
+- Follow each repository's `.clang-format` and existing naming, allocation,
+  logging, error, and ownership conventions.
+- Update the authoritative source rather than generated output. For protocol
+  identifiers, edit `protocol/schema/game-commands.json` and regenerate. For
+  Flex or export-definition output, update the checked-in source input.
+- Update CMake source lists such as `src/cmake.txt` when files are added or
+  removed. Keep public headers minimal and document lifetime and ownership at
+  the boundary.
+- Treat compiler warnings, sanitizer findings, and static-analysis reports as
+  defects. Do not suppress a diagnostic without explaining the local contract.
+- Add focused unit or integration coverage for success, boundary, failure, and
+  cleanup paths. Preserve deterministic behavior where state or ordering is
+  observable.
+
+## Validate through the workspace
+
+Build and test every affected native component with the selected profile:
+
+```sh
+./atrinik profile show PROFILE
+./atrinik build COMPONENT --profile PROFILE --test
+```
+
+Build downstream consumers when a public `libatrinik` API or generated
+protocol identifier changes. Run repository-specific generation checks,
+formatters, sanitizers, static analysis, and the documented `linux-coverage`
+preset for substantial native logic changes, then run `git diff --check` in
+each changed repository. Keep gcovr source and test exclusions intentional.
+
+If behavior requires a live client/server check, follow the complete
+`topology show`/`up`/`ps`/`logs`/`down` lifecycle from the workspace guide and
+use `atrinik-test-scenario` when a ready account and character are useful.

--- a/.agents/skills/atrinik-c-change/agents/openai.yaml
+++ b/.agents/skills/atrinik-c-change/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Atrinik C Change"
+  short_description: "Implement and validate Atrinik native code"
+  default_prompt: "Use $atrinik-c-change to implement this native Atrinik change in the owning component and validate every affected consumer."

--- a/.agents/skills/atrinik-content-change/SKILL.md
+++ b/.agents/skills/atrinik-content-change/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: atrinik-content-change
+description: Change and validate Atrinik maps, archetypes, graphics, animations, artifacts, treasures, factions, interfaces, quests, and embedded scripts. Use when authored files or content collection in the content repository are primary.
+---
+
+# Atrinik Content Change
+
+Use this skill for authored world data in the standalone `content` repository.
+Combine it with `atrinik-multi-repo-workspace` when a server, client, resource,
+or tooling change is also required.
+
+## Establish the content contract
+
+1. Read the workspace guide plus `content/AGENTS.md` and the nearest nested
+   guide under `arch/` or `maps/`.
+2. Work in a selected content worktree. Do not write generated runtime output
+   back into the source tree or replace a mutable server-data directory.
+3. Use `tools/content_catalog` as the authoritative identity and cross-reference
+   layer. Domain-qualified stable IDs are contracts; display names, filesystem
+   order, and runtime table positions are not identities.
+4. Trace every map path, archetype, animation, image, artifact, treasure,
+   faction, interface, and script reference touched by the change.
+
+## Make the change
+
+- Preserve established file layout, formatting, naming, attribution, and
+  per-asset licensing. Keep unrelated normalizer churn out of the diff.
+- Keep map and archetype references portable and case-correct. Never hide a
+  missing reference with a local absolute path or a generated placeholder.
+- Treat embedded Python as runtime code: preserve engine-owned entry points,
+  avoid nondeterministic side effects, and validate failure behavior.
+- Use `tools/world_content_audit.py` only for read-only exploratory summaries.
+  It does not replace `tools/validate.py` or the catalog, and report findings
+  are not generated source.
+- The standalone `tools` repository owns the map checker. Do not copy its
+  implementation or bypass its released content-catalog dependency.
+
+## Validate
+
+Run the canonical content validator and build an isolated runtime tree:
+
+```sh
+python3 tools/validate.py
+python3 tools/build_runtime.py --output /tmp/atrinik-content-runtime
+python3 tools/world_content_audit.py all
+```
+
+Use a task-specific temporary directory rather than the literal example when
+concurrent work is possible. Run focused collection or audit commands for the
+changed domain, then `git diff --check`.
+
+For live behavior, select the content worktree in a workspace profile, build
+the affected server/client components with `./atrinik build ... --test`, and
+hand off the exact wrapper-native topology lifecycle. Use
+`atrinik-test-scenario` for repeatable gameplay state.

--- a/.agents/skills/atrinik-content-change/agents/openai.yaml
+++ b/.agents/skills/atrinik-content-change/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Atrinik Content Change"
+  short_description: "Change and validate Atrinik world content"
+  default_prompt: "Use $atrinik-content-change to update this authored Atrinik content and validate its identities, references, runtime collection, and behavior."

--- a/.agents/skills/atrinik-github-governance/SKILL.md
+++ b/.agents/skills/atrinik-github-governance/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: atrinik-github-governance
+description: Maintain Atrinik GitHub repository settings, rulesets, merge policy, Actions permissions, required checks, organization policy, and governance automation. Use for any repository-policy or workflow-contract change.
+---
+
+# Atrinik GitHub Governance
+
+Use this skill for changes to the standalone `github-settings` repository or
+to an Atrinik Actions workflow whose permissions, check names, dependency
+policy, or branch-protection contract may change.
+
+## Review desired and live state
+
+1. Read the workspace and `github-settings/AGENTS.md` guides.
+2. Inspect the relevant `config/*.json`, publisher script, workflow, and recent
+   repository history. Treat configuration as desired state and the GitHub API
+   as live state; do not infer policy from one alone.
+3. Use the publisher's default plan mode before considering `--apply`.
+   Applying settings, changing repositories, or dispatching workflows requires
+   explicit authorization because it mutates external organization state.
+4. Preserve the current Team-plan compatibility contract. Do not introduce an
+   Enterprise-only control without a documented, reviewed migration.
+
+## Change policy coherently
+
+- Keep required workflow job names synchronized with repository rulesets.
+- Update the Actions allowlist, permissions, dependency pinning, and required
+  aggregate status when a workflow changes those contracts.
+- Keep merge methods, semantic-release behavior, Conventional Commit policy,
+  repository visibility, and default-branch assumptions consistent.
+- Keep Codecov in the selected-actions policy and its GitHub App repository
+  access in manual desired state while coverage workflows use OIDC uploads.
+- Use least-privilege workflow permissions and immutable third-party action
+  references where project policy requires them.
+- Never print tokens or copy live secrets into configuration, logs, fixtures,
+  commits, or review text.
+
+## Validate and hand off
+
+Run JSON parsing, shell syntax, ShellCheck, actionlint for workflow changes,
+the publisher's plan mode, and `git diff --check`. Review the complete plan for
+unexpected deletions or relaxations before any authorized apply.
+
+Document affected repositories, required check names, expected plan changes,
+rollback or re-plan steps, and whether live state was intentionally left
+unchanged. Use Conventional Commits for commits and pull-request titles.

--- a/.agents/skills/atrinik-github-governance/agents/openai.yaml
+++ b/.agents/skills/atrinik-github-governance/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Atrinik GitHub Governance"
+  short_description: "Maintain Atrinik repository and Actions policy"
+  default_prompt: "Use $atrinik-github-governance to review and update this Atrinik GitHub policy safely, validating desired state before any authorized apply."

--- a/.agents/skills/atrinik-protocol-change/SKILL.md
+++ b/.agents/skills/atrinik-protocol-change/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: atrinik-protocol-change
+description: Trace, redesign, implement, document, and validate Atrinik wire contracts. Use when protocol schemas, generated IDs, classic packets, QUIC payloads, ADS, or producer-consumer compatibility are primary.
+---
+
+# Atrinik Protocol Change
+
+Use this skill whenever bytes crossing a process or repository boundary are the
+primary contract. Combine it with `atrinik-multi-repo-workspace` and the
+relevant implementation skill for coordinated consumer changes.
+
+## Trace the whole contract
+
+1. Read every affected repository guide and select all sources with a workspace
+   profile before editing.
+2. Identify the authoritative contract. Classic command IDs come from
+   `protocol/schema/game-commands.json`; payload layouts may still be owned by
+   client/server implementations; ADS schemas live with their content format;
+   metaserver bootstrap contracts are owned by `metaserver-worker`.
+3. Find producers, consumers, generated outputs, fixtures, tests,
+   documentation, packet tooling, and release dependencies. Do not assume the
+   repository containing a numeric constant owns the protocol.
+4. Write down framing, field order, widths, signedness, byte order, lengths,
+   nullability, limits, state transitions, error behavior, and compatibility
+   policy before implementation.
+
+## Implement one coherent transition
+
+- Edit schemas or other source definitions, regenerate checked-in artifacts,
+  and verify generation is clean. Never hand-edit generated IDs.
+- Update every in-scope producer and consumer together when compatibility is
+  intentionally broken. Delete superseded commands only after all selected
+  consumers have moved.
+- Reject malformed, truncated, oversized, out-of-order, or impossible input at
+  the boundary. Keep parsing transactional so partial messages cannot leak
+  half-applied state.
+- Avoid parallel old/new paths unless an explicit compatibility window owns
+  their removal. Use precise protocol names rather than vague age labels.
+- Add golden or round-trip fixtures and negative boundary tests where useful.
+
+## Validate every consumer
+
+Run protocol generation checks, the protocol unit and CMake suites, and wrapper
+build/tests for every affected component:
+
+```sh
+./atrinik profile show PROFILE
+./atrinik build protocol --profile PROFILE --test
+./atrinik build COMPONENT --profile PROFILE --test
+```
+
+Run `git diff --check` in each repository. For a live transition, hand off the
+complete wrapper topology lifecycle and exact observable result; use
+`atrinik-test-scenario` when login state is needed. The final report must name
+the authoritative source, changed consumers, compatibility decision, and tests.

--- a/.agents/skills/atrinik-protocol-change/agents/openai.yaml
+++ b/.agents/skills/atrinik-protocol-change/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Atrinik Protocol Change"
+  short_description: "Change Atrinik wire contracts coherently"
+  default_prompt: "Use $atrinik-protocol-change to trace and update this Atrinik wire contract across its authoritative source, producers, consumers, and tests."

--- a/.agents/skills/atrinik-server-runtime/SKILL.md
+++ b/.agents/skills/atrinik-server-runtime/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: atrinik-server-runtime
+description: Prepare, run, diagnose, and validate Atrinik classic server builds, collected resources, isolated state, deterministic scenarios, and supervised topologies. Use for server runtime setup, smoke tests, or failures.
+---
+
+# Atrinik Server Runtime
+
+Use this skill for running or diagnosing the classic server. Use the workspace
+wrapper for builds, collection, state registration, supervision, logs, and
+cleanup; do not reconstruct its internal paths or invoke build artifacts
+directly when the wrapper supports the operation.
+
+## Prepare an isolated runtime
+
+1. Read the workspace and server guides plus `atrinik-multi-repo-workspace`.
+2. Select exact server, content, resources, protocol, and library sources in a
+   named profile. Inspect them with `./atrinik profile show` and
+   `./atrinik topology show`.
+3. Build and test the server through the wrapper:
+
+   ```sh
+   ./atrinik build server --profile PROFILE --test
+   ```
+
+4. Use a distinct registered state for each concurrent topology. Never replace
+   a dirty worktree, overwrite mutable server data, share state between running
+   topologies, or edit wrapper-managed runtime files by hand.
+
+## Run and diagnose
+
+For persistent supervised testing:
+
+```sh
+./atrinik topology show PROFILE --state STATE --json
+./atrinik up --name NAME --profile PROFILE --state STATE
+./atrinik ps NAME --json
+./atrinik logs NAME server --follow
+./atrinik down NAME
+```
+
+Let `up` allocate ports unless a distinct port is required. Use wrapper logs
+and status rather than internal PID or log files. Separate build failures,
+missing collected resources, invalid state, plugin loading, network setup, and
+gameplay behavior before changing code.
+
+Use `atrinik-test-scenario` when the check needs a deterministic account and
+character. The server's offline provisioner must remain listener-, plugin-,
+console-, and metaserver-free and must persist through normal account APIs;
+never handcraft account or player files.
+
+## Validate and clean up
+
+Run the complete server test suite and task-specific resource or map generation
+checks. For client-visible behavior, inspect both service logs and state the
+exact login actions and expected outcome. Always stop the named topology; reset
+only scenario-owned state through `./atrinik scenario reset NAME` when a clean
+repeat is needed. Finish with `git diff --check` in each changed repository.

--- a/.agents/skills/atrinik-server-runtime/agents/openai.yaml
+++ b/.agents/skills/atrinik-server-runtime/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Atrinik Server Runtime"
+  short_description: "Run and diagnose isolated Atrinik servers"
+  default_prompt: "Use $atrinik-server-runtime to prepare and diagnose this Atrinik server runtime through an exact profile, isolated state, supervised logs, and safe cleanup."

--- a/.agents/skills/atrinik-test-scenario/agents/openai.yaml
+++ b/.agents/skills/atrinik-test-scenario/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Atrinik Test Scenario"
   short_description: "Provision deterministic local Atrinik test players"
-  default_prompt: "Set up the smallest deterministic local Atrinik account and character scenario for this manual reproduction, then provide exact ./atrinik verification and cleanup commands."
+  default_prompt: "Use $atrinik-test-scenario to set up the smallest deterministic local Atrinik account and character scenario for this reproduction, then provide exact ./atrinik verification and cleanup commands."

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ __pycache__/
 .venv/
 .coverage
 coverage.xml
+*:Zone.Identifier

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,12 @@
 - For work that spans component repositories, read and follow
   `.agents/skills/atrinik-multi-repo-workspace/SKILL.md` before changing a
   checkout, worktree, profile, release configuration, or GitHub repository.
+- Use the narrowest specialist skill that owns the change: `atrinik-c-change`
+  for native code, `atrinik-protocol-change` for wire contracts,
+  `atrinik-content-change` for authored world data, `atrinik-server-runtime`
+  for classic server execution, and `atrinik-github-governance` for repository
+  policy or Actions. Combine one with the multi-repository skill when ownership
+  crosses component boundaries.
 - Primary component checkouts are independent ignored Git repositories directly
   below the wrapper root. Component worktrees, builds, profiles, and default
   mutable state belong below the ignored workspace directory or an explicit
@@ -28,6 +34,8 @@
   merge is released by semantic-release.
 - Run the complete Python test suite, compileall, ShellCheck for shell changes,
   actionlint for workflow changes, and `git diff --check` before finishing.
+  Coordinator logic changes must also preserve the `.coveragerc` source and
+  omission boundaries and the OIDC-authenticated Codecov report.
 - Every implementation or change handoff must include copy-pasteable manual
   verification commands that use the thin `./atrinik` wrapper whenever it
   supports the workflow. Use exact profile, worktree, topology, service, and
@@ -39,9 +47,15 @@
 - Use `.agents/skills/atrinik-test-scenario/SKILL.md` when manual verification
   benefits from a ready local account and character. Keep scenario credentials
   and state ignored and isolated; never handcraft account or player files.
+- Keep component-specific instructions in the owning component repository.
+  Wrapper skills may coordinate those contracts, but must not duplicate their
+  implementation or become a second source of truth for component commands.
 - Deep-review reports are ignored local artifacts under `build/`; do not commit
   them.
 - Keep this guide, the multi-repository skill, `README.md`, and
   `docs/ARCHITECTURE.md` synchronized with changes to the `atrinik` command,
   `components.json`, managed layout, ownership boundaries, or cross-repository
   development and release procedures.
+- When major rework changes ownership, layout, commands, safety boundaries, or
+  validation contracts, update every affected `AGENTS.md` and skill in the same
+  change. Treat stale agent guidance as an implementation defect.


### PR DESCRIPTION
## Summary

- add specialist skills for native C, content, protocol, server runtime, and GitHub governance work
- route the workspace guide to the narrowest owning skill and require agent guidance to self-update with major rework
- fix deterministic-scenario skill invocation metadata and ignore Windows zone sidecars

## Validation

- all seven workspace skills pass skill-creator quick validation
- 79 wrapper unit tests pass
- compileall, ShellCheck, and git diff checks pass
- the complete agent-guidance component profile builds and tests successfully

## Manual verification

From the Atrinik workspace root:

```sh
./atrinik profile show agent-guidance
./atrinik build all --profile agent-guidance --test
```

This documentation and skill change does not require a live topology and creates no mutable server state.