### PR TITLE
docs: register MIT provenance grantors

### DIFF
--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -182,22 +182,26 @@ files directly.
   publishing. Report repository-specific commits, checks, releases, and any
   incomplete external operation separately.
 
-## Reuse Zoey Rose contributions under MIT
+## Apply approved historical MIT provenance grants
 
-Zoey Rose grants permission to copy, migrate, translate, or relicense under
-MIT any of her original past Atrinik contributions. Apply that grant only to
-selected material for which a complete Git-history audit proves sole Zoey Rose
-authorship and a content review finds no embedded third-party or
-conflicting-licensed material. This grant is not an automatic license change
-for a repository, file, or current-blame region.
+The following registry is exhaustive. Each person explicitly grants permission
+for the listed treatment of the listed original past Atrinik contributions.
 
-Before applying the grant:
+| Grantor | Covered material | Permitted operations | Destination license |
+| --- | --- | --- | --- |
+| Zoey Rose | All original past Atrinik contributions solely authored by Zoey Rose | Copy, migrate, translate, or relicense | MIT |
+| Daniel Liptrot | All original past Atrinik contributions solely authored by Daniel Liptrot | Copy, migrate, translate, or relicense | MIT |
+
+A registry entry is not an automatic license change for a repository, file, or
+current-blame region. Before applying a grant:
 
 1. Identify the exact source repository, path, and revision or revision range,
    following renames and moves through the complete, non-shallow history.
 2. Inspect the creation and every subsequent change to the selected material,
-   including relevant commit diffs. Map historical author identities to Zoey
-   Rose with recorded evidence; do not treat current blame alone as proof.
+   including relevant commit diffs. Prove that it is the named grantor's
+   original work and that the grantor solely authored it. Map historical author
+   identities to that grantor with recorded evidence; do not treat current
+   blame alone as proof.
 3. Review the material for copied, generated, vendored, or otherwise embedded
    third-party work and for notices or licenses that conflict with MIT reuse.
    A history gap, unresolved identity, mixed authorship, or uncertain origin
@@ -207,9 +211,11 @@ Before applying the grant:
    qualify.
 5. Record the exact source and destination repositories and paths, source
    revision, complete history and identity evidence, transformation performed,
-   third-party review, and Zoey Rose's grant in the destination pull request or
-   a committed provenance manifest. Retain any notices required by material
-   that is deliberately included under another compatible license.
+   third-party review, and the applicable grantor and grant in the destination
+   pull request or a committed provenance manifest. Cite the exact wrapper
+   repository revision containing the applicable registry entry as the grant
+   evidence. Retain any notices required by material that is deliberately
+   included under another compatible license.
 
 ## Maintain this guidance
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,15 +30,9 @@
 - Use precise component and protocol names; do not use vague age-based labels.
 - Do not mention confidential or unreleased Atrinik work in committed files or
   public project surfaces.
-- Zoey Rose grants permission to copy, migrate, translate, or relicense under
-  MIT any of her original past Atrinik contributions, but only when a complete
-  Git-history audit proves that she solely authored the selected material and
-  a content review finds no embedded third-party or conflicting-licensed
-  material. Current blame alone and mixed, incomplete, or uncertain history
-  are not sufficient. Record the exact source repository, path, and revision;
-  the destination repository and path; the complete history and author-identity
-  evidence; the performed transformation and third-party review; and this
-  grant in the destination pull request or a committed provenance manifest.
+- Apply a historical MIT provenance grant only for a person listed in the
+  approved grantors table below and only within that row's stated scope. Every
+  use must satisfy the shared proof and recording requirements below the table.
 - Pull-request titles and commits use Conventional Commits style. Every squash
   merge is released by semantic-release.
 - Run the complete Python test suite, compileall, ShellCheck for shell changes,
@@ -73,3 +67,27 @@
 - When major rework changes ownership, layout, commands, safety boundaries, or
   validation contracts, update every affected `AGENTS.md` and skill in the same
   change. Treat stale agent guidance as an implementation defect.
+
+## Approved historical MIT provenance grantors
+
+This table is exhaustive. Each person explicitly grants permission for the
+listed treatment of the listed original past Atrinik contributions.
+
+| Grantor | Covered material | Permitted operations | Destination license |
+| --- | --- | --- | --- |
+| Zoey Rose | All original past Atrinik contributions solely authored by Zoey Rose | Copy, migrate, translate, or relicense | MIT |
+| Daniel Liptrot | All original past Atrinik contributions solely authored by Daniel Liptrot | Copy, migrate, translate, or relicense | MIT |
+
+Apply a grant only when a complete, non-shallow Git-history audit, including
+renames and moves, proves that the selected material is the named grantor's
+original work and that the grantor solely authored it. Verify historical author
+identities and review the material for embedded third-party or
+conflicting-licensed work. Current blame alone and mixed, incomplete, or
+uncertain history are not sufficient; fail closed until every doubt is
+independently resolved. Reuse only independently separable material covered by
+the proof. Record the exact source repository, path, and revision; destination
+repository and path; complete history and author-identity evidence;
+transformation and third-party review; and the applicable grantor and grant in
+the destination pull request or a committed provenance manifest. Cite the exact
+wrapper repository revision containing the applicable registry entry as the
+grant evidence.

