### PR TITLE
fix(migration): harden replacement identity audit

### DIFF
--- a/atrinik_workspace/migration.py
+++ b/atrinik_workspace/migration.py
@@ -2956,11 +2956,22 @@ class RepositoryMigration:
         )
         if checkout is None:
             return False
+        canonical = str(getattr(checkout, "name", ""))
+        if canonical not in {value[0] for value in CLASSIC_SOURCES}:
+            return False
+        if self.repository_root / canonical != source_path:
+            return False
         repository = str(getattr(checkout, "repository", ""))
-        identity, _, _, _ = self._repository_identity(source_path, {repository})
-        if identity != "expected":
+        if not self._effective_repository_remote_matches(source_path, repository):
             return False
         try:
+            top_level = Path(
+                self._git_text(source_path, "rev-parse", "--show-toplevel")
+            ).resolve()
+            if top_level != source_path.resolve():
+                return False
+            if self._classic_lineage(source_path, canonical):
+                return False
             return self._git_common_directory(source_path) != self._git_common_directory(
                 archive
             )
@@ -3048,6 +3059,21 @@ class RepositoryMigration:
             "no identifying origin/upstream URL"
             + (f" (found {', '.join(coordinates)})" if coordinates else ""),
         )
+
+    def _effective_repository_remote_matches(
+        self, path: Path, expected: str
+    ) -> bool:
+        """Match only the first URL Git fetches for origin or upstream."""
+
+        expected = expected.lower()
+        for remote in ("origin", "upstream"):
+            process = self._git_process(path, "remote", "get-url", "--all", remote)
+            if process.returncode:
+                continue
+            urls = process.stdout.decode(errors="replace").splitlines()
+            if urls and self._repository_from_url(urls[0].strip()) == expected:
+                return True
+        return False
 
     def _repository_coordinates(self, path: Path) -> set[str]:
         result: set[str] = set()

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -400,6 +400,114 @@ class RepositoryMigrationTests(unittest.TestCase):
             {row["code"] for row in audit["refusals"]},
         )
 
+    def test_audit_rejects_later_matching_fetch_url(self) -> None:
+        source = self.make_repository("client", "client")
+        self.make_classic({"client": source})
+        self.assertEqual(self.migration().execute("apply")["status"], "applied")
+        replacement = self.make_repository(
+            "client",
+            "client",
+            repository="someone-else/client",
+            classic=False,
+            text="unrelated client\n",
+        )
+        command(
+            "git",
+            "remote",
+            "set-url",
+            "--add",
+            "origin",
+            "https://github.com/atrinik/client.git",
+            cwd=replacement,
+        )
+        self.manifest.by_checkout["client"] = SimpleNamespace(
+            name="client",
+            repository="atrinik/client",
+            branch="main",
+            path="client",
+            generation="replacement",
+        )
+
+        audit = self.migration().execute("audit")
+
+        self.assertEqual(audit["status"], "incomplete")
+        self.assertIn(
+            "source_archive_audit_failed",
+            {row["code"] for row in audit["refusals"]},
+        )
+
+    def test_audit_rejects_classic_history_disguised_as_replacement(self) -> None:
+        source = self.make_repository("client", "client")
+        self.make_classic({"client": source})
+        result = self.migration().execute("apply")
+        self.assertEqual(result["status"], "applied")
+        archive = Path(result["sources"][0]["archive"])
+        command("git", "clone", str(archive), str(source), cwd=self.wrapper)
+        command(
+            "git",
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/atrinik/client.git",
+            cwd=source,
+        )
+        self.manifest.by_checkout["client"] = SimpleNamespace(
+            name="client",
+            repository="atrinik/client",
+            branch="main",
+            path="client",
+            generation="replacement",
+        )
+
+        audit = self.migration().execute("audit")
+
+        self.assertEqual(audit["status"], "incomplete")
+        self.assertIn(
+            "source_archive_audit_failed",
+            {row["code"] for row in audit["refusals"]},
+        )
+
+    def test_audit_rejects_replacement_path_nested_in_another_checkout(self) -> None:
+        source = self.make_repository("client", "client")
+        self.make_classic({"client": source})
+        self.assertEqual(self.migration().execute("apply")["status"], "applied")
+        source.mkdir()
+        command("git", "init", "-b", "main", cwd=self.wrapper)
+        command("git", "config", "user.name", "Migration Tests", cwd=self.wrapper)
+        command(
+            "git",
+            "config",
+            "user.email",
+            "migration@example.invalid",
+            cwd=self.wrapper,
+        )
+        (source / "tracked.txt").write_text("nested replacement\n", encoding="utf-8")
+        command("git", "add", "client/tracked.txt", cwd=self.wrapper)
+        command("git", "commit", "-m", "feat: nested replacement", cwd=self.wrapper)
+        command(
+            "git",
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/atrinik/client.git",
+            cwd=self.wrapper,
+        )
+        self.manifest.by_checkout["client"] = SimpleNamespace(
+            name="client",
+            repository="atrinik/client",
+            branch="main",
+            path="client",
+            generation="replacement",
+        )
+
+        audit = self.migration().execute("audit")
+
+        self.assertEqual(audit["status"], "incomplete")
+        self.assertIn(
+            "source_archive_audit_failed",
+            {row["code"] for row in audit["refusals"]},
+        )
+
     def test_audit_rejects_symlink_at_reused_source_path(self) -> None:
         source = self.make_repository("client", "client")
         self.make_classic({"client": source})


### PR DESCRIPTION
## Summary

- require a reused replacement path to be the exact Git worktree root
- validate the effective first fetch URL for `origin`/`upstream`, matching Git's actual fetch behavior
- reject any checkout containing registered pre-monorepo Classic lineage even when its remote and Git directory appear independent
- retain the distinct-common-directory and archived-source fingerprint proofs from #283

## Security review

Independent review of #283 reproduced two fail-open identities: a clone of archived Classic history with a renamed remote, and an unrelated origin whose second URL looked canonical. This follow-up closes both cases and also rejects a canonical path nested inside another checkout.

## Validation

- `python3 -m unittest discover -q` (214 tests)
- `python3 -m compileall -q atrinik_workspace tests`
- `actionlint`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `git diff --check`
- patched audit against the migrated local workspace: `complete`, zero refusals

## Manual verification

```sh
./atrinik init --with classic
./atrinik migrate repositories --audit
./atrinik status
```

Expected: audit reports `complete`; both generations remain listed and unchanged. A replacement path containing Classic lineage, a non-effective matching URL, a nested checkout, symlink, wrong repository, or shared archive Git directory reports `source_archive_audit_failed`.
