### PR TITLE
feat: automate supply-chain ownership

### DIFF
--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -157,6 +157,14 @@ files directly.
 
 ## Coordinate releases and GitHub changes
 
+- Treat `supply-chain/inventory.json` in the wrapper as the aggregate ownership
+  catalog while component lockfiles remain their release integrity boundary.
+  Update the catalog when a supported dependency, toolchain, action, image,
+  vendored source, license, owner, cadence, EOL response, or validation path
+  changes. Keep remote Actions on full commits with updater comments, images on
+  manifest digests, and Git submodules absent. Validate a coordinated profile
+  with `./atrinik supply-chain audit --profile PROFILE` and generate ignored
+  license/CycloneDX/SPDX reports through the same command.
 - Keep each repository independently releasable. A component squash commit
   changes and releases that component; never couple publication to a wrapper
   checkout or submodule pointer.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Atrinik 2026 Linux Build",
-  "image": "ghcr.io/atrinik/linux-build:1.0.3",
+  "image": "ghcr.io/atrinik/linux-build:1.0.5@sha256:be3427cfc7dabcf837450c7306d55883c32e20ba1ab7cc96b4da4b966b8066de",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:4": {
       "moby": false

--- a/.devcontainer/windows-cross/devcontainer.json
+++ b/.devcontainer/windows-cross/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Atrinik Windows cross-build (MXE)",
-  "image": "ghcr.io/atrinik/windows-build:1.0.3",
+  "image": "ghcr.io/atrinik/windows-build:1.0.5@sha256:9cc373f620a577328fc0a7a7fa823bddaca6d7dc75ac73bcf21be421c49676f7",
   "workspaceFolder": "/workspaces/atrinik",
   "remoteUser": "vscode",
   "initializeCommand": "if [ ! -e \"${localEnv:HOME}/.gitconfig\" ]; then install -m 600 /dev/null \"${localEnv:HOME}/.gitconfig\"; fi",

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           cache: pip
           cache-dependency-path: requirements-dev.txt
@@ -33,8 +33,9 @@ jobs:
           python3 -m coverage xml
           python3 -m compileall -q atrinik atrinik_workspace tests
           ./atrinik manifest validate
+          ./atrinik supply-chain validate
       - name: Upload coverage report
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:
           disable_search: true
           fail_ci_if_error: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
       - name: Analyze commits and publish

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,0 +1,86 @@
+name: Supply chain
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 5 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Organization dependency audit
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: atrinik/client
+          path: client
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: atrinik/server
+          path: server
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: atrinik/protocol
+          path: protocol
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: atrinik/libatrinik
+          path: libatrinik
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: atrinik/content
+          path: content
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: atrinik/sound
+          path: sound
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: atrinik/resources
+          path: resources
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: atrinik/tools
+          path: tools
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: atrinik/editor
+          path: editor
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: atrinik/metaserver-worker
+          path: metaserver-worker
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: atrinik/devcontainer
+          path: devcontainer
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: atrinik/github-settings
+          path: github-settings
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.13"
+      - name: Audit dependency ownership
+        run: |
+          ./atrinik supply-chain validate
+          ./atrinik supply-chain audit
+          ./atrinik supply-chain versions \
+            --output build/supply-chain/versions.json
+          ./atrinik supply-chain report --format licenses \
+            --output build/supply-chain/licenses.md
+          ./atrinik supply-chain report --format cyclonedx \
+            --output build/supply-chain/cyclonedx.json
+          ./atrinik supply-chain report --format spdx \
+            --output build/supply-chain/spdx.json
+      - name: Upload supply-chain reports
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: atrinik-supply-chain
+          path: build/supply-chain
+          if-no-files-found: error

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,11 @@
   actionlint for workflow changes, and `git diff --check` before finishing.
   Coordinator logic changes must also preserve the `.coveragerc` source and
   omission boundaries and the OIDC-authenticated Codecov report.
+- `supply-chain/inventory.json` is the organization-wide dependency ownership
+  source. Update it with every supported toolchain, package source, action,
+  image, vendored input, license, owner, cadence, EOL response, and validation
+  path. Keep Actions and images immutable, retain updater hints, do not add Git
+  submodules, and run the profile-aware `./atrinik supply-chain audit`.
 - Every implementation or change handoff must include copy-pasteable manual
   verification commands that use the thin `./atrinik` wrapper whenever it
   supports the workflow. Use exact profile, worktree, topology, service, and

--- a/README.md
+++ b/README.md
@@ -39,6 +39,40 @@ The wrapper owns these launch configurations because they compose the complete
 development workspace. The standalone `devcontainer` component owns only the
 published Linux and Windows toolchain images they reference.
 
+## Dependency and supply-chain ownership
+
+`supply-chain/inventory.json` records every supported repository and the owned
+toolchains, actions, images, source archives, system libraries, optional tools,
+vendored sources, licenses, update cadences, EOL responses, and validation
+paths they consume. The strict schema is checked without a third-party Python
+dependency. GitHub Actions and container images use immutable commits or
+digests with human-readable update hints, and every active repository enables
+weekly Dependabot updates for its supported ecosystems. Git submodules are not
+a supported dependency path.
+
+Validate the catalog alone or audit the exact checkouts selected by a profile:
+
+~~~sh
+./atrinik supply-chain validate
+./atrinik supply-chain audit --profile default
+./atrinik supply-chain versions --output build/supply-chain/versions.json
+./atrinik supply-chain report --format licenses \
+  --output build/supply-chain/licenses.md
+./atrinik supply-chain report --format cyclonedx \
+  --output build/supply-chain/cyclonedx.json
+./atrinik supply-chain report --format spdx \
+  --output build/supply-chain/spdx.json
+~~~
+
+Generated reports remain ignored under `build/`. A scheduled organization
+audit checks out every active repository, rejects unowned dependency inputs,
+movable workflow/image references, and submodules, prints exact available tool
+versions, and publishes deterministic license, CycloneDX, and SPDX artifacts.
+When auditing a wrapper worktree that cannot safely share its containing
+workspace directory, use repeated absolute `--repository NAME=PATH` overrides;
+the command verifies each override's GitHub repository identity before reading
+it.
+
 ## Quick start
 
 ~~~sh

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import sys
 
 from .model import Manifest, WorkspaceError
+from .supply_chain import Inventory, repository_roots, version_report, write_generated
 from .workspace import Workspace
 
 
@@ -152,6 +153,30 @@ def parser() -> argparse.ArgumentParser:
     scenario_reset.add_argument("name")
     scenario_reset.add_argument("--json", action="store_true")
 
+    supply_chain = commands.add_parser(
+        "supply-chain", help="validate and report dependency ownership"
+    )
+    supply_chain_commands = supply_chain.add_subparsers(
+        dest="supply_chain_command", required=True
+    )
+    supply_chain_commands.add_parser("validate")
+    supply_chain_audit = supply_chain_commands.add_parser("audit")
+    supply_chain_audit.add_argument("--profile", default="default")
+    supply_chain_audit.add_argument(
+        "--repository",
+        action="append",
+        default=[],
+        metavar="NAME=PATH",
+        help="override one component checkout for a read-only audit",
+    )
+    supply_chain_report = supply_chain_commands.add_parser("report")
+    supply_chain_report.add_argument(
+        "--format", choices=["cyclonedx", "licenses", "spdx"], required=True
+    )
+    supply_chain_report.add_argument("--output", type=Path)
+    supply_chain_versions = supply_chain_commands.add_parser("versions")
+    supply_chain_versions.add_argument("--output", type=Path)
+
     launch = commands.add_parser("run", help="build and run client or server")
     launch_commands = launch.add_subparsers(dest="target", required=True)
     for target in ("client", "server"):
@@ -205,7 +230,30 @@ def main(arguments: list[str] | None = None) -> int:
             return 0
 
         workspace = Workspace(ROOT)
-        if options.command == "init":
+        if options.command == "supply-chain":
+            inventory = Inventory.load(
+                ROOT / "supply-chain" / "inventory.json", ROOT / "components.json"
+            )
+            inventory.validate_schema(ROOT / "supply-chain" / "schema.json")
+            if options.supply_chain_command == "validate":
+                print(
+                    "supply-chain/inventory.json: valid "
+                    f"({len(inventory.dependencies)} dependencies)"
+                )
+            elif options.supply_chain_command == "audit":
+                for message in inventory.audit(
+                    repository_roots(
+                        ROOT, workspace, options.profile, options.repository
+                    )
+                ):
+                    print(message)
+            elif options.supply_chain_command == "report":
+                write_generated(
+                    ROOT, options.output, inventory.report(options.format)
+                )
+            else:
+                write_generated(ROOT, options.output, version_report(inventory))
+        elif options.command == "init":
             workspace.initialize(options.components, options.jobs)
         elif options.command == "sync":
             workspace.sync(options.components, options.worktrees)

--- a/atrinik_workspace/supply_chain.py
+++ b/atrinik_workspace/supply_chain.py
@@ -14,11 +14,15 @@ from .model import Manifest, WorkspaceError, load_json, require_keys
 SCHEMA_VERSION = 1
 ACTION_COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 CHECKSUM_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
-DEPENDENCY_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._/-]*$")
 SPDX_PATTERN = re.compile(r"^(?:[A-Za-z0-9-.+]+|NOASSERTION|LicenseRef-[A-Za-z0-9-.]+)$")
 ACTION_REFERENCE_PATTERN = re.compile(
-    r"uses:\s*([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*)"
-    r"@([^\s#]+)(?:\s*#\s*([^\s]+))?"
+    r"^\s*(?:-\s*)?uses:\s*"
+    r"([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*)"
+    r"@([^\s#]+)(?:\s*#\s*([^\s]+))?\s*$",
+    re.MULTILINE,
+)
+USES_DECLARATION_PATTERN = re.compile(
+    r"^\s*(?:-\s*)?uses:\s*(.*?)\s*$", re.MULTILINE
 )
 FROM_PATTERN = re.compile(
     r"^\s*FROM(?:\s+--platform=[^\s]+)?\s+([^\s]+)(?:\s+AS\s+([^\s]+))?",
@@ -26,7 +30,7 @@ FROM_PATTERN = re.compile(
 )
 SYNTAX_PATTERN = re.compile(r"^\s*#\s*syntax=([^\s]+)", re.IGNORECASE | re.MULTILINE)
 DOCKER_PULL_PATTERN = re.compile(r"\bdocker\s+pull\s+([^\s'\"\\]+)")
-RUNNER_PATTERN = re.compile(r"^\s*runs-on:\s*([A-Za-z0-9_.-]+)", re.MULTILINE)
+RUNNER_PATTERN = re.compile(r"^\s*runs-on:\s*(.*?)\s*$", re.MULTILINE)
 DEPENDENCY_FILE_NAMES = {
     "catalog.lock.json",
     "dependencies.lock.json",
@@ -267,6 +271,32 @@ class Inventory:
                 path for path in tracked if path.startswith(".github/workflows/") and path.endswith((".yml", ".yaml"))
             ):
                 text = _read_metadata(root / relative)
+                for match in USES_DECLARATION_PATTERN.finditer(text):
+                    reference = match.group(1).partition("#")[0].strip()
+                    if reference.startswith("./"):
+                        if ".." in PurePosixPath(reference).parts:
+                            raise WorkspaceError(
+                                f"{repository_name}/{relative}: local Action escapes "
+                                f"its repository: {reference}"
+                            )
+                        continue
+                    if reference.startswith("docker://"):
+                        _validate_container_reference(
+                            self.dependencies,
+                            repository_name,
+                            relative,
+                            reference.removeprefix("docker://"),
+                        )
+                        continue
+                    if not re.fullmatch(
+                        r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+"
+                        r"(?:/[A-Za-z0-9_.-]+)*@[^\s#]+",
+                        reference,
+                    ):
+                        raise WorkspaceError(
+                            f"{repository_name}/{relative}: unsupported external "
+                            f"Action reference {reference or '<empty>'}"
+                        )
                 for match in ACTION_REFERENCE_PATTERN.finditer(text):
                     locator, commit, comment = match.groups()
                     dependency = action_dependencies.get(locator)
@@ -298,7 +328,12 @@ class Inventory:
                         self.dependencies, repository_name, relative, image
                     )
                 for match in RUNNER_PATTERN.finditer(text):
-                    runner = match.group(1)
+                    runner = match.group(1).partition("#")[0].strip()
+                    if not re.fullmatch(r"[A-Za-z0-9_.-]+", runner):
+                        raise WorkspaceError(
+                            f"{repository_name}/{relative}: workflow runner must be "
+                            f"an explicit literal: {runner or '<empty>'}"
+                        )
                     locator = f"github-hosted-runner/{runner}"
                     dependency = runner_dependencies.get(locator)
                     if dependency is None:
@@ -325,13 +360,6 @@ class Inventory:
                             self.dependencies, repository_name, relative, image
                         )
 
-            for name in VENDORED_FILE_NAMES & {PurePosixPath(path).name for path in tracked}:
-                candidates = [path for path in tracked if PurePosixPath(path).name == name]
-                for relative in candidates:
-                    if (repository_name, relative) not in evidence_paths:
-                        raise WorkspaceError(
-                            f"{repository_name}/{relative}: vendored source is absent from the inventory"
-                        )
             messages.append(
                 f"{repository_name}: audited {len(tracked)} version-controlled inputs and {action_count} action references"
             )
@@ -524,8 +552,6 @@ def _load_dependency(
     }
     require_keys(value, keys, context)
     identifier = _identifier(value["id"], f"{context}.id")
-    if not DEPENDENCY_ID_PATTERN.fullmatch(identifier):
-        raise WorkspaceError(f"{context}.id has invalid characters")
     if identifier in identifiers:
         raise WorkspaceError(f"duplicate dependency id: {identifier}")
     identifiers.add(identifier)
@@ -973,9 +999,15 @@ def write_generated(root: Path, output: Path | None, value: str) -> None:
     if output is None:
         print(value, end="")
         return
+    root = root.resolve(strict=True)
+    build_entry = root / "build"
+    if build_entry.is_symlink():
+        raise WorkspaceError(
+            f"generated output directory must not be a symlink: {build_entry}"
+        )
     target = output if output.is_absolute() else root / output
     target = target.resolve(strict=False)
-    build = (root / "build").resolve(strict=False)
+    build = build_entry.resolve(strict=False)
     try:
         target.relative_to(build)
     except ValueError as error:

