### PR TITLE
chore: catalog replacement repositories

### DIFF
--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -13,13 +13,19 @@
       "name": "client",
       "repository": "atrinik/client",
       "supported": true,
-      "role": "SDL3 game client"
+      "role": "MIT Rust game client replacement awaiting bootstrap"
     },
     {
       "name": "content",
       "repository": "atrinik/content",
       "supported": true,
       "role": "Authored world content and content tooling"
+    },
+    {
+      "name": "content-toolkit",
+      "repository": "atrinik/content-toolkit",
+      "supported": false,
+      "role": "MIT content model, compiler, validator, and migration tooling awaiting wrapper integration"
     },
     {
       "name": "devcontainer",
@@ -31,7 +37,7 @@
       "name": "editor",
       "repository": "atrinik/editor",
       "supported": true,
-      "role": "Gridarta packaging utility"
+      "role": "MIT Rust content editor replacement awaiting bootstrap"
     },
     {
       "name": "github-settings",
@@ -40,10 +46,40 @@
       "role": "Organization governance desired state"
     },
     {
+      "name": "legacy-client",
+      "repository": "atrinik/legacy-client",
+      "supported": false,
+      "role": "GPL classic SDL3 game client retained for migration and maintenance"
+    },
+    {
+      "name": "legacy-editor",
+      "repository": "atrinik/legacy-editor",
+      "supported": false,
+      "role": "GPL classic Gridarta packaging utility retained for migration and maintenance"
+    },
+    {
+      "name": "legacy-libatrinik",
+      "repository": "atrinik/legacy-libatrinik",
+      "supported": false,
+      "role": "GPL classic reusable native libraries retained for migration and maintenance"
+    },
+    {
+      "name": "legacy-protocol",
+      "repository": "atrinik/legacy-protocol",
+      "supported": false,
+      "role": "MIT classic C protocol schemas and generated bindings retained for migration and maintenance"
+    },
+    {
+      "name": "legacy-server",
+      "repository": "atrinik/legacy-server",
+      "supported": false,
+      "role": "GPL classic authoritative game server retained for migration and maintenance"
+    },
+    {
       "name": "libatrinik",
       "repository": "atrinik/libatrinik",
       "supported": true,
-      "role": "Reusable native libraries"
+      "role": "Transitional manifest coordinate for classic reusable native libraries"
     },
     {
       "name": "metaserver-worker",
@@ -61,7 +97,13 @@
       "name": "protocol",
       "repository": "atrinik/protocol",
       "supported": true,
-      "role": "Canonical protocol schema and generated bindings"
+      "role": "MIT replacement wire schemas and generated Go and Rust bindings awaiting bootstrap"
+    },
+    {
+      "name": "renderer",
+      "repository": "atrinik/renderer",
+      "supported": false,
+      "role": "MIT shared Rust GPU renderer for the client and editor awaiting wrapper integration"
     },
     {
       "name": "resources",
@@ -73,7 +115,7 @@
       "name": "server",
       "repository": "atrinik/server",
       "supported": true,
-      "role": "Authoritative game server"
+      "role": "MIT Go authoritative game server replacement awaiting bootstrap"
     },
     {
       "name": "sound",
@@ -86,6 +128,12 @@
       "repository": "atrinik/tools",
       "supported": true,
       "role": "Standalone operator and content-inspection tools"
+    },
+    {
+      "name": "website",
+      "repository": "atrinik/website",
+      "supported": false,
+      "role": "MIT atrinik.org source awaiting wrapper integration"
     }
   ],
   "dependencies": [
@@ -95,7 +143,7 @@
       "kind": "github-action",
       "owner": "github-settings",
       "scope": [
-        "client"
+        "legacy-client"
       ],
       "required": true,
       "version": "v6",
@@ -109,12 +157,12 @@
       "update_cadence_days": 7,
       "update_mechanism": "Dependabot GitHub Actions update group",
       "eol_response": "Upgrade all cache consumers together or remove the cache step",
-      "validation": "Actionlint plus client CI cache restore/save coverage",
+      "validation": "Actionlint plus legacy-client CI cache restore/save coverage",
       "disposition": "retain",
       "packages": [],
       "evidence": [
         {
-          "repository": "client",
+          "repository": "legacy-client",
           "path": ".github/workflows/check.yml",
           "contains": "actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6"
         }
@@ -127,16 +175,16 @@
       "owner": "github-settings",
       "scope": [
         "atrinik",
-        "client",
         "content",
         "devcontainer",
-        "editor",
         "github-settings",
+        "legacy-client",
+        "legacy-editor",
+        "legacy-protocol",
+        "legacy-server",
         "libatrinik",
         "metaserver-worker",
-        "protocol",
         "resources",
-        "server",
         "sound",
         "tools"
       ],
@@ -169,8 +217,8 @@
       "kind": "github-action",
       "owner": "github-settings",
       "scope": [
-        "client",
-        "server"
+        "legacy-client",
+        "legacy-server"
       ],
       "required": true,
       "version": "v8",
@@ -189,7 +237,7 @@
       "packages": [],
       "evidence": [
         {
-          "repository": "client",
+          "repository": "legacy-client",
           "path": ".github/workflows/package-release.yml",
           "contains": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8"
         }
@@ -235,7 +283,7 @@
       "scope": [
         "atrinik",
         "content",
-        "protocol"
+        "legacy-protocol"
       ],
       "required": true,
       "version": "v6",
@@ -267,8 +315,8 @@
       "owner": "github-settings",
       "scope": [
         "atrinik",
-        "client",
-        "server"
+        "legacy-client",
+        "legacy-server"
       ],
       "required": true,
       "version": "v7",
@@ -287,7 +335,7 @@
       "packages": [],
       "evidence": [
         {
-          "repository": "server",
+          "repository": "legacy-server",
           "path": ".github/workflows/package-release.yml",
           "contains": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7"
         }
@@ -300,9 +348,9 @@
       "owner": "github-settings",
       "scope": [
         "atrinik",
-        "client",
-        "libatrinik",
-        "server"
+        "legacy-client",
+        "legacy-server",
+        "libatrinik"
       ],
       "required": false,
       "version": "v6",
@@ -334,7 +382,7 @@
       "owner": "github-settings",
       "scope": [
         "devcontainer",
-        "server"
+        "legacy-server"
       ],
       "required": true,
       "version": "v7",
@@ -365,9 +413,9 @@
       "kind": "github-action",
       "owner": "github-settings",
       "scope": [
-        "client",
         "devcontainer",
-        "server"
+        "legacy-client",
+        "legacy-server"
       ],
       "required": true,
       "version": "v4",
@@ -399,7 +447,7 @@
       "owner": "github-settings",
       "scope": [
         "devcontainer",
-        "server"
+        "legacy-server"
       ],
       "required": true,
       "version": "v4",
@@ -467,7 +515,7 @@
       "owner": "devcontainer",
       "scope": [
         "devcontainer",
-        "server"
+        "legacy-server"
       ],
       "required": true,
       "version": "1",
@@ -496,7 +544,7 @@
           "contains": "docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89"
         },
         {
-          "repository": "server",
+          "repository": "legacy-server",
           "path": "Dockerfile",
           "contains": "docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89"
         }
@@ -570,9 +618,9 @@
       "kind": "container-image",
       "owner": "devcontainer",
       "scope": [
-        "client",
         "devcontainer",
-        "server"
+        "legacy-client",
+        "legacy-server"
       ],
       "required": true,
       "version": "26.04",
@@ -584,29 +632,29 @@
       "checksum": "sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7a03",
       "acquisition": "BuildKit pulls the LTS tag and immutable multi-platform manifest digest",
       "update_cadence_days": 30,
-      "update_mechanism": "Dependabot Docker update followed by Linux and server image builds",
+      "update_mechanism": "Dependabot Docker update followed by Linux and legacy-server image builds",
       "eol_response": "Move all consumers to the next supported Ubuntu LTS before standard support ends",
-      "validation": "Docker build checks, native tests, and server startup smoke test",
+      "validation": "Docker build checks, native tests, and legacy-server startup smoke test",
       "disposition": "retain",
       "packages": [],
       "evidence": [
-        {
-          "repository": "client",
-          "path": ".github/workflows/check.yml",
-          "contains": "ubuntu@sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7a03"
-        },
         {
           "repository": "devcontainer",
           "path": "linux/Dockerfile",
           "contains": "ubuntu:26.04@sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7a03"
         },
         {
-          "repository": "server",
+          "repository": "legacy-client",
           "path": ".github/workflows/check.yml",
           "contains": "ubuntu@sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7a03"
         },
         {
-          "repository": "server",
+          "repository": "legacy-server",
+          "path": ".github/workflows/check.yml",
+          "contains": "ubuntu@sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7a03"
+        },
+        {
+          "repository": "legacy-server",
           "path": "Dockerfile",
           "contains": "ubuntu@sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7a03"
         }
@@ -619,8 +667,8 @@
       "owner": "devcontainer",
       "scope": [
         "atrinik",
-        "client",
-        "server"
+        "legacy-client",
+        "legacy-server"
       ],
       "required": true,
       "version": "1.0.5",
@@ -644,12 +692,12 @@
           "contains": "ghcr.io/atrinik/windows-build:1.0.5@sha256:9cc373f620a577328fc0a7a7fa823bddaca6d7dc75ac73bcf21be421c49676f7"
         },
         {
-          "repository": "client",
+          "repository": "legacy-client",
           "path": ".github/workflows/package-release.yml",
           "contains": "ghcr.io/atrinik/windows-build:1.0.5@sha256:9cc373f620a577328fc0a7a7fa823bddaca6d7dc75ac73bcf21be421c49676f7"
         },
         {
-          "repository": "server",
+          "repository": "legacy-server",
           "path": ".github/workflows/package-release.yml",
           "contains": "ghcr.io/atrinik/windows-build:1.0.5@sha256:9cc373f620a577328fc0a7a7fa823bddaca6d7dc75ac73bcf21be421c49676f7"
         }
@@ -690,9 +738,9 @@
       "id": "external/gridarta",
       "name": "Gridarta source checkout",
       "kind": "external-tool",
-      "owner": "editor",
+      "owner": "legacy-editor",
       "scope": [
-        "editor"
+        "legacy-editor"
       ],
       "required": false,
       "version": "operator-supplied-reviewed-checkout",
@@ -704,14 +752,14 @@
       "checksum": null,
       "acquisition": "Operator supplies a separate checkout; Atrinik never downloads or mutates it",
       "update_cadence_days": 180,
-      "update_mechanism": "Manual compatibility review until the editor is retired",
+      "update_mechanism": "Manual compatibility review until legacy-editor is retired",
       "eol_response": "Retire this packaging path through atrinik/content#5 rather than vendoring Gridarta",
       "validation": "Disposable Gradle fixture and expected AtrinikEditor.jar contract",
       "disposition": "remove",
       "packages": [],
       "evidence": [
         {
-          "repository": "editor",
+          "repository": "legacy-editor",
           "path": "build.sh",
           "contains": "./gradlew clean :src:atrinik:preparePublish"
         }
@@ -766,7 +814,7 @@
       "checksum": null,
       "acquisition": "Optional operator-managed Python environment",
       "update_cadence_days": 90,
-      "update_mechanism": "Manual GUI compatibility review pending native editor replacement",
+      "update_mechanism": "Manual GUI compatibility review pending the atrinik/editor replacement",
       "eol_response": "Port or retire the GUI rather than pinning an unsupported Python/Qt stack",
       "validation": "Headless map-checker tests plus explicit GUI smoke test",
       "disposition": "replace",
@@ -888,9 +936,9 @@
       "id": "language/protocol-python-build",
       "name": "Protocol Python build toolchain",
       "kind": "language-package-set",
-      "owner": "protocol",
+      "owner": "legacy-protocol",
       "scope": [
-        "protocol"
+        "legacy-protocol"
       ],
       "required": true,
       "version": "setuptools>=77; setuptools-scm>=8,<10; build=1.3.0",
@@ -913,7 +961,7 @@
       ],
       "evidence": [
         {
-          "repository": "protocol",
+          "repository": "legacy-protocol",
           "path": "pyproject.toml",
           "contains": "setuptools-scm>=8,<10"
         }
@@ -958,26 +1006,26 @@
       "kind": "source-archive",
       "owner": "content",
       "scope": [
-        "server"
+        "legacy-server"
       ],
       "required": true,
       "version": "v1.2.0",
-      "version_source": "server/dependencies.lock.json",
+      "version_source": "legacy-server/dependencies.lock.json",
       "license": "LicenseRef-Atrinik-Asset-Per-File",
       "source_url": "https://github.com/atrinik/content/releases/tag/v1.2.0",
       "locator": "pkg:github/atrinik/content@v1.2.0",
       "commit": "766cb6e67aa03dd86b1c333c607885df31c3aca5",
       "checksum": "sha256:06dd946dbd121429d4a2b8b5ac1de02e7561b723916f6400b3e87134364ac4c2",
-      "acquisition": "Server dependency tool downloads and safely extracts the release archive",
+      "acquisition": "Legacy-server dependency tool downloads and safely extracts the release archive",
       "update_cadence_days": 30,
       "update_mechanism": "Weekly lock drift audit and reviewed release consumption",
-      "eol_response": "Update the lock to a supported content release or stop packaging the server",
-      "validation": "Lock validation, checksum, safe extraction, collection, and server runtime tests",
+      "eol_response": "Update the lock to a supported content release or stop packaging legacy-server",
+      "validation": "Lock validation, checksum, safe extraction, collection, and legacy-server runtime tests",
       "disposition": "isolate",
       "packages": [],
       "evidence": [
         {
-          "repository": "server",
+          "repository": "legacy-server",
           "path": "dependencies.lock.json",
           "contains": "atrinik-content-1.2.0-runtime.tar.gz"
         }
@@ -985,20 +1033,20 @@
     },
     {
       "id": "source/atrinik-libatrinik",
-      "name": "libatrinik release source",
+      "name": "legacy-libatrinik release source",
       "kind": "source-archive",
-      "owner": "libatrinik",
+      "owner": "legacy-libatrinik",
       "scope": [
-        "client",
-        "libatrinik",
-        "server"
+        "legacy-client",
+        "legacy-server",
+        "libatrinik"
       ],
       "required": true,
       "version": "v1.0.3",
-      "version_source": "client/server CMake dependency locks",
+      "version_source": "legacy-client/legacy-server CMake dependency locks",
       "license": "GPL-2.0-or-later",
-      "source_url": "https://github.com/atrinik/libatrinik/releases/tag/v1.0.3",
-      "locator": "pkg:github/atrinik/libatrinik@v1.0.3",
+      "source_url": "https://github.com/atrinik/legacy-libatrinik/releases/tag/v1.0.3",
+      "locator": "pkg:github/atrinik/legacy-libatrinik@v1.0.3",
       "commit": "2996df2866eb220d45a1493408f4e54851f72c8e",
       "checksum": "sha256:6dc6823aca9cf24242bd67f5aed7469da9ca57fe2cdf7ada30e105b908a396d4",
       "acquisition": "CMake FetchContent downloads the checksum-pinned release archive",
@@ -1010,7 +1058,12 @@
       "packages": [],
       "evidence": [
         {
-          "repository": "client",
+          "repository": "legacy-client",
+          "path": "cmake/dependencies.lock.json",
+          "contains": "libatrinik-1.0.3.tar.gz"
+        },
+        {
+          "repository": "legacy-server",
           "path": "cmake/dependencies.lock.json",
           "contains": "libatrinik-1.0.3.tar.gz"
         },
@@ -1018,29 +1071,24 @@
           "repository": "libatrinik",
           "path": "tests/consumer/CMakeLists.txt",
           "contains": "find_package(LibAtrinik 1 CONFIG REQUIRED)"
-        },
-        {
-          "repository": "server",
-          "path": "cmake/dependencies.lock.json",
-          "contains": "libatrinik-1.0.3.tar.gz"
         }
       ]
     },
     {
       "id": "source/atrinik-protocol-client-server",
-      "name": "Atrinik protocol release source for client/server",
+      "name": "Atrinik classic protocol release source for legacy-client/legacy-server",
       "kind": "source-archive",
-      "owner": "protocol",
+      "owner": "legacy-protocol",
       "scope": [
-        "client",
-        "server"
+        "legacy-client",
+        "legacy-server"
       ],
       "required": true,
       "version": "v1.0.1",
-      "version_source": "client/server CMake dependency locks",
+      "version_source": "legacy-client/legacy-server CMake dependency locks",
       "license": "MIT",
-      "source_url": "https://github.com/atrinik/protocol/releases/tag/v1.0.1",
-      "locator": "pkg:github/atrinik/protocol@v1.0.1",
+      "source_url": "https://github.com/atrinik/legacy-protocol/releases/tag/v1.0.1",
+      "locator": "pkg:github/atrinik/legacy-protocol@v1.0.1",
       "commit": "7e10ecaa279489fcdb843ecbe020fc9befeba4fd",
       "checksum": "sha256:d8e113210a395913d27446e5764f212f6f1de028c9945ae9f0479588474b3137",
       "acquisition": "CMake FetchContent downloads the checksum-pinned release archive",
@@ -1052,12 +1100,12 @@
       "packages": [],
       "evidence": [
         {
-          "repository": "client",
+          "repository": "legacy-client",
           "path": "cmake/dependencies.lock.json",
           "contains": "atrinik-protocol-1.0.1.tar.gz"
         },
         {
-          "repository": "server",
+          "repository": "legacy-server",
           "path": "cmake/dependencies.lock.json",
           "contains": "atrinik-protocol-1.0.1.tar.gz"
         }
@@ -1065,18 +1113,18 @@
     },
     {
       "id": "source/atrinik-protocol-libatrinik",
-      "name": "Atrinik protocol release source for libatrinik",
+      "name": "Atrinik classic protocol release source for legacy-libatrinik",
       "kind": "source-archive",
-      "owner": "protocol",
+      "owner": "legacy-protocol",
       "scope": [
         "libatrinik"
       ],
       "required": true,
       "version": "v1.0.0",
-      "version_source": "libatrinik/dependencies.lock.json",
+      "version_source": "legacy-libatrinik/dependencies.lock.json",
       "license": "MIT",
-      "source_url": "https://github.com/atrinik/protocol/releases/tag/v1.0.0",
-      "locator": "pkg:github/atrinik/protocol@v1.0.0",
+      "source_url": "https://github.com/atrinik/legacy-protocol/releases/tag/v1.0.0",
+      "locator": "pkg:github/atrinik/legacy-protocol@v1.0.0",
       "commit": "8be5e46bbf471b108e9ce70d3f929f74a0fb1f8d",
       "checksum": "sha256:1e37b970bfa47b119b5156fb90178915ee933c1a42ba061766ecd99f1d6640e8",
       "acquisition": "CMake FetchContent downloads the checksum-pinned release archive",
@@ -1096,30 +1144,30 @@
     },
     {
       "id": "source/atrinik-resources-runtime",
-      "name": "Atrinik server resource archive",
+      "name": "Atrinik legacy-server resource archive",
       "kind": "source-archive",
       "owner": "resources",
       "scope": [
-        "server"
+        "legacy-server"
       ],
       "required": true,
       "version": "v1.0.1",
-      "version_source": "server/dependencies.lock.json",
+      "version_source": "legacy-server/dependencies.lock.json",
       "license": "LicenseRef-Atrinik-Asset-Per-File",
       "source_url": "https://github.com/atrinik/resources/releases/tag/v1.0.1",
       "locator": "pkg:github/atrinik/resources@v1.0.1",
       "commit": "a3bd8c8a2b746d15b397a67d9f641af7d97a6078",
       "checksum": "sha256:4db9ecdd74aa570bc7e20eccac980844f3aba8d668230502728b22146d3b2c54",
-      "acquisition": "Server dependency tool downloads and safely extracts the release archive",
+      "acquisition": "Legacy-server dependency tool downloads and safely extracts the release archive",
       "update_cadence_days": 30,
       "update_mechanism": "Weekly lock drift audit and reviewed release consumption",
-      "eol_response": "Update the lock to a supported resource release or stop packaging the server",
+      "eol_response": "Update the lock to a supported resource release or stop packaging legacy-server",
       "validation": "Lock validation, checksum, safe extraction, and runtime allowlist",
       "disposition": "isolate",
       "packages": [],
       "evidence": [
         {
-          "repository": "server",
+          "repository": "legacy-server",
           "path": "dependencies.lock.json",
           "contains": "atrinik-resources-1.0.1.tar.gz"
         }
@@ -1131,26 +1179,26 @@
       "kind": "source-archive",
       "owner": "sound",
       "scope": [
-        "client"
+        "legacy-client"
       ],
       "required": true,
       "version": "v1.0.3",
-      "version_source": "client/dependencies.lock.json",
+      "version_source": "legacy-client/dependencies.lock.json",
       "license": "LicenseRef-Atrinik-Asset-Per-File",
       "source_url": "https://github.com/atrinik/sound/releases/tag/v1.0.3",
       "locator": "pkg:github/atrinik/sound@v1.0.3",
       "commit": "18234cce19bf641f24d81333d8abcc0f1e34cd08",
       "checksum": "sha256:5427d2d2b5b73bad30c279ea5b7f012c380fd402249d45d9363b85ea7674e4bb",
-      "acquisition": "Client dependency tool downloads and safely extracts the release archive",
+      "acquisition": "Legacy-client dependency tool downloads and safely extracts the release archive",
       "update_cadence_days": 30,
       "update_mechanism": "Weekly lock drift audit and reviewed release consumption",
       "eol_response": "Update the lock to a supported sound release or disable packaging",
-      "validation": "Lock validation, checksum, safe extraction, and client package test",
+      "validation": "Lock validation, checksum, safe extraction, and legacy-client package test",
       "disposition": "isolate",
       "packages": [],
       "evidence": [
         {
-          "repository": "client",
+          "repository": "legacy-client",
           "path": "dependencies.lock.json",
           "contains": "atrinik-sound-1.0.3.tar.gz"
         }
@@ -1191,13 +1239,13 @@
       "id": "source/libpcpnatpmp",
       "name": "libpcpnatpmp",
       "kind": "source-archive",
-      "owner": "server",
+      "owner": "legacy-server",
       "scope": [
-        "server"
+        "legacy-server"
       ],
       "required": true,
       "version": "866d283da99f5e98eecff702a8df63e2ae57ffca",
-      "version_source": "server/cmake/pcpnatpmp.cmake",
+      "version_source": "legacy-server/cmake/pcpnatpmp.cmake",
       "license": "BSD-3-Clause",
       "source_url": "https://github.com/libpcpnatpmp/libpcpnatpmp",
       "locator": "pkg:github/libpcpnatpmp/libpcpnatpmp@866d283da99f5e98eecff702a8df63e2ae57ffca",
@@ -1212,7 +1260,7 @@
       "packages": [],
       "evidence": [
         {
-          "repository": "server",
+          "repository": "legacy-server",
           "path": "cmake/pcpnatpmp.cmake",
           "contains": "866d283da99f5e98eecff702a8df63e2ae57ffca.tar.gz"
         }
@@ -1267,9 +1315,9 @@
       "checksum": null,
       "acquisition": "The Windows image shallow-clones and checks out the immutable commit",
       "update_cadence_days": 30,
-      "update_mechanism": "Scheduled commit review with cold Windows image and client/server builds",
+      "update_mechanism": "Scheduled commit review with cold Windows image and legacy-client/legacy-server builds",
       "eol_response": "Advance MXE and its compiler before existing targets leave support",
-      "validation": "Patched MXE package builds and portable MinGW client/server tests",
+      "validation": "Patched MXE package builds and portable MinGW legacy-client/legacy-server tests",
       "disposition": "isolate",
       "packages": [
         "cmake",
@@ -1308,8 +1356,8 @@
       "acquisition": "Windows image downloads the official checksum-pinned SDK",
       "update_cadence_days": 30,
       "update_mechanism": "Scheduled release drift review with Windows sound import verification",
-      "eol_response": "Upgrade with SDL3 and rebuild the complete portable client",
-      "validation": "Checksum, pkg-config version, DLL presence, and client import check",
+      "eol_response": "Upgrade with SDL3 and rebuild the complete portable legacy-client",
+      "validation": "Checksum, pkg-config version, DLL presence, and legacy-client import check",
       "disposition": "isolate",
       "packages": [],
       "evidence": [
@@ -1326,12 +1374,12 @@
       "kind": "source-archive",
       "owner": "devcontainer",
       "scope": [
-        "client",
-        "devcontainer"
+        "devcontainer",
+        "legacy-client"
       ],
       "required": true,
       "version": "3.2.4",
-      "version_source": "Linux image and client CI installer",
+      "version_source": "Linux image and legacy-client CI installer",
       "license": "Zlib",
       "source_url": "https://github.com/libsdl-org/SDL_mixer/releases/tag/release-3.2.4",
       "locator": "pkg:github/libsdl-org/SDL_mixer@release-3.2.4",
@@ -1339,21 +1387,21 @@
       "checksum": "sha256:182a07c745375e113dc740d43964ff21b0be29f29f59876c4dbc4db3d32f6901",
       "acquisition": "Checksum-pinned official release source is built with a bounded codec set",
       "update_cadence_days": 30,
-      "update_mechanism": "Scheduled release drift review and client audio tests",
+      "update_mechanism": "Scheduled release drift review and legacy-client audio tests",
       "eol_response": "Upgrade with SDL3 or temporarily disable unsupported codecs explicitly",
-      "validation": "Checksum, pkg-config version, native client build, and sound tests",
+      "validation": "Checksum, pkg-config version, native legacy-client build, and sound tests",
       "disposition": "isolate",
       "packages": [],
       "evidence": [
         {
-          "repository": "client",
-          "path": "tools/install-linux-ci-dependencies.sh",
-          "contains": "182a07c745375e113dc740d43964ff21b0be29f29f59876c4dbc4db3d32f6901"
-        },
-        {
           "repository": "devcontainer",
           "path": "linux/Dockerfile",
           "contains": "SDL3_MIXER_SHA256=182a07c745375e113dc740d43964ff21b0be29f29f59876c4dbc4db3d32f6901"
+        },
+        {
+          "repository": "legacy-client",
+          "path": "tools/install-linux-ci-dependencies.sh",
+          "contains": "182a07c745375e113dc740d43964ff21b0be29f29f59876c4dbc4db3d32f6901"
         }
       ]
     },
@@ -1361,9 +1409,9 @@
       "id": "system/check",
       "name": "Check unit-testing framework",
       "kind": "system-library",
-      "owner": "server",
+      "owner": "legacy-server",
       "scope": [
-        "server"
+        "legacy-server"
       ],
       "required": false,
       "version": "distribution-provided",
@@ -1377,7 +1425,7 @@
       "update_cadence_days": 30,
       "update_mechanism": "Pinned image rebuild and package-version report",
       "eol_response": "Upgrade the image or migrate focused tests without suppressing them",
-      "validation": "Optional CHECK_PKG discovery and server unit suite",
+      "validation": "Optional CHECK_PKG discovery and legacy-server unit suite",
       "disposition": "retain",
       "packages": [
         "check",
@@ -1385,7 +1433,7 @@
       ],
       "evidence": [
         {
-          "repository": "server",
+          "repository": "legacy-server",
           "path": "CMakeLists.txt",
           "contains": "pkg_check_modules(CHECK_PKG QUIET IMPORTED_TARGET check)"
         }
@@ -1393,11 +1441,11 @@
     },
     {
       "id": "system/client-ci-packages",
-      "name": "Client Linux CI package set",
+      "name": "Legacy-client Linux CI package set",
       "kind": "system-package-set",
-      "owner": "client",
+      "owner": "legacy-client",
       "scope": [
-        "client"
+        "legacy-client"
       ],
       "required": true,
       "version": "ubuntu-24.04-runner",
@@ -1432,7 +1480,7 @@
       ],
       "evidence": [
         {
-          "repository": "client",
+          "repository": "legacy-client",
           "path": "tools/install-linux-ci-dependencies.sh",
           "contains": "apt-get install -y -qq --no-install-recommends"
         }
@@ -1442,12 +1490,12 @@
       "id": "system/curl",
       "name": "libcurl",
       "kind": "system-library",
-      "owner": "libatrinik",
+      "owner": "legacy-libatrinik",
       "scope": [
-        "client",
         "devcontainer",
-        "libatrinik",
-        "server"
+        "legacy-client",
+        "legacy-server",
+        "libatrinik"
       ],
       "required": true,
       "version": "distribution/MXE-provided",
@@ -1461,7 +1509,7 @@
       "update_cadence_days": 30,
       "update_mechanism": "Image rebuild, MXE review, and exact version report",
       "eol_response": "Upgrade immediately for unsupported or security-affected TLS/HTTP lines",
-      "validation": "CMake discovery, TLS backend check, and client/server network tests",
+      "validation": "CMake discovery, TLS backend check, and legacy-client/legacy-server network tests",
       "disposition": "retain",
       "packages": [
         "libcurl4-openssl-dev"
@@ -1478,10 +1526,10 @@
       "id": "system/flex",
       "name": "Flex",
       "kind": "toolchain",
-      "owner": "server",
+      "owner": "legacy-server",
       "scope": [
         "devcontainer",
-        "server"
+        "legacy-server"
       ],
       "required": true,
       "version": "distribution-provided",
@@ -1502,7 +1550,7 @@
       ],
       "evidence": [
         {
-          "repository": "server",
+          "repository": "legacy-server",
           "path": "CMakeLists.txt",
           "contains": "find_package(FLEX REQUIRED)"
         }
@@ -1512,10 +1560,10 @@
       "id": "system/gd",
       "name": "libgd",
       "kind": "system-library",
-      "owner": "server",
+      "owner": "legacy-server",
       "scope": [
         "devcontainer",
-        "server"
+        "legacy-server"
       ],
       "required": false,
       "version": "distribution-provided",
@@ -1528,7 +1576,7 @@
       "acquisition": "CMake finds the optional world-maker library from the image",
       "update_cadence_days": 30,
       "update_mechanism": "Image update and world-maker generation test",
-      "eol_response": "Replace the world-maker dependency through client-rendered imagery before removal",
+      "eol_response": "Replace the world-maker dependency through atrinik/client-rendered imagery before removal",
       "validation": "CMake GD_LIBRARY discovery and isolated world-maker generation",
       "disposition": "replace",
       "packages": [
@@ -1536,7 +1584,7 @@
       ],
       "evidence": [
         {
-          "repository": "server",
+          "repository": "legacy-server",
           "path": "CMakeLists.txt",
           "contains": "find_library(GD_LIBRARY gd)"
         }
@@ -1546,11 +1594,11 @@
       "id": "system/libxml2",
       "name": "libxml2",
       "kind": "system-library",
-      "owner": "client",
+      "owner": "legacy-client",
       "scope": [
-        "client",
         "devcontainer",
-        "server"
+        "legacy-client",
+        "legacy-server"
       ],
       "required": true,
       "version": "distribution/MXE-provided",
@@ -1571,7 +1619,7 @@
       ],
       "evidence": [
         {
-          "repository": "client",
+          "repository": "legacy-client",
           "path": "CMakeLists.txt",
           "contains": "find_package(LibXml2 REQUIRED)"
         }
@@ -1581,10 +1629,10 @@
       "id": "system/miniupnpc",
       "name": "MiniUPnPc",
       "kind": "system-library",
-      "owner": "server",
+      "owner": "legacy-server",
       "scope": [
         "devcontainer",
-        "server"
+        "legacy-server"
       ],
       "required": true,
       "version": "distribution/MXE-pinned",
@@ -1605,7 +1653,7 @@
       ],
       "evidence": [
         {
-          "repository": "server",
+          "repository": "legacy-server",
           "path": "CMakeLists.txt",
           "contains": "pkg_check_modules(MINIUPNPC REQUIRED IMPORTED_TARGET miniupnpc)"
         }
@@ -1615,12 +1663,12 @@
       "id": "system/openssl",
       "name": "OpenSSL",
       "kind": "system-library",
-      "owner": "libatrinik",
+      "owner": "legacy-libatrinik",
       "scope": [
-        "client",
         "devcontainer",
-        "libatrinik",
-        "server"
+        "legacy-client",
+        "legacy-server",
+        "libatrinik"
       ],
       "required": true,
       "version": "distribution/MXE-provided",
@@ -1651,11 +1699,11 @@
       "id": "system/pkg-config",
       "name": "pkg-config/pkgconf",
       "kind": "toolchain",
-      "owner": "server",
+      "owner": "legacy-server",
       "scope": [
-        "client",
         "devcontainer",
-        "server"
+        "legacy-client",
+        "legacy-server"
       ],
       "required": true,
       "version": "distribution-provided",
@@ -1676,7 +1724,7 @@
       ],
       "evidence": [
         {
-          "repository": "server",
+          "repository": "legacy-server",
           "path": "CMakeLists.txt",
           "contains": "find_package(PkgConfig REQUIRED)"
         }
@@ -1686,14 +1734,14 @@
       "id": "system/sdl3",
       "name": "SDL3",
       "kind": "system-library",
-      "owner": "client",
+      "owner": "legacy-client",
       "scope": [
-        "client",
-        "devcontainer"
+        "devcontainer",
+        "legacy-client"
       ],
       "required": true,
       "version": ">=3.4",
-      "version_source": "Client CMake constraint and pinned build images",
+      "version_source": "Legacy-client CMake constraint and pinned build images",
       "license": "Zlib",
       "source_url": "https://github.com/libsdl-org/SDL",
       "locator": "pkg:generic/SDL3",
@@ -1701,16 +1749,16 @@
       "checksum": null,
       "acquisition": "CMake imported target from Ubuntu or MXE",
       "update_cadence_days": 30,
-      "update_mechanism": "Image/MXE update and SDL3 client test matrix",
+      "update_mechanism": "Image/MXE update and SDL3 legacy-client test matrix",
       "eol_response": "Upgrade to a supported SDL3 release without reintroducing SDL2 compatibility",
-      "validation": "CMake version constraint, native tests, and live client smoke test",
+      "validation": "CMake version constraint, native tests, and live legacy-client smoke test",
       "disposition": "retain",
       "packages": [
         "libsdl3-dev"
       ],
       "evidence": [
         {
-          "repository": "client",
+          "repository": "legacy-client",
           "path": "CMakeLists.txt",
           "contains": "find_package(SDL3 3.4 CONFIG REQUIRED)"
         }
@@ -1720,14 +1768,14 @@
       "id": "system/sdl3-image",
       "name": "SDL3_image",
       "kind": "system-library",
-      "owner": "client",
+      "owner": "legacy-client",
       "scope": [
-        "client",
-        "devcontainer"
+        "devcontainer",
+        "legacy-client"
       ],
       "required": true,
       "version": ">=3.2",
-      "version_source": "Client CMake constraint and pinned build images",
+      "version_source": "Legacy-client CMake constraint and pinned build images",
       "license": "Zlib",
       "source_url": "https://github.com/libsdl-org/SDL_image",
       "locator": "pkg:generic/SDL3_image",
@@ -1737,14 +1785,14 @@
       "update_cadence_days": 30,
       "update_mechanism": "Image/MXE update and image-decoder tests",
       "eol_response": "Upgrade with SDL3 and preserve supported image formats explicitly",
-      "validation": "CMake version constraint, image fixtures, and portable client build",
+      "validation": "CMake version constraint, image fixtures, and portable legacy-client build",
       "disposition": "retain",
       "packages": [
         "libsdl3-image-dev"
       ],
       "evidence": [
         {
-          "repository": "client",
+          "repository": "legacy-client",
           "path": "CMakeLists.txt",
           "contains": "find_package(SDL3_image 3.2 CONFIG REQUIRED)"
         }
@@ -1754,14 +1802,14 @@
       "id": "system/sdl3-mixer",
       "name": "SDL3_mixer",
       "kind": "system-library",
-      "owner": "client",
+      "owner": "legacy-client",
       "scope": [
-        "client",
-        "devcontainer"
+        "devcontainer",
+        "legacy-client"
       ],
       "required": true,
       "version": ">=3.2.4",
-      "version_source": "Client CMake constraint and checksum-pinned source/SDK",
+      "version_source": "Legacy-client CMake constraint and checksum-pinned source/SDK",
       "license": "Zlib",
       "source_url": "https://github.com/libsdl-org/SDL_mixer",
       "locator": "pkg:generic/SDL3_mixer",
@@ -1776,7 +1824,7 @@
       "packages": [],
       "evidence": [
         {
-          "repository": "client",
+          "repository": "legacy-client",
           "path": "CMakeLists.txt",
           "contains": "find_package(SDL3_mixer 3.2.4 CONFIG REQUIRED)"
         }
@@ -1786,14 +1834,14 @@
       "id": "system/sdl3-ttf",
       "name": "SDL3_ttf",
       "kind": "system-library",
-      "owner": "client",
+      "owner": "legacy-client",
       "scope": [
-        "client",
-        "devcontainer"
+        "devcontainer",
+        "legacy-client"
       ],
       "required": true,
       "version": ">=3.2",
-      "version_source": "Client CMake constraint and pinned build images",
+      "version_source": "Legacy-client CMake constraint and pinned build images",
       "license": "Zlib",
       "source_url": "https://github.com/libsdl-org/SDL_ttf",
       "locator": "pkg:generic/SDL3_ttf",
@@ -1803,14 +1851,14 @@
       "update_cadence_days": 30,
       "update_mechanism": "Image/MXE update and text-rendering tests",
       "eol_response": "Upgrade with SDL3 and preserve font behavior through fixtures",
-      "validation": "CMake version constraint, text tests, and portable client build",
+      "validation": "CMake version constraint, text tests, and portable legacy-client build",
       "disposition": "retain",
       "packages": [
         "libsdl3-ttf-dev"
       ],
       "evidence": [
         {
-          "repository": "client",
+          "repository": "legacy-client",
           "path": "CMakeLists.txt",
           "contains": "find_package(SDL3_ttf 3.2 CONFIG REQUIRED)"
         }
@@ -1818,15 +1866,15 @@
     },
     {
       "id": "system/server-image-packages",
-      "name": "Server container package sets",
+      "name": "Legacy-server container package sets",
       "kind": "system-package-set",
-      "owner": "server",
+      "owner": "legacy-server",
       "scope": [
-        "server"
+        "legacy-server"
       ],
       "required": true,
       "version": "ubuntu-26.04-digest-locked",
-      "version_source": "Server Dockerfile stages",
+      "version_source": "Legacy-server Dockerfile stages",
       "license": "NOASSERTION",
       "source_url": "https://packages.ubuntu.com/",
       "locator": "ubuntu-server-image-packages",
@@ -1865,7 +1913,7 @@
       ],
       "evidence": [
         {
-          "repository": "server",
+          "repository": "legacy-server",
           "path": "Dockerfile",
           "contains": "libpython3.14 libreadline8t64 libssl3t64 python3 zlib1g"
         }
@@ -1875,7 +1923,7 @@
       "id": "system/threads",
       "name": "CMake Threads",
       "kind": "system-library",
-      "owner": "libatrinik",
+      "owner": "legacy-libatrinik",
       "scope": [
         "libatrinik"
       ],
@@ -2009,7 +2057,7 @@
       "update_cadence_days": 30,
       "update_mechanism": "Dependabot base-image update and exact installed-version report",
       "eol_response": "Update package names and base image together before Debian support ends",
-      "validation": "Cold MXE image build and portable client/server builds",
+      "validation": "Cold MXE image build and portable legacy-client/legacy-server builds",
       "disposition": "isolate",
       "packages": [
         "autoconf",
@@ -2074,12 +2122,12 @@
       "id": "system/zlib",
       "name": "zlib",
       "kind": "system-library",
-      "owner": "libatrinik",
+      "owner": "legacy-libatrinik",
       "scope": [
-        "client",
         "devcontainer",
-        "libatrinik",
-        "server"
+        "legacy-client",
+        "legacy-server",
+        "libatrinik"
       ],
       "required": true,
       "version": "distribution/MXE-provided",
@@ -2145,11 +2193,11 @@
       "kind": "toolchain",
       "owner": "devcontainer",
       "scope": [
-        "client",
         "devcontainer",
-        "libatrinik",
-        "protocol",
-        "server"
+        "legacy-client",
+        "legacy-protocol",
+        "legacy-server",
+        "libatrinik"
       ],
       "required": true,
       "version": ">=3.21",
@@ -2170,22 +2218,22 @@
       ],
       "evidence": [
         {
-          "repository": "client",
+          "repository": "legacy-client",
+          "path": "CMakeLists.txt",
+          "contains": "cmake_minimum_required(VERSION 3.21)"
+        },
+        {
+          "repository": "legacy-protocol",
+          "path": "CMakeLists.txt",
+          "contains": "cmake_minimum_required(VERSION 3.21)"
+        },
+        {
+          "repository": "legacy-server",
           "path": "CMakeLists.txt",
           "contains": "cmake_minimum_required(VERSION 3.21)"
         },
         {
           "repository": "libatrinik",
-          "path": "CMakeLists.txt",
-          "contains": "cmake_minimum_required(VERSION 3.21)"
-        },
-        {
-          "repository": "protocol",
-          "path": "CMakeLists.txt",
-          "contains": "cmake_minimum_required(VERSION 3.21)"
-        },
-        {
-          "repository": "server",
           "path": "CMakeLists.txt",
           "contains": "cmake_minimum_required(VERSION 3.21)"
         }
@@ -2231,16 +2279,16 @@
       "owner": "github-settings",
       "scope": [
         "atrinik",
-        "client",
         "content",
         "devcontainer",
-        "editor",
         "github-settings",
+        "legacy-client",
+        "legacy-editor",
+        "legacy-protocol",
+        "legacy-server",
         "libatrinik",
         "metaserver-worker",
-        "protocol",
         "resources",
-        "server",
         "sound",
         "tools"
       ],
@@ -2266,11 +2314,6 @@
           "contains": "runs-on: ubuntu-24.04"
         },
         {
-          "repository": "client",
-          "path": ".github/workflows/check.yml",
-          "contains": "runs-on: ubuntu-24.04"
-        },
-        {
           "repository": "content",
           "path": ".github/workflows/check.yml",
           "contains": "runs-on: ubuntu-24.04"
@@ -2281,12 +2324,27 @@
           "contains": "runs-on: ubuntu-24.04"
         },
         {
-          "repository": "editor",
+          "repository": "github-settings",
           "path": ".github/workflows/check.yml",
           "contains": "runs-on: ubuntu-24.04"
         },
         {
-          "repository": "github-settings",
+          "repository": "legacy-client",
+          "path": ".github/workflows/check.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "legacy-editor",
+          "path": ".github/workflows/check.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "legacy-protocol",
+          "path": ".github/workflows/check.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "legacy-server",
           "path": ".github/workflows/check.yml",
           "contains": "runs-on: ubuntu-24.04"
         },
@@ -2301,17 +2359,7 @@
           "contains": "runs-on: ubuntu-24.04"
         },
         {
-          "repository": "protocol",
-          "path": ".github/workflows/check.yml",
-          "contains": "runs-on: ubuntu-24.04"
-        },
-        {
           "repository": "resources",
-          "path": ".github/workflows/check.yml",
-          "contains": "runs-on: ubuntu-24.04"
-        },
-        {
-          "repository": "server",
           "path": ".github/workflows/check.yml",
           "contains": "runs-on: ubuntu-24.04"
         },
@@ -2400,16 +2448,16 @@
       "owner": "atrinik",
       "scope": [
         "atrinik",
-        "client",
         "content",
         "devcontainer",
-        "protocol",
-        "server",
+        "legacy-client",
+        "legacy-protocol",
+        "legacy-server",
         "tools"
       ],
       "required": true,
       "version": ">=3.11; Windows runtime 3.14.6",
-      "version_source": "Wrapper requirement, protocol metadata, and Windows image arguments",
+      "version_source": "Wrapper requirement, legacy-protocol metadata, and Windows image arguments",
       "license": "PSF-2.0",
       "source_url": "https://www.python.org/",
       "locator": "pkg:generic/python",
@@ -2437,12 +2485,12 @@
           "contains": "PYTHON_VERSION=3.14.6"
         },
         {
-          "repository": "protocol",
+          "repository": "legacy-protocol",
           "path": "CMakeLists.txt",
           "contains": "find_package(Python3 REQUIRED COMPONENTS Interpreter)"
         },
         {
-          "repository": "server",
+          "repository": "legacy-server",
           "path": "CMakeLists.txt",
           "contains": "find_package(Python3 REQUIRED COMPONENTS Interpreter)"
         }
@@ -2452,13 +2500,13 @@
       "id": "vendored/sdl-gfx-rotozoom",
       "name": "SDL_gfx rotozoom implementation",
       "kind": "vendored-source",
-      "owner": "client",
+      "owner": "legacy-client",
       "scope": [
-        "client"
+        "legacy-client"
       ],
       "required": false,
       "version": "retired",
-      "version_source": "Client source audit",
+      "version_source": "Legacy-client source audit",
       "license": "LGPL-2.1-or-later",
       "source_url": "https://www.ferzkopp.net/Software/SDL_gfx-2.0/",
       "locator": "sdl-gfx-rotozoom",
@@ -2473,7 +2521,7 @@
       "packages": [],
       "evidence": [
         {
-          "repository": "client",
+          "repository": "legacy-client",
           "path": "src/gui/toolkit/surface_primitives.c",
           "contains": "rotozoomSurfaceXY"
         }
@@ -2483,7 +2531,7 @@
       "id": "vendored/uthash-family",
       "name": "uthash, utarray, and utlist",
       "kind": "vendored-source",
-      "owner": "libatrinik",
+      "owner": "legacy-libatrinik",
       "scope": [
         "libatrinik"
       ],


### PR DESCRIPTION
## Summary

- catalog the fresh MIT `client`, `server`, `editor`, `protocol`, `renderer`, `content-toolkit`, and `website` repositories
- catalog the five renamed legacy repositories and move every classic dependency owner, scope, evidence path, and release coordinate to the precise legacy repository name
- retain `libatrinik` only as the current manifest compatibility coordinate until the wrapper coexistence change removes its redirect dependency
- leave repositories that are not yet wrapper components marked unsupported instead of inventing build or dependency contracts

## Validation

- `python3 -m unittest discover -v` (110 tests)
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `jq -e . supply-chain/inventory.json supply-chain/schema.json`
- `./atrinik supply-chain validate`
- `git diff --check`

## Known transition blocker

The complete profile-aware audit is intentionally not reported as passing. The live repository rename changed `components.json` coordinates for `client`, `server`, `editor`, and `protocol` to the fresh bootstrap repositories before their wrapper contracts and `.github/dependabot.yml` files exist. Auditing clean clones reaches the exact expected first failure:

```text
error: client: missing .github/dependabot.yml
```

The classic local checkouts now identify as `legacy-*`, so they also cannot be supplied under the fresh component selectors. A separate M1 wrapper/coexistence issue will move those checkouts safely, bootstrap the fresh repositories, remove the transitional `libatrinik` redirect coordinate, and restore the complete audit. This pull request deliberately does not fabricate those contracts or overwrite any checkout.

## Manual verification

No runtime topology applies to catalog metadata. From this branch run:

```sh
./atrinik supply-chain validate
python3 -m unittest discover -v
python3 -m compileall -q atrinik atrinik_workspace tests
git diff --check origin/main...HEAD
```

After the M1 bootstrap/coexistence work lands, also run `./atrinik supply-chain audit --profile default`.

## Rollback

Revert this pull request. Do not restore stale repository names independently of the live repository layout.