### PR TITLE
refactor(agents): reduce guidance context and drift

### DIFF
--- a/.agents/skills/atrinik-c-change/SKILL.md
+++ b/.agents/skills/atrinik-c-change/SKILL.md
@@ -1,58 +1,39 @@
 ---
 name: atrinik-c-change
-description: Implement and validate Atrinik C17 code, headers, native builds, warnings, formatting, tests, and public APIs. Use when native client, server, libatrinik, CMake, or generated-consumer code is the primary change.
+description: Implement and validate classic Atrinik C17/CMake changes. Use for native classic client, server, libatrinik, generated consumers, or shared headers; replacement client/server work is Rust/Go.
 ---
 
-# Atrinik C Change
+# Atrinik classic C change
 
-Use this skill for native implementation work whose primary contract is C or
-C++. Use `atrinik-protocol-change` instead when the wire contract is primary,
-and combine this skill with `atrinik-multi-repo-workspace` when more than one
-standalone repository is involved.
+Use this wrapper skill to coordinate native work in the `atrinik/classic`
+monorepo. Load `atrinik-protocol-change` when bytes on the wire are primary and
+`atrinik-multi-repo-workspace` when another physical checkout is affected.
 
 ## Establish ownership
 
-1. Read the workspace and selected component `AGENTS.md` files.
-2. Select the owning component through a workspace profile; do not edit a dirty
-   primary checkout or copy implementation into the wrapper repository.
-3. Trace declarations, implementations, generated inputs, callers, and tests
-   before changing an API. `client` and `server` are C17 applications;
-   `libatrinik` owns reusable native libraries; `protocol` owns generated
-   command identifiers.
-4. Preserve component boundaries. Move generally reusable code into
-   `libatrinik` only when its ownership and consumer contract are clear.
+1. Create/select one full `classic` worktree and a classic-derived profile.
+   Never edit a dirty primary or treat a module subdirectory as an independent
+   repository.
+2. Read `classic/AGENTS.md`, the nearest module guide, and the applicable local
+   `classic-native-change` or `classic-protocol-change` skill.
+3. Trace declarations, implementations, generated inputs, callers, and tests.
+   `classic/client`, `classic/server`, and `classic/libatrinik` own native code;
+   `classic/protocol/schema/game-commands.json` owns generated command IDs.
 
-## Implement the contract
+Follow the monorepo's formatting, allocation, lifetime, error, and CMake
+conventions. Edit authoritative inputs instead of generated output, update
+source lists, and cover success, boundaries, failure, and cleanup. Treat
+warnings, sanitizer findings, and static-analysis reports as defects.
 
-- Follow each repository's `.clang-format` and existing naming, allocation,
-  logging, error, and ownership conventions.
-- Update the authoritative source rather than generated output. For protocol
-  identifiers, edit `protocol/schema/game-commands.json` and regenerate. For
-  Flex or export-definition output, update the checked-in source input.
-- Update CMake source lists such as `src/cmake.txt` when files are added or
-  removed. Keep public headers minimal and document lifetime and ownership at
-  the boundary.
-- Treat compiler warnings, sanitizer findings, and static-analysis reports as
-  defects. Do not suppress a diagnostic without explaining the local contract.
-- Add focused unit or integration coverage for success, boundary, failure, and
-  cleanup paths. Preserve deterministic behavior where state or ordering is
-  observable.
-
-## Validate through the workspace
-
-Build and test every affected native component with the selected profile:
+## Validate
 
 ```sh
 ./atrinik profile show PROFILE
 ./atrinik build COMPONENT --profile PROFILE --test
 ```
 
-Build downstream consumers when a public `libatrinik` API or generated
-protocol identifier changes. Run repository-specific generation checks,
-formatters, sanitizers, static analysis, and the documented `linux-coverage`
-preset for substantial native logic changes, then run `git diff --check` in
-each changed repository. Keep gcovr source and test exclusions intentional.
-
-If behavior requires a live client/server check, follow the complete
-`topology show`/`up`/`ps`/`logs`/`down` lifecycle from the workspace guide and
-use `atrinik-test-scenario` when a ready account and character are useful.
+Build every affected consumer of a public library or generated protocol
+change. Run the module's generation/dependency checks, the documented coverage
+preset for substantial logic, and `git diff --check`. For live behavior, use
+`atrinik-server-runtime` and the complete supervised lifecycle; add
+`atrinik-test-scenario` when login state is useful.

--- a/.agents/skills/atrinik-c-change/SKILL.md
+++ b/.agents/skills/atrinik-c-change/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: atrinik-c-change
-description: Implement and validate classic Atrinik C17/CMake changes. Use for native classic client, server, libatrinik, generated consumers, or shared headers; replacement client/server work is Rust/Go.
+description: Change classic C17/CMake code, headers, and generated consumers; excludes Rust/Go replacements.
 ---
 
 # Atrinik classic C change

--- a/.agents/skills/atrinik-c-change/agents/openai.yaml
+++ b/.agents/skills/atrinik-c-change/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Atrinik C Change"
-  short_description: "Implement and validate Atrinik native code"
-  default_prompt: "Use $atrinik-c-change to implement this native Atrinik change in the owning component and validate every affected consumer."
+  short_description: "Implement and validate classic native code"
+  default_prompt: "Use $atrinik-c-change to implement this classic C change in its owning module and validate every affected consumer."

--- a/.agents/skills/atrinik-content-change/SKILL.md
+++ b/.agents/skills/atrinik-content-change/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: atrinik-content-change
-description: Change and validate Atrinik authored world data. Use for maps, archetypes, media metadata, quests, interfaces, embedded scripts, or content collection on `main` or `1.x`.
+description: Change authored content on `main` or `1.x`, including maps, archetypes, media, and scripts.
 ---
 
 # Atrinik content change

--- a/.agents/skills/atrinik-content-change/SKILL.md
+++ b/.agents/skills/atrinik-content-change/SKILL.md
@@ -1,55 +1,40 @@
 ---
 name: atrinik-content-change
-description: Change and validate Atrinik maps, archetypes, graphics, animations, artifacts, treasures, factions, interfaces, quests, and embedded scripts. Use when authored files or content collection in the content repository are primary.
+description: Change and validate Atrinik authored world data. Use for maps, archetypes, media metadata, quests, interfaces, embedded scripts, or content collection on `main` or `1.x`.
 ---
 
-# Atrinik Content Change
+# Atrinik content change
 
-Use this skill for authored world data in the standalone `content` repository.
-Combine it with `atrinik-multi-repo-workspace` when a server, client, resource,
-or tooling change is also required.
+Use `content@main` for replacement forward authoring and `content-1x@1.x` for
+classic maintenance. Never assume a format or generated artifact belongs on
+both lines; cross-line changes use separate worktrees, validation, commits, and
+pull requests. Add `atrinik-multi-repo-workspace` when another checkout is
+affected.
 
-## Establish the content contract
+## Establish the contract
 
-1. Read the workspace guide plus `content/AGENTS.md` and the nearest nested
-   guide under `arch/` or `maps/`.
-2. Work in a selected content worktree. Do not write generated runtime output
-   back into the source tree or replace a mutable server-data directory.
-3. Use `tools/content_catalog` as the authoritative identity and cross-reference
-   layer. Domain-qualified stable IDs are contracts; display names, filesystem
-   order, and runtime table positions are not identities.
-4. Trace every map path, archetype, animation, image, artifact, treasure,
-   faction, interface, and script reference touched by the change.
-
-## Make the change
-
-- Preserve established file layout, formatting, naming, attribution, and
-  per-asset licensing. Keep unrelated normalizer churn out of the diff.
-- Keep map and archetype references portable and case-correct. Never hide a
-  missing reference with a local absolute path or a generated placeholder.
-- Treat embedded Python as runtime code: preserve engine-owned entry points,
-  avoid nondeterministic side effects, and validate failure behavior.
-- Use `tools/world_content_audit.py` only for read-only exploratory summaries.
-  It does not replace `tools/validate.py` or the catalog, and report findings
-  are not generated source.
-- The standalone `tools` repository owns the map checker. Do not copy its
-  implementation or bypass its released content-catalog dependency.
+1. Select the exact content checkout/branch, then read its root guide and the
+   nearest `arch/` or `maps/` guide.
+2. Use `tools/content_catalog` for stable domain identities and references.
+   Trace every affected map, archetype, animation, image, artifact, treasure,
+   faction, interface, and script reference.
+3. Preserve layout, formatting, case, attribution, and per-asset licenses.
+   Keep unrelated normalization out of the diff. Never mask a missing
+   reference with an absolute path or generated placeholder.
+4. Treat embedded Python as classic runtime code. Keep runtime output in an
+   isolated generated directory and never overwrite mutable server state.
 
 ## Validate
 
-Run the canonical content validator and build an isolated runtime tree:
+Run the checkout's canonical aggregate validator; it already performs contract,
+schema, syntax, and runtime-build validation:
 
 ```sh
 python3 tools/validate.py
-python3 tools/build_runtime.py --output /tmp/atrinik-content-runtime
-python3 tools/world_content_audit.py all
+git diff --check
 ```
 
-Use a task-specific temporary directory rather than the literal example when
-concurrent work is possible. Run focused collection or audit commands for the
-changed domain, then `git diff --check`.
-
-For live behavior, select the content worktree in a workspace profile, build
-the affected server/client components with `./atrinik build ... --test`, and
-hand off the exact wrapper-native topology lifecycle. Use
-`atrinik-test-scenario` for repeatable gameplay state.
+Run `python3 tools/world_content_audit.py all` only when its read-only report is
+relevant, plus focused commands named by the changed domain. For live behavior,
+select the exact content worktree in a coherent profile and use wrapper-native
+build/topology commands. Use `atrinik-test-scenario` for repeatable state.

--- a/.agents/skills/atrinik-github-governance/SKILL.md
+++ b/.agents/skills/atrinik-github-governance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: atrinik-github-governance
-description: Change Atrinik GitHub settings, rulesets, merge/release policy, Actions permissions, required checks, or governance automation.
+description: Change Atrinik GitHub policy, settings, Actions, required checks, or release governance.
 ---
 
 # Atrinik GitHub Governance

--- a/.agents/skills/atrinik-github-governance/SKILL.md
+++ b/.agents/skills/atrinik-github-governance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: atrinik-github-governance
-description: Maintain Atrinik GitHub repository settings, rulesets, merge policy, Actions permissions, required checks, organization policy, and governance automation. Use for any repository-policy or workflow-contract change.
+description: Change Atrinik GitHub settings, rulesets, merge/release policy, Actions permissions, required checks, or governance automation.
 ---
 
 # Atrinik GitHub Governance

--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -1,267 +1,111 @@
 ---
 name: atrinik-multi-repo-workspace
-description: Coordinate changes, reviews, builds, releases, and Git worktrees across Atrinik's repositories and monorepos through the atrinik/atrinik workspace. Use for tasks spanning components, choosing an owning repository, synchronizing default branches, creating or combining worktrees, collecting runtime resources, sharing server state, publishing coordinated changes, or changing the workspace manifest, CLI, layout, or operating procedures.
+description: Coordinate Atrinik work across checkouts, profiles, worktrees, cleanup, wrapper builds/runtime, releases, or workspace CLI and layout. Use when ownership crosses a physical repository or the wrapper itself changes.
 ---
 
 # Atrinik multi-repository workspace
 
-## Establish scope and ownership
+## Resolve scope and ownership
 