--- a/atrinik_workspace/supply_chain.py
+++ b/atrinik_workspace/supply_chain.py
@@ -1,0 +1,985 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+import re
+import subprocess
+from typing import Any, Iterable
+
+from .model import Manifest, WorkspaceError, load_json, require_keys
+
+
+SCHEMA_VERSION = 1
+ACTION_COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+CHECKSUM_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+DEPENDENCY_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._/-]*$")
+SPDX_PATTERN = re.compile(r"^(?:[A-Za-z0-9-.+]+|NOASSERTION|LicenseRef-[A-Za-z0-9-.]+)$")
+ACTION_REFERENCE_PATTERN = re.compile(
+    r"uses:\s*([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*)"
+    r"@([^\s#]+)(?:\s*#\s*([^\s]+))?"
+)
+FROM_PATTERN = re.compile(
+    r"^\s*FROM(?:\s+--platform=[^\s]+)?\s+([^\s]+)(?:\s+AS\s+([^\s]+))?",
+    re.IGNORECASE,
+)
+SYNTAX_PATTERN = re.compile(r"^\s*#\s*syntax=([^\s]+)", re.IGNORECASE | re.MULTILINE)
+DOCKER_PULL_PATTERN = re.compile(r"\bdocker\s+pull\s+([^\s'\"\\]+)")
+RUNNER_PATTERN = re.compile(r"^\s*runs-on:\s*([A-Za-z0-9_.-]+)", re.MULTILINE)
+DEPENDENCY_FILE_NAMES = {
+    "catalog.lock.json",
+    "dependencies.lock.json",
+    "devcontainer-lock.json",
+    "package-lock.json",
+    "package.json",
+    "pyproject.toml",
+    "requirements-dev.txt",
+}
+VENDORED_FILE_NAMES = {"uthash.h", "utarray.h", "utlist.h"}
+DEPENDENCY_KINDS = {
+    "container-feature",
+    "container-image",
+    "external-tool",
+    "github-action",
+    "language-package-set",
+    "source-archive",
+    "system-library",
+    "system-package-set",
+    "toolchain",
+    "vendored-source",
+}
+DISPOSITIONS = {"isolate", "remove", "replace", "retain"}
+MAX_METADATA_BYTES = 16 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class Evidence:
+    repository: str
+    path: str
+    contains: str
+
+
+@dataclass(frozen=True)
+class Dependency:
+    identifier: str
+    name: str
+    kind: str
+    owner: str
+    scope: tuple[str, ...]
+    required: bool
+    version: str
+    version_source: str
+    license: str
+    source_url: str
+    locator: str
+    commit: str | None
+    checksum: str | None
+    acquisition: str
+    update_cadence_days: int
+    update_mechanism: str
+    eol_response: str
+    validation: str
+    disposition: str
+    packages: tuple[str, ...]
+    evidence: tuple[Evidence, ...]
+
+
+@dataclass(frozen=True)
+class Repository:
+    name: str
+    repository: str
+    supported: bool
+    role: str
+
+
+class Inventory:
+    def __init__(
+        self,
+        organization: str,
+        created: str,
+        repositories: list[Repository],
+        dependencies: list[Dependency],
+    ):
+        self.organization = organization
+        self.created = created
+        self.repositories = repositories
+        self.dependencies = dependencies
+        self.repositories_by_name = {repository.name: repository for repository in repositories}
+        self.dependencies_by_id = {dependency.identifier: dependency for dependency in dependencies}
+
+    @classmethod
+    def load(cls, path: Path, manifest_path: Path) -> "Inventory":
+        root = load_json(path)
+        if not isinstance(root, dict):
+            raise WorkspaceError("supply-chain inventory root must be an object")
+        require_keys(
+            root,
+            {"schema_version", "organization", "created", "repositories", "dependencies"},
+            "supply-chain inventory",
+        )
+        if root["schema_version"] != SCHEMA_VERSION:
+            raise WorkspaceError("unsupported supply-chain inventory schema")
+        if root["organization"] != "atrinik":
+            raise WorkspaceError("supply-chain organization must be atrinik")
+        created = _text(root["created"], "inventory.created")
+
+        raw_repositories = root["repositories"]
+        if not isinstance(raw_repositories, list) or not raw_repositories:
+            raise WorkspaceError("inventory.repositories must be a non-empty array")
+        repositories: list[Repository] = []
+        repository_names: set[str] = set()
+        repository_coordinates: set[str] = set()
+        for index, value in enumerate(raw_repositories):
+            context = f"inventory repository {index}"
+            if not isinstance(value, dict):
+                raise WorkspaceError(f"{context} must be an object")
+            require_keys(value, {"name", "repository", "supported", "role"}, context)
+            name = _identifier(value["name"], f"{context}.name")
+            coordinate = _text(value["repository"], f"{context}.repository")
+            if not re.fullmatch(r"atrinik/[a-z0-9][a-z0-9._-]*", coordinate):
+                raise WorkspaceError(f"{context}.repository must be an Atrinik repository")
+            if not isinstance(value["supported"], bool):
+                raise WorkspaceError(f"{context}.supported must be a boolean")
+            role = _text(value["role"], f"{context}.role")
+            if name in repository_names or coordinate in repository_coordinates:
+                raise WorkspaceError(f"duplicate inventory repository: {name}")
+            repository_names.add(name)
+            repository_coordinates.add(coordinate)
+            repositories.append(Repository(name, coordinate, value["supported"], role))
+
+        manifest = Manifest.load(manifest_path)
+        expected_supported = {"atrinik", *(component.name for component in manifest.components)}
+        actual_supported = {repository.name for repository in repositories if repository.supported}
+        if actual_supported != expected_supported:
+            missing = sorted(expected_supported - actual_supported)
+            extra = sorted(actual_supported - expected_supported)
+            raise WorkspaceError(
+                "inventory supported repositories do not match components.json: "
+                f"missing={missing}, extra={extra}"
+            )
+        expected_coordinates = {component.name: component.repository for component in manifest.components}
+        expected_coordinates["atrinik"] = "atrinik/atrinik"
+        for repository in repositories:
+            if repository.supported and expected_coordinates[repository.name] != repository.repository:
+                raise WorkspaceError(
+                    f"inventory repository mismatch for {repository.name}: {repository.repository}"
+                )
+
+        raw_dependencies = root["dependencies"]
+        if not isinstance(raw_dependencies, list) or not raw_dependencies:
+            raise WorkspaceError("inventory.dependencies must be a non-empty array")
+        dependencies: list[Dependency] = []
+        identifiers: set[str] = set()
+        for index, value in enumerate(raw_dependencies):
+            dependencies.append(
+                _load_dependency(value, index, repository_names, identifiers)
+            )
+        if [dependency.identifier for dependency in dependencies] != sorted(identifiers):
+            raise WorkspaceError("inventory dependencies must be sorted by id")
+        action_locators = [
+            dependency.locator
+            for dependency in dependencies
+            if dependency.kind == "github-action"
+        ]
+        if len(action_locators) != len(set(action_locators)):
+            raise WorkspaceError("inventory GitHub Action locators must be unique")
+        return cls(root["organization"], created, repositories, dependencies)
+
+    def validate_schema(self, schema_path: Path) -> None:
+        schema = load_json(schema_path)
+        if not isinstance(schema, dict):
+            raise WorkspaceError("supply-chain schema root must be an object")
+        if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+            raise WorkspaceError("supply-chain schema must use JSON Schema draft 2020-12")
+        if schema.get("$id") != "https://atrinik.org/schema/supply-chain-inventory-v1.json":
+            raise WorkspaceError("supply-chain schema has an unexpected $id")
+        if schema.get("additionalProperties") is not False:
+            raise WorkspaceError("supply-chain schema must reject additional root properties")
+
+    def audit(self, roots: dict[str, Path], *, require_all: bool = True) -> list[str]:
+        supported = {repository.name for repository in self.repositories if repository.supported}
+        supplied = set(roots)
+        if require_all and supplied != supported:
+            raise WorkspaceError(
+                "supply-chain audit roots are incomplete: "
+                f"missing={sorted(supported - supplied)}, extra={sorted(supplied - supported)}"
+            )
+        unknown = supplied - supported
+        if unknown:
+            raise WorkspaceError(f"unknown supply-chain audit repositories: {sorted(unknown)}")
+        normalized: dict[str, Path] = {}
+        for name, root in roots.items():
+            resolved = root.resolve(strict=True)
+            if not resolved.is_dir():
+                raise WorkspaceError(f"audit root is not a directory: {resolved}")
+            normalized[name] = resolved
+
+        action_dependencies = {
+            dependency.locator: dependency
+            for dependency in self.dependencies
+            if dependency.kind == "github-action"
+        }
+        runner_dependencies = {
+            dependency.locator: dependency
+            for dependency in self.dependencies
+            if dependency.kind == "toolchain"
+            and dependency.locator.startswith("github-hosted-runner/")
+        }
+        evidence_paths = {
+            (evidence.repository, evidence.path)
+            for dependency in self.dependencies
+            for evidence in dependency.evidence
+        }
+        messages: list[str] = []
+        observed_action_scopes = {
+            locator: set() for locator in action_dependencies
+        }
+        observed_runner_scopes = {
+            locator: set() for locator in runner_dependencies
+        }
+        for dependency in self.dependencies:
+            for evidence in dependency.evidence:
+                if evidence.repository not in normalized:
+                    continue
+                path = _safe_repository_path(normalized[evidence.repository], evidence.path)
+                text = _read_metadata(path)
+                if evidence.contains not in text:
+                    raise WorkspaceError(
+                        f"{dependency.identifier}: expected text is absent from "
+                        f"{evidence.repository}/{evidence.path}: {evidence.contains}"
+                    )
+
+        for repository_name, root in sorted(normalized.items()):
+            tracked = _tracked_files(root)
+            if ".gitmodules" in tracked:
+                raise WorkspaceError(f"{repository_name}: Git submodules are not supported")
+            dependabot = ".github/dependabot.yml"
+            if dependabot not in tracked:
+                raise WorkspaceError(f"{repository_name}: missing {dependabot}")
+            if "package-ecosystem: github-actions" not in _read_metadata(root / dependabot):
+                raise WorkspaceError(
+                    f"{repository_name}: Dependabot does not own GitHub Actions updates"
+                )
+
+            action_count = 0
+            for relative in sorted(
+                path for path in tracked if path.startswith(".github/workflows/") and path.endswith((".yml", ".yaml"))
+            ):
+                text = _read_metadata(root / relative)
+                for match in ACTION_REFERENCE_PATTERN.finditer(text):
+                    locator, commit, comment = match.groups()
+                    dependency = action_dependencies.get(locator)
+                    if dependency is None:
+                        raise WorkspaceError(
+                            f"{repository_name}/{relative}: unowned GitHub Action {locator}"
+                        )
+                    if not ACTION_COMMIT_PATTERN.fullmatch(commit):
+                        raise WorkspaceError(
+                            f"{repository_name}/{relative}: {locator} is not pinned to a full commit"
+                        )
+                    if dependency.commit != commit:
+                        raise WorkspaceError(
+                            f"{repository_name}/{relative}: {locator}@{commit} differs from inventory {dependency.commit}"
+                        )
+                    if comment != dependency.version:
+                        raise WorkspaceError(
+                            f"{repository_name}/{relative}: {locator} must retain the '# {dependency.version}' updater hint"
+                        )
+                    if repository_name not in dependency.scope:
+                        raise WorkspaceError(
+                            f"{repository_name}/{relative}: {locator} is absent from inventory scope"
+                        )
+                    observed_action_scopes[locator].add(repository_name)
+                    action_count += 1
+                for match in DOCKER_PULL_PATTERN.finditer(text):
+                    image = match.group(1)
+                    _validate_container_reference(
+                        self.dependencies, repository_name, relative, image
+                    )
+                for match in RUNNER_PATTERN.finditer(text):
+                    runner = match.group(1)
+                    locator = f"github-hosted-runner/{runner}"
+                    dependency = runner_dependencies.get(locator)
+                    if dependency is None:
+                        raise WorkspaceError(
+                            f"{repository_name}/{relative}: unowned workflow runner {runner}"
+                        )
+                    if repository_name not in dependency.scope:
+                        raise WorkspaceError(
+                            f"{repository_name}/{relative}: {runner} is absent from inventory scope"
+                        )
+                    observed_runner_scopes[locator].add(repository_name)
+
+            for relative in sorted(tracked):
+                if not _is_dependency_input(relative, root):
+                    continue
+                if (repository_name, relative) not in evidence_paths:
+                    raise WorkspaceError(
+                        f"{repository_name}/{relative}: dependency input is absent from the inventory"
+                    )
+                text = _read_metadata(root / relative)
+                if _is_container_input(relative):
+                    for image in _container_references(relative, text):
+                        _validate_container_reference(
+                            self.dependencies, repository_name, relative, image
+                        )
+
+            for name in VENDORED_FILE_NAMES & {PurePosixPath(path).name for path in tracked}:
+                candidates = [path for path in tracked if PurePosixPath(path).name == name]
+                for relative in candidates:
+                    if (repository_name, relative) not in evidence_paths:
+                        raise WorkspaceError(
+                            f"{repository_name}/{relative}: vendored source is absent from the inventory"
+                        )
+            messages.append(
+                f"{repository_name}: audited {len(tracked)} version-controlled inputs and {action_count} action references"
+            )
+        for locator, dependency in sorted(action_dependencies.items()):
+            expected_scope = set(dependency.scope) & supplied
+            actual_scope = observed_action_scopes[locator]
+            if actual_scope != expected_scope:
+                raise WorkspaceError(
+                    f"{locator}: inventory scope differs from audited use: "
+                    f"missing={sorted(expected_scope - actual_scope)}, "
+                    f"extra={sorted(actual_scope - expected_scope)}"
+                )
+        for locator, dependency in sorted(runner_dependencies.items()):
+            expected_scope = set(dependency.scope) & supplied
+            actual_scope = observed_runner_scopes[locator]
+            if actual_scope != expected_scope:
+                raise WorkspaceError(
+                    f"{locator}: inventory scope differs from audited use: "
+                    f"missing={sorted(expected_scope - actual_scope)}, "
+                    f"extra={sorted(actual_scope - expected_scope)}"
+                )
+        return messages
+
+    def report(self, format_name: str) -> str:
+        if format_name == "licenses":
+            return self._license_report()
+        if format_name == "cyclonedx":
+            return json.dumps(self._cyclonedx(), indent=2, sort_keys=True) + "\n"
+        if format_name == "spdx":
+            return json.dumps(self._spdx(), indent=2, sort_keys=True) + "\n"
+        raise WorkspaceError(f"unsupported supply-chain report format: {format_name}")
+
+    def _license_report(self) -> str:
+        lines = [
+            "# Atrinik third-party dependency and provenance report",
+            "",
+            "Generated deterministically from `supply-chain/inventory.json`.",
+            "",
+            "| Dependency | Version | License | Owner | Disposition | Source |",
+            "| --- | --- | --- | --- | --- | --- |",
+        ]
+        for dependency in self.dependencies:
+            lines.append(
+                f"| {dependency.name} | {dependency.version} | {dependency.license} | "
+                f"{dependency.owner} | {dependency.disposition} | {dependency.source_url} |"
+            )
+        return "\n".join(lines) + "\n"
+
+    def _cyclonedx(self) -> dict[str, Any]:
+        components = []
+        for dependency in self.dependencies:
+            license_value = (
+                {"name": dependency.license}
+                if dependency.license == "NOASSERTION"
+                or dependency.license.startswith("LicenseRef-")
+                else {"id": dependency.license}
+            )
+            component: dict[str, Any] = {
+                "type": _cyclonedx_type(dependency.kind),
+                "bom-ref": dependency.locator,
+                "name": dependency.name,
+                "version": dependency.version,
+                "licenses": [{"license": license_value}],
+                "externalReferences": [
+                    {"type": "website", "url": dependency.source_url}
+                ],
+                "properties": [
+                    {"name": "atrinik:owner", "value": dependency.owner},
+                    {"name": "atrinik:scope", "value": ",".join(dependency.scope)},
+                    {"name": "atrinik:disposition", "value": dependency.disposition},
+                    {
+                        "name": "atrinik:update-cadence-days",
+                        "value": str(dependency.update_cadence_days),
+                    },
+                ],
+            }
+            if dependency.packages:
+                component["properties"].append(
+                    {
+                        "name": "atrinik:declared-packages",
+                        "value": ",".join(dependency.packages),
+                    }
+                )
+            if dependency.checksum is not None:
+                component["hashes"] = [
+                    {"alg": "SHA-256", "content": dependency.checksum.removeprefix("sha256:")}
+                ]
+            components.append(component)
+        return {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "version": 1,
+            "metadata": {"component": {"type": "application", "name": "Atrinik"}},
+            "components": components,
+        }
+
+    def _spdx(self) -> dict[str, Any]:
+        packages = []
+        relationships = []
+        extracted_licenses: dict[str, dict[str, str]] = {}
+        for dependency in self.dependencies:
+            suffix = hashlib.sha256(dependency.identifier.encode()).hexdigest()[:16]
+            spdx_id = f"SPDXRef-Dependency-{suffix}"
+            package = {
+                "SPDXID": spdx_id,
+                "name": dependency.name,
+                "versionInfo": dependency.version,
+                "downloadLocation": dependency.source_url,
+                "filesAnalyzed": False,
+                "licenseConcluded": dependency.license,
+                "licenseDeclared": dependency.license,
+                "supplier": "NOASSERTION",
+                "packageComment": (
+                    f"Atrinik owner: {dependency.owner}; scope: "
+                    f"{','.join(dependency.scope)}; disposition: {dependency.disposition}."
+                ),
+            }
+            if dependency.packages:
+                package["packageComment"] += (
+                    f" Declared packages: {','.join(dependency.packages)}."
+                )
+            packages.append(package)
+            relationships.append(
+                {
+                    "spdxElementId": "SPDXRef-DOCUMENT",
+                    "relationshipType": "DESCRIBES",
+                    "relatedSpdxElement": spdx_id,
+                }
+            )
+            if dependency.license.startswith("LicenseRef-"):
+                extracted_licenses[dependency.license] = {
+                    "licenseId": dependency.license,
+                    "extractedText": (
+                        "The applicable license and provenance are recorded by the "
+                        "dependency's source-local licensing files and inventory evidence."
+                    ),
+                    "name": dependency.license,
+                }
+        document = {
+            "spdxVersion": "SPDX-2.3",
+            "dataLicense": "CC0-1.0",
+            "SPDXID": "SPDXRef-DOCUMENT",
+            "name": "Atrinik supply-chain inventory",
+            "documentNamespace": "https://atrinik.org/spdx/supply-chain-v1",
+            "creationInfo": {
+                "created": self.created,
+                "creators": ["Organization: Atrinik"],
+            },
+            "packages": packages,
+            "relationships": relationships,
+        }
+        if extracted_licenses:
+            document["hasExtractedLicensingInfos"] = [
+                extracted_licenses[key] for key in sorted(extracted_licenses)
+            ]
+        return document
+
+
+def _load_dependency(
+    value: object,
+    index: int,
+    repository_names: set[str],
+    identifiers: set[str],
+) -> Dependency:
+    context = f"inventory dependency {index}"
+    if not isinstance(value, dict):
+        raise WorkspaceError(f"{context} must be an object")
+    keys = {
+        "id",
+        "name",
+        "kind",
+        "owner",
+        "scope",
+        "required",
+        "version",
+        "version_source",
+        "license",
+        "source_url",
+        "locator",
+        "commit",
+        "checksum",
+        "acquisition",
+        "update_cadence_days",
+        "update_mechanism",
+        "eol_response",
+        "validation",
+        "disposition",
+        "packages",
+        "evidence",
+    }
+    require_keys(value, keys, context)
+    identifier = _identifier(value["id"], f"{context}.id")
+    if not DEPENDENCY_ID_PATTERN.fullmatch(identifier):
+        raise WorkspaceError(f"{context}.id has invalid characters")
+    if identifier in identifiers:
+        raise WorkspaceError(f"duplicate dependency id: {identifier}")
+    identifiers.add(identifier)
+    name = _text(value["name"], f"{context}.name")
+    kind = _text(value["kind"], f"{context}.kind")
+    if kind not in DEPENDENCY_KINDS:
+        raise WorkspaceError(f"{context}.kind is unsupported: {kind}")
+    owner = _identifier(value["owner"], f"{context}.owner")
+    if owner not in repository_names:
+        raise WorkspaceError(f"{context}.owner is not an inventory repository")
+    scope = _string_array(value["scope"], f"{context}.scope")
+    if not scope or set(scope) - repository_names:
+        raise WorkspaceError(f"{context}.scope contains an unknown repository")
+    if list(scope) != sorted(scope):
+        raise WorkspaceError(f"{context}.scope must be sorted")
+    if not isinstance(value["required"], bool):
+        raise WorkspaceError(f"{context}.required must be a boolean")
+    version = _text(value["version"], f"{context}.version")
+    version_source = _text(value["version_source"], f"{context}.version_source")
+    license_id = _text(value["license"], f"{context}.license")
+    if not SPDX_PATTERN.fullmatch(license_id):
+        raise WorkspaceError(f"{context}.license is not an SPDX expression or LicenseRef")
+    source_url = _text(value["source_url"], f"{context}.source_url")
+    if not source_url.startswith("https://"):
+        raise WorkspaceError(f"{context}.source_url must use HTTPS")
+    locator = _text(value["locator"], f"{context}.locator")
+    commit = value["commit"]
+    if commit is not None and (
+        not isinstance(commit, str) or not ACTION_COMMIT_PATTERN.fullmatch(commit)
+    ):
+        raise WorkspaceError(f"{context}.commit must be null or a full lowercase Git commit")
+    checksum = value["checksum"]
+    if checksum is not None and (
+        not isinstance(checksum, str) or not CHECKSUM_PATTERN.fullmatch(checksum)
+    ):
+        raise WorkspaceError(f"{context}.checksum must be null or a lowercase SHA-256")
+    acquisition = _text(value["acquisition"], f"{context}.acquisition")
+    cadence = value["update_cadence_days"]
+    if not isinstance(cadence, int) or isinstance(cadence, bool) or not 1 <= cadence <= 366:
+        raise WorkspaceError(f"{context}.update_cadence_days must be between 1 and 366")
+    update_mechanism = _text(value["update_mechanism"], f"{context}.update_mechanism")
+    eol_response = _text(value["eol_response"], f"{context}.eol_response")
+    validation = _text(value["validation"], f"{context}.validation")
+    disposition = _text(value["disposition"], f"{context}.disposition")
+    if disposition not in DISPOSITIONS:
+        raise WorkspaceError(f"{context}.disposition is unsupported")
+    packages = _string_array(value["packages"], f"{context}.packages", allow_empty=True)
+    if list(packages) != sorted(packages) or len(set(packages)) != len(packages):
+        raise WorkspaceError(f"{context}.packages must be sorted and unique")
+
+    raw_evidence = value["evidence"]
+    if not isinstance(raw_evidence, list) or not raw_evidence:
+        raise WorkspaceError(f"{context}.evidence must be a non-empty array")
+    evidence: list[Evidence] = []
+    for evidence_index, raw in enumerate(raw_evidence):
+        evidence_context = f"{context}.evidence[{evidence_index}]"
+        if not isinstance(raw, dict):
+            raise WorkspaceError(f"{evidence_context} must be an object")
+        require_keys(raw, {"repository", "path", "contains"}, evidence_context)
+        repository = _identifier(raw["repository"], f"{evidence_context}.repository")
+        if repository not in repository_names:
+            raise WorkspaceError(f"{evidence_context}.repository is unknown")
+        path = _relative_path(raw["path"], f"{evidence_context}.path")
+        contains = _text(raw["contains"], f"{evidence_context}.contains")
+        evidence.append(Evidence(repository, path, contains))
+
+    evidence_keys = [
+        (item.repository, item.path, item.contains) for item in evidence
+    ]
+    if evidence_keys != sorted(evidence_keys) or len(evidence_keys) != len(set(evidence_keys)):
+        raise WorkspaceError(f"{context}.evidence must be sorted and unique")
+    for item in evidence:
+        if item.repository not in scope:
+            raise WorkspaceError(
+                f"{context}.evidence repository must be present in dependency scope"
+            )
+
+    if kind == "github-action":
+        if commit is None:
+            raise WorkspaceError(f"{context}: GitHub Actions require a commit")
+        if not re.fullmatch(
+            r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*", locator
+        ):
+            raise WorkspaceError(f"{context}.locator must be an owner/action coordinate")
+    return Dependency(
+        identifier,
+        name,
+        kind,
+        owner,
+        scope,
+        value["required"],
+        version,
+        version_source,
+        license_id,
+        source_url,
+        locator,
+        commit,
+        checksum,
+        acquisition,
+        cadence,
+        update_mechanism,
+        eol_response,
+        validation,
+        disposition,
+        packages,
+        tuple(evidence),
+    )
+
+
+def _text(value: object, context: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise WorkspaceError(f"{context} must be a non-empty trimmed string")
+    return value
+
+
+def _identifier(value: object, context: str) -> str:
+    text = _text(value, context)
+    if not re.fullmatch(r"[a-z0-9][a-z0-9._/-]*", text):
+        raise WorkspaceError(f"{context} must use lowercase identifier characters")
+    return text
+
+
+def _string_array(value: object, context: str, *, allow_empty: bool = False) -> tuple[str, ...]:
+    if not isinstance(value, list) or (not value and not allow_empty):
+        raise WorkspaceError(f"{context} must be {'an' if allow_empty else 'a non-empty'} array")
+    return tuple(_text(item, f"{context} item") for item in value)
+
+
+def _relative_path(value: object, context: str) -> str:
+    text = _text(value, context)
+    path = PurePosixPath(text)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise WorkspaceError(f"{context} must be a safe repository-relative path")
+    return path.as_posix()
+
+
+def _safe_repository_path(root: Path, relative: str) -> Path:
+    path = root.joinpath(*PurePosixPath(relative).parts)
+    try:
+        path.resolve(strict=True).relative_to(root)
+    except (FileNotFoundError, ValueError) as error:
+        raise WorkspaceError(f"dependency evidence is missing or escapes its repository: {path}") from error
+    if not path.is_file() or path.is_symlink():
+        raise WorkspaceError(f"dependency evidence must be a regular non-symlink file: {path}")
+    return path
+
+
+def _read_metadata(path: Path) -> str:
+    try:
+        if path.stat().st_size > MAX_METADATA_BYTES:
+            raise WorkspaceError(f"dependency metadata exceeds size limit: {path}")
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as error:
+        raise WorkspaceError(f"cannot read dependency metadata {path}: {error}") from error
+
+
+def _tracked_files(root: Path) -> set[str]:
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(root),
+            "ls-files",
+            "-z",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode(errors="replace").strip()
+        raise WorkspaceError(f"cannot list tracked files for {root}: {detail}")
+    try:
+        return {
+            PurePosixPath(path).as_posix()
+            for path in result.stdout.decode("utf-8").split("\0")
+            if path
+        }
+    except UnicodeDecodeError as error:
+        raise WorkspaceError(f"tracked path is not UTF-8 in {root}") from error
+
+
+def _is_dependency_input(relative: str, root: Path) -> bool:
+    path = PurePosixPath(relative)
+    if path.name in DEPENDENCY_FILE_NAMES:
+        return True
+    if path.name in VENDORED_FILE_NAMES:
+        return True
+    if path.name.startswith("Dockerfile"):
+        return True
+    if path.name == "CMakeLists.txt" or path.suffix == ".cmake":
+        text = _read_metadata(root / relative)
+        return bool(re.search(r"find_package\(|pkg_check_modules\(|FetchContent", text))
+    if relative in {
+        ".devcontainer/devcontainer.json",
+        ".devcontainer/windows-cross/devcontainer.json",
+        "tools/install-linux-ci-dependencies.sh",
+    }:
+        return True
+    return False
+
+
+def _is_container_input(relative: str) -> bool:
+    return PurePosixPath(relative).name.startswith("Dockerfile") or relative in {
+        ".devcontainer/devcontainer.json",
+        ".devcontainer/windows-cross/devcontainer.json",
+    }
+
+
+def _container_references(relative: str, text: str) -> list[str]:
+    if PurePosixPath(relative).name.startswith("Dockerfile"):
+        references = SYNTAX_PATTERN.findall(text)
+        stages: set[str] = set()
+        for line in text.splitlines():
+            match = FROM_PATTERN.match(line)
+            if match is None:
+                continue
+            image, stage = match.groups()
+            if image.casefold() not in stages:
+                references.append(image)
+            if stage is not None:
+                stages.add(stage.casefold())
+        return references
+    try:
+        value = json.loads(text, object_pairs_hook=_reject_duplicate_json_keys)
+    except json.JSONDecodeError as error:
+        raise WorkspaceError(f"invalid devcontainer JSON {relative}: {error}") from error
+    image = value.get("image") if isinstance(value, dict) else None
+    return [image] if isinstance(image, str) else []
+
+
+def _validate_container_reference(
+    dependencies: list[Dependency],
+    repository: str,
+    relative: str,
+    image: str,
+) -> None:
+    coordinate, separator, digest = image.rpartition("@sha256:")
+    if not separator or not re.fullmatch(r"[0-9a-f]{64}", digest):
+        raise WorkspaceError(f"{repository}/{relative}: movable container image {image}")
+    if ":" in coordinate.rsplit("/", 1)[-1]:
+        coordinate = coordinate.rsplit(":", 1)[0]
+    first_part = coordinate.partition("/")[0]
+    if "/" not in coordinate:
+        coordinate = f"docker.io/library/{coordinate}"
+    elif "." not in first_part and ":" not in first_part and first_part != "localhost":
+        coordinate = f"docker.io/{coordinate}"
+    expected_checksum = f"sha256:{digest}"
+    if not any(
+        dependency.kind == "container-image"
+        and dependency.locator == coordinate
+        and dependency.checksum == expected_checksum
+        and repository in dependency.scope
+        and any(
+            evidence.repository == repository
+            and evidence.path == relative
+            and image in evidence.contains
+            for evidence in dependency.evidence
+        )
+        for dependency in dependencies
+    ):
+        raise WorkspaceError(
+            f"{repository}/{relative}: unowned container image {image}"
+        )
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise WorkspaceError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _cyclonedx_type(kind: str) -> str:
+    if kind in {"container-image", "container-feature"}:
+        return "container"
+    if kind in {"external-tool", "github-action", "toolchain"}:
+        return "application"
+    return "library"
+
+
+def version_report(inventory: Inventory | None = None) -> str:
+    probes: dict[str, list[str]] = {
+        "actionlint": ["actionlint", "--version"],
+        "clang": ["clang", "--version"],
+        "cmake": ["cmake", "--version"],
+        "curl": ["curl", "--version"],
+        "flex": ["flex", "--version"],
+        "gcc": ["gcc", "--version"],
+        "gh": ["gh", "--version"],
+        "git": ["git", "--version"],
+        "library:libcurl": ["pkg-config", "--modversion", "libcurl"],
+        "library:libxml2": ["pkg-config", "--modversion", "libxml-2.0"],
+        "library:miniupnpc": ["pkg-config", "--modversion", "miniupnpc"],
+        "library:openssl": ["pkg-config", "--modversion", "openssl"],
+        "library:sdl3": ["pkg-config", "--modversion", "sdl3"],
+        "library:sdl3-image": ["pkg-config", "--modversion", "sdl3-image"],
+        "library:sdl3-mixer": ["pkg-config", "--modversion", "sdl3-mixer"],
+        "library:sdl3-ttf": ["pkg-config", "--modversion", "sdl3-ttf"],
+        "library:zlib": ["pkg-config", "--modversion", "zlib"],
+        "ninja": ["ninja", "--version"],
+        "node": ["node", "--version"],
+        "npm": ["npm", "--version"],
+        "openssl": ["openssl", "version"],
+        "pkg-config": ["pkg-config", "--version"],
+        "python": ["python3", "--version"],
+        "shellcheck": ["shellcheck", "--version"],
+    }
+    versions: dict[str, dict[str, object]] = {}
+    for name, command in probes.items():
+        try:
+            result = subprocess.run(
+                command,
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                timeout=10,
+            )
+        except FileNotFoundError:
+            versions[name] = {"available": False, "version": None}
+            continue
+        lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        available = result.returncode == 0
+        version = None
+        if available and lines:
+            version = next((line for line in lines if re.search(r"\d", line)), lines[0])
+        versions[name] = {"available": available, "version": version}
+    if inventory is not None:
+        versions["declared-dependencies"] = {
+            dependency.identifier: {
+                "checksum": dependency.checksum,
+                "commit": dependency.commit,
+                "kind": dependency.kind,
+                "version": dependency.version,
+            }
+            for dependency in inventory.dependencies
+        }
+        package_names = sorted(
+            {
+                package
+                for dependency in inventory.dependencies
+                if dependency.kind in {"system-library", "system-package-set", "toolchain"}
+                for package in dependency.packages
+            }
+        )
+        versions["system-packages"] = _system_package_versions(package_names)
+    return json.dumps(versions, indent=2, sort_keys=True) + "\n"
+
+
+def _system_package_versions(package_names: list[str]) -> dict[str, dict[str, object]]:
+    versions = {
+        package: {"available": False, "version": None} for package in package_names
+    }
+    if not package_names:
+        return versions
+    try:
+        result = subprocess.run(
+            [
+                "dpkg-query",
+                "--show",
+                "--showformat=${binary:Package}\t${Version}\n",
+                "--",
+                *package_names,
+            ],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        return versions
+    for line in result.stdout.splitlines():
+        package, separator, version = line.partition("\t")
+        package = package.removesuffix(":amd64").removesuffix(":i386")
+        if separator and package in versions and version:
+            versions[package] = {"available": True, "version": version}
+    return versions
+
+
+def repository_roots(
+    root: Path,
+    workspace: Any,
+    profile: str,
+    overrides: Iterable[str] = (),
+) -> dict[str, Path]:
+    manifest = Manifest.load(root / "components.json")
+    known = {component.name for component in manifest.components}
+    expected = {component.name: component.repository for component in manifest.components}
+    selected: dict[str, Path] = {}
+    for override in overrides:
+        name, separator, raw_path = override.partition("=")
+        if not separator or name not in known or not raw_path:
+            raise WorkspaceError(
+                f"supply-chain repository override must be NAME=PATH for a component: {override}"
+            )
+        if name in selected:
+            raise WorkspaceError(f"duplicate supply-chain repository override: {name}")
+        path = Path(raw_path)
+        if not path.is_absolute():
+            raise WorkspaceError(f"supply-chain repository override must be absolute: {override}")
+        resolved = path.resolve(strict=True)
+        if _git_repository_coordinate(resolved) != expected[name]:
+            raise WorkspaceError(
+                f"supply-chain repository override is not {expected[name]}: {resolved}"
+            )
+        selected[name] = resolved
+    roots = {"atrinik": root}
+    roots.update(
+        {
+            component.name: selected.get(component.name)
+            or workspace.component_path(component.name, profile)
+            for component in manifest.components
+        }
+    )
+    return roots
+
+
+def _git_repository_coordinate(root: Path) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(root), "remote", "get-url", "origin"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise WorkspaceError(f"cannot inspect repository identity for {root}")
+    url = result.stdout.strip().removesuffix("/").removesuffix(".git")
+    match = re.search(r"github\.com(?::|/)([^/]+)/([^/]+)$", url)
+    if match is None:
+        raise WorkspaceError(f"unsupported repository remote for supply-chain audit: {url}")
+    return f"{match.group(1)}/{match.group(2)}"
+
+
+def write_generated(root: Path, output: Path | None, value: str) -> None:
+    if output is None:
+        print(value, end="")
+        return
+    target = output if output.is_absolute() else root / output
+    target = target.resolve(strict=False)
+    build = (root / "build").resolve(strict=False)
+    try:
+        target.relative_to(build)
+    except ValueError as error:
+        raise WorkspaceError(f"generated supply-chain output must be under {build}") from error
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(value, encoding="utf-8")
+    print(target)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,6 +19,26 @@ branch, and local build contract. Profile and state schemas are intentionally
 strict: duplicate keys, missing fields, unknown fields, invalid names, and
 repository mismatches fail before an operation changes data.
 
+Supply-chain ownership is a wrapper-level cross-repository contract.
+`supply-chain/inventory.json` names every active or archived organization
+repository and records each supported dependency's owner, consumers, version
+source, license, acquisition path, update cadence, EOL response, validation,
+and retain/isolate/replace/remove disposition. Component lockfiles remain the
+integrity boundary for independently released source and runtime archives; the
+aggregate catalog describes and audits those boundaries instead of copying
+their fetching implementations into the wrapper.
+
+The `supply-chain` command resolves component inputs through the same profile
+selectors as builds, then reads Git-indexed files without mutating a checkout.
+The audit requires immutable remote Actions and container images, updater
+hints, an owned catalog entry for every dependency input, weekly GitHub Actions
+update configuration, and no submodules. Explicit worktree overrides are
+absolute and must match the expected `atrinik/NAME` origin. Deterministic
+license, CycloneDX, SPDX, and local version reports are generated only below
+the ignored build directory. The scheduled audit composes all current default
+branches; pull-request CI validates the catalog and its implementation without
+silently accepting a partial organization snapshot.
+
 Read-only inspection commands keep structured data on stdout and suppress Git
 traces so callers can safely consume `status --json`, `worktree list --json`,
 `profile show --json`, `state list --json`, and `path`. Status never fetches;

--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -1,0 +1,2524 @@
+{
+  "schema_version": 1,
+  "organization": "atrinik",
+  "created": "2026-08-07T00:00:00Z",
+  "repositories": [
+    {
+      "name": "atrinik",
+      "repository": "atrinik/atrinik",
+      "supported": true,
+      "role": "Workspace orchestration and aggregate supply-chain ownership"
+    },
+    {
+      "name": "client",
+      "repository": "atrinik/client",
+      "supported": true,
+      "role": "SDL3 game client"
+    },
+    {
+      "name": "content",
+      "repository": "atrinik/content",
+      "supported": true,
+      "role": "Authored world content and content tooling"
+    },
+    {
+      "name": "devcontainer",
+      "repository": "atrinik/devcontainer",
+      "supported": true,
+      "role": "Linux and Windows build images"
+    },
+    {
+      "name": "editor",
+      "repository": "atrinik/editor",
+      "supported": true,
+      "role": "Gridarta packaging utility"
+    },
+    {
+      "name": "github-settings",
+      "repository": "atrinik/github-settings",
+      "supported": true,
+      "role": "Organization governance desired state"
+    },
+    {
+      "name": "libatrinik",
+      "repository": "atrinik/libatrinik",
+      "supported": true,
+      "role": "Reusable native libraries"
+    },
+    {
+      "name": "metaserver-worker",
+      "repository": "atrinik/metaserver-worker",
+      "supported": true,
+      "role": "Cloudflare metaserver and rendezvous Worker"
+    },
+    {
+      "name": "nawerhals",
+      "repository": "atrinik/nawerhals",
+      "supported": false,
+      "role": "Archived historical source; no supported build or update surface"
+    },
+    {
+      "name": "protocol",
+      "repository": "atrinik/protocol",
+      "supported": true,
+      "role": "Canonical protocol schema and generated bindings"
+    },
+    {
+      "name": "resources",
+      "repository": "atrinik/resources",
+      "supported": true,
+      "role": "Server runtime media"
+    },
+    {
+      "name": "server",
+      "repository": "atrinik/server",
+      "supported": true,
+      "role": "Authoritative game server"
+    },
+    {
+      "name": "sound",
+      "repository": "atrinik/sound",
+      "supported": true,
+      "role": "Client music and sound effects"
+    },
+    {
+      "name": "tools",
+      "repository": "atrinik/tools",
+      "supported": true,
+      "role": "Standalone operator and content-inspection tools"
+    }
+  ],
+  "dependencies": [
+    {
+      "id": "action/actions-cache",
+      "name": "actions/cache",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "client"
+      ],
+      "required": true,
+      "version": "v6",
+      "version_source": "Reviewed upstream major release",
+      "license": "MIT",
+      "source_url": "https://github.com/actions/cache",
+      "locator": "actions/cache",
+      "commit": "55cc8345863c7cc4c66a329aec7e433d2d1c52a9",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade all cache consumers together or remove the cache step",
+      "validation": "Actionlint plus client CI cache restore/save coverage",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "client",
+          "path": ".github/workflows/check.yml",
+          "contains": "actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6"
+        }
+      ]
+    },
+    {
+      "id": "action/actions-checkout",
+      "name": "actions/checkout",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "atrinik",
+        "client",
+        "content",
+        "devcontainer",
+        "editor",
+        "github-settings",
+        "libatrinik",
+        "metaserver-worker",
+        "protocol",
+        "resources",
+        "server",
+        "sound",
+        "tools"
+      ],
+      "required": true,
+      "version": "v6",
+      "version_source": "Reviewed upstream major release",
+      "license": "MIT",
+      "source_url": "https://github.com/actions/checkout",
+      "locator": "actions/checkout",
+      "commit": "d23441a48e516b6c34aea4fa41551a30e30af803",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade every repository in one coordinated policy change",
+      "validation": "Organization-wide immutable-reference audit and actionlint",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": ".github/workflows/integration.yml",
+          "contains": "actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6"
+        }
+      ]
+    },
+    {
+      "id": "action/actions-download-artifact",
+      "name": "actions/download-artifact",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "client",
+        "server"
+      ],
+      "required": true,
+      "version": "v8",
+      "version_source": "Reviewed upstream major release",
+      "license": "MIT",
+      "source_url": "https://github.com/actions/download-artifact",
+      "locator": "actions/download-artifact",
+      "commit": "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade package aggregation workflows before the major is retired",
+      "validation": "Actionlint and package-release artifact aggregation",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "client",
+          "path": ".github/workflows/package-release.yml",
+          "contains": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8"
+        }
+      ]
+    },
+    {
+      "id": "action/actions-setup-node",
+      "name": "actions/setup-node",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "atrinik",
+        "metaserver-worker"
+      ],
+      "required": true,
+      "version": "v6",
+      "version_source": "Reviewed upstream major release",
+      "license": "MIT",
+      "source_url": "https://github.com/actions/setup-node",
+      "locator": "actions/setup-node",
+      "commit": "249970729cb0ef3589644e2896645e5dc5ba9c38",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Move CI and semantic-release to the next supported Node line",
+      "validation": "Actionlint plus Worker and semantic-release jobs",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": ".github/workflows/release.yml",
+          "contains": "actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6"
+        }
+      ]
+    },
+    {
+      "id": "action/actions-setup-python",
+      "name": "actions/setup-python",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "atrinik",
+        "content",
+        "protocol"
+      ],
+      "required": true,
+      "version": "v6",
+      "version_source": "Reviewed upstream major release",
+      "license": "MIT",
+      "source_url": "https://github.com/actions/setup-python",
+      "locator": "actions/setup-python",
+      "commit": "ece7cb06caefa5fff74198d8649806c4678c61a1",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade the action and supported Python matrix together",
+      "validation": "Actionlint plus Python generation, content, and workspace tests",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": ".github/workflows/integration.yml",
+          "contains": "actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6"
+        }
+      ]
+    },
+    {
+      "id": "action/actions-upload-artifact",
+      "name": "actions/upload-artifact",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "atrinik",
+        "client",
+        "server"
+      ],
+      "required": true,
+      "version": "v7",
+      "version_source": "Reviewed upstream major release",
+      "license": "MIT",
+      "source_url": "https://github.com/actions/upload-artifact",
+      "locator": "actions/upload-artifact",
+      "commit": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade package producer workflows before the major is retired",
+      "validation": "Actionlint and package-release artifact round trips",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "server",
+          "path": ".github/workflows/package-release.yml",
+          "contains": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7"
+        }
+      ]
+    },
+    {
+      "id": "action/codecov",
+      "name": "Codecov Action",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "atrinik",
+        "client",
+        "libatrinik",
+        "server"
+      ],
+      "required": false,
+      "version": "v6",
+      "version_source": "Reviewed upstream major release",
+      "license": "MIT",
+      "source_url": "https://github.com/codecov/codecov-action",
+      "locator": "codecov/codecov-action",
+      "commit": "fb8b3582c8e4def4969c97caa2f19720cb33a72f",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit and authenticates with OIDC",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Retain local coverage reports while replacing or upgrading the uploader",
+      "validation": "Actionlint, selected-action policy, and non-blocking OIDC upload",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": ".github/workflows/integration.yml",
+          "contains": "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6"
+        }
+      ]
+    },
+    {
+      "id": "action/docker-build-push",
+      "name": "Docker Build Push Action",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "devcontainer",
+        "server"
+      ],
+      "required": true,
+      "version": "v7",
+      "version_source": "Reviewed upstream major release",
+      "license": "Apache-2.0",
+      "source_url": "https://github.com/docker/build-push-action",
+      "locator": "docker/build-push-action",
+      "commit": "53b7df96c91f9c12dcc8a07bcb9ccacbed38856a",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade image build workflows and verify both image families",
+      "validation": "Actionlint, Docker build checks, and image smoke tests",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": ".github/workflows/validate.yml",
+          "contains": "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7"
+        }
+      ]
+    },
+    {
+      "id": "action/docker-login",
+      "name": "Docker Login Action",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "client",
+        "devcontainer",
+        "server"
+      ],
+      "required": true,
+      "version": "v4",
+      "version_source": "Reviewed upstream major release",
+      "license": "Apache-2.0",
+      "source_url": "https://github.com/docker/login-action",
+      "locator": "docker/login-action",
+      "commit": "dbcb813823bdd20940b903addbd779551569679f",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade all GHCR publisher jobs before the major is retired",
+      "validation": "Actionlint and least-privilege package publisher review",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": ".github/workflows/publish-linux.yml",
+          "contains": "docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4"
+        }
+      ]
+    },
+    {
+      "id": "action/docker-setup-buildx",
+      "name": "Docker Setup Buildx Action",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "devcontainer",
+        "server"
+      ],
+      "required": true,
+      "version": "v4",
+      "version_source": "Reviewed upstream major release",
+      "license": "Apache-2.0",
+      "source_url": "https://github.com/docker/setup-buildx-action",
+      "locator": "docker/setup-buildx-action",
+      "commit": "bb05f3f5519dd87d3ba754cc423b652a5edd6d2c",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade alongside build-push-action and rebuild images",
+      "validation": "Actionlint and BuildKit image validation",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": ".github/workflows/validate.yml",
+          "contains": "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4"
+        }
+      ]
+    },
+    {
+      "id": "container/devcontainer-docker-feature",
+      "name": "Dev Container Docker-in-Docker feature",
+      "kind": "container-feature",
+      "owner": "atrinik",
+      "scope": [
+        "atrinik"
+      ],
+      "required": true,
+      "version": "4.0.0",
+      "version_source": ".devcontainer/devcontainer-lock.json",
+      "license": "MIT",
+      "source_url": "https://github.com/devcontainers/features",
+      "locator": "ghcr.io/devcontainers/features/docker-in-docker",
+      "commit": null,
+      "checksum": "sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5",
+      "acquisition": "Dev Containers resolves the checksum-locked OCI feature",
+      "update_cadence_days": 30,
+      "update_mechanism": "devcontainer lock refresh followed by Docker smoke validation",
+      "eol_response": "Upgrade the feature or remove nested Docker support",
+      "validation": "Lock digest audit and devcontainer configuration tests",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": ".devcontainer/devcontainer-lock.json",
+          "contains": "ghcr.io/devcontainers/features/docker-in-docker@sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5"
+        },
+        {
+          "repository": "atrinik",
+          "path": ".devcontainer/devcontainer.json",
+          "contains": "ghcr.io/devcontainers/features/docker-in-docker:4"
+        }
+      ]
+    },
+    {
+      "id": "container/dockerfile-frontend",
+      "name": "Dockerfile frontend",
+      "kind": "container-image",
+      "owner": "devcontainer",
+      "scope": [
+        "devcontainer",
+        "server"
+      ],
+      "required": true,
+      "version": "1",
+      "version_source": "Docker Hub manifest",
+      "license": "Apache-2.0",
+      "source_url": "https://github.com/moby/buildkit",
+      "locator": "docker.io/docker/dockerfile",
+      "commit": null,
+      "checksum": "sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89",
+      "acquisition": "BuildKit pulls the Dockerfile syntax frontend by immutable manifest digest",
+      "update_cadence_days": 30,
+      "update_mechanism": "Dependabot Docker update with both image validations",
+      "eol_response": "Advance to a supported stable Dockerfile frontend before removing old syntax support",
+      "validation": "Docker build checks plus Linux and Windows image builds",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "linux/Dockerfile",
+          "contains": "docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89"
+        },
+        {
+          "repository": "devcontainer",
+          "path": "windows/Dockerfile",
+          "contains": "docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89"
+        },
+        {
+          "repository": "server",
+          "path": "Dockerfile",
+          "contains": "docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89"
+        }
+      ]
+    },
+    {
+      "id": "container/linux-build",
+      "name": "Atrinik Linux build image",
+      "kind": "container-image",
+      "owner": "devcontainer",
+      "scope": [
+        "atrinik"
+      ],
+      "required": true,
+      "version": "1.0.5",
+      "version_source": "Immutable semantic-release image tag",
+      "license": "LicenseRef-Atrinik-Image-Contents",
+      "source_url": "https://github.com/atrinik/devcontainer/pkgs/container/linux-build",
+      "locator": "ghcr.io/atrinik/linux-build",
+      "commit": null,
+      "checksum": "sha256:be3427cfc7dabcf837450c7306d55883c32e20ba1ab7cc96b4da4b966b8066de",
+      "acquisition": "Dev Containers pulls the release tag and immutable manifest digest",
+      "update_cadence_days": 30,
+      "update_mechanism": "Weekly audit plus reviewed devcontainer release update",
+      "eol_response": "Publish a supported replacement image and update the wrapper atomically",
+      "validation": "Devcontainer configuration tests and complete native build",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": ".devcontainer/devcontainer.json",
+          "contains": "ghcr.io/atrinik/linux-build:1.0.5@sha256:be3427cfc7dabcf837450c7306d55883c32e20ba1ab7cc96b4da4b966b8066de"
+        }
+      ]
+    },
+    {
+      "id": "container/microsoft-devcontainer-base",
+      "name": "Microsoft Dev Containers Debian base",
+      "kind": "container-image",
+      "owner": "devcontainer",
+      "scope": [
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "bookworm",
+      "version_source": "Microsoft Container Registry manifest",
+      "license": "LicenseRef-Microsoft-Dev-Container",
+      "source_url": "https://github.com/devcontainers/images",
+      "locator": "mcr.microsoft.com/devcontainers/base",
+      "commit": null,
+      "checksum": "sha256:73d85a96694a2cadca1ba3fcb5721f2312a64f1d571dd86f6c77e10a708931dc",
+      "acquisition": "BuildKit pulls the named base and immutable manifest digest",
+      "update_cadence_days": 30,
+      "update_mechanism": "Dependabot Docker update with cold MXE build review",
+      "eol_response": "Move the Windows toolchain image to the next supported Debian base",
+      "validation": "Docker build check and Windows image smoke build",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "windows/Dockerfile",
+          "contains": "mcr.microsoft.com/devcontainers/base:bookworm@sha256:73d85a96694a2cadca1ba3fcb5721f2312a64f1d571dd86f6c77e10a708931dc"
+        }
+      ]
+    },
+    {
+      "id": "container/ubuntu-26.04",
+      "name": "Ubuntu 26.04 base image",
+      "kind": "container-image",
+      "owner": "devcontainer",
+      "scope": [
+        "client",
+        "devcontainer",
+        "server"
+      ],
+      "required": true,
+      "version": "26.04",
+      "version_source": "Docker Official Images manifest",
+      "license": "LicenseRef-Ubuntu-Archive",
+      "source_url": "https://hub.docker.com/_/ubuntu",
+      "locator": "docker.io/library/ubuntu",
+      "commit": null,
+      "checksum": "sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7a03",
+      "acquisition": "BuildKit pulls the LTS tag and immutable multi-platform manifest digest",
+      "update_cadence_days": 30,
+      "update_mechanism": "Dependabot Docker update followed by Linux and server image builds",
+      "eol_response": "Move all consumers to the next supported Ubuntu LTS before standard support ends",
+      "validation": "Docker build checks, native tests, and server startup smoke test",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "client",
+          "path": ".github/workflows/check.yml",
+          "contains": "ubuntu@sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7a03"
+        },
+        {
+          "repository": "devcontainer",
+          "path": "linux/Dockerfile",
+          "contains": "ubuntu:26.04@sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7a03"
+        },
+        {
+          "repository": "server",
+          "path": ".github/workflows/check.yml",
+          "contains": "ubuntu@sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7a03"
+        },
+        {
+          "repository": "server",
+          "path": "Dockerfile",
+          "contains": "ubuntu@sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7a03"
+        }
+      ]
+    },
+    {
+      "id": "container/windows-build",
+      "name": "Atrinik Windows build image",
+      "kind": "container-image",
+      "owner": "devcontainer",
+      "scope": [
+        "atrinik",
+        "client",
+        "server"
+      ],
+      "required": true,
+      "version": "1.0.5",
+      "version_source": "Immutable semantic-release image tag",
+      "license": "LicenseRef-Atrinik-Image-Contents",
+      "source_url": "https://github.com/atrinik/devcontainer/pkgs/container/windows-build",
+      "locator": "ghcr.io/atrinik/windows-build",
+      "commit": null,
+      "checksum": "sha256:9cc373f620a577328fc0a7a7fa823bddaca6d7dc75ac73bcf21be421c49676f7",
+      "acquisition": "Dev Containers pulls the release tag and immutable manifest digest",
+      "update_cadence_days": 30,
+      "update_mechanism": "Weekly audit plus reviewed devcontainer release update",
+      "eol_response": "Publish a supported replacement image and update the wrapper atomically",
+      "validation": "Devcontainer configuration tests and portable MinGW builds",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": ".devcontainer/windows-cross/devcontainer.json",
+          "contains": "ghcr.io/atrinik/windows-build:1.0.5@sha256:9cc373f620a577328fc0a7a7fa823bddaca6d7dc75ac73bcf21be421c49676f7"
+        },
+        {
+          "repository": "client",
+          "path": ".github/workflows/package-release.yml",
+          "contains": "ghcr.io/atrinik/windows-build:1.0.5@sha256:9cc373f620a577328fc0a7a7fa823bddaca6d7dc75ac73bcf21be421c49676f7"
+        },
+        {
+          "repository": "server",
+          "path": ".github/workflows/package-release.yml",
+          "contains": "ghcr.io/atrinik/windows-build:1.0.5@sha256:9cc373f620a577328fc0a7a7fa823bddaca6d7dc75ac73bcf21be421c49676f7"
+        }
+      ]
+    },
+    {
+      "id": "external/content-assets",
+      "name": "Authored content asset licenses",
+      "kind": "external-tool",
+      "owner": "content",
+      "scope": [
+        "content"
+      ],
+      "required": true,
+      "version": "per-file",
+      "version_source": "Nearest tracked LICENSE/COPYING file",
+      "license": "LicenseRef-Atrinik-Asset-Per-File",
+      "source_url": "https://github.com/atrinik/content",
+      "locator": "atrinik-content-assets",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Reviewed authored/imported assets retain source-local attribution",
+      "update_cadence_days": 90,
+      "update_mechanism": "Content license validator and review of every imported asset",
+      "eol_response": "Remove assets whose provenance or redistribution grant cannot be maintained",
+      "validation": "arch/license_check.py and deterministic content packaging",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "content",
+          "path": "arch/license_check.py",
+          "contains": "LICENSE"
+        }
+      ]
+    },
+    {
+      "id": "external/gridarta",
+      "name": "Gridarta source checkout",
+      "kind": "external-tool",
+      "owner": "editor",
+      "scope": [
+        "editor"
+      ],
+      "required": false,
+      "version": "operator-supplied-reviewed-checkout",
+      "version_source": "Explicit build.sh positional checkout",
+      "license": "GPL-2.0-only",
+      "source_url": "https://github.com/gridarta/gridarta",
+      "locator": "gridarta",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Operator supplies a separate checkout; Atrinik never downloads or mutates it",
+      "update_cadence_days": 180,
+      "update_mechanism": "Manual compatibility review until the editor is retired",
+      "eol_response": "Retire this packaging path through atrinik/content#5 rather than vendoring Gridarta",
+      "validation": "Disposable Gradle fixture and expected AtrinikEditor.jar contract",
+      "disposition": "remove",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "editor",
+          "path": "build.sh",
+          "contains": "./gradlew clean :src:atrinik:preparePublish"
+        }
+      ]
+    },
+    {
+      "id": "external/php",
+      "name": "PHP runtime for legacy worldviewer",
+      "kind": "external-tool",
+      "owner": "tools",
+      "scope": [
+        "tools"
+      ],
+      "required": false,
+      "version": "operator-supplied",
+      "version_source": "Legacy worldviewer deployment environment",
+      "license": "PHP-3.01",
+      "source_url": "https://www.php.net/",
+      "locator": "php",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Optional system runtime outside supported CI",
+      "update_cadence_days": 180,
+      "update_mechanism": "Manual compatibility audit while the legacy viewer remains",
+      "eol_response": "Remove the viewer if it cannot run safely on a supported PHP release",
+      "validation": "PHP syntax check in a deliberately provisioned legacy environment",
+      "disposition": "remove",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "tools",
+          "path": "worldviewer/world.php",
+          "contains": "php_sapi_name()"
+        }
+      ]
+    },
+    {
+      "id": "external/pyqt5",
+      "name": "PyQt5",
+      "kind": "external-tool",
+      "owner": "tools",
+      "scope": [
+        "tools"
+      ],
+      "required": false,
+      "version": "5.x operator-supplied",
+      "version_source": "Legacy Qt map-checker runtime",
+      "license": "GPL-3.0-only",
+      "source_url": "https://www.riverbankcomputing.com/software/pyqt/",
+      "locator": "pkg:pypi/PyQt5",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Optional operator-managed Python environment",
+      "update_cadence_days": 90,
+      "update_mechanism": "Manual GUI compatibility review pending native editor replacement",
+      "eol_response": "Port or retire the GUI rather than pinning an unsupported Python/Qt stack",
+      "validation": "Headless map-checker tests plus explicit GUI smoke test",
+      "disposition": "replace",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "tools",
+          "path": "map-checker-qt/ui/window_main.py",
+          "contains": "from PyQt5"
+        }
+      ]
+    },
+    {
+      "id": "external/resource-assets",
+      "name": "Server resource asset licenses",
+      "kind": "external-tool",
+      "owner": "resources",
+      "scope": [
+        "resources"
+      ],
+      "required": true,
+      "version": "per-file",
+      "version_source": "Nearest tracked LICENSE file",
+      "license": "LicenseRef-Atrinik-Asset-Per-File",
+      "source_url": "https://github.com/atrinik/resources",
+      "locator": "atrinik-resource-assets",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Reviewed assets retain source-local attribution",
+      "update_cadence_days": 90,
+      "update_mechanism": "Release allowlist and license review",
+      "eol_response": "Remove assets whose provenance or redistribution grant cannot be maintained",
+      "validation": "Deterministic resource archive and required license checks",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "resources",
+          "path": "runtime-paths.txt",
+          "contains": "paintings"
+        }
+      ]
+    },
+    {
+      "id": "external/sound-assets",
+      "name": "Music and sound-effect licenses",
+      "kind": "external-tool",
+      "owner": "sound",
+      "scope": [
+        "sound"
+      ],
+      "required": true,
+      "version": "per-file",
+      "version_source": "Nearest tracked LICENSE file",
+      "license": "LicenseRef-Atrinik-Asset-Per-File",
+      "source_url": "https://github.com/atrinik/sound",
+      "locator": "atrinik-sound-assets",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Reviewed audio retains source-local attribution",
+      "update_cadence_days": 90,
+      "update_mechanism": "Release package and license review",
+      "eol_response": "Remove audio whose provenance or redistribution grant cannot be maintained",
+      "validation": "Deterministic sound archive and required license checks",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "sound",
+          "path": "effects/LICENSE",
+          "contains": "GNU GPL 2.0"
+        }
+      ]
+    },
+    {
+      "id": "language/metaserver-npm",
+      "name": "Metaserver Worker npm dependency graph",
+      "kind": "language-package-set",
+      "owner": "metaserver-worker",
+      "scope": [
+        "metaserver-worker"
+      ],
+      "required": true,
+      "version": "lockfileVersion-3",
+      "version_source": "package-lock.json",
+      "license": "NOASSERTION",
+      "source_url": "https://www.npmjs.com/",
+      "locator": "pkg:npm/atrinik-metaserver@1.0.0",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "npm ci installs the exact package-lock graph",
+      "update_cadence_days": 7,
+      "update_mechanism": "Grouped Dependabot npm development updates",
+      "eol_response": "Upgrade incompatible packages on the supported Node line or replace them",
+      "validation": "npm ci, type checks, Vitest, admin tests, and Wrangler dry run",
+      "disposition": "retain",
+      "packages": [
+        "@cloudflare/vitest-pool-workers",
+        "@types/node",
+        "tsx",
+        "typescript",
+        "vitest",
+        "wrangler"
+      ],
+      "evidence": [
+        {
+          "repository": "metaserver-worker",
+          "path": "package-lock.json",
+          "contains": "\"lockfileVersion\": 3"
+        },
+        {
+          "repository": "metaserver-worker",
+          "path": "package.json",
+          "contains": "\"wrangler\": \"^4.118.0\""
+        }
+      ]
+    },
+    {
+      "id": "language/protocol-python-build",
+      "name": "Protocol Python build toolchain",
+      "kind": "language-package-set",
+      "owner": "protocol",
+      "scope": [
+        "protocol"
+      ],
+      "required": true,
+      "version": "setuptools>=77; setuptools-scm>=8,<10; build=1.3.0",
+      "version_source": "pyproject.toml and workflows",
+      "license": "MIT",
+      "source_url": "https://pypi.org/project/build/",
+      "locator": "pkg:pypi/build@1.3.0",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "pip build isolation plus an exact wheel frontend version",
+      "update_cadence_days": 30,
+      "update_mechanism": "Dependabot pip updates with wheel reproducibility tests",
+      "eol_response": "Move to supported PyPA build backends before current versions expire",
+      "validation": "Generated-binding check, unit tests, and wheel build",
+      "disposition": "retain",
+      "packages": [
+        "build",
+        "setuptools",
+        "setuptools-scm"
+      ],
+      "evidence": [
+        {
+          "repository": "protocol",
+          "path": "pyproject.toml",
+          "contains": "setuptools-scm>=8,<10"
+        }
+      ]
+    },
+    {
+      "id": "language/wrapper-python-development",
+      "name": "Workspace Python development dependencies",
+      "kind": "language-package-set",
+      "owner": "atrinik",
+      "scope": [
+        "atrinik"
+      ],
+      "required": false,
+      "version": "coverage=7.15.2",
+      "version_source": "requirements-dev.txt",
+      "license": "Apache-2.0",
+      "source_url": "https://pypi.org/project/coverage/",
+      "locator": "pkg:pypi/coverage@7.15.2",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "pip installs the exact development requirement",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot pip updates",
+      "eol_response": "Upgrade with the supported Python line or retain stdlib test execution without coverage",
+      "validation": "Complete unittest suite and coverage report",
+      "disposition": "retain",
+      "packages": [
+        "coverage"
+      ],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": "requirements-dev.txt",
+          "contains": "coverage==7.15.2"
+        }
+      ]
+    },
+    {
+      "id": "source/atrinik-content-runtime",
+      "name": "Atrinik content runtime archive",
+      "kind": "source-archive",
+      "owner": "content",
+      "scope": [
+        "server"
+      ],
+      "required": true,
+      "version": "v1.2.0",
+      "version_source": "server/dependencies.lock.json",
+      "license": "LicenseRef-Atrinik-Asset-Per-File",
+      "source_url": "https://github.com/atrinik/content/releases/tag/v1.2.0",
+      "locator": "pkg:github/atrinik/content@v1.2.0",
+      "commit": "766cb6e67aa03dd86b1c333c607885df31c3aca5",
+      "checksum": "sha256:06dd946dbd121429d4a2b8b5ac1de02e7561b723916f6400b3e87134364ac4c2",
+      "acquisition": "Server dependency tool downloads and safely extracts the release archive",
+      "update_cadence_days": 30,
+      "update_mechanism": "Weekly lock drift audit and reviewed release consumption",
+      "eol_response": "Update the lock to a supported content release or stop packaging the server",
+      "validation": "Lock validation, checksum, safe extraction, collection, and server runtime tests",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "server",
+          "path": "dependencies.lock.json",
+          "contains": "atrinik-content-1.2.0-runtime.tar.gz"
+        }
+      ]
+    },
+    {
+      "id": "source/atrinik-libatrinik",
+      "name": "libatrinik release source",
+      "kind": "source-archive",
+      "owner": "libatrinik",
+      "scope": [
+        "client",
+        "libatrinik",
+        "server"
+      ],
+      "required": true,
+      "version": "v1.0.3",
+      "version_source": "client/server CMake dependency locks",
+      "license": "GPL-2.0-or-later",
+      "source_url": "https://github.com/atrinik/libatrinik/releases/tag/v1.0.3",
+      "locator": "pkg:github/atrinik/libatrinik@v1.0.3",
+      "commit": "2996df2866eb220d45a1493408f4e54851f72c8e",
+      "checksum": "sha256:6dc6823aca9cf24242bd67f5aed7469da9ca57fe2cdf7ada30e105b908a396d4",
+      "acquisition": "CMake FetchContent downloads the checksum-pinned release archive",
+      "update_cadence_days": 30,
+      "update_mechanism": "Weekly lock drift audit and coordinated downstream update",
+      "eol_response": "Release and consume a supported library version before removing the old release",
+      "validation": "CMake lock validation, downstream native tests, and install consumer",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "client",
+          "path": "cmake/dependencies.lock.json",
+          "contains": "libatrinik-1.0.3.tar.gz"
+        },
+        {
+          "repository": "libatrinik",
+          "path": "tests/consumer/CMakeLists.txt",
+          "contains": "find_package(LibAtrinik 1 CONFIG REQUIRED)"
+        },
+        {
+          "repository": "server",
+          "path": "cmake/dependencies.lock.json",
+          "contains": "libatrinik-1.0.3.tar.gz"
+        }
+      ]
+    },
+    {
+      "id": "source/atrinik-protocol-client-server",
+      "name": "Atrinik protocol release source for client/server",
+      "kind": "source-archive",
+      "owner": "protocol",
+      "scope": [
+        "client",
+        "server"
+      ],
+      "required": true,
+      "version": "v1.0.1",
+      "version_source": "client/server CMake dependency locks",
+      "license": "MIT",
+      "source_url": "https://github.com/atrinik/protocol/releases/tag/v1.0.1",
+      "locator": "pkg:github/atrinik/protocol@v1.0.1",
+      "commit": "7e10ecaa279489fcdb843ecbe020fc9befeba4fd",
+      "checksum": "sha256:d8e113210a395913d27446e5764f212f6f1de028c9945ae9f0479588474b3137",
+      "acquisition": "CMake FetchContent downloads the checksum-pinned release archive",
+      "update_cadence_days": 30,
+      "update_mechanism": "Weekly lock drift audit and coordinated endpoint update",
+      "eol_response": "Release and consume a supported protocol version across both endpoints",
+      "validation": "Lock validation, generated bindings, native endpoint tests, and MinGW builds",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "client",
+          "path": "cmake/dependencies.lock.json",
+          "contains": "atrinik-protocol-1.0.1.tar.gz"
+        },
+        {
+          "repository": "server",
+          "path": "cmake/dependencies.lock.json",
+          "contains": "atrinik-protocol-1.0.1.tar.gz"
+        }
+      ]
+    },
+    {
+      "id": "source/atrinik-protocol-libatrinik",
+      "name": "Atrinik protocol release source for libatrinik",
+      "kind": "source-archive",
+      "owner": "protocol",
+      "scope": [
+        "libatrinik"
+      ],
+      "required": true,
+      "version": "v1.0.0",
+      "version_source": "libatrinik/dependencies.lock.json",
+      "license": "MIT",
+      "source_url": "https://github.com/atrinik/protocol/releases/tag/v1.0.0",
+      "locator": "pkg:github/atrinik/protocol@v1.0.0",
+      "commit": "8be5e46bbf471b108e9ce70d3f929f74a0fb1f8d",
+      "checksum": "sha256:1e37b970bfa47b119b5156fb90178915ee933c1a42ba061766ecd99f1d6640e8",
+      "acquisition": "CMake FetchContent downloads the checksum-pinned release archive",
+      "update_cadence_days": 30,
+      "update_mechanism": "Weekly lock drift audit and library compatibility review",
+      "eol_response": "Update the library release input before the protocol line is unsupported",
+      "validation": "Lock validation, library tests, and installed consumer",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "libatrinik",
+          "path": "dependencies.lock.json",
+          "contains": "atrinik-protocol-1.0.0.tar.gz"
+        }
+      ]
+    },
+    {
+      "id": "source/atrinik-resources-runtime",
+      "name": "Atrinik server resource archive",
+      "kind": "source-archive",
+      "owner": "resources",
+      "scope": [
+        "server"
+      ],
+      "required": true,
+      "version": "v1.0.1",
+      "version_source": "server/dependencies.lock.json",
+      "license": "LicenseRef-Atrinik-Asset-Per-File",
+      "source_url": "https://github.com/atrinik/resources/releases/tag/v1.0.1",
+      "locator": "pkg:github/atrinik/resources@v1.0.1",
+      "commit": "a3bd8c8a2b746d15b397a67d9f641af7d97a6078",
+      "checksum": "sha256:4db9ecdd74aa570bc7e20eccac980844f3aba8d668230502728b22146d3b2c54",
+      "acquisition": "Server dependency tool downloads and safely extracts the release archive",
+      "update_cadence_days": 30,
+      "update_mechanism": "Weekly lock drift audit and reviewed release consumption",
+      "eol_response": "Update the lock to a supported resource release or stop packaging the server",
+      "validation": "Lock validation, checksum, safe extraction, and runtime allowlist",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "server",
+          "path": "dependencies.lock.json",
+          "contains": "atrinik-resources-1.0.1.tar.gz"
+        }
+      ]
+    },
+    {
+      "id": "source/atrinik-sound-runtime",
+      "name": "Atrinik sound archive",
+      "kind": "source-archive",
+      "owner": "sound",
+      "scope": [
+        "client"
+      ],
+      "required": true,
+      "version": "v1.0.3",
+      "version_source": "client/dependencies.lock.json",
+      "license": "LicenseRef-Atrinik-Asset-Per-File",
+      "source_url": "https://github.com/atrinik/sound/releases/tag/v1.0.3",
+      "locator": "pkg:github/atrinik/sound@v1.0.3",
+      "commit": "18234cce19bf641f24d81333d8abcc0f1e34cd08",
+      "checksum": "sha256:5427d2d2b5b73bad30c279ea5b7f012c380fd402249d45d9363b85ea7674e4bb",
+      "acquisition": "Client dependency tool downloads and safely extracts the release archive",
+      "update_cadence_days": 30,
+      "update_mechanism": "Weekly lock drift audit and reviewed release consumption",
+      "eol_response": "Update the lock to a supported sound release or disable packaging",
+      "validation": "Lock validation, checksum, safe extraction, and client package test",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "client",
+          "path": "dependencies.lock.json",
+          "contains": "atrinik-sound-1.0.3.tar.gz"
+        }
+      ]
+    },
+    {
+      "id": "source/content-catalog",
+      "name": "Content catalog package",
+      "kind": "source-archive",
+      "owner": "content",
+      "scope": [
+        "tools"
+      ],
+      "required": true,
+      "version": "v1.2.0",
+      "version_source": "tools/map-checker-qt/catalog.lock.json",
+      "license": "MIT",
+      "source_url": "https://github.com/atrinik/content/releases/tag/v1.2.0",
+      "locator": "pkg:github/atrinik/content@v1.2.0#tools/content_catalog",
+      "commit": "766cb6e67aa03dd86b1c333c607885df31c3aca5",
+      "checksum": "sha256:c9ad1cfa555e2c9f23e7e814599ce67ea79a2779879787b6ad91f4a0c9e713f1",
+      "acquisition": "Map checker dependency tool safely extracts the catalog subtree",
+      "update_cadence_days": 30,
+      "update_mechanism": "Weekly lock drift audit and catalog parity tests",
+      "eol_response": "Consume a supported content catalog release before removing the old package",
+      "validation": "Checksum, archive-prefix, path, import-origin, and catalog tests",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "tools",
+          "path": "map-checker-qt/catalog.lock.json",
+          "contains": "atrinik-content-1.2.0/tools/content_catalog"
+        }
+      ]
+    },
+    {
+      "id": "source/libpcpnatpmp",
+      "name": "libpcpnatpmp",
+      "kind": "source-archive",
+      "owner": "server",
+      "scope": [
+        "server"
+      ],
+      "required": true,
+      "version": "866d283da99f5e98eecff702a8df63e2ae57ffca",
+      "version_source": "server/cmake/pcpnatpmp.cmake",
+      "license": "BSD-3-Clause",
+      "source_url": "https://github.com/libpcpnatpmp/libpcpnatpmp",
+      "locator": "pkg:github/libpcpnatpmp/libpcpnatpmp@866d283da99f5e98eecff702a8df63e2ae57ffca",
+      "commit": "866d283da99f5e98eecff702a8df63e2ae57ffca",
+      "checksum": "sha256:65ab99547ecc8277434527607d24f8a1b02a2344ed4cea475bed751606e60202",
+      "acquisition": "CMake FetchContent downloads the commit archive and applies a reviewed MinGW patch",
+      "update_cadence_days": 90,
+      "update_mechanism": "Scheduled source-pin audit and sanitizer/network smoke review",
+      "eol_response": "Update the isolated source or replace NAT-PMP support without a fallback copy",
+      "validation": "Checksum, idempotent patch, native tests, and Linux/MinGW builds",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "server",
+          "path": "cmake/pcpnatpmp.cmake",
+          "contains": "866d283da99f5e98eecff702a8df63e2ae57ffca.tar.gz"
+        }
+      ]
+    },
+    {
+      "id": "source/miniupnpc",
+      "name": "MiniUPnPc source for MinGW",
+      "kind": "source-archive",
+      "owner": "devcontainer",
+      "scope": [
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "bf4215a7574f88aa55859db9db00e3ae58cf42d6",
+      "version_source": "windows/Dockerfile MINIUPNPC_COMMIT",
+      "license": "BSD-3-Clause",
+      "source_url": "https://github.com/miniupnp/miniupnp",
+      "locator": "pkg:github/miniupnp/miniupnp@bf4215a7574f88aa55859db9db00e3ae58cf42d6",
+      "commit": "bf4215a7574f88aa55859db9db00e3ae58cf42d6",
+      "checksum": null,
+      "acquisition": "The Windows image shallow-clones and checks out the immutable commit",
+      "update_cadence_days": 90,
+      "update_mechanism": "Scheduled commit drift review and full Windows image build",
+      "eol_response": "Update or remove UPnP support if the source line becomes unsupported",
+      "validation": "Exact checkout plus MinGW configure/build/install",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "windows/Dockerfile",
+          "contains": "MINIUPNPC_COMMIT=bf4215a7574f88aa55859db9db00e3ae58cf42d6"
+        }
+      ]
+    },
+    {
+      "id": "source/mxe",
+      "name": "MXE cross-toolchain source",
+      "kind": "toolchain",
+      "owner": "devcontainer",
+      "scope": [
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "8784776b145a8ddd350ce32aa0908ac10977060c",
+      "version_source": "windows/Dockerfile MXE_REF",
+      "license": "MIT",
+      "source_url": "https://github.com/mxe/mxe",
+      "locator": "pkg:github/mxe/mxe@8784776b145a8ddd350ce32aa0908ac10977060c",
+      "commit": "8784776b145a8ddd350ce32aa0908ac10977060c",
+      "checksum": null,
+      "acquisition": "The Windows image shallow-clones and checks out the immutable commit",
+      "update_cadence_days": 30,
+      "update_mechanism": "Scheduled commit review with cold Windows image and client/server builds",
+      "eol_response": "Advance MXE and its compiler before existing targets leave support",
+      "validation": "Patched MXE package builds and portable MinGW client/server tests",
+      "disposition": "isolate",
+      "packages": [
+        "cmake",
+        "curl",
+        "libxml2",
+        "openssl",
+        "sdl3",
+        "sdl3_image",
+        "sdl3_ttf",
+        "zlib"
+      ],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "windows/Dockerfile",
+          "contains": "MXE_REF=8784776b145a8ddd350ce32aa0908ac10977060c"
+        }
+      ]
+    },
+    {
+      "id": "source/sdl3-mixer-mingw",
+      "name": "SDL3_mixer MinGW SDK",
+      "kind": "source-archive",
+      "owner": "devcontainer",
+      "scope": [
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "3.2.4",
+      "version_source": "windows/Dockerfile",
+      "license": "Zlib",
+      "source_url": "https://github.com/libsdl-org/SDL_mixer/releases/tag/release-3.2.4",
+      "locator": "pkg:github/libsdl-org/SDL_mixer@release-3.2.4#mingw",
+      "commit": null,
+      "checksum": "sha256:2ff5f59be4683e0afb4339c4fa73c6228651e52d37b040ecf80da08edb3cecd6",
+      "acquisition": "Windows image downloads the official checksum-pinned SDK",
+      "update_cadence_days": 30,
+      "update_mechanism": "Scheduled release drift review with Windows sound import verification",
+      "eol_response": "Upgrade with SDL3 and rebuild the complete portable client",
+      "validation": "Checksum, pkg-config version, DLL presence, and client import check",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "windows/Dockerfile",
+          "contains": "SDL3_MIXER_MINGW_SHA256=2ff5f59be4683e0afb4339c4fa73c6228651e52d37b040ecf80da08edb3cecd6"
+        }
+      ]
+    },
+    {
+      "id": "source/sdl3-mixer-source",
+      "name": "SDL3_mixer source archive",
+      "kind": "source-archive",
+      "owner": "devcontainer",
+      "scope": [
+        "client",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "3.2.4",
+      "version_source": "Linux image and client CI installer",
+      "license": "Zlib",
+      "source_url": "https://github.com/libsdl-org/SDL_mixer/releases/tag/release-3.2.4",
+      "locator": "pkg:github/libsdl-org/SDL_mixer@release-3.2.4",
+      "commit": null,
+      "checksum": "sha256:182a07c745375e113dc740d43964ff21b0be29f29f59876c4dbc4db3d32f6901",
+      "acquisition": "Checksum-pinned official release source is built with a bounded codec set",
+      "update_cadence_days": 30,
+      "update_mechanism": "Scheduled release drift review and client audio tests",
+      "eol_response": "Upgrade with SDL3 or temporarily disable unsupported codecs explicitly",
+      "validation": "Checksum, pkg-config version, native client build, and sound tests",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "client",
+          "path": "tools/install-linux-ci-dependencies.sh",
+          "contains": "182a07c745375e113dc740d43964ff21b0be29f29f59876c4dbc4db3d32f6901"
+        },
+        {
+          "repository": "devcontainer",
+          "path": "linux/Dockerfile",
+          "contains": "SDL3_MIXER_SHA256=182a07c745375e113dc740d43964ff21b0be29f29f59876c4dbc4db3d32f6901"
+        }
+      ]
+    },
+    {
+      "id": "system/check",
+      "name": "Check unit-testing framework",
+      "kind": "system-library",
+      "owner": "server",
+      "scope": [
+        "server"
+      ],
+      "required": false,
+      "version": "distribution-provided",
+      "version_source": "Ubuntu 26.04 package set",
+      "license": "LGPL-2.1-or-later",
+      "source_url": "https://libcheck.github.io/check/",
+      "locator": "pkg:generic/check",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "pkg-config resolves the build-image package",
+      "update_cadence_days": 30,
+      "update_mechanism": "Pinned image rebuild and package-version report",
+      "eol_response": "Upgrade the image or migrate focused tests without suppressing them",
+      "validation": "Optional CHECK_PKG discovery and server unit suite",
+      "disposition": "retain",
+      "packages": [
+        "check",
+        "libsubunit-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "server",
+          "path": "CMakeLists.txt",
+          "contains": "pkg_check_modules(CHECK_PKG QUIET IMPORTED_TARGET check)"
+        }
+      ]
+    },
+    {
+      "id": "system/client-ci-packages",
+      "name": "Client Linux CI package set",
+      "kind": "system-package-set",
+      "owner": "client",
+      "scope": [
+        "client"
+      ],
+      "required": true,
+      "version": "ubuntu-24.04-runner",
+      "version_source": "GitHub-hosted runner package repositories",
+      "license": "NOASSERTION",
+      "source_url": "https://github.com/actions/runner-images",
+      "locator": "ubuntu-client-ci-packages",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "apt installs the declared packages in the ephemeral CI runner",
+      "update_cadence_days": 30,
+      "update_mechanism": "Weekly dependency audit and exact CI version report",
+      "eol_response": "Move the job to a supported runner/image and update package names together",
+      "validation": "Dependency installer, native build, CTest, and coverage",
+      "disposition": "isolate",
+      "packages": [
+        "build-essential",
+        "ca-certificates",
+        "cmake",
+        "curl",
+        "gcovr",
+        "libcurl4-openssl-dev",
+        "libsdl3-dev",
+        "libsdl3-image-dev",
+        "libsdl3-ttf-dev",
+        "libssl-dev",
+        "libxml2-dev",
+        "ninja-build",
+        "pkgconf",
+        "python3",
+        "zlib1g-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "client",
+          "path": "tools/install-linux-ci-dependencies.sh",
+          "contains": "apt-get install -y -qq --no-install-recommends"
+        }
+      ]
+    },
+    {
+      "id": "system/curl",
+      "name": "libcurl",
+      "kind": "system-library",
+      "owner": "libatrinik",
+      "scope": [
+        "client",
+        "devcontainer",
+        "libatrinik",
+        "server"
+      ],
+      "required": true,
+      "version": "distribution/MXE-provided",
+      "version_source": "Pinned build images and MXE commit",
+      "license": "LicenseRef-curl",
+      "source_url": "https://curl.se/libcurl/",
+      "locator": "pkg:generic/libcurl",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake imported target from the pinned native or MXE package set",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image rebuild, MXE review, and exact version report",
+      "eol_response": "Upgrade immediately for unsupported or security-affected TLS/HTTP lines",
+      "validation": "CMake discovery, TLS backend check, and client/server network tests",
+      "disposition": "retain",
+      "packages": [
+        "libcurl4-openssl-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "libatrinik",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(CURL REQUIRED)"
+        }
+      ]
+    },
+    {
+      "id": "system/flex",
+      "name": "Flex",
+      "kind": "toolchain",
+      "owner": "server",
+      "scope": [
+        "devcontainer",
+        "server"
+      ],
+      "required": true,
+      "version": "distribution-provided",
+      "version_source": "Pinned build images",
+      "license": "BSD-2-Clause",
+      "source_url": "https://github.com/westes/flex",
+      "locator": "pkg:generic/flex",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake finds the lexer generator from the build image",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image update and generated-loader parity tests",
+      "eol_response": "Upgrade the image or replace generated loader inputs deliberately",
+      "validation": "CMake FLEX discovery and loader/runtime tests",
+      "disposition": "retain",
+      "packages": [
+        "flex"
+      ],
+      "evidence": [
+        {
+          "repository": "server",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(FLEX REQUIRED)"
+        }
+      ]
+    },
+    {
+      "id": "system/gd",
+      "name": "libgd",
+      "kind": "system-library",
+      "owner": "server",
+      "scope": [
+        "devcontainer",
+        "server"
+      ],
+      "required": false,
+      "version": "distribution-provided",
+      "version_source": "Pinned build images",
+      "license": "NOASSERTION",
+      "source_url": "https://github.com/libgd/libgd",
+      "locator": "pkg:generic/libgd",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake finds the optional world-maker library from the image",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image update and world-maker generation test",
+      "eol_response": "Replace the world-maker dependency through client-rendered imagery before removal",
+      "validation": "CMake GD_LIBRARY discovery and isolated world-maker generation",
+      "disposition": "replace",
+      "packages": [
+        "libgd-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "server",
+          "path": "CMakeLists.txt",
+          "contains": "find_library(GD_LIBRARY gd)"
+        }
+      ]
+    },
+    {
+      "id": "system/libxml2",
+      "name": "libxml2",
+      "kind": "system-library",
+      "owner": "client",
+      "scope": [
+        "client",
+        "devcontainer",
+        "server"
+      ],
+      "required": true,
+      "version": "distribution/MXE-provided",
+      "version_source": "Pinned build images and MXE commit",
+      "license": "MIT",
+      "source_url": "https://gitlab.gnome.org/GNOME/libxml2",
+      "locator": "pkg:generic/libxml2",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake imported target from the native or MXE package set",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image rebuild, MXE review, and parser tests",
+      "eol_response": "Upgrade promptly for unsupported or security-affected parser lines",
+      "validation": "CMake discovery and malformed XML fixtures",
+      "disposition": "retain",
+      "packages": [
+        "libxml2-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "client",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(LibXml2 REQUIRED)"
+        }
+      ]
+    },
+    {
+      "id": "system/miniupnpc",
+      "name": "MiniUPnPc",
+      "kind": "system-library",
+      "owner": "server",
+      "scope": [
+        "devcontainer",
+        "server"
+      ],
+      "required": true,
+      "version": "distribution/MXE-pinned",
+      "version_source": "Ubuntu image packages and MinGW source commit",
+      "license": "BSD-3-Clause",
+      "source_url": "https://github.com/miniupnp/miniupnp",
+      "locator": "pkg:generic/miniupnpc",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "pkg-config on Linux and isolated static MinGW build",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image/package update plus MinGW source review",
+      "eol_response": "Update or remove automatic port mapping without weakening network defaults",
+      "validation": "Pkg-config discovery, MinGW static library, and network-disabled runtime tests",
+      "disposition": "isolate",
+      "packages": [
+        "libminiupnpc-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "server",
+          "path": "CMakeLists.txt",
+          "contains": "pkg_check_modules(MINIUPNPC REQUIRED IMPORTED_TARGET miniupnpc)"
+        }
+      ]
+    },
+    {
+      "id": "system/openssl",
+      "name": "OpenSSL",
+      "kind": "system-library",
+      "owner": "libatrinik",
+      "scope": [
+        "client",
+        "devcontainer",
+        "libatrinik",
+        "server"
+      ],
+      "required": true,
+      "version": "distribution/MXE-provided",
+      "version_source": "Pinned build images and MXE commit",
+      "license": "Apache-2.0",
+      "source_url": "https://www.openssl.org/",
+      "locator": "pkg:generic/openssl",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake imported target from the native or MXE package set",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image/MXE update, security advisory review, and exact version report",
+      "eol_response": "Upgrade before the supported OpenSSL line reaches EOL; security fixes are urgent",
+      "validation": "CMake discovery, crypto known-answer tests, and TLS runtime tests",
+      "disposition": "retain",
+      "packages": [
+        "libssl-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "libatrinik",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(OpenSSL REQUIRED)"
+        }
+      ]
+    },
+    {
+      "id": "system/pkg-config",
+      "name": "pkg-config/pkgconf",
+      "kind": "toolchain",
+      "owner": "server",
+      "scope": [
+        "client",
+        "devcontainer",
+        "server"
+      ],
+      "required": true,
+      "version": "distribution-provided",
+      "version_source": "Pinned build images",
+      "license": "LicenseRef-System-Distribution",
+      "source_url": "https://github.com/pkgconf/pkgconf",
+      "locator": "pkg:generic/pkgconf",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake resolves native package metadata from the build image",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image update and exact version report",
+      "eol_response": "Upgrade the image or migrate affected discovery to supported imported targets",
+      "validation": "CMake PkgConfig discovery across Linux and MinGW",
+      "disposition": "retain",
+      "packages": [
+        "pkgconf"
+      ],
+      "evidence": [
+        {
+          "repository": "server",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(PkgConfig REQUIRED)"
+        }
+      ]
+    },
+    {
+      "id": "system/sdl3",
+      "name": "SDL3",
+      "kind": "system-library",
+      "owner": "client",
+      "scope": [
+        "client",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": ">=3.4",
+      "version_source": "Client CMake constraint and pinned build images",
+      "license": "Zlib",
+      "source_url": "https://github.com/libsdl-org/SDL",
+      "locator": "pkg:generic/SDL3",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake imported target from Ubuntu or MXE",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image/MXE update and SDL3 client test matrix",
+      "eol_response": "Upgrade to a supported SDL3 release without reintroducing SDL2 compatibility",
+      "validation": "CMake version constraint, native tests, and live client smoke test",
+      "disposition": "retain",
+      "packages": [
+        "libsdl3-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "client",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(SDL3 3.4 CONFIG REQUIRED)"
+        }
+      ]
+    },
+    {
+      "id": "system/sdl3-image",
+      "name": "SDL3_image",
+      "kind": "system-library",
+      "owner": "client",
+      "scope": [
+        "client",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": ">=3.2",
+      "version_source": "Client CMake constraint and pinned build images",
+      "license": "Zlib",
+      "source_url": "https://github.com/libsdl-org/SDL_image",
+      "locator": "pkg:generic/SDL3_image",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake imported target from Ubuntu or patched MXE",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image/MXE update and image-decoder tests",
+      "eol_response": "Upgrade with SDL3 and preserve supported image formats explicitly",
+      "validation": "CMake version constraint, image fixtures, and portable client build",
+      "disposition": "retain",
+      "packages": [
+        "libsdl3-image-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "client",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(SDL3_image 3.2 CONFIG REQUIRED)"
+        }
+      ]
+    },
+    {
+      "id": "system/sdl3-mixer",
+      "name": "SDL3_mixer",
+      "kind": "system-library",
+      "owner": "client",
+      "scope": [
+        "client",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": ">=3.2.4",
+      "version_source": "Client CMake constraint and checksum-pinned source/SDK",
+      "license": "Zlib",
+      "source_url": "https://github.com/libsdl-org/SDL_mixer",
+      "locator": "pkg:generic/SDL3_mixer",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake imported target built from the reviewed source or SDK",
+      "update_cadence_days": 30,
+      "update_mechanism": "Source/SDK update with codec and import verification",
+      "eol_response": "Upgrade with SDL3 and retain only deliberately supported codecs",
+      "validation": "CMake version constraint, pkg-config version, and audio smoke tests",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "client",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(SDL3_mixer 3.2.4 CONFIG REQUIRED)"
+        }
+      ]
+    },
+    {
+      "id": "system/sdl3-ttf",
+      "name": "SDL3_ttf",
+      "kind": "system-library",
+      "owner": "client",
+      "scope": [
+        "client",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": ">=3.2",
+      "version_source": "Client CMake constraint and pinned build images",
+      "license": "Zlib",
+      "source_url": "https://github.com/libsdl-org/SDL_ttf",
+      "locator": "pkg:generic/SDL3_ttf",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake imported target from Ubuntu or MXE",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image/MXE update and text-rendering tests",
+      "eol_response": "Upgrade with SDL3 and preserve font behavior through fixtures",
+      "validation": "CMake version constraint, text tests, and portable client build",
+      "disposition": "retain",
+      "packages": [
+        "libsdl3-ttf-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "client",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(SDL3_ttf 3.2 CONFIG REQUIRED)"
+        }
+      ]
+    },
+    {
+      "id": "system/server-image-packages",
+      "name": "Server container package sets",
+      "kind": "system-package-set",
+      "owner": "server",
+      "scope": [
+        "server"
+      ],
+      "required": true,
+      "version": "ubuntu-26.04-digest-locked",
+      "version_source": "Server Dockerfile stages",
+      "license": "NOASSERTION",
+      "source_url": "https://packages.ubuntu.com/",
+      "locator": "ubuntu-server-image-packages",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "apt installs declared build/runtime packages from the digest-pinned image",
+      "update_cadence_days": 30,
+      "update_mechanism": "Dependabot base-image update plus exact installed-version report",
+      "eol_response": "Update package names and base image together; never retain an EOL runtime layer",
+      "validation": "Reproducible image build, world-maker run, and startup healthcheck",
+      "disposition": "isolate",
+      "packages": [
+        "build-essential",
+        "ca-certificates",
+        "cmake",
+        "flex",
+        "git",
+        "libcrypt1",
+        "libcurl4-openssl-dev",
+        "libcurl4t64",
+        "libgd-dev",
+        "libgd3",
+        "libminiupnpc-dev",
+        "libminiupnpc21",
+        "libpython3.14",
+        "libreadline-dev",
+        "libreadline8t64",
+        "libssl-dev",
+        "libssl3t64",
+        "ninja-build",
+        "pkgconf",
+        "python3",
+        "python3-dev",
+        "zlib1g",
+        "zlib1g-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "server",
+          "path": "Dockerfile",
+          "contains": "libpython3.14 libreadline8t64 libssl3t64 python3 zlib1g"
+        }
+      ]
+    },
+    {
+      "id": "system/threads",
+      "name": "CMake Threads",
+      "kind": "system-library",
+      "owner": "libatrinik",
+      "scope": [
+        "libatrinik"
+      ],
+      "required": true,
+      "version": "platform-provided",
+      "version_source": "CMake platform thread discovery",
+      "license": "NOASSERTION",
+      "source_url": "https://cmake.org/cmake/help/latest/module/FindThreads.html",
+      "locator": "pkg:generic/platform-threads",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake maps the portable Threads target to the platform runtime",
+      "update_cadence_days": 90,
+      "update_mechanism": "Compiler/platform image update",
+      "eol_response": "Move supported platforms together rather than carrying obsolete thread shims",
+      "validation": "CMake discovery and native lifecycle tests",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "libatrinik",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(Threads REQUIRED)"
+        }
+      ]
+    },
+    {
+      "id": "system/ubuntu-linux-image-packages",
+      "name": "Linux build-image apt package set",
+      "kind": "system-package-set",
+      "owner": "devcontainer",
+      "scope": [
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "ubuntu-26.04-digest-locked",
+      "version_source": "linux/Dockerfile",
+      "license": "NOASSERTION",
+      "source_url": "https://packages.ubuntu.com/",
+      "locator": "ubuntu-linux-build-packages",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "apt installs the declared packages from the digest-pinned image",
+      "update_cadence_days": 30,
+      "update_mechanism": "Dependabot base-image update and exact installed-version report",
+      "eol_response": "Update package names and base image together before Ubuntu support ends",
+      "validation": "Docker build, tool version probes, and complete native workspace build",
+      "disposition": "isolate",
+      "packages": [
+        "alsa-utils",
+        "build-essential",
+        "ca-certificates",
+        "ccache",
+        "check",
+        "clang",
+        "clang-format",
+        "clang-tidy",
+        "clangd",
+        "cmake",
+        "cppcheck",
+        "cproto",
+        "curl",
+        "fd-find",
+        "file",
+        "flex",
+        "fzf",
+        "gdb",
+        "gh",
+        "git",
+        "iproute2",
+        "jq",
+        "libasound2-plugins",
+        "libclang-rt-dev",
+        "libcurl4-openssl-dev",
+        "libgd-dev",
+        "libminiupnpc-dev",
+        "libreadline-dev",
+        "libsdl3-dev",
+        "libsdl3-image-dev",
+        "libsdl3-ttf-dev",
+        "libssl-dev",
+        "libsubunit-dev",
+        "libxml2-dev",
+        "libxml2-utils",
+        "llvm",
+        "ninja-build",
+        "nodejs",
+        "npm",
+        "openssh-client",
+        "patch",
+        "pkgconf",
+        "pulseaudio-utils",
+        "python3-dev",
+        "python3-pip",
+        "python3-venv",
+        "ripgrep",
+        "shellcheck",
+        "shfmt",
+        "sudo",
+        "timidity",
+        "tree",
+        "unzip",
+        "valgrind",
+        "zlib1g-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "linux/Dockerfile",
+          "contains": "apt-get install -y --no-install-recommends"
+        }
+      ]
+    },
+    {
+      "id": "system/ubuntu-windows-image-packages",
+      "name": "Windows build-image host package set",
+      "kind": "system-package-set",
+      "owner": "devcontainer",
+      "scope": [
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "debian-bookworm-digest-locked",
+      "version_source": "windows/Dockerfile",
+      "license": "NOASSERTION",
+      "source_url": "https://packages.debian.org/bookworm/",
+      "locator": "debian-windows-build-packages",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "apt installs declared host and native-build packages from the digest-pinned image",
+      "update_cadence_days": 30,
+      "update_mechanism": "Dependabot base-image update and exact installed-version report",
+      "eol_response": "Update package names and base image together before Debian support ends",
+      "validation": "Cold MXE image build and portable client/server builds",
+      "disposition": "isolate",
+      "packages": [
+        "autoconf",
+        "automake",
+        "autopoint",
+        "bison",
+        "bzip2",
+        "ca-certificates",
+        "cmake",
+        "flex",
+        "g++",
+        "g++-multilib",
+        "gettext",
+        "git",
+        "gperf",
+        "intltool",
+        "libc6-dev-i386",
+        "libclang-dev",
+        "libcurl4-openssl-dev",
+        "libgd-dev",
+        "libgdk-pixbuf-2.0-dev",
+        "libgl-dev",
+        "libltdl-dev",
+        "libminiupnpc-dev",
+        "libpcre2-dev",
+        "libssl-dev",
+        "libtool-bin",
+        "libxml-parser-perl",
+        "lzip",
+        "make",
+        "mingw-w64-tools",
+        "ninja-build",
+        "openssh-client",
+        "openssl",
+        "p7zip-full",
+        "patch",
+        "perl",
+        "python-is-python3",
+        "python3",
+        "python3-dev",
+        "python3-mako",
+        "python3-packaging",
+        "python3-pkg-resources",
+        "python3-setuptools",
+        "ruby",
+        "sqlite3",
+        "unzip",
+        "wget",
+        "xz-utils",
+        "zip",
+        "zlib1g-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "windows/Dockerfile",
+          "contains": "mingw-w64-tools"
+        }
+      ]
+    },
+    {
+      "id": "system/zlib",
+      "name": "zlib",
+      "kind": "system-library",
+      "owner": "libatrinik",
+      "scope": [
+        "client",
+        "devcontainer",
+        "libatrinik",
+        "server"
+      ],
+      "required": true,
+      "version": "distribution/MXE-provided",
+      "version_source": "Pinned build images and MXE commit",
+      "license": "Zlib",
+      "source_url": "https://zlib.net/",
+      "locator": "pkg:generic/zlib",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake imported target from the native or MXE package set",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image/MXE update and exact version report",
+      "eol_response": "Upgrade promptly for unsupported or security-affected compression lines",
+      "validation": "CMake discovery and compression/packet tests",
+      "disposition": "retain",
+      "packages": [
+        "zlib1g-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "libatrinik",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(ZLIB REQUIRED)"
+        }
+      ]
+    },
+    {
+      "id": "toolchain/actionlint",
+      "name": "actionlint",
+      "kind": "toolchain",
+      "owner": "devcontainer",
+      "scope": [
+        "atrinik",
+        "devcontainer",
+        "github-settings"
+      ],
+      "required": true,
+      "version": "1.7.12",
+      "version_source": "linux/Dockerfile",
+      "license": "MIT",
+      "source_url": "https://github.com/rhysd/actionlint/releases/tag/v1.7.12",
+      "locator": "pkg:github/rhysd/actionlint@v1.7.12",
+      "commit": null,
+      "checksum": "sha256:8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8",
+      "acquisition": "Linux image downloads the checksum-pinned official binary",
+      "update_cadence_days": 30,
+      "update_mechanism": "Scheduled release drift review and workflow validation",
+      "eol_response": "Upgrade before new workflow syntax outgrows the validator",
+      "validation": "Checksum, exact version assertion, and all workflow files",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "linux/Dockerfile",
+          "contains": "ACTIONLINT_SHA256=8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+        }
+      ]
+    },
+    {
+      "id": "toolchain/cmake",
+      "name": "CMake",
+      "kind": "toolchain",
+      "owner": "devcontainer",
+      "scope": [
+        "client",
+        "devcontainer",
+        "libatrinik",
+        "protocol",
+        "server"
+      ],
+      "required": true,
+      "version": ">=3.21",
+      "version_source": "Native repository minimums and pinned build images",
+      "license": "BSD-3-Clause",
+      "source_url": "https://cmake.org/",
+      "locator": "pkg:generic/cmake",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Pinned Linux image packages and MXE toolchain package",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image/MXE update and exact version report",
+      "eol_response": "Raise the project minimum only after every supported image supplies it",
+      "validation": "All native configure/build/test presets",
+      "disposition": "retain",
+      "packages": [
+        "cmake"
+      ],
+      "evidence": [
+        {
+          "repository": "client",
+          "path": "CMakeLists.txt",
+          "contains": "cmake_minimum_required(VERSION 3.21)"
+        },
+        {
+          "repository": "libatrinik",
+          "path": "CMakeLists.txt",
+          "contains": "cmake_minimum_required(VERSION 3.21)"
+        },
+        {
+          "repository": "protocol",
+          "path": "CMakeLists.txt",
+          "contains": "cmake_minimum_required(VERSION 3.21)"
+        },
+        {
+          "repository": "server",
+          "path": "CMakeLists.txt",
+          "contains": "cmake_minimum_required(VERSION 3.21)"
+        }
+      ]
+    },
+    {
+      "id": "toolchain/devcontainer-cli",
+      "name": "Dev Container CLI",
+      "kind": "toolchain",
+      "owner": "devcontainer",
+      "scope": [
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "0.88.0",
+      "version_source": "linux/Dockerfile",
+      "license": "MIT",
+      "source_url": "https://github.com/devcontainers/cli",
+      "locator": "pkg:npm/@devcontainers/cli@0.88.0",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "npm installs the exact global package in the Linux image",
+      "update_cadence_days": 30,
+      "update_mechanism": "Scheduled npm release review and devcontainer configuration tests",
+      "eol_response": "Upgrade before supported Dev Container metadata requires a newer CLI",
+      "validation": "Exact version assertion and devcontainer configuration tests",
+      "disposition": "isolate",
+      "packages": [
+        "@devcontainers/cli"
+      ],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "linux/Dockerfile",
+          "contains": "DEVCONTAINER_CLI_VERSION=0.88.0"
+        }
+      ]
+    },
+    {
+      "id": "toolchain/github-hosted-ubuntu-24.04",
+      "name": "GitHub-hosted Ubuntu 24.04 runner",
+      "kind": "toolchain",
+      "owner": "github-settings",
+      "scope": [
+        "atrinik",
+        "client",
+        "content",
+        "devcontainer",
+        "editor",
+        "github-settings",
+        "libatrinik",
+        "metaserver-worker",
+        "protocol",
+        "resources",
+        "server",
+        "sound",
+        "tools"
+      ],
+      "required": true,
+      "version": "ubuntu-24.04",
+      "version_source": "Explicit GitHub Actions runner label and generated version report",
+      "license": "LicenseRef-GitHub-Hosted-Runner",
+      "source_url": "https://github.com/actions/runner-images",
+      "locator": "github-hosted-runner/ubuntu-24.04",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "GitHub Actions provisions the named runner image for each job",
+      "update_cadence_days": 30,
+      "update_mechanism": "Monthly runner-image review with exact in-job tool version report",
+      "eol_response": "Move every consumer to a supported explicit runner label before removal",
+      "validation": "Actionlint plus required repository checks",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": ".github/workflows/integration.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "client",
+          "path": ".github/workflows/check.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "content",
+          "path": ".github/workflows/check.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "devcontainer",
+          "path": ".github/workflows/pr-title.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "editor",
+          "path": ".github/workflows/check.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "github-settings",
+          "path": ".github/workflows/check.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "libatrinik",
+          "path": ".github/workflows/check.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "metaserver-worker",
+          "path": ".github/workflows/check.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "protocol",
+          "path": ".github/workflows/check.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "resources",
+          "path": ".github/workflows/check.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "server",
+          "path": ".github/workflows/check.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "sound",
+          "path": ".github/workflows/check.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "tools",
+          "path": ".github/workflows/check.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        }
+      ]
+    },
+    {
+      "id": "toolchain/github-hosted-ubuntu-26.04",
+      "name": "GitHub-hosted Ubuntu 26.04 runner",
+      "kind": "toolchain",
+      "owner": "devcontainer",
+      "scope": [
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "ubuntu-26.04",
+      "version_source": "Explicit GitHub Actions runner label and generated version report",
+      "license": "LicenseRef-GitHub-Hosted-Runner",
+      "source_url": "https://github.com/actions/runner-images",
+      "locator": "github-hosted-runner/ubuntu-26.04",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "GitHub Actions provisions the named runner image for image validation",
+      "update_cadence_days": 30,
+      "update_mechanism": "Monthly runner-image review and devcontainer cold-build validation",
+      "eol_response": "Move image validation to a supported explicit runner label before removal",
+      "validation": "Actionlint plus Linux and Windows image builds",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": ".github/workflows/validate.yml",
+          "contains": "runs-on: ubuntu-26.04"
+        }
+      ]
+    },
+    {
+      "id": "toolchain/node",
+      "name": "Node.js",
+      "kind": "toolchain",
+      "owner": "metaserver-worker",
+      "scope": [
+        "atrinik",
+        "metaserver-worker"
+      ],
+      "required": true,
+      "version": ">=20",
+      "version_source": "Worker package engines and semantic-release",
+      "license": "MIT",
+      "source_url": "https://nodejs.org/",
+      "locator": "pkg:generic/node",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "GitHub setup-node or the digest-pinned Linux image",
+      "update_cadence_days": 30,
+      "update_mechanism": "setup-node Dependabot updates and supported-LTS review",
+      "eol_response": "Advance to a supported Node LTS before the current line reaches EOL",
+      "validation": "Exact version report, npm ci, Worker tests, and semantic-release",
+      "disposition": "retain",
+      "packages": [
+        "nodejs",
+        "npm"
+      ],
+      "evidence": [
+        {
+          "repository": "metaserver-worker",
+          "path": "package.json",
+          "contains": "\"node\": \">=20\""
+        }
+      ]
+    },
+    {
+      "id": "toolchain/python",
+      "name": "Python",
+      "kind": "toolchain",
+      "owner": "atrinik",
+      "scope": [
+        "atrinik",
+        "client",
+        "content",
+        "devcontainer",
+        "protocol",
+        "server",
+        "tools"
+      ],
+      "required": true,
+      "version": ">=3.11; Windows runtime 3.14.6",
+      "version_source": "Wrapper requirement, protocol metadata, and Windows image arguments",
+      "license": "PSF-2.0",
+      "source_url": "https://www.python.org/",
+      "locator": "pkg:generic/python",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Pinned build images, setup-python, and checksum-pinned Windows runtime/source archives",
+      "update_cadence_days": 30,
+      "update_mechanism": "Supported-version matrix review and image rebuild",
+      "eol_response": "Advance every maintained tool and embedded runtime before Python EOL",
+      "validation": "Exact version report, compileall, Python tests, plugin tests, and MinGW package smoke test",
+      "disposition": "retain",
+      "packages": [
+        "python3",
+        "python3-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": "README.md",
+          "contains": "Python 3.11 or newer"
+        },
+        {
+          "repository": "devcontainer",
+          "path": "windows/Dockerfile",
+          "contains": "PYTHON_VERSION=3.14.6"
+        },
+        {
+          "repository": "protocol",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(Python3 REQUIRED COMPONENTS Interpreter)"
+        },
+        {
+          "repository": "server",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(Python3 REQUIRED COMPONENTS Interpreter)"
+        }
+      ]
+    },
+    {
+      "id": "vendored/sdl-gfx-rotozoom",
+      "name": "SDL_gfx rotozoom implementation",
+      "kind": "vendored-source",
+      "owner": "client",
+      "scope": [
+        "client"
+      ],
+      "required": false,
+      "version": "retired",
+      "version_source": "Client source audit",
+      "license": "LGPL-2.1-or-later",
+      "source_url": "https://www.ferzkopp.net/Software/SDL_gfx-2.0/",
+      "locator": "sdl-gfx-rotozoom",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "No external acquisition remains; owned SDL3 surface primitives replaced the vendored implementation",
+      "update_cadence_days": 180,
+      "update_mechanism": "Repository search prevents reintroduction",
+      "eol_response": "Keep the retired source absent and maintain the focused owned API",
+      "validation": "Surface primitive unit tests and repository search for SDL_gfx source",
+      "disposition": "replace",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "client",
+          "path": "src/gui/toolkit/surface_primitives.c",
+          "contains": "rotozoomSurfaceXY"
+        }
+      ]
+    },
+    {
+      "id": "vendored/uthash-family",
+      "name": "uthash, utarray, and utlist",
+      "kind": "vendored-source",
+      "owner": "libatrinik",
+      "scope": [
+        "libatrinik"
+      ],
+      "required": true,
+      "version": "1.9.4",
+      "version_source": "Embedded version macros",
+      "license": "BSD-1-Clause",
+      "source_url": "https://github.com/troydhanson/uthash",
+      "locator": "pkg:github/troydhanson/uthash@v1.9.4",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Historical vendored headers retained behind the shared library boundary",
+      "update_cadence_days": 90,
+      "update_mechanism": "Scheduled upstream/security review before any isolated upgrade or replacement",
+      "eol_response": "Replace with owned typed containers or update all three headers together after sanitizer/performance tests",
+      "validation": "Version macro audit, native tests, sanitizers, and downstream builds",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "libatrinik",
+          "path": "utarray.h",
+          "contains": "UTARRAY_VERSION 1.9 .4"
+        },
+        {
+          "repository": "libatrinik",
+          "path": "uthash.h",
+          "contains": "UTHASH_VERSION 1.9 .4"
+        },
+        {
+          "repository": "libatrinik",
+          "path": "utlist.h",
+          "contains": "UTLIST_VERSION 1.9 .4"
+        }
+      ]
+    }
+  ]
+}

