### PR TITLE
chore: retire website preview inventory

### DIFF
--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -2132,19 +2132,18 @@
       "locator": "pkg:npm/%40atrinik/website@0.0.0-development",
       "commit": null,
       "checksum": null,
-      "acquisition": "npm ci installs the exact package-lock graph with denied optional scripts omitted, only reviewed esbuild and workerd install scripts allowed, and the audited npm security override applied",
+      "acquisition": "npm ci installs the exact package-lock graph with denied optional scripts omitted, only the reviewed esbuild install script allowed, and the audited npm security override applied",
       "update_cadence_days": 7,
       "update_mechanism": "Grouped Dependabot npm updates constrained by Astro compatibility",
       "eol_response": "Upgrade compatible packages on the supported Node line or replace them",
       "validation": "npm ci, Astro/type/format tests, install-script audit, npm audit, deploy dry run, and npm CycloneDX SBOM",
       "disposition": "retain",
-      "packages": ["@astrojs/check", "@semantic-release/commit-analyzer", "@semantic-release/exec", "@semantic-release/github", "@semantic-release/release-notes-generator", "astro", "conventional-changelog-conventionalcommits", "npm", "prettier", "prettier-plugin-astro", "semantic-release", "typescript", "wrangler"],
+      "packages": ["@astrojs/check", "@semantic-release/commit-analyzer", "@semantic-release/exec", "@semantic-release/github", "@semantic-release/release-notes-generator", "astro", "conventional-changelog-conventionalcommits", "npm", "prettier", "prettier-plugin-astro", "semantic-release", "typescript"],
       "evidence": [
         {"repository":"website","path":"package-lock.json","contains":"\"lockfileVersion\": 3"},
         {"repository":"website","path":"package.json","contains":"\"name\": \"@atrinik/website\""},
-        {"repository":"website","path":"policy/dependencies.json","contains":"\"name\": \"npm\""},
-        {"repository":"website","path":"policy/dependencies.json","contains":"\"name\": \"workerd\""},
-        {"repository":"website","path":"policy/dependencies.json","contains":"\"name\": \"wrangler\""}
+        {"repository":"website","path":"policy/dependencies.json","contains":"\"name\": \"esbuild\""},
+        {"repository":"website","path":"policy/dependencies.json","contains":"\"name\": \"npm\""}
       ]
     },
     {


### PR DESCRIPTION
## Summary

- remove Wrangler and workerd from the website supply-chain record after website PR #15 removed custom and manual preview tooling
- retain the independent audited npm override and its evidence
- retain exact esbuild install-script ownership and evidence

## Validation

- 271 wrapper tests under coverage; 77 percent report
- compileall
- atrinik manifest validate
- atrinik supply-chain validate
- direct evidence verification against website main bba69d1
- git diff --check

The full default profile audit reaches a pre-existing protocol actions/setup-go evidence mismatch before website validation. The identical failure was reproduced from a clean worktree byte-identical to unmodified wrapper main; this PR does not alter that action or protocol inventory.