### PR TITLE
docs(agents): govern pull request publication

### DIFF
--- a/.agents/skills/atrinik-github-governance/SKILL.md
+++ b/.agents/skills/atrinik-github-governance/SKILL.md
@@ -1,25 +1,19 @@
 ---
 name: atrinik-github-governance
-description: Change Atrinik GitHub policy, settings, Actions, required checks, or release governance.
+description: Manage Atrinik PR publication, GitHub policy, Actions, checks, settings, or releases.
 ---
 
 # Atrinik GitHub Governance
 
-Use this skill for changes to the standalone `github-settings` repository or
-to an Atrinik Actions workflow whose permissions, check names, dependency
-policy, or branch-protection contract may change.
-
 ## Review desired and live state
 
 1. Read the workspace and `github-settings/AGENTS.md` guides.
-2. Inspect the relevant `config/*.json`, publisher script, workflow, and recent
-   repository history. Treat configuration as desired state and the GitHub API
-   as live state; do not infer policy from one alone.
-3. Use the publisher's default plan mode before considering `--apply`.
-   Applying settings, changing repositories, or dispatching workflows requires
-   explicit authorization because it mutates external organization state.
-4. Preserve the current Team-plan compatibility contract. Do not introduce an
-   Enterprise-only control without a documented, reviewed migration.
+2. Inspect relevant configuration, publisher code, workflows, and history.
+   Treat configuration as desired state and the GitHub API as live state.
+3. Run the publisher's plan before `--apply`. External settings changes and
+   workflow dispatch require explicit authorization.
+4. Keep controls Team-plan compatible; document and review any migration to an
+   Enterprise-only feature.
 
 ## Change policy coherently
 
@@ -35,12 +29,21 @@ policy, or branch-protection contract may change.
 - Never print tokens or copy live secrets into configuration, logs, fixtures,
   commits, or review text.
 
+## Publish pull requests
+
+Use `type(optional-scope)!: concise description` for PR titles. Write bodies as
+renderable GitHub-Flavored Markdown with actual line breaks, never visible
+literal `\n` separators. Pass multi-section bodies by file, standard input, or
+another newline-preserving method. After create/edit, inspect the remote PR and
+verify headings, lists, inline code, issue-closing references, and validation
+sections render normally.
+
 ## Validate and hand off
 
 Run JSON parsing, shell syntax, ShellCheck, actionlint for workflow changes,
 the publisher's plan mode, and `git diff --check`. Review the complete plan for
 unexpected deletions or relaxations before any authorized apply.
 
-Document affected repositories, required check names, expected plan changes,
-rollback or re-plan steps, and whether live state was intentionally left
-unchanged. Use Conventional Commits for commits and pull-request titles.
+Document affected repositories, required checks, expected plan changes,
+rollback or re-plan steps, and intentionally unchanged live state. Use
+Conventional Commits for commits.

--- a/.agents/skills/atrinik-github-governance/SKILL.md
+++ b/.agents/skills/atrinik-github-governance/SKILL.md
@@ -1,31 +1,33 @@
 ---
 name: atrinik-github-governance
-description: Manage Atrinik PR publication, GitHub policy, Actions, checks, settings, or releases.
+description: Publish Atrinik PRs or change GitHub policy, settings, Actions, required checks, or release governance.
 ---
 
 # Atrinik GitHub Governance
 
-## Review desired and live state
+## Route and review the task
 
-1. Read the workspace and `github-settings/AGENTS.md` guides.
-2. Inspect relevant configuration, publisher code, workflows, and history.
-   Treat configuration as desired state and the GitHub API as live state.
-3. Run the publisher's plan before `--apply`. External settings changes and
-   workflow dispatch require explicit authorization.
-4. Keep controls Team-plan compatible; document and review any migration to an
-   Enterprise-only feature.
+1. For PR-only work, read its repository's `AGENTS.md`, use **Publish pull
+   requests**, and skip steps 2–5.
+2. For policy, settings, Actions, checks, or release governance, read the
+   workspace and `github-settings/AGENTS.md` guides.
+3. Compare relevant configuration, publisher, workflows, and history with the
+   live GitHub API; inspect desired and live state.
+4. Run the publisher plan before `--apply`; external changes and workflow
+   dispatch need explicit authorization.
+5. Keep controls Team-plan compatible; document and review Enterprise-only
+   migrations.
 
 ## Change policy coherently
 
