### PR TITLE
fix(supply-chain): require complete audit profiles

### DIFF
--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -278,7 +278,12 @@ files directly.
   coordinates. Keep remote Actions on full commits with updater comments,
   images on manifest
   digests, and Git submodules absent. Validate a coordinated profile with
-  `./atrinik supply-chain audit --profile PROFILE` and generate ignored
+  `./atrinik supply-chain audit --profile PROFILE`; initialize every checkout
+  selected by the profile first because an unavailable physical checkout or
+  logical component fails the audit. A review-worktree override changes only
+  its named checkout and never makes the other profile members optional. In
+  CI, provision the selected stacks through wrapper-native `init` rather than
+  duplicating the manifest as a checkout list. Generate ignored
   license/CycloneDX/SPDX reports with
   `./atrinik supply-chain report --profile PROFILE`; unresolved and
   non-selected component commits must remain explicitly unavailable. For a

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -17,55 +17,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          repository: atrinik/classic
-          path: classic
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          repository: atrinik/content
-          path: content
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          repository: atrinik/content
-          ref: 1.x
-          path: content-1x
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          repository: atrinik/sound
-          path: sound
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          repository: atrinik/resources
-          path: resources
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          repository: atrinik/tools
-          path: tools
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          repository: atrinik/metaserver-worker
-          path: metaserver-worker
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          repository: atrinik/devcontainer
-          path: devcontainer
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          repository: atrinik/github-settings
-          path: github-settings
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
+      - name: Initialize complete audit profiles
+        run: ./atrinik init --with classic
       - name: Audit dependency ownership
         run: |
           ./atrinik supply-chain validate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,11 @@
   image, vendored input, license, owner, cadence, EOL response, and validation
   path. Keep Actions and images immutable, retain updater hints, do not add Git
   submodules, and run the profile-aware `./atrinik supply-chain audit`.
+  Initialize every checkout selected by that profile first; audits fail closed
+  when any physical checkout or logical component is unavailable, and a
+  review-worktree override never makes other profile members optional. CI must
+  use wrapper-native initialization rather than maintain a parallel checkout
+  list.
   For an aggregate monorepo checkout, inventory and audit active Actions and
   Dependabot configuration at the checkout root; imported `.github/workflows`
   and `.github/dependabot.yml` files below logical component source roots are

--- a/README.md
+++ b/README.md
@@ -69,11 +69,16 @@ digests with human-readable update hints, and every active repository enables
 weekly Dependabot updates for its supported ecosystems. Git submodules are not
 a supported dependency path.
 
-Validate the catalog alone or audit the exact checkouts selected by a profile:
+Validate the catalog alone or audit the exact checkouts selected by a complete
+profile. Initialize the replacement stack before its audit; use the additive
+Classic initialization when auditing either stack together or the Classic
+stack itself:
 
 ~~~sh
 ./atrinik supply-chain validate
+./atrinik init
 ./atrinik supply-chain audit --profile default
+./atrinik init --with classic
 ./atrinik supply-chain audit --profile classic
 ./atrinik supply-chain versions --output build/supply-chain/versions.json
 ./atrinik supply-chain report --profile default --format licenses \
@@ -86,18 +91,27 @@ Validate the catalog alone or audit the exact checkouts selected by a profile:
   --output build/supply-chain/classic/licenses.md
 ~~~
 
-Generated reports remain ignored under `build/`. A scheduled organization
-audit checks out every physical audit-ready repository once, audits both
-default and classic component source roots, rejects unowned dependency inputs,
-movable workflow/image references, and submodules, prints exact available tool
+An audit fails before scanning when any physical checkout or logical component
+selected by its profile is unavailable, including components that are not yet
+marked audit-ready. This prevents an isolated wrapper worktree or partial local
+workspace from silently weakening an aggregate audit. Absolute
+`--repository NAME=PATH` overrides can select review worktrees, but cannot make
+the rest of the profile optional.
+
+Generated reports remain ignored under `build/`. The scheduled organization
+audit uses `./atrinik init --with classic` to materialize the manifest-defined
+union of both stacks, audits their physical checkout metadata and logical
+component source roots, rejects unowned dependency inputs, movable
+workflow/image references, and submodules, prints exact available tool
 versions, and publishes
 separate deterministic license, CycloneDX, and SPDX artifacts for each stack.
