### PR TITLE
feat(workspace): register the playtester component

### DIFF
--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -7,23 +7,23 @@ description: Coordinate work across checkouts, profiles, worktrees, cleanup, rel
 
 ## Resolve scope and ownership
 
-Run commands from the `atrinik/atrinik` wrapper root.
+Run from the `atrinik/atrinik` wrapper root.
 
-1. Read root `AGENTS.md` and only task-relevant wrapper sources:
+1. Read root `AGENTS.md` and task-relevant wrapper sources:
    - ownership, cohorts, roles, and build contracts: `components.json`;
    - operator behavior: the matching `README.md` section;
    - layout, locking, trust, and lifecycle design: the matching
      `docs/ARCHITECTURE.md` section;
    - pre-split repositories: [repository migration](references/repository-migration.md).
-2. Resolve each logical component to its physical checkout and safe source root;
+2. Resolve each component to its physical checkout and safe source root;
    read that checkout's nearest `AGENTS.md` before editing.
 3. Keep implementation, tests, packages, and releases in the physical owner;
    keep only orchestration, composition, manifest, and wrapper docs here.
 
-Checkouts are independent ignored Git repositories. One `classic` worktree
-contains all five `classic-*` components; `content@main` and `content-1x@1.x`
-are separate checkouts. Keep wrapper VS Code composition under `.devcontainer/`
-and reusable images in the `devcontainer` checkout.
+Checkouts are independent ignored repositories. A `classic` worktree contains
+all five `classic-*` components; `content@main` and `content-1x@1.x` stay
+separate. Keep wrapper composition in `.devcontainer/` and reusable images in
+the `devcontainer` checkout.
 
 ## Prepare safe worktrees
 
@@ -46,12 +46,12 @@ clones.
 ./atrinik worktree create COMPONENT LABEL --branch TYPE/TOPIC
 ```
 
-Synchronize only clean primaries; never implicitly replace, move, or remove a
+Sync only clean primaries; never implicitly replace, move, or remove a
 dirty checkout or worktree. A logical classic selector creates the full
 repository under `workspace/worktrees/classic/LABEL`. Commit and push from each
 owning worktree.
 
-Reclaim completed review data only through preview-first cleanup:
+Reclaim review data only through preview-first cleanup:
 
 ```sh
 ./atrinik cleanup --dry-run --json