-- Keep required workflow job names synchronized with repository rulesets.
-- Update the Actions allowlist, permissions, dependency pinning, and required
-  aggregate status when a workflow changes those contracts.
-- Keep merge methods, semantic-release behavior, Conventional Commit policy,
-  repository visibility, and default-branch assumptions consistent.
-- Keep Codecov in the selected-actions policy and its GitHub App repository
-  access in manual desired state while coverage workflows use OIDC uploads.
-- Use least-privilege workflow permissions and immutable third-party action
-  references where project policy requires them.
+- Synchronize required workflow job names with repository rulesets.
+- When workflow contracts change, update the Actions allowlist, permissions,
+  dependency pins, and required aggregate status.
+- Keep merge methods, semantic-release, Conventional Commit policy, visibility,
+  and default branches consistent.
+- Keep Codecov in the selected-actions policy and its GitHub App access in
+  manual desired state while coverage uses OIDC.
+- Use least-privilege permissions and policy-required immutable action refs.
 - Never print tokens or copy live secrets into configuration, logs, fixtures,
   commits, or review text.
 
@@ -34,16 +36,18 @@ description: Manage Atrinik PR publication, GitHub policy, Actions, checks, sett
 Use `type(optional-scope)!: concise description` for PR titles. Write bodies as
 renderable GitHub-Flavored Markdown with actual line breaks, never visible
 literal `\n` separators. Pass multi-section bodies by file, standard input, or
-another newline-preserving method. After create/edit, inspect the remote PR and
-verify headings, lists, inline code, issue-closing references, and validation
-sections render normally.
+another newline-preserving method. After create/edit, inspect GitHub's rendered
+web view or rendered `bodyHTML`/`body_html`, not only the raw body. Verify
+headings, lists, inline code, issue-closing references, and validation sections
+render normally.
 
 ## Validate and hand off
 
-Run JSON parsing, shell syntax, ShellCheck, actionlint for workflow changes,
-the publisher's plan mode, and `git diff --check`. Review the complete plan for
-unexpected deletions or relaxations before any authorized apply.
+For policy changes, run JSON/shell validation, ShellCheck, workflow actionlint,
+publisher plan mode, and `git diff --check`; inspect the plan for unexpected
+deletions or relaxations before apply. For PR-only work, run the owning
+repository's validation and the rendered-view check.
 
-Document affected repositories, required checks, expected plan changes,
-rollback or re-plan steps, and intentionally unchanged live state. Use
+For policy, document affected repositories, required check names, plan/rollback
+steps, and unchanged live state. For PRs, record remote render verification. Use
 Conventional Commits for commits.

--- a/.agents/skills/atrinik-github-governance/agents/openai.yaml
+++ b/.agents/skills/atrinik-github-governance/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Atrinik GitHub Governance"
-  short_description: "Maintain Atrinik repository and Actions policy"
-  default_prompt: "Use $atrinik-github-governance to review and update this Atrinik GitHub policy safely, validating desired state before any authorized apply."
+  short_description: "Publish PRs and maintain Atrinik GitHub policy"
+  default_prompt: "Use $atrinik-github-governance to publish this pull request or safely update Atrinik GitHub policy after validating desired and live state."

--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: atrinik-multi-repo-workspace
-description: Coordinate Atrinik repositories, worktrees, profiles, cleanup, publication, releases, or wrapper CLI/layout.
+description: Coordinate work across checkouts, profiles, worktrees, cleanup, releases, or wrapper CLI and layout.
 ---
 
 # Atrinik multi-repository workspace
@@ -47,8 +47,9 @@ clones.
 ```
 
 Synchronize only clean primaries; never implicitly replace, move, or remove a
-dirty checkout or worktree. A classic alias creates the full repository under
-`workspace/worktrees/classic/LABEL`. Commit and push from each owning worktree.
+dirty checkout or worktree. A logical classic selector creates the full
+repository under `workspace/worktrees/classic/LABEL`. Commit and push from each
+owning worktree.
 
 Reclaim completed review data only through preview-first cleanup:
 
@@ -58,12 +59,12 @@ Reclaim completed review data only through preview-first cleanup:
 ./atrinik cleanup --scope all --older-than 7 --apply
 ```
 
-Default scope covers registered worktrees/marker-owned builds; npm cache is
+Default scope covers registered worktrees and marker-owned builds; npm cache is
 opt-in. Text uses IEC sizes; JSON keeps exact bytes. References, Git ambiguity,
-and unsafe paths/markers protect targets. Only an `atrinik/atrinik@main`
+and unsafe paths or markers protect targets. Only an `atrinik/atrinik@main`
 wrapper worktree directly below `build/worktrees/` may use the historical-base
-exception: its PR targets `master` and supplies head, base, and merge SHAs. The
-merge's first parent must match the base, and the merge must be an ancestor of
+exception: its PR must target `master` and provide head, base, and merge SHAs.
+The merge's first parent must match the base, and it must be an ancestor of
 frozen boundary `ee5ba2096c94bce0161629423d4962a966bc61d8`. Graph proof ignores
 replace refs and rejects `info/grafts`. Under the layout lock, `--apply`
 inventories fully and reruns the proof plus exact-target safety without