-When auditing a wrapper worktree that cannot safely share its containing
-workspace directory, use repeated absolute `--repository NAME=PATH` overrides;
-the command verifies each override's GitHub repository and branch identity
-before reading it. For duplicate coordinates, a review branch is accepted only
-when its linked worktree shares the expected checkout primary's common Git
-directory, so `content` and `content-1x` cannot be exchanged.
+When auditing review code, initialize the complete profile beside that wrapper
+checkout and use repeated absolute `--repository NAME=PATH` overrides only for
+the components under review. The command verifies each override's GitHub
+repository and branch identity before reading it. For duplicate coordinates, a
+review branch is accepted only when its linked worktree shares the expected
+checkout primary's common Git directory, so `content` and `content-1x` cannot
+be exchanged.
 
 ### Historical MIT provenance grants
 

--- a/atrinik_workspace/supply_chain.py
+++ b/atrinik_workspace/supply_chain.py
@@ -8,7 +8,15 @@ import re
 import subprocess
 from typing import Any, Iterable
 
-from .model import Checkout, Component, Manifest, WorkspaceError, load_json, require_keys
+from .model import (
+    Checkout,
+    Component,
+    Manifest,
+    Stack,
+    WorkspaceError,
+    load_json,
+    require_keys,
+)
 
 
 SCHEMA_VERSION = 3
@@ -1456,6 +1464,19 @@ def _component_source_root(checkout_root: Path, component: Component) -> Path:
     return resolved
 
 