@@ -89,8 +89,8 @@ wrapper replacement build/runtime closure yet.
 ./atrinik build COMPONENT --profile REVIEW --test
 ```
 
-Selecting `classic`, its components, or its roles updates all five selectors to
-one root. Never treat a classic subdirectory as an independent worktree.
+Selecting `classic`, its components, or roles updates all five selectors to one
+root. Classic subdirectories are not independent worktrees.
 
 Classic server builds cache validated region maps only for matching clean
 inputs; dirty inputs regenerate. Runtimes do not overlay state, and topologies

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 /libatrinik/
 /metaserver-worker/
 /protocol/
+/playtester/
 /renderer/
 /resources/
 /server/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,32 +2,33 @@
 
 ## Overview
 
-- This MIT Python 3.11+ repository coordinates independent Atrinik Git
-  repositories, not component source. `./atrinik` and `components.json` manage
-  profiles, worktrees, builds, supervised runtimes, cleanup, migration, and
-  supply-chain reports.
+- This MIT Python 3.11+ repository coordinates Atrinik repositories, not
+  component source.
+  `./atrinik` and `components.json` manage profiles, worktrees, builds, runtimes,
+  cleanup, migration, and supply-chain reports.
 - `default` selects the MIT replacement stack (Rust, Go, Protobuf, and Astro).
   Its standalone M1 foundations lack wrapper build/runtime integration.
-  `classic` selects the playable C17/CMake/Ninja stack. Never mix providers or
-  route unavailable replacement adapters through classic.
+  `classic` selects playable C17/CMake/Ninja plus the MIT playtester. Never mix
+  providers or route unavailable replacement adapters through classic.
 
 ## Folder structure and ownership
 
-- `atrinik` is the CLI; `atrinik_workspace/` owns orchestration and `tests/` the
-  standard-library `unittest` suite.
+- `atrinik` is the CLI, `atrinik_workspace/` owns orchestration, and `tests/`
+  the `unittest` suite.
 - Checkout, cohort, stack, role, source, and build contracts live in
   `components.json`; machine policy in `supply-chain/` and `governance/`; longer
   guidance in `docs/`, `README.md`, and `CONTRIBUTING.md`.
-- Task workflows live in `.agents/skills/`, workspace composition in
-  `.devcontainer/`, CI/release in `.github/`, and helpers in `scripts/`.
-- Manifest destinations such as `client/`, `server/`, and `classic/` are
-  independent ignored repositories; `workspace/` and `build/` are ignored
-  generated state. Root `git status` omits them.
-- Resolve ownership through `components.json` and the owning checkout's nearest
-  `AGENTS.md`. Keep implementation, tests, packages, and component releases in
-  that physical repository.
-- The `classic/` monorepo provides five `classic-*` components. `content/` is
-  `atrinik/content@main`; `content-1x/` is its separate `1.x` checkout.
+- Workflows live in `.agents/skills/`, composition in `.devcontainer/`,
+  CI/release in `.github/`, and helpers in `scripts/`.
+- Manifest destinations (`client/`, `server/`, `classic/`) are independent
+  ignored repositories; `workspace/` and `build/` are ignored generated state,
+  so root `git status` omits them.
+- Resolve ownership through `components.json` and the checkout's nearest
+  `AGENTS.md`; keep implementation, tests, packages, and releases there.
+- `classic/` provides five `classic-*` components. `content/` is
+  `atrinik/content@main`; `content-1x/` its `1.x` checkout. `playtester/` is
+  classic-only `atrinik/playtester` with wrapper `build: none` and
+  repository-owned validation.
   `.devcontainer/` owns wrapper composition and `devcontainer/` reusable images.
 
 ## Core behaviors and patterns
@@ -40,15 +41,14 @@
   issue-to-ready-PR delivery; it stops before merge.
 - Never replace or move a dirty primary checkout, remove a dirty worktree, or
   overwrite mutable server data. Preserve recoverable migration inputs.
-- Cleanup is explicit and preview-first. Run
+- Cleanup is explicit and preview-first: run
   `./atrinik cleanup --dry-run --json` before the same scoped `--apply`; never
-  invoke cleanup implicitly.
-  Preserve dirty, detached, locked, active, referenced, or uncertain targets.
-  Historical eligibility fails closed. The multi-repository skill owns the
-  full cleanup proof and retention contract.
-- A worktree belongs to its physical checkout. Selecting `classic`, any
-  `classic-*` component, or one of its roles selects one root for all five;
-  profile resolution appends each manifest source directory.
+  invoke it implicitly. Preserve dirty, detached, locked, active, referenced,
+  or uncertain targets. Historical eligibility fails closed; the
+  multi-repository skill owns cleanup proof and retention.
+- Worktrees belong to physical checkouts. Selecting `classic`, a `classic-*`
+  component, or one of its roles selects one root for all five; profiles append
+  manifest source directories.
 - Use `./atrinik path`, `topology show`, `up`, `ps`, `logs`, and `down`. Do not
   reconstruct managed build, PID, log, lock, runtime, or state paths. Give
   concurrent topologies distinct names, states, ports, and client config.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,11 +27,14 @@ The canonical `server`, `client`, `editor`, `protocol`, `renderer`,
 `content-toolkit`, and `website` repositories form the MIT replacement stack.
 Plain `./atrinik init` is replacement/default-only. Exact
 `./atrinik init --with classic` adds the complete currently playable classic
-cohort: the `atrinik/classic` monorepo checkout, `content-1x@1.x`, and retained
-GPL tools. The monorepo supplies the logical classic client, server, editor,
-protocol, and libatrinik components from source subdirectories. Do not put
-those checkouts in the default cohort or mix replacement and classic providers
-in one runnable profile. Replacement repositories have validated standalone M1
+cohort: the `atrinik/classic` monorepo checkout, `content-1x@1.x`, the
+independent MIT `atrinik/playtester` checkout, and retained GPL tools. The
+monorepo supplies the logical classic client, server, editor, protocol, and
+libatrinik components from source subdirectories. The playtester remains
+classic-only, has a wrapper `build: none` contract, and owns its installation
+and validation in its physical repository. Do not put those checkouts in the
+default cohort or mix replacement and classic providers in one runnable
+profile. Replacement repositories have validated standalone M1
 foundations; their wrapper build/runtime adapters and integrated service
 closure have not landed, so current game integration uses a profile created
 from `classic`.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository is a small, MIT-licensed coordinator for Atrinik's physical
 repositories and logical components. Each checkout remains a normal Git
 repository with its own branches, remotes, commits, and worktrees. A logical
 component may occupy that checkout's root or a declared source directory. The
-coordinator keeps the MIT replacement stack and the opt-in GPL classic
+coordinator keeps the MIT replacement stack and the opt-in playable classic
 stack as explicit, coherent sets. It supplies one command for safe
 initialization and synchronization, composes worktrees into stack-aware review
 profiles, builds components whose contracts are available, and shares
@@ -38,8 +38,8 @@ Open this wrapper repository in VS Code and choose **Dev Containers: Reopen in
 Container** to use the pinned Linux build environment. On first creation, the
 container runs `./atrinik init`; it clones only missing replacement/default
 repositories and validates existing checkouts without updating or replacing
-them. It never adds classic repositories, `content@1.x`, or GPL tools
-implicitly. The Windows cross-build configuration is available at
+them. It never adds classic repositories, `content@1.x`, the MIT playtester,
+or GPL tools implicitly. The Windows cross-build configuration is available at
 `.devcontainer/windows-cross/devcontainer.json` after the required component
 checkouts have been initialized.
 
@@ -153,7 +153,8 @@ initialization cohort. That includes the replacement MIT `server`, `client`,
 `editor`, `protocol`, `renderer`, `content-toolkit`, and `website` repositories;
 `content` from `atrinik/content@main`; compatible shared resources, sound, and
 metaserver code; and required development infrastructure. It does not clone
-`atrinik/classic`, `atrinik/content@1.x`, or the GPL `tools` repository.
+`atrinik/classic`, `atrinik/content@1.x`, `atrinik/playtester`, or the GPL
+`tools` repository.
 The replacement repositories have independently validated M1 build, package,
 provenance, and dependency contracts. Their wrapper manifest build/runtime
 adapters and complete service integration have not landed, so `default` is
@@ -194,13 +195,20 @@ the next time that topology name is launched.
 `--with classic` has one exact meaning: add the complete classic initialization
 cohort to the replacement/default cohort. It is not a classic-only mode. The
 cohort consists of one `atrinik/classic` checkout, a distinct `content-1x`
-checkout of `atrinik/content@1.x`, and the retained GPL `tools` repository.
+checkout of `atrinik/content@1.x`, the MIT `atrinik/playtester` checkout, and
+the retained GPL `tools` repository.
 The classic monorepo supplies logical `classic-server`, `classic-client`,
 `classic-editor`, `classic-libatrinik`, and `classic-protocol` components from
 its `server/`, `client/`, `editor/`, `libatrinik/`, and `protocol/` source
 directories. Compatible shared assets and infrastructure are reused from the
 default cohort. Rerunning either initialization mode is idempotent and never
 updates, rebranches, replaces, or repurposes an existing checkout.
+
+The `playtester` logical component provides the classic-only `playtester` role
+and declares `content`, `libatrinik`, and `protocol` inputs. Its wrapper build
+contract is `none`: initialization, profiles, worktrees, and supply-chain
+identity are coordinated here, while installation and tests remain owned by
+`atrinik/playtester`.
 
 Checkout entries have explicit local destinations; normally these are direct
 children of the wrapper root such as `./client`, `./classic`, `./content`, and
@@ -220,9 +228,9 @@ checkouts are reported as optional rather than invalidating status or a
 built-in profile.
 
 The manifest assigns logical roles such as `client`, `server`, `protocol`,
-`libatrinik`, and `content` to providers within each stack. The built-in
-`default` and `classic` profiles resolve exactly one compatible provider for
-every role they require.
+`libatrinik`, `content`, and `playtester` to providers within each stack. The
+built-in `default` and `classic` profiles resolve exactly one compatible
+provider for every role they require.
 A runnable service closure cannot combine replacement and classic
 implementations; shared read-only repositories are reusable only where the
 manifest declares them compatible.

--- a/atrinik_workspace/migration.py
+++ b/atrinik_workspace/migration.py
@@ -3024,6 +3024,7 @@ class RepositoryMigration:
                 "classic-libatrinik",
                 "classic-protocol",
                 "content-1x",
+                "playtester",
                 "tools",
                 "sound",
                 "resources",

--- a/atrinik_workspace/model.py
+++ b/atrinik_workspace/model.py
@@ -62,6 +62,7 @@ REQUIRED_COHORT_CHECKOUTS = {
     "classic": {
         "classic",
         "content-1x",
+        "playtester",
         "tools",
     },
 }
@@ -88,6 +89,7 @@ REQUIRED_STACK_PROVIDERS = {
         "libatrinik": "classic-libatrinik",
         "editor": "classic-editor",
         "content": "content-1x",
+        "playtester": "playtester",
         "tools": "tools",
         "sound": "sound",
         "resources": "resources",
@@ -106,6 +108,7 @@ LOGICAL_ROLES = {
     "content-toolkit",
     "website",
     "content",
+    "playtester",
     "tools",
     "sound",
     "resources",

--- a/components.json
+++ b/components.json
@@ -19,6 +19,7 @@
     "classic": [
       "classic",
       "content-1x",
+      "playtester",
       "tools"
     ]
   },
@@ -65,6 +66,7 @@
         "classic-libatrinik",
         "classic-editor",
         "content-1x",
+        "playtester",
         "tools",
         "sound",
         "resources",
@@ -79,6 +81,7 @@
         "libatrinik": "classic-libatrinik",
         "editor": "classic-editor",
         "content": "content-1x",
+        "playtester": "playtester",
         "tools": "tools",
         "sound": "sound",
         "resources": "resources",
@@ -208,6 +211,14 @@
       "path": "content-1x",
       "generation": "classic",
       "license": "LicenseRef-Atrinik-Content"
+    },
+    {
+      "name": "playtester",
+      "repository": "atrinik/playtester",
+      "branch": "main",
+      "path": "playtester",
+      "generation": "classic",
+      "license": "MIT"
     },
     {
       "name": "tools",
@@ -408,6 +419,16 @@
       "provides": ["content"],
       "requires": [],
       "license": "LicenseRef-Atrinik-Content"
+    },
+    {
+      "name": "playtester",
+      "checkout": "playtester",
+      "source": ".",
+      "build": "none",
+      "generation": "classic",
+      "provides": ["playtester"],
+      "requires": ["content", "libatrinik", "protocol"],
+      "license": "MIT"
     },
     {
       "name": "tools",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,6 +33,10 @@ components: `classic-client` from `client/`, `classic-server` from `server/`,
 `classic-protocol` from `protocol/`. `content` remains
 `atrinik/content@main` at `./content` for the replacement stack, while
 `content-1x` is `atrinik/content@1.x` at `./content-1x` for the classic stack.
+The classic-only `playtester` component occupies `atrinik/playtester@main` at
+`./playtester`, provides the `playtester` role, and requires the classic stack's
+`content`, `libatrinik`, and `protocol` providers. Its `build: none` contract
+keeps repository-owned installation and validation outside wrapper adapters.
 
 Manifest validation rejects duplicate checkout or component names, duplicate
 local destinations, unsafe or overlapping source roots within one checkout,
@@ -140,12 +144,12 @@ public HTTPS is the fallback when the wrapper has no recognized GitHub remote.
 With no explicit arguments, initialization resolves only the
 replacement/default cohort. `init --with classic` resolves the union of the
 default and classic cohorts; the option is additive and has no classic-only
-alias. The `classic` monorepo, GPL `tools`, and `content-1x@1.x` are absent from
-ordinary initialization. Explicit checkout or logical-component
-initialization remains available for partial workspaces. Aliases that own one
-physical checkout are deduplicated. Initialization is idempotent, stages clones
-away from their destination, and does not update or repurpose an existing
-checkout.
+alias. The `classic` monorepo, GPL `tools`, MIT `playtester`, and
+`content-1x@1.x` are absent from ordinary initialization. Explicit checkout or
+logical-component initialization remains available for partial workspaces.
+Aliases that own one physical checkout are deduplicated. Initialization is
+idempotent, stages clones away from their destination, and does not update or
+repurpose an existing checkout.
 
 Synchronization is intentionally narrower than initialization. With no names
 it visits only already-initialized default-cohort primaries; `--with classic`

--- a/docs/CLASSIC_TOOLS_MIGRATION.md
+++ b/docs/CLASSIC_TOOLS_MIGRATION.md
@@ -9,7 +9,7 @@ select it nor depend on it for a build or runtime.
 
 | Old command/workflow | Replacement or removal | Owner and gate |
 | --- | --- | --- |
-| `python3 -m atrinik_bot` and bot utilities | Migrate policy to the released local automation SDK and headless client, then remove the duplicate transport/model | `atrinik/client#18`, M4 |
+| `python3 -m atrinik_bot` and bot utilities | Move to the standalone MIT playtester; retain the Classic backend behind a narrow interface and expand toward an unattended full-game run | `atrinik/playtester#1`, M1 |
 | Gridarta type/material converters | Bounded editor import/conversion commands | `atrinik/editor#11`, M4 |
 | `python3 map-checker-qt/map-checker.py --cli` | `atrinik-content check`; retain the Qt checker until diagnostic parity | `atrinik/content-toolkit#8`, M4 |
 | Python 2/PyGTK map checker | Retire; use the Qt checker during migration | `atrinik/content-toolkit#8`, M4 |