-- Run commands from the `atrinik/atrinik` wrapper root. Read `AGENTS.md`,
-  `components.json`, `README.md`, and `docs/ARCHITECTURE.md` before changing
-  orchestration behavior.
-- Treat `components.json` as the source of truth for physical checkout
-  identity, repository, branch, destination, initialization-cohort membership,
-  and for each logical component's safe source root, provider roles,
-  requirements, license, and build contract. Inspect the selected component's
-  own instructions at its resolved source root before editing it.
-- Put implementation, tests, packages, and component release configuration in
-  the owning physical repository. Put only orchestration, composition,
-  manifest, and workspace documentation in the wrapper.
-- Expect physical repositories at their manifest destinations below the
-  wrapper root, such as `./client`, `./classic`, `./content`, and
-  `./content-1x`. The single `atrinik/classic` checkout contains logical
-  `classic-server`, `classic-client`, `classic-editor`,
-  `classic-libatrinik`, and `classic-protocol` components at their respective
-  source directories. The two content checkouts use the same repository but
-  distinct `main` and `1.x` branches, destinations, cohorts, and roles.
-  Generated worktrees, profiles, builds, and default state remain under
-  `./workspace`; `ATRINIK_WORKSPACE_DIR` relocates only that generated and
-  mutable data.
-- Keep workspace-specific VS Code launch configurations in the wrapper's
-  `.devcontainer/` directory. The standalone `devcontainer` component owns the
-  reusable images; use `./atrinik init` for post-create repository setup.
-- Preserve dirty checkouts and worktrees. Never move component source into the
-  wrapper or replace persistent state manually. The checked repository
-  migration preserves recoverable originals and may repair only a linked
-  worktree's Git administrative `.git` pointer while leaving its path and
-  working files untouched.
+Run commands from the `atrinik/atrinik` wrapper root.
 
-## Prepare repositories and worktrees
+1. Read root `AGENTS.md`. Read only the task-relevant wrapper source/docs:
+   - ownership, cohorts, roles, or build contracts: `components.json`;
+   - operator command behavior: the matching `README.md` section;
+   - layout, locking, trust, or lifecycle design: the matching
+     `docs/ARCHITECTURE.md` section;
+   - pre-split repositories: [repository migration](references/repository-migration.md).
+2. Resolve every affected logical component to its physical checkout and safe
+   source root. Read that checkout's nearest `AGENTS.md` before editing.
+3. Put component implementation/tests/packages/releases in the owning physical
+   repository. Put only orchestration, composition, manifest, and wrapper docs
+   here.
 
-1. Validate and initialize only the required repositories:
+Physical checkouts are independent ignored Git repositories. One `classic`
+worktree contains its five logical source directories. `content@main` and
+`content-1x@1.x` are distinct checkouts even though their GitHub coordinate is
+the same. Keep wrapper VS Code composition under `.devcontainer/`; reusable
+images belong to the `devcontainer` checkout.
 
-   ```sh
-   ./atrinik manifest validate
-   ./atrinik init
-   ./atrinik init COMPONENT...
-   ./atrinik init --with classic
-   ```
+## Prepare safe worktrees
 
-   Plain `init` resolves only the replacement/default cohort. Exact
-   `--with classic` is additive: it resolves the default cohort plus the
-   complete classic cohort consisting of the `atrinik/classic` monorepo,
-   `content-1x@1.x`, and retained GPL tools. The option never means
-   classic-only and has no competing alias. Explicit checkout or logical
-   component initialization remains available for partial workspaces; aliases
-   that own the same physical checkout are cloned once.
-   Initialization follows the wrapper repository's GitHub SSH or HTTPS
-   transport for new component clones. Keep the wrapper's `origin` (or
-   `upstream`) transport current instead of adding per-component URL overrides.
-
-2. Inspect local state with `./atrinik status --json`. This is a quiet,
-   non-networked snapshot suitable for automation; its records describe
-   physical checkouts, their logical modules, default/classic membership, and
-   optional initialization state. Use `sync` before relying on cached
-   ahead/behind counts as current GitHub state.
-3. Synchronize clean primary checkouts before starting work. Plain
-   `./atrinik sync` visits only initialized default-cohort checkouts and never
-   clones a missing repository. Use `./atrinik sync --with classic` for
-   already initialized default plus classic-cohort members, or `./atrinik sync
-   CHECKOUT_OR_COMPONENT...` for exact identities. Multiple names that resolve
-   to one physical checkout are synchronized once. Use `--worktrees merge` or
-   `--worktrees rebase` only
-   when updating every clean attached feature worktree is intentional.
-4. Create checkout worktrees through the coordinator:
-
-   ```sh
-   ./atrinik worktree create CHECKOUT_OR_COMPONENT LABEL \
-     --branch TYPE/TOPIC [--from START_POINT]
-   ```
-
-   A Git worktree always contains the complete physical repository. A classic
-   worktree therefore lives at `workspace/worktrees/classic/LABEL` and contains
-   all five classic source directories, even when it was requested through a
-   logical component alias.
-
-5. Commit and push from inside each checkout worktree. Use Conventional
-   Commits and open the pull request in that physical repository. Do not create
-   a wrapper commit for component-source-only changes.
-
-6. Reclaim completed review data only through the explicit preview-first
-   workflow. Default cleanup covers worktrees plus profile builds; npm cache
-   removal is always opt-in:
-
-   ```sh
-   ./atrinik cleanup --dry-run --json
-   ./atrinik cleanup --scope worktrees --scope builds CHECKOUT... --older-than 7
-   ./atrinik cleanup --scope all --older-than 7 --apply
-   ```
-
-   A saved profile, retained scenario, live topology, migration record,
-   build-retention record, dirty/detached/locked/in-progress worktree, or
-   uncertain Git/GitHub/marker identity protects its target. Exact merged PR
-   heads alone qualify after the grace period. Apply recomputes under the
-   repository-layout lock, removes marker-owned builds first, invokes
-   non-force Git worktree removal second, and handles the explicit cache and
-   safely shared prunable metadata last. It never removes profiles, scenarios,
-   states, topology records/logs, migration evidence/archives, branches, Git
-   objects, deep-review reports, or arbitrary unmarked paths.
-
-## Migrate a pre-split workspace
-
-Before replacing a workspace containing the former standalone classic
-repositories, initialize the destination `classic` checkout and use the checked
-migration workflow:
+Inspect local state before mutation:
 
 ```sh
-./atrinik init classic
-./atrinik migrate repositories --dry-run
-./atrinik migrate repositories --dry-run --json
-./atrinik migrate repositories --apply
-./atrinik migrate repositories --audit --json
+./atrinik manifest validate
+./atrinik status --json
 ```
 
-`init classic` needs only the maintained classic `main` branch. Commit maps
-prove integrated history. If a mapped branch-only rewritten object was retired,
-migration imports the exact verified local source commit as a bridge parent;
-do not recreate or fetch a `history/*` namespace.
+Initialize only missing repositories. Plain `init` selects the replacement
+cohort; exact `--with classic` adds the complete classic cohort. `sync` never
+clones an absent checkout.
 
-- Dry-run and audit are read-only. Review every planned move, worktree repair,
-  and profile rewrite before apply.
-- Historical sources may be at their original canonical paths or the later
-  `legacy-server`, `legacy-client`, `legacy-editor`, `legacy-libatrinik`, and
-  `legacy-protocol` paths. Apply preflights their identities and matching
-  `./classic/server`, `./classic/client`, `./classic/editor`,
-  `./classic/libatrinik`, and `./classic/protocol` destinations as one
-  recoverable operation. It preserves attributable history and recoverable
-  originals, and refuses ambiguous identities, conflicting occupants, unsafe
-  Git states, or live affected topologies.
-- Leave linked worktree directories at their existing paths, including dirty
-  linked worktrees. The migration may repair Git administrative metadata and a
-  linked worktree's `.git` pointer as the former common Git directory is
-  incorporated or archived; that repair must not change or move its working
-  files.
-- Rewrite saved classic profiles atomically from former repository roots to
-  the new checkout-root/source-root model. Fail the complete profile migration
-  when a selector cannot be proven; in particular, never assign an ambiguous
-  content worktree to `content-1x` merely because an old profile predates the
-  content branch split.
-- Treat the migration-only `migrated-worktree` selector as provenance for an
-  exact classic profile, not a general override. It is valid only for
-  `content-1x` at the old managed content-worktree path while attached to the
-  `content@main` Git directory; never create it through `profile set`.
-  Exclude it before dirty checks and updates when synchronizing worktrees from
-  `content@main`; use a normal `content-1x` worktree for new classic work.
-- Do not move or reinterpret content checkouts, state directories, build trees,
-  collected runtimes, scenario data, topology records, or logs. Repository
-  migration never initializes a checkout. In a pre-split workspace, initialize
-  only the destination with `init classic` before the dry run; additive
-  `init --with classic` also preflights occupied replacement paths and belongs
-  after migration when the rest of the classic cohort is needed.
+```sh
+./atrinik init [COMPONENT...]
+./atrinik init --with classic
+./atrinik sync [COMPONENT...]
+./atrinik sync --with classic
+./atrinik worktree create COMPONENT LABEL --branch TYPE/TOPIC
+```
 
-## Compose and validate coordinated changes
+Synchronize only clean primaries. Preserve dirty checkouts and worktrees; never
+replace, move, or remove them implicitly. A logical classic name creates one
+full `classic` repository worktree under
+`workspace/worktrees/classic/LABEL`. Commit and push inside each owning
+worktree with Conventional Commits.
 
-Create a profile from the coherent stack that owns the work. `default` selects
-the MIT replacement providers; `classic` selects the currently playable
-classic providers. A profile retains this identity and cannot mix replacement
-and classic providers in one runnable service closure:
+Reclaim completed review data only through preview-first cleanup:
+
+```sh
+./atrinik cleanup --dry-run --json
+./atrinik cleanup --scope worktrees --scope builds CHECKOUT... --older-than 7
+./atrinik cleanup --scope all --older-than 7 --apply
+```
+
+The default covers registered worktrees and marker-owned builds; npm cache is
+always opt-in. References, local/Git uncertainty, and unsafe path or marker
+state protect a target. Apply recomputes under the repository-layout lock,
+removes builds before non-force Git worktrees, and preserves profiles,
+scenarios, states, topology records/logs, migrations, retention records,
+branches, Git objects, review reports, and unmarked paths. For cleanup changes,
+hand off exact fixture names, JSON preview/apply commands, expected reason
+codes, and the preserved records.
+
+## Compose coherent sources
+
+Use `default` for replacement sources and `classic` for the currently playable
+classic stack. Never mix providers or use classic C/CMake as a fallback for a
+missing replacement adapter. Replacement repositories have standalone M1
+foundations, but the wrapper replacement build/runtime closure is not yet
+available.
 
 ```sh
 ./atrinik profile create REVIEW --from classic
-./atrinik profile set REVIEW classic --worktree LABEL
-./atrinik profile set REVIEW COMPONENT --path /absolute/checkout-root
-./atrinik profile show REVIEW
-./atrinik build all --profile REVIEW --test
+./atrinik profile set REVIEW CHECKOUT_OR_COMPONENT --worktree LABEL
+./atrinik profile show REVIEW --json
+./atrinik path COMPONENT --profile REVIEW
+./atrinik build COMPONENT --profile REVIEW --test
 ```
 
-Selecting physical checkout `classic`, logical component `classic-server`, or
-role `server` has the same checkout-wide effect: every in-stack component owned
-by `atrinik/classic` receives one identical selector. Profile schema 3 rejects
-a profile that tries to select two roots for one physical checkout. Resolution
-then appends each component's declared source (`server`, `client`, `editor`,
-`libatrinik`, or `protocol`). Combine separate classic module branches into
-one monorepo branch and worktree before selecting them in a profile; never
-pretend a subdirectory is an independent Git worktree.
+Selecting checkout `classic`, one of its logical components, or a provided
+role updates all five classic selectors to one checkout root. Resolution then
+appends each manifest source path. Do not treat a classic subdirectory as an
+independent worktree.
 
-Create a related profile with `./atrinik profile create NEW --from REVIEW`.
-Resolve a logical component source root for shell or tool use with
-`./atrinik path COMPONENT --profile REVIEW`; do not reconstruct managed paths
-in scripts. Prefer `--json` for status, worktree, profile, and state listings.
+Build, scenario, and topology records bind the exact repository, branch,
+checkout, source, component, and provider. Treat older records without current
+immutable coordinates as inert. Let the wrapper collect content/resources and
+own generated paths, locks, state, PIDs, logs, and process cleanup.
 