+def _profile_component_rows(
+    stack: Stack, summary: dict[str, Any]
+) -> dict[str, dict[str, Any]]:
+    raw_rows = summary["components"]
+    rows = {row["component"]: row for row in raw_rows}
+    expected_components = {component.name for component in stack.components}
+    if len(rows) != len(raw_rows) or set(rows) != expected_components:
+        raise WorkspaceError(
+            f"profile summary component set does not match {stack.name} stack"
+        )
+    return rows
+
+
 def repository_roots(
     root: Path,
     workspace: Any,
@@ -1567,12 +1588,7 @@ def repository_roots(
                 continue
             selected[member.name] = _component_source_root(checkout_root, member)
             selected_checkouts[member.name] = checkout_root
-    rows = {row["component"]: row for row in summary["components"]}
-    expected_components = {component.name for component in stack.components}
-    if set(rows) != expected_components:
-        raise WorkspaceError(
-            f"profile summary component set does not match {stack.name} stack"
-        )
+    rows = _profile_component_rows(stack, summary)
     missing_checkouts: dict[str, list[str]] = {}
     for component in stack.components:
         if component.name in selected or rows[component.name]["initialized"]:
@@ -1585,14 +1601,23 @@ def repository_roots(
             f"{checkout} ({', '.join(components)})"
             for checkout, components in sorted(missing_checkouts.items())
         )
-        initialization = (
-            "./atrinik init --with classic"
-            if stack.name == "classic"
-            else "./atrinik init"
-        )
+        if profile == stack.name:
+            initialization = (
+                "./atrinik init --with classic"
+                if stack.name == "classic"
+                else "./atrinik init"
+            )
+            remediation = (
+                "initialize every selected checkout before auditing with "
+                f"{initialization}"
+            )
+        else:
+            remediation = (
+                "repair its selectors or initialize their selected checkouts "
+                "before auditing"
+            )
         raise WorkspaceError(
-            f"supply-chain profile {profile} is incomplete; initialize every "
-            f"selected checkout before auditing with {initialization}: {missing}"
+            f"supply-chain profile {profile} is incomplete; {remediation}: {missing}"
         )
 
     roots = {"atrinik": root}
@@ -1642,12 +1667,7 @@ def report_component_commits(
     manifest = Manifest.load(root / "components.json")
     summary = workspace.profile_summary(profile)
     stack = manifest.stack(summary["stack"])
-    rows = {row["component"]: row for row in summary["components"]}
-    expected = {component.name for component in stack.components}
-    if set(rows) != expected:
-        raise WorkspaceError(
-            f"profile summary component set does not match {stack.name} stack"
-        )
+    rows = _profile_component_rows(stack, summary)
     commits: dict[str, str | None] = {"atrinik": _git_head(root)}
     checkout_commits: dict[str, str] = {}
     for component in stack.components:

--- a/atrinik_workspace/supply_chain.py
+++ b/atrinik_workspace/supply_chain.py
@@ -1567,8 +1567,35 @@ def repository_roots(
                 continue
             selected[member.name] = _component_source_root(checkout_root, member)
             selected_checkouts[member.name] = checkout_root
-    roots = {"atrinik": root}
     rows = {row["component"]: row for row in summary["components"]}
+    expected_components = {component.name for component in stack.components}
+    if set(rows) != expected_components:
+        raise WorkspaceError(
+            f"profile summary component set does not match {stack.name} stack"
+        )
+    missing_checkouts: dict[str, list[str]] = {}
+    for component in stack.components:
+        if component.name in selected or rows[component.name]["initialized"]:
+            continue
+        missing_checkouts.setdefault(component.checkout_name, []).append(
+            component.name
+        )
+    if missing_checkouts:
+        missing = ", ".join(
+            f"{checkout} ({', '.join(components)})"
+            for checkout, components in sorted(missing_checkouts.items())
+        )
+        initialization = (
+            "./atrinik init --with classic"
+            if stack.name == "classic"
+            else "./atrinik init"
+        )
+        raise WorkspaceError(
+            f"supply-chain profile {profile} is incomplete; initialize every "
+            f"selected checkout before auditing with {initialization}: {missing}"
+        )
+
+    roots = {"atrinik": root}
     for component in stack.components:
         if component.name not in audit_ready:
             continue

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -83,6 +83,11 @@ every doubt is independently resolved.
 
 The `supply-chain` command resolves component inputs through the same profile
 selectors as builds, then reads Git-indexed files without mutating a checkout.
+Before selecting audit-ready roots, it requires every physical checkout and
+logical component in the profile to resolve. Review-worktree overrides replace
+specific roots but never relax that completeness invariant. An unavailable
+member therefore fails the aggregate operation instead of turning it into a
+partial audit.
 The audit requires immutable remote Actions and container images, updater
 hints, an owned catalog entry for every dependency input, weekly GitHub Actions
 update configuration, and no submodules. For a shared monorepo checkout, only
@@ -95,11 +100,11 @@ common Git directory, preventing `content` and `content-1x` from being
 interchanged. Deterministic
 license, CycloneDX, SPDX, and local version reports are generated only below
 the ignored build directory; report generation resolves full commit IDs through
-`--profile PROFILE`. The scheduled audit composes and audits the initialized
-default and classic stacks explicitly, including both content release lines,
-and publishes stack-separated reports; pull-request CI validates the catalog
-and its implementation without silently accepting a partial organization
-snapshot.
+`--profile PROFILE`. The scheduled audit delegates checkout composition to
+`./atrinik init --with classic`, audits both complete stacks including both
+content release lines, and publishes stack-separated reports; regression tests
+bind that initialization ordering, the fail-closed profile contract, and the
+`content@1.x` workflow-runner policy.
 
 Read-only inspection commands keep structured data on stdout and suppress Git
 traces so callers can safely consume `status --json`, `worktree list --json`,

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -1516,7 +1516,8 @@ FROM toolchain AS final
 
         with self.assertRaisesRegex(
             WorkspaceError,
-            r"profile classic-review is incomplete.*classic \(classic-client, "
+            r"profile classic-review is incomplete.*repair its selectors.*"
+            r"classic \(classic-client, "
             r"classic-server, classic-protocol, classic-libatrinik, "
             r"classic-editor\)",
         ):
@@ -1556,6 +1557,25 @@ FROM toolchain AS final
             "components": [],
         }
 
+        with self.assertRaisesRegex(
+            WorkspaceError, "component set does not match classic stack"
+        ):
+            repository_roots(ROOT, workspace, "classic")
+
+        classic_components = json.loads(
+            (ROOT / "components.json").read_text(encoding="utf-8")
+        )["stacks"]["classic"]["components"]
+        workspace.profile_summary.return_value["components"] = [
+            {
+                "component": name,
+                "initialized": True,
+                "path": f"/workspace/classic/{name}",
+            }
+            for name in classic_components
+        ]
+        workspace.profile_summary.return_value["components"].append(
+            workspace.profile_summary.return_value["components"][0]
+        )
         with self.assertRaisesRegex(
             WorkspaceError, "component set does not match classic stack"
         ):

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -116,21 +116,13 @@ class InventoryTests(unittest.TestCase):
             encoding="utf-8"
         )
 
-        self.assertIn(
-            "repository: atrinik/content\n          path: content\n",
-            workflow,
-        )
-        self.assertIn(
-            "repository: atrinik/content\n          ref: 1.x\n"
-            "          path: content-1x\n",
-            workflow,
-        )
-        self.assertEqual(workflow.count("repository: atrinik/classic\n"), 1)
-        self.assertNotIn("repository: atrinik/legacy-", workflow)
+        initialize = "./atrinik init --with classic"
+        self.assertEqual(workflow.count(initialize), 1)
+        self.assertNotIn("          repository: atrinik/", workflow)
         for profile in ("default", "classic"):
-            self.assertIn(
-                f"./atrinik supply-chain audit --profile {profile}", workflow
-            )
+            audit = f"./atrinik supply-chain audit --profile {profile}"
+            self.assertIn(audit, workflow)
+            self.assertLess(workflow.index(initialize), workflow.index(audit))
             for report in ("licenses.md", "cyclonedx.json", "spdx.json"):
                 self.assertIn(
                     f"build/supply-chain/{profile}/{report}", workflow
@@ -675,6 +667,65 @@ class InventoryTests(unittest.TestCase):
                     workflow.write_text(original, encoding="utf-8")
                     with self.assertRaisesRegex(WorkspaceError, expected):
                         semantic_inventory.audit({"fixture": root})
+
+    def test_content_1x_runner_policy_violation_fails_audit(self) -> None:
+        repository = fixture_repository(
+            name="content-1x",
+            repository="atrinik/content",
+            branch="1.x",
+            checkout="content-1x",
+            cohorts=("classic",),
+            stacks=("classic",),
+            roles=("content",),
+            license="LicenseRef-Atrinik-Content",
+        )
+        action = fixture_dependency(
+            owner="content-1x",
+            scope=("content-1x",),
+            evidence=(
+                Evidence(
+                    "content-1x",
+                    ".github/workflows/ci.yml",
+                    f"example/action@{'a' * 40} # v1",
+                ),
+            ),
+        )
+        runner = fixture_dependency(
+            identifier="runner/ubuntu-24.04",
+            name="Ubuntu runner",
+            kind="toolchain",
+            owner="content-1x",
+            scope=("content-1x",),
+            locator="github-hosted-runner/ubuntu-24.04",
+            commit=None,
+            evidence=(
+                Evidence(
+                    "content-1x",
+                    ".github/dependabot.yml",
+                    "package-ecosystem: github-actions",
+                ),
+            ),
+        )
+        inventory = Inventory(
+            "atrinik", "2026-08-08T00:00:00Z", [repository], [action, runner]
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.make_audit_repository(root)
+            workflow = root / ".github" / "workflows" / "ci.yml"
+            workflow.write_text(
+                workflow.read_text(encoding="utf-8").replace(
+                    "runs-on: ubuntu-24.04", "runs-on: ${{ matrix.os }}"
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                WorkspaceError,
+                r"content-1x/.github/workflows/ci.yml: workflow runner must "
+                r"be an explicit literal",
+            ):
+                inventory.audit({"content-1x": root})
 
     def test_audit_rejects_inventory_scope_drift(self) -> None:
         inventory = self.audit_inventory()
@@ -1287,7 +1338,7 @@ FROM toolchain AS final
             "components": [
                 {
                     "component": name,
-                    "initialized": False,
+                    "initialized": True,
                     "path": f"/workspace/profile/{name}",
                 }
                 for name in default_components
@@ -1375,7 +1426,7 @@ FROM toolchain AS final
             "components": [
                 {
                     "component": name,
-                    "initialized": False,
+                    "initialized": True,
                     "path": f"/workspace/review/{name}",
                 }
                 for name in default_components
@@ -1463,11 +1514,52 @@ FROM toolchain AS final
             ],
         }
 
-        roots = repository_roots(ROOT, workspace, "classic-review")
+        with self.assertRaisesRegex(
+            WorkspaceError,
+            r"profile classic-review is incomplete.*classic \(classic-client, "
+            r"classic-server, classic-protocol, classic-libatrinik, "
+            r"classic-editor\)",
+        ):
+            repository_roots(ROOT, workspace, "classic-review")
 
-        self.assertIn("content-1x", roots)
-        self.assertNotIn("content", roots)
-        self.assertNotIn("classic-server", roots)
+    def test_repository_roots_fail_closed_when_content_1x_is_missing(self) -> None:
+        workspace = mock.Mock()
+        document = json.loads(
+            (ROOT / "components.json").read_text(encoding="utf-8")
+        )
+        classic_components = document["stacks"]["classic"]["components"]
+        workspace.profile_summary.return_value = {
+            "name": "classic",
+            "stack": "classic",
+            "components": [
+                {
+                    "component": name,
+                    "initialized": name != "content-1x",
+                    "path": f"/workspace/classic/{name}",
+                }
+                for name in classic_components
+            ],
+        }
+
+        with self.assertRaisesRegex(
+            WorkspaceError,
+            r"profile classic is incomplete.*./atrinik init --with classic.*"
+            r"content-1x \(content-1x\)",
+        ):
+            repository_roots(ROOT, workspace, "classic")
+
+    def test_repository_roots_reject_incomplete_profile_summary(self) -> None:
+        workspace = mock.Mock()
+        workspace.profile_summary.return_value = {
+            "name": "classic",
+            "stack": "classic",
+            "components": [],
+        }
+
+        with self.assertRaisesRegex(
+            WorkspaceError, "component set does not match classic stack"
+        ):
+            repository_roots(ROOT, workspace, "classic")
 
     def test_repository_roots_add_one_classic_checkout_metadata_root(self) -> None:
         workspace = mock.Mock()
@@ -1484,7 +1576,7 @@ FROM toolchain AS final
             "components": [
                 {
                     "component": name,
-                    "initialized": components[name]["checkout"] == "classic",
+                    "initialized": True,
                     "checkout_path": (
                         "/workspace/classic"
                         if components[name]["checkout"] == "classic"
@@ -1523,7 +1615,7 @@ FROM toolchain AS final
             "components": [
                 {
                     "component": name,
-                    "initialized": component_documents[name]["checkout"] == "classic",
+                    "initialized": component_documents[name]["checkout"] != "classic",
                     "checkout_path": (
                         "/workspace/classic"
                         if component_documents[name]["checkout"] == "classic"


### PR DESCRIPTION
## Summary

- make profile-aware supply-chain audits fail closed when any selected physical checkout or logical component is unavailable
- replace the scheduled workflow's hand-maintained repository checkout list with manifest-driven `./atrinik init --with classic`
- add regressions for incomplete profiles, duplicate profile rows, workflow ordering, and the concrete `content@1.x` dynamic-runner violation
- synchronize README, architecture, agent guidance, and the multi-repository skill

## Safety and review

The implementation was reviewed iteratively in the ignored `build/issue-287-deep-review.md` report. The follow-up checkpoint centralized audit/report profile integrity validation, added duplicate-row rejection, and corrected remediation for saved profiles. The final review found no remaining actionable issues.

No GitHub permissions, required check names, or organization settings change. The workflow retains `contents: read` and immutable action references.

## Validation

- `python3 -m coverage run -m unittest discover -v` — 218 passed
- `python3 -m coverage report --show-missing` — 76% overall, 96% for `supply_chain.py`
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `actionlint`
- `git diff origin/main...HEAD --check`
- isolated-worktree audit verified to fail closed with the complete missing-Classic-checkout diagnostic

The full aggregate audit is intentionally expected to expose the owning `content@1.x` explicit-runner policy violation until that repository repair and its Windows-runner inventory ownership land.

Closes #287