--- a/README.md
+++ b/README.md
@@ -73,14 +73,25 @@ workspace directory, use repeated absolute `--repository NAME=PATH` overrides;
 the command verifies each override's GitHub repository identity before reading
 it.
 
-Historical contributions by Zoey Rose may be copied, migrated, translated, or
-relicensed under MIT under her explicit grant only after a complete Git-history
-audit proves sole authorship of the selected material and a content review
-excludes embedded third-party or conflicting-licensed work. Current blame is
-not sufficient proof. The destination pull request or committed provenance
-manifest records the exact source, revision, destination, history and identity
-evidence, transformation, third-party review, and grant. Mixed or uncertain
-material remains under its existing license until its provenance is resolved.
+### Historical MIT provenance grants
+
+The approved grantor registry is exhaustive:
+
+| Grantor | Covered material | Permitted operations | Destination license |
+| --- | --- | --- | --- |
+| Zoey Rose | All original past Atrinik contributions solely authored by Zoey Rose | Copy, migrate, translate, or relicense | MIT |
+| Daniel Liptrot | All original past Atrinik contributions solely authored by Daniel Liptrot | Copy, migrate, translate, or relicense | MIT |
+
+Apply a grant only after a complete, non-shallow Git-history audit follows
+renames and moves, proves the selected material is the named grantor's original
+work and was solely authored by that grantor, and verifies historical author
+identities. Review also excludes embedded third-party or conflicting-licensed
+work. Current blame alone is not proof; mixed, incomplete, or uncertain
+material remains under its existing license until independently resolved. The
+destination pull request or committed provenance manifest records the exact
+source, revision, destination, history and identity evidence, transformation,
+third-party review, applicable grantor and grant, and exact wrapper repository
+revision containing the registry entry as grant evidence.
 
 ## Quick start
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,16 +28,26 @@ integrity boundary for independently released source and runtime archives; the
 aggregate catalog describes and audits those boundaries instead of copying
 their fetching implementations into the wrapper.
 
-Source provenance is also a cross-repository contract. Zoey Rose's explicit
-grant permits her original past Atrinik contributions to be copied, migrated,
-translated, or relicensed under MIT only when complete, non-shallow Git history
-proves she solely authored the selected material and review excludes embedded
-third-party or conflicting-licensed work. A migration records the exact source
-repository, path, and revision; destination repository and path; author
-identity and complete-history evidence; transformation; third-party review;
-and grant in its pull request or a committed provenance manifest. Current
-blame, incomplete history, or authorship of only part of a mixed file does not
-establish eligibility for the whole material.
+Source provenance is also a cross-repository contract. Its exhaustive approved
+historical MIT provenance grantor registry is:
+
+| Grantor | Covered material | Permitted operations | Destination license |
+| --- | --- | --- | --- |
+| Zoey Rose | All original past Atrinik contributions solely authored by Zoey Rose | Copy, migrate, translate, or relicense | MIT |
+| Daniel Liptrot | All original past Atrinik contributions solely authored by Daniel Liptrot | Copy, migrate, translate, or relicense | MIT |
+
+A grant applies only when complete, non-shallow Git history follows renames and
+moves, proves the selected material is the named grantor's original work and
+was solely authored by that grantor, and supports the historical author-identity
+mapping. Review must exclude embedded third-party or conflicting-licensed work.
+A migration records the exact source repository, path, and revision;
+destination repository and path; author identity and complete-history evidence;
+transformation; third-party review; applicable grantor and grant; and exact
+wrapper repository revision containing the registry entry as grant evidence in
+its pull request or a committed provenance manifest. Current blame, incomplete
+or uncertain history, or authorship of only part of a mixed file does not
+establish eligibility for the whole material; the process fails closed until
+every doubt is independently resolved.
 
 The `supply-chain` command resolves component inputs through the same profile
 selectors as builds, then reads Git-indexed files without mutating a checkout.


### PR DESCRIPTION
## Summary

- replace the person-specific provenance directive with an exhaustive, extensible approved-grantor registry
- retain Zoey Rose and add Daniel Liptrot with the same permission for all original past Atrinik contributions solely authored by each grantor
- preserve complete non-shallow history, rename and move tracing, identity verification, sole-original-authorship, and third-party/conflicting-license review requirements
- continue to fail closed for mixed, incomplete, unresolved, or uncertain provenance
- require exact source, destination, transformation, review, grantor, and grant evidence, including the wrapper revision containing the applicable registry entry
- synchronize AGENTS.md, the multi-repository skill, README, and architecture guidance

## Validation

- python3 -m unittest discover -v (110 tests)
- python3 -m compileall -q atrinik atrinik_workspace tests
- ./atrinik manifest validate
- ./atrinik supply-chain validate
- python3 /home/ubuntu/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/atrinik-multi-repo-workspace
- git diff --check

The configured Git transport did not publish a ref, so the branch was created through the Git Data API from the exact four locally validated blob IDs. Runtime verification is not applicable because this changes documentation and agent operating policy only.