-Use primary selectors for unaffected physical checkouts. Logical roles resolve
-to one compatible provider per selected stack before paths or build commands
-are chosen. The profile build collects the selected content, resources, and
-sound into isolated generated views; do not manually copy dependencies between
-repositories. Build a single dependency closure with `./atrinik build
-COMPONENT --profile REVIEW --test` when a full system build is unnecessary.
-Build keys and persisted scenario/topology resolutions include repository,
-branch, checkout, source, and logical provider identities. Treat older records
-without that full coordinate as inert; never reinterpret them through a newer
-manifest.
+For classic server execution or diagnosis, load `atrinik-server-runtime`. For
+a ready account and character, also load `atrinik-test-scenario`; never
+handcraft saves or expose credentials. Keep every concurrent topology on a
+distinct name and server state.
 
-The replacement `server`, `client`, `editor`, `protocol`, `renderer`,
-`content-toolkit`, and `website` repositories have validated standalone M1
-foundations. Their wrapper build/runtime adapters and integrated service
-closure have not landed. Do not route `default` through classic C/CMake code or
-claim it is currently runnable. Use a profile derived from `classic` for
-present game build, scenario, and runtime verification. GPL tools belong only
-to that classic closure.
+## Validate and hand off
 
-The resources repository owns its runtime distribution boundary in
-`runtime-paths.txt`. Add a new tracked asset collection to that allowlist in
-the same resources change; do not stage repository-wide files or alter the
-wrapper to special-case individual metadata filenames. The coordinator serves
-only tracked regular files selected by the manifest.
-
-For current runtime testing, use a classic-derived profile. Register persistent
-server state once and reuse it across compatible classic profiles:
-
-```sh
-./atrinik state add NAME
-./atrinik state add NAME --path /absolute/server-data
-./atrinik run server --profile REVIEW --state NAME --port UDP_PORT --dry-run
-./atrinik run client --profile REVIEW --state NAME --port UDP_PORT --dry-run
-```
-
-Remove `--dry-run` only when an actual launch is intended. For foreground use,
-start the server first so its persistent QUIC identity exists, then use the
-same state and port for the client. The client is pinned to that identity and
-metaserver/STUN discovery is disabled; the server disables STUN discovery and
-automatic port mapping. Verify display forwarding before opening the client.
-Do not run two servers against one state directory outside the coordinator's
-locking model. Prefer the supervised lifecycle below for routine paired use.
-
-For a persistent client/server review session, treat the profile as a source
-topology and use the supervised lifecycle:
-
-```sh
-./atrinik topology show REVIEW --json
-./atrinik up --name RUNTIME --profile REVIEW --state NAME [--port UDP_PORT]
-./atrinik ps [RUNTIME] --json
-./atrinik logs RUNTIME server --follow
-./atrinik down RUNTIME
-```
-
-Select one service with `up --service server` or `--service client`. Use a
-distinct `--name` and state for every concurrent server topology; omit `--port`
-for automatic allocation or choose a distinct explicit port. Once the
-replacement stack becomes runnable, a concurrent `default`/`classic`
-comparison must also keep the two profiles, topology names, state names,
-generated views, and client configuration roots distinct. The supervisor waits
-for completed server initialization and its fingerprint, pins the paired client
-to it, and isolates each runtime's client configuration. Do not signal
-recorded PIDs directly or tail internal files by reconstructed paths: the
-coordinator verifies process start identity, rotates logs, performs graceful
-shutdown, and holds the server-state lock through its supervisor.
-
-## Provide manual verification handoffs
-
-End every implementation or change handoff with copy-pasteable manual
-verification commands using `./atrinik` wherever the coordinator supports the
-workflow. Use the concrete names created for the task rather than placeholders.
-Include the narrow automated build/test command and, when runtime behavior is
-relevant, the complete supervised lifecycle:
+Use wrapper-native commands wherever supported. A runtime handoff includes
+concrete names and the complete lifecycle:
 
 ```sh
 ./atrinik profile show PROFILE
@@ -273,112 +117,30 @@ relevant, the complete supervised lifecycle:
 ./atrinik down TOPOLOGY
 ```
 
-State display forwarding or other prerequisites, describe the exact manual
-actions and expected results between `up` and `down`, and always include the
-cleanup command. Do not substitute reconstructed internal build/runtime paths
-or direct executable invocations for a supported wrapper command. If runtime
-verification is not applicable, say so and provide the wrapper build/test and
-inspection commands that are applicable.
+State prerequisites, feature actions, expected results, and cleanup. When
+runtime is irrelevant, say so and provide the applicable build/test and
+inspection commands. Do not substitute internal executable or generated paths
+for supported wrapper operations.
 
-For cleanup changes, runtime launch is normally not applicable. Use the exact
-worktree/profile fixture names from the task and include both a stable JSON
-preview and the opt-in apply form, with expected candidate/protection reasons
-and an explicit statement that branches and retained records remain.
+## Coordinate publication and policy
 
-When the reviewer needs a ready login, also use the
-`atrinik-test-scenario` skill. Provision with `./atrinik scenario create`,
-retrieve the secret only through `scenario credentials`, and use the scenario's
-dedicated state in the lifecycle above. Never construct account or player save
-files directly.
+- Use `atrinik-github-governance` for Actions, permissions, required checks,
+  merge/release policy, or repository settings. Inspect live and desired state
+  before an authorized external change.
+- Keep each physical repository independently releasable. Semantic-release
+  owns version selection, tags, notes, and recovery; never publish manually.
+- Update `supply-chain/inventory.json` for changed dependency inputs and audit
+  the complete selected profile. Review overrides never make another member
+  optional. Only aggregate-checkout root workflows/Dependabot are active.
+- Apply historical MIT grants only under
+  [`docs/PROVENANCE.md`](../../../docs/PROVENANCE.md). Fail closed and record the
+  complete evidence in the destination repository.
 
-## Coordinate releases and GitHub changes
+## Maintain the contract
 
-- Treat `supply-chain/inventory.json` in the wrapper as the aggregate ownership
-  catalog while component lockfiles remain their release integrity boundary.
-  Update the catalog when a supported dependency, toolchain, action, image,
-  vendored source, license, owner, cadence, EOL response, or validation path
-  changes. Preserve physical checkout, logical component, source root,
-  repository, branch, resolved commit, initialization cohort, role, and license
-  in audits and generated SBOMs, including when several classic components
-  share one checkout or `content` and `content-1x` share repository
-  coordinates. Keep remote Actions on full commits with updater comments,
-  images on manifest
-  digests, and Git submodules absent. Validate a coordinated profile with
-  `./atrinik supply-chain audit --profile PROFILE`; initialize every checkout
-  selected by the profile first because an unavailable physical checkout or
-  logical component fails the audit. A review-worktree override changes only
-  its named checkout and never makes the other profile members optional. In
-  CI, provision the selected stacks through wrapper-native `init` rather than
-  duplicating the manifest as a checkout list. Generate ignored
-  license/CycloneDX/SPDX reports with
-  `./atrinik supply-chain report --profile PROFILE`; unresolved and
-  non-selected component commits must remain explicitly unavailable. For a
-  repeated repository coordinate, accept a supply-chain review-worktree
-  override only when it shares the expected checkout primary's common Git
-  directory; never infer `content` versus `content-1x` from one-way ancestry.
-  In an aggregate monorepo, treat root workflows and Dependabot configuration
-  as the active GitHub surface. Imported nested component workflows and
-  Dependabot files are inert and must not supply active inventory evidence;
-  dependency inputs elsewhere in each logical source remain audited.
-- Keep each physical repository independently releasable. A squash commit in
-  `atrinik/classic` changes and releases that monorepo; do not describe its
-  logical source directories as independently cloned repositories. Never
-  couple publication to a wrapper checkout or submodule pointer.
-- Preserve semantic-release's Conventional Commits precedence: breaking
-  changes are major, `feat` is minor, and other accepted squash commits are
-  patch releases. Keep the catch-all patch rule below explicit major and minor
-  rules so every squash commit releases without downgrading them.
-- Keep release workflows manually dispatchable without alternate version
-  inputs. After an Actions outage, rerun a failed release run or dispatch the
-  standard semantic-release workflow; do not create tags by hand.
-- Apply repository-policy, workflow, required-check, permission, or release
-  changes using the Atrinik GitHub-governance instructions. Update
-  `atrinik/github-settings` whenever desired organization state changes.
-- Inspect every affected repository's status and remote default branch before
-  publishing. Report repository-specific commits, checks, releases, and any
-  incomplete external operation separately.
-
-## Apply approved historical MIT provenance grants
-
-The following registry is exhaustive. Each person explicitly grants permission
-for the listed treatment of the listed original past Atrinik contributions.
-
-| Grantor | Covered material | Permitted operations | Destination license |
-| --- | --- | --- | --- |
-| Zoey Rose | All original past Atrinik contributions solely authored by Zoey Rose | Copy, migrate, translate, or relicense | MIT |
-| Daniel Liptrot | All original past Atrinik contributions solely authored by Daniel Liptrot | Copy, migrate, translate, or relicense | MIT |
-
-A registry entry is not an automatic license change for a repository, file, or
-current-blame region. Before applying a grant:
-
-1. Identify the exact source repository, path, and revision or revision range,
-   following renames and moves through the complete, non-shallow history.
-2. Inspect the creation and every subsequent change to the selected material,
-   including relevant commit diffs. Prove that it is the named grantor's
-   original work and that the grantor solely authored it. Map historical author
-   identities to that grantor with recorded evidence; do not treat current
-   blame alone as proof.
-3. Review the material for copied, generated, vendored, or otherwise embedded
-   third-party work and for notices or licenses that conflict with MIT reuse.
-   A history gap, unresolved identity, mixed authorship, or uncertain origin
-   makes the material ineligible until independently resolved.
-4. Limit reuse to independently separable material covered by the proof. Do
-   not copy a whole mixed-authorship file merely because some surviving lines
-   qualify.
-5. Record the exact source and destination repositories and paths, source
-   revision, complete history and identity evidence, transformation performed,
-   third-party review, and the applicable grantor and grant in the destination
-   pull request or a committed provenance manifest. Cite the exact wrapper
-   repository revision containing the applicable registry entry as the grant
-   evidence. Retain any notices required by material that is deliberately
-   included under another compatible license.
-
-## Maintain this guidance
-
-After changing the wrapper CLI, manifest schema or entries, managed directory
-layout, ownership boundary, profile/build/runtime behavior, release policy, or
-cross-repository procedure, review and update this skill, root `AGENTS.md`,
-`README.md`, and `docs/ARCHITECTURE.md` in the same wrapper change. Remove
-superseded instructions instead of documenting parallel procedures. Validate
-the skill with the repository's skill validator and exercise the affected CLI
-workflow before committing.
+When the wrapper CLI, manifest, layout, ownership, profile/build/runtime,
+cleanup, release, or cross-repository procedure changes, update the affected
+root guide, skill, README, and architecture sections together. Remove
+superseded instructions. Validate skills, exercise the affected CLI path, run
+the complete wrapper tests/coverage and compileall, and finish with
+`git diff --check`.

--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: atrinik-multi-repo-workspace
-description: Coordinate Atrinik work across checkouts, profiles, worktrees, cleanup, wrapper builds/runtime, releases, or workspace CLI and layout. Use when ownership crosses a physical repository or the wrapper itself changes.
+description: Coordinate work across checkouts, profiles, worktrees, cleanup, releases, or wrapper CLI and layout.
 ---
 
 # Atrinik multi-repository workspace

