### PR TITLE
feat(workspace): add safe cleanup workflow

### DIFF
--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -88,6 +88,26 @@ description: Coordinate changes, reviews, builds, releases, and Git worktrees ac
    Commits and open the pull request in that physical repository. Do not create
    a wrapper commit for component-source-only changes.
 
+6. Reclaim completed review data only through the explicit preview-first
+   workflow. Default cleanup covers worktrees plus profile builds; npm cache
+   removal is always opt-in:
+
+   ```sh
+   ./atrinik cleanup --dry-run --json
+   ./atrinik cleanup --scope worktrees --scope builds CHECKOUT... --older-than 7
+   ./atrinik cleanup --scope all --older-than 7 --apply
+   ```
+
+   A saved profile, retained scenario, live topology, migration record,
+   build-retention record, dirty/detached/locked/in-progress worktree, or
+   uncertain Git/GitHub/marker identity protects its target. Exact merged PR
+   heads alone qualify after the grace period. Apply recomputes under the
+   repository-layout lock, removes marker-owned builds first, invokes
+   non-force Git worktree removal second, and handles the explicit cache and
+   safely shared prunable metadata last. It never removes profiles, scenarios,
+   states, topology records/logs, migration evidence/archives, branches, Git
+   objects, deep-review reports, or arbitrary unmarked paths.
+
 ## Migrate a pre-split workspace
 
 Before replacing a workspace containing the former standalone classic
@@ -259,6 +279,11 @@ cleanup command. Do not substitute reconstructed internal build/runtime paths
 or direct executable invocations for a supported wrapper command. If runtime
 verification is not applicable, say so and provide the wrapper build/test and
 inspection commands that are applicable.
+
+For cleanup changes, runtime launch is normally not applicable. Use the exact
+worktree/profile fixture names from the task and include both a stable JSON
+preview and the opt-in apply form, with expected candidate/protection reasons
+and an explicit statement that branches and retained records remain.
 
 When the reviewer needs a ready login, also use the
 `atrinik-test-scenario` skill. Provision with `./atrinik scenario create`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,15 @@
   initialized default-cohort checkouts; opt-in classic-cohort synchronization
   uses exact `--with classic` or explicit checkout/component names. Operations
   deduplicate aliases that resolve to the same physical checkout.
+- Workspace cleanup is explicit and preview-first. Use `./atrinik cleanup`
+  or `--dry-run --json` before exact `--apply`; never add implicit cleanup to
+  init, sync, build, topology, scenario, or startup paths. Only registered,
+  exact-merged-head worktrees and marker-owned stale builds are candidates.
+  Preserve every profile/scenario/live-topology/migration/retention reference,
+  ordinary local change, branch/ref, state, log, archive, review report, and
+  unmarked path. The npm cache requires an explicit scope. Apply must hold the
+  repository-layout lock, recompute and immediately revalidate, use non-force
+  Git worktree removal, and stop accurately on the first post-mutation error.
 - Before combining former standalone classic repositories, use
   exact `./atrinik init classic`, then
   `./atrinik migrate repositories --dry-run`, `--apply`, and `--audit`.

--- a/README.md
+++ b/README.md
@@ -380,6 +380,73 @@ physical repository, so a classic worktree contains all five classic source
 directories. Ordinary `git commit`, `git push`, and `gh pr create` work from
 inside it.
 
+## Previewing and reclaiming stale workspace data
+
+Cleanup is always operator-invoked and preview-first. With no options it
+inventories registered worktrees and marker-owned profile builds older than
+seven days without changing the filesystem:
+
+~~~sh
+./atrinik cleanup
+./atrinik cleanup --dry-run --json
+./atrinik cleanup --scope worktrees classic-server --older-than 14
+./atrinik cleanup --scope builds --scope npm-cache --older-than 0
+./atrinik cleanup --scope all --older-than 7 --apply
+~~~
+
+`--dry-run` is the explicit spelling of the default mode; only `--apply`
+mutates. Repeated `--scope` options combine `worktrees`, `builds`, and the
+opt-in `npm-cache`; `all` selects all three. Positional checkout or logical
+component names narrow only the worktree inventory and still deduplicate
+aliases to one physical checkout. The special `atrinik` filter selects wrapper
+worktrees. JSON output is stable schema-versioned data and keeps Git/GitHub
+diagnostics off stdout. Text output ends with candidate, protected, removed,
+error, and allocated-byte totals.
+
+The worktree inventory covers every initialized physical checkout plus wrapper
+worktrees that Git proves are direct children of exactly
+`workspace/worktrees/atrinik/` or the historical `build/worktrees/`
+namespace. A worktree becomes eligible only when it is registered to the
+expected common Git directory and repository, named and unlocked, has no Git
+operation or ordinary tracked/untracked change, and is not retained by a
+profile, scenario, live topology, or repository-migration record. The
+authenticated `gh` commit-associated-pulls query must prove one merged PR with
+the manifest base branch, an exact `head.sha` match, no associated open PR, and
+a merge age beyond the grace period. Query failure, ambiguity, wrong base,
+closed-unmerged PR, advanced branch, detached worktree, external path, or any
+ownership uncertainty protects the item. Ignored compiler/dependency output
+does not make a worktree dirty, but its paths and allocated bytes are reported
+because `git worktree remove` will reclaim it. Apply never uses `--force` and
+does not delete local or remote branch refs.
+
+Profile builds are eligible only as direct
+`workspace/build/profiles/<profile>-<key>` children with an exact regular
+ownership marker. Each build use atomically refreshes strict metadata with its
+profile/key, selected repository/branch/checkout/source coordinates, commits,
+and `last_used_at`. A marker-proven build created before that metadata uses the
+maximum no-follow tree mtime as a conservative legacy age. A build selected by
+a live topology, busy build lock, registered worktree, or the optional strict
+`workspace/build/retention.json` record is protected. That retention record is
+schema 1 and contains exactly `schema_version` plus an absolute `build_roots`
+array. A build sourced from a worktree eligible in the same plan may be
+reclaimed regardless of age unless another protection applies.
+
+The shared `workspace/build/npm-cache` is never part of default cleanup. Its
+explicit scope accepts the exact marker-owned path or the one legacy known
+cache at that fixed location after proving the workspace marker, path shape,
+age, and absence of an active build. Unmarked profile roots, other
+`workspace/build` children, and all remaining mixed top-level `build/`
+entries are report-only `unmanaged-build` items. Deep-review reports, ad hoc
+builds, packages, archives, and unregistered siblings are never recursively
+deleted.
+
+Apply holds the repository-layout lock, recomputes the entire plan, then
+revalidates each target immediately before removal. It removes eligible builds
+first, exact Git worktrees second, and the explicitly selected cache or safely
+shared prunable Git metadata last. A pre-mutation race aborts without deletion;
+after the first successful mutation, the deterministic policy stops on the
+first error and reports exactly what was reclaimed without claiming rollback.
+
 ## Composing coherent component sources
 
 A profile retains a stack identity and chooses one physical checkout root for
@@ -755,12 +822,19 @@ worktrees, so commit, stash, or otherwise preserve intentional edits first:
 
 ~~~sh
 ./atrinik down combined-review
-./atrinik worktree remove classic combined-classic
-./atrinik worktree remove content-1x maps-review
+./atrinik profile set combined-review classic --primary
+./atrinik profile set combined-review content-1x --primary
+./atrinik cleanup --scope worktrees --scope builds \
+  classic content-1x --older-than 7 --dry-run
+./atrinik cleanup --scope worktrees --scope builds \
+  classic content-1x --older-than 7 --apply
 ~~~
 
-Profiles and rotated logs are small ignored metadata and may remain as a review
-record. Commits and branches remain owned by their physical Git repositories.
+The saved `combined-review` profile protects both selected worktrees until the
+explicit `profile set` commands repoint it. Do that only when the retained
+review selection is no longer useful, then preview cleanup. Cleanup never removes profiles,
+scenarios, topology records/logs, state, migration evidence, commits, or
+branches.
 
 ## Persistent server state
 
@@ -826,6 +900,7 @@ python3 -m coverage run -m unittest discover -v
 python3 -m coverage report --show-missing
 python3 -m compileall -q atrinik atrinik_workspace tests
 ./atrinik manifest validate
+./atrinik cleanup --scope all --older-than 7 --dry-run --json
 ~~~
 
 Use `./atrinik build COMPONENT --profile classic --test` for current native

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -239,9 +239,16 @@ class Cleanup:
                 identity = (target["kind"], target["path"])
                 if identity in completed:
                     continue
-                fresh = self._plan(
-                    selected_scopes, older_than_days, selected_names, "apply"
-                )
+                try:
+                    fresh = self._plan(
+                        selected_scopes, older_than_days, selected_names, "apply"
+                    )
+                except (OSError, RuntimeError, WorkspaceError) as error:
+                    target["disposition"] = "error"
+                    target["reasons"] = ["revalidation_error"]
+                    target["error"] = str(error)
+                    report["aborted"] = True
+                    break
                 match = next(
                     (
                         item
@@ -267,7 +274,7 @@ class Cleanup:
                 report["mutation_attempted"] = True
                 try:
                     self._remove(match)
-                except (OSError, WorkspaceError) as error:
+                except (OSError, RuntimeError, WorkspaceError) as error:
                     target["disposition"] = "error"
                     target["reasons"] = ["removal_failed"]
                     target["error"] = str(error)
@@ -391,11 +398,18 @@ class Cleanup:
             "retention": {},
         }
         errors: set[str] = set()
-        self._profile_references(references, errors)
-        self._scenario_references(references, errors)
-        self._topology_references(references, errors)
-        self._migration_references(references, errors)
-        self._retention_references(references, errors)
+        collectors = (
+            (self._profile_references, "profile_inventory_error"),
+            (self._scenario_references, "scenario_inventory_error"),
+            (self._topology_references, "topology_inventory_error"),
+            (self._migration_references, "migration_inventory_error"),
+            (self._retention_references, "retention_inventory_error"),
+        )
+        for collector, reason in collectors:
+            try:
+                collector(references, errors)
+            except (OSError, RuntimeError, WorkspaceError):
+                errors.add(reason)
         return references, errors
 
     def _registered_worktree_paths(self) -> tuple[set[Path], bool]:
@@ -443,6 +457,22 @@ class Cleanup:
         except (OSError, RuntimeError) as error:
             raise WorkspaceError(f"cannot resolve retained path {path}: {error}") from error
         container.setdefault(normalized, []).append(name)
+
+    @staticmethod
+    def _owned_direct_child(path: Path, namespace: Path) -> bool:
+        """Prove a path is directly below one fixed non-symlink namespace."""
+
+        try:
+            if (
+                namespace.is_symlink()
+                or not namespace.is_dir()
+                or namespace.parent.is_symlink()
+                or not namespace.parent.is_dir()
+            ):
+                return False
+            return path.resolve(strict=False).parent == namespace.resolve()
+        except (OSError, RuntimeError):
+            return False
 
     def _profile_references(self, references: dict[str, Any], errors: set[str]) -> None:
         if not self.paths.profiles.is_dir() or self.paths.profiles.is_symlink():
@@ -507,7 +537,9 @@ class Cleanup:
                 ):
                     raise WorkspaceError("scenario metadata is a symlink")
                 metadata = load_json(metadata_path)
-                resolved = metadata.get("resolved") if isinstance(metadata, dict) else None
+                if not isinstance(metadata, dict):
+                    raise WorkspaceError("scenario metadata is invalid")
+                resolved = metadata.get("resolved")
                 if metadata.get("name") != root.name or not isinstance(resolved, dict):
                     raise WorkspaceError("scenario resolution is invalid")
                 for row in resolved.values():
@@ -576,21 +608,84 @@ class Cleanup:
                     continue
                 build_root = status_value.get("build_root")
                 resolved = status_value.get("resolved")
-                if not isinstance(build_root, str) or not Path(build_root).is_absolute():
+                if (
+                    status_value.get("schema_version") != SCHEMA_VERSION
+                    or status_value.get("name") != root.name
+                    or not isinstance(build_root, str)
+                    or not Path(build_root).is_absolute()
+                ):
                     raise WorkspaceError("topology build root is invalid")
                 self._add_reference(references["live_builds"], Path(build_root), root.name)
                 if not isinstance(resolved, dict):
                     raise WorkspaceError("topology resolution is invalid")