@@ -106,8 +107,8 @@ distinct name and server state.
 
 ## Validate and hand off
 
-Use wrapper-native commands wherever supported; a runtime handoff names
-concrete resources and follows this lifecycle:
+Use wrapper-native commands wherever supported; a runtime handoff uses concrete
+names and follows this lifecycle:
 
 ```sh
 ./atrinik profile show PROFILE
@@ -121,13 +122,14 @@ concrete resources and follows this lifecycle:
 
 Record prerequisites, actions, expected results, and cleanup. If runtime is
 irrelevant, hand off applicable build/test/inspection commands. Do not
-substitute internal executables or generated paths for supported operations.
+substitute internal executables or generated paths for supported wrapper
+operations.
 
 ## Coordinate publication and policy
 
 - Use `atrinik-github-governance` for PR publication, Actions, permissions,
-  required checks, merge/release policy, or repository settings. Inspect live
-  and desired state before an authorized external change.
+  required checks, merge/release policy, or repository settings. For policy
+  changes, inspect live and desired state before an authorized external change.
 - PR titles use `type(optional-scope)!: concise description`; bodies use
   renderable GitHub-Flavored Markdown and actual line breaks, never visible
   literal `\n` separators. Feed multi-section bodies by file or stdin; after

--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: atrinik-multi-repo-workspace
-description: Coordinate work across checkouts, profiles, worktrees, cleanup, releases, or wrapper CLI and layout.
+description: Coordinate Atrinik repositories, worktrees, profiles, cleanup, publication, releases, or wrapper CLI/layout.
 ---
 
 # Atrinik multi-repository workspace
@@ -9,23 +9,21 @@ description: Coordinate work across checkouts, profiles, worktrees, cleanup, rel
 
 Run commands from the `atrinik/atrinik` wrapper root.
 
-1. Read root `AGENTS.md`. Read only the task-relevant wrapper source/docs:
-   - ownership, cohorts, roles, or build contracts: `components.json`;
-   - operator command behavior: the matching `README.md` section;
-   - layout, locking, trust, or lifecycle design: the matching
+1. Read root `AGENTS.md` and only task-relevant wrapper sources:
+   - ownership, cohorts, roles, and build contracts: `components.json`;
+   - operator behavior: the matching `README.md` section;
+   - layout, locking, trust, and lifecycle design: the matching
      `docs/ARCHITECTURE.md` section;
    - pre-split repositories: [repository migration](references/repository-migration.md).
-2. Resolve every affected logical component to its physical checkout and safe
-   source root. Read that checkout's nearest `AGENTS.md` before editing.
-3. Put component implementation/tests/packages/releases in the owning physical
-   repository. Put only orchestration, composition, manifest, and wrapper docs
-   here.
+2. Resolve each logical component to its physical checkout and safe source root;
+   read that checkout's nearest `AGENTS.md` before editing.
+3. Keep implementation, tests, packages, and releases in the physical owner;
+   keep only orchestration, composition, manifest, and wrapper docs here.
 
-Physical checkouts are independent ignored Git repositories. One `classic`
-worktree contains its five logical source directories. `content@main` and
-`content-1x@1.x` are distinct checkouts even though their GitHub coordinate is
-the same. Keep wrapper VS Code composition under `.devcontainer/`; reusable
-images belong to the `devcontainer` checkout.
+Checkouts are independent ignored Git repositories. One `classic` worktree
+contains all five `classic-*` components; `content@main` and `content-1x@1.x`
+are separate checkouts. Keep wrapper VS Code composition under `.devcontainer/`
+and reusable images in the `devcontainer` checkout.
 
 ## Prepare safe worktrees
 
@@ -36,9 +34,9 @@ Inspect local state before mutation:
 ./atrinik status --json
 ```
 
-Initialize only missing repositories. Plain `init` selects the replacement
+Initialize only absent repositories. Plain `init` selects the replacement
 cohort; exact `--with classic` adds the complete classic cohort. `sync` never
-clones an absent checkout.
+clones.
 
 ```sh
 ./atrinik init [COMPONENT...]
@@ -48,11 +46,9 @@ clones an absent checkout.
 ./atrinik worktree create COMPONENT LABEL --branch TYPE/TOPIC
 ```
 
-Synchronize only clean primaries. Preserve dirty checkouts and worktrees; never
-replace, move, or remove them implicitly. A logical classic name creates one
-full `classic` repository worktree under
-`workspace/worktrees/classic/LABEL`. Commit and push inside each owning
-worktree with Conventional Commits.
+Synchronize only clean primaries; never implicitly replace, move, or remove a
+dirty checkout or worktree. A classic alias creates the full repository under
+`workspace/worktrees/classic/LABEL`. Commit and push from each owning worktree.
 
 Reclaim completed review data only through preview-first cleanup:
 