--- a/.agents/skills/atrinik-multi-repo-workspace/references/repository-migration.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/references/repository-migration.md
@@ -1,0 +1,42 @@
+# Pre-split classic repository migration
+
+Read this reference only when a workspace still contains the five former
+standalone classic repositories.
+
+Initialize only the maintained monorepo destination, then plan, apply, and
+audit through the wrapper:
+
+```sh
+./atrinik init classic
+./atrinik migrate repositories --dry-run
+./atrinik migrate repositories --dry-run --json
+./atrinik migrate repositories --apply
+./atrinik migrate repositories --audit --json
+```
+
+Do not run additive `init --with classic` first: its default-cohort preflight
+must reject former classic repositories occupying replacement paths.
+
+Migration proves repository identity, history, worktrees, destinations,
+profiles, and topology safety before changing anything. It accepts former
+canonical or `legacy-*` paths, preserves recoverable originals and linked
+worktree directories, and may repair only required Git administrative links.
+It refuses ambiguous identities, conflicting occupants, unsafe Git states,
+live affected topologies, and selectors it cannot prove. Resolve a reported
+condition and rerun the full dry run; never move paths manually to bypass it.
+
+Integrated commit-map targets remain bridge parents. If a verified local
+branch-only commit no longer has a published rewritten target, migration
+imports that exact local commit; never recreate or depend on a retired
+`history/*` namespace.
+
+Classic profile rewrites are atomic and select one complete monorepo root for
+all five logical components. The internal `migrated-worktree` selector is
+provenance for an exact historical `content-1x` worktree only; `profile set`
+must never create it. New classic content work uses a normal `content-1x`
+worktree.
+
+Migration does not initialize other repositories or move/reinterpret content,
+states, builds, runtimes, scenarios, topologies, or logs. After a successful
+apply and audit, `./atrinik init --with classic` may initialize the remaining
+classic cohort.

--- a/.agents/skills/atrinik-protocol-change/SKILL.md
+++ b/.agents/skills/atrinik-protocol-change/SKILL.md
@@ -1,55 +1,48 @@
 ---
 name: atrinik-protocol-change
-description: Trace, redesign, implement, document, and validate Atrinik wire contracts. Use when protocol schemas, generated IDs, classic packets, QUIC payloads, ADS, or producer-consumer compatibility are primary.
+description: Change Atrinik wire contracts and all producers/consumers. Use for GP1 Protobuf/QUIC, classic packets and IDs, ADS, generated bindings, or compatibility transitions.
 ---
 
-# Atrinik Protocol Change
+# Atrinik protocol change
 
-Use this skill whenever bytes crossing a process or repository boundary are the
-primary contract. Combine it with `atrinik-multi-repo-workspace` and the
-relevant implementation skill for coordinated consumer changes.
+Use this skill when bytes crossing a process or repository boundary are the
+primary contract. Add `atrinik-multi-repo-workspace` and the relevant
+implementation skill for coordinated consumers.
 
-## Trace the whole contract
+## Select the authoritative contract
 
-1. Read every affected repository guide and select all sources with a workspace
-   profile before editing.
-2. Identify the authoritative contract. Classic command IDs come from
-   `protocol/schema/game-commands.json`; payload layouts may still be owned by
-   client/server implementations; ADS schemas live with their content format;
-   metaserver bootstrap contracts are owned by `metaserver-worker`.
-3. Find producers, consumers, generated outputs, fixtures, tests,
-   documentation, packet tooling, and release dependencies. Do not assume the
-   repository containing a numeric constant owns the protocol.
-4. Write down framing, field order, widths, signedness, byte order, lengths,
-   nullability, limits, state transitions, error behavior, and compatibility
-   policy before implementation.
+- Replacement Game Protocol 1 lives in the physical `protocol` checkout and
+  owns Protobuf/Buf policy, normative QUIC/framing specifications, generated
+  Go/Rust contracts, and conformance fixtures.
+- Classic numeric command IDs live at
+  `classic/protocol/schema/game-commands.json`; packet payloads may be owned by
+  classic client/server producers and consumers. Use a classic-derived profile
+  and the monorepo's `classic-protocol-change` skill.
+- ADS/authored schemas live with their exact `content@main` or
+  `content-1x@1.x` format. Metaserver contracts identify their own owner.
 
-## Implement one coherent transition
-
-- Edit schemas or other source definitions, regenerate checked-in artifacts,
-  and verify generation is clean. Never hand-edit generated IDs.
-- Update every in-scope producer and consumer together when compatibility is
-  intentionally broken. Delete superseded commands only after all selected
-  consumers have moved.
-- Reject malformed, truncated, oversized, out-of-order, or impossible input at
-  the boundary. Keep parsing transactional so partial messages cannot leak
-  half-applied state.
-- Avoid parallel old/new paths unless an explicit compatibility window owns
-  their removal. Use precise protocol names rather than vague age labels.
-- Add golden or round-trip fixtures and negative boundary tests where useful.
-
-## Validate every consumer
-
-Run protocol generation checks, the protocol unit and CMake suites, and wrapper
-build/tests for every affected component:
+Resolve paths rather than assuming the wrapper CWD:
 
 ```sh
-./atrinik profile show PROFILE
-./atrinik build protocol --profile PROFILE --test
-./atrinik build COMPONENT --profile PROFILE --test
+./atrinik path protocol --profile default
+./atrinik path classic-protocol --profile classic
 ```
 
-Run `git diff --check` in each repository. For a live transition, hand off the
-complete wrapper topology lifecycle and exact observable result; use
-`atrinik-test-scenario` when login state is needed. The final report must name
-the authoritative source, changed consumers, compatibility decision, and tests.
+Trace schemas, specifications, generated outputs, producers, consumers,
+fixtures, tests, tooling, and release dependencies. Define framing, field
+order, widths, signedness, byte order, bounds, state transitions, failures, and
+compatibility before implementation.
+
+Edit authoritative definitions and regenerate; never hand-edit generated IDs.
+Keep parsing bounded and transactional, test malformed/truncated/oversized and
+state-order failures, and remove an old path only after every selected consumer
+moves. Avoid parallel compatibility paths without an issue-owned removal gate.
+
+## Validate
+
+Run each owning repository's aggregate generation/test contract and every
+affected producer/consumer build. Use wrapper builds only for components whose
+wrapper adapters exist; do not route replacement GP1 through classic code.
+Finish with `git diff --check` in every repository and report the source,
+consumers, compatibility decision, and tests. Use a supervised topology and
+scenario when runtime proof is required.

--- a/.agents/skills/atrinik-protocol-change/SKILL.md
+++ b/.agents/skills/atrinik-protocol-change/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: atrinik-protocol-change
-description: Change Atrinik wire contracts and all producers/consumers. Use for GP1 Protobuf/QUIC, classic packets and IDs, ADS, generated bindings, or compatibility transitions.
+description: Change GP1, classic, QUIC, or ADS wire contracts and their producers or consumers.
 ---
 
 # Atrinik protocol change

--- a/.agents/skills/atrinik-server-runtime/SKILL.md
+++ b/.agents/skills/atrinik-server-runtime/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: atrinik-server-runtime
-description: Run or diagnose isolated classic server builds, state, resources, scenarios, and supervised topologies through `./atrinik`.
+description: Run or diagnose isolated classic servers and supervised topologies through `./atrinik`.
 ---
 
 # Atrinik server runtime

--- a/.agents/skills/atrinik-server-runtime/SKILL.md
+++ b/.agents/skills/atrinik-server-runtime/SKILL.md
@@ -1,36 +1,22 @@
 ---
 name: atrinik-server-runtime
-description: Prepare, run, diagnose, and validate Atrinik classic server builds, collected resources, isolated state, deterministic scenarios, and supervised topologies. Use for server runtime setup, smoke tests, or failures.
+description: Run or diagnose isolated classic server builds, state, resources, scenarios, and supervised topologies through `./atrinik`.
 ---
 
-# Atrinik Server Runtime
+# Atrinik server runtime
 
-Use this skill for running or diagnosing the classic server. Use the workspace
-wrapper for builds, collection, state registration, supervision, logs, and
-cleanup; do not reconstruct its internal paths or invoke build artifacts
-directly when the wrapper supports the operation.
+Use the wrapper for build, collection, state locking, supervision, logs, and
+cleanup. Do not reconstruct internal paths or invoke generated binaries when a
+wrapper command owns the operation.
 
-## Prepare an isolated runtime
-
-1. Read the workspace and server guides plus `atrinik-multi-repo-workspace`.
-2. Select exact server, content, resources, protocol, and library sources in a
-   named profile. Inspect them with `./atrinik profile show` and
-   `./atrinik topology show`.
-3. Build and test the server through the wrapper:
-
-   ```sh
-   ./atrinik build server --profile PROFILE --test
-   ```
-
-4. Use a distinct registered state for each concurrent topology. Never replace
-   a dirty worktree, overwrite mutable server data, share state between running
-   topologies, or edit wrapper-managed runtime files by hand.
-
-## Run and diagnose
-
-For persistent supervised testing:
+1. Read the workspace and selected classic server/content/resource guides.
+2. Select a coherent classic-derived profile and inspect it with `profile show`
+   and `topology show`.
+3. Use a distinct registered state for each concurrent topology. Never replace
+   source, share live state, or edit wrapper-managed runtime files.
 
 ```sh
+./atrinik build server --profile PROFILE --test
 ./atrinik topology show PROFILE --state STATE --json
 ./atrinik up --name NAME --profile PROFILE --state STATE
 ./atrinik ps NAME --json
@@ -38,20 +24,9 @@ For persistent supervised testing:
 ./atrinik down NAME
 ```
 
-Let `up` allocate ports unless a distinct port is required. Use wrapper logs
-and status rather than internal PID or log files. Separate build failures,
-missing collected resources, invalid state, plugin loading, network setup, and
-gameplay behavior before changing code.
-
-Use `atrinik-test-scenario` when the check needs a deterministic account and
-character. The server's offline provisioner must remain listener-, plugin-,
-console-, and metaserver-free and must persist through normal account APIs;
-never handcraft account or player files.
-
-## Validate and clean up
-
-Run the complete server test suite and task-specific resource or map generation
-checks. For client-visible behavior, inspect both service logs and state the
-exact login actions and expected outcome. Always stop the named topology; reset
-only scenario-owned state through `./atrinik scenario reset NAME` when a clean
-repeat is needed. Finish with `git diff --check` in each changed repository.
+Let `up` allocate a port unless an exact distinct port is required. Separate
+build, collection, state, plugin, network, and gameplay failures before editing
+code. Use `atrinik-test-scenario` for a provisioned account/character; never
+handcraft saves. Inspect relevant service logs, state exact actions/results,
+always stop the topology, and reset only scenario-owned state with `scenario
+reset`. Finish with each changed repository's tests and `git diff --check`.

--- a/.agents/skills/atrinik-test-scenario/SKILL.md
+++ b/.agents/skills/atrinik-test-scenario/SKILL.md
@@ -1,99 +1,40 @@
 ---
 name: atrinik-test-scenario
-description: Provision, inspect, reset, and hand off deterministic local Atrinik account-and-character scenarios through the ./atrinik wrapper. Use when an issue, pull request, gameplay change, client/server fix, or manual reproduction needs a ready-to-login test player, isolated mutable server state, repeatable credentials, or exact wrapper-native runtime verification commands.
+description: Provision, inspect, reset, and hand off a deterministic classic account/character with isolated state through `./atrinik`.
 ---
 
-# Atrinik Test Scenario
+# Atrinik test scenario
 
-Use the workspace scenario lifecycle to give a reviewer the smallest safe,
-repeatable local player setup for a manual reproduction. Keep account creation
-inside the server API and orchestration inside `./atrinik`; never construct or
-edit account or player save files directly.
+Use scenarios for repeatable manual reproductions. Keep account creation inside
+the server API and orchestration inside the wrapper; never construct or edit
+account/player files.
 