--- a/supply-chain/schema.json
+++ b/supply-chain/schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://atrinik.org/schema/supply-chain-inventory-v1.json",
+  "title": "Atrinik supply-chain inventory",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "organization", "created", "repositories", "dependencies"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "organization": {"const": "atrinik"},
+    "created": {"type": "string", "format": "date-time"},
+    "repositories": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "repository", "supported", "role"],
+        "properties": {
+          "name": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$"},
+          "repository": {"type": "string", "pattern": "^atrinik/[a-z0-9][a-z0-9._-]*$"},
+          "supported": {"type": "boolean"},
+          "role": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "dependencies": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/dependency"}
+    }
+  },
+  "$defs": {
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "path", "contains"],
+      "properties": {
+        "repository": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$"},
+        "path": {"type": "string", "minLength": 1},
+        "contains": {"type": "string", "minLength": 1}
+      }
+    },
+    "dependency": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id", "name", "kind", "owner", "scope", "required", "version",
+        "version_source", "license", "source_url", "locator", "commit",
+        "checksum", "acquisition", "update_cadence_days", "update_mechanism",
+        "eol_response", "validation", "disposition", "packages", "evidence"
+      ],
+      "properties": {
+        "id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._/-]*$"},
+        "name": {"type": "string", "minLength": 1},
+        "kind": {
+          "enum": [
+            "container-feature", "container-image", "external-tool",
+            "github-action", "language-package-set", "source-archive",
+            "system-library", "system-package-set", "toolchain", "vendored-source"
+          ]
+        },
+        "owner": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$"},
+        "scope": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$"}
+        },
+        "required": {"type": "boolean"},
+        "version": {"type": "string", "minLength": 1},
+        "version_source": {"type": "string", "minLength": 1},
+        "license": {"type": "string", "minLength": 1},
+        "source_url": {"type": "string", "format": "uri", "pattern": "^https://"},
+        "locator": {"type": "string", "minLength": 1},
+        "commit": {"type": ["string", "null"], "pattern": "^[0-9a-f]{40}$"},
+        "checksum": {"type": ["string", "null"], "pattern": "^sha256:[0-9a-f]{64}$"},
+        "acquisition": {"type": "string", "minLength": 1},
+        "update_cadence_days": {"type": "integer", "minimum": 1, "maximum": 366},
+        "update_mechanism": {"type": "string", "minLength": 1},
+        "eol_response": {"type": "string", "minLength": 1},
+        "validation": {"type": "string", "minLength": 1},
+        "disposition": {"enum": ["isolate", "remove", "replace", "retain"]},
+        "packages": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "evidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/evidence"}
+        }
+      }
+    }
+  }
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,81 @@ from atrinik_workspace.model import WorkspaceError
 
 
 class ParserTests(unittest.TestCase):