@@ -62,29 +58,29 @@ Reclaim completed review data only through preview-first cleanup:
 ./atrinik cleanup --scope all --older-than 7 --apply
 ```
 
-The default covers registered worktrees and marker-owned builds; npm cache is
+Default scope covers registered worktrees/marker-owned builds; npm cache is
 opt-in. Text uses IEC sizes; JSON keeps exact bytes. References, Git ambiguity,
-and unsafe paths or markers protect a target. The only historical-base
-exception is an `atrinik/atrinik@main` wrapper worktree directly below
-`build/worktrees/`; its PR must target `master` with head, base, and merge SHAs.
-The merge's first parent must match the base and it must be an ancestor of
+and unsafe paths/markers protect targets. Only an `atrinik/atrinik@main`
+wrapper worktree directly below `build/worktrees/` may use the historical-base
+exception: its PR targets `master` and supplies head, base, and merge SHAs. The
+merge's first parent must match the base, and the merge must be an ancestor of
 frozen boundary `ee5ba2096c94bce0161629423d4962a966bc61d8`. Graph proof ignores
-replace refs and rejects `info/grafts`. Apply inventories fully under the layout
-lock, then reruns the proof and exact-target safety without unrelated report
-scans; uncertainty fails closed.
-Status uses `--ignore-submodules=none`; populated submodule Git data protects.
-Cleanup removes builds first, uses only non-force Git removal, and preserves
-branch refs, profiles, scenarios, states, topology records/logs, migrations,
-retention records, Git objects, review reports, and unmarked paths. Hand off
-exact fixtures, JSON commands, reasons, and preserved records.
+replace refs and rejects `info/grafts`. Under the layout lock, `--apply`
+inventories fully and reruns the proof plus exact-target safety without
+unrelated report scans; uncertainty fails closed. Status uses
+`--ignore-submodules=none`;
+populated submodule Git data protects. Cleanup removes builds first, uses only
+non-force Git removal, and preserves branch refs, profiles, scenarios, states,
+topology records/logs, migrations, retention records, Git objects, review
+reports, and unmarked paths. Hand off exact fixtures, JSON commands, reasons,
+and preserved records.
 
 ## Compose coherent sources
 
-Use `default` for replacement sources and `classic` for the currently playable
-classic stack. Never mix providers or use classic C/CMake as a fallback for a
-missing replacement adapter. Replacement repositories have standalone M1
-foundations, but the wrapper replacement build/runtime closure is not yet
-available.
+Use `default` for replacement sources and `classic` for the playable stack.
+Never mix providers or substitute classic C/CMake for a missing replacement
+adapter. Replacement repositories have standalone M1 foundations, but no
+wrapper replacement build/runtime closure yet.
 
 ```sh
 ./atrinik profile create REVIEW --from classic
@@ -94,15 +90,14 @@ available.
 ./atrinik build COMPONENT --profile REVIEW --test
 ```
 
-Selecting checkout `classic`, one of its logical components, or a provided
-role updates all five classic selectors to one checkout root. Resolution then
-appends each manifest source path. Do not treat a classic subdirectory as an
-independent worktree.
+Selecting `classic`, one of its components, or a provided role updates all five
+classic selectors to one root; resolution appends each manifest source. Never
+treat a classic subdirectory as an independent worktree.
 
-Build, scenario, and topology records bind the exact repository, branch,
-checkout, source, component, and provider. Treat older records without current
-immutable coordinates as inert. Let the wrapper collect content/resources and
-own generated paths, locks, state, PIDs, logs, and process cleanup.
+Build, scenario, and topology records bind exact repository, branch, checkout,
+source, component, and provider coordinates. Records lacking current immutable
+coordinates are inert. Let the wrapper collect content/resources and own
+generated paths, locks, state, PIDs, logs, and process cleanup.
 
 For classic server execution or diagnosis, load `atrinik-server-runtime`. For
 a ready account and character, also load `atrinik-test-scenario`; never
@@ -111,8 +106,8 @@ distinct name and server state.
 
 ## Validate and hand off
 
-Use wrapper-native commands wherever supported. A runtime handoff includes
-concrete names and the complete lifecycle:
+Use wrapper-native commands wherever supported; a runtime handoff names
+concrete resources and follows this lifecycle:
 
 ```sh
 ./atrinik profile show PROFILE
