### PR TITLE
docs(guidance): resolve weekly audit drift

### DIFF
--- a/.agents/skills/atrinik-protocol-change/SKILL.md
+++ b/.agents/skills/atrinik-protocol-change/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: atrinik-protocol-change
-description: Change GP1, classic, QUIC, or ADS wire contracts and their producers or consumers.
+description: Change GP1, metaserver, classic, QUIC, or ADS wire contracts and their producers or consumers.
 ---
 
 # Atrinik protocol change
@@ -11,15 +11,16 @@ implementation skill for coordinated consumers.
 
 ## Select the authoritative contract
 
-- Replacement Game Protocol 1 lives in the physical `protocol` checkout and
-  owns Protobuf/Buf policy, normative QUIC/framing specifications, generated
-  Go/Rust contracts, and conformance fixtures.
+- Replacement GP1 and metaserver publisher/directory contracts live in the
+  physical `protocol` checkout, which owns Protobuf/Buf policy, normative
+  specifications, generated Go/Rust contracts, and conformance fixtures.
 - Classic numeric command IDs live at
   `classic/protocol/schema/game-commands.json`; packet payloads may be owned by
   classic client/server producers and consumers. Use a classic-derived profile
   and the monorepo's `classic-protocol-change` skill.
 - ADS/authored schemas live with their exact `content@main` or
-  `content-1x@1.x` format. Metaserver contracts identify their own owner.
+  `content-1x@1.x` format; `metaserver-worker` owns discovery implementation
+  and state rather than the shared contracts.
 
 Resolve paths rather than assuming the wrapper CWD:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,10 +41,13 @@ target disappeared with the retired classic `history/*` namespace.
 Before opening a pull request, run:
 
 ~~~sh
-python3 -m unittest discover -v
+python3 -m pip install --requirement requirements-dev.txt
+python3 -m coverage run -m unittest discover -v
+python3 -m coverage report --show-missing
 python3 -m compileall -q atrinik atrinik_workspace tests
 python3 -m atrinik_workspace.guidance_inventory --check
 ./atrinik manifest validate
+./atrinik supply-chain validate
 git diff --check
 ~~~
 

--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -720,7 +720,7 @@
         "server"
       ],
       "required": true,
-      "version": "v6.0.0",
+      "version": "v7.0.0",
       "version_source": "Reviewed upstream release",
       "license": "MIT",
       "source_url": "https://github.com/actions/setup-go",
@@ -738,12 +738,12 @@
         {
           "repository": "protocol",
           "path": ".github/workflows/validate.yml",
-          "contains": "actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6.0.0"
+          "contains": "actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0"
         },
         {
           "repository": "server",
           "path": ".github/workflows/validate.yml",
-          "contains": "actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6.0.0"
+          "contains": "actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0"
         }
       ]
     },
@@ -2201,7 +2201,7 @@
       "version_source": "requirements-dev.txt",
       "license": "Apache-2.0",
       "source_url": "https://pypi.org/project/coverage/",
-      "locator": "pkg:pypi/coverage@7.15.2",
+      "locator": "pkg:pypi/coverage@7.15.3",
       "commit": null,
       "checksum": null,
       "acquisition": "pip installs the exact development requirement",


### PR DESCRIPTION
## Summary

- synchronize contributor validation with the wrapper CI and authoritative agent checklist
- route shared metaserver contracts through the physical protocol checkout in the protocol-change skill
- align setup-go v7 and Coverage 7.15.3 supply-chain metadata with their authoritative inputs

## Related audit PRs

- atrinik/client#49
- atrinik/server#74
- atrinik/protocol#23
- atrinik/content#55
- atrinik/content#56
- atrinik/sound#15
- atrinik/resources#16
- atrinik/devcontainer#20
- atrinik/tools#18

## Validation

- `.venv/bin/python3 -m coverage run -m unittest discover -v` — 292 tests, 291 passed; the known initialized-checkout-sensitive repository-root override test failed
- `.venv/bin/python3 -m coverage report --show-missing` — passed, 78% total
- `python3 -m compileall -q atrinik atrinik_workspace tests` — passed
- `python3 -m atrinik_workspace.guidance_inventory --check` — passed; root AGENTS.md remains 116 lines
- `./atrinik manifest validate` — passed, 20 components
- `./atrinik supply-chain validate` — passed, 88 dependencies
- `./atrinik supply-chain audit --profile default` — passed, 14 roots
- active skill validator for `atrinik-protocol-change` — passed
- `git diff --check origin/main...HEAD` — passed