@@ -20,8 +20,12 @@ select it nor depend on it for a build or runtime.
 | `php -S ... -t worldviewer` | Deterministic renderer imagery and projection metadata | `atrinik/renderer#13`, M6 |
 
 The JSON record is authoritative for paths, consumers, inputs, outputs, current
-usage, license method, security controls, and exact verification. A replacement
-owner may use behavior and fixtures as public compatibility evidence, but may
+usage, license method, security controls, and exact verification. Zoey Rose has
+directly granted MIT relicensing for the wholly authored `atrinik_bot` source,
+so its destination owner is `atrinik/playtester`. That grant does not relicense
+the separately fetched GPL libatrinik source or any combined binary; those
+obligations remain explicit in the supply-chain inventory. Other replacement
+owners may use behavior and fixtures as public compatibility evidence, but may
 not translate mixed GPL implementation. A provenance grant is considered only
 after the full root process in
 [`REPLACEMENT_FOUNDATIONS.md`](REPLACEMENT_FOUNDATIONS.md) proves a separable
@@ -48,4 +52,3 @@ critical-maintenance boundary and duplicated the released MIT client
 foundation. It was not silently merged. The former repositories remain
 archived read-only; the wrapper migration retains recoverable local work and
 the supply-chain catalog resolves active module paths through `atrinik/classic`.
