### PR TITLE
chore(deps): inventory classic libidn2

### DIFF
--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -2857,6 +2857,7 @@
         "curl",
         "gcovr",
         "libcurl4-openssl-dev",
+        "libidn2-dev",
         "libsdl3-dev",
         "libsdl3-image-dev",
         "libsdl3-ttf-dev",
@@ -2976,6 +2977,42 @@
           "repository": "classic-server",
           "path": "CMakeLists.txt",
           "contains": "find_library(GD_LIBRARY gd)"
+        }
+      ]
+    },
+    {
+      "id": "system/idn2",
+      "name": "GNU Libidn2",
+      "kind": "system-library",
+      "owner": "classic-libatrinik",
+      "scope": [
+        "classic-client",
+        "classic-libatrinik",
+        "classic-server",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "distribution/MXE-provided",
+      "version_source": "Pinned build images and MXE commit",
+      "license": "LGPL-3.0-or-later",
+      "source_url": "https://gitlab.com/libidn/libidn2",
+      "locator": "pkg:generic/libidn2",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake links the native or MXE library already present in the reviewed package set",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image rebuild, MXE review, and exact version report",
+      "eol_response": "Upgrade promptly for unsupported or security-affected IDNA implementations",
+      "validation": "CMake discovery plus shared hostname positive and adversarial UTS 46 tests",
+      "disposition": "retain",
+      "packages": [
+        "libidn2-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "classic-libatrinik",
+          "path": "CMakeLists.txt",
+          "contains": "pkg_check_modules(IDN2 REQUIRED IMPORTED_TARGET libidn2)"
         }
       ]
     },
@@ -3286,6 +3323,8 @@
         "libcurl4t64",
         "libgd-dev",
         "libgd3",
+        "libidn2-0",
+        "libidn2-dev",
         "libminiupnpc-dev",
         "libminiupnpc21",
         "libpython3.14",
@@ -3388,6 +3427,7 @@
         "libclang-rt-dev",
         "libcurl4-openssl-dev",
         "libgd-dev",
+        "libidn2-dev",
         "libminiupnpc-dev",
         "libreadline-dev",
         "libsdl3-dev",


### PR DESCRIPTION
## Summary

- register GNU Libidn2 as the required system-library dependency owned by `classic-libatrinik`
- include the native development and runtime package names used by classic CI, release images, and the shared Linux build image
- preserve the existing distribution/MXE version authority, monthly review cadence, and complete-profile validation contract

## Dependency context

This follows the merged classic directory-service cutover in atrinik/classic#58 and the released Linux/Windows build-image support. It records the dependency already required by the merged LibAtrinik hostname validator; it does not alter runtime behavior or any live service.

## Review

The ignored local review at `build/deep-review-classic-idn2-inventory.md` covered security, correctness, license/provenance, performance, scale, maintainability, duplication, package acquisition, and scope ownership. No unresolved finding remains.

## Validation

- `python3 -m coverage run --branch -m unittest discover -s tests -p test_*.py` — 299/299 passed
- `python3 -m coverage report --show-missing` — 78% aggregate coverage
- `python3 -m coverage xml`
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate` — 21 components
- `./atrinik supply-chain validate` — 91 dependencies
- `./atrinik supply-chain audit --profile classic` with explicit read-only coordinates for every selected merged checkout
- `jq empty supply-chain/inventory.json`
- `git diff --check main...HEAD`

The classic-profile audit covered the wrapper, all five logical classic components, the extracted playtester, both content/resource cohorts, build images, GitHub policy, metaserver Worker, sound, and tools. No live Cloudflare or GitHub policy state was mutated.
