### PR TITLE
perf(workspace): speed up cleanup planning

### DIFF
--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -63,21 +63,20 @@ Reclaim completed review data only through preview-first cleanup:
 ```
 
 The default covers registered worktrees and marker-owned builds; npm cache is
-always opt-in. References, local/Git uncertainty, and unsafe path or marker
-state protect a target. The only historical-base exception is an
-`atrinik/atrinik@main` wrapper worktree directly below `build/worktrees/`; the
-PR must target `master` with head, base, and merge SHAs. The merge's first
-parent must match the base and it must be an ancestor of
+opt-in. Text uses IEC sizes; JSON keeps exact bytes. References, Git ambiguity,
+and unsafe paths or markers protect a target. The only historical-base
+exception is an `atrinik/atrinik@main` wrapper worktree directly below
+`build/worktrees/`; its PR must target `master` with head, base, and merge SHAs.
+The merge's first parent must match the base and it must be an ancestor of
 frozen boundary `ee5ba2096c94bce0161629423d4962a966bc61d8`. Graph proof ignores
 replace refs and rejects `info/grafts`. Apply inventories fully under the layout
 lock, then reruns the proof and exact-target safety without unrelated report
 scans; uncertainty fails closed.
-Status uses `--ignore-submodules=none`; populated submodules protect because
-worktree-specific Git directories can retain private refs, reflogs, and objects.
+Status uses `--ignore-submodules=none`; populated submodule Git data protects.
 Cleanup removes builds first, uses only non-force Git removal, and preserves
 branch refs, profiles, scenarios, states, topology records/logs, migrations,
-retention records, Git objects, review reports, and unmarked paths. For cleanup
-changes, hand off exact fixtures, JSON commands, reasons, and preserved records.
+retention records, Git objects, review reports, and unmarked paths. Hand off
+exact fixtures, JSON commands, reasons, and preserved records.
 
 ## Compose coherent sources
 

--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -64,14 +64,20 @@ Reclaim completed review data only through preview-first cleanup:
 
 The default covers registered worktrees and marker-owned builds; npm cache is
 always opt-in. References, local/Git uncertainty, and unsafe path or marker
-state protect a target. Apply performs one complete inventory and size
-recomputation under the repository-layout lock, then freshly revalidates each
-target's safety dependencies without rescanning unrelated report-only payloads;
-new uncertainty fails closed. It removes builds before non-force Git worktrees
-and preserves profiles, scenarios, states, topology records/logs, migrations,
-retention records, branches, Git objects, review reports, and unmarked paths.
-For cleanup changes, hand off exact fixture names, JSON preview/apply commands,
-expected reason codes, and the preserved records.
+state protect a target. The only historical-base exception is an
+`atrinik/atrinik@main` wrapper worktree directly below `build/worktrees/`; the
+PR must target `master` with head, base, and merge SHAs. The merge's first
+parent must match the base and it must be an ancestor of
+frozen boundary `ee5ba2096c94bce0161629423d4962a966bc61d8`. Graph proof ignores
+replace refs and rejects `info/grafts`. Apply inventories fully under the layout
+lock, then reruns the proof and exact-target safety without unrelated report
+scans; uncertainty fails closed.
+Status uses `--ignore-submodules=none`; populated submodules protect because
+worktree-specific Git directories can retain private refs, reflogs, and objects.
+Cleanup removes builds first, uses only non-force Git removal, and preserves
+branch refs, profiles, scenarios, states, topology records/logs, migrations,
+retention records, Git objects, review reports, and unmarked paths. For cleanup
+changes, hand off exact fixtures, JSON commands, reasons, and preserved records.
 
 ## Compose coherent sources
 

--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -64,12 +64,14 @@ Reclaim completed review data only through preview-first cleanup:
 
 The default covers registered worktrees and marker-owned builds; npm cache is
 always opt-in. References, local/Git uncertainty, and unsafe path or marker
-state protect a target. Apply recomputes under the repository-layout lock,
-removes builds before non-force Git worktrees, and preserves profiles,
-scenarios, states, topology records/logs, migrations, retention records,
-branches, Git objects, review reports, and unmarked paths. For cleanup changes,
-hand off exact fixture names, JSON preview/apply commands, expected reason
-codes, and the preserved records.
+state protect a target. Apply performs one complete inventory and size
+recomputation under the repository-layout lock, then freshly revalidates each
+target's safety dependencies without rescanning unrelated report-only payloads;
+new uncertainty fails closed. It removes builds before non-force Git worktrees
+and preserves profiles, scenarios, states, topology records/logs, migrations,
+retention records, branches, Git objects, review reports, and unmarked paths.
+For cleanup changes, hand off exact fixture names, JSON preview/apply commands,
+expected reason codes, and the preserved records.
 
 ## Compose coherent sources
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,19 +24,18 @@
   overwrite mutable server data. Preserve recoverable originals during checked
   migration; only the migration command may repair a linked worktree's Git
   administrative pointer without changing its working files.
-- Workspace cleanup is explicit and preview-first. Use `./atrinik cleanup
-  --dry-run --json` before exact `--apply`; never add implicit cleanup to other
-  commands. Preserve dirty, detached, locked, in-progress, referenced, or
+- Cleanup is explicit: preview `./atrinik cleanup --dry-run --json` before exact
+  `--apply`; never run it implicitly. Text uses IEC sizes; JSON keeps exact
+  bytes. Preserve dirty, detached, locked, in-progress, referenced, or
   uncertain worktrees; profiles, scenarios, states, topology records/logs,
   migrations, retention records, branches, Git objects, review reports, and
   unmarked paths. The npm cache is opt-in. Apply recomputes under the layout
-  lock, uses only non-force Git worktree removal, and reports partial failure
-  accurately. Status uses `--ignore-submodules=none`; populated submodules
-  protect the target because worktree-specific Git directories can retain
-  private refs, reflogs, and objects. Historical wrapper cleanup is confined to
-  direct `build/worktrees/` children and requires exact authenticated PR plus
-  frozen local merge ancestry. The proof ignores replace refs, rejects
-  `info/grafts`, fails closed on ambiguity, and is rerun by apply.
+  lock, uses non-force Git worktree removal, and reports partial failures.
+  Status uses `--ignore-submodules=none`; populated submodules protect
+  worktree-specific refs, reflogs, and objects. Historical wrapper cleanup
+  allows only direct `build/worktrees/` children with authenticated PR and
+  frozen ancestry proof. It ignores replace refs, rejects `info/grafts`, fails
+  closed on ambiguity, and is rerun by apply.
 - Use profiles for source selection. `default` selects the MIT replacement
   stack and `classic` the playable classic stack. Never mix providers or route
   unavailable replacement adapters through classic code. Replacement

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,13 @@
   uncertain worktrees; profiles, scenarios, states, topology records/logs,
   migrations, retention records, branches, Git objects, review reports, and
   unmarked paths. The npm cache is opt-in. Apply recomputes under the layout
-  lock, uses non-force Git removal, and reports partial failure accurately.
+  lock, uses only non-force Git worktree removal, and reports partial failure
+  accurately. Status uses `--ignore-submodules=none`; populated submodules
+  protect the target because worktree-specific Git directories can retain
+  private refs, reflogs, and objects. Historical wrapper cleanup is confined to
+  direct `build/worktrees/` children and requires exact authenticated PR plus
+  frozen local merge ancestry. The proof ignores replace refs, rejects
+  `info/grafts`, fails closed on ambiguity, and is rerun by apply.
 - Use profiles for source selection. `default` selects the MIT replacement
   stack and `classic` the playable classic stack. Never mix providers or route
   unavailable replacement adapters through classic code. Replacement

--- a/README.md
+++ b/README.md
@@ -394,21 +394,40 @@ worktrees. JSON output is stable schema-versioned data and keeps Git/GitHub
 diagnostics off stdout. Text output ends with candidate, protected, removed,
 error, and allocated-byte totals.
 
-The worktree inventory covers every initialized physical checkout plus wrapper
-worktrees that Git proves are direct children of exactly
-`workspace/worktrees/atrinik/` or the historical `build/worktrees/`
-namespace. A worktree becomes eligible only when it is registered to the
-expected common Git directory and repository, named and unlocked, has no Git
-operation or ordinary tracked/untracked change, and is not retained by a
-profile, scenario, live topology, or repository-migration record. The
-authenticated `gh` commit-associated-pulls query must prove one merged PR with
-the manifest base branch, an exact `head.sha` match, no associated open PR, and
-a merge age beyond the grace period. Query failure, ambiguity, wrong base,
-closed-unmerged PR, advanced branch, detached worktree, external path, or any
-ownership uncertainty protects the item. Ignored compiler/dependency output
-does not make a worktree dirty, but its paths and allocated bytes are reported
-because `git worktree remove` will reclaim it. Apply never uses `--force` and
-does not delete local or remote branch refs.
+The worktree inventory covers every initialized physical checkout plus current
+wrapper worktrees that Git proves are direct children of exactly
+`workspace/worktrees/atrinik/`. Historical wrapper worktrees are considered
+only as direct children of the top-level `build/worktrees/` namespace. A
+worktree becomes eligible only when it is registered to the expected common
+Git directory and repository, named and unlocked, has no Git operation or
+ordinary tracked/untracked change, and is not retained by a profile, scenario,
+live topology, or repository-migration record. Normally, the authenticated
+`gh` commit-associated-pulls query must prove one merged PR with the manifest
+base branch, an exact `head.sha` match, no associated open PR, and a merge age
+beyond the grace period.
+
+The only historical-base exception is a wrapper worktree directly below
+`build/worktrees/`. Its expected coordinate remains `atrinik/atrinik@main`, but
+the PR base must be `master`. The authenticated API evidence must include the
+exact head, `base.sha`, and `merge_commit_sha`; the local merge commit's first
+parent must equal that base SHA, and the merge commit must be an ancestor of
+the frozen final-`master` boundary
+`ee5ba2096c94bce0161629423d4962a966bc61d8`. The local graph proof ignores
+replace refs and fails closed if `info/grafts` exists. Missing, unavailable,
+mismatched, or ambiguous API or local Git evidence protects the item, and
+apply reruns the proof immediately before removal. Wrong base, closed-unmerged
+PR, advanced branch, detached worktree, external path, or any other ownership
+uncertainty also protects it.
+
+Status inspection uses `--ignore-submodules=none`, so repository configuration
+cannot hide submodule changes. A worktree with populated submodules remains
+protected even when otherwise clean because its per-worktree Git directories
+can contain private refs, reflogs, and objects. If only its prunable
+administrative record remains, that record protects the repository-wide prune
+scope for the same reason. Ignored compiler/dependency output does not make a
+worktree dirty, but its paths and allocated bytes are reported because
+`git worktree remove` will reclaim it. Apply uses only ordinary non-force
+worktree removal and preserves local and remote branch refs and Git objects.
 
 Profile builds are eligible only as direct
 `workspace/build/profiles/<profile>-<key>` children with an exact regular

--- a/README.md
+++ b/README.md
@@ -391,8 +391,9 @@ opt-in `npm-cache`; `all` selects all three. Positional checkout or logical
 component names narrow only the worktree inventory and still deduplicate
 aliases to one physical checkout. The special `atrinik` filter selects wrapper
 worktrees. JSON output is stable schema-versioned data and keeps Git/GitHub
-diagnostics off stdout. Text output ends with candidate, protected, removed,
-error, and allocated-byte totals.
+diagnostics off stdout; its byte fields remain exact integers. Text output uses
+compact base-1024 IEC sizes (`KiB`, `MiB`, `GiB`, and larger) for allocated,
+ignored, candidate, protected, and removed bytes.
 
 The worktree inventory covers every initialized physical checkout plus current
 wrapper worktrees that Git proves are direct children of exactly

--- a/README.md
+++ b/README.md
@@ -431,12 +431,14 @@ entries are report-only `unmanaged-build` items. Deep-review reports, ad hoc
 builds, packages, archives, and unregistered siblings are never recursively
 deleted.
 
-Apply holds the repository-layout lock, recomputes the entire plan, then
-revalidates each target immediately before removal. It removes eligible builds
-first, exact Git worktrees second, and the explicitly selected cache or safely
-shared prunable Git metadata last. A pre-mutation race aborts without deletion;
-after the first successful mutation, the deterministic policy stops on the
-first error and reports exactly what was reclaimed without claiming rollback.
+Apply holds the repository-layout lock and performs one complete inventory and
+size recomputation. Immediately before each removal it freshly revalidates the
+target's safety dependencies without rescanning unrelated report-only payloads.
+Any new uncertainty fails closed. It removes eligible builds first, exact Git
+worktrees second, and the explicitly selected cache or safely shared prunable
+Git metadata last. A pre-mutation race aborts without deletion; after the first
+successful mutation, the deterministic policy stops on the first error and
+reports exactly what was reclaimed without claiming rollback.
 
 ## Composing coherent component sources
 

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -56,6 +56,13 @@ PROFILE_PURPOSE = re.compile(
     r"^profile:(?P<profile>[a-z0-9][a-z0-9._-]*):(?P<key>[0-9a-f]{12})$"
 )
 HEAD_PATTERN = re.compile(r"^[0-9a-f]{40,64}$")
+HISTORICAL_PULL_BASE_BOUNDARIES = {
+    (
+        "atrinik/atrinik",
+        "main",
+        "master",
+    ): "ee5ba2096c94bce0161629423d4962a966bc61d8",
+}
 
 
 def _command(path: Path, *arguments: str) -> str:
@@ -1171,6 +1178,12 @@ class Cleanup:
                 item["reasons"].append(reference_reason)
         item["reasons"].extend(sorted(reference_errors))
         if prunable:
+            try:
+                if self._prunable_metadata_has_submodules(common, path):
+                    item["reasons"].append("populated_submodules")
+            except WorkspaceError as error:
+                item["reasons"].append("git_inspection_error")
+                item["error"] = str(error)
             item["reasons"].append("prunable_metadata")
             if item["reasons"] == ["prunable_metadata"]:
                 item["disposition"] = "skipped"
@@ -1194,10 +1207,16 @@ class Cleanup:
                 item["reasons"].append("unexpected_git_common_directory")
             if worktree_git == common and normalized != primary.resolve():
                 item["reasons"].append("unexpected_primary_identity")
+            if self._populated_submodules(path, worktree_git):
+                item["reasons"].append("populated_submodules")
             if self._operation_in_progress(path):
                 item["reasons"].append("git_operation_in_progress")
             status_value = _command(
-                path, "status", "--porcelain=v1", "--untracked-files=all"
+                path,
+                "status",
+                "--porcelain=v1",
+                "--untracked-files=all",
+                "--ignore-submodules=none",
             )
             if status_value:
                 item["reasons"].append("dirty_worktree")
@@ -1241,6 +1260,74 @@ class Cleanup:
                 return True
         return False
 
+    @staticmethod
+    def _populated_submodules(path: Path, git_directory: Path) -> bool:
+        """Match Git's conservative refusal to remove populated submodules."""
+
+        try:
+            modules = git_directory / "modules"
+            if modules.exists() or modules.is_symlink():
+                return True
+            gitmodules = path / ".gitmodules"
+            if not gitmodules.exists() and not gitmodules.is_symlink():
+                return False
+            if gitmodules.is_symlink() or not gitmodules.is_file():
+                raise WorkspaceError(
+                    f"worktree has unsafe .gitmodules metadata: {path}"
+                )
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot inspect worktree submodule metadata at {path}: {error}"
+            ) from error
+        output = _command(path, "submodule", "status", "--recursive")
+        for line in output.splitlines():
+            if not line or line[0] not in {" ", "-", "+", "U"}:
+                raise WorkspaceError(f"git returned invalid submodule status at {path}")
+            if line[0] != "-":
+                return True
+        return False
+
+    @staticmethod
+    def _prunable_metadata_has_submodules(common: Path, path: Path) -> bool:
+        """Inspect the exact missing worktree's retained administrative directory."""
+
+        worktrees = common / "worktrees"
+        try:
+            if worktrees.is_symlink() or not worktrees.is_dir():
+                raise WorkspaceError("worktree administrative directory is unsafe")
+            expected = (path / ".git").resolve(strict=False)
+            matches: list[Path] = []
+            for admin in worktrees.iterdir():
+                if admin.is_symlink() or not admin.is_dir():
+                    raise WorkspaceError(
+                        "worktree administrative entry is unsafe"
+                    )
+                gitdir = admin / "gitdir"
+                if gitdir.is_symlink() or not gitdir.is_file():
+                    raise WorkspaceError("worktree gitdir metadata is unsafe")
+                value = gitdir.read_text(encoding="utf-8")
+                if (
+                    not value.endswith("\n")
+                    or "\n" in value[:-1]
+                    or "\0" in value
+                    or not Path(value[:-1]).is_absolute()
+                ):
+                    raise WorkspaceError("worktree gitdir metadata is invalid")
+                if Path(value[:-1]).resolve(strict=False) == expected:
+                    matches.append(admin)
+            if len(matches) != 1:
+                raise WorkspaceError(
+                    "cannot map prunable worktree to administrative metadata"
+                )
+            modules = matches[0] / "modules"
+            return modules.exists() or modules.is_symlink()
+        except WorkspaceError:
+            raise
+        except (OSError, RuntimeError, UnicodeError) as error:
+            raise WorkspaceError(
+                f"cannot inspect prunable worktree metadata for {path}: {error}"
+            ) from error
+
     def _resolve_github(self, items: list[dict[str, Any]], older_than_days: int) -> None:
         pending = [
             item
@@ -1273,6 +1360,22 @@ class Cleanup:
             reason, evidence, merged_at = self._pull_evidence(
                 pulls, item["head"], item["base_branch"]
             )
+            historical_base = False
+            if reason == "wrong_base_branch":
+                row = pulls[0]
+                boundary = self._historical_pull_boundary(item, row)
+                if boundary is not None:
+                    historical_branch = row["base"]["ref"]
+                    reason, evidence, merged_at = self._pull_evidence(
+                        pulls, item["head"], historical_branch
+                    )
+                    if reason is None and not self._historical_merge_proven(
+                        item, row, boundary
+                    ):
+                        reason = "historical_base_unverified"
+                        evidence = None
+                        merged_at = None
+                    historical_base = reason is None
             if reason is not None:
                 item["reasons"] = [reason]
                 continue
@@ -1287,9 +1390,91 @@ class Cleanup:
                 item["reasons"] = ["younger_than_grace_period"]
             else:
                 item["disposition"] = "eligible"
-                item["reasons"] = ["merged_pr_head"]
+                item["reasons"] = [
+                    "merged_pr_head_historical_base"
+                    if historical_base
+                    else "merged_pr_head"
+                ]
                 if item["kind"] == "prunable-metadata":
                     item["reasons"].append("prunable_metadata")
+
+    def _historical_pull_boundary(
+        self, item: dict[str, Any], row: dict[str, Any]
+    ) -> str | None:
+        """Return the frozen pre-rewrite boundary for one legacy wrapper path."""
+
+        base = row.get("base")
+        primary = item.get("_primary")
+        if (
+            item.get("owner") != "atrinik"
+            or item.get("repository") != "atrinik/atrinik"
+            or item.get("base_branch") != "main"
+            or not isinstance(primary, str)
+            or not isinstance(base, dict)
+            or not isinstance(base.get("ref"), str)
+            or not self._owned_direct_child(
+                Path(item["path"]), Path(primary) / "build" / "worktrees"
+            )
+        ):
+            return None
+        return HISTORICAL_PULL_BASE_BOUNDARIES.get(
+            (item["repository"], item["base_branch"], base["ref"])
+        )
+
+    @staticmethod
+    def _historical_merge_proven(
+        item: dict[str, Any], row: dict[str, Any], boundary: str
+    ) -> bool:
+        """Prove GitHub's merge commit belongs to the frozen historical line."""
+
+        primary = item.get("_primary")
+        base = row.get("base")
+        merge_commit = row.get("merge_commit_sha")
+        if (
+            not isinstance(primary, str)
+            or not isinstance(base, dict)
+            or not isinstance(base.get("sha"), str)
+            or not isinstance(merge_commit, str)
+            or not HEAD_PATTERN.fullmatch(base["sha"])
+            or not HEAD_PATTERN.fullmatch(merge_commit)
+            or not HEAD_PATTERN.fullmatch(boundary)
+        ):
+            return False
+        try:
+            common = _git_common_directory(Path(primary))
+            grafts = common / "info" / "grafts"
+            try:
+                grafts.lstat()
+            except FileNotFoundError:
+                pass
+            else:
+                return False
+            commit = _command(
+                Path(primary),
+                "--no-replace-objects",
+                "rev-list",
+                "--parents",
+                "-n",
+                "1",
+                merge_commit,
+            ).split()
+            if (
+                len(commit) < 2
+                or commit[0] != merge_commit
+                or commit[1] != base["sha"]
+            ):
+                return False
+            _command(
+                Path(primary),
+                "--no-replace-objects",
+                "merge-base",
+                "--is-ancestor",
+                merge_commit,
+                boundary,
+            )
+        except (OSError, RuntimeError, WorkspaceError):
+            return False
+        return True
 
     @staticmethod
     def _protect_shared_prune_scope(items: list[dict[str, Any]]) -> None:
@@ -1320,8 +1505,8 @@ class Cleanup:
                     "Accept: application/vnd.github+json",
                     "--paginate",
                     "--jq",
-                    ".[] | {number,state,merged_at,head:{sha:.head.sha},"
-                    "base:{ref:.base.ref},html_url}",
+                    ".[] | {number,state,merged_at,merge_commit_sha,"
+                    "head:{sha:.head.sha},base:{ref:.base.ref,sha:.base.sha},html_url}",
                 ],
                 check=True,
                 capture_output=True,
@@ -1405,9 +1590,19 @@ class Cleanup:
         head = row.get("head")
         base = row.get("base")
         merged_at = row.get("merged_at")
+        merge_commit = row.get("merge_commit_sha")
         state_value = row.get("state")
         return (
-            set(row) == {"number", "state", "html_url", "merged_at", "head", "base"}
+            set(row)
+            == {
+                "number",
+                "state",
+                "html_url",
+                "merged_at",
+                "merge_commit_sha",
+                "head",
+                "base",
+            }
             and isinstance(row.get("number"), int)
             and not isinstance(row.get("number"), bool)
             and isinstance(row.get("html_url"), str)
@@ -1420,9 +1615,16 @@ class Cleanup:
             and isinstance(head.get("sha"), str)
             and bool(HEAD_PATTERN.fullmatch(head["sha"]))
             and isinstance(base, dict)
-            and set(base) == {"ref"}
+            and set(base) == {"ref", "sha"}
             and isinstance(base.get("ref"), str)
             and bool(base["ref"])
+            and isinstance(base.get("sha"), str)
+            and bool(HEAD_PATTERN.fullmatch(base["sha"]))
+            and (
+                merge_commit is None and merged_at is None
+                or isinstance(merge_commit, str)
+                and bool(HEAD_PATTERN.fullmatch(merge_commit))
+            )
         )
 
     def _builds(

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -95,13 +95,24 @@ def _worktree_records(repository: Path) -> list[dict[str, str]]:
 
 
 def _git_common_directory(path: Path) -> Path:
-    value = _command(path, "rev-parse", "--path-format=absolute", "--git-common-dir")
-    return Path(value).resolve()
+    return _git_directories(path)[0]
 
 
 def _git_directory(path: Path) -> Path:
-    value = _command(path, "rev-parse", "--path-format=absolute", "--git-dir")
-    return Path(value).resolve()
+    return _git_directories(path)[1]
+
+
+def _git_directories(path: Path) -> tuple[Path, Path]:
+    values = _command(
+        path,
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-common-dir",
+        "--git-dir",
+    ).splitlines()
+    if len(values) != 2 or not all(values):
+        raise WorkspaceError(f"git returned invalid directory metadata at {path}")
+    return Path(values[0]).resolve(), Path(values[1]).resolve()
 
 
 def _parse_time(value: Any, context: str) -> datetime:
@@ -145,27 +156,84 @@ def _tree_usage(
 ) -> tuple[dict[tuple[int, int], int], datetime | None, str | None]:
     sizes: dict[tuple[int, int], int] = {}
     maximum: float | None = None
-    stack = [root]
     try:
-        excluded_paths = {path.resolve(strict=False) for path in excluded}
+        root_value = os.fspath(root)
+        excluded_values = tuple(excluded)
+        if not excluded_values:
+            stack = [root_value]
+            while stack:
+                raw_path = stack.pop()
+                metadata = os.lstat(raw_path)
+                key = (metadata.st_dev, metadata.st_ino)
+                sizes.setdefault(key, metadata.st_blocks * 512)
+                maximum = (
+                    metadata.st_mtime
+                    if maximum is None
+                    else max(maximum, metadata.st_mtime)
+                )
+                if stat.S_ISDIR(metadata.st_mode) and not stat.S_ISLNK(
+                    metadata.st_mode
+                ):
+                    with os.scandir(raw_path) as entries:
+                        stack.extend(entry.path for entry in entries)
+            observed = (
+                datetime.fromtimestamp(maximum, timezone.utc)
+                if maximum is not None
+                else None
+            )
+            return sizes, observed, None
+        resolved_root = root.resolve(strict=False)
+        excluded_paths = {
+            path.resolve(strict=False) for path in excluded_values
+        }
+        stack = [(root_value, resolved_root)]
         while stack:
-            path = stack.pop()
-            normalized = path.resolve(strict=False)
-            if path != root and normalized in excluded_paths:
+            raw_path, normalized = stack.pop()
+            if raw_path != root_value and normalized in excluded_paths:
                 continue
-            metadata = path.lstat()
+            metadata = os.lstat(raw_path)
             key = (metadata.st_dev, metadata.st_ino)
             sizes.setdefault(key, metadata.st_blocks * 512)
             maximum = metadata.st_mtime if maximum is None else max(maximum, metadata.st_mtime)
             if stat.S_ISDIR(metadata.st_mode) and not stat.S_ISLNK(metadata.st_mode):
-                with os.scandir(path) as entries:
-                    stack.extend(Path(entry.path) for entry in entries)
+                with os.scandir(raw_path) as entries:
+                    stack.extend(
+                        (entry.path, normalized / entry.name) for entry in entries
+                    )
     except (OSError, RuntimeError) as error:
         return {}, None, str(error)
     observed = (
         datetime.fromtimestamp(maximum, timezone.utc) if maximum is not None else None
     )
     return sizes, observed, None
+
+
+def _listed_usage(root: Path, relative_paths: Iterable[str]) -> dict[tuple[int, int], int]:
+    """Account for Git-listed paths without resolving and rewalking every file."""
+
+    sizes: dict[tuple[int, int], int] = {}
+    root_value = os.fspath(root)
+    for relative in relative_paths:
+        parts = relative.split("/")
+        if (
+            not relative
+            or relative.startswith("/")
+            or ".." in parts
+            or "" in parts
+        ):
+            continue
+        candidate = os.path.join(root_value, *parts)
+        try:
+            metadata = os.lstat(candidate)
+        except OSError:
+            continue
+        if stat.S_ISDIR(metadata.st_mode) and not stat.S_ISLNK(metadata.st_mode):
+            nested, _, error = _tree_usage(Path(candidate))
+            if error is None:
+                sizes.update(nested)
+            continue
+        sizes.setdefault((metadata.st_dev, metadata.st_ino), metadata.st_blocks * 512)
+    return sizes
 
 
 def _base_item(kind: str, owner: str, repository: str, path: Path) -> dict[str, Any]:
@@ -199,6 +267,10 @@ class Cleanup:
         self.now = datetime.now(timezone.utc)
         self._repositories: dict[str, Path] = {}
         self._wrapper_primary = self.paths.repository
+        self._repository_cache: dict[
+            tuple[str, str],
+            tuple[Path, list[dict[str, str]], Path] | str,
+        ] = {}
         self._github_cache: dict[
             tuple[str, str], tuple[list[dict[str, Any]] | None, str | None]
         ] = {}
@@ -239,8 +311,11 @@ class Cleanup:
                 if identity in completed:
                     continue
                 try:
-                    fresh = self._plan(
-                        selected_scopes, older_than_days, selected_names, "apply"
+                    match = self._revalidate_target(
+                        target,
+                        older_than_days,
+                        selected_scopes,
+                        selected_names,
                     )
                 except (OSError, RuntimeError, WorkspaceError) as error:
                     target["disposition"] = "error"
@@ -248,15 +323,6 @@ class Cleanup:
                     target["error"] = str(error)
                     report["aborted"] = True
                     break
-                match = next(
-                    (
-                        item
-                        for item in fresh["items"]
-                        if item["kind"] == target["kind"]
-                        and item["path"] == target["path"]
-                    ),
-                    None,
-                )
                 if match is None or match["disposition"] != "eligible":
                     target["disposition"] = "error"
                     target["reasons"] = ["revalidation_failed"]
@@ -267,9 +333,15 @@ class Cleanup:
                         }
                     report["aborted"] = True
                     break
+                credited = {
+                    key: target[key]
+                    for key in ("allocated_bytes", "ignored_bytes", "ignored_paths")
+                    if key in target
+                }
                 for key, value in match.items():
                     if not key.startswith("_"):
                         target[key] = value
+                target.update(credited)
                 report["mutation_attempted"] = True
                 try:
                     self._remove(match)
@@ -331,9 +403,7 @@ class Cleanup:
         names: set[str] | None,
         mode: str,
     ) -> dict[str, Any]:
-        self.now = datetime.now(timezone.utc)
-        self._repositories = {}
-        self._github_cache = {}
+        self._reset_inventory()
         references, reference_errors = self._references()
         items: list[dict[str, Any]] = []
         registered, registered_error = self._registered_worktree_paths()
@@ -371,9 +441,7 @@ class Cleanup:
         items.sort(key=lambda item: (item["kind"], item["owner"], item["path"]))
         self._credit_sizes(items)
         for item in items:
-            item.pop("_inodes", None)
-            item.pop("_primary", None)
-            item.pop("_purpose", None)
+            self._strip_internal(item)
         summary = self._summary(items)
         summary["error_count"] += len(reference_errors)
         return {
@@ -386,6 +454,185 @@ class Cleanup:
             "items": items,
             "summary": summary,
         }
+
+    def _reset_inventory(self) -> None:
+        self.now = datetime.now(timezone.utc)
+        self._repositories = {}
+        self._repository_cache = {}
+        self._github_cache = {}
+
+    @staticmethod
+    def _strip_internal(item: dict[str, Any]) -> None:
+        item.pop("_inodes", None)
+        item.pop("_primary", None)
+        item.pop("_purpose", None)
+
+    def _revalidate_target(
+        self,
+        target: dict[str, Any],
+        older_than_days: int,
+        scopes: list[str],
+        names: set[str] | None,
+    ) -> dict[str, Any] | None:
+        """Refresh one target's safety predicates without rebuilding report payloads."""
+
+        self._reset_inventory()
+        references, reference_errors = self._references()
+        registered, registered_error = self._registered_worktree_paths()
+        if registered_error:
+            reference_errors.add("worktree_inventory_error")
+        path = Path(target["path"])
+        kind = target["kind"]
+        if kind == "profile-build":
+            removable_worktrees = (
+                self._revalidate_build_sources(
+                    path,
+                    older_than_days,
+                    references,
+                    reference_errors,
+                    names,
+                )
+                if target.get("source_worktree_removal")
+                and "worktrees" in scopes
+                else set()
+            )
+            item = self._build_item(
+                path,
+                older_than_days,
+                registered,
+                removable_worktrees,
+                references,
+                reference_errors,
+            )
+        elif kind in {"worktree", "prunable-metadata"}:
+            item = self._revalidate_worktree(
+                target["owner"],
+                path,
+                kind,
+                older_than_days,
+                references,
+                reference_errors,
+            )
+        elif kind == "npm-cache":
+            item = self._npm_cache(
+                older_than_days,
+                references,
+                reference_errors,
+            )
+            if item is not None and item["path"] != target["path"]:
+                item = None
+        else:
+            raise WorkspaceError(f"unsupported cleanup target: {kind}")
+        if item is not None:
+            self._strip_internal(item)
+        return item
+
+    def _revalidate_build_sources(
+        self,
+        path: Path,
+        older_than_days: int,
+        references: dict[str, Any],
+        reference_errors: set[str],
+        names: set[str] | None,
+    ) -> set[Path]:
+        try:
+            purpose, profile, key = self._profile_marker(path)
+            probe = _base_item("profile-build", "atrinik", "atrinik/atrinik", path)
+            probe.update(
+                {"profile": profile, "key": key, "_purpose": purpose}
+            )
+            metadata = self._load_build_metadata(path / BUILD_METADATA, probe)
+        except (OSError, RuntimeError, WorkspaceError):
+            return set()
+        removable: set[Path] = set()
+        candidates = {
+            (row["checkout"], Path(row["checkout_path"]).resolve(strict=False))
+            for row in metadata["coordinates"].values()
+            if names is None or row["checkout"] in names
+        }
+        for owner, candidate in sorted(candidates, key=lambda value: str(value[1])):
+            item = self._revalidate_worktree(
+                owner,
+                candidate,
+                "worktree",
+                older_than_days,
+                references,
+                reference_errors,
+            )
+            if item is not None and item["disposition"] == "eligible":
+                removable.add(candidate)
+        return removable
+
+    def _revalidate_worktree(
+        self,
+        owner: str,
+        target: Path,
+        kind: str,
+        older_than_days: int,
+        references: dict[str, Any],
+        reference_errors: set[str],
+    ) -> dict[str, Any] | None:
+        if owner == "atrinik":
+            repository = "atrinik/atrinik"
+            base = "main"
+            invocation = self.paths.repository
+            wrapper = True
+        else:
+            checkout = self.manifest.by_checkout.get(owner)
+            if checkout is None:
+                raise WorkspaceError(f"unknown cleanup worktree owner: {owner}")
+            repository = checkout.repository
+            base = checkout.branch
+            invocation = self.paths.repositories / checkout.path
+            wrapper = False
+        self._repository_cache.pop((repository, str(invocation)), None)
+        common, records, primary = self._repository_inventory(repository, invocation)
+        self._repositories[owner] = primary
+        allowed = (
+            [
+                self.paths.worktrees / "atrinik",
+                primary / "build" / "worktrees",
+            ]
+            if wrapper
+            else [self.paths.worktrees / owner]
+        )
+        normalized_target = target.resolve(strict=False)
+        selected: list[dict[str, Any]] = []
+        for row in records:
+            raw = row.get("worktree")
+            if raw is None:
+                continue
+            candidate = Path(raw)
+            if kind == "prunable-metadata":
+                if "prunable" not in row or candidate.exists():
+                    continue
+            elif candidate.resolve(strict=False) != normalized_target:
+                continue
+            selected.append(
+                self._worktree_item(
+                    owner,
+                    repository,
+                    base,
+                    primary,
+                    common,
+                    allowed,
+                    row,
+                    references,
+                    reference_errors,
+                )
+            )
+        self._resolve_github(selected, older_than_days)
+        if kind == "prunable-metadata":
+            self._protect_shared_prune_scope(selected)
+        return next(
+            (
+                item
+                for item in selected
+                if item["kind"] == kind
+                and Path(item["path"]).resolve(strict=False) == normalized_target
+            ),
+            None,
+        )
 
     def _references(self) -> tuple[dict[str, Any], set[str]]:
         references: dict[str, Any] = {
@@ -423,21 +670,9 @@ class Cleanup:
                 repositories.append((checkout.repository, candidate))
         for repository, invocation in repositories:
             try:
-                records = _worktree_records(invocation)
-                common = _git_common_directory(invocation)
-                primary = None
-                for row in records:
-                    candidate = Path(row.get("worktree", ""))
-                    if not candidate.is_dir() or candidate.is_symlink():
-                        continue
-                    try:
-                        if _git_directory(candidate) == common:
-                            primary = candidate
-                            break
-                    except WorkspaceError:
-                        continue
-                if primary is None or not self._remote_identity(primary, repository):
-                    raise WorkspaceError("repository identity is unproven")
+                _, records, primary = self._repository_inventory(
+                    repository, invocation
+                )
                 if repository == "atrinik/atrinik":
                     self._wrapper_primary = primary.resolve()
                 registered.update(
@@ -448,6 +683,39 @@ class Cleanup:
             except (OSError, RuntimeError, WorkspaceError):
                 failed = True
         return registered, failed
+
+    def _repository_inventory(
+        self, repository: str, invocation: Path
+    ) -> tuple[Path, list[dict[str, str]], Path]:
+        key = (repository, str(invocation))
+        cached = self._repository_cache.get(key)
+        if isinstance(cached, str):
+            raise WorkspaceError(cached)
+        if cached is not None:
+            return cached
+        try:
+            common = _git_common_directory(invocation)
+            records = _worktree_records(invocation)
+            primary = None
+            for row in records:
+                candidate = Path(row.get("worktree", ""))
+                if not candidate.is_dir() or candidate.is_symlink():
+                    continue
+                try:
+                    if _git_directory(candidate) == common:
+                        primary = candidate.resolve()
+                        break
+                except WorkspaceError:
+                    continue
+            if primary is None or not self._remote_identity(primary, repository):
+                raise WorkspaceError("repository identity is unproven")
+        except (OSError, RuntimeError, WorkspaceError) as error:
+            detail = str(error)
+            self._repository_cache[key] = detail
+            raise WorkspaceError(detail) from error
+        result = (common, records, primary)
+        self._repository_cache[key] = result
+        return result
 
     @staticmethod
     def _add_reference(container: dict[Path, list[str]], path: Path, name: str) -> None:
@@ -796,21 +1064,9 @@ class Cleanup:
                 )
         for owner, repository, base, invocation, wrapper in repositories:
             try:
-                common = _git_common_directory(invocation)
-                records = _worktree_records(invocation)
-                primary = None
-                for row in records:
-                    candidate = Path(row.get("worktree", ""))
-                    if not candidate.is_dir() or candidate.is_symlink():
-                        continue
-                    try:
-                        if _git_directory(candidate) == common:
-                            primary = candidate.resolve()
-                            break
-                    except WorkspaceError:
-                        continue
-                if primary is None or not self._remote_identity(primary, repository):
-                    raise WorkspaceError("repository identity is unproven")
+                common, records, primary = self._repository_inventory(
+                    repository, invocation
+                )
                 self._repositories[owner] = primary
                 allowed = (
                     [
@@ -826,18 +1082,19 @@ class Cleanup:
                     path = Path(row["worktree"])
                     normalized = path.resolve(strict=False)
                     registered.add(normalized)
-                    item = self._worktree_item(
-                        owner,
-                        repository,
-                        base,
-                        primary,
-                        common,
-                        allowed,
-                        row,
-                        references,
-                        reference_errors,
+                    items.append(
+                        self._worktree_item(
+                            owner,
+                            repository,
+                            base,
+                            primary,
+                            common,
+                            allowed,
+                            row,
+                            references,
+                            reference_errors,
+                        )
                     )
-                    items.append(item)
             except (OSError, RuntimeError, WorkspaceError) as error:
                 item = _base_item("worktree", owner, repository, invocation)
                 item["disposition"] = "error"
@@ -932,9 +1189,10 @@ class Cleanup:
             item["reasons"].append("missing_worktree")
             return item
         try:
-            if _git_common_directory(path) != common:
+            worktree_common, worktree_git = _git_directories(path)
+            if worktree_common != common:
                 item["reasons"].append("unexpected_git_common_directory")
-            if _git_directory(path) == common and normalized != primary.resolve():
+            if worktree_git == common and normalized != primary.resolve():
                 item["reasons"].append("unexpected_primary_identity")
             if self._operation_in_progress(path):
                 item["reasons"].append("git_operation_in_progress")
@@ -952,11 +1210,7 @@ class Cleanup:
                 "-z",
             )
             ignored_paths = [value for value in ignored.split("\0") if value]
-            ignored_sizes: dict[tuple[int, int], int] = {}
-            for raw in ignored_paths:
-                candidate = path / raw
-                sizes, _, _ = _tree_usage(candidate)
-                ignored_sizes.update(sizes)
+            ignored_sizes = _listed_usage(path, ignored_paths)
             item["ignored_paths"] = len(ignored_paths)
             item["ignored_bytes"] = sum(ignored_sizes.values())
         except WorkspaceError as error:
@@ -969,8 +1223,18 @@ class Cleanup:
 
     @staticmethod
     def _operation_in_progress(path: Path) -> bool:
-        for name in OPERATION_PATHS:
-            operation_path = Path(_command(path, "rev-parse", "--git-path", name))
+        arguments = tuple(
+            argument
+            for name in OPERATION_PATHS
+            for argument in ("--git-path", name)
+        )
+        values = _command(path, "rev-parse", *arguments).splitlines()
+        if len(values) != len(OPERATION_PATHS):
+            raise WorkspaceError(
+                f"git returned invalid operation metadata at {path}"
+            )
+        for value in values:
+            operation_path = Path(value)
             if not operation_path.is_absolute():
                 operation_path = path / operation_path
             if operation_path.exists() or operation_path.is_symlink():
@@ -1226,6 +1490,7 @@ class Cleanup:
         reference_errors: set[str],
     ) -> dict[str, Any]:
         item = _base_item("profile-build", "atrinik", "atrinik/atrinik", path)
+        metadata_path = path / BUILD_METADATA
         inodes, observed, walk_error = _tree_usage(path)
         item["_inodes"] = inodes
         if walk_error:
@@ -1261,7 +1526,6 @@ class Cleanup:
         elif busy:
             item["reasons"].append("build_lock_busy")
         source_removal = False
-        metadata_path = path / BUILD_METADATA
         if metadata_path.exists() or metadata_path.is_symlink():
             try:
                 metadata = self._load_build_metadata(metadata_path, item)
@@ -1465,6 +1729,7 @@ class Cleanup:
             item["reasons"] = ["invalid_cache_path"]
             item["legacy_known_cache"] = False
             return item
+        metadata_path = path / CACHE_METADATA
         inodes, observed, walk_error = _tree_usage(path)
         item["_inodes"] = inodes
         if walk_error:
@@ -1505,7 +1770,6 @@ class Cleanup:
         elif busy:
             item["reasons"].append("active_build")
         item["reasons"].extend(sorted(reference_errors))
-        metadata_path = path / CACHE_METADATA
         if metadata_path.exists() or metadata_path.is_symlink():
             try:
                 if metadata_path.is_symlink() or not metadata_path.is_file():

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -19,6 +19,27 @@ from .workspace import Workspace
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def _human_bytes(value: int) -> str:
+    """Render an exact byte count compactly for human-facing output."""
+
+    if value < 0:
+        raise ValueError("byte count cannot be negative")
+    units = ("B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB")
+    unit = 0
+    amount = float(value)
+    while amount >= 1024 and unit < len(units) - 1:
+        amount /= 1024
+        unit += 1
+    rounded = round(amount, 1)
+    if rounded >= 1024 and unit < len(units) - 1:
+        rounded /= 1024
+        unit += 1
+    if unit == 0:
+        return f"{value}{units[unit]}"
+    rendered = f"{rounded:.1f}".removesuffix(".0")
+    return f"{rendered}{units[unit]}"
+
+
 class _ExactArgumentParser(argparse.ArgumentParser):
     def __init__(self, *args: object, **kwargs: object):
         kwargs.setdefault("allow_abbrev", False)
@@ -469,20 +490,28 @@ def main(arguments: list[str] | None = None) -> int:
                         else f"{item['age_seconds'] // 86400}d"
                     )
                     reasons = ",".join(item["reasons"])
+                    sizes = [
+                        f"allocated={_human_bytes(item['allocated_bytes'])}"
+                    ]
+                    if "ignored_bytes" in item:
+                        sizes.append(
+                            f"ignored={_human_bytes(item['ignored_bytes'])}"
+                        )
+                    size_fields = ",".join(sizes)
                     print(
                         f"{item['disposition']}\t{item['kind']}\t"
-                        f"{item['allocated_bytes']}\t{age}\t{item['path']}\t"
+                        f"{size_fields}\t{age}\t{item['path']}\t"
                         f"{reasons}"
                     )
                 summary = report["summary"]
                 print(
                     "summary\t"
                     f"candidates={summary['candidate_count']} "
-                    f"candidate_bytes={summary['candidate_bytes']} "
+                    f"candidate_bytes={_human_bytes(summary['candidate_bytes'])} "
                     f"protected={summary['protected_count']} "
-                    f"protected_bytes={summary['protected_bytes']} "
+                    f"protected_bytes={_human_bytes(summary['protected_bytes'])} "
                     f"removed={summary['removed_count']} "
-                    f"removed_bytes={summary['removed_bytes']} "
+                    f"removed_bytes={_human_bytes(summary['removed_bytes'])} "
                     f"errors={summary['error_count']}"
                 )
             if report["summary"]["error_count"] or report.get("aborted"):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -173,11 +173,12 @@ to reconstruct generated data.
 Inventory records are stable-sorted and carry a kind, physical owner and
 repository, exact path, no-follow allocated size, age and age basis,
 disposition, stable reason codes, and applicable profile/scenario/topology/
-migration/retention or merged-PR evidence. Size accounting uses device/inode
-identity and excludes registered nested worktree roots from mixed container
-records, preventing hard links or overlapping roots from inflating global byte
-totals. Filesystem traversal or metadata ambiguity protects the affected
-scope.
+migration/retention or merged-PR evidence. JSON retains exact integer byte
+fields; text renders compact base-1024 IEC sizes. Size accounting uses
+device/inode identity and excludes registered nested worktree roots from mixed
+container records, preventing hard links or overlapping roots from inflating
+global byte totals. Filesystem traversal or metadata ambiguity protects the
+affected scope.
 
 Current-checkout worktrees are owned only as direct children of
 `workspace/worktrees/<checkout>/`. Current wrapper-self worktrees are owned

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -161,12 +161,14 @@ side effect.
 of initialization, synchronization, build, or startup. Default and explicit
 `--dry-run` modes are read-only. `--apply` first takes the same
 repository-layout lock used by checkout, build, topology, foreground-run, and
-scenario operations, fully recomputes the plan, and immediately revalidates
-each target. Build roots are removed before Git worktrees; the explicitly
-selected npm cache and safe prunable Git metadata come last. A race before the
-first mutation aborts the plan. A later failure stops the ordered sequence and
-reports completed reclamation without attempting to reconstruct generated
-data.
+scenario operations, then performs one complete inventory and size
+recomputation. Immediately before each removal it freshly revalidates that
+target's safety dependencies without rescanning unrelated report-only
+payloads; any new ambiguity fails closed. Build roots are removed before Git
+worktrees; the explicitly selected npm cache and safe prunable Git metadata
+come last. A race before the first mutation aborts the plan. A later failure
+stops the ordered sequence and reports completed reclamation without attempting
+to reconstruct generated data.
 
 Inventory records are stable-sorted and carry a kind, physical owner and
 repository, exact path, no-follow allocated size, age and age basis,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -180,8 +180,9 @@ totals. Filesystem traversal or metadata ambiguity protects the affected
 scope.
 
 Current-checkout worktrees are owned only as direct children of
-`workspace/worktrees/<checkout>/`. Wrapper-self worktrees are owned only when
-Git registers them under `workspace/worktrees/atrinik/` or the historical
+`workspace/worktrees/<checkout>/`. Current wrapper-self worktrees are owned
+only when Git registers them directly under `workspace/worktrees/atrinik/`;
+historical wrapper worktrees are recognized only as direct children of the
 top-level `build/worktrees/` namespace. Common-Git-directory and canonical
 repository identity, named/unlocked state, absence of in-progress Git
 operations, and ordinary tracked/untracked cleanliness are mandatory. Saved
@@ -189,12 +190,30 @@ profile selectors of kind `worktree`, absolute `path`, or migration-only
 `migrated-worktree`; retained scenario coordinates; live topology coordinates;
 and every original/destination/composite migration path protect exact
 worktrees. Ignored output is sized and disclosed but does not defeat
-eligibility. GitHub's authenticated commit-associated-pulls API must prove an
-exact merged head against the checkout's manifest branch, no open association,
-and the requested grace age. Apply delegates to `git worktree remove` without
-force and preserves refs. Prunable administrative records use the same PR and
-ownership proof and are pruned only when no protected prunable sibling shares
-that repository-wide Git prune operation.
+eligibility. GitHub's authenticated commit-associated-pulls API normally must
+prove an exact merged head against the checkout's manifest branch, no open
+association, and the requested grace age.
+
+Only a historical wrapper worktree directly below `build/worktrees/` may use
+the historical PR-base proof. Its expected coordinate remains
+`atrinik/atrinik@main`, while the PR base must be `master`. Authenticated API
+evidence supplies the exact `head.sha`, `base.sha`, and `merge_commit_sha`; the
+local merge commit's first parent must equal the API base SHA and that merge
+commit must be an ancestor of the frozen final-`master` boundary
+`ee5ba2096c94bce0161629423d4962a966bc61d8`. Graph inspection ignores replace
+refs and fails closed when `info/grafts` exists, so neither replacement nor
+graft metadata can rewrite the ancestry proof. Missing, mismatched,
+unavailable, or ambiguous evidence protects the target. Apply reruns this API
+and local Git proof immediately before removal.
+
+Worktree status is inspected with `--ignore-submodules=none`. A populated
+submodule protects the worktree even when its visible files are clean because
+per-worktree Git directories can retain private refs, reflogs, and objects. A
+missing worktree whose administrative record retains such a `modules`
+directory protects its repository-wide prune scope. Removal remains entirely
+non-force and preserves local and remote branch refs and Git objects. Prunable
+administrative records use the same PR and ownership proof and are pruned only
+when no protected prunable sibling shares that Git prune operation.
 
 Profile build ownership is a direct-child path plus an exact regular
 `.atrinik-workspace-managed.json` purpose marker. Each use under the per-build

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -14,9 +14,11 @@ from atrinik_workspace.cleanup import (
     Cleanup,
     _base_item,
     _command,
+    _listed_usage,
     _parse_time,
     _path_relation,
     _tree_usage,
+    _worktree_records,
     _workspace_owned,
 )
 from atrinik_workspace.model import (
@@ -111,13 +113,18 @@ class CleanupTests(unittest.TestCase):
         (path / "ignored" / "output.o").write_bytes(b"x" * 4096)
         return path
 
-    def make_component_worktree(self, label: str = "component-review") -> Path:
-        primary = self.wrapper / "client"
+    def make_component_worktree(
+        self,
+        label: str = "component-review",
+        *,
+        component: str = "client",
+    ) -> Path:
+        primary = self.wrapper / component
         primary.mkdir()
         command("git", "init", "-b", "main", cwd=primary)
         command("git", "config", "user.name", "Tests", cwd=primary)
         command("git", "config", "user.email", "tests@example.invalid", cwd=primary)
-        (primary / "README").write_text("client\n", encoding="utf-8")
+        (primary / "README").write_text(f"{component}\n", encoding="utf-8")
         command("git", "add", ".", cwd=primary)
         command("git", "commit", "-m", "feat: seed", cwd=primary)
         command(
@@ -125,10 +132,10 @@ class CleanupTests(unittest.TestCase):
             "remote",
             "add",
             "origin",
-            "https://github.com/atrinik/client.git",
+            f"https://github.com/atrinik/{component}.git",
             cwd=primary,
         )
-        path = self.workspace.paths.worktrees / "client" / label
+        path = self.workspace.paths.worktrees / component / label
         path.parent.mkdir(parents=True, exist_ok=True)
         command(
             "git",
@@ -211,7 +218,7 @@ class CleanupTests(unittest.TestCase):
 
         with mock.patch.object(Path, "resolve", side_effect=RuntimeError("loop")):
             self.assertTrue(_path_relation(usage_root, excluded))
-            sizes, observed, error = _tree_usage(usage_root)
+            sizes, observed, error = _tree_usage(usage_root, [excluded])
         self.assertEqual(sizes, {})
         self.assertIsNone(observed)
         self.assertIn("loop", error or "")
@@ -262,6 +269,40 @@ class CleanupTests(unittest.TestCase):
             "invalid_pull_request_evidence",
         )
 
+    def test_tree_usage_is_no_follow_deduplicated_and_excludes_subtrees(self) -> None:
+        root = self.root / "tree-usage"
+        excluded = root / "excluded"
+        excluded.mkdir(parents=True)
+        (excluded / "payload").write_bytes(b"excluded")
+        artifact = root / "artifact"
+        artifact.write_bytes(b"included")
+        hardlink = root / "hardlink"
+        os.link(artifact, hardlink)
+        outside = self.root / "outside"
+        outside.write_bytes(b"outside")
+        symlink = root / "symlink"
+        symlink.symlink_to(outside)
+
+        sizes, observed, error = _tree_usage(root, [excluded])
+
+        artifact_key = (artifact.lstat().st_dev, artifact.lstat().st_ino)
+        excluded_key = (excluded.lstat().st_dev, excluded.lstat().st_ino)
+        outside_key = (outside.lstat().st_dev, outside.lstat().st_ino)
+        symlink_key = (symlink.lstat().st_dev, symlink.lstat().st_ino)
+        self.assertIsNone(error)
+        self.assertIsNotNone(observed)
+        self.assertIn(artifact_key, sizes)
+        self.assertIn(symlink_key, sizes)
+        self.assertNotIn(excluded_key, sizes)
+        self.assertNotIn(outside_key, sizes)
+        self.assertEqual(
+            _listed_usage(root, ["artifact", "hardlink", "symlink"]),
+            {
+                artifact_key: artifact.lstat().st_blocks * 512,
+                symlink_key: symlink.lstat().st_blocks * 512,
+            },
+        )
+
     def test_dry_run_finds_exact_merged_head_and_preserves_ignored_output(self) -> None:
         worktree = self.make_wrapper_worktree()
         report = self.plan(["worktrees"])
@@ -277,6 +318,22 @@ class CleanupTests(unittest.TestCase):
         self.assertEqual(primary["allocated_bytes"], 0)
         self.assertTrue(worktree.is_dir())
         self.assertEqual(report["mode"], "dry-run")
+
+    def test_plan_reuses_each_repository_worktree_inventory(self) -> None:
+        self.make_component_worktree()
+
+        def pulls(_repository: str, head: str) -> list[dict[str, object]]:
+            return self.merged_pull(head)
+
+        with mock.patch(
+            "atrinik_workspace.cleanup._worktree_records",
+            wraps=_worktree_records,
+        ) as records, mock.patch.object(
+            Cleanup, "_github_pulls", side_effect=pulls
+        ):
+            self.workspace.cleanup(["worktrees"], 7, [], False)
+
+        self.assertEqual(records.call_count, 2)
 
     def test_non_exact_or_unavailable_pull_evidence_fails_closed(self) -> None:
         worktree = self.make_wrapper_worktree()
@@ -524,9 +581,15 @@ class CleanupTests(unittest.TestCase):
             calls += 1
             return self.merged_pull(head, state="closed" if calls == 1 else "open")
 
-        with mock.patch.object(Cleanup, "_github_pulls", side_effect=pulls):
+        with mock.patch.object(
+            Cleanup, "_github_pulls", side_effect=pulls
+        ), mock.patch(
+            "atrinik_workspace.cleanup._worktree_records",
+            wraps=_worktree_records,
+        ) as records:
             report = self.workspace.cleanup(["worktrees"], 7, [], True)
         item = next(row for row in report["items"] if row["path"] == str(worktree))
+        self.assertEqual(records.call_count, 3)
         self.assertTrue(report["aborted"])
         self.assertEqual(item["disposition"], "error")
         self.assertEqual(item["reasons"], ["revalidation_failed"])
@@ -549,6 +612,35 @@ class CleanupTests(unittest.TestCase):
         item = next(row for row in report["items"] if row["kind"] == "prunable-metadata")
         self.assertEqual(item["disposition"], "removed")
         self.assertNotIn(str(worktree), command("git", "worktree", "list", cwd=self.wrapper))
+
+    def test_prunable_revalidation_protects_the_repository_wide_scope(self) -> None:
+        first = self.make_wrapper_worktree("prunable-first")
+        second = self.make_wrapper_worktree("prunable-second")
+        (second / "unique").write_text("second\n", encoding="utf-8")
+        command("git", "add", "unique", cwd=second)
+        command("git", "commit", "-m", "test: unique head", cwd=second)
+        first_head = command("git", "rev-parse", "HEAD", cwd=first)
+        second_head = command("git", "rev-parse", "HEAD", cwd=second)
+        shutil.rmtree(first)
+        shutil.rmtree(second)
+        calls: dict[str, int] = {}
+
+        def pulls(_repository: str, head: str) -> list[dict[str, object]]:
+            calls[head] = calls.get(head, 0) + 1
+            if head == second_head and calls[head] > 1:
+                return self.merged_pull(head, state="open")
+            return self.merged_pull(head)
+
+        with mock.patch.object(Cleanup, "_github_pulls", side_effect=pulls):
+            report = self.workspace.cleanup(["worktrees"], 7, [], True)
+
+        listing = command("git", "worktree", "list", cwd=self.wrapper)
+        self.assertEqual(calls[first_head], 2)
+        self.assertEqual(calls[second_head], 2)
+        self.assertTrue(report["aborted"])
+        self.assertFalse(report["mutated"])
+        self.assertIn(str(first), listing)
+        self.assertIn(str(second), listing)
 
     def make_build(self, profile: str = "review", key: str = "a" * 12) -> Path:
         path = self.workspace.paths.builds / "profiles" / f"{profile}-{key}"
@@ -610,6 +702,68 @@ class CleanupTests(unittest.TestCase):
         self.assertEqual(item["disposition"], "eligible")
         self.assertTrue(item["source_worktree_removal"])
         self.assertEqual(item["reasons"], ["source_worktree_removal"])
+
+    def test_apply_revalidates_a_builds_removable_source_worktree(self) -> None:
+        worktree = self.make_component_worktree()
+        unselected = self.make_component_worktree(
+            "server-review", component="server"
+        )
+        head = command("git", "rev-parse", "HEAD", cwd=worktree)
+        unselected_head = command("git", "rev-parse", "HEAD", cwd=unselected)
+        build = self.make_build()
+        atomic_json(
+            build / ".atrinik-build.json",
+            {
+                "schema_version": 1,
+                "profile": "review",
+                "key": "a" * 12,
+                "purpose": f"profile:review:{'a' * 12}",
+                "coordinates": {
+                    "client": {
+                        "component": "client",
+                        "checkout": "client",
+                        "repository": "atrinik/client",
+                        "branch": "main",
+                        "source": ".",
+                        "checkout_path": str(worktree),
+                        "source_path": str(worktree),
+                        "head": head,
+                    },
+                    "server": {
+                        "component": "server",
+                        "checkout": "server",
+                        "repository": "atrinik/server",
+                        "branch": "main",
+                        "source": ".",
+                        "checkout_path": str(unselected),
+                        "source_path": str(unselected),
+                        "head": unselected_head,
+                    }
+                },
+                "last_used_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+        calls: dict[str, int] = {}
+
+        def pulls(_repository: str, head: str) -> list[dict[str, object]]:
+            calls[head] = calls.get(head, 0) + 1
+            state = "open" if calls[head] > 1 else "closed"
+            return self.merged_pull(head, state=state)
+
+        with mock.patch.object(Cleanup, "_github_pulls", side_effect=pulls):
+            report = self.workspace.cleanup(
+                ["worktrees", "builds"], 7, ["client"], True
+            )
+
+        item = next(row for row in report["items"] if row["path"] == str(build))
+        self.assertEqual(calls, {head: 2})
+        self.assertEqual(item["disposition"], "error")
+        self.assertEqual(item["reasons"], ["revalidation_failed"])
+        self.assertFalse(report["mutated"])
+        self.assertTrue(report["aborted"])
+        self.assertTrue(build.exists())
+        self.assertTrue(worktree.exists())
+        self.assertTrue(unselected.exists())
 
     def test_build_use_refreshes_exact_coordinate_metadata(self) -> None:
         worktree = self.make_component_worktree()
@@ -706,20 +860,22 @@ class CleanupTests(unittest.TestCase):
         self.assertTrue(second.exists())
         self.assertTrue(report["aborted"])
 
-    def test_apply_reports_replan_error_after_a_completed_mutation(self) -> None:
+    def test_apply_reports_revalidation_error_after_a_completed_mutation(self) -> None:
         first = self.make_build("first", "a" * 12)
         second = self.make_build("second", "b" * 12)
-        original = Cleanup._plan
+        original = Cleanup._revalidate_target
         calls = 0
 
-        def plan(cleanup: Cleanup, *arguments: object) -> dict[str, object]:
+        def revalidate(
+            cleanup: Cleanup, *arguments: object
+        ) -> dict[str, object] | None:
             nonlocal calls
             calls += 1
-            if calls == 3:
+            if calls == 2:
                 raise WorkspaceError("raced inventory")
             return original(cleanup, *arguments)
 
-        with mock.patch.object(Cleanup, "_plan", new=plan):
+        with mock.patch.object(Cleanup, "_revalidate_target", new=revalidate):
             report = self.workspace.cleanup(["builds"], 7, [], True)
 
         by_path = {row["path"]: row for row in report["items"]}
@@ -730,6 +886,112 @@ class CleanupTests(unittest.TestCase):
         self.assertTrue(report["aborted"])
         self.assertFalse(first.exists())
         self.assertTrue(second.exists())
+
+    def test_apply_plans_once_and_revalidates_only_candidates(self) -> None:
+        first = self.make_build("first", "a" * 12)
+        second = self.make_build("second", "b" * 12)
+        protected = self.make_build("young", "c" * 12)
+        timestamp = datetime.now(timezone.utc).timestamp()
+        for candidate in (
+            protected / MANAGED_MARKER,
+            protected / "artifact",
+            protected,
+        ):
+            os.utime(candidate, (timestamp, timestamp), follow_symlinks=False)
+
+        original_plan = Cleanup._plan
+        original_revalidate = Cleanup._revalidate_target
+        plan_calls = 0
+        revalidated: list[str] = []
+
+        def plan(cleanup: Cleanup, *arguments: object) -> dict[str, object]:
+            nonlocal plan_calls
+            plan_calls += 1
+            return original_plan(cleanup, *arguments)
+
+        def revalidate(
+            cleanup: Cleanup, target: dict[str, object], *arguments: object
+        ) -> dict[str, object] | None:
+            revalidated.append(str(target["path"]))
+            return original_revalidate(cleanup, target, *arguments)
+
+        with mock.patch.object(Cleanup, "_plan", new=plan), mock.patch.object(
+            Cleanup, "_revalidate_target", new=revalidate
+        ):
+            report = self.workspace.cleanup(["builds"], 7, [], True)
+
+        self.assertEqual(plan_calls, 1)
+        self.assertEqual(revalidated, [str(first), str(second)])
+        self.assertFalse(first.exists())
+        self.assertFalse(second.exists())
+        self.assertTrue(protected.exists())
+        self.assertFalse(report["aborted"] if "aborted" in report else False)
+
+    def test_apply_preserves_globally_deduplicated_candidate_bytes(self) -> None:
+        first = self.make_build("first", "a" * 12)
+        second = self.make_build("second", "b" * 12)
+        (second / "artifact").unlink()
+        os.link(first / "artifact", second / "artifact")
+        timestamp = self.old.timestamp()
+        os.utime(second, (timestamp, timestamp), follow_symlinks=False)
+
+        preview = self.workspace.cleanup(["builds"], 7, [], False)
+        report = self.workspace.cleanup(["builds"], 7, [], True)
+
+        self.assertEqual(
+            report["summary"]["removed_bytes"],
+            preview["summary"]["candidate_bytes"],
+        )
+        self.assertFalse(first.exists())
+        self.assertFalse(second.exists())
+
+    def test_apply_target_revalidation_repeats_traversal_safety(self) -> None:
+        build = self.make_build()
+        checkout = self.wrapper / "client"
+        atomic_json(
+            build / ".atrinik-build.json",
+            {
+                "schema_version": 1,
+                "profile": "review",
+                "key": "a" * 12,
+                "purpose": f"profile:review:{'a' * 12}",
+                "coordinates": {
+                    "client": {
+                        "component": "client",
+                        "checkout": "client",
+                        "repository": "atrinik/client",
+                        "branch": "main",
+                        "source": ".",
+                        "checkout_path": str(checkout),
+                        "source_path": str(checkout),
+                        "head": "a" * 40,
+                    }
+                },
+                "last_used_at": self.old.isoformat(),
+            },
+        )
+        original = _tree_usage
+        build_walks = 0
+
+        def usage(
+            root: Path, excluded: object = ()
+        ) -> tuple[dict[tuple[int, int], int], datetime | None, str | None]:
+            nonlocal build_walks
+            if root == build:
+                build_walks += 1
+                if build_walks == 2:
+                    return {}, None, "raced traversal"
+            return original(root, excluded)
+
+        with mock.patch("atrinik_workspace.cleanup._tree_usage", side_effect=usage):
+            report = self.workspace.cleanup(["builds"], 7, [], True)
+
+        item = next(row for row in report["items"] if row["path"] == str(build))
+        self.assertEqual(build_walks, 2)
+        self.assertEqual(item["disposition"], "error")
+        self.assertEqual(item["reasons"], ["revalidation_failed"])
+        self.assertIn("filesystem_traversal_error", item["revalidation"]["reasons"])
+        self.assertTrue(build.exists())
 
     def test_invalid_marker_and_busy_lock_protect_builds(self) -> None:
         build = self.make_build()

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -113,6 +113,84 @@ class CleanupTests(unittest.TestCase):
         (path / "ignored" / "output.o").write_bytes(b"x" * 4096)
         return path
 
+    def add_local_submodule_to_wrapper(self) -> Path:
+        source = self.root / "local-submodule"
+        source.mkdir()
+        command("git", "init", "-b", "main", cwd=source)
+        command("git", "config", "user.name", "Tests", cwd=source)
+        command("git", "config", "user.email", "tests@example.invalid", cwd=source)
+        (source / "README").write_text("local dependency\n", encoding="utf-8")
+        command("git", "add", "README", cwd=source)
+        command("git", "commit", "-m", "test: seed dependency", cwd=source)
+        command(
+            "git",
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            str(source),
+            "vendor/dependency",
+            cwd=self.wrapper,
+        )
+        command("git", "commit", "-am", "test: add local submodule", cwd=self.wrapper)
+        return source
+
+    @staticmethod
+    def initialize_local_submodule(worktree: Path) -> None:
+        command(
+            "git",
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "update",
+            "--init",
+            "--recursive",
+            cwd=worktree,
+        )
+
+    def make_historical_wrapper_graph(
+        self, label: str = "legacy-master-review"
+    ) -> tuple[Path, str, str, str, str]:
+        base = command("git", "rev-parse", "main", cwd=self.wrapper)
+        path = self.wrapper / "build" / "worktrees" / label
+        path.parent.mkdir(parents=True, exist_ok=True)
+        command(
+            "git",
+            "worktree",
+            "add",
+            "-b",
+            f"feat/{label}",
+            str(path),
+            "main",
+            cwd=self.wrapper,
+        )
+        (path / "review").write_text("historical review\n", encoding="utf-8")
+        command("git", "add", "review", cwd=path)
+        command("git", "commit", "-m", "test: historical review", cwd=path)
+        head = command("git", "rev-parse", "HEAD", cwd=path)
+        tree = command("git", "rev-parse", f"{head}^{{tree}}", cwd=self.wrapper)
+        merge = command(
+            "git",
+            "commit-tree",
+            tree,
+            "-p",
+            base,
+            "-m",
+            "test: squash historical review",
+            cwd=self.wrapper,
+        )
+        boundary = command(
+            "git",
+            "commit-tree",
+            tree,
+            "-p",
+            merge,
+            "-m",
+            "test: freeze historical master",
+            cwd=self.wrapper,
+        )
+        return path, base, head, merge, boundary
+
     def make_component_worktree(
         self,
         label: str = "component-review",
@@ -150,7 +228,13 @@ class CleanupTests(unittest.TestCase):
         return path
 
     def merged_pull(
-        self, head: str, *, state: str = "closed", base: str = "main"
+        self,
+        head: str,
+        *,
+        state: str = "closed",
+        base: str = "main",
+        base_sha: str = "b" * 40,
+        merge_commit_sha: str = "c" * 40,
     ) -> list[dict[str, object]]:
         return [
             {
@@ -158,8 +242,11 @@ class CleanupTests(unittest.TestCase):
                 "state": state,
                 "html_url": "https://github.com/atrinik/atrinik/pull/42",
                 "merged_at": self.old.isoformat() if state == "closed" else None,
+                "merge_commit_sha": (
+                    merge_commit_sha if state == "closed" else None
+                ),
                 "head": {"sha": head},
-                "base": {"ref": base},
+                "base": {"ref": base, "sha": base_sha},
             }
         ]
 
@@ -258,8 +345,11 @@ class CleanupTests(unittest.TestCase):
         )
         with mock.patch(
             "atrinik_workspace.cleanup.subprocess.run", return_value=completed
-        ):
+        ) as process:
             self.assertEqual(Cleanup._github_pulls(repository, head), [row])
+        query = process.call_args.args[0][-1]
+        self.assertIn("merge_commit_sha", query)
+        self.assertIn("sha:.base.sha", query)
 
         self.assertEqual(
             Cleanup._pull_evidence([], head, "main")[0], "no_associated_pr"
@@ -365,6 +455,229 @@ class CleanupTests(unittest.TestCase):
         self.assertEqual(item["reasons"], ["github_unavailable"])
         self.assertEqual(item["github_error"], "offline")
 
+    def test_historical_master_pull_requires_the_legacy_wrapper_namespace(
+        self,
+    ) -> None:
+        historical, base, _, merge, boundary = self.make_historical_wrapper_graph()
+        modern = self.make_wrapper_worktree("modern-master-review")
+
+        def pulls(_repository: str, head: str) -> list[dict[str, object]]:
+            return self.merged_pull(
+                head,
+                base="master",
+                base_sha=base,
+                merge_commit_sha=merge,
+            )
+
+        with mock.patch.dict(
+            "atrinik_workspace.cleanup.HISTORICAL_PULL_BASE_BOUNDARIES",
+            {("atrinik/atrinik", "main", "master"): boundary},
+            clear=True,
+        ), mock.patch.object(Cleanup, "_github_pulls", side_effect=pulls):
+            report = self.workspace.cleanup(["worktrees"], 0, [], False)
+
+        by_path = {row["path"]: row for row in report["items"]}
+        historical_item = by_path[str(historical)]
+        self.assertEqual(historical_item["disposition"], "eligible")
+        self.assertEqual(
+            historical_item["reasons"], ["merged_pr_head_historical_base"]
+        )
+        self.assertEqual(historical_item["base_branch"], "main")
+        self.assertEqual(historical_item["merged_pr"]["base"], "master")
+        self.assertEqual(by_path[str(modern)]["disposition"], "protected")
+        self.assertEqual(by_path[str(modern)]["reasons"], ["wrong_base_branch"])
+
+    def test_historical_pull_graph_fields_are_strict(self) -> None:
+        worktree, base, head, merge, boundary = self.make_historical_wrapper_graph()
+        valid = self.merged_pull(
+            head,
+            base="master",
+            base_sha=base,
+            merge_commit_sha=merge,
+        )[0]
+        cases: list[tuple[str, dict[str, object]]] = []
+        for label, container, field, value in (
+            ("missing-base-sha", "base", "sha", None),
+            ("malformed-base-sha", "base", "sha", "not-a-sha"),
+            ("missing-merge-commit", "row", "merge_commit_sha", None),
+            ("malformed-merge-commit", "row", "merge_commit_sha", "not-a-sha"),
+        ):
+            row = json.loads(json.dumps(valid))
+            target = row if container == "row" else row[container]
+            if value is None:
+                del target[field]
+            else:
+                target[field] = value
+            cases.append((label, row))
+
+        for label, row in cases:
+            with self.subTest(label=label), mock.patch.dict(
+                "atrinik_workspace.cleanup.HISTORICAL_PULL_BASE_BOUNDARIES",
+                {("atrinik/atrinik", "main", "master"): boundary},
+                clear=True,
+            ), mock.patch.object(Cleanup, "_github_pulls", return_value=[row]):
+                report = self.workspace.cleanup(["worktrees"], 0, [], False)
+
+            item = next(
+                row for row in report["items"] if row["path"] == str(worktree)
+            )
+            self.assertEqual(item["disposition"], "protected")
+            self.assertEqual(item["reasons"], ["invalid_pull_request_evidence"])
+
+    def test_historical_pull_requires_first_parent_and_frozen_boundary(self) -> None:
+        worktree, base, head, merge, boundary = self.make_historical_wrapper_graph()
+        tree = command("git", "rev-parse", f"{merge}^{{tree}}", cwd=self.wrapper)
+        outside = command(
+            "git",
+            "commit-tree",
+            tree,
+            "-p",
+            boundary,
+            "-m",
+            "test: outside frozen master",
+            cwd=self.wrapper,
+        )
+        cases = (
+            ("wrong-first-parent", head, merge),
+            ("outside-boundary", boundary, outside),
+        )
+
+        for label, base_sha, merge_commit in cases:
+            pulls = self.merged_pull(
+                head,
+                base="master",
+                base_sha=base_sha,
+                merge_commit_sha=merge_commit,
+            )
+            with self.subTest(label=label), mock.patch.dict(
+                "atrinik_workspace.cleanup.HISTORICAL_PULL_BASE_BOUNDARIES",
+                {("atrinik/atrinik", "main", "master"): boundary},
+                clear=True,
+            ), mock.patch.object(Cleanup, "_github_pulls", return_value=pulls):
+                report = self.workspace.cleanup(["worktrees"], 0, [], False)
+
+            item = next(
+                row for row in report["items"] if row["path"] == str(worktree)
+            )
+            self.assertEqual(item["disposition"], "protected")
+            self.assertEqual(item["reasons"], ["historical_base_unverified"])
+
+    def test_historical_pull_graph_proof_ignores_git_replace_refs(self) -> None:
+        worktree, base, head, merge, _ = self.make_historical_wrapper_graph()
+        tree = command("git", "rev-parse", f"{merge}^{{tree}}", cwd=self.wrapper)
+        invalid_merge = command(
+            "git",
+            "commit-tree",
+            tree,
+            "-p",
+            head,
+            "-m",
+            "test: invalid historical merge parent",
+            cwd=self.wrapper,
+        )
+        boundary = command(
+            "git",
+            "commit-tree",
+            tree,
+            "-p",
+            invalid_merge,
+            "-m",
+            "test: boundary containing invalid merge",
+            cwd=self.wrapper,
+        )
+        command("git", "replace", invalid_merge, merge, cwd=self.wrapper)
+
+        self.assertEqual(
+            command(
+                "git",
+                "rev-list",
+                "--parents",
+                "-n",
+                "1",
+                invalid_merge,
+                cwd=self.wrapper,
+            ).split(),
+            [invalid_merge, base],
+        )
+        pulls = self.merged_pull(
+            head,
+            base="master",
+            base_sha=base,
+            merge_commit_sha=invalid_merge,
+        )
+        with mock.patch.dict(
+            "atrinik_workspace.cleanup.HISTORICAL_PULL_BASE_BOUNDARIES",
+            {("atrinik/atrinik", "main", "master"): boundary},
+            clear=True,
+        ), mock.patch.object(Cleanup, "_github_pulls", return_value=pulls):
+            report = self.workspace.cleanup(["worktrees"], 0, [], False)
+
+        item = next(row for row in report["items"] if row["path"] == str(worktree))
+        self.assertEqual(item["disposition"], "protected")
+        self.assertEqual(item["reasons"], ["historical_base_unverified"])
+
+    def test_historical_pull_graph_proof_rejects_info_grafts(self) -> None:
+        worktree, base, head, merge, boundary = self.make_historical_wrapper_graph()
+        common_git = Path(
+            command(
+                "git",
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-common-dir",
+                cwd=self.wrapper,
+            )
+        )
+        grafts = common_git / "info" / "grafts"
+        grafts.parent.mkdir(parents=True, exist_ok=True)
+        grafts.write_text(f"{boundary} {merge}\n", encoding="utf-8")
+        pulls = self.merged_pull(
+            head,
+            base="master",
+            base_sha=base,
+            merge_commit_sha=merge,
+        )
+
+        with mock.patch.dict(
+            "atrinik_workspace.cleanup.HISTORICAL_PULL_BASE_BOUNDARIES",
+            {("atrinik/atrinik", "main", "master"): boundary},
+            clear=True,
+        ), mock.patch.object(Cleanup, "_github_pulls", return_value=pulls):
+            report = self.workspace.cleanup(["worktrees"], 0, [], False)
+
+        item = next(row for row in report["items"] if row["path"] == str(worktree))
+        self.assertEqual(item["disposition"], "protected")
+        self.assertEqual(item["reasons"], ["historical_base_unverified"])
+
+    def test_historical_namespace_is_proven_from_repository_primary(self) -> None:
+        historical, base, head, merge, boundary = (
+            self.make_historical_wrapper_graph()
+        )
+        invocation = self.make_wrapper_worktree("linked-invocation")
+        linked_workspace = Workspace(invocation)
+
+        def pulls(_repository: str, queried_head: str) -> list[dict[str, object]]:
+            if queried_head == head:
+                return self.merged_pull(
+                    queried_head,
+                    base="master",
+                    base_sha=base,
+                    merge_commit_sha=merge,
+                )
+            return self.merged_pull(queried_head, state="open")
+
+        with mock.patch.dict(
+            "atrinik_workspace.cleanup.HISTORICAL_PULL_BASE_BOUNDARIES",
+            {("atrinik/atrinik", "main", "master"): boundary},
+            clear=True,
+        ), mock.patch.object(Cleanup, "_github_pulls", side_effect=pulls):
+            report = linked_workspace.cleanup(["worktrees"], 0, [], False)
+
+        item = next(
+            row for row in report["items"] if row["path"] == str(historical)
+        )
+        self.assertEqual(item["disposition"], "eligible")
+        self.assertEqual(item["reasons"], ["merged_pr_head_historical_base"])
+
     def test_detached_locked_and_in_progress_worktrees_are_protected(self) -> None:
         detached = self.workspace.paths.worktrees / "atrinik" / "detached"
         detached.parent.mkdir(parents=True, exist_ok=True)
@@ -432,6 +745,61 @@ class CleanupTests(unittest.TestCase):
             report = self.workspace.cleanup(["worktrees"], 0, [], False)
         item = next(row for row in report["items"] if row["path"] == str(dirty))
         self.assertIn("dirty_worktree", item["reasons"])
+        pulls.assert_not_called()
+
+    def test_submodule_changes_are_dirty_even_when_configuration_ignores_them(
+        self,
+    ) -> None:
+        self.add_local_submodule_to_wrapper()
+        dirty = self.make_wrapper_worktree("dirty-submodule")
+        untracked = self.make_wrapper_worktree("untracked-submodule")
+        self.initialize_local_submodule(dirty)
+        self.initialize_local_submodule(untracked)
+        command(
+            "git",
+            "config",
+            "submodule.vendor/dependency.ignore",
+            "all",
+            cwd=self.wrapper,
+        )
+        (dirty / "vendor" / "dependency" / "README").write_text(
+            "dirty dependency\n", encoding="utf-8"
+        )
+        (untracked / "vendor" / "dependency" / "untracked").write_text(
+            "local dependency output\n", encoding="utf-8"
+        )
+        self.assertEqual(
+            command(
+                "git",
+                "status",
+                "--porcelain=v1",
+                "--untracked-files=all",
+                cwd=dirty,
+            ),
+            "",
+        )
+        self.assertEqual(
+            command(
+                "git",
+                "status",
+                "--porcelain=v1",
+                "--untracked-files=all",
+                cwd=untracked,
+            ),
+            "",
+        )
+
+        with mock.patch.object(Cleanup, "_github_pulls") as pulls:
+            report = self.workspace.cleanup(["worktrees"], 0, [], False)
+
+        by_path = {row["path"]: row for row in report["items"]}
+        for worktree in (dirty, untracked):
+            with self.subTest(worktree=worktree.name):
+                self.assertEqual(by_path[str(worktree)]["disposition"], "protected")
+                self.assertIn(
+                    "populated_submodules", by_path[str(worktree)]["reasons"]
+                )
+                self.assertIn("dirty_worktree", by_path[str(worktree)]["reasons"])
         pulls.assert_not_called()
 
     def test_all_profile_selector_kinds_and_retained_scenarios_protect_worktrees(self) -> None:
@@ -572,6 +940,123 @@ class CleanupTests(unittest.TestCase):
             f"{branch}",
         )
 
+    def test_populated_submodule_worktree_is_protected_in_preview_and_apply(
+        self,
+    ) -> None:
+        self.add_local_submodule_to_wrapper()
+        worktree = self.make_wrapper_worktree("populated-submodule")
+        self.initialize_local_submodule(worktree)
+        branch = command("git", "branch", "--show-current", cwd=worktree)
+        submodule_git = worktree / "vendor" / "dependency" / ".git"
+
+        for apply in (False, True):
+            with self.subTest(apply=apply), mock.patch.object(
+                Cleanup, "_github_pulls"
+            ) as pulls, mock.patch(
+                "atrinik_workspace.cleanup._command", wraps=_command
+            ) as git_command:
+                report = self.workspace.cleanup(["worktrees"], 0, [], apply)
+
+            item = next(
+                row for row in report["items"] if row["path"] == str(worktree)
+            )
+            remove_calls = [
+                call.args[1:]
+                for call in git_command.call_args_list
+                if call.args[1:3] == ("worktree", "remove")
+            ]
+            self.assertEqual(item["disposition"], "protected")
+            self.assertEqual(item["reasons"], ["populated_submodules"])
+            self.assertEqual(remove_calls, [])
+            pulls.assert_not_called()
+            if apply:
+                self.assertFalse(report["mutated"])
+                self.assertFalse(report["mutation_attempted"])
+            self.assertTrue(submodule_git.exists())
+            self.assertTrue(
+                command(
+                    "git", "branch", "--list", branch, cwd=self.wrapper
+                ).endswith(branch)
+            )
+
+        self.assertTrue(worktree.is_dir())
+
+    def test_apply_revalidates_and_removes_a_proven_historical_worktree(self) -> None:
+        worktree, base, head, merge, boundary = self.make_historical_wrapper_graph()
+        branch = command("git", "branch", "--show-current", cwd=worktree)
+        pulls = self.merged_pull(
+            head,
+            base="master",
+            base_sha=base,
+            merge_commit_sha=merge,
+        )
+
+        with mock.patch.dict(
+            "atrinik_workspace.cleanup.HISTORICAL_PULL_BASE_BOUNDARIES",
+            {("atrinik/atrinik", "main", "master"): boundary},
+            clear=True,
+        ), mock.patch.object(
+            Cleanup, "_github_pulls", return_value=pulls
+        ) as pull_query:
+            report = self.workspace.cleanup(["worktrees"], 0, [], True)
+
+        item = next(row for row in report["items"] if row["path"] == str(worktree))
+        self.assertEqual(pull_query.call_count, 2)
+        self.assertEqual(item["disposition"], "removed")
+        self.assertFalse(worktree.exists())
+        self.assertEqual(
+            command("git", "branch", "--list", branch, cwd=self.wrapper).strip(),
+            branch,
+        )
+
+    def test_apply_aborts_when_historical_graph_revalidation_changes(self) -> None:
+        worktree, base, head, merge, boundary = self.make_historical_wrapper_graph()
+        tree = command("git", "rev-parse", f"{merge}^{{tree}}", cwd=self.wrapper)
+        outside = command(
+            "git",
+            "commit-tree",
+            tree,
+            "-p",
+            boundary,
+            "-m",
+            "test: raced outside frozen master",
+            cwd=self.wrapper,
+        )
+        calls = 0
+
+        def pulls(_repository: str, queried_head: str) -> list[dict[str, object]]:
+            nonlocal calls
+            calls += 1
+            return self.merged_pull(
+                queried_head,
+                base="master",
+                base_sha=base if calls == 1 else boundary,
+                merge_commit_sha=merge if calls == 1 else outside,
+            )
+
+        with mock.patch.dict(
+            "atrinik_workspace.cleanup.HISTORICAL_PULL_BASE_BOUNDARIES",
+            {("atrinik/atrinik", "main", "master"): boundary},
+            clear=True,
+        ), mock.patch.object(Cleanup, "_github_pulls", side_effect=pulls):
+            report = self.workspace.cleanup(["worktrees"], 0, [], True)
+
+        item = next(row for row in report["items"] if row["path"] == str(worktree))
+        self.assertEqual(calls, 2)
+        self.assertTrue(report["aborted"])
+        self.assertFalse(report["mutated"])
+        self.assertFalse(report["mutation_attempted"])
+        self.assertEqual(item["disposition"], "error")
+        self.assertEqual(item["reasons"], ["revalidation_failed"])
+        self.assertEqual(
+            item["revalidation"],
+            {
+                "disposition": "protected",
+                "reasons": ["historical_base_unverified"],
+            },
+        )
+        self.assertTrue(worktree.is_dir())
+
     def test_apply_aborts_before_mutation_when_revalidation_changes(self) -> None:
         worktree = self.make_wrapper_worktree()
         calls = 0
@@ -612,6 +1097,92 @@ class CleanupTests(unittest.TestCase):
         item = next(row for row in report["items"] if row["kind"] == "prunable-metadata")
         self.assertEqual(item["disposition"], "removed")
         self.assertNotIn(str(worktree), command("git", "worktree", "list", cwd=self.wrapper))
+
+    def test_prunable_metadata_preserves_populated_submodule_admin_objects(
+        self,
+    ) -> None:
+        self.add_local_submodule_to_wrapper()
+        populated = self.make_wrapper_worktree("prunable-populated-submodule")
+        self.initialize_local_submodule(populated)
+        submodule = populated / "vendor" / "dependency"
+        command("git", "config", "user.name", "Tests", cwd=submodule)
+        command("git", "config", "user.email", "tests@example.invalid", cwd=submodule)
+        (submodule / "private").write_text(
+            "private linked-worktree object\n", encoding="utf-8"
+        )
+        command("git", "add", "private", cwd=submodule)
+        command(
+            "git",
+            "commit",
+            "-m",
+            "test: private linked-worktree object",
+            cwd=submodule,
+        )
+        private_commit = command("git", "rev-parse", "HEAD", cwd=submodule)
+        worktree_git = Path(
+            command(
+                "git",
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-dir",
+                cwd=populated,
+            )
+        )
+        modules = worktree_git / "modules"
+        private_object = Path(
+            command(
+                "git",
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-path",
+                f"objects/{private_commit[:2]}/{private_commit[2:]}",
+                cwd=submodule,
+            )
+        )
+        self.assertTrue(private_object.is_relative_to(modules))
+        private_object_evidence = private_object.read_bytes()
+
+        ordinary = self.make_wrapper_worktree("prunable-ordinary")
+        (ordinary / "review").write_text("ordinary prunable\n", encoding="utf-8")
+        command("git", "add", "review", cwd=ordinary)
+        command("git", "commit", "-m", "test: ordinary prunable", cwd=ordinary)
+        ordinary_head = command("git", "rev-parse", "HEAD", cwd=ordinary)
+        shutil.rmtree(populated)
+        shutil.rmtree(ordinary)
+        self.assertTrue(modules.is_dir())
+        self.assertEqual(private_object.read_bytes(), private_object_evidence)
+
+        for apply in (False, True):
+            with self.subTest(apply=apply), mock.patch.object(
+                Cleanup,
+                "_github_pulls",
+                return_value=self.merged_pull(ordinary_head),
+            ) as pulls, mock.patch(
+                "atrinik_workspace.cleanup._command", wraps=_command
+            ) as git_command:
+                report = self.workspace.cleanup(["worktrees"], 0, [], apply)
+
+            by_path = {row["path"]: row for row in report["items"]}
+            populated_item = by_path[str(populated)]
+            ordinary_item = by_path[str(ordinary)]
+            prune_calls = [
+                call.args[1:]
+                for call in git_command.call_args_list
+                if call.args[1:3] == ("worktree", "prune")
+            ]
+            self.assertEqual(populated_item["disposition"], "protected")
+            self.assertIn("populated_submodules", populated_item["reasons"])
+            self.assertEqual(ordinary_item["disposition"], "protected")
+            self.assertEqual(
+                ordinary_item["reasons"], ["shared_prune_scope_protected"]
+            )
+            self.assertEqual(prune_calls, [])
+            pulls.assert_called_once_with("atrinik/atrinik", ordinary_head)
+            if apply:
+                self.assertFalse(report["mutated"])
+                self.assertFalse(report["mutation_attempted"])
+            self.assertTrue(modules.is_dir())
+            self.assertEqual(private_object.read_bytes(), private_object_evidence)
 
     def test_prunable_revalidation_protects_the_repository_wide_scope(self) -> None:
         first = self.make_wrapper_worktree("prunable-first")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,11 +5,24 @@ from pathlib import Path
 import unittest
 from unittest import mock
 
-from atrinik_workspace.cli import main, parser
+from atrinik_workspace.cli import _human_bytes, main, parser
 from atrinik_workspace.model import WorkspaceError
 
 
 class ParserTests(unittest.TestCase):
+    def test_human_bytes_uses_compact_iec_units_and_promotes_rounding(self) -> None:
+        self.assertEqual(
+            [_human_bytes(value) for value in (0, 1023, 1024, 1536)],
+            ["0B", "1023B", "1KiB", "1.5KiB"],
+        )
+        self.assertEqual(_human_bytes(1024**2 - 1), "1MiB")
+        self.assertEqual(_human_bytes(1024**3), "1GiB")
+        self.assertEqual(_human_bytes(1024**4), "1TiB")
+        self.assertEqual(_human_bytes(1024**5), "1PiB")
+        self.assertEqual(_human_bytes(1024**6), "1EiB")
+        with self.assertRaisesRegex(ValueError, "cannot be negative"):
+            _human_bytes(-1)
+
     def test_cleanup_defaults_to_preview_and_reports_json(self) -> None:
         report = {
             "schema_version": 1,
@@ -41,6 +54,37 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(result, 0)
         workspace_type.return_value.cleanup.assert_called_once_with([], 7, [], False)
         self.assertEqual(json.loads(output.call_args.args[0]), report)
+
+    def test_cleanup_json_preserves_exact_numeric_byte_fields(self) -> None:
+        allocated = 1024**4 + 123
+        ignored = 1024**3 + 7
+        report = {
+            "items": [
+                {
+                    "allocated_bytes": allocated,
+                    "ignored_bytes": ignored,
+                }
+            ],
+            "summary": {
+                "candidate_bytes": allocated,
+                "protected_bytes": ignored,
+                "removed_bytes": allocated + ignored,
+                "error_count": 0,
+            },
+        }
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.cleanup.return_value = report
+            with mock.patch("builtins.print") as output:
+                result = main(["cleanup", "--json"])
+
+        rendered = json.loads(output.call_args.args[0])
+        self.assertEqual(result, 0)
+        self.assertEqual(rendered, report)
+        self.assertEqual(rendered["items"][0]["allocated_bytes"], allocated)
+        self.assertEqual(rendered["items"][0]["ignored_bytes"], ignored)
+        self.assertEqual(
+            rendered["summary"]["removed_bytes"], allocated + ignored
+        )
 
     def test_cleanup_combines_scopes_filters_and_reports_apply_failure(self) -> None:
         report = {
@@ -96,6 +140,7 @@ class ParserTests(unittest.TestCase):
                     "disposition": "eligible",
                     "kind": "worktree",
                     "allocated_bytes": 4096,
+                    "ignored_bytes": 1024,
                     "age_seconds": 2 * 86400,
                     "path": "/workspace/review",
                     "reasons": ["merged_pr_head"],
@@ -119,12 +164,95 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(result, 0)
         lines = [call.args[0] for call in output.call_args_list]
         self.assertIn(
-            "eligible\tworktree\t4096\t2d\t/workspace/review\tmerged_pr_head",
+            "eligible\tworktree\tallocated=4KiB,ignored=1KiB\t2d\t"
+            "/workspace/review\tmerged_pr_head",
             lines,
         )
         self.assertIn(
-            "summary\tcandidates=1 candidate_bytes=4096 protected=0 "
-            "protected_bytes=0 removed=0 removed_bytes=0 errors=0",
+            "summary\tcandidates=1 candidate_bytes=4KiB protected=0 "
+            "protected_bytes=0B removed=0 removed_bytes=0B errors=0",
+            lines,
+        )
+
+    def test_cleanup_text_report_uses_concise_iec_byte_units(self) -> None:
+        report = {
+            "items": [
+                {
+                    "disposition": "eligible",
+                    "kind": "worktree",
+                    "allocated_bytes": 0,
+                    "ignored_bytes": 511,
+                    "age_seconds": None,
+                    "path": "/workspace/zero",
+                    "reasons": ["zero-sized"],
+                },
+                {
+                    "disposition": "protected",
+                    "kind": "worktree",
+                    "allocated_bytes": 1536,
+                    "ignored_bytes": 1024**2,
+                    "age_seconds": 0,
+                    "path": "/workspace/medium",
+                    "reasons": ["protected"],
+                },
+                {
+                    "disposition": "removed",
+                    "kind": "worktree",
+                    "allocated_bytes": 1024**3,
+                    "ignored_bytes": 1024**4,
+                    "age_seconds": 86400,
+                    "path": "/workspace/large",
+                    "reasons": ["removed"],
+                },
+                {
+                    "disposition": "skipped",
+                    "kind": "profile-build",
+                    "allocated_bytes": 1,
+                    "age_seconds": None,
+                    "path": "/workspace/no-ignored-size",
+                    "reasons": ["retained"],
+                },
+            ],
+            "summary": {
+                "candidate_count": 1,
+                "candidate_bytes": 0,
+                "protected_count": 1,
+                "protected_bytes": 1536,
+                "removed_count": 1,
+                "removed_bytes": 1024**3,
+                "error_count": 0,
+            },
+        }
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.cleanup.return_value = report
+            with mock.patch("builtins.print") as output:
+                result = main(["cleanup"])
+
+        lines = [call.args[0] for call in output.call_args_list]
+        self.assertEqual(result, 0)
+        self.assertIn(
+            "eligible\tworktree\tallocated=0B,ignored=511B\t-\t"
+            "/workspace/zero\tzero-sized",
+            lines,
+        )
+        self.assertIn(
+            "protected\tworktree\tallocated=1.5KiB,ignored=1MiB\t0d\t"
+            "/workspace/medium\tprotected",
+            lines,
+        )
+        self.assertIn(
+            "removed\tworktree\tallocated=1GiB,ignored=1TiB\t1d\t"
+            "/workspace/large\tremoved",
+            lines,
+        )
+        self.assertIn(
+            "skipped\tprofile-build\tallocated=1B\t-\t"
+            "/workspace/no-ignored-size\tretained",
+            lines,
+        )
+        self.assertIn(
+            "summary\tcandidates=1 candidate_bytes=0B protected=1 "
+            "protected_bytes=1.5KiB removed=1 removed_bytes=1GiB errors=0",
             lines,
         )
 


### PR DESCRIPTION
## Summary

- replace per-entry path resolution and repeated ignored-path tree walks with no-follow scandir/lstat accounting
- reuse repository inventory within a plan, batch Git safety checks, and replace per-target full replans with exact fail-closed revalidation
- recognize pre-rewrite `atrinik/atrinik` PRs that targeted `master` only for historical top-level `build/worktrees/` paths, using authenticated SHA evidence and an immutable local graph proof
- protect existing and prunable worktrees when populated submodule administration may retain private refs, reflogs, or objects
- render text-mode allocated, ignored, and summary sizes as compact IEC units while keeping JSON byte integers exact
- preserve global inode-deduplicated byte reporting and synchronize cleanup docs and agent guidance

## Performance

Comparable live runs on this workspace:

    ./atrinik cleanup --scope all --older-than 1 --dry-run --json

- before: 112.71 seconds
- after: 22.32 seconds
- reduction: about 80 percent, or roughly 5x faster
- latest authenticated preview: about 20.2 seconds

Apply now performs one complete inventory plus one exact revalidation per candidate, instead of one complete inventory for every candidate.

## Historical branch migration

The expected coordinate remains `atrinik/atrinik@main`. A historical `master` PR is accepted only for a direct child of the proven primary repository's top-level `build/worktrees/` namespace. GitHub must return exact `head.sha`, `base.sha`, and `merge_commit_sha`; locally, the merge first parent must equal the API base SHA and the merge must be an ancestor of frozen final-`master` boundary `ee5ba2096c94bce0161629423d4962a966bc61d8`.

The proof disables replace objects, rejects `info/grafts`, and is rerun immediately before apply. Other repositories, branches, namespaces, malformed evidence, or graph ambiguity remain protected.

## Safety and output

Exact targets are still rewalked. Revalidation refreshes references, registered worktrees, repository records, Git state, GitHub evidence, locks, markers, metadata, selected filters, removable source worktrees, and repository-wide prunable siblings. New uncertainty fails closed.

Status explicitly uses `--ignore-submodules=none`. Populated submodules protect both live worktrees and retained prunable administration, preventing non-force removal or repository-wide prune from discarding private Git data. Branches, Git objects, profiles, scenarios, states, topology data, migrations, review reports, and unmarked paths remain preserved.

Text rows retain a fixed column shape and render sizes such as `118.5MiB` and `31.1GiB`. The schema-1 JSON fields remain exact integers.

## Validation

- 49 cleanup tests pass
- 26 CLI tests pass
- 7 agent-guidance tests pass
- complete local suite: 291 of 292 pass; the remaining environment-specific failure is in the untouched supply-chain override test, where an initialized local content checkout changes the expected error wording
- compileall passes
- manifest validation passes for 20 components
- `git diff --check` passes
- latest authenticated all-scope preview reports two candidates totaling `432KiB` and no inventory errors