-

--- a/governance/classic-tools.json
+++ b/governance/classic-tools.json
@@ -22,15 +22,15 @@
       "purpose": "Headless classic client automation, navigation policy, and loopback dashboard.",
       "inputs": ["classic game service", "content runtime", "protocol bindings", "pathfinding library"],
       "outputs": ["player actions", "bot state", "operator dashboard", "benchmarks"],
-      "current_usage": ".github/workflows/check.yml builds and tests the bot; direct protocol operation remains a classic-only operator workflow.",
-      "owner_repository": "atrinik/client",
-      "owner_issue": "https://github.com/atrinik/client/issues/18",
-      "owner_milestone": "M4 — Shared editor and scalable presentation",
+      "current_usage": "Migration to atrinik/playtester preserves direct Classic protocol operation as a classic-only operator workflow.",
+      "owner_repository": "atrinik/playtester",
+      "owner_issue": "https://github.com/atrinik/playtester/issues/1",
+      "owner_milestone": "M1 — Standalone runner",
       "disposition": "migrate-then-retire",
-      "replacement_command": "Future released client automation SDK and headless-client command from atrinik/client#18.",
-      "licensing_method": "Keep the GPL implementation in tools. Treat behavior as public specification only unless a later path-level grant record proves complete history, sole authorship, identity, and embedded-material eligibility.",
+      "replacement_command": "The independently released atrinik/playtester command; a future client automation SDK may become an additional backend without owning campaign policy.",
+      "licensing_method": "Zoey Rose directly granted MIT relicensing for the wholly authored bot source. Keep the fetched GPL-2.0-or-later libatrinik dependency separate and report its combined-binary obligations.",
       "safety": "Do not expose its loopback control service remotely; isolate credentials and mutable memory; remove its duplicate transport and decoder after API parity.",
-      "verification": "cmake -S atrinik_bot -B build/atrinik-bot -G Ninja -DBUILD_TESTING=ON && cmake --build build/atrinik-bot && ctest --test-dir build/atrinik-bot --output-on-failure"
+      "verification": "Run the repository-owned CMake, native pathfinding, Python regression, and content-identity checks in atrinik/playtester."
     },
     {
       "id": "gridarta-converters",

--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -355,6 +355,28 @@
       "audit_mode": "full",
       "branch": "main",
       "cohorts": [
+        "classic"
+      ],
+      "license": "MIT",
+      "commit": null,
+      "name": "playtester",
+      "repository": "atrinik/playtester",
+      "role": "MIT autonomous end-to-end playtester for the classic game",
+      "roles": [
+        "playtester"
+      ],
+      "stacks": [
+        "classic"
+      ],
+      "supported": true,
+      "checkout": "playtester",
+      "source": "."
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
         "default"
       ],
       "license": "MIT",
@@ -586,6 +608,7 @@
         "editor",
         "github-settings",
         "metaserver-worker",
+        "playtester",
         "protocol",
         "renderer",
         "resources",
@@ -632,6 +655,16 @@
         },
         {
           "repository": "editor",
+          "path": ".github/workflows/validate.yml",
+          "contains": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1"
+        },
+        {
+          "repository": "playtester",
+          "path": ".github/workflows/release.yml",
+          "contains": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1"
+        },
+        {
+          "repository": "playtester",
           "path": ".github/workflows/validate.yml",
           "contains": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1"
         },
@@ -763,6 +796,7 @@
         "editor",
         "github-settings",
         "metaserver-worker",
+        "playtester",
         "protocol",
         "renderer",
         "resources",