@@ -124,21 +119,24 @@ concrete names and the complete lifecycle:
 ./atrinik down TOPOLOGY
 ```
 
-State prerequisites, feature actions, expected results, and cleanup. When
-runtime is irrelevant, say so and provide the applicable build/test and
-inspection commands. Do not substitute internal executable or generated paths
-for supported wrapper operations.
+Record prerequisites, actions, expected results, and cleanup. If runtime is
+irrelevant, hand off applicable build/test/inspection commands. Do not
+substitute internal executables or generated paths for supported operations.
 
 ## Coordinate publication and policy
 
-- Use `atrinik-github-governance` for Actions, permissions, required checks,
-  merge/release policy, or repository settings. Inspect live and desired state
-  before an authorized external change.
-- Keep each physical repository independently releasable. Semantic-release
-  owns version selection, tags, notes, and recovery; never publish manually.
-- Update `supply-chain/inventory.json` for changed dependency inputs and audit
-  the complete selected profile. Review overrides never make another member
-  optional. Only aggregate-checkout root workflows/Dependabot are active.
+- Use `atrinik-github-governance` for PR publication, Actions, permissions,
+  required checks, merge/release policy, or repository settings. Inspect live
+  and desired state before an authorized external change.
+- PR titles use `type(optional-scope)!: concise description`; bodies use
+  renderable GitHub-Flavored Markdown and actual line breaks, never visible
+  literal `\n` separators. Feed multi-section bodies by file or stdin; after
+  create/edit, verify remote rendering.
+- Keep each physical repository independently releasable; semantic-release owns
+  versions, tags, notes, and recovery. Never publish manually.
+- For dependency-input changes, update `supply-chain/inventory.json` and audit
+  the complete profile. Overrides never make members optional; only aggregate
+  roots own active workflows and Dependabot.
 - Apply historical MIT grants only under
   [`docs/PROVENANCE.md`](../../../docs/PROVENANCE.md). Fail closed and record the
   complete evidence in the destination repository.

--- a/.agents/skills/atrinik-multi-repo-workspace/agents/openai.yaml
+++ b/.agents/skills/atrinik-multi-repo-workspace/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Atrinik Multi-Repo Workspace"
   short_description: "Coordinate Atrinik repositories and worktrees"
-  default_prompt: "Use $atrinik-multi-repo-workspace to coordinate this change across the owning Atrinik repositories."
+  default_prompt: "Use $atrinik-multi-repo-workspace to coordinate this change and its publication across the owning Atrinik repositories."

--- a/.agents/skills/atrinik-multi-repo-workspace/agents/openai.yaml
+++ b/.agents/skills/atrinik-multi-repo-workspace/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Atrinik Multi-Repo Workspace"
   short_description: "Coordinate Atrinik repositories and worktrees"
-  default_prompt: "Use $atrinik-multi-repo-workspace to coordinate this change and its publication across the owning Atrinik repositories."
+  default_prompt: "Use $atrinik-multi-repo-workspace to coordinate this change across the owning Atrinik repositories."

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -20,6 +20,6 @@ jobs:
           pattern='^[a-z][a-z0-9-]*(\([a-z0-9][a-z0-9._/-]*\))?(!)?: .+'
           if [[ ! ${PR_TITLE} =~ ${pattern} ]]; then
             echo "PR title must use Conventional Commits style:" >&2
-            echo "  type(scope)!: concise description" >&2
+            echo "  type(optional-scope)!: concise description" >&2
             exit 1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,28 +7,28 @@
   profiles, worktrees, builds, supervised runtimes, cleanup, migration, and
   supply-chain reports.
 - `default` selects the MIT replacement stack (Rust, Go, Protobuf, and Astro).
-  Its standalone M1 foundations lack wrapper integration. `classic` selects the
-  playable C17/CMake/Ninja stack. Never mix providers or route unavailable
-  replacement adapters through classic.
+  Its standalone M1 foundations lack wrapper build/runtime integration.
+  `classic` selects the playable C17/CMake/Ninja stack. Never mix providers or
+  route unavailable replacement adapters through classic.
 
 ## Folder structure and ownership
 
-- `atrinik` is the CLI entry point; `atrinik_workspace/` owns orchestration;
-  `tests/` is the standard-library `unittest` suite.
-- `components.json` owns checkout, cohort, stack, role, source, and build
-  contracts. `supply-chain/` and `governance/` own machine policy; `docs/`,
-  `README.md`, and `CONTRIBUTING.md` own longer guidance.
-- `.agents/skills/` contains task workflows; `.devcontainer/`, `.github/`, and
-  `scripts/` own workspace composition, CI/release, and helpers.
+- `atrinik` is the CLI; `atrinik_workspace/` owns orchestration and `tests/` the
+  standard-library `unittest` suite.
+- Checkout, cohort, stack, role, source, and build contracts live in
+  `components.json`; machine policy in `supply-chain/` and `governance/`; longer
+  guidance in `docs/`, `README.md`, and `CONTRIBUTING.md`.
+- Task workflows live in `.agents/skills/`, workspace composition in
+  `.devcontainer/`, CI/release in `.github/`, and helpers in `scripts/`.
 - Manifest destinations such as `client/`, `server/`, and `classic/` are
-  independent ignored repositories. `workspace/` and `build/` are ignored
-  generated state. Root `git status` does not inspect those repositories.
-- Resolve ownership through `components.json`, then read the owning checkout's
-  nearest `AGENTS.md`; a nested guide governs its subtree. Keep implementation,
-  tests, packages, and component release configuration in that physical repo.
-- `classic/` is one monorepo providing five `classic-*` components. `content/`
-  is `atrinik/content@main`; `content-1x/` is its independent `1.x` checkout.
-  `.devcontainer/` owns wrapper composition; `devcontainer/` owns images.
+  independent ignored repositories; `workspace/` and `build/` are ignored
+  generated state. Root `git status` omits them.
+- Resolve ownership through `components.json` and the owning checkout's nearest
+  `AGENTS.md`. Keep implementation, tests, packages, and component releases in
+  that physical repository.
+- The `classic/` monorepo provides five `classic-*` components. `content/` is
+  `atrinik/content@main`; `content-1x/` is its separate `1.x` checkout.
+  `.devcontainer/` owns wrapper composition and `devcontainer/` reusable images.
 
 ## Core behaviors and patterns
 
@@ -67,8 +67,8 @@
 
 ## Working agreements and commands
 
-Run commands from this repository root. Inspect before mutation; initialization
-clones only missing repositories, and `sync` never initializes one:
+Run from this repository root. Inspect before mutation: initialization clones
+only missing repositories, and `sync` never initializes one:
 
 ```sh
 ./atrinik manifest validate