+    def test_supply_chain_commands_dispatch_validated_inventory(self) -> None:
+        inventory = mock.Mock()
+        inventory.dependencies = [object(), object()]
+        inventory.audit.return_value = ["client: audited"]
+        inventory.report.return_value = "report\n"
+        roots = {"atrinik": Path("/workspace/atrinik")}
+        with (
+            mock.patch("atrinik_workspace.cli.Workspace"),
+            mock.patch(
+                "atrinik_workspace.cli.Inventory.load", return_value=inventory
+            ) as load,
+            mock.patch(
+                "atrinik_workspace.cli.repository_roots", return_value=roots
+            ) as resolve_roots,
+            mock.patch(
+                "atrinik_workspace.cli.version_report", return_value="versions\n"
+            ) as versions,
+            mock.patch("atrinik_workspace.cli.write_generated") as write,
+            mock.patch("builtins.print") as output,
+        ):
+            self.assertEqual(main(["supply-chain", "validate"]), 0)
+            self.assertEqual(
+                main(
+                    [
+                        "supply-chain",
+                        "audit",
+                        "--profile",
+                        "review",
+                        "--repository",
+                        "client=/tmp/client",
+                    ]
+                ),
+                0,
+            )
+            self.assertEqual(
+                main(
+                    [
+                        "supply-chain",
+                        "report",
+                        "--format",
+                        "spdx",
+                        "--output",
+                        "build/report.json",
+                    ]
+                ),
+                0,
+            )
+            self.assertEqual(
+                main(
+                    [
+                        "supply-chain",
+                        "versions",
+                        "--output",
+                        "build/versions.json",
+                    ]
+                ),
+                0,
+            )
+
+        self.assertEqual(load.call_count, 4)
+        self.assertEqual(inventory.validate_schema.call_count, 4)
+        resolve_roots.assert_called_once()
+        self.assertEqual(resolve_roots.call_args.args[2], "review")
+        self.assertEqual(resolve_roots.call_args.args[3], ["client=/tmp/client"])
+        inventory.audit.assert_called_once_with(roots)
+        inventory.report.assert_called_once_with("spdx")
+        versions.assert_called_once_with(inventory)
+        self.assertEqual(write.call_count, 2)
+        self.assertTrue(
+            any("valid (2 dependencies)" in str(call.args[0]) for call in output.call_args_list)
+        )
+        self.assertTrue(
+            any("client: audited" in str(call.args[0]) for call in output.call_args_list)
+        )
+
     def test_status_supports_machine_readable_output(self) -> None:
         rows = [
             {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,6 +68,7 @@ class ParserTests(unittest.TestCase):
                 ),
                 0,
             )