@@ -829,6 +863,11 @@
         },
         {
           "repository": "github-settings",
+          "path": ".github/workflows/release.yml",
+          "contains": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0"
+        },
+        {
+          "repository": "playtester",
           "path": ".github/workflows/release.yml",
           "contains": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0"
         },
@@ -1652,7 +1691,8 @@
       "owner": "atrinik",
       "scope": [
         "atrinik",
-        "classic"
+        "classic",
+        "playtester"
       ],
       "required": true,
       "version": "9.3.1",
@@ -1681,6 +1721,11 @@
           "repository": "classic",
           "path": ".github/workflows/release.yml",
           "contains": "--package=conventional-changelog-conventionalcommits@9.3.1"
+        },
+        {
+          "repository": "playtester",
+          "path": ".github/workflows/release.yml",
+          "contains": "--package=conventional-changelog-conventionalcommits@9.3.1"
         }
       ]
     },
@@ -1691,7 +1736,8 @@
       "owner": "atrinik",
       "scope": [
         "atrinik",
-        "classic"
+        "classic",
+        "playtester"
       ],
       "required": true,
       "version": "25.0.9",
@@ -1720,6 +1766,16 @@
           "repository": "classic",
           "path": ".github/workflows/release.yml",
           "contains": "--package=semantic-release@25.0.9"
+        },
+        {
+          "repository": "playtester",
+          "path": ".github/workflows/release.yml",
+          "contains": "--package=semantic-release@25.0.9"
+        },
+        {
+          "repository": "playtester",
+          "path": ".releaserc.json",
+          "contains": "\"@semantic-release/github\""
         }
       ]
     },
@@ -1882,6 +1938,31 @@
           "path": "package.json",
           "contains": "\"wrangler\": \"^4.118.0\""
         }
+      ]
+    },
+    {
+      "id": "language/playtester-python",
+      "name": "Playtester Python package graph",
+      "kind": "language-package-set",
+      "owner": "playtester",
+      "scope": ["playtester"],
+      "required": true,
+      "version": "Python>=3.11; scikit-build-core>=0.10; aioquic>=1.2",
+      "version_source": "pyproject.toml",
+      "license": "NOASSERTION",
+      "source_url": "https://pypi.org/",
+      "locator": "pkg:pypi/atrinik-playtester@0.1.0",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Python build isolation and optional operator environment install declared packages",
+      "update_cadence_days": 30,
+      "update_mechanism": "Dependabot pip review and playtester build/test validation",
+      "eol_response": "Upgrade or replace the playtester package dependency before EOL",
+      "validation": "CMake strict build, native/Python tests, compileall, and loopback security checks",
+      "disposition": "retain",
+      "packages": ["aioquic", "atrinik-protocol", "scikit-build-core"],
+      "evidence": [
+        {"repository":"playtester","path":"pyproject.toml","contains":"scikit-build-core>=0.10"}
       ]
     },
     {
@@ -2164,31 +2245,6 @@
       ]
     },
     {
-      "id": "language/tools-bot-python",
-      "name": "Classic bot Python package graph",
-      "kind": "language-package-set",
-      "owner": "tools",
-      "scope": ["tools"],
-      "required": true,
-      "version": "Python>=3.11; scikit-build-core>=0.10; aioquic>=1.2",
-      "version_source": "atrinik_bot/pyproject.toml",
-      "license": "NOASSERTION",
-      "source_url": "https://pypi.org/",
-      "locator": "pkg:pypi/atrinik-bot@0.1.0",
-      "commit": null,
-      "checksum": null,
-      "acquisition": "Python build isolation and optional operator environment install declared packages",
-      "update_cadence_days": 30,
-      "update_mechanism": "Dependabot pip review and classic bot build/test validation",
-      "eol_response": "Upgrade, replace, or retire the classic-only bot package before dependency EOL",
-      "validation": "CMake strict build, native/Python tests, compileall, and loopback security checks",
-      "disposition": "replace",
-      "packages": ["aioquic", "atrinik-protocol", "scikit-build-core"],
-      "evidence": [
-        {"repository":"tools","path":"atrinik_bot/pyproject.toml","contains":"scikit-build-core>=0.10"}
-      ]
-    },
-    {
       "id": "language/wrapper-python-development",
       "name": "Workspace Python development dependencies",
       "kind": "language-package-set",
@@ -2222,13 +2278,43 @@
       ]
     },
     {
+      "id": "source/atrinik-content-playtester",
+      "name": "Atrinik content source for playtester world planning",
+      "kind": "source-archive",
+      "owner": "content-1x",
+      "scope": [
+        "playtester"
+      ],
+      "required": true,
+      "version": "v1.8.0",
+      "version_source": "dependencies.lock.json content input",
+      "license": "LicenseRef-Atrinik-Content",
+      "source_url": "https://github.com/atrinik/content/releases/tag/v1.8.0",
+      "locator": "pkg:github/atrinik/content@v1.8.0",
+      "commit": "96073eeff1854fc29347fdafd32e622394f24c07",
+      "checksum": null,
+      "acquisition": "The playtester verifies the exact content release commit before compiling world and runtime inputs",
+      "update_cadence_days": 30,
+      "update_mechanism": "Reviewed content compatibility update with complete playtester regression validation",
+      "eol_response": "Advance to a supported content release before removing the pinned compatibility baseline",
+      "validation": "Content identity verification, world-graph compilation, runtime asset loading, and playtester regression tests",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "playtester",
+          "path": "dependencies.lock.json",
+          "contains": "96073eeff1854fc29347fdafd32e622394f24c07"
+        }
+      ]
+    },
+    {
       "id": "source/atrinik-content-runtime",
       "name": "Atrinik content runtime archive",
       "kind": "source-archive",
       "owner": "content",
       "scope": [
-        "classic-server",
-        "tools"
+        "classic-server"
       ],
       "required": true,
       "version": "v1.2.0",
@@ -2285,13 +2371,48 @@
       ]
     },
     {
+      "id": "source/atrinik-libatrinik-playtester",
+      "name": "Archived classic libatrinik release source for the playtester",
+      "kind": "source-archive",
+      "owner": "playtester",
+      "scope": [
+        "playtester"
+      ],
+      "required": true,
+      "version": "v1.1.5",
+      "version_source": "CMakeLists.txt FetchContent declaration",
+      "license": "GPL-2.0-or-later",
+      "source_url": "https://github.com/atrinik/legacy-libatrinik/releases/tag/v1.1.5",
+      "locator": "pkg:github/atrinik/legacy-libatrinik@v1.1.5",
+      "commit": "4c3410063972ea22689b66ad7dd8c7949cc1fbff",
+      "checksum": "sha256:3c07b178cc236881f52272df6e38bc2d4186943b782e4cee34b2e733da9c8f9a",
+      "acquisition": "CMake FetchContent downloads the checksum-pinned release archive",
+      "update_cadence_days": 30,
+      "update_mechanism": "Reviewed pathfinding compatibility update and complete playtester regression validation",
+      "eol_response": "Update or replace the pathfinding dependency before its archived release becomes unusable",
+      "validation": "CMake lock validation, native pathfinding tests, and playtester Python regression tests",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "playtester",
+          "path": "CMakeLists.txt",
+          "contains": "libatrinik-1.1.5.tar.gz"
+        },
+        {
+          "repository": "playtester",
+          "path": "dependencies.lock.json",
+          "contains": "3c07b178cc236881f52272df6e38bc2d4186943b782e4cee34b2e733da9c8f9a"
+        }
+      ]
+    },
+    {
       "id": "source/atrinik-libatrinik-server",
       "name": "Archived classic libatrinik release source for the classic server",
       "kind": "source-archive",
       "owner": "classic-server",
       "scope": [
-        "classic-server",
-        "tools"
+        "classic-server"
       ],
       "required": true,
       "version": "v1.1.5",
@@ -2313,37 +2434,7 @@
           "repository": "classic-server",
           "path": "cmake/dependencies.lock.json",
           "contains": "libatrinik-1.1.5.tar.gz"
-        },
-        {
-          "repository": "tools",
-          "path": "atrinik_bot/CMakeLists.txt",
-          "contains": "libatrinik-1.1.5.tar.gz"
         }