-## Select the scenario
-
-1. Read the workspace `AGENTS.md` and the `atrinik-multi-repo-workspace` skill.
-2. Identify the exact mixed-component profile for the change. Create or update
-   that profile with `./atrinik profile` when the task already authorizes
-   workspace setup.
-3. Choose a lowercase scenario name tied to the issue or feature, such as
-   `issue-42` or `inventory-filter`.
-4. Use `basic-player` unless the reproduction truly needs another server-owned
-   preset. It provides a normal `human_male` first-login character, including
-   the configured starting map, standard skills, and initial items.
-5. If the required state cannot be reached cheaply from `basic-player`, extend
-   the server provisioner and wrapper preset contract with tests. Do not bypass
-   validation by writing a handcrafted player file.
-
-## Provision and inspect
-
-Create the scenario once:
+1. Select the exact coherent classic-derived profile.
+2. Choose a lowercase issue/feature name and use `basic-player` unless a tested
+   server-owned preset is genuinely required.
+3. If the needed state is expensive to reach, extend the provisioner/preset
+   contract with tests rather than writing a fixture save.
 
 ```sh
 ./atrinik scenario create NAME --profile PROFILE --preset basic-player
-```
-
-The command builds the selected server, creates a dedicated registered state
-named `scenario-NAME`, writes mode-0600 credentials below the ignored workspace
-directory, provisions the account through the server's normal password and
-account persistence APIs, and prints the complete manual lifecycle.
-
-Inspect it without revealing the password:
-
-```sh
 ./atrinik scenario show NAME --json
-./atrinik scenario list --json
-```
-
-Retrieve credentials only when login is about to be tested:
-
-```sh
 ./atrinik scenario credentials NAME
-```
-
-Do not copy the password into commits, review documents, issue comments, logs,
-shell arguments, or final responses. Give reviewers the credentials command.
-
-## Run the reproduction
-
-Use the scenario's recorded profile and state. A client/server check normally
-uses:
-
-```sh
-./atrinik profile show PROFILE
-./atrinik build server --profile PROFILE --test
 ./atrinik topology show PROFILE --state scenario-NAME --json
 ./atrinik up --name NAME --profile PROFILE --state scenario-NAME
 ./atrinik ps NAME --json
 ./atrinik logs NAME server --follow
 ./atrinik logs NAME client --follow
 ./atrinik down NAME
-```
-
-Confirm display forwarding before `up` when the client is included. Between
-`up` and `down`, state the exact login steps, feature actions, and expected
-results for the issue. Use `ps` and wrapper-managed logs instead of reading
-internal PID, build, runtime, or log paths.
-
-## Reset safely
-
-After stopping the topology, restore the scenario to its pristine provisioned
-state with:
-
-```sh
-./atrinik down NAME
 ./atrinik scenario reset NAME
 ```
 
-Reset is intentionally destructive only to the scenario-owned state. It keeps
-the same account, character, password, profile, preset, and state name. It
-refuses a running or otherwise locked server state and never replaces an
-external, shared, symlinked, malformed, or unregistered directory.
+`show`/`list` never reveal the password. Retrieve it only immediately before
+login and never copy it into commits, review text, issues, logs, arguments, or
+final responses. Confirm display forwarding when using the client. State the
+exact login/actions/expected result between `up` and `down`.
 
-## Hand off
-
-Every final handoff must include copy-pasteable commands with concrete profile,
-scenario, topology, and state names; the credentials lookup; prerequisites;
-the exact manual actions and expected outcome; and `down` for cleanup. Mention
-`scenario reset` as the repeat-test command when appropriate. Never replace a
-supported wrapper command with a reconstructed internal path or direct binary.
+Reset only after stopping the topology. It is destructive solely to the
+scenario-owned state and refuses running, locked, external, shared, symlinked,
+malformed, or unregistered targets. Handoffs include concrete profile,
+scenario, topology, state, credentials lookup, prerequisites, expected result,
+cleanup, and repeat-test commands.

--- a/.agents/skills/atrinik-test-scenario/SKILL.md
+++ b/.agents/skills/atrinik-test-scenario/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: atrinik-test-scenario
-description: Provision, inspect, reset, and hand off a deterministic classic account/character with isolated state through `./atrinik`.
+description: Provision deterministic classic account/character scenarios with isolated state through `./atrinik`.
 ---
 
 # Atrinik test scenario

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,167 +1,89 @@
 # Atrinik workspace repository guide
 
-- This repository owns multi-repository development orchestration, not
-  component source. Never copy component implementation into it.
-- For work that spans physical repositories or logical component source roots,
-  read and follow
-  `.agents/skills/atrinik-multi-repo-workspace/SKILL.md` before changing a
-  checkout, worktree, profile, release configuration, or GitHub repository.
-- Use the narrowest specialist skill that owns the change: `atrinik-c-change`
-  for native code, `atrinik-protocol-change` for wire contracts,
-  `atrinik-content-change` for authored world data, `atrinik-server-runtime`
-  for classic server execution, and `atrinik-github-governance` for repository
-  policy or Actions. Combine one with the multi-repository skill when ownership
-  crosses component boundaries.
-- Physical checkouts are independent ignored Git repositories at the
-  manifest's explicit destinations directly below the wrapper root. Logical
-  components resolve to safe source roots within those checkouts. In
-  particular, the single `atrinik/classic` checkout at `./classic` owns the
-  `classic-server`, `classic-client`, `classic-editor`,
-  `classic-libatrinik`, and `classic-protocol` source directories. Treat
-  `content` (`atrinik/content@main`) and `content-1x`
-  (`atrinik/content@1.x`) as distinct physical checkouts. Checkout worktrees,
-  builds, profiles, and default mutable state belong below the ignored
-  workspace directory or an explicit external path.
-- Keep wrapper-specific VS Code launch configuration under `.devcontainer/`.
-  The standalone `devcontainer` component owns reusable toolchain images, not
-  workspace composition. Plain `./atrinik init` is replacement/default-only;
-  only exact `./atrinik init --with classic` adds the complete classic cohort:
-  the `classic` monorepo, `content-1x`, and retained GPL tools.
-- Never manually replace or move a dirty primary checkout, remove a dirty
-  worktree, or overwrite an existing mutable server-data directory. A checked
-  repository migration preserves recoverable originals and may repair a dirty
-  linked worktree's Git administrative `.git` pointer while leaving its
-  working directory and files in place; no other dirty-worktree mutation is
-  implicit.
-- Use profiles to declare coherent component sources. `default` selects the MIT
-  replacement stack and `classic` selects the current playable classic stack;
-  never mix replacement and classic providers in one runnable service closure.
-  Use `topology show` to audit exact role resolution and `up`/`ps`/`logs`/`down`
-  for persistent supervised testing; do not reconstruct internal build,
-  runtime, PID, log, or state-lock paths in ad hoc scripts.
-- Build namespaces and persisted scenario/topology resolution records bind
-  every provider's repository, branch, checkout, source, and logical identity.
-  Records lacking the current immutable coordinate shape are historical and
-  inert; never reinterpret them through the current manifest.
-- Replacement `server`, `client`, `editor`, `protocol`, `renderer`,
-  `content-toolkit`, and `website` repositories have validated standalone M1
-  foundations. Their wrapper build/runtime adapters and integrated service
-  closure have not landed. Do not route `default` through classic code or claim
-  it is currently runnable. Current game build/runtime verification uses a
-  profile created from `classic`.
-- Give concurrent topologies distinct names and server states. A concurrent
-  classic/replacement comparison also uses distinct `classic`/`default`
-  profiles and generated roots. Let `up` choose ports or assign distinct
-  `--port` values; do not manually assemble a client endpoint or share client
-  configuration directories between topology names.
-- Use precise component and protocol names; do not use vague age-based labels.
-- A worktree always belongs to a physical checkout. Classic worktrees therefore
-  live below `workspace/worktrees/classic/` and contain every monorepo source
-  directory. In `profile set`, selecting physical checkout `classic`, any
-  `classic-*` logical component, or one of its roles changes all five classic
-  selectors together. They must always name the same full checkout root.
-  Profile resolution then appends each component's manifest `source` path.
-- Do not mention confidential or unreleased Atrinik work in committed files or
-  public project surfaces.
-- Apply a historical MIT provenance grant only for a person listed in the
-  approved grantors table below and only within that row's stated scope. Every
-  use must satisfy the shared proof and recording requirements below the table.
-- Pull-request titles and commits use Conventional Commits style. Every squash
-  merge is released by semantic-release.
-- Run the complete Python test suite, compileall, ShellCheck for shell changes,
-  actionlint for workflow changes, and `git diff --check` before finishing.
-  Coordinator logic changes must also preserve the `.coveragerc` source and
-  omission boundaries and the OIDC-authenticated Codecov report.
-- `supply-chain/inventory.json` is the organization-wide dependency ownership
-  source. Update it with every supported toolchain, package source, action,
-  image, vendored input, license, owner, cadence, EOL response, and validation
-  path. Keep Actions and images immutable, retain updater hints, do not add Git
-  submodules, and run the profile-aware `./atrinik supply-chain audit`.
-  Initialize every checkout selected by that profile first; audits fail closed
-  when any physical checkout or logical component is unavailable, and a
-  review-worktree override never makes other profile members optional. CI must
-  use wrapper-native initialization rather than maintain a parallel checkout
-  list.
-  For an aggregate monorepo checkout, inventory and audit active Actions and
-  Dependabot configuration at the checkout root; imported `.github/workflows`
-  and `.github/dependabot.yml` files below logical component source roots are
-  inert history, not active dependency evidence.
-  Records and SBOMs must distinguish physical checkout, logical component,
-  source root, repository, branch, commit, cohort, role, and license even when
-  repository coordinates repeat or components share one checkout.
-- `sync` never initializes a repository. With no names it touches only
-  initialized default-cohort checkouts; opt-in classic-cohort synchronization
-  uses exact `--with classic` or explicit checkout/component names. Operations
-  deduplicate aliases that resolve to the same physical checkout.
-- Workspace cleanup is explicit and preview-first. Use `./atrinik cleanup`
-  or `--dry-run --json` before exact `--apply`; never add implicit cleanup to
-  init, sync, build, topology, scenario, or startup paths. Only registered,
-  exact-merged-head worktrees and marker-owned stale builds are candidates.
-  Preserve every profile/scenario/live-topology/migration/retention reference,
-  ordinary local change, branch/ref, state, log, archive, review report, and
-  unmarked path. The npm cache requires an explicit scope. Apply must hold the
-  repository-layout lock, recompute and immediately revalidate, use non-force
-  Git worktree removal, and stop accurately on the first post-mutation error.
-- Before combining former standalone classic repositories, use
-  exact `./atrinik init classic`, then
-  `./atrinik migrate repositories --dry-run`, `--apply`, and `--audit`.
-  Initialization uses classic `main` only. Migration must bridge a verified
-  branch-only local commit directly when its retired rewritten map target is
-  absent; never recreate or depend on a classic `history/*` namespace.
-  Do not run additive `init --with classic` until after migration in a
-  pre-split workspace because its default-cohort preflight must reject the
-  former classic repositories occupying replacement paths.
-  Migration preflights proven former primaries for the corresponding
-  `./classic/<source>` directories, preserves recoverable originals and
-  linked-worktree paths, rewrites proven classic profiles atomically, and
-  refuses ambiguous or unsafe states, live affected topologies, or conflicting
-  destinations. It leaves content, states, builds, runtimes, and logs
-  untouched.
-- Every implementation or change handoff must include copy-pasteable manual
-  verification commands that use the thin `./atrinik` wrapper whenever it
-  supports the workflow. Use exact profile, worktree, topology, service, and
-  state names; include the automated build/test command, the complete
-  `topology show`/`up`/`ps`/`logs`/`down` lifecycle when runtime verification
-  is relevant, feature-specific actions and expected results, display or other
-  prerequisites, and the cleanup command. Do not replace supported wrapper
-  commands with reconstructed build paths or direct executable invocations.
-- Use `.agents/skills/atrinik-test-scenario/SKILL.md` when manual verification
-  benefits from a ready local account and character. Keep scenario credentials
-  and state ignored and isolated; never handcraft account or player files.
-- Keep component-specific instructions in the owning physical repository and
-  its appropriate logical source root.
-  Wrapper skills may coordinate those contracts, but must not duplicate their
-  implementation or become a second source of truth for component commands.
-- Deep-review reports are ignored local artifacts under `build/`; do not commit
-  them.
-- Keep this guide, the multi-repository skill, `README.md`, and
-  `docs/ARCHITECTURE.md` synchronized with changes to the `atrinik` command,
-  `components.json`, managed layout, ownership boundaries, or cross-repository
-  development and release procedures.
-- When major rework changes ownership, layout, commands, safety boundaries, or
-  validation contracts, update every affected `AGENTS.md` and skill in the same
-  change. Treat stale agent guidance as an implementation defect.
+## Ownership and routing
 
