### PR TITLE
fix(migration): remove classic history-ref dependency

### DIFF
--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -102,9 +102,10 @@ migration workflow:
 ./atrinik migrate repositories --audit --json
 ```
 
-`init classic` fetches the preserved `history/*` branches used to prove and
-remap former standalone branches and linked worktrees. Do not substitute a
-plain single-branch clone.
+`init classic` needs only the maintained classic `main` branch. Commit maps
+prove integrated history. If a mapped branch-only rewritten object was retired,
+migration imports the exact verified local source commit as a bridge parent;
+do not recreate or fetch a `history/*` namespace.
 
 - Dry-run and audit are read-only. Review every planned move, worktree repair,
   and profile rewrite before apply.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,8 +86,9 @@
 - Before combining former standalone classic repositories, use
   exact `./atrinik init classic`, then
   `./atrinik migrate repositories --dry-run`, `--apply`, and `--audit`.
-  Initialization must retain the wrapper-fetched classic `history/*` refs used
-  to prove and remap former branches and linked worktrees.
+  Initialization uses classic `main` only. Migration must bridge a verified
+  branch-only local commit directly when its retired rewritten map target is
+  absent; never recreate or depend on a classic `history/*` namespace.
   Do not run additive `init --with classic` until after migration in a
   pre-split workspace because its default-cohort preflight must reject the
   former classic repositories occupying replacement paths.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,12 +29,13 @@ uses a profile created from `classic`.
 
 For a pre-split workspace, initialize only the destination with
 `./atrinik init classic`, run `./atrinik migrate repositories --dry-run`
-before apply, and finish with `--audit`. Using the preserved `history/*` refs
-fetched by `init classic`, the checked migration combines proven pre-monorepo
-repositories under `classic/`, preserves recoverable
+before apply, and finish with `--audit`. The checked migration combines proven
+pre-monorepo repositories under `classic/`, preserves recoverable
 originals and worktree state, refuses ambiguous or unsafe layouts, and rewrites
 proven classic profiles atomically. States, builds, runtimes, and logs remain
-outside the repository-layout migration.
+outside the repository-layout migration. It uses integrated commit-map targets
+when available and imports an exact verified local commit when a branch-only
+target disappeared with the retired classic `history/*` namespace.
 
 Before opening a pull request, run:
 

--- a/README.md
+++ b/README.md
@@ -206,9 +206,11 @@ migration instead of moving directories by hand:
 ./atrinik migrate repositories --audit --json
 ~~~
 
-`init classic` also fetches the preserved `history/*` branches required to
-prove and remap former standalone branches and linked worktrees; a normal
-single-branch clone is not sufficient for this migration.
+`init classic` needs only the maintained `main` branch. The migration verifies
+integrated commits against the immutable commit maps. When an old local
+worktree points at a branch-only commit whose rewritten object is no longer
+published, apply imports that exact local source commit as a bridge parent
+instead of depending on a retired `history/*` ref.
 
 The dry run produces the complete migration plan without changing the
 workspace. Apply combines each proven former repository at the matching

--- a/atrinik_workspace/migration.py
+++ b/atrinik_workspace/migration.py
@@ -941,11 +941,8 @@ class RepositoryMigration:
                     )
                 mapped_parent = self._mapped_parent(
                     classic.path,
-                    path,
                     canonical,
-                    prefix,
                     head,
-                    branch,
                 )
             result.append(
                 _Worktree(
@@ -974,11 +971,8 @@ class RepositoryMigration:
     def _mapped_parent(
         self,
         classic: Path,
-        source: Path,
         canonical: str,
-        prefix: str,
         old_head: str,
-        branch: str | None,
     ) -> str | None:
         path = classic / "docs" / "history" / f"{canonical}-commit-map.txt"
         if path.exists() or path.is_symlink():
@@ -1017,43 +1011,11 @@ class RepositoryMigration:
                     )
             mapped = mappings.get(old_head)
             if mapped is not None and set(mapped) != {"0"}:
-                self._verify_mapped_parent(classic, prefix, old_head, mapped)
-                return mapped
-        if branch:
-            for ref in (
-                f"refs/remotes/origin/history/{canonical}/{branch}",
-                f"refs/heads/history/{canonical}/{branch}",
-            ):
-                candidate = self._git_optional_text(classic, "rev-parse", "--verify", ref)
-                if candidate and self._mapped_tree_matches(
-                    classic,
-                    source,
-                    prefix,
-                    old_head,
-                    candidate,
+                if self._git_optional_text(
+                    classic, "rev-parse", "--verify", f"{mapped}^{{commit}}"
                 ):
-                    return candidate
+                    return mapped
         return None
-
-    def _verify_mapped_parent(
-        self, classic: Path, prefix: str, old_head: str, mapped: str
-    ) -> None:
-        if not self._git_optional_text(classic, "rev-parse", "--verify", f"{mapped}^{{commit}}"):
-            raise WorkspaceError(f"commit-map target is absent from classic history: {mapped}")
-        # The source object may not have been fetched into classic yet.  Tree
-        # equality is checked again after it is imported during apply.
-
-    def _mapped_tree_matches(
-        self,
-        classic: Path,
-        source: Path,
-        prefix: str,
-        old_head: str,
-        mapped: str,
-    ) -> bool:
-        old_tree = self._git_optional_text(source, "rev-parse", f"{old_head}^{{tree}}")
-        mapped_tree = self._git_optional_text(classic, "rev-parse", f"{mapped}:{prefix}")
-        return old_tree is not None and old_tree == mapped_tree
 
     def _inspect_profiles(
         self, sources: list[_Source], classic: _Classic | None

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -73,9 +73,6 @@ PRE_MONOREPO_REPOSITORIES = {
     "libatrinik": "legacy-libatrinik",
     "protocol": "legacy-protocol",
 }
-CLASSIC_HISTORY_REFSPEC = (
-    "+refs/heads/history/*:refs/remotes/{remote}/history/*"
-)
 RESOURCE_PATHS_MANIFEST = "runtime-paths.txt"
 SERVER_IDENTITY_MAX_SIZE = 64 * 1024
 SCENARIO_KEYS = {
@@ -348,7 +345,6 @@ class Workspace:
     def _ensure_repository(self, value: Checkout | Component) -> Path:
         checkout = self._checkout_identity(value)
         destination = self._primary_path(checkout)
-        support_refs_ready = False
         if not destination.exists() and not destination.is_symlink():
             temporary = Path(
                 tempfile.mkdtemp(
@@ -369,9 +365,7 @@ class Workspace:
                         str(temporary),
                     ]
                 )
-                remote = self._validate_primary_checkout(checkout, temporary)
-                self._ensure_support_refs(checkout, temporary, remote)
-                support_refs_ready = True
+                self._validate_primary_checkout(checkout, temporary)
                 if destination.exists() or destination.is_symlink():
                     raise WorkspaceError(
                         f"component destination appeared during clone: {destination}"
@@ -380,24 +374,8 @@ class Workspace:
             except BaseException:
                 shutil.rmtree(temporary, ignore_errors=True)
                 raise
-        remote = self._validate_primary_checkout(checkout, destination)
-        if not support_refs_ready:
-            self._ensure_support_refs(checkout, destination, remote)
+        self._validate_primary_checkout(checkout, destination)
         return destination
-
-    def _ensure_support_refs(
-        self, checkout: Checkout, path: Path, remote: str
-    ) -> None:
-        if checkout.name != "classic":
-            return
-        git(
-            path,
-            "fetch",
-            "--prune",
-            "--no-tags",
-            remote,
-            CLASSIC_HISTORY_REFSPEC.format(remote=remote),
-        )
 
     def _validate_primary_checkout(
         self, value: Checkout | Component, path: Path, *, trace: bool = True

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,9 +158,8 @@ side effect.
 `migrate repositories` is a checked transaction for workspaces that still
 contain the five former standalone classic repositories. After the destination
 `./classic` checkout is initialized with exact `./atrinik init classic`,
-which fetches the monorepo's preserved `history/*` migration refs in addition
-to `main`, `--dry-run` computes and reports the full plan, `--apply` executes
-that plan, and `--audit` verifies the resulting
+`--dry-run` computes and reports the full plan, `--apply` executes that plan,
+and `--audit` verifies the resulting
 invariants; each mode supports `--json` for machine-readable output.
 Additive `init --with classic` is deferred until after migration because its
 default-cohort preflight refuses former classic repositories that still occupy
@@ -184,6 +183,11 @@ ambiguous or conflicting occupants, unsafe Git states, running affected
 topologies, or selectors that cannot be proven. The operator resolves a
 reported condition and reruns the complete dry run rather than moving paths by
 hand. Interruption and rollback handling never deletes a user path.
+
+Commit-map targets already integrated into classic history are reused as
+bridge parents. A branch-only map target that disappeared with the retired
+`history/*` namespace is not an error: apply imports the exact commit from the
+verified local source checkout and records it as the bridge parent.
 
 Repository migration does not move or reinterpret `content`, `content-1x`,
 state directories, build trees, collected runtimes, scenario data, topology

--- a/tests/test_cohorts.py
+++ b/tests/test_cohorts.py
@@ -140,19 +140,6 @@ class CohortWorkspaceTests(unittest.TestCase):
         ):
             self.workspace.initialize(None, jobs=4, include_classic=True)
 
-            classic = self.wrapper / "classic"
-            subprocess.run(
-                [
-                    "git",
-                    "update-ref",
-                    "-d",
-                    "refs/remotes/origin/history/client/pr-48",
-                ],
-                cwd=classic,
-                check=True,
-            )
-            self.workspace.initialize(["classic"], jobs=1)
-
         classic_history = subprocess.run(
             [
                 "git",
@@ -161,20 +148,11 @@ class CohortWorkspaceTests(unittest.TestCase):
                 "refs/remotes/origin/history/client/pr-48",
             ],
             cwd=self.wrapper / "classic",
-            check=True,
+            check=False,
             capture_output=True,
             text=True,
-        ).stdout.strip()
-        self.assertEqual(
-            classic_history,
-            subprocess.run(
-                ["git", "rev-parse", "history/client/pr-48"],
-                cwd=seed,
-                check=True,
-                capture_output=True,
-                text=True,
-            ).stdout.strip(),
         )
+        self.assertNotEqual(classic_history.returncode, 0)
 
         for component in defaults:
             checkout = self.wrapper / component.path

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -699,6 +699,51 @@ class RepositoryMigrationTests(unittest.TestCase):
         parents = command("git", "show", "-s", "--format=%P", "HEAD", cwd=migrated).decode().split()
         self.assertIn(mapped, parents)
 
+    def test_absent_branch_only_map_target_bridges_from_source_head(self) -> None:
+        source = self.make_repository("client", "client")
+        classic = self.make_classic({"client": source})
+        linked = self.paths.worktrees / "client" / "branch-only"
+        linked.parent.mkdir(parents=True)
+        command(
+            "git",
+            "worktree",
+            "add",
+            "-b",
+            "feat/branch-only",
+            str(linked),
+            cwd=source,
+        )
+        (linked / "tracked.txt").write_text(
+            "branch-only feature\n", encoding="utf-8"
+        )
+        command("git", "add", "tracked.txt", cwd=linked)
+        command("git", "commit", "-m", "feat: branch-only feature", cwd=linked)
+        old_head = command("git", "rev-parse", "HEAD", cwd=linked).decode().strip()
+        unavailable = "f" * 40
+        history = classic / "docs" / "history"
+        history.mkdir(parents=True)
+        (history / "client-commit-map.txt").write_text(
+            f"old                                      new\n{old_head} {unavailable}\n",
+            encoding="ascii",
+        )
+        command("git", "add", "docs/history/client-commit-map.txt", cwd=classic)
+        command("git", "commit", "-m", "docs: record branch-only map", cwd=classic)
+
+        result = self.migration().execute("apply")
+
+        row = next(
+            row
+            for row in result["worktree_migrations"]
+            if row["component"] == "classic-client" and not row["primary"]
+        )
+        self.assertIsNone(row["mapped_parent"])
+        migrated = Path(row["destination"])
+        parents = command(
+            "git", "show", "-s", "--format=%P", "HEAD", cwd=migrated
+        ).decode().split()
+        self.assertIn(old_head, parents)
+        self.assertEqual(self.migration().execute("audit")["status"], "complete")
+
     def test_malformed_exact_commit_map_fails_closed_without_writes(self) -> None:
         source = self.make_repository("client", "client")
         classic = self.make_classic({"client": source})


### PR DESCRIPTION
Summary
- initialize classic with its maintained main branch only
- stop fetching or consulting the retired history namespace
- reuse an immutable commit-map target when its object remains integrated
- safely fall back to importing the exact verified old local commit as a bridge parent when a branch-only rewritten target is absent
- document the post-retirement migration behavior

This is the wrapper-side prerequisite for deleting all classic history branches.

Automated verification
- python3 -m unittest discover -q (207 tests)
- python3 -m compileall -q atrinik_workspace tests
- ./atrinik migrate repositories --audit --json (complete)
- ./atrinik manifest validate (20 components)
- ./atrinik supply-chain validate (64 dependencies)
- actionlint
- git diff --check

The new regression test creates a valid commit map whose branch-only target is unavailable, applies migration, proves mapped_parent is null, proves the exact old source head is a bridge parent, and completes the post-migration audit.

Manual verification
1. In a workspace without classic, run ./atrinik init classic and confirm only main is fetched.
2. Run ./atrinik migrate repositories --dry-run and expect ready for verified former repositories even when branch-only mapped objects are absent.
3. Run ./atrinik migrate repositories --apply and then ./atrinik migrate repositories --audit; expect applied then complete.
4. Run ./atrinik status and ./atrinik profile show test-scenarios to verify both replacement and classic identities remain resolvable.

Runtime topology verification is not applicable to this initialization/provenance follow-up; the already migrated local workspace continues to audit complete.