-      ]
-    },
-    {
-      "id": "source/atrinik-protocol-bot",
-      "name": "Atrinik protocol Python wheel for the classic bot",
-      "kind": "source-archive",
-      "owner": "tools",
-      "scope": ["tools"],
-      "required": true,
-      "version": "v1.0.9",
-      "version_source": "atrinik_bot/pyproject.toml exact wheel URL and fragment",
-      "license": "MIT",
-      "source_url": "https://github.com/atrinik/protocol/releases/tag/v1.0.9",
-      "locator": "pkg:pypi/atrinik-protocol@1.0.9",
-      "commit": null,
-      "checksum": "sha256:78954264fa49ac8736dbfc7a72669f619e0202e6ae15445a0b0839aa8f30eb8a",
-      "acquisition": "pip downloads the exact HTTPS release wheel and verifies the URL-fragment digest",
-      "update_cadence_days": 30,
-      "update_mechanism": "Protocol release review and bot contract tests",
-      "eol_response": "Update to a supported protocol binding or retire direct-protocol bot operation",
-      "validation": "pip hash verification, bot protocol tests, and migration parity against the client automation API",
-      "disposition": "replace",
-      "packages": [],
-      "evidence": [
-        {"repository":"tools","path":"atrinik_bot/pyproject.toml","contains":"atrinik_protocol-1.0.9-py3-none-any.whl#sha256=78954264fa49ac8736dbfc7a72669f619e0202e6ae15445a0b0839aa8f30eb8a"}
       ]
     },
     {
@@ -2412,6 +2503,32 @@
           "path": "dependencies.lock.json",
           "contains": "atrinik-protocol-1.0.0.tar.gz"
         }
+      ]
+    },
+    {
+      "id": "source/atrinik-protocol-playtester",
+      "name": "Atrinik protocol Python wheel for the playtester",
+      "kind": "source-archive",
+      "owner": "playtester",
+      "scope": ["playtester"],
+      "required": true,
+      "version": "v1.0.9",
+      "version_source": "pyproject.toml exact wheel URL and fragment",
+      "license": "MIT",
+      "source_url": "https://github.com/atrinik/legacy-protocol/releases/tag/v1.0.9",
+      "locator": "pkg:pypi/atrinik-protocol@1.0.9",
+      "commit": null,
+      "checksum": "sha256:78954264fa49ac8736dbfc7a72669f619e0202e6ae15445a0b0839aa8f30eb8a",
+      "acquisition": "pip downloads the exact HTTPS release wheel and verifies the URL-fragment digest",
+      "update_cadence_days": 30,
+      "update_mechanism": "Protocol release review and playtester contract tests",
+      "eol_response": "Update to a supported protocol binding or retire direct Classic protocol operation",
+      "validation": "pip hash verification, playtester protocol tests, and migration parity against the client automation API",
+      "disposition": "replace",
+      "packages": [],
+      "evidence": [
+        {"repository":"playtester","path":"dependencies.lock.json","contains":"78954264fa49ac8736dbfc7a72669f619e0202e6ae15445a0b0839aa8f30eb8a"},
+        {"repository":"playtester","path":"pyproject.toml","contains":"atrinik_protocol-1.0.9-py3-none-any.whl#sha256=78954264fa49ac8736dbfc7a72669f619e0202e6ae15445a0b0839aa8f30eb8a"}
       ]
     },
     {
@@ -3496,7 +3613,7 @@
         "classic-protocol",
         "classic-server",
         "devcontainer",
-        "tools"
+        "playtester"
       ],
       "required": true,
       "version": ">=3.21",