-## Approved historical MIT provenance grantors
+- This repository owns multi-repository orchestration, not component source.
+  Keep implementation, tests, packages, and component release configuration in
+  the owning physical repository.
+- Use `atrinik-multi-repo-workspace` for cross-checkout ownership, profiles,
+  worktrees, migration, cleanup, releases, or wrapper CLI/layout changes. Add
+  only the narrow specialist skill needed for classic C, protocol, content,
+  runtime, scenarios, or GitHub governance work.
+- Resolve ownership from `components.json`, then read the owning checkout's
+  nearest `AGENTS.md`. Wrapper skills coordinate those contracts; they must not
+  duplicate component implementation guidance.
+- Checkouts are independent ignored Git repositories at manifest destinations.
+  `./classic` is one monorepo owning five `classic-*` logical components;
+  `content` is `atrinik/content@main`, while `content-1x` is the independent
+  `atrinik/content@1.x` checkout. `.devcontainer/` owns workspace composition;
+  the `devcontainer` checkout owns reusable images.
 
-This table is exhaustive. Each person explicitly grants permission for the
-listed treatment of the listed original past Atrinik contributions.
+## Safety and coherent stacks
 
-| Grantor | Covered material | Permitted operations | Destination license |
-| --- | --- | --- | --- |
-| Zoey Rose | All original past Atrinik contributions solely authored by Zoey Rose | Copy, migrate, translate, or relicense | MIT |
-| Daniel Liptrot | All original past Atrinik contributions solely authored by Daniel Liptrot | Copy, migrate, translate, or relicense | MIT |
+- Never replace or move a dirty primary checkout, remove a dirty worktree, or
+  overwrite mutable server data. Preserve recoverable originals during checked
+  migration; only the migration command may repair a linked worktree's Git
+  administrative pointer without changing its working files.
+- Workspace cleanup is explicit and preview-first. Use `./atrinik cleanup
+  --dry-run --json` before exact `--apply`; never add implicit cleanup to other
+  commands. Preserve dirty, detached, locked, in-progress, referenced, or
+  uncertain worktrees; profiles, scenarios, states, topology records/logs,
+  migrations, retention records, branches, Git objects, review reports, and
+  unmarked paths. The npm cache is opt-in. Apply recomputes under the layout
+  lock, uses non-force Git removal, and reports partial failure accurately.
+- Use profiles for source selection. `default` selects the MIT replacement
+  stack and `classic` the playable classic stack. Never mix providers or route
+  unavailable replacement adapters through classic code. Replacement
+  repositories have standalone M1 foundations, but their wrapper build/runtime
+  adapters and integrated service closure have not landed.
+- A worktree belongs to a physical checkout. Selecting `classic`, a
+  `classic-*` component, or one of its roles changes all five classic selectors
+  to the same checkout root; profile resolution appends the manifest source.
+- Use `./atrinik path`, `topology show`, `up`, `ps`, `logs`, and `down`; do not
+  reconstruct managed build, runtime, PID, log, lock, or state paths. Persisted
+  records without current immutable repository/branch/checkout/source/provider
+  coordinates are historical and inert.
+- Give concurrent topologies distinct names and server states. Keep comparison
+  profiles, ports, generated roots, and client configuration isolated.
+- Do not mention confidential or unreleased Atrinik work in commits, issues,
+  pull requests, or other public surfaces.
 
-Apply a grant only when a complete, non-shallow Git-history audit, including
-renames and moves, proves that the selected material is the named grantor's
-original work and that the grantor solely authored it. Verify historical author
-identities and review the material for embedded third-party or
-conflicting-licensed work. Current blame alone and mixed, incomplete, or
-uncertain history are not sufficient; fail closed until every doubt is
-independently resolved. Reuse only independently separable material covered by
-the proof. Record the exact source repository, path, and revision; destination
-repository and path; complete history and author-identity evidence;
-transformation and third-party review; and the applicable grantor and grant in
-the destination pull request or a committed provenance manifest. Cite the exact
-wrapper repository revision containing the applicable registry entry as the
-grant evidence.
+## Provenance, dependencies, and publication
+
+- Follow [`docs/PROVENANCE.md`](docs/PROVENANCE.md) for the exhaustive approved
+  historical MIT grantor registry and evidence contract. Reuse fails closed on
+  incomplete history, mixed authorship, uncertain identity, or embedded
+  third-party material. Cite the exact wrapper revision containing the registry
+  used.
+- `supply-chain/inventory.json` is the organization dependency-ownership source.
+  Update it for changed toolchains, packages, Actions, images, vendored inputs,
+  licenses, owners, cadences, EOL responses, or validation paths. Keep Actions
+  and images immutable, retain updater hints, add no submodules, initialize the
+  complete selected profile, and run `./atrinik supply-chain audit --profile
+  PROFILE`. A review override never makes another profile member optional.
+- Treat only an aggregate checkout's root workflows and Dependabot file as
+  active GitHub configuration. Nested imported copies are inert history.
+- Commits and pull-request titles use Conventional Commits. Semantic-release
+  owns every squash release; never create or move release tags/assets manually.
+  Use `atrinik-github-governance` for policy, Actions, or release contracts.
+
+## Workflow and validation
+
+- `./atrinik init` initializes the replacement/default cohort. Exact
+  `./atrinik init --with classic` adds the complete classic cohort; `sync`
+  never initializes repositories. Use the multi-repository skill's migration
+  reference for a pre-split workspace.
+- Handoffs must provide copy-pasteable wrapper commands with exact profile,
+  worktree, topology, service, state, and scenario names. Include automated
+  validation, prerequisites, observable results, and cleanup. Use
+  `atrinik-test-scenario` for a ready account/character; never handcraft saves or
+  expose credentials.
+- Before finishing wrapper changes, run the complete unittest/coverage suite,
+  compileall, manifest validation, `git diff --check`, ShellCheck for shell
+  changes, actionlint for workflows, and the profile-aware supply-chain audit
+  when dependency inputs change. Preserve `.coveragerc` and OIDC Codecov
+  boundaries.
+- Keep this guide, affected skills, `README.md`, and `docs/ARCHITECTURE.md`
+  synchronized when wrapper ownership, commands, layout, or safety contracts
+  change. Treat stale agent guidance as a defect. Deep-review reports are
+  ignored local artifacts under `build/`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,9 +23,10 @@ cohort: the `atrinik/classic` monorepo checkout, `content-1x@1.x`, and retained
 GPL tools. The monorepo supplies the logical classic client, server, editor,
 protocol, and libatrinik components from source subdirectories. Do not put
 those checkouts in the default cohort or mix replacement and classic providers
-in one runnable profile. Replacement repositories remain seed components
-until their owning build/runtime contracts land, so current game integration
-uses a profile created from `classic`.
+in one runnable profile. Replacement repositories have validated standalone M1
+foundations; their wrapper build/runtime adapters and integrated service
+closure have not landed, so current game integration uses a profile created
+from `classic`.
 
 For a pre-split workspace, initialize only the destination with
 `./atrinik init classic`, run `./atrinik migrate repositories --dry-run`
@@ -42,6 +43,7 @@ Before opening a pull request, run:
 ~~~sh
 python3 -m unittest discover -v
 python3 -m compileall -q atrinik atrinik_workspace tests
+python3 -m atrinik_workspace.guidance_inventory --check
 ./atrinik manifest validate
 git diff --check
 ~~~
@@ -52,6 +54,7 @@ environment-specific.
 
 Exercise the smallest relevant real profile build as well. Changes to current
 source-view, collection, runtime, or CMake composition should validate both
-classic client and server with `--profile classic --test`. Default seed
-components should be inspected through their manifest/profile contracts until
-their standalone builds are implemented.
+classic client and server with `--profile classic --test`. Replacement
+components use their repository-owned aggregate validation today and remain
+inspectable through wrapper manifest/profile contracts until wrapper build
+adapters are implemented.

--- a/README.md
+++ b/README.md
@@ -119,12 +119,9 @@ be exchanged.
 
 ### Historical MIT provenance grants
 
-The approved grantor registry is exhaustive:
-
-| Grantor | Covered material | Permitted operations | Destination license |
-| --- | --- | --- | --- |
-| Zoey Rose | All original past Atrinik contributions solely authored by Zoey Rose | Copy, migrate, translate, or relicense | MIT |
-| Daniel Liptrot | All original past Atrinik contributions solely authored by Daniel Liptrot | Copy, migrate, translate, or relicense | MIT |
+[`docs/PROVENANCE.md`](docs/PROVENANCE.md) is the single exhaustive approved
+grantor registry and evidence contract. Do not duplicate its table in component
+guides or skills.
 
 The cross-repository M1 evidence and exact reuse procedure are indexed in
 [`docs/REPLACEMENT_FOUNDATIONS.md`](docs/REPLACEMENT_FOUNDATIONS.md). The
@@ -132,16 +129,10 @@ machine record maps every fresh repository to its local CI, provenance,
 dependency, notices, packaging, SBOM, and mixed-license gates without making
 this coordinator a second copy of their implementation policy.
 
-Apply a grant only after a complete, non-shallow Git-history audit follows
-renames and moves, proves the selected material is the named grantor's original
-work and was solely authored by that grantor, and verifies historical author
-identities. Review also excludes embedded third-party or conflicting-licensed
-work. Current blame alone is not proof; mixed, incomplete, or uncertain
-material remains under its existing license until independently resolved. The
-destination pull request or committed provenance manifest records the exact
-source, revision, destination, history and identity evidence, transformation,
-third-party review, applicable grantor and grant, and exact wrapper repository
-revision containing the registry entry as grant evidence.
+Historical reuse fails closed unless the canonical contract proves complete
+history, sole original authorship, identity, separability, and third-party
+review. Destination evidence cites the exact wrapper revision containing the
+registry used.
 
 The GPL classic utilities and their user-facing replacement/retirement paths
 are inventoried in
@@ -769,10 +760,10 @@ one another, while the common state makes the comparison repeatable.
 
 ### Use case: run classic and replacement topologies at the same time
 
-Once the wrapper's replacement composition and runtime contracts land, use
-distinct profiles, topology names, server states, and ports to run `classic`
-beside `default`. This is the required isolation pattern; today only the
-classic command is runnable:
+Once the replacement components' wrapper build/runtime adapters and integrated
+service closure land, use distinct profiles, topology names, server states, and
+ports to run `classic` beside `default`. This is the required isolation
+pattern; today only the classic command is runnable:
 
 ~~~sh
 ./atrinik state add classic-world
@@ -904,6 +895,7 @@ python3 -m compileall -q atrinik atrinik_workspace tests
 ~~~
 
 Use `./atrinik build COMPONENT --profile classic --test` for current native
-component integration. Replacement components still fail with a clear
-unavailable-contract error until their wrapper build adapters land. The
-`metaserver-worker` contract always runs its complete `npm run check` suite.
+component integration. Replacement repositories run their standalone
+aggregate validations today; wrapper builds still fail with a clear
+unavailable-contract error until their adapters land. The `metaserver-worker`
+wrapper contract runs its complete `npm run check` suite.