@@ -77,8 +77,8 @@ clones only missing repositories, and `sync` never initializes one:
 ./atrinik init --with classic
 ```
 
-Use this exact currently playable build/runtime lifecycle (use `--follow` only
-for an interactive log session):
+Use this exact playable build/runtime lifecycle (`--follow` only for an
+interactive log session):
 
 ```sh
 ./atrinik profile show classic --json
@@ -89,8 +89,7 @@ for an interactive log session):
 ./atrinik down classic-local
 ```
 
-Install test tooling once, then run the complete wrapper validation before
-finishing wrapper changes:
+Install test tooling once, then run the complete wrapper validation:
 
 ```sh
 python3 -m pip install --requirement requirements-dev.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,14 +2,14 @@
 
 ## Overview
 
-- This MIT Python 3.11+ repository coordinates Atrinik's independent Git
-  repositories; it does not own component source. `./atrinik` and
-  `components.json` manage profiles, worktrees, builds, supervised runtimes,
-  cleanup, migration, and supply-chain reports.
+- This MIT Python 3.11+ repository coordinates independent Atrinik Git
+  repositories, not component source. `./atrinik` and `components.json` manage
+  profiles, worktrees, builds, supervised runtimes, cleanup, migration, and
+  supply-chain reports.
 - `default` selects the MIT replacement stack (Rust, Go, Protobuf, and Astro).
-  Its standalone M1 foundations exist, but wrapper build/runtime integration
-  has not landed. `classic` selects the playable C17/CMake/Ninja stack. Never
-  mix providers or route unavailable replacement adapters through classic.
+  Its standalone M1 foundations lack wrapper integration. `classic` selects the
+  playable C17/CMake/Ninja stack. Never mix providers or route unavailable
+  replacement adapters through classic.
 
 ## Folder structure and ownership
 
@@ -58,9 +58,12 @@
 - Update `supply-chain/inventory.json` when dependency ownership or validation
   changes. Keep Actions/images immutable, add no submodules, and audit a
   complete profile. Only aggregate-root workflows and Dependabot are active.
-- Use Conventional Commits for commits and PR titles. Semantic-release owns
-  tags and release assets. Do not disclose confidential or unreleased work on
-  public surfaces; use `atrinik-github-governance` for GitHub policy.
+- Commits and PR titles use `type(optional-scope)!: concise description`. PR
+  bodies require renderable GitHub-Flavored Markdown and actual line breaks,
+  never visible literal `\n` separators. Feed multi-section bodies by file or
+  stdin; after create/edit, verify remote rendering. Use
+  `atrinik-github-governance` for publication and policy. Semantic-release owns
+  tags/assets; keep confidential or unreleased work off public surfaces.
 
 ## Working agreements and commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,9 @@ Write pull-request descriptions as renderable GitHub-Flavored Markdown with
 actual line breaks, never visible literal `\n` separators. For a multi-section
 body, prefer `gh pr create --body-file FILE` or `gh pr edit --body-file FILE`;
 `--body-file -` reads standard input. After creating or editing a pull request,