-                for row in resolved.values():
-                    if not isinstance(row, dict) or not isinstance(
-                        row.get("checkout_path"), str
+                stack_name = status_value.get("stack")
+                providers = status_value.get("providers")
+                dependencies = status_value.get("dependencies")
+                if (
+                    not isinstance(stack_name, str)
+                    or stack_name not in self.manifest.stacks
+                    or not isinstance(providers, dict)
+                    or not isinstance(dependencies, list)
+                    or not all(isinstance(value, str) for value in dependencies)
+                    or not all(
+                        isinstance(role, str) and isinstance(component, str)
+                        for role, component in providers.items()
+                    )
+                    or set(providers) != set(dependencies)
+                    or set(resolved) != set(providers.values())
+                ):
+                    raise WorkspaceError("topology coordinates are historical or invalid")
+                for role, component_name in providers.items():
+                    if (
+                        not isinstance(role, str)
+                        or not isinstance(component_name, str)
+                        or component_name not in self.manifest.by_name
+                        or self.manifest.provider(stack_name, role).name
+                        != component_name
                     ):
-                        raise WorkspaceError("topology checkout path is invalid")
+                        raise WorkspaceError("topology provider identity is invalid")
+                coordinate_keys = {
+                    "path",
+                    "checkout_path",
+                    "checkout",
+                    "repository",
+                    "branch",
+                    "source",
+                    "head",
+                    "dirty",
+                }
+                for component_name, row in resolved.items():
+                    component = self.manifest.by_name[component_name]
+                    if (
+                        not isinstance(row, dict)
+                        or set(row) != coordinate_keys
+                        or not isinstance(row.get("checkout_path"), str)
+                        or not isinstance(row.get("path"), str)
+                        or not isinstance(row.get("head"), str)
+                        or not HEAD_PATTERN.fullmatch(row["head"])
+                        or not isinstance(row.get("dirty"), bool)
+                        or row.get("checkout") != component.checkout_name
+                        or row.get("repository") != component.repository
+                        or row.get("branch") != component.branch
+                        or row.get("source") != component.source
+                    ):
+                        raise WorkspaceError("topology checkout identity is invalid")
                     selected = Path(row["checkout_path"])
-                    if not selected.is_absolute():
+                    source_path = Path(row["path"])
+                    if not selected.is_absolute() or not source_path.is_absolute():
                         raise WorkspaceError("topology checkout path is relative")
+                    source = PurePosixPath(component.source)
+                    expected_source = (
+                        selected
+                        if component.source == "."
+                        else selected.joinpath(*source.parts)
+                    )
+                    if source_path.resolve(strict=False) != expected_source.resolve(
+                        strict=False
+                    ):
+                        raise WorkspaceError("topology source path is invalid")
                     self._add_reference(references["topologies"], selected, root.name)
-            except (OSError, WorkspaceError):
+            except (OSError, RuntimeError, KeyError, WorkspaceError):
                 errors.add("topology_inventory_error")
 
     def _migration_references(self, references: dict[str, Any], errors: set[str]) -> None:
@@ -652,6 +747,12 @@ class Cleanup:
 
     def _retention_references(self, references: dict[str, Any], errors: set[str]) -> None:
         path = self.paths.builds / BUILD_RETENTION_RECORD
+        if self.paths.builds.is_symlink() or (
+            self.paths.builds.exists() and not self.paths.builds.is_dir()
+        ):
+            if path.exists() or path.is_symlink():
+                errors.add("retention_inventory_error")
+            return
         if not path.exists() and not path.is_symlink():
             return
         try:
@@ -795,9 +896,12 @@ class Cleanup:
             item["reasons"].append("detached_head")
         if "locked" in record:
             item["reasons"].append("locked_worktree")
-        owned = any(normalized.parent == root.resolve(strict=False) for root in allowed)
+        owned = any(self._owned_direct_child(path, root) for root in allowed)
         if not owned:
             item["reasons"].append("external_path")
+        primary_item = normalized == primary.resolve()
+        if primary_item:
+            item["reasons"].append("primary_checkout")
         reference_reasons = {
             "profiles": "profile_reference",
             "scenarios": "scenario_reference",
@@ -816,6 +920,8 @@ class Cleanup:
                 item["disposition"] = "skipped"
                 item["reasons"] = ["github_pending"]
             return item
+        if primary_item:
+            return item
         inodes, _, walk_error = _tree_usage(path)
         item["_inodes"] = inodes
         if walk_error:
@@ -823,8 +929,6 @@ class Cleanup:
             item["error"] = walk_error
         if path.is_symlink():
             item["reasons"].append("symlinked_worktree")
-        if normalized == primary.resolve():
-            item["reasons"].append("primary_checkout")
         if not path.is_dir():
             item["reasons"].append("missing_worktree")
             return item
@@ -1066,6 +1170,19 @@ class Cleanup:
         references: dict[str, Any],
         reference_errors: set[str],
     ) -> list[dict[str, Any]]:
+        if self.paths.builds.is_symlink() or (
+            self.paths.builds.exists() and not self.paths.builds.is_dir()
+        ):
+            item = _base_item(
+                "unmanaged-build", "atrinik", "atrinik/atrinik", self.paths.builds
+            )
+            item["reasons"] = ["invalid_build_container"]
+            inodes, _, error = _tree_usage(self.paths.builds)
+            item["_inodes"] = inodes
+            if error:
+                item["reasons"].append("filesystem_traversal_error")
+                item["error"] = error
+            return [item]
         profiles = self.paths.builds / "profiles"
         if not profiles.is_dir() or profiles.is_symlink():
             if profiles.exists() or profiles.is_symlink():
@@ -1079,6 +1196,15 @@ class Cleanup:
                     item["error"] = error
                 return [item]
             return []
+        try:
+            profile_roots = sorted(profiles.iterdir())
+        except OSError as error:
+            item = _base_item(
+                "unmanaged-build", "atrinik", "atrinik/atrinik", profiles
+            )
+            item["reasons"] = ["profiles_inventory_error"]
+            item["error"] = str(error)
+            return [item]
         return [
             self._build_item(
                 path,
@@ -1088,7 +1214,7 @@ class Cleanup:
                 references,
                 reference_errors,
             )
-            for path in sorted(profiles.iterdir())
+            for path in profile_roots
         ]
 
     def _build_item(
@@ -1197,8 +1323,9 @@ class Cleanup:
             raise WorkspaceError("profile build marker does not match its path")
         return purpose, profile, key
 
-    @staticmethod
-    def _load_build_metadata(path: Path, item: dict[str, Any]) -> dict[str, Any]:
+    def _load_build_metadata(
+        self, path: Path, item: dict[str, Any]
+    ) -> dict[str, Any]:
         if path.is_symlink() or not path.is_file():
             raise WorkspaceError("build metadata is not a regular file")
         value = load_json(path)
@@ -1227,6 +1354,16 @@ class Cleanup:
             validate_name(role, "build coordinate role")
             validate_name(row["component"], "build coordinate component")
             validate_name(row["checkout"], "build coordinate checkout")
+            component = self.manifest.by_name.get(row["component"])
+            if (
+                component is None
+                or role not in component.provides
+                or row["checkout"] != component.checkout_name
+                or row["repository"] != component.repository
+                or row["branch"] != component.branch
+                or row["source"] != component.source
+            ):
+                raise WorkspaceError("build coordinate manifest identity is invalid")
             if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", row["repository"]):
                 raise WorkspaceError("build coordinate repository is invalid")
             if any(character in row["branch"] for character in "\0\r\n"):
@@ -1282,30 +1419,36 @@ class Cleanup:
         roots: list[tuple[Path, list[Path]]] = []
         top = self._wrapper_primary / "build"
         if top.is_dir() and not top.is_symlink():
-            for path in sorted(top.iterdir()):
-                try:
-                    if path.resolve(strict=False) in registered:
+            try:
+                for path in sorted(top.iterdir()):
+                    try:
+                        if path.resolve(strict=False) in registered:
+                            continue
+                    except (OSError, RuntimeError):
+                        roots.append((path, []))
                         continue
-                except (OSError, RuntimeError):
-                    roots.append((path, []))
-                    continue
-                roots.append(
-                    (
-                        path,
-                        [
-                            candidate
-                            for candidate in registered
-                            if _path_relation(path, candidate)
-                        ],
+                    roots.append(
+                        (
+                            path,
+                            [
+                                candidate
+                                for candidate in registered
+                                if _path_relation(path, candidate)
+                            ],
+                        )
                     )
-                )
+            except OSError:
+                roots.append((top, []))
         elif top.exists() or top.is_symlink():
             roots.append((top, []))
         if self.paths.builds.is_dir() and not self.paths.builds.is_symlink():
-            for path in sorted(self.paths.builds.iterdir()):
-                if path.name in {"profiles", "npm-cache"}:
-                    continue
-                roots.append((path, []))
+            try:
+                for path in sorted(self.paths.builds.iterdir()):
+                    if path.name in {"profiles", "npm-cache"}:
+                        continue
+                    roots.append((path, []))
+            except OSError:
+                roots.append((self.paths.builds, []))
         for path, excluded in roots:
             item = _base_item("unmanaged-build", "atrinik", "atrinik/atrinik", path)
             inodes, observed, error = _tree_usage(path, excluded)
@@ -1332,6 +1475,10 @@ class Cleanup:
             return None
         item = _base_item("npm-cache", "atrinik", "atrinik/atrinik", path)
         item["_purpose"] = "npm-cache"
+        if self.paths.builds.is_symlink() or not self.paths.builds.is_dir():
+            item["reasons"] = ["invalid_cache_path"]
+            item["legacy_known_cache"] = False
+            return item
         inodes, observed, walk_error = _tree_usage(path)
         item["_inodes"] = inodes
         if walk_error:
@@ -1341,7 +1488,9 @@ class Cleanup:
             item["reasons"].append("invalid_workspace_marker")
         try:
             valid_path = (
-                not path.is_symlink()
+                not self.paths.builds.is_symlink()
+                and self.paths.builds.is_dir()
+                and not path.is_symlink()
                 and path.is_dir()
                 and path.resolve(strict=False)
                 == self.paths.builds.resolve(strict=False) / "npm-cache"
@@ -1413,10 +1562,13 @@ class Cleanup:
             return False, None
         if locks.is_symlink() or not locks.is_dir():
             return False, f"build lock directory is invalid: {locks}"
-        for path in sorted(locks.iterdir()):
-            busy, error = self._lock_busy(path)
-            if error or busy:
-                return busy, error
+        try:
+            for path in sorted(locks.iterdir()):
+                busy, error = self._lock_busy(path)
+                if error or busy:
+                    return busy, error
+        except OSError as error:
+            return False, str(error)
         return False, None
 
     @staticmethod

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -1,0 +1,1495 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+import fcntl
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import stat
+import subprocess
+from typing import Any, Iterable
+
+from .migration import MIGRATION_PENDING, MIGRATION_RECORD, OPERATION_PATHS
+from .model import (
+    MANAGED_MARKER,
+    SCHEMA_VERSION,
+    WorkspaceError,
+    atomic_json,
+    load_json,
+    managed_remove,
+    validate_name,
+)
+from .supervisor import process_matches
+from .workspace import (
+    BUILD_METADATA,
+    BUILD_METADATA_SCHEMA_VERSION,
+    CACHE_METADATA,
+    _remote_matches,
+    exclusive_lock,
+)
+
+
+CLEANUP_SCHEMA_VERSION = 1
+DEFAULT_SCOPES = ("worktrees", "builds")
+ALL_SCOPES = (*DEFAULT_SCOPES, "npm-cache")
+BUILD_RETENTION_RECORD = "retention.json"
+BUILD_METADATA_KEYS = {
+    "schema_version",
+    "profile",
+    "key",
+    "purpose",
+    "coordinates",
+    "last_used_at",
+}
+BUILD_COORDINATE_KEYS = {
+    "component",
+    "checkout",
+    "repository",
+    "branch",
+    "source",
+    "checkout_path",
+    "source_path",
+    "head",
+}
+PROFILE_PURPOSE = re.compile(
+    r"^profile:(?P<profile>[a-z0-9][a-z0-9._-]*):(?P<key>[0-9a-f]{12})$"
+)
+HEAD_PATTERN = re.compile(r"^[0-9a-f]{40,64}$")
+
+
+def _command(path: Path, *arguments: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(path), *arguments],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as error:
+        raise WorkspaceError("required command not found: git") from error
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr.strip()
+        suffix = f": {detail}" if detail else ""
+        raise WorkspaceError(
+            f"git command failed ({error.returncode}) at {path}{suffix}"
+        ) from error
+    return result.stdout.strip()
+
+
+def _worktree_records(repository: Path) -> list[dict[str, str]]:
+    output = _command(repository, "worktree", "list", "--porcelain", "-z")
+    records: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    for field in output.split("\0"):
+        if not field:
+            if current:
+                records.append(current)
+                current = {}
+            continue
+        key, _, value = field.partition(" ")
+        current[key] = value
+    if current:
+        records.append(current)
+    return records
+
+
+def _git_common_directory(path: Path) -> Path:
+    value = _command(path, "rev-parse", "--path-format=absolute", "--git-common-dir")
+    return Path(value).resolve()
+
+
+def _git_directory(path: Path) -> Path:
+    value = _command(path, "rev-parse", "--path-format=absolute", "--git-dir")
+    return Path(value).resolve()
+
+
+def _parse_time(value: Any, context: str) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise WorkspaceError(f"{context} must be a timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise WorkspaceError(f"{context} is not a valid timestamp") from error
+    if parsed.tzinfo is None:
+        raise WorkspaceError(f"{context} must include a UTC offset")
+    return parsed.astimezone(timezone.utc)
+
+
+def _workspace_owned(paths: Any) -> bool:
+    marker = paths.marker
+    if (
+        not paths.workspace.is_dir()
+        or paths.workspace.is_symlink()
+        or not marker.is_file()
+        or marker.is_symlink()
+    ):
+        return False
+    try:
+        return load_json(marker) == {"schema_version": SCHEMA_VERSION}
+    except WorkspaceError:
+        return False
+
+
+def _path_relation(root: Path, path: Path) -> bool:
+    try:
+        root = root.resolve(strict=False)
+        path = path.resolve(strict=False)
+    except (OSError, RuntimeError):
+        return True
+    return root == path or root in path.parents
+
+
+def _tree_usage(
+    root: Path, excluded: Iterable[Path] = ()
+) -> tuple[dict[tuple[int, int], int], datetime | None, str | None]:
+    sizes: dict[tuple[int, int], int] = {}
+    maximum: float | None = None
+    stack = [root]
+    try:
+        excluded_paths = {path.resolve(strict=False) for path in excluded}
+        while stack:
+            path = stack.pop()
+            normalized = path.resolve(strict=False)
+            if path != root and normalized in excluded_paths:
+                continue
+            metadata = path.lstat()
+            key = (metadata.st_dev, metadata.st_ino)
+            sizes.setdefault(key, metadata.st_blocks * 512)
+            maximum = metadata.st_mtime if maximum is None else max(maximum, metadata.st_mtime)
+            if stat.S_ISDIR(metadata.st_mode) and not stat.S_ISLNK(metadata.st_mode):
+                with os.scandir(path) as entries:
+                    stack.extend(Path(entry.path) for entry in entries)
+    except (OSError, RuntimeError) as error:
+        return {}, None, str(error)
+    observed = (
+        datetime.fromtimestamp(maximum, timezone.utc) if maximum is not None else None
+    )
+    return sizes, observed, None
+
+
+def _base_item(kind: str, owner: str, repository: str, path: Path) -> dict[str, Any]:
+    return {
+        "kind": kind,
+        "owner": owner,
+        "repository": repository,
+        "path": str(path),
+        "allocated_bytes": 0,
+        "age_seconds": None,
+        "age_basis": None,
+        "disposition": "protected",
+        "reasons": [],
+        "references": {
+            "profiles": [],
+            "scenarios": [],
+            "topologies": [],
+            "migration": [],
+            "retention": [],
+        },
+    }
+
+
+class Cleanup:
+    """Build and optionally execute a fail-closed workspace cleanup plan."""
+
+    def __init__(self, workspace: Any):
+        self.workspace = workspace
+        self.paths = workspace.paths
+        self.manifest = workspace.manifest
+        self.now = datetime.now(timezone.utc)
+        self._repositories: dict[str, Path] = {}
+        self._wrapper_primary = self.paths.repository
+        self._github_cache: dict[
+            tuple[str, str], tuple[list[dict[str, Any]] | None, str | None]
+        ] = {}
+
+    def execute(
+        self,
+        scopes: list[str],
+        older_than_days: int,
+        names: list[str],
+        apply: bool,
+    ) -> dict[str, Any]:
+        selected_scopes = self._normalize_scopes(scopes)
+        selected_names = self._normalize_names(names)
+        if older_than_days < 0:
+            raise WorkspaceError("--older-than must be zero or greater")
+        if not apply:
+            return self._plan(selected_scopes, older_than_days, selected_names, "dry-run")
+        if not _workspace_owned(self.paths):
+            raise WorkspaceError(
+                f"workspace ownership marker is invalid: {self.paths.marker}"
+            )
+        with exclusive_lock(
+            self.paths.workspace / "repository-layout.lock",
+            "repository layout",
+        ):
+            report = self._plan(selected_scopes, older_than_days, selected_names, "apply")
+            if report["summary"]["error_count"]:
+                report["aborted"] = True
+                return report
+            targets = [
+                item for item in report["items"] if item["disposition"] == "eligible"
+            ]
+            targets.sort(key=self._apply_order)
+            mutated = False
+            completed: set[tuple[str, str]] = set()
+            for target in targets:
+                identity = (target["kind"], target["path"])
+                if identity in completed:
+                    continue
+                fresh = self._plan(
+                    selected_scopes, older_than_days, selected_names, "apply"
+                )
+                match = next(
+                    (
+                        item
+                        for item in fresh["items"]
+                        if item["kind"] == target["kind"]
+                        and item["path"] == target["path"]
+                    ),
+                    None,
+                )
+                if match is None or match["disposition"] != "eligible":
+                    target["disposition"] = "error"
+                    target["reasons"] = ["revalidation_failed"]
+                    if match is not None:
+                        target["revalidation"] = {
+                            "disposition": match["disposition"],
+                            "reasons": match["reasons"],
+                        }
+                    report["aborted"] = True
+                    break
+                for key, value in match.items():
+                    if not key.startswith("_"):
+                        target[key] = value
+                report["mutation_attempted"] = True
+                try:
+                    self._remove(match)
+                except (OSError, WorkspaceError) as error:
+                    target["disposition"] = "error"
+                    target["reasons"] = ["removal_failed"]
+                    target["error"] = str(error)
+                    report["aborted"] = True
+                    break
+                target["disposition"] = "removed"
+                target["reasons"] = ["removed"]
+                mutated = True
+                completed.add(identity)
+                if target["kind"] == "prunable-metadata":
+                    for related in targets:
+                        if (
+                            related["kind"] == "prunable-metadata"
+                            and related["owner"] == target["owner"]
+                        ):
+                            related["disposition"] = "removed"
+                            related["reasons"] = ["removed"]
+                            completed.add((related["kind"], related["path"]))
+            report["mutated"] = mutated
+            report.setdefault("mutation_attempted", False)
+            report["summary"] = self._summary(report["items"])
+            return report
+
+    @staticmethod
+    def _normalize_scopes(scopes: list[str]) -> list[str]:
+        requested = scopes or list(DEFAULT_SCOPES)
+        if "all" in requested:
+            requested = list(ALL_SCOPES)
+        return [scope for scope in ALL_SCOPES if scope in set(requested)]
+
+    def _normalize_names(self, names: list[str]) -> set[str] | None:
+        if not names:
+            return None
+        selected: set[str] = set()
+        unknown: list[str] = []
+        for name in names:
+            if name == "atrinik":
+                selected.add(name)
+            elif name in self.manifest.by_checkout:
+                selected.add(name)
+            elif name in self.manifest.by_name:
+                selected.add(self.manifest.by_name[name].checkout_name)
+            else:
+                unknown.append(name)
+        if unknown:
+            raise WorkspaceError(
+                f"unknown components or checkouts: {', '.join(sorted(set(unknown)))}"
+            )
+        return selected
+
+    def _plan(
+        self,
+        scopes: list[str],
+        older_than_days: int,
+        names: set[str] | None,
+        mode: str,
+    ) -> dict[str, Any]:
+        self.now = datetime.now(timezone.utc)
+        self._repositories = {}
+        self._github_cache = {}
+        references, reference_errors = self._references()
+        items: list[dict[str, Any]] = []
+        registered, registered_error = self._registered_worktree_paths()
+        if registered_error:
+            reference_errors.add("worktree_inventory_error")
+        if "worktrees" in scopes:
+            worktrees, _ = self._worktrees(names, references, reference_errors)
+            items.extend(worktrees)
+            self._resolve_github(worktrees, older_than_days)
+            self._protect_shared_prune_scope(worktrees)
+        removable_worktrees: set[Path] = set()
+        try:
+            removable_worktrees = {
+                Path(item["path"]).resolve(strict=False)
+                for item in items
+                if item["kind"] == "worktree" and item["disposition"] == "eligible"
+            }
+        except (OSError, RuntimeError):
+            reference_errors.add("worktree_inventory_error")
+        if "builds" in scopes:
+            items.extend(
+                self._builds(
+                    older_than_days,
+                    registered,
+                    removable_worktrees,
+                    references,
+                    reference_errors,
+                )
+            )
+            items.extend(self._unmanaged_builds(registered))
+        if "npm-cache" in scopes:
+            cache = self._npm_cache(older_than_days, references, reference_errors)
+            if cache is not None:
+                items.append(cache)
+        items.sort(key=lambda item: (item["kind"], item["owner"], item["path"]))
+        self._credit_sizes(items)
+        for item in items:
+            item.pop("_inodes", None)
+            item.pop("_primary", None)
+            item.pop("_purpose", None)
+        summary = self._summary(items)
+        summary["error_count"] += len(reference_errors)
+        return {
+            "schema_version": CLEANUP_SCHEMA_VERSION,
+            "mode": mode,
+            "scopes": scopes,
+            "older_than_days": older_than_days,
+            "filters": sorted(names or []),
+            "inventory_errors": sorted(reference_errors),
+            "items": items,
+            "summary": summary,
+        }
+
+    def _references(self) -> tuple[dict[str, Any], set[str]]:
+        references: dict[str, Any] = {
+            "profiles": {},
+            "scenarios": {},
+            "topologies": {},
+            "live_builds": {},
+            "migration": {},
+            "retention": {},
+        }
+        errors: set[str] = set()
+        self._profile_references(references, errors)
+        self._scenario_references(references, errors)
+        self._topology_references(references, errors)
+        self._migration_references(references, errors)
+        self._retention_references(references, errors)
+        return references, errors
+
+    def _registered_worktree_paths(self) -> tuple[set[Path], bool]:
+        registered: set[Path] = set()
+        failed = False
+        repositories: list[tuple[str, Path]] = [
+            ("atrinik/atrinik", self.paths.repository)
+        ]
+        for checkout in self.manifest.checkouts:
+            candidate = self.paths.repositories / checkout.path
+            if candidate.exists() or candidate.is_symlink():
+                repositories.append((checkout.repository, candidate))
+        for repository, invocation in repositories:
+            try:
+                records = _worktree_records(invocation)
+                common = _git_common_directory(invocation)
+                primary = None
+                for row in records:
+                    candidate = Path(row.get("worktree", ""))
+                    if not candidate.is_dir() or candidate.is_symlink():
+                        continue
+                    try:
+                        if _git_directory(candidate) == common:
+                            primary = candidate
+                            break
+                    except WorkspaceError:
+                        continue
+                if primary is None or not self._remote_identity(primary, repository):
+                    raise WorkspaceError("repository identity is unproven")
+                if repository == "atrinik/atrinik":
+                    self._wrapper_primary = primary.resolve()
+                registered.update(
+                    Path(row["worktree"]).resolve(strict=False)
+                    for row in records
+                    if "worktree" in row
+                )
+            except (OSError, RuntimeError, WorkspaceError):
+                failed = True
+        return registered, failed
+
+    @staticmethod
+    def _add_reference(container: dict[Path, list[str]], path: Path, name: str) -> None:
+        try:
+            normalized = path.resolve(strict=False)
+        except (OSError, RuntimeError) as error:
+            raise WorkspaceError(f"cannot resolve retained path {path}: {error}") from error
+        container.setdefault(normalized, []).append(name)
+
+    def _profile_references(self, references: dict[str, Any], errors: set[str]) -> None:
+        if not self.paths.profiles.is_dir() or self.paths.profiles.is_symlink():
+            if self.paths.profiles.exists() or self.paths.profiles.is_symlink():
+                errors.add("profile_inventory_error")
+            return
+        for path in sorted(self.paths.profiles.glob("*.json")):
+            try:
+                if path.is_symlink():
+                    raise WorkspaceError("profile is a symlink")
+                profile = self.workspace._load_profile(path.stem, require_file=True)
+                for component_name, selector in profile["components"].items():
+                    if component_name not in self.manifest.by_name or not isinstance(
+                        selector, dict
+                    ):
+                        raise WorkspaceError("profile selector is invalid")
+                    if set(selector) != {"kind", "value"} or not isinstance(
+                        selector.get("value"), str
+                    ):
+                        raise WorkspaceError("profile selector is invalid")
+                    checkout = self.manifest.by_name[component_name].checkout_name
+                    kind = selector.get("kind")
+                    if kind == "worktree":
+                        selected = self.paths.worktrees / checkout / selector["value"]
+                    elif kind == "path":
+                        selected = Path(selector["value"])
+                        if not selected.is_absolute():
+                            raise WorkspaceError("profile path is relative")
+                    elif kind == "migrated-worktree":
+                        selected = Path(selector["value"])
+                        if not selected.is_absolute():
+                            raise WorkspaceError("migrated worktree path is relative")
+                    elif kind == "primary":
+                        continue
+                    else:
+                        raise WorkspaceError("profile selector kind is invalid")
+                    self._add_reference(references["profiles"], selected, path.stem)
+            except (OSError, WorkspaceError):
+                errors.add("profile_inventory_error")
+
+    def _scenario_references(self, references: dict[str, Any], errors: set[str]) -> None:
+        if not self.paths.scenarios.is_dir() or self.paths.scenarios.is_symlink():
+            if self.paths.scenarios.exists() or self.paths.scenarios.is_symlink():
+                errors.add("scenario_inventory_error")
+            return
+        for root in sorted(self.paths.scenarios.iterdir()):
+            if root.name.startswith("."):
+                continue
+            if root.is_symlink():
+                errors.add("scenario_inventory_error")
+                continue
+            if not root.is_dir():
+                continue
+            try:
+                marker = root / MANAGED_MARKER
+                metadata_path = root / "scenario.json"
+                if (
+                    marker.is_symlink()
+                    or load_json(marker)
+                    != {"schema_version": SCHEMA_VERSION, "purpose": "test-scenario"}
+                    or metadata_path.is_symlink()
+                ):
+                    raise WorkspaceError("scenario metadata is a symlink")
+                metadata = load_json(metadata_path)
+                resolved = metadata.get("resolved") if isinstance(metadata, dict) else None
+                if metadata.get("name") != root.name or not isinstance(resolved, dict):
+                    raise WorkspaceError("scenario resolution is invalid")
+                for row in resolved.values():
+                    if (
+                        not isinstance(row, dict)
+                        or not isinstance(row.get("checkout_path"), str)
+                        or not isinstance(row.get("checkout"), str)
+                        or not isinstance(row.get("repository"), str)
+                        or not isinstance(row.get("branch"), str)
+                        or not isinstance(row.get("source"), str)
+                        or not isinstance(row.get("head"), str)
+                        or not HEAD_PATTERN.fullmatch(row["head"])
+                    ):
+                        raise WorkspaceError("scenario checkout path is invalid")
+                    selected = Path(row["checkout_path"])
+                    if not selected.is_absolute():
+                        raise WorkspaceError("scenario checkout path is relative")
+                    self._add_reference(references["scenarios"], selected, root.name)
+            except (OSError, WorkspaceError):
+                errors.add("scenario_inventory_error")
+
+    def _topology_references(self, references: dict[str, Any], errors: set[str]) -> None:
+        if not self.paths.topologies.is_dir() or self.paths.topologies.is_symlink():
+            if self.paths.topologies.exists() or self.paths.topologies.is_symlink():
+                errors.add("topology_inventory_error")
+            return
+        for root in sorted(self.paths.topologies.iterdir()):
+            status_path = root / "status.json"
+            if not status_path.exists() and not status_path.is_symlink():
+                continue
+            try:
+                marker = root / MANAGED_MARKER
+                if (
+                    root.is_symlink()
+                    or not root.is_dir()
+                    or marker.is_symlink()
+                    or load_json(marker)
+                    != {
+                        "schema_version": SCHEMA_VERSION,
+                        "purpose": f"topology:{root.name}",
+                    }
+                    or status_path.is_symlink()
+                ):
+                    raise WorkspaceError("topology path is invalid")
+                status_value = load_json(status_path)
+                if not isinstance(status_value, dict):
+                    raise WorkspaceError("topology status is invalid")
+                process_records: list[Any] = [status_value.get("supervisor")]
+                services = status_value.get("services")
+                if not isinstance(services, dict):
+                    raise WorkspaceError("topology service status is invalid")
+                process_records.extend(services.values())
+                live = False
+                for record in process_records:
+                    if not isinstance(record, dict):
+                        raise WorkspaceError("topology process status is invalid")
+                    pid, start_time = record.get("pid"), record.get("start_time")
+                    if (
+                        not isinstance(pid, int)
+                        or isinstance(pid, bool)
+                        or not isinstance(start_time, str)
+                    ):
+                        raise WorkspaceError("topology process identity is invalid")
+                    live = live or process_matches(pid, start_time)
+                if not live:
+                    continue
+                build_root = status_value.get("build_root")
+                resolved = status_value.get("resolved")
+                if not isinstance(build_root, str) or not Path(build_root).is_absolute():
+                    raise WorkspaceError("topology build root is invalid")
+                self._add_reference(references["live_builds"], Path(build_root), root.name)
+                if not isinstance(resolved, dict):
+                    raise WorkspaceError("topology resolution is invalid")
+                for row in resolved.values():
+                    if not isinstance(row, dict) or not isinstance(
+                        row.get("checkout_path"), str
+                    ):
+                        raise WorkspaceError("topology checkout path is invalid")
+                    selected = Path(row["checkout_path"])
+                    if not selected.is_absolute():
+                        raise WorkspaceError("topology checkout path is relative")
+                    self._add_reference(references["topologies"], selected, root.name)
+            except (OSError, WorkspaceError):
+                errors.add("topology_inventory_error")
+
+    def _migration_references(self, references: dict[str, Any], errors: set[str]) -> None:
+        for relative in (MIGRATION_RECORD, MIGRATION_PENDING):
+            path = self.paths.workspace / relative
+            if not path.exists() and not path.is_symlink():
+                continue
+            try:
+                if path.is_symlink():
+                    raise WorkspaceError("migration record is a symlink")
+                value = load_json(path)
+                if not isinstance(value, dict):
+                    raise WorkspaceError("migration record is invalid")
+                found = False
+                for label, candidate in self._migration_paths(value):
+                    found = True
+                    self._add_reference(references["migration"], candidate, label)
+                if not found:
+                    raise WorkspaceError("migration record contains no paths")
+            except (OSError, WorkspaceError):
+                errors.add("migration_inventory_error")
+
+    @staticmethod
+    def _migration_paths(value: dict[str, Any]) -> Iterable[tuple[str, Path]]:
+        sections = (
+            ("sources", ("source", "archive", "path")),
+            ("worktree_migrations", ("path", "destination")),
+            ("composite_worktrees", ("destination",)),
+            ("worktrees", ("destination",)),
+        )
+        for section, keys in sections:
+            rows = value.get(section, [])
+            if not isinstance(rows, list):
+                raise WorkspaceError(f"migration {section} is not a list")
+            for index, row in enumerate(rows):
+                if not isinstance(row, dict):
+                    raise WorkspaceError(f"migration {section}[{index}] is invalid")
+                for key in keys:
+                    raw = row.get(key)
+                    if raw is None:
+                        continue
+                    if not isinstance(raw, str) or not Path(raw).is_absolute():
+                        raise WorkspaceError(
+                            f"migration {section}[{index}].{key} is invalid"
+                        )
+                    if raw:
+                        yield f"{section}[{index}].{key}", Path(raw)
+        classic = value.get("classic")
+        if isinstance(classic, str) and Path(classic).is_absolute():
+            yield "classic", Path(classic)
+        elif isinstance(classic, dict):
+            raw = classic.get("path")
+            if isinstance(raw, str) and Path(raw).is_absolute():
+                yield "classic.path", Path(raw)
+            elif raw is not None:
+                raise WorkspaceError("migration classic.path is invalid")
+        elif classic is not None:
+            raise WorkspaceError("migration classic path is invalid")
+
+    def _retention_references(self, references: dict[str, Any], errors: set[str]) -> None:
+        path = self.paths.builds / BUILD_RETENTION_RECORD
+        if not path.exists() and not path.is_symlink():
+            return
+        try:
+            if path.is_symlink():
+                raise WorkspaceError("build retention record is a symlink")
+            value = load_json(path)
+            if not isinstance(value, dict) or set(value) != {
+                "schema_version", "build_roots"
+            } or value.get("schema_version") != CLEANUP_SCHEMA_VERSION or not isinstance(
+                value.get("build_roots"), list
+            ):
+                raise WorkspaceError("build retention record is invalid")
+            for index, raw in enumerate(value["build_roots"]):
+                if not isinstance(raw, str) or not Path(raw).is_absolute():
+                    raise WorkspaceError("retained build root is invalid")
+                self._add_reference(references["retention"], Path(raw), str(index))
+            if len(value["build_roots"]) != len(set(value["build_roots"])):
+                raise WorkspaceError("retained build roots must be unique")
+        except (OSError, WorkspaceError):
+            errors.add("retention_inventory_error")
+
+    def _worktrees(
+        self,
+        names: set[str] | None,
+        references: dict[str, Any],
+        reference_errors: set[str],
+    ) -> tuple[list[dict[str, Any]], set[Path]]:
+        items: list[dict[str, Any]] = []
+        registered: set[Path] = set()
+        repositories: list[tuple[str, str, str, Path, bool]] = []
+        if names is None or "atrinik" in names:
+            repositories.append(
+                ("atrinik", "atrinik/atrinik", "main", self.paths.repository, True)
+            )
+        for checkout in self.manifest.checkouts:
+            if names is not None and checkout.name not in names:
+                continue
+            primary = self.paths.repositories / checkout.path
+            if primary.exists() or primary.is_symlink():
+                repositories.append(
+                    (checkout.name, checkout.repository, checkout.branch, primary, False)
+                )
+        for owner, repository, base, invocation, wrapper in repositories:
+            try:
+                common = _git_common_directory(invocation)
+                records = _worktree_records(invocation)
+                primary = None
+                for row in records:
+                    candidate = Path(row.get("worktree", ""))
+                    if not candidate.is_dir() or candidate.is_symlink():
+                        continue
+                    try:
+                        if _git_directory(candidate) == common:
+                            primary = candidate.resolve()
+                            break
+                    except WorkspaceError:
+                        continue
+                if primary is None or not self._remote_identity(primary, repository):
+                    raise WorkspaceError("repository identity is unproven")
+                self._repositories[owner] = primary
+                allowed = (
+                    [
+                        self.paths.worktrees / "atrinik",
+                        primary / "build" / "worktrees",
+                    ]
+                    if wrapper
+                    else [self.paths.worktrees / owner]
+                )
+                for row in records:
+                    if "worktree" not in row:
+                        continue
+                    path = Path(row["worktree"])
+                    normalized = path.resolve(strict=False)
+                    registered.add(normalized)
+                    item = self._worktree_item(
+                        owner,
+                        repository,
+                        base,
+                        primary,
+                        common,
+                        allowed,
+                        row,
+                        references,
+                        reference_errors,
+                    )
+                    items.append(item)
+            except (OSError, RuntimeError, WorkspaceError) as error:
+                item = _base_item("worktree", owner, repository, invocation)
+                item["disposition"] = "error"
+                item["reasons"] = ["repository_inventory_error"]
+                item["error"] = str(error)
+                items.append(item)
+        return items, registered
+
+    @staticmethod
+    def _remote_identity(path: Path, repository: str) -> bool:
+        for remote in ("origin", "upstream"):
+            try:
+                urls = _command(path, "remote", "get-url", "--all", remote).splitlines()
+            except WorkspaceError:
+                continue
+            if urls and _remote_matches(urls[0], repository):
+                return True
+        return False
+
+    def _worktree_item(
+        self,
+        owner: str,
+        repository: str,
+        base: str,
+        primary: Path,
+        common: Path,
+        allowed: list[Path],
+        record: dict[str, str],
+        references: dict[str, Any],
+        reference_errors: set[str],
+    ) -> dict[str, Any]:
+        path = Path(record["worktree"])
+        normalized = path.resolve(strict=False)
+        prunable = "prunable" in record and not path.exists()
+        item = _base_item(
+            "prunable-metadata" if prunable else "worktree",
+            owner,
+            repository,
+            path,
+        )
+        item.update(
+            {
+                "branch": record.get("branch", "").removeprefix("refs/heads/") or None,
+                "head": record.get("HEAD"),
+                "base_branch": base,
+                "ignored_bytes": 0,
+                "ignored_paths": 0,
+                "merged_pr": None,
+                "_primary": str(primary),
+            }
+        )
+        if not isinstance(item["head"], str) or not HEAD_PATTERN.fullmatch(item["head"]):
+            item["reasons"].append("invalid_worktree_head")
+        if "branch" not in record:
+            item["reasons"].append("detached_head")
+        if "locked" in record:
+            item["reasons"].append("locked_worktree")
+        owned = any(normalized.parent == root.resolve(strict=False) for root in allowed)
+        if not owned:
+            item["reasons"].append("external_path")
+        reference_reasons = {
+            "profiles": "profile_reference",
+            "scenarios": "scenario_reference",
+            "topologies": "topology_reference",
+            "migration": "migration_reference",
+        }
+        for category, reference_reason in reference_reasons.items():
+            values = references[category].get(normalized, [])
+            if values:
+                item["references"][category] = sorted(set(values))
+                item["reasons"].append(reference_reason)
+        item["reasons"].extend(sorted(reference_errors))
+        if prunable:
+            item["reasons"].append("prunable_metadata")
+            if item["reasons"] == ["prunable_metadata"]:
+                item["disposition"] = "skipped"
+                item["reasons"] = ["github_pending"]
+            return item
+        inodes, _, walk_error = _tree_usage(path)
+        item["_inodes"] = inodes
+        if walk_error:
+            item["reasons"].append("filesystem_traversal_error")
+            item["error"] = walk_error
+        if path.is_symlink():
+            item["reasons"].append("symlinked_worktree")
+        if normalized == primary.resolve():
+            item["reasons"].append("primary_checkout")
+        if not path.is_dir():
+            item["reasons"].append("missing_worktree")
+            return item
+        try:
+            if _git_common_directory(path) != common:
+                item["reasons"].append("unexpected_git_common_directory")
+            if _git_directory(path) == common and normalized != primary.resolve():
+                item["reasons"].append("unexpected_primary_identity")
+            if self._operation_in_progress(path):
+                item["reasons"].append("git_operation_in_progress")
+            status_value = _command(
+                path, "status", "--porcelain=v1", "--untracked-files=all"
+            )
+            if status_value:
+                item["reasons"].append("dirty_worktree")
+            ignored = _command(
+                path,
+                "ls-files",
+                "--others",
+                "--ignored",
+                "--exclude-standard",
+                "-z",
+            )
+            ignored_paths = [value for value in ignored.split("\0") if value]
+            ignored_sizes: dict[tuple[int, int], int] = {}
+            for raw in ignored_paths:
+                candidate = path / raw
+                sizes, _, _ = _tree_usage(candidate)
+                ignored_sizes.update(sizes)
+            item["ignored_paths"] = len(ignored_paths)
+            item["ignored_bytes"] = sum(ignored_sizes.values())
+        except WorkspaceError as error:
+            item["reasons"].append("git_inspection_error")
+            item["error"] = str(error)
+        if not item["reasons"]:
+            item["disposition"] = "skipped"
+            item["reasons"] = ["github_pending"]
+        return item
+
+    @staticmethod
+    def _operation_in_progress(path: Path) -> bool:
+        for name in OPERATION_PATHS:
+            operation_path = Path(_command(path, "rev-parse", "--git-path", name))
+            if not operation_path.is_absolute():
+                operation_path = path / operation_path
+            if operation_path.exists() or operation_path.is_symlink():
+                return True
+        return False
+
+    def _resolve_github(self, items: list[dict[str, Any]], older_than_days: int) -> None:
+        pending = [
+            item
+            for item in items
+            if item["kind"] in {"worktree", "prunable-metadata"}
+            and item["disposition"] == "skipped"
+            and item["reasons"] == ["github_pending"]
+        ]
+        keys = sorted({(item["repository"], item["head"]) for item in pending})
+        with ThreadPoolExecutor(max_workers=min(8, max(1, len(keys)))) as executor:
+            futures = {
+                executor.submit(self._github_pulls, repository, head): (repository, head)
+                for repository, head in keys
+            }
+            for future in as_completed(futures):
+                key = futures[future]
+                try:
+                    self._github_cache[key] = (future.result(), None)
+                except WorkspaceError as error:
+                    self._github_cache[key] = (None, str(error))
+        cutoff = older_than_days * 86400
+        for item in pending:
+            pulls, error = self._github_cache[(item["repository"], item["head"])]
+            item["disposition"] = "protected"
+            item["reasons"] = []
+            if error is not None or pulls is None:
+                item["reasons"] = ["github_unavailable"]
+                item["github_error"] = error
+                continue
+            reason, evidence, merged_at = self._pull_evidence(
+                pulls, item["head"], item["base_branch"]
+            )
+            if reason is not None:
+                item["reasons"] = [reason]
+                continue
+            assert evidence is not None and merged_at is not None
+            age = max(0, int((self.now - merged_at).total_seconds()))
+            item["age_seconds"] = age
+            item["age_basis"] = "pr-merge-time"
+            item["merged_pr"] = evidence
+            if merged_at > self.now:
+                item["reasons"] = ["future_merge_time"]
+            elif age < cutoff:
+                item["reasons"] = ["younger_than_grace_period"]
+            else:
+                item["disposition"] = "eligible"
+                item["reasons"] = ["merged_pr_head"]
+                if item["kind"] == "prunable-metadata":
+                    item["reasons"].append("prunable_metadata")
+
+    @staticmethod
+    def _protect_shared_prune_scope(items: list[dict[str, Any]]) -> None:
+        owners = {
+            item["owner"]
+            for item in items
+            if item["kind"] == "prunable-metadata"
+            and item["disposition"] != "eligible"
+        }
+        for item in items:
+            if (
+                item["kind"] == "prunable-metadata"
+                and item["owner"] in owners
+                and item["disposition"] == "eligible"
+            ):
+                item["disposition"] = "protected"
+                item["reasons"] = ["shared_prune_scope_protected"]
+
+    @staticmethod
+    def _github_pulls(repository: str, head: str) -> list[dict[str, Any]]:
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{repository}/commits/{head}/pulls?per_page=100",
+                    "--header",
+                    "Accept: application/vnd.github+json",
+                    "--paginate",
+                    "--jq",
+                    ".[] | {number,state,merged_at,head:{sha:.head.sha},"
+                    "base:{ref:.base.ref},html_url}",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except FileNotFoundError as error:
+            raise WorkspaceError("required command not found: gh") from error
+        except subprocess.CalledProcessError as error:
+            detail = error.stderr.strip()
+            raise WorkspaceError(detail or "GitHub pull request query failed") from error
+        except subprocess.TimeoutExpired as error:
+            raise WorkspaceError("GitHub pull request query timed out") from error
+        pulls: list[dict[str, Any]] = []
+        try:
+            for line in result.stdout.splitlines():
+                row = json.loads(line)
+                if not isinstance(row, dict):
+                    raise WorkspaceError(
+                        "GitHub pull request response has an invalid shape"
+                    )
+                pulls.append(row)
+        except json.JSONDecodeError as error:
+            raise WorkspaceError("GitHub pull request response is not JSON") from error
+        return pulls
+
+    @staticmethod
+    def _pull_evidence(
+        pulls: list[dict[str, Any]], head: str, base: str
+    ) -> tuple[str | None, dict[str, Any] | None, datetime | None]:
+        if not pulls:
+            return "no_associated_pr", None, None
+        if not all(Cleanup._valid_pull_record(row) for row in pulls):
+            return "invalid_pull_request_evidence", None, None
+        if any(row.get("state") == "open" for row in pulls):
+            return "open_pull_request", None, None
+        if any(not row.get("merged_at") for row in pulls):
+            return "closed_unmerged_pr", None, None
+        if len(pulls) != 1:
+            return "ambiguous_pull_requests", None, None
+        merged = pulls
+        exact_head = [
+            row
+            for row in merged
+            if isinstance(row.get("head"), dict) and row["head"].get("sha") == head
+        ]
+        if not exact_head:
+            return "pr_head_mismatch", None, None
+        exact_base = [
+            row
+            for row in exact_head
+            if isinstance(row.get("base"), dict) and row["base"].get("ref") == base
+        ]
+        if not exact_base:
+            return "wrong_base_branch", None, None
+        if len(exact_base) != 1:
+            return "ambiguous_pull_requests", None, None
+        row = exact_base[0]
+        try:
+            merged_at = _parse_time(row.get("merged_at"), "PR merge time")
+        except WorkspaceError:
+            return "invalid_pull_request_evidence", None, None
+        number = row.get("number")
+        url = row.get("html_url")
+        if not isinstance(number, int) or isinstance(number, bool) or not isinstance(url, str):
+            return "invalid_pull_request_evidence", None, None
+        return (
+            None,
+            {
+                "number": number,
+                "url": url,
+                "base": base,
+                "head": head,
+                "merged_at": merged_at.isoformat(),
+            },
+            merged_at,
+        )
+
+    @staticmethod
+    def _valid_pull_record(row: dict[str, Any]) -> bool:
+        head = row.get("head")
+        base = row.get("base")
+        merged_at = row.get("merged_at")
+        state_value = row.get("state")
+        return (
+            set(row) == {"number", "state", "html_url", "merged_at", "head", "base"}
+            and isinstance(row.get("number"), int)
+            and not isinstance(row.get("number"), bool)
+            and isinstance(row.get("html_url"), str)
+            and bool(row["html_url"])
+            and state_value in {"open", "closed"}
+            and (merged_at is None or isinstance(merged_at, str) and bool(merged_at))
+            and not (state_value == "open" and merged_at is not None)
+            and isinstance(head, dict)
+            and set(head) == {"sha"}
+            and isinstance(head.get("sha"), str)
+            and bool(HEAD_PATTERN.fullmatch(head["sha"]))
+            and isinstance(base, dict)
+            and set(base) == {"ref"}
+            and isinstance(base.get("ref"), str)
+            and bool(base["ref"])
+        )
+
+    def _builds(
+        self,
+        older_than_days: int,
+        registered: set[Path],
+        removable_worktrees: set[Path],
+        references: dict[str, Any],
+        reference_errors: set[str],
+    ) -> list[dict[str, Any]]:
+        profiles = self.paths.builds / "profiles"
+        if not profiles.is_dir() or profiles.is_symlink():
+            if profiles.exists() or profiles.is_symlink():
+                item = _base_item(
+                    "unmanaged-build", "atrinik", "atrinik/atrinik", profiles
+                )
+                item["reasons"] = ["invalid_profiles_container"]
+                inodes, _, error = _tree_usage(profiles)
+                item["_inodes"] = inodes
+                if error:
+                    item["error"] = error
+                return [item]
+            return []
+        return [
+            self._build_item(
+                path,
+                older_than_days,
+                registered,
+                removable_worktrees,
+                references,
+                reference_errors,
+            )
+            for path in sorted(profiles.iterdir())
+        ]
+
+    def _build_item(
+        self,
+        path: Path,
+        older_than_days: int,
+        registered: set[Path],
+        removable_worktrees: set[Path],
+        references: dict[str, Any],
+        reference_errors: set[str],
+    ) -> dict[str, Any]:
+        item = _base_item("profile-build", "atrinik", "atrinik/atrinik", path)
+        inodes, observed, walk_error = _tree_usage(path)
+        item["_inodes"] = inodes
+        if walk_error:
+            item["reasons"].append("filesystem_traversal_error")
+            item["error"] = walk_error
+        try:
+            purpose, profile, key = self._profile_marker(path)
+            item["profile"] = profile
+            item["key"] = key
+            item["_purpose"] = purpose
+        except (OSError, WorkspaceError) as error:
+            item["kind"] = "unmanaged-build"
+            item["reasons"].append("invalid_managed_marker")
+            item["error"] = str(error)
+            return item
+        normalized = path.resolve(strict=False)
+        for category, reason in (
+            ("live_builds", "live_topology"),
+            ("retention", "retention_reference"),
+        ):
+            values = references[category].get(normalized, [])
+            if values:
+                target = "topologies" if category == "live_builds" else "retention"
+                item["references"][target] = sorted(set(values))
+                item["reasons"].append(reason)
+        item["reasons"].extend(sorted(reference_errors))
+        if any(_path_relation(normalized, worktree) for worktree in registered):
+            item["reasons"].append("contains_registered_worktree")
+        busy, lock_error = self._build_lock_busy(item["profile"], item["key"])
+        if lock_error:
+            item["reasons"].append("build_lock_error")
+            item["error"] = lock_error
+        elif busy:
+            item["reasons"].append("build_lock_busy")
+        source_removal = False
+        metadata_path = path / BUILD_METADATA
+        if metadata_path.exists() or metadata_path.is_symlink():
+            try:
+                metadata = self._load_build_metadata(metadata_path, item)
+                used_at = _parse_time(metadata["last_used_at"], "build last_used_at")
+                item["age_basis"] = "last-used-at"
+                try:
+                    source_removal = any(
+                        Path(row["checkout_path"]).resolve(strict=False)
+                        in removable_worktrees
+                        for row in metadata["coordinates"].values()
+                    )
+                except RuntimeError as error:
+                    raise WorkspaceError(
+                        "build source worktree path cannot be resolved"
+                    ) from error
+                item["source_worktree_removal"] = source_removal
+            except (OSError, WorkspaceError) as error:
+                item["reasons"].append("invalid_build_metadata")
+                item["error"] = str(error)
+                used_at = None
+        else:
+            used_at = observed
+            item["age_basis"] = "legacy-tree-mtime"
+            item["source_worktree_removal"] = False
+        if used_at is None:
+            item["reasons"].append("build_age_unavailable")
+        else:
+            age = max(0, int((self.now - used_at).total_seconds()))
+            item["age_seconds"] = age
+            if used_at > self.now:
+                item["reasons"].append("future_last_used")
+            elif not source_removal and age < older_than_days * 86400:
+                item["reasons"].append("younger_than_grace_period")
+        item["reasons"] = sorted(set(item["reasons"]))
+        if not item["reasons"]:
+            item["disposition"] = "eligible"
+            item["reasons"] = [
+                "source_worktree_removal" if source_removal else "stale_profile_build"
+            ]
+        return item
+
+    @staticmethod
+    def _profile_marker(path: Path) -> tuple[str, str, str]:
+        if path.is_symlink() or not path.is_dir():
+            raise WorkspaceError("profile build is not a regular directory")
+        marker = path / MANAGED_MARKER
+        if not marker.is_file() or marker.is_symlink():
+            raise WorkspaceError("profile build marker is missing or invalid")
+        value = load_json(marker)
+        if not isinstance(value, dict) or set(value) != {"schema_version", "purpose"}:
+            raise WorkspaceError("profile build marker shape is invalid")
+        purpose = value.get("purpose")
+        match = PROFILE_PURPOSE.fullmatch(purpose) if isinstance(purpose, str) else None
+        if value.get("schema_version") != SCHEMA_VERSION or match is None:
+            raise WorkspaceError("profile build marker purpose is invalid")
+        profile, key = match.group("profile"), match.group("key")
+        if path.name != f"{profile}-{key}":
+            raise WorkspaceError("profile build marker does not match its path")
+        return purpose, profile, key
+
+    @staticmethod
+    def _load_build_metadata(path: Path, item: dict[str, Any]) -> dict[str, Any]:
+        if path.is_symlink() or not path.is_file():
+            raise WorkspaceError("build metadata is not a regular file")
+        value = load_json(path)
+        if not isinstance(value, dict) or set(value) != BUILD_METADATA_KEYS:
+            raise WorkspaceError("build metadata fields are invalid")
+        if (
+            value.get("schema_version") != BUILD_METADATA_SCHEMA_VERSION
+            or value.get("profile") != item["profile"]
+            or value.get("key") != item["key"]
+            or value.get("purpose") != item["_purpose"]
+            or not isinstance(value.get("coordinates"), dict)
+            or not value["coordinates"]
+        ):
+            raise WorkspaceError("build metadata identity is invalid")
+        for role, row in value["coordinates"].items():
+            if (
+                not isinstance(role, str)
+                or not isinstance(row, dict)
+                or set(row) != BUILD_COORDINATE_KEYS
+                or not all(isinstance(raw, str) and raw for raw in row.values())
+                or not Path(row["checkout_path"]).is_absolute()
+                or not Path(row["source_path"]).is_absolute()
+                or not HEAD_PATTERN.fullmatch(row["head"])
+            ):
+                raise WorkspaceError("build coordinate metadata is invalid")
+            validate_name(role, "build coordinate role")
+            validate_name(row["component"], "build coordinate component")
+            validate_name(row["checkout"], "build coordinate checkout")
+            if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", row["repository"]):
+                raise WorkspaceError("build coordinate repository is invalid")
+            if any(character in row["branch"] for character in "\0\r\n"):
+                raise WorkspaceError("build coordinate branch is invalid")
+            source = PurePosixPath(row["source"])
+            if (
+                source.is_absolute()
+                or any(part in {"", ".."} for part in source.parts)
+                or row["source"] != "." and ":" in row["source"]
+            ):
+                raise WorkspaceError("build coordinate source is invalid")
+            try:
+                checkout_path = Path(row["checkout_path"]).resolve(strict=False)
+                expected_source = (
+                    checkout_path
+                    if row["source"] == "."
+                    else checkout_path.joinpath(*source.parts).resolve(strict=False)
+                )
+                if Path(row["source_path"]).resolve(strict=False) != expected_source:
+                    raise WorkspaceError("build coordinate source path is invalid")
+            except RuntimeError as error:
+                raise WorkspaceError("build coordinate path cannot be resolved") from error
+        return value
+
+    def _build_lock_busy(self, profile: str, key: str) -> tuple[bool, str | None]:
+        return self._lock_busy(self.paths.builds / "locks" / f"{profile}-{key}.lock")
+
+    @staticmethod
+    def _lock_busy(path: Path) -> tuple[bool, str | None]:
+        if not path.exists() and not path.is_symlink():
+            return False, None
+        flags = os.O_RDWR | os.O_CLOEXEC
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        try:
+            descriptor = os.open(path, flags)
+            if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+                os.close(descriptor)
+                return False, f"lock is not a regular file: {path}"
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                os.close(descriptor)
+                return True, None
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+            os.close(descriptor)
+            return False, None
+        except OSError as error:
+            return False, str(error)
+
+    def _unmanaged_builds(self, registered: set[Path]) -> list[dict[str, Any]]:
+        items: list[dict[str, Any]] = []
+        roots: list[tuple[Path, list[Path]]] = []
+        top = self._wrapper_primary / "build"
+        if top.is_dir() and not top.is_symlink():
+            for path in sorted(top.iterdir()):
+                try:
+                    if path.resolve(strict=False) in registered:
+                        continue
+                except (OSError, RuntimeError):
+                    roots.append((path, []))
+                    continue
+                roots.append(
+                    (
+                        path,
+                        [
+                            candidate
+                            for candidate in registered
+                            if _path_relation(path, candidate)
+                        ],
+                    )
+                )
+        elif top.exists() or top.is_symlink():
+            roots.append((top, []))
+        if self.paths.builds.is_dir() and not self.paths.builds.is_symlink():
+            for path in sorted(self.paths.builds.iterdir()):
+                if path.name in {"profiles", "npm-cache"}:
+                    continue
+                roots.append((path, []))
+        for path, excluded in roots:
+            item = _base_item("unmanaged-build", "atrinik", "atrinik/atrinik", path)
+            inodes, observed, error = _tree_usage(path, excluded)
+            item["_inodes"] = inodes
+            item["age_basis"] = "tree-mtime" if observed else None
+            item["age_seconds"] = (
+                max(0, int((self.now - observed).total_seconds())) if observed else None
+            )
+            item["reasons"] = ["unmanaged_build"]
+            if error:
+                item["reasons"].append("filesystem_traversal_error")
+                item["error"] = error
+            items.append(item)
+        return items
+
+    def _npm_cache(
+        self,
+        older_than_days: int,
+        references: dict[str, Any],
+        reference_errors: set[str],
+    ) -> dict[str, Any] | None:
+        path = self.paths.builds / "npm-cache"
+        if not path.exists() and not path.is_symlink():
+            return None
+        item = _base_item("npm-cache", "atrinik", "atrinik/atrinik", path)
+        item["_purpose"] = "npm-cache"
+        inodes, observed, walk_error = _tree_usage(path)
+        item["_inodes"] = inodes
+        if walk_error:
+            item["reasons"].append("filesystem_traversal_error")
+            item["error"] = walk_error
+        if not _workspace_owned(self.paths):
+            item["reasons"].append("invalid_workspace_marker")
+        try:
+            valid_path = (
+                not path.is_symlink()
+                and path.is_dir()
+                and path.resolve(strict=False)
+                == self.paths.builds.resolve(strict=False) / "npm-cache"
+            )
+        except (OSError, RuntimeError):
+            valid_path = False
+        if not valid_path:
+            item["reasons"].append("invalid_cache_path")
+        marker = path / MANAGED_MARKER
+        legacy = not marker.exists() and not marker.is_symlink()
+        if not legacy:
+            try:
+                if marker.is_symlink() or load_json(marker) != {
+                    "schema_version": SCHEMA_VERSION,
+                    "purpose": "npm-cache",
+                }:
+                    raise WorkspaceError("npm cache marker is invalid")
+            except WorkspaceError as error:
+                item["reasons"].append("invalid_managed_marker")
+                item["error"] = str(error)
+        item["legacy_known_cache"] = legacy
+        busy, lock_error = self._any_build_lock_busy()
+        if lock_error:
+            item["reasons"].append("build_lock_error")
+            item["error"] = lock_error
+        elif busy:
+            item["reasons"].append("active_build")
+        item["reasons"].extend(sorted(reference_errors))
+        metadata_path = path / CACHE_METADATA
+        if metadata_path.exists() or metadata_path.is_symlink():
+            try:
+                if metadata_path.is_symlink() or not metadata_path.is_file():
+                    raise WorkspaceError("cache metadata is not a regular file")
+                metadata = load_json(metadata_path)
+                if (
+                    not isinstance(metadata, dict)
+                    or set(metadata) != {"schema_version", "purpose", "last_used_at"}
+                    or metadata.get("schema_version") != BUILD_METADATA_SCHEMA_VERSION
+                    or metadata.get("purpose") != "npm-cache"
+                ):
+                    raise WorkspaceError("cache metadata fields are invalid")
+                used_at = _parse_time(metadata["last_used_at"], "cache last_used_at")
+                item["age_basis"] = "last-used-at"
+            except (OSError, WorkspaceError) as error:
+                item["reasons"].append("invalid_cache_metadata")
+                item["error"] = str(error)
+                used_at = None
+        else:
+            used_at = observed
+            item["age_basis"] = "legacy-tree-mtime"
+        if used_at is None:
+            item["reasons"].append("cache_age_unavailable")
+        else:
+            age = max(0, int((self.now - used_at).total_seconds()))
+            item["age_seconds"] = age
+            if used_at > self.now:
+                item["reasons"].append("future_last_used")
+            elif age < older_than_days * 86400:
+                item["reasons"].append("younger_than_grace_period")
+        item["reasons"] = sorted(set(item["reasons"]))
+        if not item["reasons"]:
+            item["disposition"] = "eligible"
+            item["reasons"] = ["stale_npm_cache"]
+        return item
+
+    def _any_build_lock_busy(self) -> tuple[bool, str | None]:
+        locks = self.paths.builds / "locks"
+        if not locks.exists() and not locks.is_symlink():
+            return False, None
+        if locks.is_symlink() or not locks.is_dir():
+            return False, f"build lock directory is invalid: {locks}"
+        for path in sorted(locks.iterdir()):
+            busy, error = self._lock_busy(path)
+            if error or busy:
+                return busy, error
+        return False, None
+
+    @staticmethod
+    def _credit_sizes(items: list[dict[str, Any]]) -> None:
+        claimed: set[tuple[int, int]] = set()
+        for item in items:
+            inodes = item.get("_inodes", {})
+            item["allocated_bytes"] = sum(
+                size for inode, size in inodes.items() if inode not in claimed
+            )
+            claimed.update(inodes)
+
+    @staticmethod
+    def _summary(items: list[dict[str, Any]]) -> dict[str, int]:
+        summary = {
+            "item_count": len(items),
+            "candidate_count": 0,
+            "candidate_bytes": 0,
+            "protected_count": 0,
+            "protected_bytes": 0,
+            "skipped_count": 0,
+            "skipped_bytes": 0,
+            "removed_count": 0,
+            "removed_bytes": 0,
+            "error_count": 0,
+            "error_bytes": 0,
+        }
+        for item in items:
+            disposition = item["disposition"]
+            prefix = "candidate" if disposition == "eligible" else disposition
+            summary[f"{prefix}_count"] += 1
+            summary[f"{prefix}_bytes"] += item["allocated_bytes"]
+        return summary
+
+    @staticmethod
+    def _apply_order(item: dict[str, Any]) -> tuple[int, str]:
+        order = {
+            "profile-build": 0,
+            "worktree": 1,
+            "npm-cache": 2,
+            "prunable-metadata": 3,
+        }
+        return order.get(item["kind"], 99), item["path"]
+
+    def _remove(self, item: dict[str, Any]) -> None:
+        path = Path(item["path"])
+        if item["kind"] == "profile-build":
+            lock = self.paths.builds / "locks" / f"{item['profile']}-{item['key']}.lock"
+            with exclusive_lock(
+                lock,
+                f"profile build {item['profile']}",
+                nonblocking=True,
+            ):
+                managed_remove(
+                    path,
+                    self.paths.builds,
+                    f"profile:{item['profile']}:{item['key']}",
+                )
+        elif item["kind"] == "worktree":
+            primary = self._repositories[item["owner"]]
+            _command(primary, "worktree", "remove", "--", str(path))
+        elif item["kind"] == "npm-cache":
+            if item.get("legacy_known_cache"):
+                marker = path / MANAGED_MARKER
+                if marker.exists() or marker.is_symlink():
+                    raise WorkspaceError("legacy npm cache marker appeared before removal")
+                atomic_json(
+                    marker,
+                    {"schema_version": SCHEMA_VERSION, "purpose": "npm-cache"},
+                )
+            managed_remove(path, self.paths.builds, "npm-cache")
+        elif item["kind"] == "prunable-metadata":
+            primary = self._repositories[item["owner"]]
+            _command(primary, "worktree", "prune", "--expire", "now")
+        else:
+            raise WorkspaceError(f"unsupported cleanup target: {item['kind']}")

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -19,7 +19,6 @@ from .model import (
     atomic_json,
     load_json,
     managed_remove,
-    validate_name,
 )
 from .supervisor import process_matches
 from .workspace import (
@@ -1351,9 +1350,6 @@ class Cleanup:
                 or not HEAD_PATTERN.fullmatch(row["head"])
             ):
                 raise WorkspaceError("build coordinate metadata is invalid")
-            validate_name(role, "build coordinate role")
-            validate_name(row["component"], "build coordinate component")
-            validate_name(row["checkout"], "build coordinate checkout")
             component = self.manifest.by_name.get(row["component"])
             if (
                 component is None
@@ -1364,17 +1360,7 @@ class Cleanup:
                 or row["source"] != component.source
             ):
                 raise WorkspaceError("build coordinate manifest identity is invalid")
-            if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", row["repository"]):
-                raise WorkspaceError("build coordinate repository is invalid")
-            if any(character in row["branch"] for character in "\0\r\n"):
-                raise WorkspaceError("build coordinate branch is invalid")
             source = PurePosixPath(row["source"])
-            if (
-                source.is_absolute()
-                or any(part in {"", ".."} for part in source.parts)
-                or row["source"] != "." and ":" in row["source"]
-            ):
-                raise WorkspaceError("build coordinate source is invalid")
             try:
                 checkout_path = Path(row["checkout_path"]).resolve(strict=False)
                 expected_source = (

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -103,6 +103,26 @@ def parser() -> argparse.ArgumentParser:
     worktree_list.add_argument("components", nargs="*")
     worktree_list.add_argument("--json", action="store_true")
 
+    cleanup = commands.add_parser(
+        "cleanup", help="preview or reclaim stale workspace data"
+    )
+    cleanup.add_argument(
+        "components",
+        nargs="*",
+        help="limit worktrees to repeated checkout/component identities",
+    )
+    cleanup.add_argument(
+        "--scope",
+        action="append",
+        choices=["worktrees", "builds", "npm-cache", "all"],
+        default=[],
+    )
+    cleanup.add_argument("--older-than", type=int, default=7, metavar="DAYS")
+    cleanup_mode = cleanup.add_mutually_exclusive_group()
+    cleanup_mode.add_argument("--dry-run", action="store_true")
+    cleanup_mode.add_argument("--apply", action="store_true")
+    cleanup.add_argument("--json", action="store_true")
+
     profile = commands.add_parser("profile", help="manage coherent source profiles")
     profile_commands = profile.add_subparsers(dest="profile_command", required=True)
     profile_create = profile_commands.add_parser("create")
@@ -432,6 +452,41 @@ def main(arguments: list[str] | None = None) -> int:
                             "refs/heads/"
                         )
                         print(f"{component}\t{branch}\t{record['worktree']}")
+        elif options.command == "cleanup":
+            report = workspace.cleanup(
+                options.scope,
+                options.older_than,
+                options.components,
+                options.apply,
+            )
+            if options.json:
+                print(json.dumps(report, indent=2, sort_keys=True))
+            else:
+                for item in report["items"]:
+                    age = (
+                        "-"
+                        if item["age_seconds"] is None
+                        else f"{item['age_seconds'] // 86400}d"
+                    )
+                    reasons = ",".join(item["reasons"])
+                    print(
+                        f"{item['disposition']}\t{item['kind']}\t"
+                        f"{item['allocated_bytes']}\t{age}\t{item['path']}\t"
+                        f"{reasons}"
+                    )
+                summary = report["summary"]
+                print(
+                    "summary\t"
+                    f"candidates={summary['candidate_count']} "
+                    f"candidate_bytes={summary['candidate_bytes']} "
+                    f"protected={summary['protected_count']} "
+                    f"protected_bytes={summary['protected_bytes']} "
+                    f"removed={summary['removed_count']} "
+                    f"removed_bytes={summary['removed_bytes']} "
+                    f"errors={summary['error_count']}"
+                )
+            if report["summary"]["error_count"] or report.get("aborted"):
+                return 1
         elif options.command == "profile":
             if options.profile_command == "create":
                 workspace.create_profile(options.name, options.source)

--- a/atrinik_workspace/model.py
+++ b/atrinik_workspace/model.py
@@ -1125,11 +1125,15 @@ def managed_directory(path: Path, workspace_builds: Path, purpose: str) -> None:
 def managed_remove(path: Path, workspace_builds: Path, purpose: str) -> None:
     """Remove one marker-owned build root after repeating every ownership check."""
 
+    if workspace_builds.is_symlink() or not workspace_builds.is_dir():
+        raise WorkspaceError(
+            f"workspace builds path is not a regular directory: {workspace_builds}"
+        )
     builds = workspace_builds.resolve()
     if path.is_symlink():
         raise WorkspaceError(f"refusing symlinked managed build path: {path}")
     path = path.parent.resolve() / path.name
-    if builds != path and builds not in path.parents:
+    if builds not in path.parents:
         raise WorkspaceError(f"refusing to remove path outside workspace builds: {path}")
     marker = path / MANAGED_MARKER
     if not path.is_dir() or not marker.is_file() or marker.is_symlink():

--- a/atrinik_workspace/model.py
+++ b/atrinik_workspace/model.py
@@ -1122,6 +1122,24 @@ def managed_directory(path: Path, workspace_builds: Path, purpose: str) -> None:
     atomic_json(marker, {"schema_version": SCHEMA_VERSION, "purpose": purpose})
 
 
+def managed_remove(path: Path, workspace_builds: Path, purpose: str) -> None:
+    """Remove one marker-owned build root after repeating every ownership check."""
+
+    builds = workspace_builds.resolve()
+    if path.is_symlink():
+        raise WorkspaceError(f"refusing symlinked managed build path: {path}")
+    path = path.parent.resolve() / path.name
+    if builds != path and builds not in path.parents:
+        raise WorkspaceError(f"refusing to remove path outside workspace builds: {path}")
+    marker = path / MANAGED_MARKER
+    if not path.is_dir() or not marker.is_file() or marker.is_symlink():
+        raise WorkspaceError(f"refusing to remove unmanaged build path: {path}")
+    metadata = load_json(marker)
+    if metadata != {"schema_version": SCHEMA_VERSION, "purpose": purpose}:
+        raise WorkspaceError(f"managed build marker does not match {purpose}: {path}")
+    shutil.rmtree(path)
+
+
 def profile_key(paths: dict[str, Path], *, namespace: str = "") -> str:
     coordinates = {name: str(path) for name, path in paths.items()}
     value: Any = (

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -92,6 +92,9 @@ SCENARIO_KEYS = {
 SCENARIO_SCHEMA_VERSION = 4
 SCENARIO_PRESETS = {"basic-player": {"archetype": "human_male"}}
 SCENARIO_PASSWORD_MAX_SIZE = 128
+BUILD_METADATA = ".atrinik-build.json"
+BUILD_METADATA_SCHEMA_VERSION = 1
+CACHE_METADATA = ".atrinik-cache.json"
 
 
 def display_arguments(arguments: list[str]) -> str:
@@ -261,6 +264,19 @@ class Workspace:
         return RepositoryMigration(
             self.paths.repository, self.paths, self.manifest
         ).execute(mode)
+
+    def cleanup(
+        self,
+        scopes: list[str],
+        older_than_days: int,
+        names: list[str],
+        apply: bool,
+    ) -> dict[str, Any]:
+        # Import lazily so the planner can reuse the workspace lock and metadata
+        # helpers without creating a module import cycle.
+        from .cleanup import Cleanup
+
+        return Cleanup(self).execute(scopes, older_than_days, names, apply)
 
     def _checkout_identity(self, value: Checkout | Component) -> Checkout:
         if isinstance(value, Checkout):
@@ -1323,6 +1339,7 @@ class Workspace:
         lock = self.paths.builds / "locks" / f"{profile_name}-{key}.lock"
         with exclusive_lock(lock, f"profile build {profile_name}"):
             managed_directory(root, self.paths.builds, f"profile:{profile_name}:{key}")
+            self._refresh_build_metadata(root, profile_name, key, selected)
             if "content" in targets or "server" in targets:
                 self._collect_content(root, selected)
             if "server" in targets:
@@ -1340,6 +1357,47 @@ class Workspace:
             if target in {"sound", "resources"}:
                 print(f"{target}: selected {selected[target]}")
         return root
+
+    def _refresh_build_metadata(
+        self,
+        root: Path,
+        profile_name: str,
+        key: str,
+        selected: dict[str, Path],
+    ) -> None:
+        profile = self._load_profile(profile_name, require_file=False)
+        stack = self.manifest.stack(profile["stack"])
+        coordinates: dict[str, dict[str, str]] = {}
+        for role in sorted(selected):
+            component = stack.providers[role]
+            checkout_path = self._selector_root(profile, component).resolve()
+            coordinates[role] = {
+                "component": component.name,
+                "checkout": component.checkout_name,
+                "repository": component.repository,
+                "branch": component.branch,
+                "source": component.source,
+                "checkout_path": str(checkout_path),
+                "source_path": str(selected[role].resolve()),
+                "head": git(
+                    checkout_path,
+                    "rev-parse",
+                    "HEAD",
+                    capture=True,
+                    trace=False,
+                ),
+            }
+        atomic_json(
+            root / BUILD_METADATA,
+            {
+                "schema_version": BUILD_METADATA_SCHEMA_VERSION,
+                "profile": profile_name,
+                "key": key,
+                "purpose": f"profile:{profile_name}:{key}",
+                "coordinates": coordinates,
+                "last_used_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
 
     def _profile_build_key(
         self, profile_name: str, selected: dict[str, Path]
@@ -1678,7 +1736,23 @@ class Workspace:
         )
         environment = os.environ.copy()
         npm_cache = self.paths.builds / "npm-cache"
-        npm_cache.mkdir(parents=True, exist_ok=True)
+        marker = npm_cache / MANAGED_MARKER
+        if npm_cache.exists() and not marker.exists() and not marker.is_symlink():
+            if npm_cache.is_symlink() or not npm_cache.is_dir():
+                raise WorkspaceError(f"npm cache path is invalid: {npm_cache}")
+            atomic_json(
+                marker,
+                {"schema_version": SCHEMA_VERSION, "purpose": "npm-cache"},
+            )
+        managed_directory(npm_cache, self.paths.builds, "npm-cache")
+        atomic_json(
+            npm_cache / CACHE_METADATA,
+            {
+                "schema_version": BUILD_METADATA_SCHEMA_VERSION,
+                "purpose": "npm-cache",
+                "last_used_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
         environment["npm_config_cache"] = str(npm_cache)
         run(["npm", "ci"], cwd=view, env=environment)
         run(["npm", "run", "check"], cwd=view, env=environment)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -131,6 +131,7 @@ workspace/
   profiles/<name>.json               logical component -> checkout selectors
   build/profiles/<name>-<key>/       isolated sources, builds, and runtime
   build/npm-cache/                   shared package download cache
+  build/retention.json               optional strict build pin/rollback record
   topologies/<name>/                 supervised process state and rotated logs
   state/server/<name>/               persistent mutable server data
   states.json                        named external-state registry
@@ -167,6 +168,67 @@ exact physical checkouts through either checkout or logical-component
 identities. One checkout is synchronized only once. A missing optional
 repository is reported and skipped rather than cloned as a synchronization
 side effect.
+
+## Cleanup inventory and retention
+
+`cleanup` is an explicit garbage-collection boundary, never an implicit step
+of initialization, synchronization, build, or startup. Default and explicit
+`--dry-run` modes are read-only. `--apply` first takes the same
+repository-layout lock used by checkout, build, topology, foreground-run, and
+scenario operations, fully recomputes the plan, and immediately revalidates
+each target. Build roots are removed before Git worktrees; the explicitly
+selected npm cache and safe prunable Git metadata come last. A race before the
+first mutation aborts the plan. A later failure stops the ordered sequence and
+reports completed reclamation without attempting to reconstruct generated
+data.
+
+Inventory records are stable-sorted and carry a kind, physical owner and
+repository, exact path, no-follow allocated size, age and age basis,
+disposition, stable reason codes, and applicable profile/scenario/topology/
+migration/retention or merged-PR evidence. Size accounting uses device/inode
+identity and excludes registered nested worktree roots from mixed container
+records, preventing hard links or overlapping roots from inflating global byte
+totals. Filesystem traversal or metadata ambiguity protects the affected
+scope.
+
+Current-checkout worktrees are owned only as direct children of
+`workspace/worktrees/<checkout>/`. Wrapper-self worktrees are owned only when
+Git registers them under `workspace/worktrees/atrinik/` or the historical
+top-level `build/worktrees/` namespace. Common-Git-directory and canonical
+repository identity, named/unlocked state, absence of in-progress Git
+operations, and ordinary tracked/untracked cleanliness are mandatory. Saved
+profile selectors of kind `worktree`, absolute `path`, or migration-only
+`migrated-worktree`; retained scenario coordinates; live topology coordinates;
+and every original/destination/composite migration path protect exact
+worktrees. Ignored output is sized and disclosed but does not defeat
+eligibility. GitHub's authenticated commit-associated-pulls API must prove an
+exact merged head against the checkout's manifest branch, no open association,
+and the requested grace age. Apply delegates to `git worktree remove` without
+force and preserves refs. Prunable administrative records use the same PR and
+ownership proof and are pruned only when no protected prunable sibling shares
+that repository-wide Git prune operation.
+
+Profile build ownership is a direct-child path plus an exact regular
+`.atrinik-workspace-managed.json` purpose marker. Each use under the per-build
+lock atomically refreshes `.atrinik-build.json` with the profile/key, purpose,
+exact role-to-repository/branch/checkout/source paths and commits, and
+`last_used_at`. Older marker-owned roots fall back to the maximum mtime from
+the same no-follow size walk. Live topology `build_root` values, busy build
+locks, registered Git worktrees, and exact absolute roots in strict schema-1
+`workspace/build/retention.json` protect a build. A shared `managed_remove()`
+helper repeats containment, symlink, marker, schema, and purpose validation
+immediately before deletion.
+
+The npm cache has an exact `npm-cache` purpose marker and atomically refreshed
+`.atrinik-cache.json` timestamp. Its scope is opt-in. One pre-marker cache at
+that fixed path can be treated as a legacy known cache only after the workspace
+marker, fixed containment, no-symlink shape, age, and inactive-build checks
+pass; apply adopts the marker before calling the common removal helper. No
+other unmarked path receives that exception. Unmarked profile roots, unknown
+`workspace/build` children, and the mixed top-level `build/` tree remain
+visible report-only `unmanaged-build` records. Cleanup never targets profiles,
+scenarios, state, topology records/logs, migration archives/evidence, branches,
+Git objects, or arbitrary unmarked paths.
 
 ## Classic monorepo migration
 

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,499 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+from atrinik_workspace.cleanup import Cleanup
+from atrinik_workspace.model import (
+    MANAGED_MARKER,
+    SCHEMA_VERSION,
+    WorkspaceError,
+    atomic_json,
+    managed_directory,
+    managed_remove as real_managed_remove,
+)
+from atrinik_workspace.workspace import Workspace
+
+
+def command(*arguments: str, cwd: Path) -> str:
+    return subprocess.run(
+        list(arguments), cwd=cwd, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+class CleanupTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.wrapper = self.root / "wrapper"
+        self.wrapper.mkdir()
+        (self.wrapper / "components.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "components": [
+                        {
+                            "name": name,
+                            "repository": f"atrinik/{name}",
+                            "branch": "main",
+                            "build": build,
+                        }
+                        for name, build in (
+                            ("client", "client"),
+                            ("server", "server"),
+                            ("protocol", "protocol"),
+                            ("libatrinik", "library"),
+                            ("content", "content"),
+                            ("sound", "assets"),
+                            ("resources", "assets"),
+                        )
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        (self.wrapper / ".gitignore").write_text("ignored/\n", encoding="utf-8")
+        command("git", "init", "-b", "main", cwd=self.wrapper)
+        command("git", "config", "user.name", "Tests", cwd=self.wrapper)
+        command("git", "config", "user.email", "tests@example.invalid", cwd=self.wrapper)
+        command("git", "add", ".", cwd=self.wrapper)
+        command("git", "commit", "-m", "feat: seed", cwd=self.wrapper)
+        command(
+            "git",
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/atrinik/atrinik.git",
+            cwd=self.wrapper,
+        )
+        self.workspace_root = self.root / "workspace"
+        self.environment = mock.patch.dict(
+            os.environ, {"ATRINIK_WORKSPACE_DIR": str(self.workspace_root)}
+        )
+        self.environment.start()
+        self.workspace = Workspace(self.wrapper)
+        self.workspace.paths.ensure()
+        self.old = datetime.now(timezone.utc) - timedelta(days=30)
+
+    def tearDown(self) -> None:
+        self.environment.stop()
+        self.temporary.cleanup()
+
+    def make_wrapper_worktree(self, label: str = "review") -> Path:
+        path = self.workspace.paths.worktrees / "atrinik" / label
+        path.parent.mkdir(parents=True, exist_ok=True)
+        command(
+            "git",
+            "worktree",
+            "add",
+            "-b",
+            f"feat/{label}",
+            str(path),
+            "main",
+            cwd=self.wrapper,
+        )
+        (path / "ignored").mkdir()
+        (path / "ignored" / "output.o").write_bytes(b"x" * 4096)
+        return path
+
+    def make_component_worktree(self, label: str = "component-review") -> Path:
+        primary = self.wrapper / "client"
+        primary.mkdir()
+        command("git", "init", "-b", "main", cwd=primary)
+        command("git", "config", "user.name", "Tests", cwd=primary)
+        command("git", "config", "user.email", "tests@example.invalid", cwd=primary)
+        (primary / "README").write_text("client\n", encoding="utf-8")
+        command("git", "add", ".", cwd=primary)
+        command("git", "commit", "-m", "feat: seed", cwd=primary)
+        command(
+            "git",
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/atrinik/client.git",
+            cwd=primary,
+        )
+        path = self.workspace.paths.worktrees / "client" / label
+        path.parent.mkdir(parents=True, exist_ok=True)
+        command(
+            "git",
+            "worktree",
+            "add",
+            "-b",
+            f"feat/{label}",
+            str(path),
+            "main",
+            cwd=primary,
+        )
+        return path
+
+    def merged_pull(
+        self, head: str, *, state: str = "closed", base: str = "main"
+    ) -> list[dict[str, object]]:
+        return [
+            {
+                "number": 42,
+                "state": state,
+                "html_url": "https://github.com/atrinik/atrinik/pull/42",
+                "merged_at": self.old.isoformat() if state == "closed" else None,
+                "head": {"sha": head},
+                "base": {"ref": base},
+            }
+        ]
+
+    def plan(self, scopes: list[str], older: int = 7) -> dict[str, object]:
+        def pulls(_repository: str, head: str) -> list[dict[str, object]]:
+            return self.merged_pull(head)
+
+        with mock.patch.object(Cleanup, "_github_pulls", side_effect=pulls):
+            return self.workspace.cleanup(scopes, older, [], False)
+
+    def test_dry_run_finds_exact_merged_head_and_preserves_ignored_output(self) -> None:
+        worktree = self.make_wrapper_worktree()
+        report = self.plan(["worktrees"])
+        item = next(row for row in report["items"] if row["path"] == str(worktree))
+
+        self.assertEqual(item["disposition"], "eligible")
+        self.assertEqual(item["reasons"], ["merged_pr_head"])
+        self.assertGreater(item["ignored_bytes"], 0)
+        self.assertTrue(worktree.is_dir())
+        self.assertEqual(report["mode"], "dry-run")
+
+    def test_open_wrong_base_advanced_and_unavailable_prs_fail_closed(self) -> None:
+        worktree = self.make_wrapper_worktree()
+        head = command("git", "rev-parse", "HEAD", cwd=worktree)
+        cases = (
+            (self.merged_pull(head, state="open"), "open_pull_request"),
+            (self.merged_pull(head, base="release"), "wrong_base_branch"),
+            (self.merged_pull("f" * 40), "pr_head_mismatch"),
+        )
+        for pulls, reason in cases:
+            with self.subTest(reason=reason), mock.patch.object(
+                Cleanup, "_github_pulls", return_value=pulls
+            ):
+                report = self.workspace.cleanup(["worktrees"], 7, [], False)
+                item = next(row for row in report["items"] if row["path"] == str(worktree))
+                self.assertEqual(item["disposition"], "protected")
+                self.assertEqual(item["reasons"], [reason])
+
+        with mock.patch.object(
+            Cleanup, "_github_pulls", side_effect=Exception("should be wrapped")
+        ):
+            with self.assertRaises(Exception):
+                self.workspace.cleanup(["worktrees"], 7, [], False)
+
+    def test_dirty_and_profile_selected_worktrees_do_not_query_github(self) -> None:
+        dirty = self.make_wrapper_worktree("dirty")
+        (dirty / "untracked").write_text("local\n", encoding="utf-8")
+        with mock.patch.object(Cleanup, "_github_pulls") as pulls:
+            report = self.workspace.cleanup(["worktrees"], 0, [], False)
+        item = next(row for row in report["items"] if row["path"] == str(dirty))
+        self.assertIn("dirty_worktree", item["reasons"])
+        pulls.assert_not_called()
+
+    def test_all_profile_selector_kinds_and_retained_scenarios_protect_worktrees(self) -> None:
+        worktree = self.make_component_worktree()
+        self.workspace.create_profile("selected")
+        self.workspace.set_profile("selected", "client", "worktree", worktree.name)
+        with mock.patch.object(Cleanup, "_github_pulls") as pulls:
+            report = self.workspace.cleanup(["worktrees"], 0, ["client"], False)
+        item = next(row for row in report["items"] if row["path"] == str(worktree))
+        self.assertIn("profile_reference", item["reasons"])
+        self.assertEqual(item["references"]["profiles"], ["selected"])
+        pulls.assert_not_called()
+
+        profile_path = self.workspace.paths.profiles / "selected.json"
+        profile = json.loads(profile_path.read_text(encoding="utf-8"))
+        profile["components"]["client"] = {"kind": "path", "value": str(worktree)}
+        profile_path.write_text(json.dumps(profile), encoding="utf-8")
+        report = self.workspace.cleanup(["worktrees"], 0, ["client"], False)
+        item = next(row for row in report["items"] if row["path"] == str(worktree))
+        self.assertIn("profile_reference", item["reasons"])
+
+        profile_path.unlink()
+        scenario = self.workspace.paths.scenarios / "retained"
+        scenario.mkdir()
+        atomic_json(
+            scenario / MANAGED_MARKER,
+            {"schema_version": SCHEMA_VERSION, "purpose": "test-scenario"},
+        )
+        atomic_json(
+            scenario / "scenario.json",
+            {
+                "name": "retained",
+                "resolved": {
+                    "client": {
+                        "checkout_path": str(worktree),
+                        "checkout": "client",
+                        "repository": "atrinik/client",
+                        "branch": "main",
+                        "source": ".",
+                        "head": command("git", "rev-parse", "HEAD", cwd=worktree),
+                    }
+                },
+            },
+        )
+        report = self.workspace.cleanup(["worktrees"], 0, ["client"], False)
+        item = next(row for row in report["items"] if row["path"] == str(worktree))
+        self.assertIn("scenario_reference", item["reasons"])
+
+    def test_migration_original_and_destination_paths_are_protected(self) -> None:
+        worktree = self.make_component_worktree()
+        migrations = self.workspace.paths.workspace / "migrations"
+        migrations.mkdir()
+        atomic_json(
+            migrations / "repositories.json",
+            {
+                "sources": [{"source": str(worktree)}],
+                "worktree_migrations": [{"path": str(worktree), "destination": str(worktree)}],
+                "composite_worktrees": [{"destination": str(worktree)}],
+            },
+        )
+        report = self.workspace.cleanup(["worktrees"], 0, ["client"], False)
+        item = next(row for row in report["items"] if row["path"] == str(worktree))
+        self.assertIn("migration_reference", item["reasons"])
+        self.assertGreaterEqual(len(item["references"]["migration"]), 3)
+
+    def test_apply_revalidates_then_removes_without_deleting_branch(self) -> None:
+        worktree = self.make_wrapper_worktree()
+        branch = command("git", "branch", "--show-current", cwd=worktree)
+
+        def pulls(_repository: str, head: str) -> list[dict[str, object]]:
+            return self.merged_pull(head)
+
+        with mock.patch.object(Cleanup, "_github_pulls", side_effect=pulls):
+            report = self.workspace.cleanup(["worktrees"], 7, [], True)
+
+        item = next(row for row in report["items"] if row["path"] == str(worktree))
+        self.assertEqual(item["disposition"], "removed")
+        self.assertFalse(worktree.exists())
+        self.assertEqual(
+            command("git", "branch", "--list", branch, cwd=self.wrapper).strip(),
+            f"{branch}",
+        )
+
+    def test_apply_aborts_before_mutation_when_revalidation_changes(self) -> None:
+        worktree = self.make_wrapper_worktree()
+        calls = 0
+
+        def pulls(_repository: str, head: str) -> list[dict[str, object]]:
+            nonlocal calls
+            calls += 1
+            return self.merged_pull(head, state="closed" if calls == 1 else "open")
+
+        with mock.patch.object(Cleanup, "_github_pulls", side_effect=pulls):
+            report = self.workspace.cleanup(["worktrees"], 7, [], True)
+        item = next(row for row in report["items"] if row["path"] == str(worktree))
+        self.assertTrue(report["aborted"])
+        self.assertEqual(item["disposition"], "error")
+        self.assertEqual(item["reasons"], ["revalidation_failed"])
+        self.assertTrue(worktree.exists())
+
+    def test_prunable_metadata_requires_merged_pr_and_is_pruned(self) -> None:
+        worktree = self.make_wrapper_worktree()
+        shutil.rmtree(worktree)
+
+        def pulls(_repository: str, head: str) -> list[dict[str, object]]:
+            return self.merged_pull(head)
+
+        with mock.patch.object(Cleanup, "_github_pulls", side_effect=pulls):
+            report = self.workspace.cleanup(["worktrees"], 7, [], False)
+            item = next(
+                row for row in report["items"] if row["kind"] == "prunable-metadata"
+            )
+            self.assertEqual(item["disposition"], "eligible")
+            report = self.workspace.cleanup(["worktrees"], 7, [], True)
+        item = next(row for row in report["items"] if row["kind"] == "prunable-metadata")
+        self.assertEqual(item["disposition"], "removed")
+        self.assertNotIn(str(worktree), command("git", "worktree", "list", cwd=self.wrapper))
+
+    def make_build(self, profile: str = "review", key: str = "a" * 12) -> Path:
+        path = self.workspace.paths.builds / "profiles" / f"{profile}-{key}"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        managed_directory(path, self.workspace.paths.builds, f"profile:{profile}:{key}")
+        (path / "artifact").write_bytes(b"x" * 8192)
+        timestamp = self.old.timestamp()
+        for candidate in (path / MANAGED_MARKER, path / "artifact", path):
+            os.utime(candidate, (timestamp, timestamp), follow_symlinks=False)
+        return path
+
+    def test_legacy_build_uses_conservative_tree_age_and_apply_removes_it(self) -> None:
+        build = self.make_build()
+        report = self.plan(["builds"])
+        item = next(row for row in report["items"] if row["path"] == str(build))
+        self.assertEqual(item["disposition"], "eligible")
+        self.assertEqual(item["age_basis"], "legacy-tree-mtime")
+        self.assertTrue(build.exists())
+
+        report = self.workspace.cleanup(["builds"], 7, [], True)
+        item = next(row for row in report["items"] if row["path"] == str(build))
+        self.assertEqual(item["disposition"], "removed")
+        self.assertFalse(build.exists())
+
+    def test_removable_source_worktree_bypasses_build_age_with_metadata(
+        self,
+    ) -> None:
+        worktree = self.make_wrapper_worktree()
+        build = self.make_build()
+        atomic_json(
+            build / ".atrinik-build.json",
+            {
+                "schema_version": 1,
+                "profile": "review",
+                "key": "a" * 12,
+                "purpose": f"profile:review:{'a' * 12}",
+                "coordinates": {
+                    "client": {
+                        "component": "client",
+                        "checkout": "atrinik",
+                        "repository": "atrinik/atrinik",
+                        "branch": "main",
+                        "source": ".",
+                        "checkout_path": str(worktree),
+                        "source_path": str(worktree),
+                        "head": command("git", "rev-parse", "HEAD", cwd=worktree),
+                    }
+                },
+                "last_used_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+
+        def pulls(_repository: str, head: str) -> list[dict[str, object]]:
+            return self.merged_pull(head)
+
+        with mock.patch.object(Cleanup, "_github_pulls", side_effect=pulls):
+            report = self.workspace.cleanup(["worktrees", "builds"], 7, [], False)
+        item = next(row for row in report["items"] if row["path"] == str(build))
+        self.assertEqual(item["disposition"], "eligible")
+        self.assertTrue(item["source_worktree_removal"])
+        self.assertEqual(item["reasons"], ["source_worktree_removal"])
+
+    def test_apply_stops_after_first_post_mutation_failure_and_reports_actual_state(self) -> None:
+        first = self.make_build("first", "a" * 12)
+        second = self.make_build("second", "b" * 12)
+        calls = 0
+
+        def remove(path: Path, builds: Path, purpose: str) -> None:
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise WorkspaceError("injected removal failure")
+            real_managed_remove(path, builds, purpose)
+
+        with mock.patch("atrinik_workspace.cleanup.managed_remove", side_effect=remove):
+            report = self.workspace.cleanup(["builds"], 7, [], True)
+        by_path = {row["path"]: row for row in report["items"]}
+        self.assertEqual(by_path[str(first)]["disposition"], "removed")
+        self.assertEqual(by_path[str(second)]["disposition"], "error")
+        self.assertFalse(first.exists())
+        self.assertTrue(second.exists())
+        self.assertTrue(report["aborted"])
+
+    def test_invalid_marker_and_busy_lock_protect_builds(self) -> None:
+        build = self.make_build()
+        lock = self.workspace.paths.builds / "locks" / f"review-{'a' * 12}.lock"
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        with lock.open("w", encoding="utf-8") as stream:
+            import fcntl
+
+            fcntl.flock(stream, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            report = self.plan(["builds"])
+        item = next(row for row in report["items"] if row["path"] == str(build))
+        self.assertIn("build_lock_busy", item["reasons"])
+
+        unmanaged = self.workspace.paths.builds / "profiles" / "unmarked"
+        unmanaged.mkdir()
+        report = self.plan(["builds"])
+        item = next(row for row in report["items"] if row["path"] == str(unmanaged))
+        self.assertEqual(item["kind"], "unmanaged-build")
+        self.assertEqual(item["disposition"], "protected")
+
+    def test_build_only_scope_still_protects_a_nested_registered_worktree(self) -> None:
+        build = self.make_build()
+        nested = build / "nested-worktree"
+        command(
+            "git",
+            "worktree",
+            "add",
+            "-b",
+            "feat/nested-build-worktree",
+            str(nested),
+            "main",
+            cwd=self.wrapper,
+        )
+        report = self.workspace.cleanup(["builds"], 0, [], False)
+        item = next(row for row in report["items"] if row["path"] == str(build))
+        self.assertIn("contains_registered_worktree", item["reasons"])
+        self.assertTrue(nested.is_dir())
+
+    def test_live_topology_and_retention_record_protect_exact_build(self) -> None:
+        build = self.make_build()
+        topology = self.workspace.paths.topologies / "live"
+        topology.mkdir()
+        (topology / MANAGED_MARKER).write_text(
+            json.dumps(
+                {"schema_version": SCHEMA_VERSION, "purpose": "topology:live"}
+            ),
+            encoding="utf-8",
+        )
+        (topology / "status.json").write_text(
+            json.dumps(
+                {
+                    "supervisor": {"pid": 123, "start_time": "1"},
+                    "services": {},
+                    "build_root": str(build),
+                    "resolved": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+        with mock.patch("atrinik_workspace.cleanup.process_matches", return_value=True):
+            report = self.plan(["builds"])
+        item = next(row for row in report["items"] if row["path"] == str(build))
+        self.assertIn("live_topology", item["reasons"])
+
+        shutil.rmtree(topology)
+        (self.workspace.paths.builds / "retention.json").write_text(
+            json.dumps({"schema_version": 1, "build_roots": [str(build)]}),
+            encoding="utf-8",
+        )
+        report = self.plan(["builds"])
+        item = next(row for row in report["items"] if row["path"] == str(build))
+        self.assertIn("retention_reference", item["reasons"])
+
+    def test_npm_cache_requires_explicit_scope_and_legacy_path_is_adopted_on_apply(self) -> None:
+        cache = self.workspace.paths.builds / "npm-cache"
+        cache.mkdir()
+        (cache / "entry").write_text("cached\n", encoding="utf-8")
+        timestamp = self.old.timestamp()
+        os.utime(cache / "entry", (timestamp, timestamp))
+        os.utime(cache, (timestamp, timestamp))
+
+        self.assertFalse(any(row["kind"] == "npm-cache" for row in self.plan([])["items"]))
+        report = self.plan(["npm-cache"])
+        item = next(row for row in report["items"] if row["kind"] == "npm-cache")
+        self.assertTrue(item["legacy_known_cache"])
+        self.assertEqual(item["disposition"], "eligible")
+        self.assertTrue(cache.exists())
+
+        report = self.workspace.cleanup(["npm-cache"], 7, [], True)
+        item = next(row for row in report["items"] if row["kind"] == "npm-cache")
+        self.assertEqual(item["disposition"], "removed")
+        self.assertFalse(cache.exists())
+
+    def test_dry_run_does_not_create_an_absent_workspace(self) -> None:
+        shutil.rmtree(self.workspace.paths.workspace)
+        report = self.workspace.cleanup(["builds"], 7, [], False)
+        self.assertEqual(report["mode"], "dry-run")
+        self.assertFalse(self.workspace.paths.workspace.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -10,7 +10,7 @@ import tempfile
 import unittest
 from unittest import mock
 
-from atrinik_workspace.cleanup import Cleanup
+from atrinik_workspace.cleanup import Cleanup, _base_item
 from atrinik_workspace.model import (
     MANAGED_MARKER,
     SCHEMA_VERSION,
@@ -163,16 +163,25 @@ class CleanupTests(unittest.TestCase):
         self.assertEqual(item["disposition"], "eligible")
         self.assertEqual(item["reasons"], ["merged_pr_head"])
         self.assertGreater(item["ignored_bytes"], 0)
+        self.assertGreater(item["allocated_bytes"], 0)
+        primary = next(
+            row for row in report["items"] if row["path"] == str(self.wrapper)
+        )
+        self.assertEqual(primary["allocated_bytes"], 0)
         self.assertTrue(worktree.is_dir())
         self.assertEqual(report["mode"], "dry-run")
 
-    def test_open_wrong_base_advanced_and_unavailable_prs_fail_closed(self) -> None:
+    def test_non_exact_or_unavailable_pull_evidence_fails_closed(self) -> None:
         worktree = self.make_wrapper_worktree()
         head = command("git", "rev-parse", "HEAD", cwd=worktree)
+        closed_unmerged = self.merged_pull(head)
+        closed_unmerged[0]["merged_at"] = None
         cases = (
             (self.merged_pull(head, state="open"), "open_pull_request"),
             (self.merged_pull(head, base="release"), "wrong_base_branch"),
             (self.merged_pull("f" * 40), "pr_head_mismatch"),
+            (closed_unmerged, "closed_unmerged_pr"),
+            (self.merged_pull(head) * 2, "ambiguous_pull_requests"),
         )
         for pulls, reason in cases:
             with self.subTest(reason=reason), mock.patch.object(
@@ -184,10 +193,73 @@ class CleanupTests(unittest.TestCase):
                 self.assertEqual(item["reasons"], [reason])
 
         with mock.patch.object(
-            Cleanup, "_github_pulls", side_effect=Exception("should be wrapped")
+            Cleanup, "_github_pulls", side_effect=WorkspaceError("offline")
         ):
-            with self.assertRaises(Exception):
-                self.workspace.cleanup(["worktrees"], 7, [], False)
+            report = self.workspace.cleanup(["worktrees"], 7, [], False)
+        item = next(row for row in report["items"] if row["path"] == str(worktree))
+        self.assertEqual(item["disposition"], "protected")
+        self.assertEqual(item["reasons"], ["github_unavailable"])
+        self.assertEqual(item["github_error"], "offline")
+
+    def test_detached_locked_and_in_progress_worktrees_are_protected(self) -> None:
+        detached = self.workspace.paths.worktrees / "atrinik" / "detached"
+        detached.parent.mkdir(parents=True, exist_ok=True)
+        command(
+            "git",
+            "worktree",
+            "add",
+            "--detach",
+            str(detached),
+            "main",
+            cwd=self.wrapper,
+        )
+        locked = self.make_wrapper_worktree("locked")
+        command("git", "worktree", "lock", str(locked), cwd=self.wrapper)
+        in_progress = self.make_wrapper_worktree("in-progress")
+        merge_head = Path(
+            command("git", "rev-parse", "--git-path", "MERGE_HEAD", cwd=in_progress)
+        )
+        merge_head.write_text(
+            command("git", "rev-parse", "HEAD", cwd=in_progress) + "\n",
+            encoding="utf-8",
+        )
+
+        with mock.patch.object(Cleanup, "_github_pulls") as pulls:
+            report = self.workspace.cleanup(["worktrees"], 0, [], False)
+
+        by_path = {row["path"]: row for row in report["items"]}
+        self.assertIn("detached_head", by_path[str(detached)]["reasons"])
+        self.assertIn("locked_worktree", by_path[str(locked)]["reasons"])
+        self.assertIn(
+            "git_operation_in_progress", by_path[str(in_progress)]["reasons"]
+        )
+        pulls.assert_not_called()
+
+    def test_symlinked_allowlist_namespace_cannot_authorize_external_worktree(
+        self,
+    ) -> None:
+        namespace = self.workspace.paths.worktrees / "atrinik"
+        external = self.root / "external-worktrees"
+        external.mkdir()
+        namespace.symlink_to(external, target_is_directory=True)
+        worktree = external / "review"
+        command(
+            "git",
+            "worktree",
+            "add",
+            "-b",
+            "feat/external-review",
+            str(worktree),
+            "main",
+            cwd=self.wrapper,
+        )
+
+        with mock.patch.object(Cleanup, "_github_pulls") as pulls:
+            report = self.workspace.cleanup(["worktrees"], 0, [], False)
+
+        item = next(row for row in report["items"] if row["path"] == str(worktree))
+        self.assertIn("external_path", item["reasons"])
+        pulls.assert_not_called()
 
     def test_dirty_and_profile_selected_worktrees_do_not_query_github(self) -> None:
         dirty = self.make_wrapper_worktree("dirty")
@@ -243,6 +315,24 @@ class CleanupTests(unittest.TestCase):
         report = self.workspace.cleanup(["worktrees"], 0, ["client"], False)
         item = next(row for row in report["items"] if row["path"] == str(worktree))
         self.assertIn("scenario_reference", item["reasons"])
+
+    def test_malformed_scenario_fails_closed_without_querying_github(self) -> None:
+        worktree = self.make_wrapper_worktree()
+        scenario = self.workspace.paths.scenarios / "malformed"
+        scenario.mkdir()
+        atomic_json(
+            scenario / MANAGED_MARKER,
+            {"schema_version": SCHEMA_VERSION, "purpose": "test-scenario"},
+        )
+        atomic_json(scenario / "scenario.json", [])
+
+        with mock.patch.object(Cleanup, "_github_pulls") as pulls:
+            report = self.workspace.cleanup(["worktrees"], 0, [], False)
+
+        item = next(row for row in report["items"] if row["path"] == str(worktree))
+        self.assertIn("scenario_inventory_error", item["reasons"])
+        self.assertIn("scenario_inventory_error", report["inventory_errors"])
+        pulls.assert_not_called()
 
     def test_migration_original_and_destination_paths_are_protected(self) -> None:
         worktree = self.make_component_worktree()
@@ -340,7 +430,7 @@ class CleanupTests(unittest.TestCase):
     def test_removable_source_worktree_bypasses_build_age_with_metadata(
         self,
     ) -> None:
-        worktree = self.make_wrapper_worktree()
+        worktree = self.make_component_worktree()
         build = self.make_build()
         atomic_json(
             build / ".atrinik-build.json",
@@ -352,8 +442,8 @@ class CleanupTests(unittest.TestCase):
                 "coordinates": {
                     "client": {
                         "component": "client",
-                        "checkout": "atrinik",
-                        "repository": "atrinik/atrinik",
+                        "checkout": "client",
+                        "repository": "atrinik/client",
                         "branch": "main",
                         "source": ".",
                         "checkout_path": str(worktree),
@@ -396,6 +486,31 @@ class CleanupTests(unittest.TestCase):
         self.assertTrue(second.exists())
         self.assertTrue(report["aborted"])
 
+    def test_apply_reports_replan_error_after_a_completed_mutation(self) -> None:
+        first = self.make_build("first", "a" * 12)
+        second = self.make_build("second", "b" * 12)
+        original = Cleanup._plan
+        calls = 0
+
+        def plan(cleanup: Cleanup, *arguments: object) -> dict[str, object]:
+            nonlocal calls
+            calls += 1
+            if calls == 3:
+                raise WorkspaceError("raced inventory")
+            return original(cleanup, *arguments)
+
+        with mock.patch.object(Cleanup, "_plan", new=plan):
+            report = self.workspace.cleanup(["builds"], 7, [], True)
+
+        by_path = {row["path"]: row for row in report["items"]}
+        self.assertEqual(by_path[str(first)]["disposition"], "removed")
+        self.assertEqual(by_path[str(second)]["disposition"], "error")
+        self.assertEqual(by_path[str(second)]["reasons"], ["revalidation_error"])
+        self.assertTrue(report["mutated"])
+        self.assertTrue(report["aborted"])
+        self.assertFalse(first.exists())
+        self.assertTrue(second.exists())
+
     def test_invalid_marker_and_busy_lock_protect_builds(self) -> None:
         build = self.make_build()
         lock = self.workspace.paths.builds / "locks" / f"review-{'a' * 12}.lock"
@@ -415,6 +530,24 @@ class CleanupTests(unittest.TestCase):
         self.assertEqual(item["kind"], "unmanaged-build")
         self.assertEqual(item["disposition"], "protected")
 
+    def test_symlinked_workspace_build_container_is_report_only(self) -> None:
+        shutil.rmtree(self.workspace.paths.builds)
+        external = self.root / "external-builds"
+        target = external / "profiles" / f"review-{'a' * 12}"
+        managed_directory(target, external, f"profile:review:{'a' * 12}")
+        self.workspace.paths.builds.symlink_to(external, target_is_directory=True)
+
+        report = self.workspace.cleanup(["builds"], 0, [], False)
+
+        item = next(
+            row
+            for row in report["items"]
+            if row["path"] == str(self.workspace.paths.builds)
+        )
+        self.assertEqual(item["kind"], "unmanaged-build")
+        self.assertEqual(item["reasons"], ["invalid_build_container"])
+        self.assertTrue(target.is_dir())
+
     def test_build_only_scope_still_protects_a_nested_registered_worktree(self) -> None:
         build = self.make_build()
         nested = build / "nested-worktree"
@@ -433,6 +566,51 @@ class CleanupTests(unittest.TestCase):
         self.assertIn("contains_registered_worktree", item["reasons"])
         self.assertTrue(nested.is_dir())
 
+    def test_live_current_topology_protects_exact_worktree_coordinates(self) -> None:
+        worktree = self.make_component_worktree()
+        topology = self.workspace.paths.topologies / "live-current"
+        topology.mkdir()
+        atomic_json(
+            topology / MANAGED_MARKER,
+            {"schema_version": SCHEMA_VERSION, "purpose": "topology:live-current"},
+        )
+        atomic_json(
+            topology / "status.json",
+            {
+                "schema_version": SCHEMA_VERSION,
+                "name": "live-current",
+                "stack": "default",
+                "providers": {"client": "client"},
+                "dependencies": ["client"],
+                "supervisor": {"pid": 123, "start_time": "1"},
+                "services": {},
+                "build_root": str(self.workspace.paths.builds / "profiles" / "live"),
+                "resolved": {
+                    "client": {
+                        "path": str(worktree),
+                        "checkout_path": str(worktree),
+                        "checkout": "client",
+                        "repository": "atrinik/client",
+                        "branch": "main",
+                        "source": ".",
+                        "head": command("git", "rev-parse", "HEAD", cwd=worktree),
+                        "dirty": False,
+                    }
+                },
+            },
+        )
+
+        with mock.patch(
+            "atrinik_workspace.cleanup.process_matches", return_value=True
+        ), mock.patch.object(Cleanup, "_github_pulls") as pulls:
+            report = self.workspace.cleanup(["worktrees"], 0, ["client"], False)
+
+        item = next(row for row in report["items"] if row["path"] == str(worktree))
+        self.assertIn("topology_reference", item["reasons"])
+        self.assertEqual(item["references"]["topologies"], ["live-current"])
+        self.assertNotIn("topology_inventory_error", report["inventory_errors"])
+        pulls.assert_not_called()
+
     def test_live_topology_and_retention_record_protect_exact_build(self) -> None:
         build = self.make_build()
         topology = self.workspace.paths.topologies / "live"
@@ -446,6 +624,11 @@ class CleanupTests(unittest.TestCase):
         (topology / "status.json").write_text(
             json.dumps(
                 {
+                    "schema_version": SCHEMA_VERSION,
+                    "name": "live",
+                    "stack": "default",
+                    "providers": {},
+                    "dependencies": [],
                     "supervisor": {"pid": 123, "start_time": "1"},
                     "services": {},
                     "build_root": str(build),
@@ -493,6 +676,58 @@ class CleanupTests(unittest.TestCase):
         report = self.workspace.cleanup(["builds"], 7, [], False)
         self.assertEqual(report["mode"], "dry-run")
         self.assertFalse(self.workspace.paths.workspace.exists())
+
+    def test_physical_aliases_deduplicate_and_content_branches_stay_distinct(
+        self,
+    ) -> None:
+        repository = Path(__file__).resolve().parents[1]
+        actual_workspace = Workspace(repository)
+        cleanup = Cleanup(actual_workspace)
+        self.assertEqual(
+            cleanup._normalize_names(
+                ["classic", "classic-client", "classic-server", "classic-protocol"]
+            ),
+            {"classic"},
+        )
+        self.assertEqual(
+            cleanup._normalize_names(["content", "content-1x"]),
+            {"content", "content-1x"},
+        )
+
+        head = "a" * 40
+        pulls = self.merged_pull(head, base="main")
+        reason, _, _ = Cleanup._pull_evidence(pulls, head, "main")
+        self.assertIsNone(reason)
+        reason, _, _ = Cleanup._pull_evidence(pulls, head, "1.x")
+        self.assertEqual(reason, "wrong_base_branch")
+
+        profile = actual_workspace._load_profile("classic", require_file=False)
+        migrated = actual_workspace.paths.worktrees / "content" / "classic-maps"
+        profile["name"] = "migrated"
+        profile["components"]["content-1x"] = {
+            "kind": "migrated-worktree",
+            "value": str(migrated),
+        }
+        atomic_json(actual_workspace.paths.profiles / "migrated.json", profile)
+        references: dict[str, object] = {"profiles": {}}
+        errors: set[str] = set()
+        cleanup._profile_references(references, errors)
+        self.assertEqual(errors, set())
+        self.assertEqual(references["profiles"], {migrated: ["migrated"]})
+
+    def test_allocated_size_credit_deduplicates_shared_inodes(self) -> None:
+        first = _base_item("worktree", "atrinik", "atrinik/atrinik", self.root / "a")
+        second = _base_item("profile-build", "atrinik", "atrinik/atrinik", self.root / "b")
+        first["_inodes"] = {(1, 1): 4096, (1, 2): 4096}
+        second["_inodes"] = {(1, 2): 4096, (1, 3): 8192}
+
+        Cleanup._credit_sizes([first, second])
+
+        self.assertEqual(first["allocated_bytes"], 8192)
+        self.assertEqual(second["allocated_bytes"], 8192)
+        self.assertEqual(
+            first["allocated_bytes"] + second["allocated_bytes"], 16384
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -10,7 +10,15 @@ import tempfile
 import unittest
 from unittest import mock
 
-from atrinik_workspace.cleanup import Cleanup, _base_item
+from atrinik_workspace.cleanup import (
+    Cleanup,
+    _base_item,
+    _command,
+    _parse_time,
+    _path_relation,
+    _tree_usage,
+    _workspace_owned,
+)
 from atrinik_workspace.model import (
     MANAGED_MARKER,
     SCHEMA_VERSION,
@@ -154,6 +162,105 @@ class CleanupTests(unittest.TestCase):
 
         with mock.patch.object(Cleanup, "_github_pulls", side_effect=pulls):
             return self.workspace.cleanup(scopes, older, [], False)
+
+    def test_low_level_inventory_helpers_report_invalid_inputs(self) -> None:
+        with self.assertRaisesRegex(WorkspaceError, "zero or greater"):
+            self.workspace.cleanup(["builds"], -1, [], False)
+        with mock.patch(
+            "atrinik_workspace.cleanup.subprocess.run",
+            side_effect=FileNotFoundError,
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "required command"):
+                _command(self.wrapper, "status")
+        failure = subprocess.CalledProcessError(
+            2, ["git"], stderr="broken repository\n"
+        )
+        with mock.patch(
+            "atrinik_workspace.cleanup.subprocess.run", side_effect=failure
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "broken repository"):
+                _command(self.wrapper, "status")
+
+        for value, message in (
+            (None, "must be a timestamp"),
+            ("not-a-time", "not a valid timestamp"),
+            ("2026-01-01T00:00:00", "must include a UTC offset"),
+        ):
+            with self.subTest(value=value), self.assertRaisesRegex(
+                WorkspaceError, message
+            ):
+                _parse_time(value, "fixture")
+
+        self.assertTrue(_workspace_owned(self.workspace.paths))
+        self.workspace.paths.marker.write_text("not-json\n", encoding="utf-8")
+        self.assertFalse(_workspace_owned(self.workspace.paths))
+        self.workspace.paths.marker.unlink()
+        self.assertFalse(_workspace_owned(self.workspace.paths))
+        with self.assertRaisesRegex(WorkspaceError, "ownership marker"):
+            self.workspace.cleanup(["builds"], 0, [], True)
+
+        usage_root = self.root / "usage"
+        excluded = usage_root / "excluded"
+        excluded.mkdir(parents=True)
+        (excluded / "large").write_bytes(b"x" * 8192)
+        (usage_root / "kept").write_bytes(b"x")
+        sizes, observed, error = _tree_usage(usage_root, [excluded])
+        self.assertIsNone(error)
+        self.assertIsNotNone(observed)
+        self.assertGreater(sum(sizes.values()), 0)
+
+        with mock.patch.object(Path, "resolve", side_effect=RuntimeError("loop")):
+            self.assertTrue(_path_relation(usage_root, excluded))
+            sizes, observed, error = _tree_usage(usage_root)
+        self.assertEqual(sizes, {})
+        self.assertIsNone(observed)
+        self.assertIn("loop", error or "")
+
+    def test_github_query_wraps_process_and_response_failures(self) -> None:
+        repository = "atrinik/atrinik"
+        head = "a" * 40
+        cases = (
+            (FileNotFoundError(), "required command"),
+            (
+                subprocess.CalledProcessError(
+                    1, ["gh"], stderr="authentication required\n"
+                ),
+                "authentication required",
+            ),
+            (subprocess.TimeoutExpired(["gh"], 30), "timed out"),
+        )
+        for error, message in cases:
+            with self.subTest(message=message), mock.patch(
+                "atrinik_workspace.cleanup.subprocess.run", side_effect=error
+            ), self.assertRaisesRegex(WorkspaceError, message):
+                Cleanup._github_pulls(repository, head)
+
+        for stdout, message in (
+            ("not-json\n", "not JSON"),
+            ("[]\n", "invalid shape"),
+        ):
+            completed = subprocess.CompletedProcess(["gh"], 0, stdout, "")
+            with self.subTest(stdout=stdout), mock.patch(
+                "atrinik_workspace.cleanup.subprocess.run", return_value=completed
+            ), self.assertRaisesRegex(WorkspaceError, message):
+                Cleanup._github_pulls(repository, head)
+
+        row = self.merged_pull(head)[0]
+        completed = subprocess.CompletedProcess(
+            ["gh"], 0, json.dumps(row) + "\n", ""
+        )
+        with mock.patch(
+            "atrinik_workspace.cleanup.subprocess.run", return_value=completed
+        ):
+            self.assertEqual(Cleanup._github_pulls(repository, head), [row])
+
+        self.assertEqual(
+            Cleanup._pull_evidence([], head, "main")[0], "no_associated_pr"
+        )
+        self.assertEqual(
+            Cleanup._pull_evidence([{"number": 1}], head, "main")[0],
+            "invalid_pull_request_evidence",
+        )
 
     def test_dry_run_finds_exact_merged_head_and_preserves_ignored_output(self) -> None:
         worktree = self.make_wrapper_worktree()
@@ -334,6 +441,11 @@ class CleanupTests(unittest.TestCase):
         self.assertIn("scenario_inventory_error", report["inventory_errors"])
         pulls.assert_not_called()
 
+        report = self.workspace.cleanup(["worktrees"], 0, [], True)
+        self.assertTrue(report["aborted"])
+        self.assertGreater(report["summary"]["error_count"], 0)
+        self.assertTrue(worktree.is_dir())
+
     def test_migration_original_and_destination_paths_are_protected(self) -> None:
         worktree = self.make_component_worktree()
         migrations = self.workspace.paths.workspace / "migrations"
@@ -350,6 +462,40 @@ class CleanupTests(unittest.TestCase):
         item = next(row for row in report["items"] if row["path"] == str(worktree))
         self.assertIn("migration_reference", item["reasons"])
         self.assertGreaterEqual(len(item["references"]["migration"]), 3)
+
+    def test_migration_path_inventory_covers_every_current_record_shape(self) -> None:
+        paths = list(
+            Cleanup._migration_paths(
+                {
+                    "sources": [
+                        {
+                            "source": str(self.root / "source"),
+                            "archive": str(self.root / "archive"),
+                        }
+                    ],
+                    "worktree_migrations": [
+                        {
+                            "path": str(self.root / "old"),
+                            "destination": str(self.root / "new"),
+                        }
+                    ],
+                    "composite_worktrees": [
+                        {"destination": str(self.root / "composite")}
+                    ],
+                    "worktrees": [{"destination": str(self.root / "worktree")}],
+                    "classic": {"path": str(self.root / "classic")},
+                }
+            )
+        )
+        self.assertEqual(len(paths), 7)
+        self.assertIn(("classic.path", self.root / "classic"), paths)
+
+        with self.assertRaisesRegex(WorkspaceError, "is not a list"):
+            list(Cleanup._migration_paths({"sources": {}}))
+        with self.assertRaisesRegex(WorkspaceError, "is invalid"):
+            list(Cleanup._migration_paths({"sources": ["invalid"]}))
+        with self.assertRaisesRegex(WorkspaceError, "classic path"):
+            list(Cleanup._migration_paths({"classic": 7}))
 
     def test_apply_revalidates_then_removes_without_deleting_branch(self) -> None:
         worktree = self.make_wrapper_worktree()
@@ -465,6 +611,80 @@ class CleanupTests(unittest.TestCase):
         self.assertTrue(item["source_worktree_removal"])
         self.assertEqual(item["reasons"], ["source_worktree_removal"])
 
+    def test_build_use_refreshes_exact_coordinate_metadata(self) -> None:
+        worktree = self.make_component_worktree()
+        self.workspace.create_profile("build-review")
+        self.workspace.set_profile(
+            "build-review", "client", "worktree", worktree.name
+        )
+        selected = {"client": worktree}
+        key = "c" * 12
+        root = self.workspace.paths.builds / "profiles" / f"build-review-{key}"
+        managed_directory(
+            root, self.workspace.paths.builds, f"profile:build-review:{key}"
+        )
+
+        self.workspace._refresh_build_metadata(
+            root, "build-review", key, selected
+        )
+
+        metadata = json.loads((root / ".atrinik-build.json").read_text(encoding="utf-8"))
+        self.assertEqual(metadata["profile"], "build-review")
+        self.assertEqual(metadata["key"], key)
+        self.assertEqual(
+            metadata["coordinates"]["client"],
+            {
+                "component": "client",
+                "checkout": "client",
+                "repository": "atrinik/client",
+                "branch": "main",
+                "source": ".",
+                "checkout_path": str(worktree.resolve()),
+                "source_path": str(worktree.resolve()),
+                "head": command("git", "rev-parse", "HEAD", cwd=worktree),
+            },
+        )
+        self.assertIsNotNone(_parse_time(metadata["last_used_at"], "last use"))
+
+    def test_invalid_or_future_build_metadata_protects_profile_root(self) -> None:
+        worktree = self.make_component_worktree()
+        build = self.make_build()
+        metadata = {
+            "schema_version": 1,
+            "profile": "review",
+            "key": "a" * 12,
+            "purpose": f"profile:review:{'a' * 12}",
+            "coordinates": {
+                "client": {
+                    "component": "client",
+                    "checkout": "client",
+                    "repository": "atrinik/client",
+                    "branch": "main",
+                    "source": ".",
+                    "checkout_path": str(worktree),
+                    "source_path": str(worktree),
+                    "head": command("git", "rev-parse", "HEAD", cwd=worktree),
+                }
+            },
+            "last_used_at": (
+                datetime.now(timezone.utc) + timedelta(days=1)
+            ).isoformat(),
+        }
+        atomic_json(build / ".atrinik-build.json", metadata)
+
+        report = self.workspace.cleanup(["builds"], 0, [], False)
+        item = next(row for row in report["items"] if row["path"] == str(build))
+        self.assertEqual(item["age_basis"], "last-used-at")
+        self.assertIn("future_last_used", item["reasons"])
+
+        metadata["coordinates"]["client"]["repository"] = "atrinik/server"
+        atomic_json(build / ".atrinik-build.json", metadata)
+        report = self.workspace.cleanup(["builds"], 0, [], False)
+        item = next(row for row in report["items"] if row["path"] == str(build))
+        self.assertIn("invalid_build_metadata", item["reasons"])
+        self.assertIn("manifest identity", item["error"])
+        self.assertIn("build_age_unavailable", item["reasons"])
+
     def test_apply_stops_after_first_post_mutation_failure_and_reports_actual_state(self) -> None:
         first = self.make_build("first", "a" * 12)
         second = self.make_build("second", "b" * 12)
@@ -530,11 +750,58 @@ class CleanupTests(unittest.TestCase):
         self.assertEqual(item["kind"], "unmanaged-build")
         self.assertEqual(item["disposition"], "protected")
 
+    def test_profile_marker_and_lock_validation_rejects_unsafe_shapes(self) -> None:
+        build = self.make_build()
+        marker = build / MANAGED_MARKER
+        self.assertEqual(
+            Cleanup._profile_marker(build),
+            (f"profile:review:{'a' * 12}", "review", "a" * 12),
+        )
+
+        marker.unlink()
+        with self.assertRaisesRegex(WorkspaceError, "missing or invalid"):
+            Cleanup._profile_marker(build)
+        atomic_json(marker, {"schema_version": SCHEMA_VERSION})
+        with self.assertRaisesRegex(WorkspaceError, "shape is invalid"):
+            Cleanup._profile_marker(build)
+        atomic_json(
+            marker,
+            {"schema_version": SCHEMA_VERSION, "purpose": "not-a-profile"},
+        )
+        with self.assertRaisesRegex(WorkspaceError, "purpose is invalid"):
+            Cleanup._profile_marker(build)
+        atomic_json(
+            marker,
+            {
+                "schema_version": SCHEMA_VERSION,
+                "purpose": f"profile:other:{'a' * 12}",
+            },
+        )
+        with self.assertRaisesRegex(WorkspaceError, "does not match its path"):
+            Cleanup._profile_marker(build)
+
+        directory_lock = self.workspace.paths.builds / "directory.lock"
+        directory_lock.mkdir()
+        busy, error = Cleanup._lock_busy(directory_lock)
+        self.assertFalse(busy)
+        self.assertTrue(error)
+        fifo_lock = self.workspace.paths.builds / "fifo.lock"
+        os.mkfifo(fifo_lock)
+        busy, error = Cleanup._lock_busy(fifo_lock)
+        self.assertFalse(busy)
+        self.assertIn("not a regular file", error or "")
+        symlink_lock = self.workspace.paths.builds / "symlink.lock"
+        symlink_lock.symlink_to(directory_lock, target_is_directory=True)
+        busy, error = Cleanup._lock_busy(symlink_lock)
+        self.assertFalse(busy)
+        self.assertTrue(error)
+
     def test_symlinked_workspace_build_container_is_report_only(self) -> None:
         shutil.rmtree(self.workspace.paths.builds)
         external = self.root / "external-builds"
         target = external / "profiles" / f"review-{'a' * 12}"
         managed_directory(target, external, f"profile:review:{'a' * 12}")
+        (external / "npm-cache").mkdir()
         self.workspace.paths.builds.symlink_to(external, target_is_directory=True)
 
         report = self.workspace.cleanup(["builds"], 0, [], False)
@@ -547,6 +814,11 @@ class CleanupTests(unittest.TestCase):
         self.assertEqual(item["kind"], "unmanaged-build")
         self.assertEqual(item["reasons"], ["invalid_build_container"])
         self.assertTrue(target.is_dir())
+
+        report = self.workspace.cleanup(["npm-cache"], 0, [], False)
+        cache = next(row for row in report["items"] if row["kind"] == "npm-cache")
+        self.assertEqual(cache["reasons"], ["invalid_cache_path"])
+        self.assertFalse(cache["legacy_known_cache"])
 
     def test_build_only_scope_still_protects_a_nested_registered_worktree(self) -> None:
         build = self.make_build()
@@ -671,6 +943,69 @@ class CleanupTests(unittest.TestCase):
         self.assertEqual(item["disposition"], "removed")
         self.assertFalse(cache.exists())
 
+    def test_managed_npm_cache_honors_metadata_marker_and_active_builds(self) -> None:
+        cache = self.workspace.paths.builds / "npm-cache"
+        managed_directory(cache, self.workspace.paths.builds, "npm-cache")
+        metadata_path = cache / ".atrinik-cache.json"
+        atomic_json(
+            metadata_path,
+            {
+                "schema_version": 1,
+                "purpose": "npm-cache",
+                "last_used_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+
+        report = self.workspace.cleanup(["npm-cache"], 7, [], False)
+        item = next(row for row in report["items"] if row["kind"] == "npm-cache")
+        self.assertFalse(item["legacy_known_cache"])
+        self.assertEqual(item["age_basis"], "last-used-at")
+        self.assertIn("younger_than_grace_period", item["reasons"])
+
+        atomic_json(
+            metadata_path,
+            {
+                "schema_version": 1,
+                "purpose": "npm-cache",
+                "last_used_at": (
+                    datetime.now(timezone.utc) + timedelta(days=1)
+                ).isoformat(),
+            },
+        )
+        report = self.workspace.cleanup(["npm-cache"], 0, [], False)
+        item = next(row for row in report["items"] if row["kind"] == "npm-cache")
+        self.assertIn("future_last_used", item["reasons"])
+
+        atomic_json(metadata_path, {"schema_version": 1, "purpose": "wrong"})
+        atomic_json(
+            cache / MANAGED_MARKER,
+            {"schema_version": SCHEMA_VERSION, "purpose": "wrong"},
+        )
+        lock = self.workspace.paths.builds / "locks" / "active.lock"
+        lock.parent.mkdir()
+        with lock.open("w", encoding="utf-8") as stream:
+            import fcntl
+
+            fcntl.flock(stream, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            report = self.workspace.cleanup(["npm-cache"], 0, [], False)
+        item = next(row for row in report["items"] if row["kind"] == "npm-cache")
+        self.assertIn("invalid_managed_marker", item["reasons"])
+        self.assertIn("invalid_cache_metadata", item["reasons"])
+        self.assertIn("cache_age_unavailable", item["reasons"])
+        self.assertIn("active_build", item["reasons"])
+
+        cleanup = Cleanup(self.workspace)
+        with self.assertRaisesRegex(WorkspaceError, "marker appeared"):
+            cleanup._remove(
+                {
+                    "kind": "npm-cache",
+                    "path": str(cache),
+                    "legacy_known_cache": True,
+                }
+            )
+        with self.assertRaisesRegex(WorkspaceError, "unsupported cleanup target"):
+            cleanup._remove({"kind": "unknown", "path": str(cache)})
+
     def test_dry_run_does_not_create_an_absent_workspace(self) -> None:
         shutil.rmtree(self.workspace.paths.workspace)
         report = self.workspace.cleanup(["builds"], 7, [], False)
@@ -683,6 +1018,12 @@ class CleanupTests(unittest.TestCase):
         repository = Path(__file__).resolve().parents[1]
         actual_workspace = Workspace(repository)
         cleanup = Cleanup(actual_workspace)
+        self.assertEqual(
+            cleanup._normalize_scopes(["all"]), ["worktrees", "builds", "npm-cache"]
+        )
+        self.assertEqual(cleanup._normalize_names(["atrinik"]), {"atrinik"})
+        with self.assertRaisesRegex(WorkspaceError, "unknown components"):
+            cleanup._normalize_names(["not-a-component"])
         self.assertEqual(
             cleanup._normalize_names(
                 ["classic", "classic-client", "classic-server", "classic-protocol"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,6 +42,53 @@ class ParserTests(unittest.TestCase):
         workspace_type.return_value.cleanup.assert_called_once_with([], 7, [], False)
         self.assertEqual(json.loads(output.call_args.args[0]), report)
 
+    def test_cleanup_combines_scopes_filters_and_reports_apply_failure(self) -> None:
+        report = {
+            "schema_version": 1,
+            "mode": "apply",
+            "scopes": ["worktrees", "builds"],
+            "older_than_days": 0,
+            "filters": ["classic"],
+            "inventory_errors": [],
+            "items": [],
+            "summary": {
+                "item_count": 0,
+                "candidate_count": 0,
+                "candidate_bytes": 0,
+                "protected_count": 0,
+                "protected_bytes": 0,
+                "skipped_count": 0,
+                "skipped_bytes": 0,
+                "removed_count": 0,
+                "removed_bytes": 0,
+                "error_count": 1,
+                "error_bytes": 0,
+            },
+            "aborted": True,
+        }
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.cleanup.return_value = report
+            with mock.patch("builtins.print"):
+                result = main(
+                    [
+                        "cleanup",
+                        "classic-client",
+                        "--scope",
+                        "worktrees",
+                        "--scope",
+                        "builds",
+                        "--older-than",
+                        "0",
+                        "--apply",
+                        "--json",
+                    ]
+                )
+
+        self.assertEqual(result, 1)
+        workspace_type.return_value.cleanup.assert_called_once_with(
+            ["worktrees", "builds"], 0, ["classic-client"], True
+        )
+
     def test_init_with_classic_dispatches_only_documented_additive_option(self) -> None:
         with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
             result = main(["init", "--with", "classic", "--jobs", "2"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,38 @@ from atrinik_workspace.model import WorkspaceError
 
 
 class ParserTests(unittest.TestCase):
+    def test_cleanup_defaults_to_preview_and_reports_json(self) -> None:
+        report = {
+            "schema_version": 1,
+            "mode": "dry-run",
+            "scopes": ["worktrees", "builds"],
+            "older_than_days": 7,
+            "filters": [],
+            "inventory_errors": [],
+            "items": [],
+            "summary": {
+                "item_count": 0,
+                "candidate_count": 0,
+                "candidate_bytes": 0,
+                "protected_count": 0,
+                "protected_bytes": 0,
+                "skipped_count": 0,
+                "skipped_bytes": 0,
+                "removed_count": 0,
+                "removed_bytes": 0,
+                "error_count": 0,
+                "error_bytes": 0,
+            },
+        }
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.cleanup.return_value = report
+            with mock.patch("builtins.print") as output:
+                result = main(["cleanup", "--dry-run", "--json"])
+
+        self.assertEqual(result, 0)
+        workspace_type.return_value.cleanup.assert_called_once_with([], 7, [], False)
+        self.assertEqual(json.loads(output.call_args.args[0]), report)
+
     def test_init_with_classic_dispatches_only_documented_additive_option(self) -> None:
         with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
             result = main(["init", "--with", "classic", "--jobs", "2"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,6 +89,45 @@ class ParserTests(unittest.TestCase):
             ["worktrees", "builds"], 0, ["classic-client"], True
         )
 
+    def test_cleanup_text_report_includes_item_age_reasons_and_totals(self) -> None:
+        report = {
+            "items": [
+                {
+                    "disposition": "eligible",
+                    "kind": "worktree",
+                    "allocated_bytes": 4096,
+                    "age_seconds": 2 * 86400,
+                    "path": "/workspace/review",
+                    "reasons": ["merged_pr_head"],
+                }
+            ],
+            "summary": {
+                "candidate_count": 1,
+                "candidate_bytes": 4096,
+                "protected_count": 0,
+                "protected_bytes": 0,
+                "removed_count": 0,
+                "removed_bytes": 0,
+                "error_count": 0,
+            },
+        }
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.cleanup.return_value = report
+            with mock.patch("builtins.print") as output:
+                result = main(["cleanup", "--scope", "all"])
+
+        self.assertEqual(result, 0)
+        lines = [call.args[0] for call in output.call_args_list]
+        self.assertIn(
+            "eligible\tworktree\t4096\t2d\t/workspace/review\tmerged_pr_head",
+            lines,
+        )
+        self.assertIn(
+            "summary\tcandidates=1 candidate_bytes=4096 protected=0 "
+            "protected_bytes=0 removed=0 removed_bytes=0 errors=0",
+            lines,
+        )
+
     def test_init_with_classic_dispatches_only_documented_additive_option(self) -> None:
         with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
             result = main(["init", "--with", "classic", "--jobs", "2"])

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -654,6 +654,25 @@ class PathSafetyTests(unittest.TestCase):
                 managed_remove(outside, builds, "outside")
             self.assertTrue(outside.is_dir())
 
+    def test_managed_remove_rejects_a_symlinked_build_container(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            external = root / "external"
+            external.mkdir()
+            target = external / "profiles" / "review"
+            managed_directory(target, external, "profile:review:key")
+            builds = root / "build"
+            builds.symlink_to(external, target_is_directory=True)
+
+            with self.assertRaisesRegex(WorkspaceError, "not a regular directory"):
+                managed_remove(
+                    builds / "profiles" / "review",
+                    builds,
+                    "profile:review:key",
+                )
+
+            self.assertTrue(target.is_dir())
+
     def test_refuses_malformed_workspace_marker(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -14,6 +14,7 @@ from atrinik_workspace.model import (
     WorkspaceError,
     atomic_json,
     managed_directory,
+    managed_remove,
     managed_reset,
     profile_key,
 )
@@ -631,6 +632,27 @@ class PathSafetyTests(unittest.TestCase):
                 managed_reset(target, builds, "test")
 
             self.assertTrue(real.is_dir())
+
+    def test_managed_remove_revalidates_marker_purpose_and_containment(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            builds = root / "build"
+            target = builds / "profiles" / "review"
+            managed_directory(target, builds, "profile:review:key")
+            (target / "artifact").write_text("generated", encoding="utf-8")
+
+            with self.assertRaisesRegex(WorkspaceError, "does not match"):
+                managed_remove(target, builds, "profile:other:key")
+            self.assertTrue((target / "artifact").is_file())
+
+            managed_remove(target, builds, "profile:review:key")
+            self.assertFalse(target.exists())
+
+            outside = root / "outside"
+            managed_directory(outside, root, "outside")
+            with self.assertRaisesRegex(WorkspaceError, "outside workspace builds"):
+                managed_remove(outside, builds, "outside")
+            self.assertTrue(outside.is_dir())
 
     def test_refuses_malformed_workspace_marker(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Summary

- Add preview-first cleanup planning for registered worktrees, marker-owned profile builds, and the explicit shared npm cache.
- Fail closed on Git/GitHub, workspace-reference, marker, lock, age, topology-coordinate, and filesystem ambiguity; revalidate every apply target under the repository-layout lock.
- Record strict build/cache last-use metadata and document the retention and operator workflow.
- Harden parent-symlink boundaries, protected-primary size accounting, manifest-bound metadata, and deterministic partial-failure reporting through iterative self-review.

Closes #291.

## Validation

- Complete coverage test suite passes after rebasing onto current main; cleanup combined statement/branch coverage is 83%.
- Compileall, manifest validation, and diff checking pass.
- Authenticated real-workspace cleanup dry-run: 40 protected, 0 candidates, 0 errors, no mutation; this PR is protected as an open pull request.
- Codecov patch coverage passes at 75.52% against the 70.57% target.
- Integration validation, both CodeQL analyses, CodeQL, and conventional PR title checks pass.

Deep self-review is complete with no open finding. The ignored review report records the safety, correctness, duplication, dependency, scale, performance, and operability analysis and each resolution.