--- a/atrinik_workspace/guidance_inventory.py
+++ b/atrinik_workspace/guidance_inventory.py
@@ -81,8 +81,15 @@ def collect_inventory() -> dict[str, object]:
     catalog_bytes = len(catalog_text.encode("utf-8"))
     skill_bytes = sum(skill.file.bytes for skill in skills)
     multi = next(
-        skill for skill in skills if skill.name == "atrinik-multi-repo-workspace"
+        (
+            skill
+            for skill in skills
+            if skill.name == "atrinik-multi-repo-workspace"
+        ),
+        None,
     )
+    if multi is None:
+        raise ValueError("missing atrinik-multi-repo-workspace skill")
     startup_bytes = root_guide.bytes + catalog_bytes
 
     return {

--- a/atrinik_workspace/guidance_inventory.py
+++ b/atrinik_workspace/guidance_inventory.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+import json
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILLS_ROOT = ROOT / ".agents" / "skills"
+
+# Byte ceilings are model-independent regression guards. Exact tokenizer counts
+# remain PR evidence because tokenizer vocabularies and prompt wrappers change.
+MAX_ROOT_GUIDE_BYTES = 6_000
+MAX_CATALOG_BYTES = 2_000
+MAX_STARTUP_BYTES = 8_000
+MAX_MULTI_SELECTED_BYTES = 14_000
+MAX_ALL_SKILL_BYTES = 21_000
+
+
+@dataclass(frozen=True)
+class FileMetrics:
+    path: str
+    bytes: int
+    lines: int
+    words: int
+
+
+@dataclass(frozen=True)
+class SkillMetrics:
+    name: str
+    description: str
+    file: FileMetrics
+
+
+def file_metrics(path: Path) -> FileMetrics:
+    text = path.read_text(encoding="utf-8")
+    return FileMetrics(
+        path=path.relative_to(ROOT).as_posix(),
+        bytes=len(text.encode("utf-8")),
+        lines=len(text.splitlines()),
+        words=len(text.split()),
+    )
+
+
+def skill_frontmatter(path: Path) -> tuple[str, str]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if not lines or lines[0] != "---":
+        raise ValueError(f"{path}: missing YAML frontmatter")
+    try:
+        end = lines.index("---", 1)
+    except ValueError as exc:
+        raise ValueError(f"{path}: unterminated YAML frontmatter") from exc
+
+    values: dict[str, str] = {}
+    for line in lines[1:end]:
+        key, separator, value = line.partition(":")
+        if not separator or key not in {"name", "description"} or not value.strip():
+            raise ValueError(f"{path}: unsupported frontmatter line: {line!r}")
+        if key in values:
+            raise ValueError(f"{path}: duplicate frontmatter key: {key}")
+        values[key] = value.strip()
+    if set(values) != {"name", "description"}:
+        raise ValueError(f"{path}: frontmatter requires name and description")
+    if path.parent.name != values["name"]:
+        raise ValueError(f"{path}: skill name must match its directory")
+    return values["name"], values["description"]
+
+
+def collect_inventory() -> dict[str, object]:
+    root_guide = file_metrics(ROOT / "AGENTS.md")
+    skills = []
+    for path in sorted(SKILLS_ROOT.glob("*/SKILL.md")):
+        name, description = skill_frontmatter(path)
+        skills.append(SkillMetrics(name, description, file_metrics(path)))
+
+    catalog_text = "".join(
+        f"{skill.name}\t{skill.description}\t{skill.file.path}\n" for skill in skills
+    )
+    catalog_bytes = len(catalog_text.encode("utf-8"))
+    skill_bytes = sum(skill.file.bytes for skill in skills)
+    multi = next(
+        skill for skill in skills if skill.name == "atrinik-multi-repo-workspace"
+    )
+    startup_bytes = root_guide.bytes + catalog_bytes
+
+    return {
+        "root_guide": asdict(root_guide),
+        "skills": [asdict(skill) for skill in skills],
+        "summary": {
+            "skill_count": len(skills),
+            "catalog_bytes": catalog_bytes,
+            "startup_bytes": startup_bytes,
+            "multi_selected_bytes": startup_bytes + multi.file.bytes,
+            "all_skill_bytes": skill_bytes,
+        },
+    }
+
+
+def budget_failures(inventory: dict[str, object]) -> list[str]:
+    root = inventory["root_guide"]
+    summary = inventory["summary"]
+    checks = {
+        "root guide": (root["bytes"], MAX_ROOT_GUIDE_BYTES),
+        "skill catalog": (summary["catalog_bytes"], MAX_CATALOG_BYTES),
+        "wrapper startup": (summary["startup_bytes"], MAX_STARTUP_BYTES),
+        "wrapper + multi skill": (
+            summary["multi_selected_bytes"],
+            MAX_MULTI_SELECTED_BYTES,
+        ),
+        "all skill bodies": (summary["all_skill_bytes"], MAX_ALL_SKILL_BYTES),
+    }
+    return [
+        f"{name}: {actual} bytes exceeds {limit}"
+        for name, (actual, limit) in checks.items()
+        if actual > limit
+    ]
+
+
+def render_text(inventory: dict[str, object]) -> str:
+    rows = [inventory["root_guide"]]
+    rows.extend(skill["file"] for skill in inventory["skills"])
+    lines = ["path\tbytes\tlines\twords"]
+    lines.extend(
+        f"{row['path']}\t{row['bytes']}\t{row['lines']}\t{row['words']}"
+        for row in rows
+    )
+    summary = inventory["summary"]
+    lines.append(
+        "summary"
+        f"\tcatalog={summary['catalog_bytes']}"
+        f"\tstartup={summary['startup_bytes']}"
+        f"\tmulti-selected={summary['multi_selected_bytes']}"
+        f"\tall-skills={summary['all_skill_bytes']}"
+    )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Inventory wrapper agent guidance")
+    parser.add_argument("--json", action="store_true", help="emit stable JSON")
+    parser.add_argument("--check", action="store_true", help="enforce byte ceilings")
+    args = parser.parse_args(argv)
+
+    try:
+        inventory = collect_inventory()
+    except (OSError, UnicodeError, ValueError) as exc:
+        print(f"guidance inventory failed: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(inventory, indent=2, sort_keys=True))
+    else:
+        print(render_text(inventory))
+
+    failures = budget_failures(inventory) if args.check else []
+    for failure in failures:
+        print(f"guidance budget failed: {failure}", file=sys.stderr)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -60,26 +60,12 @@ unavailable so repeated coordinates such as `atrinik/content` or shared
 checkouts such as `atrinik/classic` cannot be collapsed into one ambiguous
 input.
 
-Source provenance is also a cross-repository contract. Its exhaustive approved
-historical MIT provenance grantor registry is:
-
-| Grantor | Covered material | Permitted operations | Destination license |
-| --- | --- | --- | --- |
-| Zoey Rose | All original past Atrinik contributions solely authored by Zoey Rose | Copy, migrate, translate, or relicense | MIT |
-| Daniel Liptrot | All original past Atrinik contributions solely authored by Daniel Liptrot | Copy, migrate, translate, or relicense | MIT |
-
-A grant applies only when complete, non-shallow Git history follows renames and
-moves, proves the selected material is the named grantor's original work and
-was solely authored by that grantor, and supports the historical author-identity
-mapping. Review must exclude embedded third-party or conflicting-licensed work.
-A migration records the exact source repository, path, and revision;
-destination repository and path; author identity and complete-history evidence;
-transformation; third-party review; applicable grantor and grant; and exact
-wrapper repository revision containing the registry entry as grant evidence in
-its pull request or a committed provenance manifest. Current blame, incomplete
-or uncertain history, or authorship of only part of a mixed file does not
-establish eligibility for the whole material; the process fails closed until
-every doubt is independently resolved.
+Source provenance is also a cross-repository contract.
+[`PROVENANCE.md`](PROVENANCE.md) is the single exhaustive historical MIT
+grantor registry and evidence procedure. Reuse fails closed unless complete,
+rename-aware history proves sole original authorship and identity, separates
+eligible material, excludes conflicting embedded work, and records the exact
+source, destination, transformation, review, and wrapper registry revision.
 
 The `supply-chain` command resolves component inputs through the same profile
 selectors as builds, then reads Git-indexed files without mutating a checkout.

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -1,0 +1,31 @@
+# Historical MIT provenance grants
+
+This file is the exhaustive Atrinik registry for approved historical MIT
+provenance grants. A registry entry is not an automatic license change for a
+repository, file, or current-blame region.
+
+| Grantor | Covered material | Permitted operations | Destination license |
+| --- | --- | --- | --- |
+| Zoey Rose | All original past Atrinik contributions solely authored by Zoey Rose | Copy, migrate, translate, or relicense | MIT |
+| Daniel Liptrot | All original past Atrinik contributions solely authored by Daniel Liptrot | Copy, migrate, translate, or relicense | MIT |
+
+Before applying a grant:
+
+1. Follow renames and moves through complete, non-shallow Git history for the
+   exact source repository, path, and revision or revision range.
+2. Prove that the selected material is the named grantor's original work and
+   that the grantor solely authored it. Verify historical author identities;
+   current blame alone is not proof.
+3. Review every relevant change and the material itself for copied, generated,
+   vendored, embedded third-party, or conflicting-licensed work. Fail closed on
+   any history gap, unresolved identity, mixed authorship, or uncertain origin.
+4. Reuse only independently separable material covered by the proof. Do not
+   copy a mixed-authorship file merely because some surviving lines qualify.
+5. Record the source repository/path/revision, destination repository/path,
+   complete history and identity evidence, transformation, third-party review,
+   applicable grantor and grant, and required notices in the destination pull
+   request or a committed provenance manifest. Cite the exact
+   `atrinik/atrinik` revision containing this registry as the grant evidence.
+
+Independent implementation from documented behavior remains the default when
+reuse cannot be proven.

--- a/docs/REPLACEMENT_FOUNDATIONS.md
+++ b/docs/REPLACEMENT_FOUNDATIONS.md
@@ -7,12 +7,13 @@ requests, stable aggregate check, contribution/provenance guidance, dependency
 policy, notices, package/SBOM contract, and mixed-license boundary.
 
 The repositories do not inherit permission to reuse classic code. New MIT work
-is the default. A historical grant is usable only through the exhaustive
-[`PROVENANCE.md`](PROVENANCE.md) registry at the exact path and revision
-recorded in the inventory and only after a complete, non-shallow, rename-aware
-history audit proves the named grantor's sole original authorship. The review
-must also verify identity, embedded third-party material, exact
-source/destination paths, transformation, copyright, grant, and reviewer.
+is the default. [`PROVENANCE.md`](PROVENANCE.md) is the current exhaustive grant
+registry. Existing reproducible decisions retain the exact historical registry
+path and revision they used; new decisions cite the merged wrapper revision
+containing this file. A grant remains usable only after a complete,
+non-shallow, rename-aware history audit proves the named grantor's sole original
+authorship. The review must also verify identity, embedded third-party material,
+exact source/destination paths, transformation, copyright, grant, and reviewer.
 Mixed or uncertain candidates are excluded; current blame, committer identity,
 or a repository-level ownership inference is never enough.
 

--- a/docs/REPLACEMENT_FOUNDATIONS.md
+++ b/docs/REPLACEMENT_FOUNDATIONS.md
@@ -7,14 +7,14 @@ requests, stable aggregate check, contribution/provenance guidance, dependency
 policy, notices, package/SBOM contract, and mixed-license boundary.
 
 The repositories do not inherit permission to reuse classic code. New MIT work
-is the default. A historical grant is usable only through the exhaustive root
-registry at the exact revision recorded in the inventory and only after a
-complete, non-shallow, rename-aware history audit proves the named grantor's
-sole original authorship. The review must also verify identity, embedded
-third-party material, exact source/destination paths, transformation,
-copyright, grant, and reviewer. Mixed or uncertain candidates are excluded;
-current blame, committer identity, or a repository-level ownership inference is
-never enough.
+is the default. A historical grant is usable only through the exhaustive
+[`PROVENANCE.md`](PROVENANCE.md) registry at the exact path and revision
+recorded in the inventory and only after a complete, non-shallow, rename-aware
+history audit proves the named grantor's sole original authorship. The review
+must also verify identity, embedded third-party material, exact
+source/destination paths, transformation, copyright, grant, and reviewer.
+Mixed or uncertain candidates are excluded; current blame, committer identity,
+or a repository-level ownership inference is never enough.
 
 ## Reproducible decisions
 
@@ -56,4 +56,3 @@ An engine package may stay MIT while carrying or referring to content, sound,
 resources, downloads, or media under different licenses. Each repository's
 `license_boundary` states that separation; generated notices and SBOMs report
 the real component licenses instead of flattening a distribution to MIT.
-

--- a/governance/replacement-foundations.json
+++ b/governance/replacement-foundations.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "root_policy": {
     "repository": "atrinik/atrinik",
-    "revision": "d64a8e958ca2adad783ad8912493d468a805f3fd",
-    "path": "AGENTS.md",
+    "revision": "d7f5fad592e9ece11ca54f5bcdebda67ac975647",
+    "path": "docs/PROVENANCE.md",
     "rule": "Independent MIT implementation is the default. Historical reuse requires a complete non-shallow rename-aware history audit, proven sole original authorship by an approved grantor, identity verification, embedded-material review, an exact transformation record, and reviewer approval; mixed or uncertain material is excluded."
   },
   "required_record_fields": [

--- a/governance/replacement-foundations.json
+++ b/governance/replacement-foundations.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "root_policy": {
     "repository": "atrinik/atrinik",
-    "revision": "d7f5fad592e9ece11ca54f5bcdebda67ac975647",
-    "path": "docs/PROVENANCE.md",
+    "revision": "d64a8e958ca2adad783ad8912493d468a805f3fd",
+    "path": "AGENTS.md",
     "rule": "Independent MIT implementation is the default. Historical reuse requires a complete non-shallow rename-aware history audit, proven sole original authorship by an approved grantor, identity verification, embedded-material review, an exact transformation record, and reviewer approval; mixed or uncertain material is excluded."
   },
   "required_record_fields": [

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -1,10 +1,23 @@
 from __future__ import annotations
 
+from contextlib import redirect_stderr, redirect_stdout
+import io
+import json
 from pathlib import Path
 import re
+import tempfile
 import unittest
+from unittest import mock
 
-from atrinik_workspace.guidance_inventory import budget_failures, collect_inventory
+from atrinik_workspace import guidance_inventory
+from atrinik_workspace.guidance_inventory import (
+    budget_failures,
+    collect_inventory,
+    file_metrics,
+    main,
+    render_text,
+    skill_frontmatter,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -28,6 +41,72 @@ class AgentGuidanceTests(unittest.TestCase):
             ),
         )
         self.assertEqual(budget_failures(inventory), [])
+
+        rendered = render_text(inventory)
+        self.assertTrue(rendered.startswith("path\tbytes\tlines\twords\n"))
+        self.assertIn("summary\tcatalog=", rendered)
+
+        metrics = file_metrics(ROOT / "AGENTS.md")
+        self.assertEqual(metrics.path, "AGENTS.md")
+        self.assertGreater(metrics.bytes, 0)
+
+    def test_frontmatter_validation_fails_closed(self) -> None:
+        cases = {
+            "missing": "# no frontmatter\n",
+            "unterminated": "---\nname: skill\n",
+            "unsupported": "---\nname: skill\nsummary: no\n---\n",
+            "duplicate": (
+                "---\nname: skill\nname: skill\ndescription: duplicate\n---\n"
+            ),
+            "incomplete": "---\nname: skill\n---\n",
+            "mismatched": "---\nname: other\ndescription: mismatch\n---\n",
+        }
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "skill" / "SKILL.md"
+            path.parent.mkdir()
+            for name, content in cases.items():
+                with self.subTest(name=name):
+                    path.write_text(content, encoding="utf-8")
+                    with self.assertRaises(ValueError):
+                        skill_frontmatter(path)
+
+    def test_inventory_requires_the_workspace_skill(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            with mock.patch.object(
+                guidance_inventory, "SKILLS_ROOT", Path(temporary)
+            ):
+                with self.assertRaisesRegex(ValueError, "missing atrinik-multi"):
+                    collect_inventory()
+
+    def test_command_output_and_failures(self) -> None:
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            self.assertEqual(main([]), 0)
+        self.assertIn("summary\tcatalog=", stdout.getvalue())
+
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            self.assertEqual(main(["--json"]), 0)
+        inventory = json.loads(stdout.getvalue())
+        self.assertEqual(inventory["summary"]["skill_count"], 7)
+
+        stderr = io.StringIO()
+        with mock.patch.object(
+            guidance_inventory, "budget_failures", return_value=["test ceiling"]
+        ), redirect_stdout(io.StringIO()), redirect_stderr(stderr):
+            self.assertEqual(main(["--check"]), 1)
+        self.assertIn("guidance budget failed: test ceiling", stderr.getvalue())
+
+        stderr = io.StringIO()
+        with mock.patch.object(
+            guidance_inventory,
+            "collect_inventory",
+            side_effect=ValueError("invalid guidance"),
+        ), redirect_stderr(stderr):
+            self.assertEqual(main([]), 1)
+        self.assertIn(
+            "guidance inventory failed: invalid guidance", stderr.getvalue()
+        )
 
     def test_local_guidance_links_resolve(self) -> None:
         paths = [ROOT / "AGENTS.md"]

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -33,7 +33,9 @@ class AgentGuidanceTests(unittest.TestCase):
                 if "://" in target or target.startswith("#"):
                     continue
                 with self.subTest(path=path.relative_to(ROOT), target=target):
-                    self.assertTrue((path.parent / target).resolve().is_file())
+                    resolved = (path.parent / target).resolve()
+                    self.assertTrue(resolved.is_relative_to(ROOT))
+                    self.assertTrue(resolved.is_file())
 
     def test_removed_stale_routes_do_not_return(self) -> None:
         paths = [ROOT / "AGENTS.md"]

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import unittest
+
+from atrinik_workspace.guidance_inventory import budget_failures, collect_inventory
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LINK = re.compile(r"\[[^]]+\]\(([^)]+)\)")
+
+
+class AgentGuidanceTests(unittest.TestCase):
+    def test_inventory_is_complete_and_within_budget(self) -> None:
+        inventory = collect_inventory()
+        self.assertEqual(inventory["summary"]["skill_count"], 7)
+        self.assertEqual(
+            [skill["name"] for skill in inventory["skills"]],
+            sorted(
+                path.parent.name
+                for path in (ROOT / ".agents/skills").glob("*/SKILL.md")
+            ),
+        )
+        self.assertEqual(budget_failures(inventory), [])
+
+    def test_local_guidance_links_resolve(self) -> None:
+        paths = [ROOT / "AGENTS.md"]
+        paths.extend(sorted((ROOT / ".agents/skills").glob("*/SKILL.md")))
+        paths.extend(sorted((ROOT / ".agents/skills").glob("*/references/*.md")))
+        for path in paths:
+            for target in LINK.findall(path.read_text(encoding="utf-8")):
+                if "://" in target or target.startswith("#"):
+                    continue
+                with self.subTest(path=path.relative_to(ROOT), target=target):
+                    self.assertTrue((path.parent / target).resolve().is_file())
+
+    def test_removed_stale_routes_do_not_return(self) -> None:
+        paths = [ROOT / "AGENTS.md"]
+        paths.extend(sorted((ROOT / ".agents/skills").glob("*/SKILL.md")))
+        corpus = "\n".join(path.read_text(encoding="utf-8") for path in paths)
+        for stale in {
+            "mixed-component profile",
+            "more than one standalone repository",
+            "Today this seed repository",
+            "scenario create NAME --state",
+        }:
+            with self.subTest(stale=stale):
+                self.assertNotIn(stale, corpus)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -12,6 +12,11 @@ LINK = re.compile(r"\[[^]]+\]\(([^)]+)\)")
 
 
 class AgentGuidanceTests(unittest.TestCase):
+    def test_current_provenance_registry_is_complete(self) -> None:
+        registry = (ROOT / "docs/PROVENANCE.md").read_text(encoding="utf-8")
+        self.assertIn("Zoey Rose", registry)
+        self.assertIn("Daniel Liptrot", registry)
+
     def test_inventory_is_complete_and_within_budget(self) -> None:
         inventory = collect_inventory()
         self.assertEqual(inventory["summary"]["skill_count"], 7)

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -68,7 +68,7 @@ class ReplacementFoundationTests(unittest.TestCase):
         policy = self.inventory["root_policy"]
         self.assertEqual(policy["repository"], "atrinik/atrinik")
         self.assertRegex(policy["revision"], r"^[0-9a-f]{40}$")
-        self.assertEqual(policy["path"], "docs/PROVENANCE.md")
+        self.assertEqual(policy["path"], "AGENTS.md")
         registry = subprocess.run(
             [
                 "git",

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import subprocess
 import unittest
 
 
@@ -67,7 +68,20 @@ class ReplacementFoundationTests(unittest.TestCase):
         policy = self.inventory["root_policy"]
         self.assertEqual(policy["repository"], "atrinik/atrinik")
         self.assertRegex(policy["revision"], r"^[0-9a-f]{40}$")
-        self.assertEqual(policy["path"], "AGENTS.md")
+        self.assertEqual(policy["path"], "docs/PROVENANCE.md")
+        registry = subprocess.run(
+            [
+                "git",
+                "show",
+                f"{policy['revision']}:{policy['path']}",
+            ],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        self.assertIn("Zoey Rose", registry)
+        self.assertIn("Daniel Liptrot", registry)
 
         required_fields = self.inventory["required_record_fields"]
         self.assertEqual(len(required_fields), len(set(required_fields)))


### PR DESCRIPTION
## Summary

- Make root AGENTS a durable ownership and safety router, preserve the new preview-first cleanup contract from #293, and establish docs/PROVENANCE.md as the canonical grant registry.
- Split the multi-repository migration procedure into an on-demand reference, remove unconditional broad reads, correct stale C/protocol/content/runtime/scenario routes, and shrink discovery metadata.
- Add a dependency-free guidance inventory with byte ceilings and tests for budgets, local pointers, canonical provenance, and stale-route regressions.

## Exact o200k_base results

Counts are repository-owned text, excluding chat/tool envelopes. Prompt cases were cross-checked with codex debug prompt-input; ordinary-root catalog paths are normalized from the review-worktree path.

| Scenario | Issue baseline | Final | Reduction |
| --- | ---: | ---: | ---: |
| Wrapper startup | 2,819 | 1,557 | 44.8% |
| Wrapper + multi-repository skill | 7,002 | 2,905 | 58.5% |
| Wrapper + multi + runtime + scenario | 8,339 | 3,572 | 57.2% |
| Standalone classic/server startup | 3,474 | 1,751 | 49.6% |
| Skill catalog at ordinary wrapper root | 575 | 354 | 38.4% |

Replacement AGENTS raw-text counts are client 1,918 to 975; server 2,501 to 967; protocol 2,643 to 987; editor 2,155 to 859; renderer 2,046 to 883; content-toolkit 1,918 to 763; and website 1,914 to 858.

## Coordinated owning-repository PRs

- atrinik/client#48
- atrinik/server#73
- atrinik/protocol#19
- atrinik/editor#21
- atrinik/renderer#27
- atrinik/content-toolkit#15
- atrinik/website#13
- atrinik/classic#35
- atrinik/content#54 (main)
- atrinik/content#53 (1.x)

## Validation

- 267 wrapper tests under coverage; 77% combined statement/branch coverage
- compileall, manifest validation, all seven skill validators, guidance inventory, cleanup dry-run, and git diff --check
- profile-aware supply-chain audit with the classic review worktree and clean current tools checkout
- complete validators in every replacement and content checkout; classic import/root/release/protocol/libatrinik/ShellCheck/Actionlint validation

Coordinates atrinik/atrinik#294. Runtime launch is not applicable to guidance-only orchestration changes; component build, packaging, GPU, content collection, and policy paths were validated in their owning repositories.