-inspect it remotely and verify that headings, lists, inline code,
-issue-closing references, and validation sections render normally.
+inspect GitHub's rendered web view or rendered `bodyHTML`/`body_html`, not only
+the raw body. Verify that headings, lists, inline code, issue-closing references,
+and validation sections render normally.
 
 Keep component implementation in its owning repository. Changes here should
 remain focused on the manifest, multi-repository workflows, or their tests and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,13 @@ Examples include `fix(cli): reject mismatched checkout paths` and
 `feat!: revise the profile schema`. Pull requests are squash-merged, and the
 squash title becomes the release-driving commit on `main`.
 
+Write pull-request descriptions as renderable GitHub-Flavored Markdown with
+actual line breaks, never visible literal `\n` separators. For a multi-section
+body, prefer `gh pr create --body-file FILE` or `gh pr edit --body-file FILE`;
+`--body-file -` reads standard input. After creating or editing a pull request,
+inspect it remotely and verify that headings, lists, inline code,
+issue-closing references, and validation sections render normally.
+
 Keep component implementation in its owning repository. Changes here should
 remain focused on the manifest, multi-repository workflows, or their tests and
 documentation. Preserve dirty physical checkouts and persistent state during

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -139,6 +139,61 @@ class AgentGuidanceTests(unittest.TestCase):
             with self.subTest(stale=stale):
                 self.assertNotIn(stale, corpus)
 
