### PR TITLE
chore: inventory website preview tooling

### DIFF
--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -2132,17 +2132,19 @@
       "locator": "pkg:npm/%40atrinik/website@0.0.0-development",
       "commit": null,
       "checksum": null,
-      "acquisition": "npm ci installs the exact package-lock graph with denied optional scripts omitted",
+      "acquisition": "npm ci installs the exact package-lock graph with denied optional scripts omitted, only reviewed esbuild and workerd install scripts allowed, and the audited npm security override applied",
       "update_cadence_days": 7,
       "update_mechanism": "Grouped Dependabot npm updates constrained by Astro compatibility",
       "eol_response": "Upgrade compatible packages on the supported Node line or replace them",
       "validation": "npm ci, Astro/type/format tests, install-script audit, npm audit, deploy dry run, and npm CycloneDX SBOM",
       "disposition": "retain",
-      "packages": ["@astrojs/check", "@semantic-release/commit-analyzer", "@semantic-release/exec", "@semantic-release/github", "@semantic-release/release-notes-generator", "astro", "conventional-changelog-conventionalcommits", "prettier", "prettier-plugin-astro", "semantic-release", "typescript"],
+      "packages": ["@astrojs/check", "@semantic-release/commit-analyzer", "@semantic-release/exec", "@semantic-release/github", "@semantic-release/release-notes-generator", "astro", "conventional-changelog-conventionalcommits", "npm", "prettier", "prettier-plugin-astro", "semantic-release", "typescript", "wrangler"],
       "evidence": [
         {"repository":"website","path":"package-lock.json","contains":"\"lockfileVersion\": 3"},
         {"repository":"website","path":"package.json","contains":"\"name\": \"@atrinik/website\""},
-        {"repository":"website","path":"policy/dependencies.json","contains":"\"schemaVersion\": 1"}
+        {"repository":"website","path":"policy/dependencies.json","contains":"\"name\": \"npm\""},
+        {"repository":"website","path":"policy/dependencies.json","contains":"\"name\": \"workerd\""},
+        {"repository":"website","path":"policy/dependencies.json","contains":"\"name\": \"wrangler\""}
       ]
     },
     {


### PR DESCRIPTION
## Summary
- add Wrangler and the controlled npm security override to the website npm package-set inventory
- record the reviewed workerd install script boundary
- keep exact package-lock, policy evidence, cadence, ownership, and validation paths synchronized

## Dependency
Website implementation: https://github.com/atrinik/website/pull/14
GitHub environment inventory: https://github.com/atrinik/github-settings/pull/46

Merge this PR only after website PR 14, because the new inventory evidence must exist on website main before an aggregate audit.

## Validation
- full Python suite: 271 tests
- focused supply-chain suite: 50 tests
- python3 -m compileall -q atrinik_workspace tests
- git diff --check

The live default-profile audit was attempted with the website review-worktree override. It reaches a pre-existing unrelated protocol inventory mismatch for the pinned actions/setup-go evidence; this change adds no Go action or protocol dependency.