### PR TITLE
fix(runtime): generate Classic region maps

### DIFF
--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -91,9 +91,12 @@ wrapper replacement build/runtime closure yet.
 ./atrinik build COMPONENT --profile REVIEW --test
 ```
 
-Selecting `classic`, one of its components, or a provided role updates all five
-classic selectors to one root; resolution appends each manifest source. Never
-treat a classic subdirectory as an independent worktree.
+Selecting `classic`, its components, or its roles updates all five selectors to
+one root. Never treat a classic subdirectory as an independent worktree.
+
+Classic server builds cache validated region maps only for matching clean
+inputs; dirty inputs regenerate. Runtimes do not overlay state, and topologies
+copy snapshots.
 
 Build, scenario, and topology records bind exact repository, branch, checkout,
 source, component, and provider coordinates. Records lacking current immutable

--- a/README.md
+++ b/README.md
@@ -188,8 +188,8 @@ or overlay an already registered state. A supervised topology copies the maps
 into its owned runtime snapshot before the server takes its immutable asset
 snapshot. Region maps are reclaimed with their marker-owned profile build by
 the normal preview-first `./atrinik cleanup --scope builds` lifecycle; topology
-snapshots remain protected by the topology record and are removed with normal
-topology cleanup.
+snapshots remain with the retained topology record and are atomically replaced
+the next time that topology name is launched.
 
 `--with classic` has one exact meaning: add the complete classic initialization
 cohort to the replacement/default cohort. It is not a classic-only mode. The

--- a/README.md
+++ b/README.md
@@ -173,6 +173,24 @@ Add the complete currently playable classic stack explicitly:
 ./atrinik down classic-local
 ~~~
 
+Building the Classic server also runs its offline worldmaker and stages the
+generated region-map `.png`/`.def` pairs in the profile build. Generation uses
+the selected Classic, `content-1x`, and resource views, so it requires the same
+native build dependencies as the server. A marker-owned cache is reused only
+while every selected checkout is clean and its recorded commit still matches;
+dirty inputs regenerate on every build. Missing `incuna_-1` output, incomplete
+pairs, malformed files, or generator failure stop the build while preserving
+the last valid cache.
+
+Server launch uses a disposable HTTP asset root that combines the named
+state's existing `http/data` with those generated maps. It does not copy into
+or overlay an already registered state. A supervised topology copies the maps
+into its owned runtime snapshot before the server takes its immutable asset
+snapshot. Region maps are reclaimed with their marker-owned profile build by
+the normal preview-first `./atrinik cleanup --scope builds` lifecycle; topology
+snapshots remain protected by the topology record and are removed with normal
+topology cleanup.
+
 `--with classic` has one exact meaning: add the complete classic initialization
 cohort to the replacement/default cohort. It is not a classic-only mode. The
 cohort consists of one `atrinik/classic` checkout, a distinct `content-1x`

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -1737,10 +1737,22 @@ class Workspace:
         stack = self.manifest.stack(profile["stack"])
         coordinates: dict[str, dict[str, str]] = {}
         cacheable = True
+        checkout_states: dict[Path, tuple[bool, str]] = {}
         for role, source in sorted(selected.items()):
             component = stack.providers[role]
             checkout = self._selector_root(profile, component).resolve()
-            clean = _is_clean(checkout, trace=False)
+            if checkout not in checkout_states:
+                checkout_states[checkout] = (
+                    _is_clean(checkout, trace=False),
+                    git(
+                        checkout,
+                        "rev-parse",
+                        "HEAD",
+                        capture=True,
+                        trace=False,
+                    ),
+                )
+            clean, head = checkout_states[checkout]
             cacheable = cacheable and clean
             coordinates[role] = {
                 "component": component.name,
@@ -1750,9 +1762,7 @@ class Workspace:
                 "source": component.source,
                 "checkout_path": str(checkout),
                 "source_path": str(source.resolve()),
-                "head": git(
-                    checkout, "rev-parse", "HEAD", capture=True, trace=False
-                ),
+                "head": head,
             }
         return (
             {
@@ -1782,23 +1792,29 @@ class Workspace:
                 raise WorkspaceError(
                     f"generated region-map output is invalid: {entry}"
                 )
-            if entry.stat().st_size == 0:
-                raise WorkspaceError(f"generated region map is empty: {entry}")
-            if entry.suffix == ".png":
-                with entry.open("rb") as stream:
-                    if stream.read(8) != b"\x89PNG\r\n\x1a\n":
+            descriptor = open_regular_file(
+                entry, os.O_RDONLY, "generated region map"
+            )
+            try:
+                with os.fdopen(descriptor, "rb") as stream:
+                    if os.fstat(stream.fileno()).st_size == 0:
                         raise WorkspaceError(
-                            f"generated region map is not a PNG file: {entry}"
+                            f"generated region map is empty: {entry}"
                         )
-                png_names.add(entry.stem)
-            else:
-                try:
-                    entry.read_text(encoding="utf-8")
-                except (OSError, UnicodeError) as error:
-                    raise WorkspaceError(
-                        f"generated region-map definition is not UTF-8: {entry}"
-                    ) from error
-                definition_names.add(entry.stem)
+                    if entry.suffix == ".png":
+                        signature = stream.read(8)
+                        if signature != b"\x89PNG\r\n\x1a\n":
+                            raise WorkspaceError(
+                                f"generated region map is not a PNG file: {entry}"
+                            )
+                        png_names.add(entry.stem)
+                    else:
+                        stream.read().decode("utf-8")
+                        definition_names.add(entry.stem)
+            except UnicodeError as error:
+                raise WorkspaceError(
+                    f"generated region-map definition is not UTF-8: {entry}"
+                ) from error
         if png_names != definition_names:
             missing_png = sorted(definition_names - png_names)
             missing_definition = sorted(png_names - definition_names)
@@ -1879,10 +1895,20 @@ class Workspace:
                     "--worldmaker",
                     f"--datapath={data}",
                     f"--httppath={http}",
+                    f"--libpath={working / 'lib'}",
+                    f"--mapspath={working / 'maps'}",
+                    f"--resourcespath={working / 'resources'}",
                 ],
                 cwd=working,
             )
             self._validate_region_maps(generated)
+            final_inputs, final_cacheable = self._region_map_inputs(
+                profile_name, selected
+            )
+            if final_inputs != inputs or final_cacheable != cacheable:
+                raise WorkspaceError(
+                    "selected region-map inputs changed during generation"
+                )
             atomic_json(
                 generated / MANAGED_MARKER,
                 {
@@ -3399,8 +3425,8 @@ class Workspace:
                 f"--port_quic={port}",
                 "--port_mapping=off",
                 "--stun_server=off",
-                f"--httppath={runtime / 'http'}",
                 *arguments,
+                f"--httppath={runtime / 'http'}",
             ]
             print(f"state: {state}")
             print(f"cwd: {runtime}")

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -95,6 +95,9 @@ SCENARIO_PASSWORD_MAX_SIZE = 128
 BUILD_METADATA = ".atrinik-build.json"
 BUILD_METADATA_SCHEMA_VERSION = 1
 CACHE_METADATA = ".atrinik-cache.json"
+REGION_MAP_METADATA = ".atrinik-region-maps.json"
+REGION_MAP_SCHEMA_VERSION = 1
+EXPECTED_REGION_MAP = "incuna_-1"
 
 
 def display_arguments(arguments: list[str]) -> str:
@@ -1352,6 +1355,7 @@ class Workspace:
                 self._build_client(root, selected, tests)
             if "server" in targets:
                 self._build_server(root, selected, tests)
+                self._generate_region_maps(root, profile_name, selected)
             if "metaserver-worker" in targets:
                 self._build_worker(root, selected)
             if target in {"sound", "resources"}:
@@ -1726,6 +1730,174 @@ class Workspace:
             tests,
         )
 
+    def _region_map_inputs(
+        self, profile_name: str, selected: dict[str, Path]
+    ) -> tuple[dict[str, Any], bool]:
+        profile = self._load_profile(profile_name, require_file=False)
+        stack = self.manifest.stack(profile["stack"])
+        coordinates: dict[str, dict[str, str]] = {}
+        cacheable = True
+        for role, source in sorted(selected.items()):
+            component = stack.providers[role]
+            checkout = self._selector_root(profile, component).resolve()
+            clean = _is_clean(checkout, trace=False)
+            cacheable = cacheable and clean
+            coordinates[role] = {
+                "component": component.name,
+                "repository": component.repository,
+                "branch": component.branch,
+                "checkout": component.checkout_name,
+                "source": component.source,
+                "checkout_path": str(checkout),
+                "source_path": str(source.resolve()),
+                "head": git(
+                    checkout, "rev-parse", "HEAD", capture=True, trace=False
+                ),
+            }
+        return (
+            {
+                "schema_version": REGION_MAP_SCHEMA_VERSION,
+                "cacheable": cacheable,
+                "coordinates": coordinates,
+            },
+            cacheable,
+        )
+
+    @staticmethod
+    def _validate_region_maps(path: Path) -> None:
+        if not path.is_dir() or path.is_symlink():
+            raise WorkspaceError(f"region-map output is not a directory: {path}")
+        png_names: set[str] = set()
+        definition_names: set[str] = set()
+        for entry in path.iterdir():
+            if entry.name in {MANAGED_MARKER, REGION_MAP_METADATA}:
+                continue
+            try:
+                mode = entry.lstat().st_mode
+            except OSError as error:
+                raise WorkspaceError(
+                    f"cannot inspect generated region map {entry}: {error}"
+                ) from error
+            if not stat.S_ISREG(mode) or entry.suffix not in {".png", ".def"}:
+                raise WorkspaceError(
+                    f"generated region-map output is invalid: {entry}"
+                )
+            if entry.stat().st_size == 0:
+                raise WorkspaceError(f"generated region map is empty: {entry}")
+            if entry.suffix == ".png":
+                with entry.open("rb") as stream:
+                    if stream.read(8) != b"\x89PNG\r\n\x1a\n":
+                        raise WorkspaceError(
+                            f"generated region map is not a PNG file: {entry}"
+                        )
+                png_names.add(entry.stem)
+            else:
+                try:
+                    entry.read_text(encoding="utf-8")
+                except (OSError, UnicodeError) as error:
+                    raise WorkspaceError(
+                        f"generated region-map definition is not UTF-8: {entry}"
+                    ) from error
+                definition_names.add(entry.stem)
+        if png_names != definition_names:
+            missing_png = sorted(definition_names - png_names)
+            missing_definition = sorted(png_names - definition_names)
+            details = []
+            if missing_png:
+                details.append(f"missing PNG: {', '.join(missing_png)}")
+            if missing_definition:
+                details.append(
+                    f"missing definition: {', '.join(missing_definition)}"
+                )
+            raise WorkspaceError(
+                f"generated region-map pairs are incomplete ({'; '.join(details)})"
+            )
+        if EXPECTED_REGION_MAP not in png_names:
+            raise WorkspaceError(
+                f"generated region maps lack required {EXPECTED_REGION_MAP} pair"
+            )
+
+    def _region_map_cache_matches(
+        self, output: Path, inputs: dict[str, Any], cacheable: bool
+    ) -> bool:
+        if not cacheable or not output.is_dir() or output.is_symlink():
+            return False
+        marker = output / MANAGED_MARKER
+        metadata = output / REGION_MAP_METADATA
+        expected_marker = {
+            "schema_version": SCHEMA_VERSION,
+            "purpose": "region-map-cache",
+        }
+        if (
+            not marker.is_file()
+            or marker.is_symlink()
+            or not metadata.is_file()
+            or metadata.is_symlink()
+        ):
+            return False
+        try:
+            if load_json(marker) != expected_marker or load_json(metadata) != inputs:
+                return False
+            self._validate_region_maps(output)
+        except WorkspaceError:
+            return False
+        return True
+
+    def _generate_region_maps(
+        self, root: Path, profile_name: str, selected: dict[str, Path]
+    ) -> Path:
+        output = root / "runtime" / "client-maps"
+        output.parent.mkdir(parents=True, exist_ok=True)
+        inputs, cacheable = self._region_map_inputs(profile_name, selected)
+        if self._region_map_cache_matches(output, inputs, cacheable):
+            print(f"region maps: cached {output}")
+            return output
+        if output.exists() or output.is_symlink():
+            managed_directory(output, self.paths.builds, "region-map-cache")
+
+        staging_root = Path(
+            tempfile.mkdtemp(prefix=".region-maps-", dir=output.parent)
+        )
+        try:
+            working = staging_root / "server"
+            working.mkdir()
+            data = staging_root / "data"
+            shutil.copytree(selected["server"] / "install_data", data)
+            (data / "tmp").mkdir(exist_ok=True)
+            http = staging_root / "http"
+            http.mkdir()
+            generated = http / "client-maps"
+            content = root / "runtime" / "content"
+            resources = root / "runtime" / "resources"
+            self._link_server_runtime_inputs(
+                working, root, selected, data, content, resources
+            )
+            executable = working / "atrinik-server"
+            run(
+                [
+                    str(executable),
+                    "--worldmaker",
+                    f"--datapath={data}",
+                    f"--httppath={http}",
+                ],
+                cwd=working,
+            )
+            self._validate_region_maps(generated)
+            atomic_json(
+                generated / MANAGED_MARKER,
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "purpose": "region-map-cache",
+                },
+            )
+            atomic_json(generated / REGION_MAP_METADATA, inputs)
+            replace_directory(output, generated, ".client-maps-previous-")
+        finally:
+            if staging_root.exists():
+                shutil.rmtree(staging_root)
+        print(f"region maps: generated {output}")
+        return output
+
     def _build_worker(self, root: Path, selected: dict[str, Path]) -> None:
         view = self._profile_source_view(
             root,
@@ -1987,6 +2159,7 @@ class Workspace:
                 f"--provision_character={metadata['character']}",
                 f"--provision_archetype={metadata['archetype']}",
                 f"--provision_password_file={password_file}",
+                f"--httppath={runtime / 'http'}",
             ],
             cwd=runtime,
         )
@@ -2349,6 +2522,7 @@ class Workspace:
         source: Path,
         name: str,
         purpose: str,
+        preserve_source: bool = False,
     ) -> Path:
         expected = {"schema_version": SCHEMA_VERSION, "purpose": purpose}
         marker = source / MANAGED_MARKER
@@ -2384,7 +2558,10 @@ class Workspace:
                     f"topology runtime destination is not managed: {destination}"
                 )
             shutil.rmtree(destination)
-        source.replace(destination)
+        if preserve_source:
+            shutil.copytree(source, destination)
+        else:
+            source.replace(destination)
         return destination
 
     def _prepare_topology_client_runtime(
@@ -2847,6 +3024,13 @@ class Workspace:
                         "resources",
                         "resource-view",
                     )
+                    client_maps = self._take_topology_runtime_input(
+                        topology_root,
+                        root / "runtime" / "client-maps",
+                        "client-maps",
+                        "region-map-cache",
+                        preserve_source=True,
+                    )
                     runtime = self._prepare_server_runtime(
                         root,
                         selected,
@@ -2854,6 +3038,7 @@ class Workspace:
                         state_name,
                         content,
                         resources,
+                        client_maps,
                     )
                     executable = runtime / "atrinik-server"
                     service_specs["server"] = {
@@ -2862,6 +3047,7 @@ class Workspace:
                             f"--port_quic={endpoint['port']}",
                             "--port_mapping=off",
                             "--stun_server=off",
+                            f"--httppath={runtime / 'http'}",
                             "--no_console",
                         ],
                         "cwd": str(runtime),
@@ -3213,6 +3399,7 @@ class Workspace:
                 f"--port_quic={port}",
                 "--port_mapping=off",
                 "--stun_server=off",
+                f"--httppath={runtime / 'http'}",
                 *arguments,
             ]
             print(f"state: {state}")
@@ -3267,22 +3454,17 @@ class Workspace:
             ) from error
         return hashlib.sha256(encoded).hexdigest()
 
-    def _prepare_server_runtime(
+    def _link_server_runtime_inputs(
         self,
+        runtime: Path,
         root: Path,
         selected: dict[str, Path],
         state: Path,
-        state_name: str,
-        content: Path | None = None,
-        resources: Path | None = None,
-    ) -> Path:
-        state_key = profile_key({"state": state})
-        runtime = root / "run" / "server" / f"{state_name}-{state_key}"
-        managed_reset(runtime, self.paths.builds, f"server-runtime:{state_key}")
+        content: Path,
+        resources: Path,
+    ) -> None:
         source = selected["server"]
         binary = root / "build" / "server"
-        content = content or root / "runtime" / "content"
-        resources = resources or root / "runtime" / "resources"
         links = {
             "atrinik-server": binary / "atrinik-server",
             "libplugin_arena.so": binary / "libplugin_arena.so",
@@ -3296,7 +3478,9 @@ class Workspace:
         for name, target in links.items():
             if not target.exists():
                 raise WorkspaceError(f"server runtime input is missing: {target}")
-            (runtime / name).symlink_to(target, target_is_directory=target.is_dir())
+            (runtime / name).symlink_to(
+                target, target_is_directory=target.is_dir()
+            )
         for name in ("ca-bundle.crt", "permissions.cfg", "server.cfg"):
             target = source / name
             if not target.is_file():
@@ -3305,6 +3489,38 @@ class Workspace:
         custom = source / "server-custom.cfg"
         if custom.is_file():
             (runtime / "server-custom.cfg").symlink_to(custom)
+
+    def _prepare_server_runtime(
+        self,
+        root: Path,
+        selected: dict[str, Path],
+        state: Path,
+        state_name: str,
+        content: Path | None = None,
+        resources: Path | None = None,
+        client_maps: Path | None = None,
+    ) -> Path:
+        state_key = profile_key({"state": state})
+        runtime = root / "run" / "server" / f"{state_name}-{state_key}"
+        managed_reset(runtime, self.paths.builds, f"server-runtime:{state_key}")
+        content = content or root / "runtime" / "content"
+        resources = resources or root / "runtime" / "resources"
+        client_maps = client_maps or root / "runtime" / "client-maps"
+        self._validate_region_maps(client_maps)
+        http_data = state / "http" / "data"
+        if not http_data.is_dir() or http_data.is_symlink():
+            raise WorkspaceError(
+                f"server state lacks required HTTP data directory: {http_data}"
+            )
+        self._link_server_runtime_inputs(
+            runtime, root, selected, state, content, resources
+        )
+        http = runtime / "http"
+        http.mkdir()
+        (http / "data").symlink_to(http_data, target_is_directory=True)
+        (http / "client-maps").symlink_to(
+            client_maps, target_is_directory=True
+        )
         return runtime
 
     def _component(self, name: str) -> Component:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -342,6 +342,7 @@ selected content-1x -> build_runtime.py -> isolated content/lib + content/maps
 selected tracked resource allowlist -> isolated resource view
 selected classic protocol/library + sound -> client source view -> CMake/Ninja
 selected classic protocol/library --------> server source view -> CMake/Ninja
+selected Classic + content + resources ---> offline worldmaker -> region-map cache
 selected Worker -------------------------> npm source view -> npm run check
 ~~~
 
@@ -364,6 +365,17 @@ only tracked regular files below those paths enter the runtime view. This keeps
 repository metadata, local untracked files, and symlinks out of the asset
 protocol.
 
+After a Classic server build, the coordinator runs the built server's offline
+worldmaker in a temporary runtime assembled from the selected server,
+collected content, and staged resources. The generator writes into a sibling
+temporary directory; the coordinator accepts it only when every output is a
+nonempty regular `.png` or UTF-8 `.def`, the basename sets form complete pairs,
+and the expected `incuna_-1` pair exists. It then installs the marker-owned
+cache atomically, preserving the previous valid cache on failure. Cache
+metadata records all selected provider, repository, branch, checkout, source,
+path, and commit coordinates. It is reusable only for clean checkouts with an
+exact metadata match; dirty inputs deliberately regenerate.
+
 ## Runtime and state
 
 For the currently runnable classic profile, server launch preparation assembles
@@ -374,6 +386,15 @@ First use initializes a state atomically from the selected server's
 `install_data`; an existing directory is validated and never overlaid. State
 inside a server source worktree is rejected. Replacement runtime preparation
 remains unavailable until its native component contracts land.
+
+The server's configured HTTP asset root is a disposable runtime view. Its
+`data` entry points at the named state's existing `http/data`, while its
+`client-maps` entry points at the validated generated cache. A supervised
+topology copies that cache into its owned runtime before launch, so a later
+build cannot change the server's immutable startup asset snapshot. Fresh and
+registered states therefore receive the selected generated maps without
+writing them into mutable state. The cache follows marker-owned profile-build
+cleanup and topology copies follow topology retention and cleanup.
 
 The coordinator takes an advisory exclusive lock next to the state directory
 before build/runtime preparation and holds it for the lifetime of a launched

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -394,7 +394,8 @@ topology copies that cache into its owned runtime before launch, so a later
 build cannot change the server's immutable startup asset snapshot. Fresh and
 registered states therefore receive the selected generated maps without
 writing them into mutable state. The cache follows marker-owned profile-build
-cleanup and topology copies follow topology retention and cleanup.
+cleanup; topology copies follow topology retention and are replaced on the
+next launch of that topology name.
 
 The coordinator takes an advisory exclusive lock next to the state directory
 before build/runtime preparation and holds it for the lifetime of a launched

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -748,12 +748,20 @@ class WorkspaceTests(unittest.TestCase):
                 shutil.rmtree(output)
             output.mkdir()
 
+        with self.assertRaisesRegex(WorkspaceError, "not a directory"):
+            self.workspace._validate_region_maps(output)
+
         reset()
         with self.assertRaisesRegex(WorkspaceError, "lack required"):
             self.workspace._validate_region_maps(output)
 
         (output / "incuna_-1.def").write_text("pixel_size 4\n", encoding="utf-8")
         with self.assertRaisesRegex(WorkspaceError, "pairs are incomplete"):
+            self.workspace._validate_region_maps(output)
+
+        reset()
+        (output / "incuna_-1.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+        with self.assertRaisesRegex(WorkspaceError, "missing definition"):
             self.workspace._validate_region_maps(output)
 
         (output / "incuna_-1.png").write_bytes(b"not a png")
@@ -775,6 +783,35 @@ class WorkspaceTests(unittest.TestCase):
         (output / "incuna_-1.def").write_text("pixel_size 4\n", encoding="utf-8")
         with self.assertRaisesRegex(WorkspaceError, "is empty"):
             self.workspace._validate_region_maps(output)
+
+        reset()
+        entry = mock.Mock()
+        entry.name = "vanished.png"
+        entry.lstat.side_effect = OSError("vanished")
+        with mock.patch("pathlib.Path.iterdir", return_value=iter([entry])):
+            with self.assertRaisesRegex(WorkspaceError, "cannot inspect"):
+                self.workspace._validate_region_maps(output)
+
+    def test_region_map_cache_rejects_incomplete_or_invalid_metadata(self) -> None:
+        output = self.make_region_map_cache(self.root)
+        marker = output / MANAGED_MARKER
+        metadata = output / ".atrinik-region-maps.json"
+        inputs = {"schema_version": 1, "cacheable": True, "coordinates": {}}
+
+        marker.unlink()
+        self.assertFalse(
+            self.workspace._region_map_cache_matches(output, inputs, True)
+        )
+
+        atomic_json(
+            marker,
+            {"schema_version": 1, "purpose": "region-map-cache"},
+        )
+        atomic_json(metadata, inputs)
+        marker.write_text("{", encoding="utf-8")
+        self.assertFalse(
+            self.workspace._region_map_cache_matches(output, inputs, True)
+        )
 
     def test_exclusive_lock_rejects_concurrent_nonblocking_user(self) -> None:
         lock = self.workspace.paths.builds / "locks" / "test.lock"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -114,6 +114,7 @@ class WorkspaceTests(unittest.TestCase):
         if name == "server":
             (seed / "install_data" / "keys").mkdir(parents=True)
             (seed / "install_data" / "unique-items").mkdir()
+            (seed / "install_data" / "http" / "data").mkdir(parents=True)
             (seed / "install_data" / "keys" / "test.pub").write_text(
                 "key\n", encoding="utf-8"
             )
@@ -122,6 +123,9 @@ class WorkspaceTests(unittest.TestCase):
             )
             (seed / "install_data" / "bans").write_text("", encoding="utf-8")
             (seed / "install_data" / "motd").write_text("Welcome\n", encoding="utf-8")
+            (seed / "install_data" / "http" / "data" / "listing.txt").write_text(
+                "assets\n", encoding="utf-8"
+            )
         command("git", "add", ".", cwd=seed)
         command("git", "commit", "-m", "feat: seed", cwd=seed)
         command("git", "remote", "add", "origin", str(origin), cwd=seed)
@@ -159,6 +163,20 @@ class WorkspaceTests(unittest.TestCase):
                 "dirty": False,
             }
         return resolved
+
+    @staticmethod
+    def make_region_map_cache(root: Path) -> Path:
+        output = root / "runtime" / "client-maps"
+        output.mkdir(parents=True)
+        (output / "incuna_-1.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+        (output / "incuna_-1.def").write_text(
+            "pixel_size 4\n", encoding="utf-8"
+        )
+        atomic_json(
+            output / MANAGED_MARKER,
+            {"schema_version": 1, "purpose": "region-map-cache"},
+        )
+        return output
 
     def advance_origin(self, name: str, filename: str) -> str:
         seed = self.seeds[name]
@@ -645,6 +663,63 @@ class WorkspaceTests(unittest.TestCase):
 
         self.assertEqual((output / "sentinel").read_text(encoding="utf-8"), "last good\n")
 
+    def test_region_maps_are_atomic_cached_and_keyed_by_clean_inputs(self) -> None:
+        source = self.workspace.paths.repositories / "server"
+        (source / "tools").mkdir()
+        for name in ("ca-bundle.crt", "permissions.cfg", "server.cfg"):
+            (source / name).write_text("test\n", encoding="utf-8")
+        command("git", "add", ".", cwd=source)
+        command("git", "commit", "-m", "test: add runtime inputs", cwd=source)
+
+        root = self.workspace.paths.builds / "profiles" / "test"
+        managed_directory(root, self.workspace.paths.builds, "test-profile")
+        binary = root / "build" / "server"
+        binary.mkdir(parents=True)
+        executable = binary / "atrinik-server"
+        executable.write_text(
+            "#!/usr/bin/env python3\n"
+            "from pathlib import Path\n"
+            "import sys\n"
+            "binary = Path(__file__).resolve()\n"
+            "counter = binary.with_name('worldmaker-count')\n"
+            "count = int(counter.read_text()) + 1 if counter.exists() else 1\n"
+            "counter.write_text(str(count))\n"
+            "http = Path(next(arg.split('=', 1)[1] for arg in sys.argv "
+            "if arg.startswith('--httppath=')))\n"
+            "output = http / 'client-maps'\n"
+            "output.mkdir(parents=True)\n"
+            "(output / 'incuna_-1.png').write_bytes(b'\\x89PNG\\r\\n\\x1a\\n')\n"
+            "(output / 'incuna_-1.def').write_text('pixel_size 4\\n')\n",
+            encoding="utf-8",
+        )
+        executable.chmod(0o755)
+        for name in ("libplugin_arena.so", "libplugin_python.so"):
+            (binary / name).write_text("test\n", encoding="utf-8")
+        for path in (
+            root / "runtime" / "content" / "lib",
+            root / "runtime" / "content" / "maps",
+            root / "runtime" / "resources",
+        ):
+            path.mkdir(parents=True, exist_ok=True)
+        selected = {
+            role: self.workspace.paths.repositories / role
+            for role in ("server", "content", "resources")
+        }
+
+        output = self.workspace._generate_region_maps(root, "default", selected)
+        self.workspace._generate_region_maps(root, "default", selected)
+
+        self.assertEqual((binary / "worldmaker-count").read_text(), "1")
+        self.assertTrue((output / "incuna_-1.png").is_file())
+        previous = (output / "incuna_-1.def").read_text(encoding="utf-8")
+        (source / "README").write_text("dirty input\n", encoding="utf-8")
+        executable.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+        with self.assertRaisesRegex(WorkspaceError, "command failed"):
+            self.workspace._generate_region_maps(root, "default", selected)
+        self.assertEqual(
+            (output / "incuna_-1.def").read_text(encoding="utf-8"), previous
+        )
+
     def test_exclusive_lock_rejects_concurrent_nonblocking_user(self) -> None:
         lock = self.workspace.paths.builds / "locks" / "test.lock"
         with exclusive_lock(lock, "test resource"):
@@ -739,10 +814,11 @@ class WorkspaceTests(unittest.TestCase):
             root / "runtime" / "resources",
         ):
             path.mkdir(parents=True, exist_ok=True)
+        self.make_region_map_cache(root)
         state_one = self.root / "state-one"
         state_two = self.root / "state-two"
-        state_one.mkdir()
-        state_two.mkdir()
+        (state_one / "http" / "data").mkdir(parents=True)
+        (state_two / "http" / "data").mkdir(parents=True)
 
         first = self.workspace._prepare_server_runtime(
             root, {"server": source}, state_one, "one"
@@ -754,6 +830,10 @@ class WorkspaceTests(unittest.TestCase):
         self.assertNotEqual(first, second)
         self.assertTrue((first / "data").is_symlink())
         self.assertEqual((second / "data").resolve(), state_two)
+        self.assertEqual(
+            (first / "http" / "client-maps").resolve(),
+            root / "runtime" / "client-maps",
+        )
 
     def test_topology_summary_resolves_service_dependency_closure(self) -> None:
         summary = self.workspace.topology_summary(
@@ -899,6 +979,7 @@ class WorkspaceTests(unittest.TestCase):
             build_root / "runtime" / "resources" / MANAGED_MARKER,
             {"schema_version": 1, "purpose": "resource-view"},
         )
+        self.make_region_map_cache(build_root)
         client = build_root / "build" / "client" / "atrinik"
         client.parent.mkdir(parents=True)
         (build_root / "sources" / "client").mkdir(parents=True)
@@ -937,6 +1018,19 @@ class WorkspaceTests(unittest.TestCase):
             / "content"
             / "maps",
         )
+        topology_maps = (
+            self.workspace.paths.topologies
+            / "server-review"
+            / "runtime"
+            / "client-maps"
+        )
+        self.assertTrue((topology_maps / "incuna_-1.png").is_file())
+        self.assertEqual(
+            (server_runtime / "http" / "client-maps").resolve(), topology_maps
+        )
+        self.assertTrue(
+            (build_root / "runtime" / "client-maps" / "incuna_-1.png").is_file()
+        )
         self.assertEqual(
             Path(status["services"]["client"]["cwd"]),
             self.workspace.paths.topologies
@@ -953,6 +1047,9 @@ class WorkspaceTests(unittest.TestCase):
         self.assertIn("'--port_quic=17300'", server_log.read_text())
         self.assertIn("'--port_mapping=off'", server_log.read_text())
         self.assertIn("'--stun_server=off'", server_log.read_text())
+        self.assertIn(
+            f"'--httppath={server_runtime / 'http'}'", server_log.read_text()
+        )
         self.assertIn(
             f"'--server=127.0.0.1 17300 {'a' * 64}'", client_log.read_text()
         )

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -751,6 +751,13 @@ class WorkspaceTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "not a directory"):
             self.workspace._validate_region_maps(output)
 
+        target = self.root / "map-target"
+        target.mkdir()
+        output.symlink_to(target, target_is_directory=True)
+        with self.assertRaisesRegex(WorkspaceError, "not a directory"):
+            self.workspace._validate_region_maps(output)
+        output.unlink()
+
         reset()
         with self.assertRaisesRegex(WorkspaceError, "lack required"):
             self.workspace._validate_region_maps(output)
@@ -801,6 +808,12 @@ class WorkspaceTests(unittest.TestCase):
         marker.unlink()
         self.assertFalse(
             self.workspace._region_map_cache_matches(output, inputs, True)
+        )
+
+        linked_output = self.root / "linked-maps"
+        linked_output.symlink_to(output, target_is_directory=True)
+        self.assertFalse(
+            self.workspace._region_map_cache_matches(linked_output, inputs, True)
         )
 
         atomic_json(
@@ -908,6 +921,22 @@ class WorkspaceTests(unittest.TestCase):
         ):
             path.mkdir(parents=True, exist_ok=True)
         self.make_region_map_cache(root)
+        missing_http_state = self.root / "state-missing-http"
+        with self.assertRaisesRegex(WorkspaceError, "lacks required HTTP data"):
+            self.workspace._prepare_server_runtime(
+                root, {"server": source}, missing_http_state, "missing-http"
+            )
+        linked_http_state = self.root / "state-linked-http"
+        (linked_http_state / "http").mkdir(parents=True)
+        http_target = self.root / "http-target"
+        http_target.mkdir()
+        (linked_http_state / "http" / "data").symlink_to(
+            http_target, target_is_directory=True
+        )
+        with self.assertRaisesRegex(WorkspaceError, "lacks required HTTP data"):
+            self.workspace._prepare_server_runtime(
+                root, {"server": source}, linked_http_state, "linked-http"
+            )
         state_one = self.root / "state-one"
         state_two = self.root / "state-two"
         (state_one / "http" / "data").mkdir(parents=True)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -712,13 +712,69 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual((binary / "worldmaker-count").read_text(), "1")
         self.assertTrue((output / "incuna_-1.png").is_file())
         previous = (output / "incuna_-1.def").read_text(encoding="utf-8")
-        (source / "README").write_text("dirty input\n", encoding="utf-8")
+        atomic_json(output / ".atrinik-region-maps.json", {"stale": True})
+
+        def mutate_after_generation(
+            arguments: list[str], **kwargs: object
+        ) -> str:
+            result = workspace_run(arguments, **kwargs)
+            if Path(arguments[0]).resolve() == executable:
+                (source / "README").write_text(
+                    "dirty input\n", encoding="utf-8"
+                )
+            return result
+
+        with mock.patch(
+            "atrinik_workspace.workspace.run", side_effect=mutate_after_generation
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "changed during generation"):
+                self.workspace._generate_region_maps(root, "default", selected)
+        self.assertEqual(
+            (output / "incuna_-1.def").read_text(encoding="utf-8"), previous
+        )
+
         executable.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
         with self.assertRaisesRegex(WorkspaceError, "command failed"):
             self.workspace._generate_region_maps(root, "default", selected)
         self.assertEqual(
             (output / "incuna_-1.def").read_text(encoding="utf-8"), previous
         )
+
+    def test_region_map_validation_rejects_malformed_outputs(self) -> None:
+        output = self.root / "client-maps"
+
+        def reset() -> None:
+            if output.exists():
+                shutil.rmtree(output)
+            output.mkdir()
+
+        reset()
+        with self.assertRaisesRegex(WorkspaceError, "lack required"):
+            self.workspace._validate_region_maps(output)
+
+        (output / "incuna_-1.def").write_text("pixel_size 4\n", encoding="utf-8")
+        with self.assertRaisesRegex(WorkspaceError, "pairs are incomplete"):
+            self.workspace._validate_region_maps(output)
+
+        (output / "incuna_-1.png").write_bytes(b"not a png")
+        with self.assertRaisesRegex(WorkspaceError, "not a PNG"):
+            self.workspace._validate_region_maps(output)
+
+        (output / "incuna_-1.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+        (output / "incuna_-1.def").write_bytes(b"\xff")
+        with self.assertRaisesRegex(WorkspaceError, "not UTF-8"):
+            self.workspace._validate_region_maps(output)
+
+        reset()
+        (output / "unexpected").mkdir()
+        with self.assertRaisesRegex(WorkspaceError, "output is invalid"):
+            self.workspace._validate_region_maps(output)
+
+        reset()
+        (output / "incuna_-1.png").write_bytes(b"")
+        (output / "incuna_-1.def").write_text("pixel_size 4\n", encoding="utf-8")
+        with self.assertRaisesRegex(WorkspaceError, "is empty"):
+            self.workspace._validate_region_maps(output)
 
     def test_exclusive_lock_rejects_concurrent_nonblocking_user(self) -> None:
         lock = self.workspace.paths.builds / "locks" / "test.lock"
@@ -1454,7 +1510,11 @@ class WorkspaceTests(unittest.TestCase):
             mock.patch("builtins.print") as output,
         ):
             result = self.workspace.run_server(
-                "default", "default", 1731, ["--no_console"], True
+                "default",
+                "default",
+                1731,
+                ["--no_console", "--httppath=/tmp/untrusted"],
+                True,
             )
 
         self.assertEqual(result, executable)
@@ -1463,6 +1523,10 @@ class WorkspaceTests(unittest.TestCase):
         self.assertIn("--port_mapping=off", rendered)
         self.assertIn("--stun_server=off", rendered)
         self.assertIn("--no_console", rendered)
+        self.assertLess(
+            rendered.index("--httppath=/tmp/untrusted"),
+            rendered.index(f"--httppath={runtime / 'http'}"),
+        )
 
     def test_foreground_launch_rejects_invalid_port(self) -> None:
         with self.assertRaisesRegex(WorkspaceError, "between 1 and 65535"):


### PR DESCRIPTION
## Summary

- generate Classic region maps in an isolated offline worldmaker runtime
- validate and atomically cache complete map pairs by clean selected revisions
- expose maps through disposable server HTTP roots and topology-owned snapshots
- document generation, invalidation, state safety, and cleanup

## Validation

- `python3 -m coverage run -m unittest discover -v` (296 tests)
- real `classic` server build and CTest (34/34), worldmaker generation, and clean cache hit
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `git diff --check`

Closes #302