+    def test_pull_request_publication_contract_is_synchronized(self) -> None:
+        governed = [
+            ROOT / "AGENTS.md",
+            ROOT / "CONTRIBUTING.md",
+            ROOT / ".agents/skills/atrinik-github-governance/SKILL.md",
+            ROOT / ".agents/skills/atrinik-multi-repo-workspace/SKILL.md",
+        ]
+        markers = {
+            "type(optional-scope)!: concise description",
+            "GitHub-Flavored Markdown",
+            "actual line breaks",
+            "literal `\\n` separators",
+            "multi-section",
+            "remote",
+        }
+        for path in governed:
+            guidance = " ".join(path.read_text(encoding="utf-8").split())
+            for marker in markers:
+                with self.subTest(path=path.relative_to(ROOT), marker=marker):
+                    self.assertIn(marker, guidance)
+            with self.subTest(path=path.relative_to(ROOT), marker="body input"):
+                self.assertRegex(
+                    guidance,
+                    r"multi-section bod(?:y|ies).*file.*(?:standard input|stdin)",
+                )
+
+        detailed = governed[1:3]
+        for path in detailed:
+            guidance = " ".join(path.read_text(encoding="utf-8").split())
+            for marker in {
+                "headings",
+                "lists",
+                "inline code",
+                "issue-closing references",
+                "validation sections",
+            }:
+                with self.subTest(path=path.relative_to(ROOT), marker=marker):
+                    self.assertIn(marker, guidance)
+
+        title_workflow = (ROOT / ".github/workflows/pr-title.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("type(optional-scope)!: concise description", title_workflow)
+
+        unrelated = {
+            path
+            for path in (ROOT / ".agents/skills").glob("*/SKILL.md")
+            if path not in governed
+        }
+        for path in unrelated:
+            with self.subTest(path=path.relative_to(ROOT)):
+                self.assertNotIn(
+                    "GitHub-Flavored Markdown", path.read_text(encoding="utf-8")
+                )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -5,6 +5,7 @@ import io
 import json
 from pathlib import Path
 import re
+import subprocess
 import tempfile
 import unittest
 from unittest import mock
@@ -140,11 +141,19 @@ class AgentGuidanceTests(unittest.TestCase):
                 self.assertNotIn(stale, corpus)
 
     def test_pull_request_publication_contract_is_synchronized(self) -> None:
+        root_guide = ROOT / "AGENTS.md"
+        contributing = ROOT / "CONTRIBUTING.md"
+        governance_skill = (
+            ROOT / ".agents/skills/atrinik-github-governance/SKILL.md"
+        )
+        workspace_skill = (
+            ROOT / ".agents/skills/atrinik-multi-repo-workspace/SKILL.md"
+        )
         governed = [
-            ROOT / "AGENTS.md",
-            ROOT / "CONTRIBUTING.md",
-            ROOT / ".agents/skills/atrinik-github-governance/SKILL.md",
-            ROOT / ".agents/skills/atrinik-multi-repo-workspace/SKILL.md",
+            root_guide,
+            contributing,
+            governance_skill,
+            workspace_skill,
         ]
         markers = {
             "type(optional-scope)!: concise description",
@@ -152,7 +161,6 @@ class AgentGuidanceTests(unittest.TestCase):
             "actual line breaks",
             "literal `\\n` separators",
             "multi-section",
-            "remote",
         }
         for path in governed:
             guidance = " ".join(path.read_text(encoding="utf-8").split())
@@ -162,11 +170,17 @@ class AgentGuidanceTests(unittest.TestCase):
             with self.subTest(path=path.relative_to(ROOT), marker="body input"):
                 self.assertRegex(
                     guidance,
-                    r"multi-section bod(?:y|ies).*file.*(?:standard input|stdin)",
+                    r"multi-section bod(?:y|ies)[^.]{0,200}file"
+                    r"[^.]{0,200}(?:standard input|stdin)",
+                )
+            with self.subTest(path=path.relative_to(ROOT), marker="remote render"):
+                self.assertRegex(
+                    guidance,
+                    r"[Aa]fter (?:create/edit|creating or editing a pull request)"
+                    r"[^.]{0,160}(?:inspect|verify)[^.]{0,80}(?:remote|GitHub)",
                 )
 
-        detailed = governed[1:3]
-        for path in detailed:
+        for path in [contributing, governance_skill]:
             guidance = " ".join(path.read_text(encoding="utf-8").split())
             for marker in {
                 "headings",
@@ -174,6 +188,8 @@ class AgentGuidanceTests(unittest.TestCase):
                 "inline code",
                 "issue-closing references",
                 "validation sections",
+                "bodyHTML",
+                "raw body",
             }:
                 with self.subTest(path=path.relative_to(ROOT), marker=marker):
                     self.assertIn(marker, guidance)
@@ -181,17 +197,70 @@ class AgentGuidanceTests(unittest.TestCase):
         title_workflow = (ROOT / ".github/workflows/pr-title.yml").read_text(
             encoding="utf-8"
         )
+        self.assertIn("pull_request_target:", title_workflow)
+        self.assertIn(
+            "types: [opened, edited, synchronize, reopened]", title_workflow
+        )
+        self.assertIn("name: Conventional PR title", title_workflow)
         self.assertIn("type(optional-scope)!: concise description", title_workflow)
 
-        unrelated = {
+        run_match = re.search(
+            r"(?m)^ {8}run: \|\n(?P<script>(?:^ {10}.*(?:\n|$))+)",
+            title_workflow,
+        )
+        if run_match is None:
+            self.fail("PR title workflow does not declare its validation script")
+        validation_script = "\n".join(
+            line[10:] for line in run_match.group("script").splitlines()
+        )
+        title_cases = {
+            True: {
+                "chore: refresh guidance",
+                "docs(agents): govern PR publication",
+                "feat!: revise the contract",
+            },
+            False: {
+                "Docs: uppercase type",
+                "docs(): empty scope",
+                "docs: ",
+                "update guidance",
+            },
+        }
+        for should_match, titles in title_cases.items():
+            for title in titles:
+                with self.subTest(title=title, should_match=should_match):
+                    result = subprocess.run(
+                        ["bash", "-c", validation_script],
+                        check=False,
+                        capture_output=True,
+                        env={"PR_TITLE": title},
+                        text=True,
+                    )
+                    self.assertEqual(
+                        result.returncode == 0,
+                        should_match,
+                        result.stderr,
+                    )
+
+        _, governance_description = skill_frontmatter(governance_skill)
+        self.assertIn("Publish Atrinik PRs", governance_description)
+        governance_interface = (
+            governance_skill.parent / "agents/openai.yaml"
+        ).read_text(encoding="utf-8")
+        self.assertIn("Publish PRs", governance_interface)
+        self.assertIn("$atrinik-github-governance", governance_interface)
+
+        unrelated = [
             path
             for path in (ROOT / ".agents/skills").glob("*/SKILL.md")
             if path not in governed
-        }
+        ]
         for path in unrelated:
             with self.subTest(path=path.relative_to(ROOT)):
-                self.assertNotIn(
-                    "GitHub-Flavored Markdown", path.read_text(encoding="utf-8")
+                guidance = " ".join(path.read_text(encoding="utf-8").split())
+                self.assertFalse(
+                    all(marker in guidance for marker in markers),
+                    "unrelated skill duplicates the complete PR publication contract",
                 )
 
 


### PR DESCRIPTION
## Summary

- require Conventional Commit syntax for every agent-created or agent-edited pull-request title
- require renderable GitHub-Flavored Markdown with real newlines for pull-request descriptions
- route multi-section CLI bodies through `--body-file` or stdin and require remote render verification
- keep canonical guidance synchronized with a focused regression test and the existing title-check diagnostic

Closes #303

## Validation

- `python3 -m coverage run -m unittest discover -v` — 293 tests passed
- `python3 -m coverage report --show-missing` — 78% total coverage
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check` — tightest combined inventory is 13,830/14,000 bytes; all skill bodies are 20,844/21,000 bytes
- active Codex skill generator plus validator for both selected skills
- `actionlint .github/workflows/pr-title.yml`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `git diff --check`
- GitHub rendered `body_html` inspection — headings, lists, inline code, issue-closing reference, and Validation render normally

Runtime/profile validation is not applicable because this change only updates publication guidance, metadata, tests, and a diagnostic string.