+            self.assertEqual(main(["init"]), 0)
 
         self.assertEqual(load.call_count, 4)
         self.assertEqual(inventory.validate_schema.call_count, 4)

--- a/tests/test_devcontainer.py
+++ b/tests/test_devcontainer.py
@@ -18,7 +18,11 @@ class DevcontainerTests(unittest.TestCase):
 
         self.assertEqual(config["workspaceFolder"], "/workspaces/atrinik")
         self.assertEqual(config["postCreateCommand"], "./atrinik init")
-        self.assertEqual(config["image"], "ghcr.io/atrinik/linux-build:1.0.3")
+        self.assertEqual(
+            config["image"],
+            "ghcr.io/atrinik/linux-build:1.0.5@sha256:"
+            "be3427cfc7dabcf837450c7306d55883c32e20ba1ab7cc96b4da4b966b8066de",
+        )
 
     def test_windows_configuration_validates_component_manifest(self) -> None:
         config = self.load_config(
@@ -29,7 +33,11 @@ class DevcontainerTests(unittest.TestCase):
         self.assertEqual(
             config["postCreateCommand"], "./atrinik manifest validate"
         )
-        self.assertEqual(config["image"], "ghcr.io/atrinik/windows-build:1.0.3")
+        self.assertEqual(
+            config["image"],
+            "ghcr.io/atrinik/windows-build:1.0.5@sha256:"
+            "9cc373f620a577328fc0a7a7fa823bddaca6d7dc75ac73bcf21be421c49676f7",
+        )
 
     def test_default_feature_lock_matches_configuration(self) -> None:
         config = self.load_config(".devcontainer/devcontainer.json")

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from atrinik_workspace.model import WorkspaceError
+from atrinik_workspace.supply_chain import (
+    ACTION_REFERENCE_PATTERN,
+    DOCKER_PULL_PATTERN,
+    Inventory,
+    _container_references,
+    version_report,
+    write_generated,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class InventoryTests(unittest.TestCase):
+    def load_inventory(self) -> Inventory:
+        return Inventory.load(
+            ROOT / "supply-chain" / "inventory.json", ROOT / "components.json"
+        )
+
+    def test_inventory_and_schema_validate(self) -> None:
+        inventory = self.load_inventory()
+        inventory.validate_schema(ROOT / "supply-chain" / "schema.json")
+
+        self.assertGreaterEqual(len(inventory.dependencies), 60)
+        self.assertIn("nawerhals", inventory.repositories_by_name)
+        self.assertFalse(inventory.repositories_by_name["nawerhals"].supported)
+
+    def test_wrapper_dependency_surface_audits_independently(self) -> None:
+        messages = self.load_inventory().audit(
+            {"atrinik": ROOT}, require_all=False
+        )
+
+        self.assertEqual(len(messages), 1)
+        self.assertIn("action references", messages[0])
+
+    def test_reports_are_deterministic_and_well_formed(self) -> None:
+        inventory = self.load_inventory()
+        first = inventory.report("cyclonedx")
+        second = inventory.report("cyclonedx")
+        cyclonedx = json.loads(first)
+        spdx = json.loads(inventory.report("spdx"))
+
+        self.assertEqual(first, second)
+        self.assertEqual(cyclonedx["specVersion"], "1.6")
+        self.assertEqual(len(cyclonedx["components"]), len(inventory.dependencies))
+        self.assertEqual(spdx["spdxVersion"], "SPDX-2.3")
+        self.assertTrue(
+            any(
+                property_["name"] == "atrinik:declared-packages"
+                for component in cyclonedx["components"]
+                for property_ in component["properties"]
+            )
+        )
+        self.assertTrue(
+            all(package["supplier"] == "NOASSERTION" for package in spdx["packages"])
+        )
+        self.assertIn("| Dependency | Version |", inventory.report("licenses"))
+
+    def test_nested_action_coordinates_are_recognized(self) -> None:
+        match = ACTION_REFERENCE_PATTERN.search(
+            "uses: organization/actions/.github/workflows/check.yml@" + "a" * 40
+        )
+
+        self.assertIsNotNone(match)
+        self.assertEqual(
+            match.group(1), "organization/actions/.github/workflows/check.yml"
+        )
+
+    def test_workflow_container_pulls_are_recognized(self) -> None:
+        match = DOCKER_PULL_PATTERN.search(
+            "run: docker pull ghcr.io/atrinik/build:1@sha256:" + "a" * 64
+        )
+
+        self.assertIsNotNone(match)
+        self.assertEqual(
+            match.group(1), "ghcr.io/atrinik/build:1@sha256:" + "a" * 64
+        )
+
+    def test_internal_docker_stages_are_not_external_images(self) -> None:
+        dockerfile = """# syntax=docker/dockerfile:1@sha256:{frontend}
+FROM ubuntu:26.04@sha256:{digest} AS toolchain
+FROM toolchain AS validation
+FROM toolchain AS final
+""".format(frontend="b" * 64, digest="a" * 64)
+
+        self.assertEqual(
+            _container_references("Dockerfile", dockerfile),
+            [
+                f"docker/dockerfile:1@sha256:{'b' * 64}",
+                f"ubuntu:26.04@sha256:{'a' * 64}",
+            ],
+        )
+
+    def test_generated_output_is_restricted_to_build(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            with self.assertRaisesRegex(WorkspaceError, "must be under"):
+                write_generated(root, Path("report.json"), "{}\n")
+
+            output = Path("build/supply-chain/report.json")
+            write_generated(root, output, "{}\n")
+            self.assertEqual((root / output).read_text(encoding="utf-8"), "{}\n")
+
+    def test_duplicate_devcontainer_keys_are_rejected(self) -> None:
+        with self.assertRaisesRegex(WorkspaceError, "duplicate JSON key"):
+            _container_references(
+                ".devcontainer/devcontainer.json",
+                '{"image":"first@sha256:a","image":"second@sha256:b"}',
+            )
+
+    def test_version_report_is_machine_readable(self) -> None:
+        versions = json.loads(version_report(self.load_inventory()))
+
+        self.assertTrue(versions["python"]["available"])
+        self.assertTrue(versions["git"]["available"])
+        self.assertIn("system-packages", versions)
+        self.assertIn("git", versions["system-packages"])
+        self.assertEqual(
+            versions["declared-dependencies"]["container/ubuntu-26.04"]["checksum"],
+            "sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7a03",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -1,16 +1,36 @@
 from __future__ import annotations
 
+import copy
+from dataclasses import replace
 import json
 from pathlib import Path
+import subprocess
 import tempfile
 import unittest
+from unittest import mock
 
 from atrinik_workspace.model import WorkspaceError
 from atrinik_workspace.supply_chain import (
     ACTION_REFERENCE_PATTERN,
     DOCKER_PULL_PATTERN,
+    Dependency,
+    Evidence,
     Inventory,
+    Repository,
     _container_references,
+    _cyclonedx_type,
+    _git_repository_coordinate,
+    _is_container_input,
+    _is_dependency_input,
+    _read_metadata,
+    _relative_path,
+    _safe_repository_path,
+    _string_array,
+    _system_package_versions,
+    _text,
+    _tracked_files,
+    _validate_container_reference,
+    repository_roots,
     version_report,
     write_generated,
 )
@@ -19,10 +39,90 @@ from atrinik_workspace.supply_chain import (
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def fixture_dependency(**changes: object) -> Dependency:
+    values: dict[str, object] = {
+        "identifier": "action/example",
+        "name": "Example action",
+        "kind": "github-action",
+        "owner": "fixture",
+        "scope": ("fixture",),
+        "required": True,
+        "version": "v1",
+        "version_source": "release tag",
+        "license": "MIT",
+        "source_url": "https://github.com/example/action",
+        "locator": "example/action",
+        "commit": "a" * 40,
+        "checksum": None,
+        "acquisition": "GitHub Actions",
+        "update_cadence_days": 7,
+        "update_mechanism": "Dependabot",
+        "eol_response": "Replace it",
+        "validation": "Run CI",
+        "disposition": "retain",
+        "packages": (),
+        "evidence": (
+            Evidence(
+                "fixture",
+                ".github/workflows/ci.yml",
+                f"example/action@{'a' * 40} # v1",
+            ),
+        ),
+    }
+    values.update(changes)
+    return Dependency(**values)
+
+
 class InventoryTests(unittest.TestCase):
     def load_inventory(self) -> Inventory:
         return Inventory.load(
             ROOT / "supply-chain" / "inventory.json", ROOT / "components.json"
+        )
+
+    def inventory_document(self) -> dict[str, object]:
+        return json.loads(
+            (ROOT / "supply-chain" / "inventory.json").read_text(encoding="utf-8")
+        )
+
+    def assert_invalid_document(
+        self, document: object, expected: str
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "inventory.json"
+            path.write_text(json.dumps(document), encoding="utf-8")
+            with self.assertRaisesRegex(WorkspaceError, expected):
+                Inventory.load(path, ROOT / "components.json")
+
+    def make_audit_repository(self, root: Path) -> None:
+        (root / ".github" / "workflows").mkdir(parents=True)
+        (root / ".github" / "dependabot.yml").write_text(
+            "updates:\n  - package-ecosystem: github-actions\n",
+            encoding="utf-8",
+        )
+        (root / ".github" / "workflows" / "ci.yml").write_text(
+            f"runs-on: ubuntu-24.04\nuses: example/action@{'a' * 40} # v1\n",
+            encoding="utf-8",
+        )
+        subprocess.run(["git", "init", "-q", str(root)], check=True)
+
+    def audit_inventory(self) -> Inventory:
+        runner = fixture_dependency(
+            identifier="runner/ubuntu-24.04",
+            name="Ubuntu runner",
+            kind="toolchain",
+            locator="github-hosted-runner/ubuntu-24.04",
+            commit=None,
+            evidence=(
+                Evidence(
+                    "fixture", ".github/workflows/ci.yml", "runs-on: ubuntu-24.04"
+                ),
+            ),
+        )
+        return Inventory(
+            "atrinik",
+            "2026-08-07T00:00:00Z",
+            [Repository("fixture", "atrinik/fixture", True, "fixture")],
+            [fixture_dependency(), runner],
         )
 
     def test_inventory_and_schema_validate(self) -> None:
@@ -33,6 +133,152 @@ class InventoryTests(unittest.TestCase):
         self.assertIn("nawerhals", inventory.repositories_by_name)
         self.assertFalse(inventory.repositories_by_name["nawerhals"].supported)
 
+    def test_inventory_rejects_invalid_root_and_repository_metadata(self) -> None:
+        self.assert_invalid_document([], "root must be an object")
+
+        mutations = [
+            ("schema_version", 2, "unsupported.*schema"),
+            ("organization", "other", "organization must be atrinik"),
+            ("created", " padded ", "non-empty trimmed string"),
+            ("repositories", [], "non-empty array"),
+        ]
+        for field, value, expected in mutations:
+            with self.subTest(field=field):
+                document = self.inventory_document()
+                document[field] = value
+                self.assert_invalid_document(document, expected)
+
+        document = self.inventory_document()
+        document["repositories"][0] = "client"
+        self.assert_invalid_document(document, "repository 0 must be an object")
+
+        repository_mutations = [
+            ("name", "Client", "lowercase identifier"),
+            ("repository", "example/client", "Atrinik repository"),
+            ("supported", "true", "must be a boolean"),
+            ("role", "", "non-empty trimmed string"),
+        ]
+        for field, value, expected in repository_mutations:
+            with self.subTest(repository_field=field):
+                document = self.inventory_document()
+                document["repositories"][0][field] = value
+                self.assert_invalid_document(document, expected)
+
+        document = self.inventory_document()
+        document["repositories"][1] = copy.deepcopy(document["repositories"][0])
+        self.assert_invalid_document(document, "duplicate inventory repository")
+
+        document = self.inventory_document()
+        document["repositories"][0]["supported"] = False
+        self.assert_invalid_document(document, "do not match components.json")
+
+        document = self.inventory_document()
+        document["repositories"][0]["repository"] = "atrinik/not-client"
+        self.assert_invalid_document(document, "repository mismatch")
+
+    def test_inventory_rejects_invalid_dependency_metadata(self) -> None:
+        document = self.inventory_document()
+        document["dependencies"] = []
+        self.assert_invalid_document(document, "dependencies must be a non-empty array")
+
+        document = self.inventory_document()
+        document["dependencies"][0] = "dependency"
+        self.assert_invalid_document(document, "dependency 0 must be an object")
+
+        dependency_mutations = [
+            ("id", "Action/example", "lowercase identifier"),
+            ("name", "", "non-empty trimmed string"),
+            ("kind", "mystery", "kind is unsupported"),
+            ("owner", "unknown", "owner is not an inventory repository"),
+            ("scope", [], "must be a non-empty array"),
+            ("scope", ["unknown"], "scope contains an unknown repository"),
+            ("scope", ["server", "client"], "scope must be sorted"),
+            ("required", 1, "required must be a boolean"),
+            ("license", "not a license!", "license is not an SPDX"),
+            ("source_url", "http://example.com", "source_url must use HTTPS"),
+            ("commit", "A" * 40, "full lowercase Git commit"),
+            ("checksum", "sha256:abc", "lowercase SHA-256"),
+            ("update_cadence_days", True, "between 1 and 366"),
+            ("update_cadence_days", 367, "between 1 and 366"),
+            ("disposition", "adopt", "disposition is unsupported"),
+            ("packages", ["z", "a"], "packages must be sorted and unique"),
+            ("packages", ["a", "a"], "packages must be sorted and unique"),
+            ("evidence", [], "evidence must be a non-empty array"),
+        ]
+        for field, value, expected in dependency_mutations:
+            with self.subTest(dependency_field=field, value=value):
+                document = self.inventory_document()
+                document["dependencies"][0][field] = value
+                self.assert_invalid_document(document, expected)
+
+        document = self.inventory_document()
+        document["dependencies"][1]["id"] = document["dependencies"][0]["id"]
+        self.assert_invalid_document(document, "duplicate dependency id")
+
+        document = self.inventory_document()
+        document["dependencies"][0], document["dependencies"][1] = (
+            document["dependencies"][1],
+            document["dependencies"][0],
+        )
+        self.assert_invalid_document(document, "dependencies must be sorted")
+
+        document = self.inventory_document()
+        actions = [
+            dependency
+            for dependency in document["dependencies"]
+            if dependency["kind"] == "github-action"
+        ]
+        actions[1]["locator"] = actions[0]["locator"]
+        self.assert_invalid_document(document, "Action locators must be unique")
+
+    def test_inventory_rejects_invalid_dependency_evidence_and_actions(self) -> None:
+        evidence_mutations = [
+            (None, "must be an object"),
+            ({"repository": "unknown", "path": "x", "contains": "x"}, "is unknown"),
+            ({"repository": "client", "path": "../x", "contains": "x"}, "safe repository-relative"),
+        ]
+        for evidence, expected in evidence_mutations:
+            with self.subTest(evidence=evidence):
+                document = self.inventory_document()
+                document["dependencies"][0]["evidence"][0] = evidence
+                self.assert_invalid_document(document, expected)
+
+        document = self.inventory_document()
+        original = copy.deepcopy(document["dependencies"][0]["evidence"][0])
+        document["dependencies"][0]["evidence"] = [original, original]
+        self.assert_invalid_document(document, "evidence must be sorted and unique")
+
+        document = self.inventory_document()
+        document["dependencies"][0]["scope"] = ["server"]
+        self.assert_invalid_document(document, "evidence repository must be present")
+
+        document = self.inventory_document()
+        document["dependencies"][0]["commit"] = None
+        self.assert_invalid_document(document, "GitHub Actions require a commit")
+
+        document = self.inventory_document()
+        document["dependencies"][0]["locator"] = "not-an-action"
+        self.assert_invalid_document(document, "owner/action coordinate")
+
+    def test_schema_contract_rejects_weak_or_unexpected_schema(self) -> None:
+        inventory = self.load_inventory()
+        schema = json.loads(
+            (ROOT / "supply-chain" / "schema.json").read_text(encoding="utf-8")
+        )
+        cases = [
+            ([], "schema root must be an object"),
+            ({**schema, "$schema": "draft-07"}, "draft 2020-12"),
+            ({**schema, "$id": "https://example.com/schema"}, "unexpected \\$id"),
+            ({**schema, "additionalProperties": True}, "reject additional"),
+        ]
+        for value, expected in cases:
+            with self.subTest(expected=expected):
+                with tempfile.TemporaryDirectory() as temporary:
+                    path = Path(temporary) / "schema.json"
+                    path.write_text(json.dumps(value), encoding="utf-8")
+                    with self.assertRaisesRegex(WorkspaceError, expected):
+                        inventory.validate_schema(path)
+
     def test_wrapper_dependency_surface_audits_independently(self) -> None:
         messages = self.load_inventory().audit(
             {"atrinik": ROOT}, require_all=False
@@ -40,6 +286,252 @@ class InventoryTests(unittest.TestCase):
 
         self.assertEqual(len(messages), 1)
         self.assertIn("action references", messages[0])
+
+    def test_minimal_repository_audit_covers_actions_and_runners(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.make_audit_repository(root)
+            workflow = root / ".github" / "workflows" / "ci.yml"
+            workflow.write_text(
+                workflow.read_text(encoding="utf-8")
+                + "- uses: ./.github/actions/local\n",
+                encoding="utf-8",
+            )
+
+            messages = self.audit_inventory().audit({"fixture": root})
+
+        self.assertEqual(len(messages), 1)
+        self.assertIn("1 action references", messages[0])
+
+    def test_audit_rejects_invalid_roots_and_evidence(self) -> None:
+        inventory = self.audit_inventory()
+        with self.assertRaisesRegex(WorkspaceError, "roots are incomplete"):
+            inventory.audit({})
+        with self.assertRaisesRegex(WorkspaceError, "unknown.*repositories"):
+            inventory.audit({"unknown": ROOT}, require_all=False)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            file_path = root / "not-a-directory"
+            file_path.write_text("x", encoding="utf-8")
+            with self.assertRaisesRegex(WorkspaceError, "not a directory"):
+                inventory.audit({"fixture": file_path})
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.make_audit_repository(root)
+            broken = Inventory(
+                inventory.organization,
+                inventory.created,
+                inventory.repositories,
+                [
+                    replace(
+                        inventory.dependencies[0],
+                        evidence=(
+                            Evidence(
+                                "fixture", ".github/workflows/ci.yml", "not present"
+                            ),
+                        ),
+                    ),
+                    inventory.dependencies[1],
+                ],
+            )
+            with self.assertRaisesRegex(WorkspaceError, "expected text is absent"):
+                broken.audit({"fixture": root})
+
+    def test_audit_rejects_unmanaged_repository_inputs(self) -> None:
+        inventory = self.audit_inventory()
+        cases = [
+            ("missing-dependabot", "missing .github/dependabot.yml"),
+            ("bad-dependabot", "does not own GitHub Actions"),
+            ("submodule", "Git submodules are not supported"),
+            ("dependency-input", "dependency input is absent"),
+        ]
+        for case, expected in cases:
+            with self.subTest(case=case):
+                with tempfile.TemporaryDirectory() as temporary:
+                    root = Path(temporary)
+                    self.make_audit_repository(root)
+                    if case == "missing-dependabot":
+                        (root / ".github" / "dependabot.yml").unlink()
+                    elif case == "bad-dependabot":
+                        (root / ".github" / "dependabot.yml").write_text(
+                            "updates: []\n", encoding="utf-8"
+                        )
+                    elif case == "submodule":
+                        (root / ".gitmodules").write_text("[submodule]\n", encoding="utf-8")
+                    else:
+                        (root / "package.json").write_text("{}\n", encoding="utf-8")
+                    with self.assertRaisesRegex(WorkspaceError, expected):
+                        inventory.audit({"fixture": root})
+
+    def test_audit_rejects_unowned_or_incorrect_action_references(self) -> None:
+        inventory = self.audit_inventory()
+        semantic_inventory = Inventory(
+            inventory.organization,
+            inventory.created,
+            inventory.repositories,
+            [
+                replace(
+                    dependency,
+                    evidence=(
+                        Evidence(
+                            "fixture",
+                            ".github/dependabot.yml",
+                            "package-ecosystem: github-actions",
+                        ),
+                    ),
+                )
+                for dependency in inventory.dependencies
+            ],
+        )
+        cases = [
+            (f"uses: unknown/action@{'a' * 40} # v1", "unowned GitHub Action"),
+            ("uses: example/action@v1 # v1", "not pinned to a full commit"),
+            (f"uses: example/action@{'b' * 40} # v1", "differs from inventory"),
+            (f"uses: example/action@{'a' * 40} # v2", "updater hint"),
+            ("runs-on: mystery-runner", "unowned workflow runner"),
+            ("uses: ${{ matrix.action }}", "unsupported external Action"),
+            ("uses: ./../outside", "local Action escapes"),
+            ("runs-on: ${{ matrix.os }}", "runner must be an explicit literal"),
+        ]
+        for line, expected in cases:
+            with self.subTest(expected=expected):
+                with tempfile.TemporaryDirectory() as temporary:
+                    root = Path(temporary)
+                    self.make_audit_repository(root)
+                    workflow = root / ".github" / "workflows" / "ci.yml"
+                    original = workflow.read_text(encoding="utf-8")
+                    if line.startswith("runs-on"):
+                        original = original.replace("runs-on: ubuntu-24.04", line)
+                    else:
+                        original = original.replace(
+                            f"uses: example/action@{'a' * 40} # v1", line
+                        )
+                    workflow.write_text(original, encoding="utf-8")
+                    with self.assertRaisesRegex(WorkspaceError, expected):
+                        semantic_inventory.audit({"fixture": root})
+
+    def test_audit_rejects_inventory_scope_drift(self) -> None:
+        inventory = self.audit_inventory()
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.make_audit_repository(root)
+            workflow = root / ".github" / "workflows" / "ci.yml"
+            workflow.write_text(
+                workflow.read_text(encoding="utf-8").replace("uses:", "use:"),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(WorkspaceError, "scope differs from audited use"):
+                inventory.audit({"fixture": root})
+
+        runner_only_drift = Inventory(
+            inventory.organization,
+            inventory.created,
+            inventory.repositories,
+            [
+                inventory.dependencies[0],
+                replace(
+                    inventory.dependencies[1],
+                    evidence=(
+                        Evidence(
+                            "fixture",
+                            ".github/dependabot.yml",
+                            "package-ecosystem: github-actions",
+                        ),
+                    ),
+                ),
+            ],
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.make_audit_repository(root)
+            workflow = root / ".github" / "workflows" / "ci.yml"
+            workflow.write_text(
+                workflow.read_text(encoding="utf-8").replace(
+                    "runs-on: ubuntu-24.04\n", ""
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(WorkspaceError, "scope differs from audited use"):
+                runner_only_drift.audit({"fixture": root})
+
+    def test_audit_rejects_action_and_runner_uses_outside_declared_scope(self) -> None:
+        inventory = self.audit_inventory()
+        common_evidence = (
+            Evidence(
+                "fixture",
+                ".github/dependabot.yml",
+                "package-ecosystem: github-actions",
+            ),
+        )
+        cases = [
+            (
+                [
+                    replace(
+                        inventory.dependencies[0],
+                        scope=("other",),
+                        evidence=common_evidence,
+                    ),
+                    inventory.dependencies[1],
+                ],
+                "example/action is absent from inventory scope",
+            ),
+            (
+                [
+                    inventory.dependencies[0],
+                    replace(
+                        inventory.dependencies[1],
+                        scope=("other",),
+                        evidence=common_evidence,
+                    ),
+                ],
+                "ubuntu-24.04 is absent from inventory scope",
+            ),
+        ]
+        for dependencies, expected in cases:
+            with self.subTest(expected=expected):
+                scoped = Inventory(
+                    inventory.organization,
+                    inventory.created,
+                    inventory.repositories,
+                    dependencies,
+                )
+                with tempfile.TemporaryDirectory() as temporary:
+                    root = Path(temporary)
+                    self.make_audit_repository(root)
+                    with self.assertRaisesRegex(WorkspaceError, expected):
+                        scoped.audit({"fixture": root})
+
+    def test_audit_validates_literal_workflow_container_pulls(self) -> None:
+        inventory = self.audit_inventory()
+        image = f"ghcr.io/atrinik/build:1@sha256:{'b' * 64}"
+        container = fixture_dependency(
+            identifier="container/build",
+            kind="container-image",
+            locator="ghcr.io/atrinik/build",
+            commit=None,
+            checksum="sha256:" + "b" * 64,
+            evidence=(Evidence("fixture", ".github/workflows/ci.yml", image),),
+        )
+        audited = Inventory(
+            inventory.organization,
+            inventory.created,
+            inventory.repositories,
+            [*inventory.dependencies, container],
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.make_audit_repository(root)
+            workflow = root / ".github" / "workflows" / "ci.yml"
+            workflow.write_text(
+                workflow.read_text(encoding="utf-8")
+                + f"run: docker pull {image}\n"
+                + f"- uses: docker://{image}\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(len(audited.audit({"fixture": root})), 1)
 
     def test_reports_are_deterministic_and_well_formed(self) -> None:
         inventory = self.load_inventory()
@@ -64,6 +556,43 @@ class InventoryTests(unittest.TestCase):
         )
         self.assertIn("| Dependency | Version |", inventory.report("licenses"))
 
+    def test_reports_cover_license_references_checksums_and_invalid_formats(self) -> None:
+        license_reference = fixture_dependency(
+            identifier="source/example",
+            kind="source-archive",
+            license="LicenseRef-Example",
+            checksum="sha256:" + "b" * 64,
+            packages=("example",),
+        )
+        inventory = Inventory(
+            "atrinik",
+            "2026-08-07T00:00:00Z",
+            [Repository("fixture", "atrinik/fixture", True, "fixture")],
+            [license_reference],
+        )
+        cyclonedx = json.loads(inventory.report("cyclonedx"))
+        spdx = json.loads(inventory.report("spdx"))
+
+        self.assertEqual(cyclonedx["components"][0]["type"], "library")
+        self.assertEqual(cyclonedx["components"][0]["hashes"][0]["alg"], "SHA-256")
+        self.assertEqual(
+            spdx["hasExtractedLicensingInfos"][0]["licenseId"],
+            "LicenseRef-Example",
+        )
+        with self.assertRaisesRegex(WorkspaceError, "unsupported.*format"):
+            inventory.report("unknown")
+        self.assertEqual(_cyclonedx_type("container-image"), "container")
+        self.assertEqual(_cyclonedx_type("external-tool"), "application")
+        ordinary_spdx = json.loads(
+            Inventory(
+                "atrinik",
+                "2026-08-07T00:00:00Z",
+                [Repository("fixture", "atrinik/fixture", True, "fixture")],
+                [fixture_dependency()],
+            ).report("spdx")
+        )
+        self.assertNotIn("hasExtractedLicensingInfos", ordinary_spdx)
+
     def test_nested_action_coordinates_are_recognized(self) -> None:
         match = ACTION_REFERENCE_PATTERN.search(
             "uses: organization/actions/.github/workflows/check.yml@" + "a" * 40
@@ -87,6 +616,7 @@ class InventoryTests(unittest.TestCase):
     def test_internal_docker_stages_are_not_external_images(self) -> None:
         dockerfile = """# syntax=docker/dockerfile:1@sha256:{frontend}
 FROM ubuntu:26.04@sha256:{digest} AS toolchain
+FROM alpine:3.23@sha256:{digest}
 FROM toolchain AS validation
 FROM toolchain AS final
 """.format(frontend="b" * 64, digest="a" * 64)
@@ -96,6 +626,7 @@ FROM toolchain AS final
             [
                 f"docker/dockerfile:1@sha256:{'b' * 64}",
                 f"ubuntu:26.04@sha256:{'a' * 64}",
+                f"alpine:3.23@sha256:{'a' * 64}",
             ],
         )
 
@@ -109,12 +640,135 @@ FROM toolchain AS final
             write_generated(root, output, "{}\n")
             self.assertEqual((root / output).read_text(encoding="utf-8"), "{}\n")
 
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "root"
+            outside = Path(temporary) / "outside"
+            root.mkdir()
+            outside.mkdir()
+            (root / "build").symlink_to(outside, target_is_directory=True)
+            with self.assertRaisesRegex(WorkspaceError, "must not be a symlink"):
+                write_generated(root, Path("build/report.json"), "{}\n")
+
     def test_duplicate_devcontainer_keys_are_rejected(self) -> None:
         with self.assertRaisesRegex(WorkspaceError, "duplicate JSON key"):
             _container_references(
                 ".devcontainer/devcontainer.json",
                 '{"image":"first@sha256:a","image":"second@sha256:b"}',
             )
+
+    def test_container_reference_parsing_rejects_invalid_json(self) -> None:
+        with self.assertRaisesRegex(WorkspaceError, "invalid devcontainer JSON"):
+            _container_references(".devcontainer/devcontainer.json", "{")
+        self.assertEqual(
+            _container_references(".devcontainer/devcontainer.json", "[]"), []
+        )
+        self.assertEqual(
+            _container_references(
+                ".devcontainer/devcontainer.json", '{"image":"example/image"}'
+            ),
+            ["example/image"],
+        )
+
+    def test_container_reference_validation_normalizes_registry_coordinates(self) -> None:
+        digest = "b" * 64
+        for image, locator in [
+            (f"ubuntu:26.04@sha256:{digest}", "docker.io/library/ubuntu"),
+            (f"atrinik/build:1@sha256:{digest}", "docker.io/atrinik/build"),
+            (f"ghcr.io/atrinik/build:1@sha256:{digest}", "ghcr.io/atrinik/build"),
+        ]:
+            with self.subTest(image=image):
+                dependency = fixture_dependency(
+                    identifier="container/example",
+                    kind="container-image",
+                    locator=locator,
+                    commit=None,
+                    checksum=f"sha256:{digest}",
+                    evidence=(Evidence("fixture", "Dockerfile", image),),
+                )
+                _validate_container_reference(
+                    [dependency], "fixture", "Dockerfile", image
+                )
+
+        with self.assertRaisesRegex(WorkspaceError, "movable container image"):
+            _validate_container_reference([], "fixture", "Dockerfile", "ubuntu:latest")
+        with self.assertRaisesRegex(WorkspaceError, "unowned container image"):
+            _validate_container_reference(
+                [], "fixture", "Dockerfile", f"ubuntu@sha256:{digest}"
+            )
+
+    def test_metadata_path_boundaries_reject_escapes_symlinks_and_bad_data(self) -> None:
+        self.assertEqual(_text("value", "field"), "value")
+        with self.assertRaisesRegex(WorkspaceError, "trimmed string"):
+            _text(" value ", "field")
+        self.assertEqual(_string_array([], "field", allow_empty=True), ())
+        with self.assertRaisesRegex(WorkspaceError, "non-empty array"):
+            _string_array([], "field")
+        self.assertEqual(_relative_path("path/to/file", "field"), "path/to/file")
+        for value in ("/absolute", "../escape"):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(WorkspaceError, "safe repository-relative"):
+                    _relative_path(value, "field")
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary).resolve()
+            regular = root / "regular"
+            regular.write_text("ok", encoding="utf-8")
+            self.assertEqual(_safe_repository_path(root, "regular"), regular)
+            with self.assertRaisesRegex(WorkspaceError, "missing or escapes"):
+                _safe_repository_path(root, "missing")
+            directory = root / "directory"
+            directory.mkdir()
+            with self.assertRaisesRegex(WorkspaceError, "regular non-symlink"):
+                _safe_repository_path(root, "directory")
+            symlink = root / "symlink"
+            symlink.symlink_to(regular)
+            with self.assertRaisesRegex(WorkspaceError, "regular non-symlink"):
+                _safe_repository_path(root, "symlink")
+
+            with mock.patch(
+                "atrinik_workspace.supply_chain.MAX_METADATA_BYTES", 1
+            ):
+                with self.assertRaisesRegex(WorkspaceError, "exceeds size limit"):
+                    _read_metadata(regular)
+            invalid_utf8 = root / "invalid"
+            invalid_utf8.write_bytes(b"\xff")
+            with self.assertRaisesRegex(WorkspaceError, "cannot read"):
+                _read_metadata(invalid_utf8)
+
+    def test_dependency_input_classification_is_content_aware(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            plain = root / "plain.cmake"
+            plain.write_text("message(STATUS okay)\n", encoding="utf-8")
+            dependency = root / "dependency.cmake"
+            dependency.write_text("find_package(OpenSSL REQUIRED)\n", encoding="utf-8")
+
+            self.assertTrue(_is_dependency_input("package.json", root))
+            self.assertTrue(_is_dependency_input("vendor/uthash.h", root))
+            self.assertTrue(_is_dependency_input("Dockerfile.release", root))
+            self.assertFalse(_is_dependency_input("plain.cmake", root))
+            self.assertTrue(_is_dependency_input("dependency.cmake", root))
+            self.assertTrue(
+                _is_dependency_input("tools/install-linux-ci-dependencies.sh", root)
+            )
+            self.assertFalse(_is_dependency_input("README.md", root))
+            self.assertTrue(_is_container_input("Dockerfile.release"))
+            self.assertTrue(_is_container_input(".devcontainer/devcontainer.json"))
+            self.assertFalse(_is_container_input("package.json"))
+
+    def test_git_file_listing_reports_command_and_encoding_failures(self) -> None:
+        failed = subprocess.CompletedProcess(
+            args=["git"], returncode=1, stdout=b"", stderr=b"not a repository"
+        )
+        invalid = subprocess.CompletedProcess(
+            args=["git"], returncode=0, stdout=b"\xff\0", stderr=b""
+        )
+        with mock.patch("atrinik_workspace.supply_chain.subprocess.run", return_value=failed):
+            with self.assertRaisesRegex(WorkspaceError, "cannot list tracked files"):
+                _tracked_files(ROOT)
+        with mock.patch("atrinik_workspace.supply_chain.subprocess.run", return_value=invalid):
+            with self.assertRaisesRegex(WorkspaceError, "tracked path is not UTF-8"):
+                _tracked_files(ROOT)
 
     def test_version_report_is_machine_readable(self) -> None:
         versions = json.loads(version_report(self.load_inventory()))
@@ -127,6 +781,126 @@ FROM toolchain AS final
             versions["declared-dependencies"]["container/ubuntu-26.04"]["checksum"],
             "sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7a03",
         )
+
+    def test_version_probe_and_package_fallbacks_are_machine_readable(self) -> None:
+        with mock.patch(
+            "atrinik_workspace.supply_chain.subprocess.run",
+            side_effect=FileNotFoundError,
+        ):
+            versions = json.loads(version_report())
+            packages = _system_package_versions(["missing"])
+
+        self.assertTrue(all(not probe["available"] for probe in versions.values()))
+        self.assertEqual(packages["missing"], {"available": False, "version": None})
+        self.assertEqual(_system_package_versions([]), {})
+
+        completed = subprocess.CompletedProcess(
+            args=["dpkg-query"],
+            returncode=1,
+            stdout="present:amd64\t1.2.3\ninvalid line\nunknown\t9\n",
+        )
+        with mock.patch(
+            "atrinik_workspace.supply_chain.subprocess.run", return_value=completed
+        ):
+            packages = _system_package_versions(["present", "missing"])
+        self.assertEqual(
+            packages["present"], {"available": True, "version": "1.2.3"}
+        )
+        self.assertFalse(packages["missing"]["available"])
+
+        no_output = subprocess.CompletedProcess(
+            args=["tool"], returncode=0, stdout="", stderr=""
+        )
+        with mock.patch(
+            "atrinik_workspace.supply_chain.subprocess.run", return_value=no_output
+        ):
+            probes = json.loads(version_report())
+        self.assertTrue(all(probe["available"] for probe in probes.values()))
+        self.assertTrue(all(probe["version"] is None for probe in probes.values()))
+
+    def test_repository_identity_accepts_https_and_ssh_only(self) -> None:
+        for url in (
+            "https://github.com/atrinik/client.git\n",
+            "git@github.com:atrinik/client.git\n",
+        ):
+            with self.subTest(url=url):
+                completed = subprocess.CompletedProcess(
+                    args=["git"], returncode=0, stdout=url, stderr=""
+                )
+                with mock.patch(
+                    "atrinik_workspace.supply_chain.subprocess.run",
+                    return_value=completed,
+                ):
+                    self.assertEqual(_git_repository_coordinate(ROOT), "atrinik/client")
+
+        failed = subprocess.CompletedProcess(
+            args=["git"], returncode=1, stdout="", stderr="failure"
+        )
+        unsupported = subprocess.CompletedProcess(
+            args=["git"], returncode=0, stdout="file:///tmp/client\n", stderr=""
+        )
+        for result, expected in [
+            (failed, "cannot inspect repository identity"),
+            (unsupported, "unsupported repository remote"),
+        ]:
+            with self.subTest(expected=expected):
+                with mock.patch(
+                    "atrinik_workspace.supply_chain.subprocess.run",
+                    return_value=result,
+                ):
+                    with self.assertRaisesRegex(WorkspaceError, expected):
+                        _git_repository_coordinate(ROOT)
+
+    def test_repository_root_overrides_are_strict_and_identity_checked(self) -> None:
+        workspace = mock.Mock()
+        workspace.component_path.side_effect = lambda name, profile: Path(
+            f"/workspace/{profile}/{name}"
+        )
+        invalid = [
+            ("bad", "must be NAME=PATH"),
+            ("unknown=/tmp", "must be NAME=PATH"),
+            ("client=relative", "must be absolute"),
+        ]
+        for override, expected in invalid:
+            with self.subTest(override=override):
+                with self.assertRaisesRegex(WorkspaceError, expected):
+                    repository_roots(ROOT, workspace, "profile", [override])
+
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary).resolve()
+            override = f"client={path}"
+            with mock.patch(
+                "atrinik_workspace.supply_chain._git_repository_coordinate",
+                return_value="atrinik/server",
+            ):
+                with self.assertRaisesRegex(WorkspaceError, "is not atrinik/client"):
+                    repository_roots(ROOT, workspace, "profile", [override])
+            with mock.patch(
+                "atrinik_workspace.supply_chain._git_repository_coordinate",
+                return_value="atrinik/client",
+            ):
+                with self.assertRaisesRegex(WorkspaceError, "duplicate.*override"):
+                    repository_roots(
+                        ROOT, workspace, "profile", [override, override]
+                    )
+                roots = repository_roots(ROOT, workspace, "profile", [override])
+
+        self.assertEqual(roots["atrinik"], ROOT)
+        self.assertEqual(roots["client"], path)
+        self.assertIn("server", roots)
+
+    def test_generated_output_can_be_printed_or_written_absolutely(self) -> None:
+        with mock.patch("builtins.print") as output:
+            write_generated(ROOT, None, "value\n")
+        output.assert_called_once_with("value\n", end="")
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            target = (root / "build" / "absolute.json").resolve()
+            with mock.patch("builtins.print") as output:
+                write_generated(root, target, "{}\n")
+            self.assertEqual(target.read_text(encoding="utf-8"), "{}\n")
+            output.assert_called_once_with(target)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add the strict organization-wide dependency/toolchain ownership catalog and schema
- audit immutable Actions, hosted runners, workflow container pulls, Dockerfiles, devcontainers, dependency manifests, CMake inputs, vendored source, update ownership, and submodule absence
- generate exact environment versions, third-party provenance, CycloneDX 1.6, and SPDX 2.3 artifacts in scheduled CI
- document the cross-repository ownership and maintenance workflow

Closes #189.

## Component dependencies

- atrinik/client#45
- atrinik/server#50
- atrinik/protocol#12
- atrinik/libatrinik#14
- atrinik/content#35
- atrinik/sound#11
- atrinik/resources#11
- atrinik/tools#13
- atrinik/editor#8
- atrinik/metaserver-worker#10
- atrinik/devcontainer#14
- atrinik/github-settings#23

The component PRs must merge first so the scheduled audit sees owned updater configuration and immutable references on every default branch.

## Validation

- all 88 wrapper unit tests and warning-as-error compileall
- complete 13-repository supply-chain audit (about 17,000 inputs)
- deterministic license, CycloneDX, SPDX, and exact version report generation
- actionlint across every workflow and policy publisher plan review
- GCC 15.2 client/server builds with 5 + 31 passing CTests
- Clang 21.1 client build with 5 passing CTests
- Linux and full cached Windows/MXE toolchain image builds and smoke tests
- server and devcontainer Dockerfile checks
- `git diff --check` across all worktrees