@@ -3542,8 +3659,8 @@
           "contains": "cmake_minimum_required(VERSION 3.21)"
         },
         {
-          "repository": "tools",
-          "path": "atrinik_bot/CMakeLists.txt",
+          "repository": "playtester",
+          "path": "CMakeLists.txt",
           "contains": "cmake_minimum_required(VERSION 3.21)"
         }
       ]
@@ -3597,6 +3714,7 @@
         "editor",
         "github-settings",
         "metaserver-worker",
+        "playtester",
         "protocol",
         "renderer",
         "resources",
@@ -3669,6 +3787,16 @@
         {
           "repository": "metaserver-worker",
           "path": ".github/workflows/check.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "playtester",
+          "path": ".github/workflows/release.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "playtester",
+          "path": ".github/workflows/validate.yml",
           "contains": "runs-on: ubuntu-24.04"
         },
         {
@@ -3812,6 +3940,7 @@
         "editor",
         "github-settings",
         "metaserver-worker",
+        "playtester",
         "protocol",
         "renderer",
         "resources",
@@ -3821,7 +3950,7 @@
         "website"
       ],
       "required": true,
-      "version": ">=20; wrapper release 22; Classic release 24; replacement releases 24.18.1",
+      "version": ">=20; wrapper release 22; Classic release 24; playtester and replacement releases 24.18.1",
       "version_source": "Worker/website package engines and exact release workflow lines",
       "license": "MIT",
       "source_url": "https://nodejs.org/",
@@ -3890,6 +4019,16 @@
           "contains": "\"node\": \">=20\""
         },
         {
+          "repository": "playtester",
+          "path": ".github/workflows/release.yml",
+          "contains": "node-version: 24.18.1"
+        },
+        {
+          "repository": "playtester",
+          "path": ".github/workflows/release.yml",
+          "contains": "npx --yes"
+        },
+        {
           "repository": "protocol",
           "path": ".github/workflows/release.yml",
           "contains": "node-version: 24.18.1"
@@ -3939,6 +4078,7 @@
         "content",
         "content-1x",
         "devcontainer",
+        "playtester",
         "tools"
       ],
       "required": true,
@@ -3979,6 +4119,11 @@
           "repository": "devcontainer",
           "path": "windows/Dockerfile",
           "contains": "PYTHON_VERSION=3.14.6"
+        },
+        {
+          "repository": "playtester",
+          "path": "pyproject.toml",
+          "contains": "requires-python = \">=3.11\""
         }
       ]
     },

--- a/tests/test_cohorts.py
+++ b/tests/test_cohorts.py
@@ -47,6 +47,7 @@ class CohortWorkspaceTests(unittest.TestCase):
         )
         self.assertNotIn("classic", selected)
         self.assertNotIn("content-1x", selected)
+        self.assertNotIn("playtester", selected)
         self.assertNotIn("tools", selected)
 
     def test_with_classic_is_additive_and_complete(self) -> None:
@@ -63,6 +64,7 @@ class CohortWorkspaceTests(unittest.TestCase):
         }
         self.assertEqual(selected, expected)
         self.assertIn("content-1x", selected)
+        self.assertIn("playtester", selected)
         self.assertIn("tools", selected)
 
     def test_with_classic_leaves_existing_default_checkouts_byte_identical(self) -> None:

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -225,6 +225,29 @@ class ClassicToolsInventoryTests(unittest.TestCase):
             if component["name"] in default_components:
                 self.assertNotIn("tools", component.get("requires", []))
 
