### PR TITLE
fix(migration): audit reused replacement paths

### DIFF
--- a/atrinik_workspace/migration.py
+++ b/atrinik_workspace/migration.py
@@ -2550,7 +2550,15 @@ class RepositoryMigration:
                 continue
             source_path = Path(str(row.get("source", "")))
             archive = Path(str(row.get("archive", "")))
-            valid = not source_path.exists() and archive.is_dir() and not archive.is_symlink()
+            source_vacated = not source_path.exists() and not source_path.is_symlink()
+            source_reused = self._replacement_checkout_occupies_source_path(
+                source_path, archive
+            )
+            valid = (
+                (source_vacated or source_reused)
+                and archive.is_dir()
+                and not archive.is_symlink()
+            )
             if valid:
                 try:
                     valid = (
@@ -2925,6 +2933,39 @@ class RepositoryMigration:
             return str(checkout.repository), str(getattr(checkout, "path", "classic"))
         component = self._component("classic-client")
         return str(component.repository), str(getattr(component, "checkout", "classic"))
+
+    def _replacement_checkout_occupies_source_path(
+        self, source_path: Path, archive: Path
+    ) -> bool:
+        """Recognize a manifest-owned replacement at a vacated classic path."""
+
+        if source_path.is_symlink() or not source_path.is_dir():
+            return False
+        by_checkout = getattr(self.manifest, "by_checkout", {})
+        if not isinstance(by_checkout, dict):
+            return False
+        checkout = next(
+            (
+                value
+                for value in by_checkout.values()
+                if getattr(value, "generation", None) == "replacement"
+                and self.repository_root / str(getattr(value, "path", ""))
+                == source_path
+            ),
+            None,
+        )
+        if checkout is None:
+            return False
+        repository = str(getattr(checkout, "repository", ""))
+        identity, _, _, _ = self._repository_identity(source_path, {repository})
+        if identity != "expected":
+            return False
+        try:
+            return self._git_common_directory(source_path) != self._git_common_directory(
+                archive
+            )
+        except WorkspaceError:
+            return False
 
     def _archive_destination(self, source: Path) -> Path:
         preferred = self.archive_root / "repositories" / source.name

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -341,6 +341,119 @@ class RepositoryMigrationTests(unittest.TestCase):
         self.assertEqual(audit["status"], "complete", audit)
         self.assertEqual(self.migration().execute("apply")["status"], "already-applied")
 
+    def test_audit_accepts_manifest_owned_replacement_at_reused_source_path(
+        self,
+    ) -> None:
+        source = self.make_repository("client", "client")
+        self.make_classic({"client": source})
+
+        result = self.migration().execute("apply")
+        self.assertEqual(result["status"], "applied")
+        replacement = self.make_repository(
+            "client",
+            "client",
+            repository="atrinik/client",
+            classic=False,
+            text="replacement client\n",
+        )
+        self.manifest.by_checkout["client"] = SimpleNamespace(
+            name="client",
+            repository="atrinik/client",
+            branch="main",
+            path="client",
+            generation="replacement",
+        )
+        (replacement / "local-change.txt").write_text(
+            "preserve me\n", encoding="utf-8"
+        )
+        status_before = self.status_bytes(replacement)
+
+        audit = self.migration().execute("audit")
+
+        self.assertEqual(audit["status"], "complete", audit)
+        self.assertEqual(self.status_bytes(replacement), status_before)
+
+    def test_audit_rejects_wrong_repository_at_reused_source_path(self) -> None:
+        source = self.make_repository("client", "client")
+        self.make_classic({"client": source})
+        self.assertEqual(self.migration().execute("apply")["status"], "applied")
+        self.make_repository(
+            "client",
+            "client",
+            repository="someone-else/client",
+            classic=False,
+            text="unrelated client\n",
+        )
+        self.manifest.by_checkout["client"] = SimpleNamespace(
+            name="client",
+            repository="atrinik/client",
+            branch="main",
+            path="client",
+            generation="replacement",
+        )
+
+        audit = self.migration().execute("audit")
+
+        self.assertEqual(audit["status"], "incomplete")
+        self.assertIn(
+            "source_archive_audit_failed",
+            {row["code"] for row in audit["refusals"]},
+        )
+
+    def test_audit_rejects_symlink_at_reused_source_path(self) -> None:
+        source = self.make_repository("client", "client")
+        self.make_classic({"client": source})
+        result = self.migration().execute("apply")
+        self.assertEqual(result["status"], "applied")
+        archive = Path(result["sources"][0]["archive"])
+        source.symlink_to(archive, target_is_directory=True)
+        self.manifest.by_checkout["client"] = SimpleNamespace(
+            name="client",
+            repository="atrinik/client",
+            branch="main",
+            path="client",
+            generation="replacement",
+        )
+
+        audit = self.migration().execute("audit")
+
+        self.assertEqual(audit["status"], "incomplete")
+        self.assertIn(
+            "source_archive_audit_failed",
+            {row["code"] for row in audit["refusals"]},
+        )
+
+    def test_audit_rejects_reused_source_path_sharing_archive_git_dir(self) -> None:
+        source = self.make_repository("client", "client")
+        self.make_classic({"client": source})
+        result = self.migration().execute("apply")
+        self.assertEqual(result["status"], "applied")
+        archive = Path(result["sources"][0]["archive"])
+        command(
+            "git",
+            "worktree",
+            "add",
+            "-b",
+            "replacement-mask",
+            str(source),
+            cwd=archive,
+        )
+        self.manifest.by_checkout["client"] = SimpleNamespace(
+            name="client",
+            repository="atrinik/legacy-client",
+            branch="main",
+            path="client",
+            generation="replacement",
+        )
+
+        audit = self.migration().execute("audit")
+
+        self.assertEqual(audit["status"], "incomplete")
+        self.assertIn(
+            "source_archive_audit_failed",
+            {row["code"] for row in audit["refusals"]},
+        )
+
     def test_content_1x_worktree_becomes_protected_migration_selector(self) -> None:
         source = self.make_repository("client", "client")
         self.make_classic({"client": source})


### PR DESCRIPTION
## Summary

- accept a fresh manifest-owned replacement checkout at a canonical path vacated by the classic repository migration
- retain every archived source HEAD, config, and worktree-status fingerprint check
- fail closed for wrong remotes, symlinks, and checkouts that share the archived repository's Git common directory
- preserve replacement branch, HEAD, and dirty state during audit

## Why

After the migration, `./atrinik init` legitimately recreates `client/`, `server/`, `editor/`, and `protocol/` as the new MIT repositories. The audit previously treated any occupant at those former source paths as corruption even though all five classic archives still matched their recorded fingerprints exactly.

## Validation

- `python3 -m unittest discover -q` (211 tests)
- `python3 -m compileall -q atrinik_workspace tests`
- `actionlint`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `git diff --check`
- exercised the patched auditor against the migrated local workspace: `status=complete`, no refusals

## Manual verification

From a migrated wrapper checkout with both default and classic cohorts initialized:

```sh
./atrinik init --with classic
./atrinik migrate repositories --audit
./atrinik status
```

Expected: migration status is `complete`; the replacement and classic checkouts remain unchanged and are both listed by `status`.