+    def test_bot_migration_is_owned_by_the_classic_only_playtester(self) -> None:
+        bot = next(
+            entry
+            for entry in self.inventory["entries"]
+            if entry["id"] == "atrinik-bot"
+        )
+
+        self.assertEqual(bot["owner_repository"], "atrinik/playtester")
+        self.assertEqual(
+            bot["owner_issue"], "https://github.com/atrinik/playtester/issues/1"
+        )
+        self.assertIn("MIT", bot["licensing_method"])
+        self.assertIn("GPL", bot["licensing_method"])
+        self.assertNotIn("playtester", self.manifest["cohorts"]["default"])
+        self.assertIn("playtester", self.manifest["cohorts"]["classic"])
+        self.assertNotIn(
+            "playtester", self.manifest["stacks"]["default"]["components"]
+        )
+        self.assertEqual(
+            self.manifest["stacks"]["classic"]["providers"]["playtester"],
+            "playtester",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -44,6 +44,7 @@ CLASSIC_LOGICAL = (
 )
 SHARED = (
     "content-1x",
+    "playtester",
     "tools",
     "sound",
     "resources",
@@ -116,6 +117,12 @@ class RepositoryMigrationTests(unittest.TestCase):
 
     def migration(self) -> RepositoryMigration:
         return RepositoryMigration(self.wrapper, self.paths, self.manifest)
+
+    def test_classic_profile_fallback_includes_playtester(self) -> None:
+        migration = self.migration()
+        migration.manifest = SimpleNamespace()
+
+        self.assertIn("playtester", migration._classic_profile_component_names())
 
     def make_repository(
         self,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -103,7 +103,7 @@ class ManifestTests(unittest.TestCase):
             )
             self.assertEqual(
                 {checkout.name for checkout in manifest.cohort("classic")},
-                {"classic", "content-1x", "tools"},
+                {"classic", "content-1x", "playtester", "tools"},
             )
             self.assertIn(
                 "content",
@@ -538,6 +538,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
             {
                 "classic",
                 "content-1x",
+                "playtester",
                 "tools",
             },
         )
@@ -546,6 +547,14 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertEqual(
             manifest.stack("classic").providers["libatrinik"].name,
             "classic-libatrinik",
+        )
+        self.assertEqual(
+            manifest.stack("classic").providers["playtester"].name,
+            "playtester",
+        )
+        self.assertEqual(
+            manifest.by_name["playtester"].requires,
+            ("content", "libatrinik", "protocol"),
         )
         self.assertEqual(
             {

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -216,6 +216,93 @@ class InventoryTests(unittest.TestCase):
         self.assertEqual(aggregate.roles, ("checkout-metadata",))
         self.assertEqual(aggregate.audit_mode, "metadata")
         self.assertNotIn("libatrinik", inventory.repositories_by_name)
+        playtester = inventory.repositories_by_name["playtester"]
+        self.assertEqual(playtester.repository, "atrinik/playtester")
+        self.assertEqual(playtester.cohorts, ("classic",))
+        self.assertEqual(playtester.stacks, ("classic",))
+        self.assertEqual(playtester.roles, ("playtester",))
+        self.assertEqual(playtester.license, "MIT")
+
+        playtester_python = inventory.dependencies_by_id[
+            "language/playtester-python"
+        ]
+        self.assertEqual(playtester_python.owner, "playtester")
+        self.assertEqual(playtester_python.scope, ("playtester",))
+        self.assertEqual(
+            playtester_python.locator,
+            "pkg:pypi/atrinik-playtester@0.1.0",
+        )
+        self.assertNotIn("language/tools-bot-python", inventory.dependencies_by_id)
+
+        playtester_content = inventory.dependencies_by_id[
+            "source/atrinik-content-playtester"
+        ]
+        self.assertEqual(playtester_content.owner, "content-1x")
+        self.assertEqual(playtester_content.scope, ("playtester",))
+        self.assertEqual(playtester_content.version, "v1.8.0")
+        self.assertEqual(
+            playtester_content.commit,
+            "96073eeff1854fc29347fdafd32e622394f24c07",
+        )
+
+        playtester_protocol = inventory.dependencies_by_id[
+            "source/atrinik-protocol-playtester"
+        ]
+        self.assertEqual(playtester_protocol.owner, "playtester")
+        self.assertEqual(playtester_protocol.scope, ("playtester",))
+        self.assertEqual(
+            playtester_protocol.source_url,
+            "https://github.com/atrinik/legacy-protocol/releases/tag/v1.0.9",
+        )
+
+        playtester_libatrinik = inventory.dependencies_by_id[
+            "source/atrinik-libatrinik-playtester"
+        ]
+        self.assertEqual(playtester_libatrinik.owner, "playtester")
+        self.assertEqual(playtester_libatrinik.scope, ("playtester",))
+        self.assertEqual(
+            inventory.dependencies_by_id[
+                "source/atrinik-libatrinik-server"
+            ].scope,
+            ("classic-server",),
+        )
+        self.assertIn(
+            "playtester",
+            inventory.dependencies_by_id["action/actions-checkout"].scope,
+        )
+        self.assertIn(
+            "playtester",
+            inventory.dependencies_by_id["action/actions-setup-node"].scope,
+        )
+        self.assertIn(
+            "playtester",
+            inventory.dependencies_by_id[
+                "language/classic-conventional-changelog"
+            ].scope,
+        )
+        self.assertIn(
+            "playtester",
+            inventory.dependencies_by_id[
+                "language/classic-semantic-release"
+            ].scope,
+        )
+        self.assertIn(
+            "playtester",
+            inventory.dependencies_by_id[
+                "toolchain/github-hosted-ubuntu-24.04"
+            ].scope,
+        )
+        self.assertIn(
+            "playtester",
+            inventory.dependencies_by_id["toolchain/node"].scope,
+        )
+        self.assertIn(
+            "playtester",
+            inventory.dependencies_by_id["toolchain/python"].scope,
+        )
+        cmake = inventory.dependencies_by_id["toolchain/cmake"]
+        self.assertIn("playtester", cmake.scope)
+        self.assertNotIn("tools", cmake.scope)
         self.assertTrue(
             all(
                 repository.commit is None


### PR DESCRIPTION
## Summary

- Register `atrinik/playtester@main` as the classic-only `playtester` checkout and component.
- Add the logical `playtester` provider to the `classic` cohort and stack while keeping it outside replacement implementation roles.
- Synchronize wrapper guidance, migration fallback behavior, governance ownership, and tests with the extracted repository.

## Topology and ownership

- The component uses source `.` and wrapper build kind `none`; `atrinik/playtester` owns its build and validation.
- It provides `playtester` and requires the classic `content`, `libatrinik`, and `protocol` contracts.
- The classic profile now selects the independent checkout without changing the default replacement stack or runtime service topology.
- The bot migration record is owned by `atrinik/playtester#1` under milestone `M1 — Standalone runner`.

## Governance and supply chain

- Record the repository as MIT under Zoey Rose's direct relicensing grant while retaining the GPL obligations of its linked legacy libatrinik dependency.
- Move the Python, CMake, content, legacy-protocol, and legacy-libatrinik dependency evidence from `tools` to `playtester` with exact pinned coordinates.
- Cover the source-only semantic-release workflow, including immutable checkout/setup-node actions, Node 24.18.1, semantic-release 25.0.9, and conventional-changelog-conventionalcommits 9.3.1. The release workflow does not publish the GPL-linked wheel.

## Validation

- `python3 -m unittest discover -v` — 299 tests passed
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check` — combined wrapper/multi-skill footprint: 13,978 bytes
- `./atrinik manifest validate` — 21 components
- `./atrinik supply-chain validate` — 90 dependencies
- Coordinated dependency audit — playtester: 43 inputs / 4 Action references; tools: 77 inputs / 3 Action references
- `git diff --check`

Related: atrinik/tools#19
