### PR TITLE
feat(cli): add native shell completion

### DIFF
--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -92,10 +92,12 @@ wrapper replacement build/runtime closure yet.
 Classic selection is checkout-wide; subdirectories are not worktrees. Region
 maps cache only clean matching inputs; runtimes copy snapshots without overlays.
 
-Build, scenario, and topology records bind exact repository, branch, checkout,
-source, component, and provider coordinates. Records lacking current immutable
-coordinates are inert. Let the wrapper collect content/resources and own
-generated paths, locks, state, PIDs, logs, and process cleanup.
+Build, scenario, and topology records bind exact immutable coordinates;
+incomplete records are inert. Let the wrapper own generated paths, locks,
+state, PIDs, logs, content/resources, and process cleanup.
+
+Keep completion parser-driven, bounded, read-only, local-only, secret-free,
+before `Workspace`, and stopped at `--` or a `run` remainder.
 
 For classic server execution or diagnosis, load `atrinik-server-runtime`. For
 a ready account and character, also load `atrinik-test-scenario`; never

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,8 +52,9 @@
 - Use `./atrinik path`, `topology show`, `up`, `ps`, `logs`, and `down`. Do not
   reconstruct managed build, PID, log, lock, runtime, or state paths. Give
   concurrent topologies distinct names, states, ports, and client config.
-- Persisted records lacking current immutable repository, branch, checkout,
-  source, and provider coordinates are historical and inert.
+- Keep shell completion parser-driven, bounded, local-only, secret-free, and
+  ahead of `Workspace` construction.
+- Persisted records without current immutable coordinates are historical and inert.
 - Follow `docs/PROVENANCE.md` for historical MIT reuse; incomplete history,
   mixed authorship, uncertain identity, or embedded third-party material fails
   closed. Cite the exact wrapper registry revision used.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,66 @@ component checkouts beside the wrapper remain indexed. Open a managed worktree
 under `workspace/worktrees/` as its own VS Code folder or window when it needs
 language-service coverage.
 
+### Shell completion
+
+Activate native completion for the current Bash, Zsh, or Fish session without
+changing a startup file:
+
+~~~sh
+# Bash (the same command works after putting atrinik on PATH)
+source <(./atrinik completion bash)
+
+# Zsh, after compinit is available
+autoload -Uz compinit && compinit
+source <(./atrinik completion zsh)
+
+# Fish
+./atrinik completion fish | source
+~~~
+
+For persistent per-user activation, create the shell's normal completion
+directory yourself and write the deterministic output to its native file:
+
+~~~sh
+# Bash
+./atrinik completion bash > ~/.local/share/bash-completion/completions/atrinik
+
+# Zsh (ensure ~/.zfunc is in fpath before compinit)
+./atrinik completion zsh > ~/.zfunc/_atrinik
+
+# Fish
+./atrinik completion fish > ~/.config/fish/completions/atrinik.fish
+~~~
+
+The wrapper never creates those directories or edits shell configuration.
+Completion works for `./atrinik`, an `atrinik` command on `PATH`, and absolute
+invocation paths. Commands, nested commands, exact options, mutually exclusive
+flags, and static parser choices come from the live `argparse` tree. Local
+manifest identities, built-in and saved profiles, owning-checkout worktree
+labels, states, scenarios, and recorded topologies are reread on every keypress.
+Filesystem values such as `--path` and `--output` remain native shell path
+completion, and wrapper suggestions stop after the `run client|server --`
+forwarding boundary.
+
+The provider reads only bounded local metadata and fails quietly to static
+parser candidates when optional state is absent or malformed. It does not
+construct a `Workspace`, inspect Git, probe processes, read scenario password
+files, or use the network. A development-container benchmark can be repeated
+with the private adapter protocol below; measure one cold invocation, then the
+median of repeated fresh processes after filesystem caches are warm:
+
+~~~sh
+time ./atrinik __complete 1 -- atrinik "" >/dev/null
+for run in $(seq 1 30); do
+  time ./atrinik __complete 1 -- atrinik "" >/dev/null
+done
+~~~
+
+On the Python 3.14 development container used for this implementation, the
+top-level candidate query measured 63 ms cold and 61 ms warm median. The
+protocol is internal to the generated adapters; scripts should be obtained
+through `completion bash|zsh|fish` rather than hand-written against it.
+
 ## Dependency and supply-chain ownership
 
 `supply-chain/inventory.json` records every supported repository and the owned

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -181,7 +181,7 @@ def parser() -> argparse.ArgumentParser:
     mark(profile_create.add_argument("name"), "none")
     mark(profile_create.add_argument("--from", dest="source", default="default"), "profile")
     profile_set = profile_commands.add_parser("set")
-    mark(profile_set.add_argument("name"), "profile")
+    mark(profile_set.add_argument("name"), "saved_profile")
     mark(profile_set.add_argument("component"), "profile_selection")
     selector = profile_set.add_mutually_exclusive_group(required=True)
     selector.add_argument("--primary", action="store_true")

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -4,16 +4,47 @@ import argparse
 import json
 from pathlib import Path
 import sys
+from typing import Any
 
+from .completion import mark, protocol, protocol_command, shell_script
 from .model import Manifest, WorkspaceError
-from .supply_chain import (
-    Inventory,
-    report_component_commits,
-    repository_roots,
-    version_report,
-    write_generated,
-)
-from .workspace import Workspace
+
+
+# Keep completion startup independent from the heavyweight workspace/runtime module.
+# Tests replace this hook directly; normal dispatch resolves it lazily below.
+Workspace: Any = None
+
+
+class Inventory:
+    @staticmethod
+    def load(*arguments: object, **keywords: object) -> object:
+        from .supply_chain import Inventory as implementation
+
+        return implementation.load(*arguments, **keywords)
+
+
+def repository_roots(*arguments: object, **keywords: object) -> object:
+    from .supply_chain import repository_roots as implementation
+
+    return implementation(*arguments, **keywords)
+
+
+def report_component_commits(*arguments: object, **keywords: object) -> object:
+    from .supply_chain import report_component_commits as implementation
+
+    return implementation(*arguments, **keywords)
+
+
+def version_report(*arguments: object, **keywords: object) -> object:
+    from .supply_chain import version_report as implementation
+
+    return implementation(*arguments, **keywords)
+
+
+def write_generated(*arguments: object, **keywords: object) -> object:
+    from .supply_chain import write_generated as implementation
+
+    return implementation(*arguments, **keywords)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -56,7 +87,7 @@ def parser() -> argparse.ArgumentParser:
     manifest.add_argument("action", choices=["validate"])
 
     initialize = commands.add_parser("init", help="clone missing physical checkouts")
-    initialize.add_argument("components", nargs="*")
+    mark(initialize.add_argument("components", nargs="*"), "component")
     initialize.add_argument(
         "--with",
         dest="additional_sets",
@@ -65,12 +96,12 @@ def parser() -> argparse.ArgumentParser:
         default=[],
         help="add the complete classic cohort to the default checkout cohort",
     )
-    initialize.add_argument("--jobs", type=int, default=4)
+    mark(initialize.add_argument("--jobs", type=int, default=4), "none")
 
     sync = commands.add_parser(
         "sync", help="fetch and fast-forward physical checkouts"
     )
-    sync.add_argument("components", nargs="*")
+    mark(sync.add_argument("components", nargs="*"), "component")
     sync.add_argument(
         "--with",
         dest="additional_sets",
@@ -89,7 +120,7 @@ def parser() -> argparse.ArgumentParser:
     status = commands.add_parser(
         "status", help="summarize primary physical-checkout state"
     )
-    status.add_argument("components", nargs="*")
+    mark(status.add_argument("components", nargs="*"), "component")
     status.add_argument("--json", action="store_true")
 
     migrate = commands.add_parser(
@@ -112,33 +143,33 @@ def parser() -> argparse.ArgumentParser:
     )
     worktree_commands = worktree.add_subparsers(dest="worktree_command", required=True)
     worktree_create = worktree_commands.add_parser("create")
-    worktree_create.add_argument("component")
-    worktree_create.add_argument("label")
-    worktree_create.add_argument("--branch", required=True)
-    worktree_create.add_argument("--from", dest="start_point")
+    mark(worktree_create.add_argument("component"), "component")
+    mark(worktree_create.add_argument("label"), "none")
+    mark(worktree_create.add_argument("--branch", required=True), "none")
+    mark(worktree_create.add_argument("--from", dest="start_point"), "none")
     worktree_create.add_argument("--existing", action="store_true")
     worktree_remove = worktree_commands.add_parser("remove")
-    worktree_remove.add_argument("component")
-    worktree_remove.add_argument("label")
+    mark(worktree_remove.add_argument("component"), "component")
+    mark(worktree_remove.add_argument("label"), "worktree")
     worktree_list = worktree_commands.add_parser("list")
-    worktree_list.add_argument("components", nargs="*")
+    mark(worktree_list.add_argument("components", nargs="*"), "component")
     worktree_list.add_argument("--json", action="store_true")
 
     cleanup = commands.add_parser(
         "cleanup", help="preview or reclaim stale workspace data"
     )
-    cleanup.add_argument(
+    mark(cleanup.add_argument(
         "components",
         nargs="*",
         help="limit worktrees to repeated checkout/component identities",
-    )
+    ), "component")
     cleanup.add_argument(
         "--scope",
         action="append",
         choices=["worktrees", "builds", "npm-cache", "all"],
         default=[],
     )
-    cleanup.add_argument("--older-than", type=int, default=7, metavar="DAYS")
+    mark(cleanup.add_argument("--older-than", type=int, default=7, metavar="DAYS"), "none")
     cleanup_mode = cleanup.add_mutually_exclusive_group()
     cleanup_mode.add_argument("--dry-run", action="store_true")
     cleanup_mode.add_argument("--apply", action="store_true")
@@ -147,28 +178,28 @@ def parser() -> argparse.ArgumentParser:
     profile = commands.add_parser("profile", help="manage coherent source profiles")
     profile_commands = profile.add_subparsers(dest="profile_command", required=True)
     profile_create = profile_commands.add_parser("create")
-    profile_create.add_argument("name")
-    profile_create.add_argument("--from", dest="source", default="default")
+    mark(profile_create.add_argument("name"), "none")
+    mark(profile_create.add_argument("--from", dest="source", default="default"), "profile")
     profile_set = profile_commands.add_parser("set")
-    profile_set.add_argument("name")
-    profile_set.add_argument("component")
+    mark(profile_set.add_argument("name"), "profile")
+    mark(profile_set.add_argument("component"), "profile_component")
     selector = profile_set.add_mutually_exclusive_group(required=True)
     selector.add_argument("--primary", action="store_true")
-    selector.add_argument("--worktree")
-    selector.add_argument("--path", type=Path)
+    mark(selector.add_argument("--worktree"), "worktree")
+    mark(selector.add_argument("--path", type=Path), "path")
     profile_show = profile_commands.add_parser("show")
-    profile_show.add_argument("name", nargs="?", default="default")
+    mark(profile_show.add_argument("name", nargs="?", default="default"), "profile")
     profile_show.add_argument("--json", action="store_true")
 
     path = commands.add_parser(
         "path", help="print a resolved logical-component source path"
     )
-    path.add_argument("component")
-    path.add_argument("--profile", default="default")
+    mark(path.add_argument("component"), "profile_component")
+    mark(path.add_argument("--profile", default="default"), "profile")
 
     build = commands.add_parser("build", help="build a component or the playable system")
-    build.add_argument("target", help="all or a component name")
-    build.add_argument("--profile", default="default")
+    mark(build.add_argument("target", help="all or a component name"), "build_target")
+    mark(build.add_argument("--profile", default="default"), "profile")
     build.add_argument("--test", action="store_true")
 
     topology = commands.add_parser(
@@ -178,44 +209,44 @@ def parser() -> argparse.ArgumentParser:
         dest="topology_command", required=True
     )
     topology_show = topology_commands.add_parser("show")
-    topology_show.add_argument("profile", nargs="?", default="default")
-    topology_show.add_argument("--state", default="default")
+    mark(topology_show.add_argument("profile", nargs="?", default="default"), "profile")
+    mark(topology_show.add_argument("--state", default="default"), "state")
     topology_show.add_argument(
         "--service", choices=["server", "client"], action="append"
     )
     topology_show.add_argument("--json", action="store_true")
 
     up = commands.add_parser("up", help="build and start a supervised topology")
-    up.add_argument("--name")
-    up.add_argument("--profile", default="default")
-    up.add_argument("--state", default="default")
-    up.add_argument(
+    mark(up.add_argument("--name"), "none")
+    mark(up.add_argument("--profile", default="default"), "profile")
+    mark(up.add_argument("--state", default="default"), "state")
+    mark(up.add_argument(
         "--port",
         type=int,
         help="server UDP port (default: choose an available port)",
-    )
+    ), "none")
     up.add_argument("--service", choices=["server", "client"], action="append")
     up.add_argument("--json", action="store_true")
 
     ps = commands.add_parser("ps", help="show supervised topology processes")
-    ps.add_argument("name", nargs="?")
+    mark(ps.add_argument("name", nargs="?"), "topology")
     ps.add_argument("--json", action="store_true")
 
     logs = commands.add_parser("logs", help="show supervised topology logs")
-    logs.add_argument("name", nargs="?", default="default")
+    mark(logs.add_argument("name", nargs="?", default="default"), "topology")
     logs.add_argument("service", nargs="?", choices=["server", "client"])
-    logs.add_argument("--tail", type=int, default=100)
+    mark(logs.add_argument("--tail", type=int, default=100), "none")
     logs.add_argument("--follow", "-f", action="store_true")
 
     down = commands.add_parser("down", help="stop a supervised topology")
-    down.add_argument("name", nargs="?", default="default")
+    mark(down.add_argument("name", nargs="?", default="default"), "topology")
     down.add_argument("--json", action="store_true")
 
     state = commands.add_parser("state", help="register persistent server state")
     state_commands = state.add_subparsers(dest="state_command", required=True)
     state_add = state_commands.add_parser("add")
-    state_add.add_argument("name")
-    state_add.add_argument("--path", type=Path)
+    mark(state_add.add_argument("name"), "none")
+    mark(state_add.add_argument("--path", type=Path), "path")
     state_list = state_commands.add_parser("list")
     state_list.add_argument("--json", action="store_true")
 
@@ -226,19 +257,19 @@ def parser() -> argparse.ArgumentParser:
         dest="scenario_command", required=True
     )
     scenario_create = scenario_commands.add_parser("create")
-    scenario_create.add_argument("name")
-    scenario_create.add_argument("--profile", default="default")
-    scenario_create.add_argument("--preset", default="basic-player")
+    mark(scenario_create.add_argument("name"), "none")
+    mark(scenario_create.add_argument("--profile", default="default"), "profile")
+    mark(scenario_create.add_argument("--preset", default="basic-player"), "none")
     scenario_create.add_argument("--json", action="store_true")
     scenario_list = scenario_commands.add_parser("list")
     scenario_list.add_argument("--json", action="store_true")
     scenario_show = scenario_commands.add_parser("show")
-    scenario_show.add_argument("name")
+    mark(scenario_show.add_argument("name"), "scenario")
     scenario_show.add_argument("--json", action="store_true")
     scenario_credentials = scenario_commands.add_parser("credentials")
-    scenario_credentials.add_argument("name")
+    mark(scenario_credentials.add_argument("name"), "scenario")
     scenario_reset = scenario_commands.add_parser("reset")
-    scenario_reset.add_argument("name")
+    mark(scenario_reset.add_argument("name"), "scenario")
     scenario_reset.add_argument("--json", action="store_true")
 
     supply_chain = commands.add_parser(
@@ -249,38 +280,43 @@ def parser() -> argparse.ArgumentParser:
     )
     supply_chain_commands.add_parser("validate")
     supply_chain_audit = supply_chain_commands.add_parser("audit")
-    supply_chain_audit.add_argument("--profile", default="default")
-    supply_chain_audit.add_argument(
+    mark(supply_chain_audit.add_argument("--profile", default="default"), "profile")
+    mark(supply_chain_audit.add_argument(
         "--repository",
         action="append",
         default=[],
         metavar="NAME=PATH",
         help="override one component checkout or source root for a read-only audit",
-    )
+    ), "none")
     supply_chain_report = supply_chain_commands.add_parser("report")
     supply_chain_report.add_argument(
         "--format", choices=["cyclonedx", "licenses", "spdx"], required=True
     )
-    supply_chain_report.add_argument(
+    mark(supply_chain_report.add_argument(
         "--profile",
         default="default",
         help="profile whose initialized checkouts supply first-party commits",
-    )
-    supply_chain_report.add_argument("--output", type=Path)
+    ), "profile")
+    mark(supply_chain_report.add_argument("--output", type=Path), "path")
     supply_chain_versions = supply_chain_commands.add_parser("versions")
-    supply_chain_versions.add_argument("--output", type=Path)
+    mark(supply_chain_versions.add_argument("--output", type=Path), "path")
 
     launch = commands.add_parser("run", help="build and run client or server")
     launch_commands = launch.add_subparsers(dest="target", required=True)
     for target in ("client", "server"):
         target_parser = launch_commands.add_parser(target)
-        target_parser.add_argument("--profile", default="default")
-        target_parser.add_argument("--state", default="default")
-        target_parser.add_argument(
+        mark(target_parser.add_argument("--profile", default="default"), "profile")
+        mark(target_parser.add_argument("--state", default="default"), "state")
+        mark(target_parser.add_argument(
             "--port", type=int, default=1730, help="server UDP port (default: 1730)"
-        )
+        ), "none")
         target_parser.add_argument("--dry-run", action="store_true")
-        target_parser.add_argument("arguments", nargs=argparse.REMAINDER)
+        mark(target_parser.add_argument("arguments", nargs=argparse.REMAINDER), "none")
+
+    completion = commands.add_parser(
+        "completion", help="emit a native shell completion activation script"
+    )
+    completion.add_argument("shell", choices=["bash", "zsh", "fish"])
     return root
 
 
@@ -315,14 +351,24 @@ def _print_scenario_handoff(summary: dict[str, object]) -> None:
 
 
 def main(arguments: list[str] | None = None) -> int:
-    options = parser().parse_args(arguments)
+    raw_arguments = list(sys.argv[1:] if arguments is None else arguments)
+    root_parser = parser()
+    if raw_arguments and raw_arguments[0] == protocol_command():
+        return protocol(root_parser, ROOT, raw_arguments[1:])
+    options = root_parser.parse_args(raw_arguments)
     try:
+        if options.command == "completion":
+            print(shell_script(options.shell), end="")
+            return 0
         if options.command == "manifest":
             manifest = Manifest.load(ROOT / "components.json")
             print(f"components.json: valid ({len(manifest.components)} components)")
             return 0
 
-        workspace = Workspace(ROOT)
+        workspace_type = Workspace
+        if workspace_type is None:
+            from .workspace import Workspace as workspace_type
+        workspace = workspace_type(ROOT)
         if options.command == "supply-chain":
             inventory = Inventory.load(
                 ROOT / "supply-chain" / "inventory.json", ROOT / "components.json"

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -182,7 +182,7 @@ def parser() -> argparse.ArgumentParser:
     mark(profile_create.add_argument("--from", dest="source", default="default"), "profile")
     profile_set = profile_commands.add_parser("set")
     mark(profile_set.add_argument("name"), "profile")
-    mark(profile_set.add_argument("component"), "profile_component")
+    mark(profile_set.add_argument("component"), "profile_selection")
     selector = profile_set.add_mutually_exclusive_group(required=True)
     selector.add_argument("--primary", action="store_true")
     mark(selector.add_argument("--worktree"), "worktree")

--- a/atrinik_workspace/completion.py
+++ b/atrinik_workspace/completion.py
@@ -286,8 +286,21 @@ def _dynamic_candidates(
         if stack_name is None:
             return []
         stack = manifest.stacks[stack_name]
+        all_roles = [
+            role for role in (
+                "content", "protocol", "libatrinik", "client", "server",
+                "metaserver-worker",
+            )
+            if role in stack.providers
+        ]
         return [
-            "all",
+            *(
+                ["all"]
+                if all(
+                    stack.providers[role].build != "none" for role in all_roles
+                )
+                else []
+            ),
             *(
                 role
                 for role, component in stack.providers.items()
@@ -481,28 +494,32 @@ def _registered_states(paths: Paths | None) -> dict[str, str]:
         return {}
     root = _workspace_descriptor(paths)
     if root is None:
-        return []
+        return {}
     try:
-        value = _json_at(root, "states.json", _MAX_RECORD_BYTES)
-        if (
-            not isinstance(value, dict)
-            or set(value) != {"schema_version", "states"}
-            or value.get("schema_version") != 1
-        ):
-            return {}
-        states = value.get("states")
-        if not isinstance(states, dict):
-            return {}
-        if any(
-            not _valid_name(name)
-            or not isinstance(path, str)
-            or not Path(path).is_absolute()
-            for name, path in states.items()
-        ):
-            return {}
-        return states
+        return _registered_states_at(root)
     finally:
         os.close(root)
+
+
+def _registered_states_at(root: int) -> dict[str, str]:
+    value = _json_at(root, "states.json", _MAX_RECORD_BYTES)
+    if (
+        not isinstance(value, dict)
+        or set(value) != {"schema_version", "states"}
+        or value.get("schema_version") != 1
+    ):
+        return {}
+    states = value.get("states")
+    if not isinstance(states, dict):
+        return {}
+    if any(
+        not _valid_name(name)
+        or not isinstance(path, str)
+        or not Path(path).is_absolute()
+        for name, path in states.items()
+    ):
+        return {}
+    return states
 
 
 def _scenario_names(manifest: Manifest | None, paths: Paths | None) -> list[str]:
@@ -512,7 +529,7 @@ def _scenario_names(manifest: Manifest | None, paths: Paths | None) -> list[str]
     if opened is None:
         return []
     root, records = opened
-    states = _registered_states(paths)
+    states = _registered_states_at(root)
     try:
         names: list[str] = []
         for name in _entry_names(
@@ -652,7 +669,7 @@ def _topology_names(manifest: Manifest | None, paths: Paths | None) -> list[str]
                 status = _json_at(record, "status.json", _MAX_RECORD_BYTES)
                 if (
                     marker == {"schema_version": 1, "purpose": f"topology:{name}"}
-                    and _valid_topology(manifest, paths, name, status)
+                    and _valid_topology(manifest, name, status)
                 ):
                     names.append(name)
             finally:
@@ -664,7 +681,7 @@ def _topology_names(manifest: Manifest | None, paths: Paths | None) -> list[str]
 
 
 def _valid_topology(
-    manifest: Manifest, paths: Paths, name: str, status: Any
+    manifest: Manifest, name: str, status: Any
 ) -> bool:
     required = {
         "schema_version", "name", "profile", "stack", "providers",
@@ -679,19 +696,17 @@ def _valid_topology(
     ):
         return False
     profile = status.get("profile")
-    stack_name = (
-        _profile_stack(manifest, paths, profile)
-        if isinstance(profile, str)
-        else None
-    )
+    stack_name = status.get("stack")
     dependencies = status.get("dependencies")
     providers = status.get("providers")
     resolved = status.get("resolved")
     if (
         status.get("schema_version") != 1
         or status.get("name") != name
-        or stack_name is None
-        or status.get("stack") != stack_name
+        or not isinstance(profile, str)
+        or not profile
+        or not isinstance(stack_name, str)
+        or stack_name not in manifest.stacks
         or not isinstance(dependencies, list)
         or not dependencies
         or not all(isinstance(role, str) and _valid_name(role) for role in dependencies)
@@ -726,7 +741,10 @@ def _valid_topology(
         if not _valid_resolution(provider, resolved.get(component_name)):
             return False
     supervisor = status.get("supervisor")
-    if not _valid_process(supervisor):
+    if (
+        not _valid_process(supervisor)
+        or set(supervisor) != {"pid", "start_time"}
+    ):
         return False
     endpoint = status.get("endpoint")
     if endpoint is not None and (
@@ -746,7 +764,7 @@ def _valid_topology(
     services = status.get("services")
     if (
         not isinstance(services, dict)
-        or not services and "error" not in status
+        or not services and not status.get("error")
         or not set(services) <= {"client", "server"}
     ):
         return False
@@ -767,7 +785,14 @@ def _valid_topology(
             or not Path(service["cwd"]).is_absolute()
         ):
             return False
-    return ("server" in services) == (endpoint is not None)
+    return (
+        ("server" in services) == (endpoint is not None)
+        and not (
+            status["ready"]
+            and endpoint is not None
+            and endpoint["fingerprint"] is None
+        )
+    )
 
 
 def _valid_process(record: Any) -> bool:

--- a/atrinik_workspace/completion.py
+++ b/atrinik_workspace/completion.py
@@ -1,0 +1,638 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import stat
+from typing import Any, Iterable
+
+from .model import MANAGED_MARKER, Manifest, Paths, WorkspaceError, validate_name
+
+
+_PROTOCOL_COMMAND = "__complete"
+_MAX_WORDS = 256
+_MAX_WORD_LENGTH = 4096
+_MAX_DIRECTORY_ENTRIES = 256
+_MAX_METADATA_BYTES = 256 * 1024
+_PROFILE_KEYS = {"schema_version", "name", "stack", "components"}
+_SCENARIO_KEYS = {
+    "schema_version",
+    "name",
+    "profile",
+    "stack",
+    "providers",
+    "preset",
+    "state",
+    "account",
+    "character",
+    "archetype",
+    "resolved",
+    "provisioned_at",
+}
+
+
+def mark(action: argparse.Action, kind: str) -> argparse.Action:
+    """Classify an argparse value for parser-driven completion."""
+
+    setattr(action, "completion_kind", kind)
+    return action
+
+
+def shell_script(shell: str) -> str:
+    scripts = {
+        "bash": _BASH_SCRIPT,
+        "zsh": _ZSH_SCRIPT,
+        "fish": _FISH_SCRIPT,
+    }
+    return scripts[shell]
+
+
+def protocol(
+    root_parser: argparse.ArgumentParser, repository: Path, arguments: list[str]
+) -> int:
+    """Emit a bounded, line-oriented completion response without side effects."""
+
+    try:
+        cursor, words = _protocol_arguments(arguments)
+        mode, candidates = complete(root_parser, repository, words, cursor)
+    except (OSError, ValueError, WorkspaceError):
+        mode, candidates = "none", []
+    print(mode)
+    for candidate in candidates:
+        print(candidate)
+    return 0
+
+
+def _protocol_arguments(arguments: list[str]) -> tuple[int, list[str]]:
+    if len(arguments) < 2 or arguments[1] != "--":
+        raise ValueError("invalid completion protocol arguments")
+    cursor = int(arguments[0])
+    words = arguments[2:]
+    if not 0 <= cursor <= len(words) or len(words) > _MAX_WORDS:
+        raise ValueError("invalid completion cursor")
+    if any(len(word) > _MAX_WORD_LENGTH for word in words):
+        raise ValueError("completion word is too long")
+    return cursor, words
+
+
+def complete(
+    root_parser: argparse.ArgumentParser,
+    repository: Path,
+    words: list[str],
+    cursor: int,
+) -> tuple[str, list[str]]:
+    current = words[cursor] if cursor < len(words) else ""
+    completed = words[1:cursor] if words else []
+    selected = _select_action(root_parser, completed)
+    if selected.forwarded:
+        return "none", []
+    if selected.pending is not None:
+        return _value_candidates(
+            selected.pending,
+            repository,
+            selected.values,
+            current,
+        )
+    if current.startswith("--") and "=" in current:
+        option, prefix = current.split("=", 1)
+        action = selected.options.get(option)
+        if action is not None and _takes_value(action):
+            mode, values = _value_candidates(
+                action, repository, selected.values, prefix
+            )
+            return mode, [f"{option}={value}" for value in values]
+    if current.startswith("-"):
+        return "candidates", _option_candidates(selected, current)
+    action = selected.positional
+    if action is None:
+        return "candidates", []
+    if action.nargs == argparse.REMAINDER:
+        return "none", []
+    return _value_candidates(action, repository, selected.values, current)
+
+
+class _Selection:
+    def __init__(self, parser: argparse.ArgumentParser):
+        self.parser = parser
+        self.positionals = _positionals(parser)
+        self.positional_index = 0
+        self.pending: argparse.Action | None = None
+        self.consumed: set[int] = set()
+        self.values: dict[str, list[str]] = {}
+        self.forwarded = False
+        self.options = _options(parser)
+
+    @property
+    def positional(self) -> argparse.Action | None:
+        if self.positional_index >= len(self.positionals):
+            return None
+        return self.positionals[self.positional_index]
+
+    def descend(self, parser: argparse.ArgumentParser) -> None:
+        self.parser = parser
+        self.positionals = _positionals(parser)
+        self.positional_index = 0
+        self.pending = None
+        self.options = _options(parser)
+
+
+def _select_action(
+    root_parser: argparse.ArgumentParser, completed: list[str]
+) -> _Selection:
+    selection = _Selection(root_parser)
+    index = 0
+    while index < len(completed):
+        word = completed[index]
+        if word == "--":
+            selection.forwarded = True
+            return selection
+        if selection.pending is not None:
+            _record(selection, selection.pending, word)
+            selection.pending = None
+            index += 1
+            continue
+        option_name, separator, option_value = word.partition("=")
+        option = selection.options.get(option_name)
+        if word.startswith("-") and option is not None:
+            selection.consumed.add(id(option))
+            if _takes_value(option):
+                if separator:
+                    _record(selection, option, option_value)
+                else:
+                    selection.pending = option
+            index += 1
+            continue
+        positional = selection.positional
+        if positional is None:
+            index += 1
+            continue
+        if isinstance(positional, argparse._SubParsersAction):
+            child = positional.choices.get(word)
+            if child is None:
+                index += 1
+                continue
+            _record(selection, positional, word)
+            selection.descend(child)
+            index += 1
+            continue
+        if positional.nargs == argparse.REMAINDER:
+            selection.forwarded = True
+            return selection
+        _record(selection, positional, word)
+        if positional.nargs not in ("*", "+"):
+            selection.positional_index += 1
+        index += 1
+    return selection
+
+
+def _record(selection: _Selection, action: argparse.Action, value: str) -> None:
+    selection.values.setdefault(action.dest, []).append(value)
+    selection.consumed.add(id(action))
+
+
+def _positionals(parser: argparse.ArgumentParser) -> list[argparse.Action]:
+    return [action for action in parser._actions if not action.option_strings]
+
+
+def _options(parser: argparse.ArgumentParser) -> dict[str, argparse.Action]:
+    return {
+        option: action
+        for action in parser._actions
+        for option in action.option_strings
+    }
+
+
+def _takes_value(action: argparse.Action) -> bool:
+    return action.nargs != 0
+
+
+def _option_candidates(selection: _Selection, prefix: str) -> list[str]:
+    excluded = set(selection.consumed)
+    for group in selection.parser._mutually_exclusive_groups:
+        if any(id(action) in selection.consumed for action in group._group_actions):
+            excluded.update(id(action) for action in group._group_actions)
+    candidates: list[str] = []
+    for action in selection.parser._actions:
+        repeatable = isinstance(action, argparse._AppendAction)
+        if id(action) in excluded and not repeatable:
+            continue
+        candidates.extend(
+            option
+            for option in action.option_strings
+            if option.startswith(prefix)
+        )
+    return sorted(set(candidates))
+
+
+def _value_candidates(
+    action: argparse.Action,
+    repository: Path,
+    values: dict[str, list[str]],
+    prefix: str,
+) -> tuple[str, list[str]]:
+    if action.choices is not None:
+        candidates = [str(choice) for choice in action.choices]
+    else:
+        kind = getattr(action, "completion_kind", "none")
+        if kind == "path":
+            return "path", []
+        candidates = _dynamic_candidates(kind, repository, values)
+    return "candidates", [
+        candidate
+        for candidate in sorted(set(candidates))
+        if candidate.startswith(prefix) and _safe_candidate(candidate)
+    ]
+
+
+def _dynamic_candidates(
+    kind: str, repository: Path, values: dict[str, list[str]]
+) -> list[str]:
+    manifest = _manifest(repository)
+    paths = _paths(repository)
+    if kind == "component":
+        if manifest is None:
+            return []
+        return [
+            *(checkout.name for checkout in manifest.checkouts),
+            *(component.name for component in manifest.components),
+        ]
+    if kind == "profile_component":
+        if manifest is None:
+            return []
+        profile = _last(values, "name") or "default"
+        stack_name = _profile_stack(manifest, paths, profile)
+        roles = manifest.stacks[stack_name].providers if stack_name else {}
+        return [
+            *(checkout.name for checkout in manifest.checkouts),
+            *(component.name for component in manifest.components),
+            *roles,
+        ]
+    if kind == "build_target":
+        if manifest is None:
+            return ["all"]
+        return [
+            "all",
+            *(
+                role
+                for component in manifest.components
+                if component.build != "none"
+                for role in component.provides
+            ),
+        ]
+    if kind == "profile":
+        builtins = list(manifest.stacks) if manifest is not None else ["default", "classic"]
+        return [*builtins, *_profile_names(manifest, paths)]
+    if kind == "worktree":
+        checkout = _selected_checkout(manifest, paths, values)
+        return _directory_names(paths.worktrees / checkout) if paths and checkout else []
+    if kind == "state":
+        return ["default", *_state_names(paths)]
+    if kind == "scenario":
+        return _record_names(paths.scenarios, "scenario.json", "name") if paths else []
+    if kind == "topology":
+        return _topology_names(paths)
+    return []
+
+
+def _manifest(repository: Path) -> Manifest | None:
+    path = repository / "components.json"
+    try:
+        if not _regular_file(path) or path.stat().st_size > _MAX_METADATA_BYTES:
+            return None
+        return Manifest.load(path)
+    except (OSError, WorkspaceError):
+        return None
+
+
+def _paths(repository: Path) -> Paths | None:
+    try:
+        return Paths.discover(repository)
+    except (OSError, WorkspaceError):
+        return None
+
+
+def _profile_names(manifest: Manifest | None, paths: Paths | None) -> list[str]:
+    if manifest is None or paths is None:
+        return []
+    names: list[str] = []
+    for path in _entries(paths.profiles):
+        if path.suffix != ".json" or not _regular_file(path):
+            continue
+        name = path.stem
+        if _profile_record(manifest, paths, name) is not None:
+            names.append(name)
+    return names
+
+
+def _profile_stack(
+    manifest: Manifest, paths: Paths | None, profile: str
+) -> str | None:
+    if profile in manifest.stacks:
+        return profile
+    if paths is None or not _valid_name(profile):
+        return None
+    value = _profile_record(manifest, paths, profile)
+    if value is None:
+        return None
+    stack = value.get("stack")
+    return stack if isinstance(stack, str) and stack in manifest.stacks else None
+
+
+def _profile_record(
+    manifest: Manifest, paths: Paths, name: str
+) -> dict[str, Any] | None:
+    if not _valid_name(name):
+        return None
+    value = _json(paths.profiles / f"{name}.json")
+    if not isinstance(value, dict) or set(value) != _PROFILE_KEYS:
+        return None
+    stack_name = value.get("stack")
+    if (
+        value.get("schema_version") != 3
+        or value.get("name") != name
+        or not isinstance(stack_name, str)
+        or stack_name not in manifest.stacks
+        or not isinstance(value.get("components"), dict)
+    ):
+        return None
+    expected = {component.name for component in manifest.stacks[stack_name].components}
+    if set(value["components"]) != expected:
+        return None
+    for selector in value["components"].values():
+        if (
+            not isinstance(selector, dict)
+            or set(selector) != {"kind", "value"}
+            or not isinstance(selector.get("kind"), str)
+            or not isinstance(selector.get("value"), str)
+        ):
+            return None
+        kind = selector["kind"]
+        selected = selector["value"]
+        if kind not in {"primary", "worktree", "path", "migrated-worktree"}:
+            return None
+        if kind == "primary" and selected:
+            return None
+        if kind == "worktree" and not _valid_name(selected):
+            return None
+        if kind in {"path", "migrated-worktree"} and not Path(selected).is_absolute():
+            return None
+    return value
+
+
+def _selected_checkout(
+    manifest: Manifest | None, paths: Paths | None, values: dict[str, list[str]]
+) -> str | None:
+    if manifest is None:
+        return None
+    selected = _last(values, "component")
+    profile = _last(values, "name")
+    if profile is None:
+        if selected in manifest.by_checkout:
+            return selected
+        if selected in manifest.by_name:
+            return manifest.by_name[selected].checkout_name
+        return None
+    stack_name = _profile_stack(manifest, paths, profile)
+    if stack_name:
+        stack = manifest.stacks[stack_name]
+        if selected in manifest.by_checkout and any(
+            component.checkout_name == selected for component in stack.components
+        ):
+            return selected
+        if selected in manifest.by_name and manifest.by_name[selected] in stack.components:
+            return manifest.by_name[selected].checkout_name
+        if selected in stack.providers:
+            return stack.providers[selected].checkout_name
+    return None
+
+
+def _state_names(paths: Paths | None) -> list[str]:
+    if paths is None:
+        return []
+    value = _json(paths.states_file)
+    if (
+        not isinstance(value, dict)
+        or set(value) != {"schema_version", "states"}
+        or value.get("schema_version") != 1
+    ):
+        return []
+    states = value.get("states")
+    if not isinstance(states, dict):
+        return []
+    if any(
+        not _valid_name(name)
+        or not isinstance(path, str)
+        or not Path(path).is_absolute()
+        for name, path in states.items()
+    ):
+        return []
+    return list(states)
+
+
+def _record_names(directory: Path, metadata: str, key: str) -> list[str]:
+    names: list[str] = []
+    for path in _entries(directory):
+        if not _normal_directory(path) or not _valid_name(path.name):
+            continue
+        value = _json(path / metadata)
+        if (
+            isinstance(value, dict)
+            and set(value) == _SCENARIO_KEYS
+            and value.get("schema_version") == 4
+            and value.get(key) == path.name
+            and all(
+                isinstance(value.get(field), str)
+                for field in (
+                    "profile",
+                    "stack",
+                    "preset",
+                    "state",
+                    "account",
+                    "character",
+                    "archetype",
+                    "provisioned_at",
+                )
+            )
+            and isinstance(value.get("providers"), dict)
+            and isinstance(value.get("resolved"), dict)
+        ):
+            names.append(path.name)
+    return names
+
+
+def _topology_names(paths: Paths | None) -> list[str]:
+    if paths is None:
+        return []
+    names: list[str] = []
+    for path in _entries(paths.topologies):
+        if not _normal_directory(path) or not _valid_name(path.name):
+            continue
+        marker = _json(path / MANAGED_MARKER)
+        if marker == {"schema_version": 1, "purpose": f"topology:{path.name}"}:
+            names.append(path.name)
+    return names
+
+
+def _directory_names(directory: Path) -> list[str]:
+    return [
+        path.name
+        for path in _entries(directory)
+        if _normal_directory(path) and _valid_name(path.name)
+    ]
+
+
+def _entries(directory: Path) -> list[Path]:
+    try:
+        if not _normal_directory(directory):
+            return []
+        with os.scandir(directory) as stream:
+            names: list[str] = []
+            for entry in stream:
+                names.append(entry.name)
+                if len(names) > _MAX_DIRECTORY_ENTRIES:
+                    return []
+        return [directory / name for name in sorted(names)]
+    except OSError:
+        return []
+
+
+def _normal_directory(path: Path) -> bool:
+    try:
+        mode = path.lstat().st_mode
+    except OSError:
+        return False
+    return stat.S_ISDIR(mode)
+
+
+def _regular_file(path: Path) -> bool:
+    try:
+        return stat.S_ISREG(path.lstat().st_mode)
+    except OSError:
+        return False
+
+
+def _json(path: Path) -> Any:
+    flags = os.O_RDONLY | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+        with os.fdopen(descriptor, encoding="utf-8") as stream:
+            metadata = os.fstat(stream.fileno())
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_size > _MAX_METADATA_BYTES
+            ):
+                return None
+            return json.load(stream, object_pairs_hook=_unique_object)
+    except (OSError, UnicodeError, ValueError, json.JSONDecodeError):
+        return None
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError("duplicate metadata key")
+        value[key] = item
+    return value
+
+
+def _valid_name(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    try:
+        validate_name(value, "completion candidate")
+    except WorkspaceError:
+        return False
+    return True
+
+
+def _safe_candidate(value: str) -> bool:
+    return bool(value) and all(character.isprintable() for character in value)
+
+
+def _last(values: dict[str, list[str]], name: str) -> str | None:
+    candidates = values.get(name, [])
+    return candidates[-1] if candidates else None
+
+
+def protocol_command() -> str:
+    return _PROTOCOL_COMMAND
+
+
+def classified_actions(root_parser: argparse.ArgumentParser) -> Iterable[argparse.Action]:
+    """Expose parser actions for the parser/completion drift regression test."""
+
+    pending = [root_parser]
+    while pending:
+        current = pending.pop()
+        for action in current._actions:
+            yield action
+            if isinstance(action, argparse._SubParsersAction):
+                pending.extend(action.choices.values())
+
+
+_BASH_SCRIPT = r'''# Atrinik Bash completion; generated by ./atrinik completion bash.
+_atrinik_completion() {
+    local current=${COMP_WORDS[COMP_CWORD]}
+    local -a response
+    mapfile -t response < <(
+        "${COMP_WORDS[0]}" __complete "$COMP_CWORD" -- "${COMP_WORDS[@]}" 2>/dev/null
+    )
+    COMPREPLY=()
+    case ${response[0]-none} in
+        path)
+            mapfile -t COMPREPLY < <(compgen -f -- "$current")
+            ;;
+        candidates)
+            local candidate
+            for candidate in "${response[@]:1}"; do
+                [[ $candidate == "$current"* ]] && COMPREPLY+=("$candidate")
+            done
+            ;;
+    esac
+}
+complete -o filenames -F _atrinik_completion atrinik ./atrinik
+'''
+
+
+_ZSH_SCRIPT = r'''# Atrinik Zsh completion; generated by ./atrinik completion zsh.
+_atrinik_completion() {
+    local output
+    local -a response
+    output=$("${words[1]}" __complete "$((CURRENT - 1))" -- "${words[@]}" 2>/dev/null)
+    response=("${(@f)output}")
+    case ${response[1]-none} in
+        path)
+            _files
+            ;;
+        candidates)
+            shift response
+            compadd -- "${response[@]}"
+            ;;
+    esac
+}
+compdef _atrinik_completion atrinik ./atrinik
+'''
+
+
+_FISH_SCRIPT = r'''# Atrinik Fish completion; generated by ./atrinik completion fish.
+function __atrinik_completion
+    set -l words (commandline -opc)
+    set -l current (commandline -ct)
+    set -a words "$current"
+    set -l cursor (math (count $words) - 1)
+    set -l response (command $words[1] __complete $cursor -- $words 2>/dev/null)
+    switch "$response[1]"
+        case path
+            __fish_complete_path "$current"
+        case candidates
+            for candidate in $response[2..-1]
+                string escape -- "$candidate"
+            end
+    end
+end
+complete -c atrinik -f -a '(__atrinik_completion)'
+'''

--- a/atrinik_workspace/completion.py
+++ b/atrinik_workspace/completion.py
@@ -16,6 +16,9 @@ _MAX_WORDS = 256
 _MAX_WORD_LENGTH = 4096
 _MAX_DIRECTORY_ENTRIES = 256
 _MAX_METADATA_BYTES = 256 * 1024
+_MAX_RECORD_ENTRIES = 64
+_MAX_RECORD_BYTES = 64 * 1024
+_MAX_MARKER_BYTES = 1024
 _PROFILE_KEYS = {"schema_version", "name", "stack", "components"}
 _SCENARIO_KEYS = {
     "schema_version",
@@ -299,6 +302,8 @@ def _dynamic_candidates(
     if kind == "profile":
         builtins = list(manifest.stacks) if manifest is not None else ["default", "classic"]
         return [*builtins, *_profile_names(manifest, paths)]
+    if kind == "saved_profile":
+        return _profile_names(manifest, paths)
     if kind == "worktree":
         checkout = _selected_checkout(manifest, paths, values)
         return _worktree_names(paths, checkout) if paths and checkout else []
@@ -338,7 +343,7 @@ def _profile_names(manifest: Manifest | None, paths: Paths | None) -> list[str]:
         return []
     root = _workspace_descriptor(paths)
     if root is None:
-        return []
+        return {}
     profiles = _directory_descriptor("profiles", dir_fd=root)
     try:
         if profiles is None:
@@ -349,7 +354,7 @@ def _profile_names(manifest: Manifest | None, paths: Paths | None) -> list[str]:
             if path.suffix != ".json":
                 continue
             name = path.stem
-            if _profile_value(manifest, profiles, name) is not None:
+            if _profile_value(manifest, paths, profiles, name) is not None:
                 names.append(name)
         return names
     finally:
@@ -371,7 +376,7 @@ def _profile_stack(
     profiles = _directory_descriptor("profiles", dir_fd=root)
     try:
         value = (
-            _profile_value(manifest, profiles, profile)
+            _profile_value(manifest, paths, profiles, profile)
             if profiles is not None
             else None
         )
@@ -386,11 +391,11 @@ def _profile_stack(
 
 
 def _profile_value(
-    manifest: Manifest, profiles: int, name: str
+    manifest: Manifest, paths: Paths, profiles: int, name: str
 ) -> dict[str, Any] | None:
     if not _valid_name(name):
         return None
-    value = _json_at(profiles, f"{name}.json")
+    value = _json_at(profiles, f"{name}.json", _MAX_RECORD_BYTES)
     if not isinstance(value, dict) or set(value) != _PROFILE_KEYS:
         return None
     stack_name = value.get("stack")
@@ -405,7 +410,8 @@ def _profile_value(
     expected = {component.name for component in manifest.stacks[stack_name].components}
     if set(value["components"]) != expected:
         return None
-    for selector in value["components"].values():
+    checkout_selectors: dict[str, dict[str, Any]] = {}
+    for component_name, selector in value["components"].items():
         if (
             not isinstance(selector, dict)
             or set(selector) != {"kind", "value"}
@@ -421,7 +427,20 @@ def _profile_value(
             return None
         if kind == "worktree" and not _valid_name(selected):
             return None
-        if kind in {"path", "migrated-worktree"} and not Path(selected).is_absolute():
+        if kind == "path" and not Path(selected).is_absolute():
+            return None
+        if kind == "migrated-worktree":
+            migrated = Path(selected)
+            if (
+                component_name != "content-1x"
+                or not migrated.is_absolute()
+                or paths is None
+                or migrated.parent != paths.worktrees / "content"
+            ):
+                return None
+        checkout = manifest.by_name[component_name].checkout_name
+        previous = checkout_selectors.setdefault(checkout, selector)
+        if selector != previous:
             return None
     return value
 
@@ -454,30 +473,34 @@ def _selected_checkout(
 
 
 def _state_names(paths: Paths | None) -> list[str]:
+    return list(_registered_states(paths))
+
+
+def _registered_states(paths: Paths | None) -> dict[str, str]:
     if paths is None:
-        return []
+        return {}
     root = _workspace_descriptor(paths)
     if root is None:
         return []
     try:
-        value = _json_at(root, "states.json")
+        value = _json_at(root, "states.json", _MAX_RECORD_BYTES)
         if (
             not isinstance(value, dict)
             or set(value) != {"schema_version", "states"}
             or value.get("schema_version") != 1
         ):
-            return []
+            return {}
         states = value.get("states")
         if not isinstance(states, dict):
-            return []
+            return {}
         if any(
             not _valid_name(name)
             or not isinstance(path, str)
             or not Path(path).is_absolute()
             for name, path in states.items()
         ):
-            return []
-        return list(states)
+            return {}
+        return states
     finally:
         os.close(root)
 
@@ -489,20 +512,23 @@ def _scenario_names(manifest: Manifest | None, paths: Paths | None) -> list[str]
     if opened is None:
         return []
     root, records = opened
+    states = _registered_states(paths)
     try:
         names: list[str] = []
-        for name in _entry_names(records, file_type="directory"):
+        for name in _entry_names(
+            records, file_type="directory", limit=_MAX_RECORD_ENTRIES
+        ):
             if not _valid_name(name):
                 continue
             record = _directory_descriptor(name, dir_fd=records)
             if record is None:
                 continue
             try:
-                marker = _json_at(record, MANAGED_MARKER)
-                value = _json_at(record, "scenario.json")
+                marker = _json_at(record, MANAGED_MARKER, _MAX_MARKER_BYTES)
+                value = _json_at(record, "scenario.json", _MAX_RECORD_BYTES)
                 if (
                     marker == {"schema_version": 1, "purpose": "test-scenario"}
-                    and _valid_scenario(manifest, paths, name, value)
+                    and _valid_scenario(manifest, paths, states, name, value)
                 ):
                     names.append(name)
             finally:
@@ -514,7 +540,11 @@ def _scenario_names(manifest: Manifest | None, paths: Paths | None) -> list[str]
 
 
 def _valid_scenario(
-    manifest: Manifest, paths: Paths, name: str, value: Any
+    manifest: Manifest,
+    paths: Paths,
+    states: dict[str, str],
+    name: str,
+    value: Any,
 ) -> bool:
     if not isinstance(value, dict) or set(value) != _SCENARIO_KEYS:
         return False
@@ -529,19 +559,27 @@ def _valid_scenario(
     stack = manifest.stacks[stack_name]
     providers = value.get("providers")
     resolved = value.get("resolved")
+    required = _required_roles(stack, "server")
+    expected_providers = {
+        role: stack.providers[role].name for role in sorted(required)
+    }
+    state_name = f"scenario-{name}"
     if (
         value.get("schema_version") != 4
+        or not required
         or value.get("name") != name
         or value.get("stack") != stack_name
-        or value.get("state") != f"scenario-{name}"
+        or value.get("state") != state_name
         or value.get("preset") != "basic-player"
         or any(
             not isinstance(value.get(field), str) or not value[field]
             for field in ("account", "character", "archetype", "provisioned_at")
         )
         or not isinstance(providers, dict)
+        or providers != expected_providers
         or not isinstance(resolved, dict)
-        or set(resolved) != set(providers)
+        or set(resolved) != required
+        or states.get(state_name) != str(paths.scenarios / name / "state")
     ):
         return False
     for role, component_name in providers.items():
@@ -577,6 +615,21 @@ def _valid_scenario(
     return True
 
 
+def _required_roles(stack: Any, role: str) -> set[str]:
+    required: set[str] = set()
+    pending = [role]
+    while pending:
+        current = pending.pop()
+        if current in required:
+            continue
+        provider = stack.providers.get(current)
+        if provider is None:
+            return set()
+        required.add(current)
+        pending.extend(provider.requires)
+    return required
+
+
 def _topology_names(manifest: Manifest | None, paths: Paths | None) -> list[str]:
     if manifest is None or paths is None:
         return []
@@ -586,15 +639,17 @@ def _topology_names(manifest: Manifest | None, paths: Paths | None) -> list[str]
     root, topologies = opened
     try:
         names: list[str] = []
-        for name in _entry_names(topologies, file_type="directory"):
+        for name in _entry_names(
+            topologies, file_type="directory", limit=_MAX_RECORD_ENTRIES
+        ):
             if not _valid_name(name):
                 continue
             record = _directory_descriptor(name, dir_fd=topologies)
             if record is None:
                 continue
             try:
-                marker = _json_at(record, MANAGED_MARKER)
-                status = _json_at(record, "status.json")
+                marker = _json_at(record, MANAGED_MARKER, _MAX_MARKER_BYTES)
+                status = _json_at(record, "status.json", _MAX_RECORD_BYTES)
                 if (
                     marker == {"schema_version": 1, "purpose": f"topology:{name}"}
                     and _valid_topology(manifest, paths, name, status)
@@ -616,7 +671,12 @@ def _valid_topology(
         "dependencies", "state", "build_root", "resolved", "endpoint", "ready",
         "started_at", "stopped_at", "supervisor", "services",
     }
-    if not isinstance(status, dict) or set(status) != required:
+    if (
+        not isinstance(status, dict)
+        or not required <= set(status) <= required | {"error"}
+        or "error" in status
+        and not isinstance(status["error"], str)
+    ):
         return False
     profile = status.get("profile")
     stack_name = (
@@ -634,8 +694,13 @@ def _valid_topology(
         or status.get("stack") != stack_name
         or not isinstance(dependencies, list)
         or not dependencies
+        or not all(isinstance(role, str) and _valid_name(role) for role in dependencies)
         or len(dependencies) != len(set(dependencies))
         or not isinstance(providers, dict)
+        or not all(
+            isinstance(role, str) and isinstance(component, str)
+            for role, component in providers.items()
+        )
         or set(providers) != set(dependencies)
         or not isinstance(resolved, dict)
         or set(resolved) != set(providers.values())
@@ -681,7 +746,7 @@ def _valid_topology(
     services = status.get("services")
     if (
         not isinstance(services, dict)
-        or not services
+        or not services and "error" not in status
         or not set(services) <= {"client", "server"}
     ):
         return False
@@ -783,7 +848,7 @@ def _workspace_descriptor(paths: Paths) -> int | None:
     root = _directory_descriptor(paths.workspace)
     if root is None:
         return None
-    if _json_at(root, paths.marker.name) != {"schema_version": 1}:
+    if _json_at(root, paths.marker.name, _MAX_MARKER_BYTES) != {"schema_version": 1}:
         os.close(root)
         return None
     return root
@@ -800,12 +865,14 @@ def _workspace_child_descriptor(paths: Paths, name: str) -> tuple[int, int] | No
     return root, child
 
 
-def _entry_names(directory: int, *, file_type: str) -> list[str]:
+def _entry_names(
+    directory: int, *, file_type: str, limit: int = _MAX_DIRECTORY_ENTRIES
+) -> list[str]:
     try:
         names: list[str] = []
         with os.scandir(directory) as stream:
             for index, entry in enumerate(stream):
-                if index >= _MAX_DIRECTORY_ENTRIES:
+                if index >= limit:
                     return []
                 matches = (
                     entry.is_dir(follow_symlinks=False)
@@ -845,7 +912,9 @@ def _json(path: Path) -> Any:
         os.close(descriptor)
 
 
-def _json_at(directory: int, name: str) -> Any:
+def _json_at(
+    directory: int, name: str, max_bytes: int = _MAX_METADATA_BYTES
+) -> Any:
     flags = os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_NONBLOCK", 0)
     flags |= getattr(os, "O_NOFOLLOW", 0)
     try:
@@ -853,18 +922,20 @@ def _json_at(directory: int, name: str) -> Any:
     except OSError:
         return None
     try:
-        return _json_descriptor(descriptor)
+        return _json_descriptor(descriptor, max_bytes)
     finally:
         os.close(descriptor)
 
 
-def _json_descriptor(descriptor: int) -> Any:
+def _json_descriptor(
+    descriptor: int, max_bytes: int = _MAX_METADATA_BYTES
+) -> Any:
     try:
         metadata = os.fstat(descriptor)
-        if not stat.S_ISREG(metadata.st_mode) or metadata.st_size > _MAX_METADATA_BYTES:
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_size > max_bytes:
             return None
         chunks: list[bytes] = []
-        remaining = _MAX_METADATA_BYTES + 1
+        remaining = max_bytes + 1
         while remaining:
             chunk = os.read(descriptor, min(64 * 1024, remaining))
             if not chunk:
@@ -872,7 +943,7 @@ def _json_descriptor(descriptor: int) -> Any:
             chunks.append(chunk)
             remaining -= len(chunk)
         data = b"".join(chunks)
-        if len(data) > _MAX_METADATA_BYTES:
+        if len(data) > max_bytes:
             return None
         return json.loads(data.decode("utf-8"), object_pairs_hook=_unique_object)
     except (OSError, UnicodeError, ValueError, RecursionError, json.JSONDecodeError):

--- a/atrinik_workspace/completion.py
+++ b/atrinik_workspace/completion.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import os
 from pathlib import Path
+import re
 import stat
 from typing import Any, Iterable
 
@@ -101,6 +102,8 @@ def complete(
             mode, values = _value_candidates(
                 action, repository, selected.values, prefix
             )
+            if mode == "path":
+                return mode, values
             return mode, [f"{option}={value}" for value in values]
     if current.startswith("-"):
         return "candidates", _option_candidates(selected, current)
@@ -236,7 +239,7 @@ def _value_candidates(
     else:
         kind = getattr(action, "completion_kind", "none")
         if kind == "path":
-            return "path", []
+            return "path", [prefix]
         candidates = _dynamic_candidates(kind, repository, values)
     return "candidates", [
         candidate
@@ -257,27 +260,40 @@ def _dynamic_candidates(
             *(checkout.name for checkout in manifest.checkouts),
             *(component.name for component in manifest.components),
         ]
-    if kind == "profile_component":
+    if kind in {"profile_component", "profile_selection"}:
         if manifest is None:
             return []
-        profile = _last(values, "name") or "default"
+        profile = _last(values, "name") or _last(values, "profile") or "default"
         stack_name = _profile_stack(manifest, paths, profile)
-        roles = manifest.stacks[stack_name].providers if stack_name else {}
-        return [
-            *(checkout.name for checkout in manifest.checkouts),
-            *(component.name for component in manifest.components),
-            *roles,
+        if stack_name is None:
+            return []
+        stack = manifest.stacks[stack_name]
+        candidates = [
+            *(component.name for component in stack.components),
+            *stack.providers,
         ]
+        if kind == "profile_selection":
+            candidates.extend(component.checkout_name for component in stack.components)
+        return candidates
     if kind == "build_target":
         if manifest is None:
             return ["all"]
+        profile = _last(values, "profile") or "default"
+        stack_name = _profile_stack(manifest, paths, profile)
+        if stack_name is None:
+            return []
+        stack = manifest.stacks[stack_name]
         return [
             "all",
             *(
                 role
-                for component in manifest.components
+                for role, component in stack.providers.items()
                 if component.build != "none"
-                for role in component.provides
+            ),
+            *(
+                component.name
+                for component in stack.components
+                if component.build != "none"
             ),
         ]
     if kind == "profile":
@@ -285,44 +301,61 @@ def _dynamic_candidates(
         return [*builtins, *_profile_names(manifest, paths)]
     if kind == "worktree":
         checkout = _selected_checkout(manifest, paths, values)
-        return _directory_names(paths.worktrees / checkout) if paths and checkout else []
+        return _worktree_names(paths, checkout) if paths and checkout else []
     if kind == "state":
         return ["default", *_state_names(paths)]
     if kind == "scenario":
-        return _record_names(paths.scenarios, "scenario.json", "name") if paths else []
+        return _scenario_names(manifest, paths)
     if kind == "topology":
-        return _topology_names(paths)
+        return _topology_names(manifest, paths)
     return []
 
 
 def _manifest(repository: Path) -> Manifest | None:
-    path = repository / "components.json"
     try:
-        if not _regular_file(path) or path.stat().st_size > _MAX_METADATA_BYTES:
+        value = _json(repository / "components.json")
+        if value is None:
             return None
-        return Manifest.load(path)
-    except (OSError, WorkspaceError):
+        return Manifest.from_value(value)
+    except (OSError, RecursionError, WorkspaceError):
         return None
 
 
 def _paths(repository: Path) -> Paths | None:
     try:
-        return Paths.discover(repository)
-    except (OSError, WorkspaceError):
+        paths = Paths.discover(repository)
+        descriptor = _workspace_descriptor(paths)
+        if descriptor is None:
+            return None
+        os.close(descriptor)
+        return paths
+    except (OSError, RuntimeError, WorkspaceError):
         return None
 
 
 def _profile_names(manifest: Manifest | None, paths: Paths | None) -> list[str]:
     if manifest is None or paths is None:
         return []
-    names: list[str] = []
-    for path in _entries(paths.profiles):
-        if path.suffix != ".json" or not _regular_file(path):
-            continue
-        name = path.stem
-        if _profile_record(manifest, paths, name) is not None:
-            names.append(name)
-    return names
+    root = _workspace_descriptor(paths)
+    if root is None:
+        return []
+    profiles = _directory_descriptor("profiles", dir_fd=root)
+    try:
+        if profiles is None:
+            return []
+        names: list[str] = []
+        for filename in _entry_names(profiles, file_type="file"):
+            path = Path(filename)
+            if path.suffix != ".json":
+                continue
+            name = path.stem
+            if _profile_value(manifest, profiles, name) is not None:
+                names.append(name)
+        return names
+    finally:
+        if profiles is not None:
+            os.close(profiles)
+        os.close(root)
 
 
 def _profile_stack(
@@ -332,19 +365,32 @@ def _profile_stack(
         return profile
     if paths is None or not _valid_name(profile):
         return None
-    value = _profile_record(manifest, paths, profile)
-    if value is None:
+    root = _workspace_descriptor(paths)
+    if root is None:
         return None
-    stack = value.get("stack")
-    return stack if isinstance(stack, str) and stack in manifest.stacks else None
+    profiles = _directory_descriptor("profiles", dir_fd=root)
+    try:
+        value = (
+            _profile_value(manifest, profiles, profile)
+            if profiles is not None
+            else None
+        )
+        if value is None:
+            return None
+        stack = value.get("stack")
+        return stack if isinstance(stack, str) and stack in manifest.stacks else None
+    finally:
+        if profiles is not None:
+            os.close(profiles)
+        os.close(root)
 
 
-def _profile_record(
-    manifest: Manifest, paths: Paths, name: str
+def _profile_value(
+    manifest: Manifest, profiles: int, name: str
 ) -> dict[str, Any] | None:
     if not _valid_name(name):
         return None
-    value = _json(paths.profiles / f"{name}.json")
+    value = _json_at(profiles, f"{name}.json")
     if not isinstance(value, dict) or set(value) != _PROFILE_KEYS:
         return None
     stack_name = value.get("stack")
@@ -410,123 +456,426 @@ def _selected_checkout(
 def _state_names(paths: Paths | None) -> list[str]:
     if paths is None:
         return []
-    value = _json(paths.states_file)
-    if (
-        not isinstance(value, dict)
-        or set(value) != {"schema_version", "states"}
-        or value.get("schema_version") != 1
-    ):
+    root = _workspace_descriptor(paths)
+    if root is None:
         return []
-    states = value.get("states")
-    if not isinstance(states, dict):
-        return []
-    if any(
-        not _valid_name(name)
-        or not isinstance(path, str)
-        or not Path(path).is_absolute()
-        for name, path in states.items()
-    ):
-        return []
-    return list(states)
-
-
-def _record_names(directory: Path, metadata: str, key: str) -> list[str]:
-    names: list[str] = []
-    for path in _entries(directory):
-        if not _normal_directory(path) or not _valid_name(path.name):
-            continue
-        value = _json(path / metadata)
+    try:
+        value = _json_at(root, "states.json")
         if (
-            isinstance(value, dict)
-            and set(value) == _SCENARIO_KEYS
-            and value.get("schema_version") == 4
-            and value.get(key) == path.name
-            and all(
-                isinstance(value.get(field), str)
-                for field in (
-                    "profile",
-                    "stack",
-                    "preset",
-                    "state",
-                    "account",
-                    "character",
-                    "archetype",
-                    "provisioned_at",
-                )
-            )
-            and isinstance(value.get("providers"), dict)
-            and isinstance(value.get("resolved"), dict)
+            not isinstance(value, dict)
+            or set(value) != {"schema_version", "states"}
+            or value.get("schema_version") != 1
         ):
-            names.append(path.name)
-    return names
-
-
-def _topology_names(paths: Paths | None) -> list[str]:
-    if paths is None:
-        return []
-    names: list[str] = []
-    for path in _entries(paths.topologies):
-        if not _normal_directory(path) or not _valid_name(path.name):
-            continue
-        marker = _json(path / MANAGED_MARKER)
-        if marker == {"schema_version": 1, "purpose": f"topology:{path.name}"}:
-            names.append(path.name)
-    return names
-
-
-def _directory_names(directory: Path) -> list[str]:
-    return [
-        path.name
-        for path in _entries(directory)
-        if _normal_directory(path) and _valid_name(path.name)
-    ]
-
-
-def _entries(directory: Path) -> list[Path]:
-    try:
-        if not _normal_directory(directory):
             return []
+        states = value.get("states")
+        if not isinstance(states, dict):
+            return []
+        if any(
+            not _valid_name(name)
+            or not isinstance(path, str)
+            or not Path(path).is_absolute()
+            for name, path in states.items()
+        ):
+            return []
+        return list(states)
+    finally:
+        os.close(root)
+
+
+def _scenario_names(manifest: Manifest | None, paths: Paths | None) -> list[str]:
+    if manifest is None or paths is None:
+        return []
+    opened = _workspace_child_descriptor(paths, "scenarios")
+    if opened is None:
+        return []
+    root, records = opened
+    try:
+        names: list[str] = []
+        for name in _entry_names(records, file_type="directory"):
+            if not _valid_name(name):
+                continue
+            record = _directory_descriptor(name, dir_fd=records)
+            if record is None:
+                continue
+            try:
+                marker = _json_at(record, MANAGED_MARKER)
+                value = _json_at(record, "scenario.json")
+                if (
+                    marker == {"schema_version": 1, "purpose": "test-scenario"}
+                    and _valid_scenario(manifest, paths, name, value)
+                ):
+                    names.append(name)
+            finally:
+                os.close(record)
+        return names
+    finally:
+        os.close(records)
+        os.close(root)
+
+
+def _valid_scenario(
+    manifest: Manifest, paths: Paths, name: str, value: Any
+) -> bool:
+    if not isinstance(value, dict) or set(value) != _SCENARIO_KEYS:
+        return False
+    profile = value.get("profile")
+    stack_name = (
+        _profile_stack(manifest, paths, profile)
+        if isinstance(profile, str)
+        else None
+    )
+    if stack_name is None:
+        return False
+    stack = manifest.stacks[stack_name]
+    providers = value.get("providers")
+    resolved = value.get("resolved")
+    if (
+        value.get("schema_version") != 4
+        or value.get("name") != name
+        or value.get("stack") != stack_name
+        or value.get("state") != f"scenario-{name}"
+        or value.get("preset") != "basic-player"
+        or any(
+            not isinstance(value.get(field), str) or not value[field]
+            for field in ("account", "character", "archetype", "provisioned_at")
+        )
+        or not isinstance(providers, dict)
+        or not isinstance(resolved, dict)
+        or set(resolved) != set(providers)
+    ):
+        return False
+    for role, component_name in providers.items():
+        provider = stack.providers.get(role)
+        record = resolved.get(role)
+        if (
+            provider is None
+            or component_name != provider.name
+            or not isinstance(record, dict)
+            or set(record)
+            != {
+                "path", "checkout_path", "checkout", "repository", "branch",
+                "source", "head", "dirty",
+            }
+            or record.get("checkout") != provider.checkout_name
+            or record.get("repository") != provider.repository
+            or record.get("branch") != provider.branch
+            or record.get("source") != provider.source
+            or not isinstance(record.get("path"), str)
+            or not Path(record["path"]).is_absolute()
+            or not isinstance(record.get("checkout_path"), str)
+            or not Path(record["checkout_path"]).is_absolute()
+            or not isinstance(record.get("head"), str)
+            or re.fullmatch(r"[0-9a-f]{40,64}", record["head"]) is None
+            or not isinstance(record.get("dirty"), bool)
+        ):
+            return False
+        expected = Path(record["checkout_path"])
+        if provider.source != ".":
+            expected = expected.joinpath(*provider.source.split("/"))
+        if Path(record["path"]) != expected:
+            return False
+    return True
+
+
+def _topology_names(manifest: Manifest | None, paths: Paths | None) -> list[str]:
+    if manifest is None or paths is None:
+        return []
+    opened = _workspace_child_descriptor(paths, "topologies")
+    if opened is None:
+        return []
+    root, topologies = opened
+    try:
+        names: list[str] = []
+        for name in _entry_names(topologies, file_type="directory"):
+            if not _valid_name(name):
+                continue
+            record = _directory_descriptor(name, dir_fd=topologies)
+            if record is None:
+                continue
+            try:
+                marker = _json_at(record, MANAGED_MARKER)
+                status = _json_at(record, "status.json")
+                if (
+                    marker == {"schema_version": 1, "purpose": f"topology:{name}"}
+                    and _valid_topology(manifest, paths, name, status)
+                ):
+                    names.append(name)
+            finally:
+                os.close(record)
+        return names
+    finally:
+        os.close(topologies)
+        os.close(root)
+
+
+def _valid_topology(
+    manifest: Manifest, paths: Paths, name: str, status: Any
+) -> bool:
+    required = {
+        "schema_version", "name", "profile", "stack", "providers",
+        "dependencies", "state", "build_root", "resolved", "endpoint", "ready",
+        "started_at", "stopped_at", "supervisor", "services",
+    }
+    if not isinstance(status, dict) or set(status) != required:
+        return False
+    profile = status.get("profile")
+    stack_name = (
+        _profile_stack(manifest, paths, profile)
+        if isinstance(profile, str)
+        else None
+    )
+    dependencies = status.get("dependencies")
+    providers = status.get("providers")
+    resolved = status.get("resolved")
+    if (
+        status.get("schema_version") != 1
+        or status.get("name") != name
+        or stack_name is None
+        or status.get("stack") != stack_name
+        or not isinstance(dependencies, list)
+        or not dependencies
+        or len(dependencies) != len(set(dependencies))
+        or not isinstance(providers, dict)
+        or set(providers) != set(dependencies)
+        or not isinstance(resolved, dict)
+        or set(resolved) != set(providers.values())
+        or status.get("state") is not None
+        and (
+            not isinstance(status["state"], str)
+            or not Path(status["state"]).is_absolute()
+        )
+        or not isinstance(status.get("build_root"), str)
+        or not Path(status["build_root"]).is_absolute()
+        or not isinstance(status.get("ready"), bool)
+        or not isinstance(status.get("started_at"), str)
+        or not status["started_at"]
+        or status.get("stopped_at") is not None
+        and not isinstance(status["stopped_at"], str)
+    ):
+        return False
+    stack = manifest.stacks[stack_name]
+    for role, component_name in providers.items():
+        provider = stack.providers.get(role)
+        if provider is None or component_name != provider.name:
+            return False
+        if not _valid_resolution(provider, resolved.get(component_name)):
+            return False
+    supervisor = status.get("supervisor")
+    if not _valid_process(supervisor):
+        return False
+    endpoint = status.get("endpoint")
+    if endpoint is not None and (
+        not isinstance(endpoint, dict)
+        or set(endpoint) != {"host", "port", "fingerprint"}
+        or endpoint.get("host") != "127.0.0.1"
+        or not isinstance(endpoint.get("port"), int)
+        or isinstance(endpoint.get("port"), bool)
+        or not 1 <= endpoint["port"] <= 65535
+        or endpoint.get("fingerprint") is not None
+        and (
+            not isinstance(endpoint["fingerprint"], str)
+            or re.fullmatch(r"[0-9a-f]{64}", endpoint["fingerprint"]) is None
+        )
+    ):
+        return False
+    services = status.get("services")
+    if (
+        not isinstance(services, dict)
+        or not services
+        or not set(services) <= {"client", "server"}
+    ):
+        return False
+    for service in services.values():
+        if (
+            not _valid_process(service)
+            or set(service)
+            != {"pid", "start_time", "status", "exit_code", "log", "cwd"}
+            or service.get("status") not in {"starting", "running", "exited"}
+            or service.get("exit_code") is not None
+            and (
+                not isinstance(service["exit_code"], int)
+                or isinstance(service["exit_code"], bool)
+            )
+            or not isinstance(service.get("log"), str)
+            or not Path(service["log"]).is_absolute()
+            or not isinstance(service.get("cwd"), str)
+            or not Path(service["cwd"]).is_absolute()
+        ):
+            return False
+    return ("server" in services) == (endpoint is not None)
+
+
+def _valid_process(record: Any) -> bool:
+    return (
+        isinstance(record, dict)
+        and isinstance(record.get("pid"), int)
+        and not isinstance(record.get("pid"), bool)
+        and record["pid"] > 0
+        and isinstance(record.get("start_time"), str)
+        and record["start_time"].isdigit()
+    )
+
+
+def _valid_resolution(provider: Any, record: Any) -> bool:
+    if (
+        not isinstance(record, dict)
+        or set(record)
+        != {
+            "path", "checkout_path", "checkout", "repository", "branch", "source",
+            "head", "dirty",
+        }
+        or record.get("checkout") != provider.checkout_name
+        or record.get("repository") != provider.repository
+        or record.get("branch") != provider.branch
+        or record.get("source") != provider.source
+        or not isinstance(record.get("path"), str)
+        or not Path(record["path"]).is_absolute()
+        or not isinstance(record.get("checkout_path"), str)
+        or not Path(record["checkout_path"]).is_absolute()
+        or not isinstance(record.get("head"), str)
+        or re.fullmatch(r"[0-9a-f]{40,64}", record["head"]) is None
+        or not isinstance(record.get("dirty"), bool)
+    ):
+        return False
+    expected = Path(record["checkout_path"])
+    if provider.source != ".":
+        expected = expected.joinpath(*provider.source.split("/"))
+    return Path(record["path"]) == expected
+
+
+def _worktree_names(paths: Paths, checkout: str) -> list[str]:
+    opened = _workspace_child_descriptor(paths, "worktrees")
+    if opened is None:
+        return []
+    root, worktrees = opened
+    selected = _directory_descriptor(checkout, dir_fd=worktrees)
+    try:
+        if selected is None:
+            return []
+        names: list[str] = []
+        for name in _entry_names(selected, file_type="directory"):
+            candidate = _directory_descriptor(name, dir_fd=selected)
+            if candidate is None:
+                continue
+            try:
+                if _valid_name(name) and _regular_at(candidate, ".git"):
+                    names.append(name)
+            finally:
+                os.close(candidate)
+        return names
+    finally:
+        if selected is not None:
+            os.close(selected)
+        os.close(worktrees)
+        os.close(root)
+
+
+def _directory_descriptor(path: str | Path, *, dir_fd: int | None = None) -> int | None:
+    flags = os.O_RDONLY | os.O_CLOEXEC
+    flags |= getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        return os.open(path, flags, dir_fd=dir_fd)
+    except OSError:
+        return None
+
+
+def _workspace_descriptor(paths: Paths) -> int | None:
+    root = _directory_descriptor(paths.workspace)
+    if root is None:
+        return None
+    if _json_at(root, paths.marker.name) != {"schema_version": 1}:
+        os.close(root)
+        return None
+    return root
+
+
+def _workspace_child_descriptor(paths: Paths, name: str) -> tuple[int, int] | None:
+    root = _workspace_descriptor(paths)
+    if root is None:
+        return None
+    child = _directory_descriptor(name, dir_fd=root)
+    if child is None:
+        os.close(root)
+        return None
+    return root, child
+
+
+def _entry_names(directory: int, *, file_type: str) -> list[str]:
+    try:
+        names: list[str] = []
         with os.scandir(directory) as stream:
-            names: list[str] = []
-            for entry in stream:
-                names.append(entry.name)
-                if len(names) > _MAX_DIRECTORY_ENTRIES:
+            for index, entry in enumerate(stream):
+                if index >= _MAX_DIRECTORY_ENTRIES:
                     return []
-        return [directory / name for name in sorted(names)]
+                matches = (
+                    entry.is_dir(follow_symlinks=False)
+                    if file_type == "directory"
+                    else entry.is_file(follow_symlinks=False)
+                )
+                if matches:
+                    names.append(entry.name)
+        return sorted(names)
     except OSError:
         return []
 
 
-def _normal_directory(path: Path) -> bool:
+def _regular_at(directory: int, name: str) -> bool:
+    flags = os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_NONBLOCK", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
     try:
-        mode = path.lstat().st_mode
+        descriptor = os.open(name, flags, dir_fd=directory)
     except OSError:
         return False
-    return stat.S_ISDIR(mode)
-
-
-def _regular_file(path: Path) -> bool:
     try:
-        return stat.S_ISREG(path.lstat().st_mode)
-    except OSError:
-        return False
+        return stat.S_ISREG(os.fstat(descriptor).st_mode)
+    finally:
+        os.close(descriptor)
 
 
 def _json(path: Path) -> Any:
-    flags = os.O_RDONLY | os.O_CLOEXEC
-    if hasattr(os, "O_NOFOLLOW"):
-        flags |= os.O_NOFOLLOW
+    flags = os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_NONBLOCK", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
     try:
         descriptor = os.open(path, flags)
-        with os.fdopen(descriptor, encoding="utf-8") as stream:
-            metadata = os.fstat(stream.fileno())
-            if (
-                not stat.S_ISREG(metadata.st_mode)
-                or metadata.st_size > _MAX_METADATA_BYTES
-            ):
-                return None
-            return json.load(stream, object_pairs_hook=_unique_object)
-    except (OSError, UnicodeError, ValueError, json.JSONDecodeError):
+    except OSError:
+        return None
+    try:
+        return _json_descriptor(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _json_at(directory: int, name: str) -> Any:
+    flags = os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_NONBLOCK", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(name, flags, dir_fd=directory)
+    except OSError:
+        return None
+    try:
+        return _json_descriptor(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _json_descriptor(descriptor: int) -> Any:
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_size > _MAX_METADATA_BYTES:
+            return None
+        chunks: list[bytes] = []
+        remaining = _MAX_METADATA_BYTES + 1
+        while remaining:
+            chunk = os.read(descriptor, min(64 * 1024, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        data = b"".join(chunks)
+        if len(data) > _MAX_METADATA_BYTES:
+            return None
+        return json.loads(data.decode("utf-8"), object_pairs_hook=_unique_object)
+    except (OSError, UnicodeError, ValueError, RecursionError, json.JSONDecodeError):
         return None
 
 
@@ -584,7 +933,12 @@ _atrinik_completion() {
     COMPREPLY=()
     case ${response[0]-none} in
         path)
-            mapfile -t COMPREPLY < <(compgen -f -- "$current")
+            local fragment=${response[1]-$current}
+            local option_prefix=${current%"$fragment"}
+            local path
+            while IFS= read -r path; do
+                COMPREPLY+=("${option_prefix}${path}")
+            done < <(compgen -f -- "$fragment")
             ;;
         candidates)
             local candidate
@@ -598,15 +952,19 @@ complete -o filenames -F _atrinik_completion atrinik ./atrinik
 '''
 
 
-_ZSH_SCRIPT = r'''# Atrinik Zsh completion; generated by ./atrinik completion zsh.
-_atrinik_completion() {
+_ZSH_SCRIPT = r'''#compdef atrinik
+# Atrinik Zsh completion; generated by ./atrinik completion zsh.
+_atrinik() {
     local output
     local -a response
     output=$("${words[1]}" __complete "$((CURRENT - 1))" -- "${words[@]}" 2>/dev/null)
     response=("${(@f)output}")
     case ${response[1]-none} in
         path)
-            _files
+            local fragment=${response[2]-${words[CURRENT]}}
+            local option_prefix=${words[CURRENT]%$fragment}
+            PREFIX=$fragment
+            _files -P "$option_prefix"
             ;;
         candidates)
             shift response
@@ -614,7 +972,11 @@ _atrinik_completion() {
             ;;
     esac
 }
-compdef _atrinik_completion atrinik ./atrinik
+if [[ ${funcstack[1]-} == _atrinik ]]; then
+    _atrinik "$@"
+else
+    compdef _atrinik atrinik ./atrinik
+fi
 '''
 
 
@@ -627,7 +989,11 @@ function __atrinik_completion
     set -l response (command $words[1] __complete $cursor -- $words 2>/dev/null)
     switch "$response[1]"
         case path
-            __fish_complete_path "$current"
+            set -l fragment "$response[2]"
+            set -l option_prefix (string replace -r -- (string escape --style=regex "$fragment")'$' '' "$current")
+            for candidate in (__fish_complete_path "$fragment")
+                printf '%s%s\n' "$option_prefix" "$candidate"
+            end
         case candidates
             for candidate in $response[2..-1]
                 string escape -- "$candidate"

--- a/atrinik_workspace/model.py
+++ b/atrinik_workspace/model.py
@@ -299,7 +299,12 @@ class Manifest:
 
     @classmethod
     def load(cls, path: Path) -> "Manifest":
-        root = load_json(path)
+        return cls.from_value(load_json(path))
+
+    @classmethod
+    def from_value(cls, root: Any) -> "Manifest":
+        """Load a manifest from an already bounded and decoded JSON value."""
+
         if not isinstance(root, dict):
             raise WorkspaceError("component manifest root must be an object")
         schema_version = root.get("schema_version")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -482,6 +482,27 @@ CMake, Python collection, npm, and runtime commands execute code from the
 selected profile. Review a pull request before selecting its worktree.
 Profiles do not provide a security sandbox.
 
+Shell completion is a separate read-only path ahead of `Workspace`
+construction and normal command dispatch. One bounded line-oriented protocol
+walks the same `argparse` metadata as execution and supplies all three generated
+shell adapters. It loads `components.json` directly and uses shallow,
+no-follow reads of existing profile, worktree-label, state, scenario, and
+topology names under the path selected by `ATRINIK_WORKSPACE_DIR`. Directory
+scans and metadata sizes are capped; malformed, stale, unreadable, symlinked,
+or unsafe/control-character records fail quietly without removing static
+parser candidates. Filesystem arguments are delegated to native shell path
+completion, and the protocol never reads scenario passwords or external state.
+
+The completion path does not create the workspace or its ownership marker,
+directories, locks, profiles, or registries. It does not inspect Git, call a
+subprocess, use the network, validate repositories, probe topology liveness,
+or enter initialization, synchronization, build, migration, cleanup, runtime,
+or credential dispatch. Each keypress starts a fresh bounded query, so local
+additions and removals are visible without a persistent cache. Generated
+adapters pass the invocation and words as argument arrays and never evaluate a
+candidate as shell code; wrapper completion stops at `--` and the `run`
+remainder boundary.
+
 Subprocesses use argument arrays rather than a shell. User-provided executable
 arguments are not evaluated as shell syntax, and recognized join-password
 forms are redacted from diagnostics. Git operations refuse dirty primary

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import argparse
-from contextlib import redirect_stderr, redirect_stdout
+from contextlib import ExitStack, redirect_stderr, redirect_stdout
 import io
 import json
 import os
@@ -9,6 +9,7 @@ from pathlib import Path
 import shutil
 import shlex
 import subprocess
+import sys
 import tempfile
 import unittest
 from unittest import mock
@@ -34,6 +35,10 @@ class CompletionTests(unittest.TestCase):
             os.environ, {"ATRINIK_WORKSPACE_DIR": str(self.workspace)}
         )
         self.environment.start()
+        self.workspace.mkdir()
+        (self.workspace / ".atrinik-workspace.json").write_text(
+            json.dumps({"schema_version": 1}), encoding="utf-8"
+        )
 
     def tearDown(self) -> None:
         self.environment.stop()
@@ -57,6 +62,40 @@ class CompletionTests(unittest.TestCase):
                 component.name: {"kind": "primary", "value": ""}
                 for component in manifest.stacks[stack].components
             },
+        }
+
+    def scenario_record(self, name: str) -> dict[str, object]:
+        manifest = Manifest.load(self.wrapper / "components.json")
+        stack = manifest.stacks["classic"]
+        roles = {"server", "content", "resources", "libatrinik", "protocol"}
+        providers = {role: stack.providers[role].name for role in sorted(roles)}
+        resolved = {}
+        for role in sorted(roles):
+            provider = stack.providers[role]
+            checkout_path = self.root / provider.checkout_name
+            resolved[role] = {
+                "path": str(checkout_path / provider.source),
+                "checkout_path": str(checkout_path),
+                "checkout": provider.checkout_name,
+                "repository": provider.repository,
+                "branch": provider.branch,
+                "source": provider.source,
+                "head": "a" * 40,
+                "dirty": False,
+            }
+        return {
+            "schema_version": 4,
+            "name": name,
+            "profile": "classic",
+            "stack": "classic",
+            "providers": providers,
+            "preset": "basic-player",
+            "state": f"scenario-{name}",
+            "account": "scenario292",
+            "character": "Scenario 292",
+            "archetype": "human_male",
+            "resolved": resolved,
+            "provisioned_at": "2026-08-10T00:00:00Z",
         }
 
     def test_commands_nested_commands_options_and_choices_follow_parser(self) -> None:
@@ -117,11 +156,18 @@ class CompletionTests(unittest.TestCase):
         self.assertIn("content", values)
         self.assertIn("content-1x", values)
 
-        mode, values = self.candidates("build", "")
+        mode, values = self.candidates("build", "--profile", "classic", "")
         self.assertEqual(mode, "candidates")
         self.assertIn("all", values)
         self.assertIn("libatrinik", values)
-        self.assertIn("metaserver-worker", values)
+        self.assertIn("classic-server", values)
+
+        _, default_values = self.candidates("build", "--profile", "default", "")
+        self.assertIn("metaserver-worker", default_values)
+        self.assertNotIn("libatrinik", default_values)
+        _, path_values = self.candidates("path", "--profile", "classic", "")
+        self.assertIn("classic-client", path_values)
+        self.assertNotIn("website", path_values)
 
     def test_profiles_refresh_and_malformed_records_fail_softly(self) -> None:
         profiles = self.workspace / "profiles"
@@ -148,6 +194,12 @@ class CompletionTests(unittest.TestCase):
         (self.workspace / "worktrees" / "content-1x" / "classic-maps").mkdir(
             parents=True
         )
+        (self.workspace / "worktrees" / "content" / "main-maps" / ".git").write_text(
+            "gitdir: /tmp/main-maps\n", encoding="utf-8"
+        )
+        (
+            self.workspace / "worktrees" / "content-1x" / "classic-maps" / ".git"
+        ).write_text("gitdir: /tmp/classic-maps\n", encoding="utf-8")
         _, main_values = self.candidates("worktree", "remove", "content", "")
         _, classic_values = self.candidates(
             "worktree", "remove", "content-1x", ""
@@ -163,6 +215,9 @@ class CompletionTests(unittest.TestCase):
             self.profile_record("review", "classic"),
         )
         (self.workspace / "worktrees" / "classic" / "feature").mkdir(parents=True)
+        (self.workspace / "worktrees" / "classic" / "feature" / ".git").write_text(
+            "gitdir: /tmp/feature\n", encoding="utf-8"
+        )
         words = [
             "atrinik",
             "profile",
@@ -184,20 +239,14 @@ class CompletionTests(unittest.TestCase):
         )
         self.write_json(
             self.workspace / "scenarios" / "issue-292" / "scenario.json",
-            {
-                "schema_version": 4,
-                "name": "issue-292",
-                "profile": "classic",
-                "stack": "classic",
-                "providers": {},
-                "preset": "basic-player",
-                "state": "scenario-issue-292",
-                "account": "scenario292",
-                "character": "Scenario 292",
-                "archetype": "human_male",
-                "resolved": {},
-                "provisioned_at": "2026-08-10T00:00:00Z",
-            },
+            self.scenario_record("issue-292"),
+        )
+        self.write_json(
+            self.workspace
+            / "scenarios"
+            / "issue-292"
+            / ".atrinik-workspace-managed.json",
+            {"schema_version": 1, "purpose": "test-scenario"},
         )
         (self.workspace / "scenarios" / "issue-292" / "password").write_text(
             "secret", encoding="utf-8"
@@ -208,6 +257,50 @@ class CompletionTests(unittest.TestCase):
             / "completion-review"
             / ".atrinik-workspace-managed.json",
             {"schema_version": 1, "purpose": "topology:completion-review"},
+        )
+        self.write_json(
+            self.workspace / "topologies" / "completion-review" / "status.json",
+            {
+                "schema_version": 1,
+                "name": "completion-review",
+                "profile": "classic",
+                "stack": "classic",
+                "providers": {"server": "classic-server"},
+                "dependencies": ["server"],
+                "state": "/tmp/completion-state",
+                "build_root": "/tmp/completion-build",
+                "resolved": {
+                    "classic-server": {
+                        "path": "/tmp/classic/server",
+                        "checkout_path": "/tmp/classic",
+                        "checkout": "classic",
+                        "repository": "atrinik/classic",
+                        "branch": "main",
+                        "source": "server",
+                        "head": "b" * 40,
+                        "dirty": False,
+                    }
+                },
+                "endpoint": {
+                    "host": "127.0.0.1",
+                    "port": 13327,
+                    "fingerprint": "c" * 64,
+                },
+                "ready": True,
+                "started_at": "2026-08-10T00:00:00Z",
+                "stopped_at": None,
+                "supervisor": {"pid": 123, "start_time": "1"},
+                "services": {
+                    "server": {
+                        "pid": 124,
+                        "start_time": "2",
+                        "status": "running",
+                        "exit_code": None,
+                        "log": "/tmp/server.log",
+                        "cwd": "/tmp/classic/server",
+                    }
+                },
+            },
         )
 
         self.assertEqual(
@@ -245,8 +338,10 @@ class CompletionTests(unittest.TestCase):
             "line\nbreak",
         ]
         (root / safe).mkdir()
+        (root / safe / ".git").write_text("gitdir: /tmp/safe\n", encoding="utf-8")
         for name in unsafe:
             (root / name).mkdir()
+            (root / name / ".git").write_text("gitdir: /tmp/unsafe\n", encoding="utf-8")
         _, values = self.candidates("worktree", "remove", "client", "")
         self.assertEqual(values, [safe])
 
@@ -263,11 +358,16 @@ class CompletionTests(unittest.TestCase):
     def test_path_arguments_delegate_to_native_shell_completion(self) -> None:
         self.assertEqual(
             self.candidates("state", "add", "review", "--path", ""),
-            ("path", []),
+            ("path", [""]),
         )
         self.assertEqual(
             self.candidates("supply-chain", "versions", "--output", ""),
-            ("path", []),
+            ("path", [""]),
+        )
+        words = ["atrinik", "state", "add", "review", "--path=some/file"]
+        self.assertEqual(
+            complete(parser(), self.wrapper, words, len(words) - 1),
+            ("path", ["some/file"]),
         )
 
     def test_missing_workspace_is_quiet_read_only_and_avoids_dispatch(self) -> None:
@@ -288,6 +388,88 @@ class CompletionTests(unittest.TestCase):
         self.assertFalse(missing.exists())
         workspace.assert_not_called()
         run.assert_not_called()
+
+    def test_completion_has_no_mutating_network_or_dispatch_path(self) -> None:
+        stdout = io.StringIO()
+        mutations = [
+            "mkdir", "write_text", "write_bytes", "unlink", "rename", "replace",
+        ]
+        with ExitStack() as stack:
+            for name in mutations:
+                stack.enter_context(mock.patch.object(Path, name))
+            workspace = stack.enter_context(
+                mock.patch("atrinik_workspace.cli.Workspace")
+            )
+            popen = stack.enter_context(mock.patch("subprocess.Popen"))
+            run = stack.enter_context(mock.patch("subprocess.run"))
+            call = stack.enter_context(mock.patch("subprocess.call"))
+            check_call = stack.enter_context(mock.patch("subprocess.check_call"))
+            check_output = stack.enter_context(mock.patch("subprocess.check_output"))
+            socket_api = stack.enter_context(mock.patch("socket.socket"))
+            connect = stack.enter_context(mock.patch("socket.create_connection"))
+            stack.enter_context(redirect_stdout(stdout))
+            result = main(["__complete", "1", "--", "atrinik", ""])
+        self.assertEqual(result, 0)
+        self.assertTrue(stdout.getvalue().startswith("candidates\n"))
+        for forbidden in (
+            workspace, popen, run, call, check_call, check_output, socket_api, connect
+        ):
+            forbidden.assert_not_called()
+
+    def test_fresh_completion_avoids_heavy_dispatch_imports(self) -> None:
+        script = "\n".join(
+            [
+                "import sys",
+                "from atrinik_workspace.cli import main",
+                "main(['__complete', '1', '--', 'atrinik', ''])",
+                "assert 'atrinik_workspace.workspace' not in sys.modules",
+                "assert 'atrinik_workspace.supply_chain' not in sys.modules",
+            ]
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True, cwd=ROOT
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_metadata_reads_are_bounded_and_non_regular_files_fail_closed(self) -> None:
+        metadata = self.wrapper / "metadata.json"
+        metadata.write_text("{}", encoding="utf-8")
+        supplied = 0
+
+        def growing_read(descriptor: int, size: int) -> bytes:
+            nonlocal supplied
+            supplied += size
+            return b" " * size
+
+        with mock.patch("atrinik_workspace.completion.os.read", side_effect=growing_read):
+            self.assertIsNone(completion._json(metadata))
+        self.assertEqual(supplied, completion._MAX_METADATA_BYTES + 1)
+
+        fifo = self.wrapper / "fifo.json"
+        os.mkfifo(fifo)
+        self.assertIsNone(completion._json(fifo))
+
+    def test_workspace_markers_symlinks_and_unmanaged_worktrees_fail_closed(self) -> None:
+        (self.workspace / ".atrinik-workspace.json").write_text(
+            "{}", encoding="utf-8"
+        )
+        self.assertEqual(self.candidates("profile", "show", ""), (
+            "candidates", ["classic", "default"]
+        ))
+
+        (self.workspace / ".atrinik-workspace.json").write_text(
+            json.dumps({"schema_version": 1}), encoding="utf-8"
+        )
+        external = self.root / "external"
+        (external / "client" / "escaped").mkdir(parents=True)
+        (external / "client" / "escaped" / ".git").write_text(
+            "gitdir: /tmp/escaped\n", encoding="utf-8"
+        )
+        (self.workspace / "worktrees").symlink_to(external, target_is_directory=True)
+        self.assertEqual(
+            self.candidates("worktree", "remove", "client", ""),
+            ("candidates", []),
+        )
 
     def test_script_generation_avoids_workspace_dispatch(self) -> None:
         with mock.patch("atrinik_workspace.cli.Workspace") as workspace:
@@ -372,6 +554,28 @@ class CompletionTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.splitlines(), ["create", "set", "show"])
 
+    def test_bash_adapter_completes_equals_form_paths(self) -> None:
+        bash = shutil.which("bash")
+        if bash is None:
+            self.skipTest("Bash is unavailable")
+        target = self.root / "path-target"
+        target.mkdir()
+        (target / "finished").touch()
+        current = f"--path={target}/fin"
+        program = shell_script("bash") + "\n" + "\n".join(
+            [
+                f"COMP_WORDS=(./atrinik state add review {shlex.quote(current)})",
+                "COMP_CWORD=4",
+                "_atrinik_completion",
+                "printf '%s\\n' \"${COMPREPLY[@]}\"",
+            ]
+        )
+        result = subprocess.run(
+            [bash], input=program, text=True, capture_output=True, cwd=ROOT
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.splitlines(), [f"--path={target}/finished"])
+
     def test_zsh_adapter_smoke(self) -> None:
         zsh = shutil.which("zsh")
         if zsh is None:
@@ -383,7 +587,7 @@ class CompletionTests(unittest.TestCase):
                 "source <(./atrinik completion zsh)",
                 "words=(./atrinik profile '')",
                 "CURRENT=3",
-                "_atrinik_completion",
+                "_atrinik",
             ]
         )
         result = subprocess.run(
@@ -393,6 +597,31 @@ class CompletionTests(unittest.TestCase):
         self.assertEqual(
             result.stdout.splitlines(), ["--", "create", "set", "show"]
         )
+
+    def test_zsh_adapter_loads_from_fpath_with_real_compinit(self) -> None:
+        zsh = shutil.which("zsh")
+        if zsh is None:
+            self.skipTest("Zsh is unavailable")
+        functions = self.root / "zfunc"
+        functions.mkdir()
+        (functions / "_atrinik").write_text(shell_script("zsh"), encoding="utf-8")
+        cache = self.root / "zcompdump"
+        program = "\n".join(
+            [
+                f"fpath=({shlex.quote(str(functions))} $fpath)",
+                "autoload -Uz compinit",
+                f"compinit -d {shlex.quote(str(cache))}",
+                "function compadd { print -l -- \"$@\" }",
+                "words=(./atrinik profile '')",
+                "CURRENT=3",
+                "_atrinik",
+            ]
+        )
+        result = subprocess.run(
+            [zsh, "-c", program], text=True, capture_output=True, cwd=ROOT
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.splitlines(), ["--", "create", "set", "show"])
 
     def test_fish_adapter_smoke(self) -> None:
         fish = shutil.which("fish")

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -171,6 +171,7 @@ class CompletionTests(unittest.TestCase):
         _, default_values = self.candidates("build", "--profile", "default", "")
         self.assertIn("metaserver-worker", default_values)
         self.assertNotIn("libatrinik", default_values)
+        self.assertNotIn("all", default_values)
         _, path_values = self.candidates("path", "--profile", "classic", "")
         self.assertIn("classic-client", path_values)
         self.assertNotIn("website", path_values)
@@ -369,6 +370,15 @@ class CompletionTests(unittest.TestCase):
             ("candidates", ["completion-review"]),
         )
 
+        status_path = self.workspace / "topologies" / "completion-review" / "status.json"
+        status = json.loads(status_path.read_text(encoding="utf-8"))
+        status["profile"] = "deleted-profile"
+        self.write_json(status_path, status)
+        self.assertEqual(
+            self.candidates("logs", ""),
+            ("candidates", ["completion-review"]),
+        )
+
         broken_scenario = self.scenario_record("broken")
         broken_scenario["providers"] = {}
         broken_scenario["resolved"] = {}
@@ -383,8 +393,6 @@ class CompletionTests(unittest.TestCase):
         _, scenarios = self.candidates("scenario", "show", "")
         self.assertNotIn("broken", scenarios)
 
-        status_path = self.workspace / "topologies" / "completion-review" / "status.json"
-        status = json.loads(status_path.read_text(encoding="utf-8"))
         status["dependencies"] = [[]]
         self.write_json(status_path, status)
         self.assertEqual(self.candidates("logs", ""), ("candidates", []))
@@ -398,6 +406,30 @@ class CompletionTests(unittest.TestCase):
             self.candidates("logs", ""),
             ("candidates", ["completion-review"]),
         )
+
+        status["error"] = ""
+        self.write_json(status_path, status)
+        self.assertEqual(self.candidates("logs", ""), ("candidates", []))
+
+        del status["error"]
+        status["services"] = {
+            "server": {
+                "pid": 124,
+                "start_time": "2",
+                "status": "running",
+                "exit_code": None,
+                "log": "/tmp/server.log",
+                "cwd": "/tmp/classic/server",
+            }
+        }
+        status["endpoint"] = {
+            "host": "127.0.0.1",
+            "port": 13327,
+            "fingerprint": None,
+        }
+        status["ready"] = True
+        self.write_json(status_path, status)
+        self.assertEqual(self.candidates("logs", ""), ("candidates", []))
 
     def test_unsafe_and_control_character_records_are_never_candidates(self) -> None:
         root = self.workspace / "worktrees" / "client"
@@ -554,6 +586,12 @@ class CompletionTests(unittest.TestCase):
             self.candidates("worktree", "remove", "client", ""),
             ("candidates", []),
         )
+        paths = completion._paths(self.wrapper)
+        self.assertIsNotNone(paths)
+        with mock.patch(
+            "atrinik_workspace.completion._workspace_descriptor", return_value=None
+        ):
+            self.assertEqual(completion._registered_states(paths), {})
 
     def test_script_generation_avoids_workspace_dispatch(self) -> None:
         with mock.patch("atrinik_workspace.cli.Workspace") as workspace:

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,0 +1,429 @@
+from __future__ import annotations
+
+import argparse
+from contextlib import redirect_stderr, redirect_stdout
+import io
+import json
+import os
+from pathlib import Path
+import shutil
+import shlex
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+from atrinik_workspace.cli import main, parser
+from atrinik_workspace import completion
+from atrinik_workspace.completion import classified_actions, complete, shell_script
+from atrinik_workspace.model import Manifest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class CompletionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.wrapper = self.root / "wrapper"
+        self.wrapper.mkdir()
+        shutil.copy2(ROOT / "components.json", self.wrapper / "components.json")
+        self.workspace = self.root / "state with spaces"
+        self.environment = mock.patch.dict(
+            os.environ, {"ATRINIK_WORKSPACE_DIR": str(self.workspace)}
+        )
+        self.environment.start()
+
+    def tearDown(self) -> None:
+        self.environment.stop()
+        self.temporary.cleanup()
+
+    def candidates(self, *words: str) -> tuple[str, list[str]]:
+        values = ["atrinik", *words]
+        return complete(parser(), self.wrapper, values, len(values) - 1)
+
+    def write_json(self, path: Path, value: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(value), encoding="utf-8")
+
+    def profile_record(self, name: str, stack: str) -> dict[str, object]:
+        manifest = Manifest.load(self.wrapper / "components.json")
+        return {
+            "schema_version": 3,
+            "name": name,
+            "stack": stack,
+            "components": {
+                component.name: {"kind": "primary", "value": ""}
+                for component in manifest.stacks[stack].components
+            },
+        }
+
+    def test_commands_nested_commands_options_and_choices_follow_parser(self) -> None:
+        mode, values = self.candidates("")
+        self.assertEqual(mode, "candidates")
+        self.assertIn("completion", values)
+        self.assertIn("worktree", values)
+
+        self.assertEqual(
+            self.candidates("worktree", ""),
+            ("candidates", ["create", "list", "remove"]),
+        )
+        self.assertEqual(
+            self.candidates("topology", "show", "default", "--service", "s"),
+            ("candidates", ["server"]),
+        )
+        self.assertEqual(
+            self.candidates("init", "--with", "c"),
+            ("candidates", ["classic"]),
+        )
+        _, profile_values = self.candidates("profile", "set", "classic", "")
+        self.assertIn("libatrinik", profile_values)
+        mode, values = self.candidates("logs", "default", "server", "--f")
+        self.assertEqual(mode, "candidates")
+        self.assertEqual(values, ["--follow"])
+
+    def test_consumed_and_mutually_exclusive_options_are_suppressed(self) -> None:
+        mode, values = self.candidates("cleanup", "--dry-run", "--", "")
+        self.assertEqual(mode, "none")
+        self.assertEqual(values, [])
+
+        words = ["atrinik", "cleanup", "--dry-run", "-"]
+        mode, values = complete(parser(), self.wrapper, words, 3)
+        self.assertEqual(mode, "candidates")
+        self.assertNotIn("--apply", values)
+        self.assertNotIn("--dry-run", values)
+        self.assertIn("--scope", values)
+
+        words = ["atrinik", "cleanup", "--scope", "builds", "-"]
+        _, values = complete(parser(), self.wrapper, words, 4)
+        self.assertIn("--scope", values)
+
+    def test_run_remainder_and_double_dash_stop_wrapper_completion(self) -> None:
+        for words in (
+            ["atrinik", "run", "server", "--", "--ver"],
+            ["atrinik", "run", "client", "forwarded"],
+        ):
+            self.assertEqual(
+                complete(parser(), self.wrapper, words, len(words) - 1),
+                ("none", []),
+            )
+
+    def test_manifest_identities_deduplicate_aliases_and_keep_variants(self) -> None:
+        mode, values = self.candidates("status", "")
+        self.assertEqual(mode, "candidates")
+        self.assertEqual(values.count("classic"), 1)
+        self.assertIn("classic-client", values)
+        self.assertIn("content", values)
+        self.assertIn("content-1x", values)
+
+        mode, values = self.candidates("build", "")
+        self.assertEqual(mode, "candidates")
+        self.assertIn("all", values)
+        self.assertIn("libatrinik", values)
+        self.assertIn("metaserver-worker", values)
+
+    def test_profiles_refresh_and_malformed_records_fail_softly(self) -> None:
+        profiles = self.workspace / "profiles"
+        self.write_json(
+            profiles / "review.json",
+            self.profile_record("review", "classic"),
+        )
+        self.write_json(profiles / "wrong.json", {"name": "different"})
+        (profiles / "broken.json").write_text("{", encoding="utf-8")
+
+        _, before = self.candidates("profile", "show", "")
+        self.assertIn("default", before)
+        self.assertIn("classic", before)
+        self.assertIn("review", before)
+        self.assertNotIn("wrong", before)
+        self.assertNotIn("broken", before)
+
+        (profiles / "review.json").unlink()
+        _, after = self.candidates("profile", "show", "")
+        self.assertNotIn("review", after)
+
+    def test_worktree_labels_are_filtered_by_selected_physical_checkout(self) -> None:
+        (self.workspace / "worktrees" / "content" / "main-maps").mkdir(parents=True)
+        (self.workspace / "worktrees" / "content-1x" / "classic-maps").mkdir(
+            parents=True
+        )
+        _, main_values = self.candidates("worktree", "remove", "content", "")
+        _, classic_values = self.candidates(
+            "worktree", "remove", "content-1x", ""
+        )
+        self.assertEqual(main_values, ["main-maps"])
+        self.assertEqual(classic_values, ["classic-maps"])
+
+    def test_profile_role_selects_owning_checkout_for_worktrees(self) -> None:
+        stack = parser()  # Ensure a fresh parser does not retain process state.
+        del stack
+        self.write_json(
+            self.workspace / "profiles" / "review.json",
+            self.profile_record("review", "classic"),
+        )
+        (self.workspace / "worktrees" / "classic" / "feature").mkdir(parents=True)
+        words = [
+            "atrinik",
+            "profile",
+            "set",
+            "review",
+            "server",
+            "--worktree",
+            "",
+        ]
+        self.assertEqual(
+            complete(parser(), self.wrapper, words, len(words) - 1),
+            ("candidates", ["feature"]),
+        )
+
+    def test_state_scenario_and_topology_records_refresh_without_secrets(self) -> None:
+        self.write_json(
+            self.workspace / "states.json",
+            {"schema_version": 1, "states": {"review": "/tmp/review"}},
+        )
+        self.write_json(
+            self.workspace / "scenarios" / "issue-292" / "scenario.json",
+            {
+                "schema_version": 4,
+                "name": "issue-292",
+                "profile": "classic",
+                "stack": "classic",
+                "providers": {},
+                "preset": "basic-player",
+                "state": "scenario-issue-292",
+                "account": "scenario292",
+                "character": "Scenario 292",
+                "archetype": "human_male",
+                "resolved": {},
+                "provisioned_at": "2026-08-10T00:00:00Z",
+            },
+        )
+        (self.workspace / "scenarios" / "issue-292" / "password").write_text(
+            "secret", encoding="utf-8"
+        )
+        self.write_json(
+            self.workspace
+            / "topologies"
+            / "completion-review"
+            / ".atrinik-workspace-managed.json",
+            {"schema_version": 1, "purpose": "topology:completion-review"},
+        )
+
+        self.assertEqual(
+            self.candidates("topology", "show", "default", "--state", ""),
+            ("candidates", ["default", "review"]),
+        )
+        with mock.patch(
+            "atrinik_workspace.completion._json", wraps=completion._json
+        ) as load_metadata:
+            self.assertEqual(
+                self.candidates("scenario", "show", ""),
+                ("candidates", ["issue-292"]),
+            )
+        self.assertNotIn(
+            self.workspace / "scenarios" / "issue-292" / "password",
+            [call.args[0] for call in load_metadata.call_args_list],
+        )
+        self.assertEqual(
+            self.candidates("logs", ""),
+            ("candidates", ["completion-review"]),
+        )
+
+    def test_unsafe_and_control_character_records_are_never_candidates(self) -> None:
+        root = self.workspace / "worktrees" / "client"
+        root.mkdir(parents=True)
+        safe = "safe-label"
+        unsafe = [
+            "with space",
+            "quote'",
+            'quote"',
+            "$(touch-x)",
+            "`touch-x`",
+            "glob*",
+            "brace{x}",
+            "line\nbreak",
+        ]
+        (root / safe).mkdir()
+        for name in unsafe:
+            (root / name).mkdir()
+        _, values = self.candidates("worktree", "remove", "client", "")
+        self.assertEqual(values, [safe])
+
+    def test_oversized_dynamic_directories_fail_closed_without_unbounded_scan(self) -> None:
+        root = self.workspace / "worktrees" / "client"
+        root.mkdir(parents=True)
+        for index in range(257):
+            (root / f"label-{index:03d}").mkdir()
+        self.assertEqual(
+            self.candidates("worktree", "remove", "client", ""),
+            ("candidates", []),
+        )
+
+    def test_path_arguments_delegate_to_native_shell_completion(self) -> None:
+        self.assertEqual(
+            self.candidates("state", "add", "review", "--path", ""),
+            ("path", []),
+        )
+        self.assertEqual(
+            self.candidates("supply-chain", "versions", "--output", ""),
+            ("path", []),
+        )
+
+    def test_missing_workspace_is_quiet_read_only_and_avoids_dispatch(self) -> None:
+        missing = self.root / "missing"
+        with mock.patch.dict(os.environ, {"ATRINIK_WORKSPACE_DIR": str(missing)}):
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with (
+                mock.patch("atrinik_workspace.cli.Workspace") as workspace,
+                mock.patch("subprocess.run") as run,
+                redirect_stdout(stdout),
+                redirect_stderr(stderr),
+            ):
+                result = main(["__complete", "1", "--", "atrinik", ""])
+        self.assertEqual(result, 0)
+        self.assertTrue(stdout.getvalue().startswith("candidates\n"))
+        self.assertEqual(stderr.getvalue(), "")
+        self.assertFalse(missing.exists())
+        workspace.assert_not_called()
+        run.assert_not_called()
+
+    def test_script_generation_avoids_workspace_dispatch(self) -> None:
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace:
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                result = main(["completion", "bash"])
+        self.assertEqual(result, 0)
+        self.assertIn("_atrinik_completion", stdout.getvalue())
+        workspace.assert_not_called()
+
+    def test_malformed_manifest_preserves_static_candidates(self) -> None:
+        (self.wrapper / "components.json").write_text("{", encoding="utf-8")
+        self.assertEqual(
+            self.candidates("topology", "show", "default", "--service", ""),
+            ("candidates", ["client", "server"]),
+        )
+        self.assertEqual(
+            self.candidates("status", ""),
+            ("candidates", []),
+        )
+
+    def test_parser_value_actions_are_classified_for_completion_drift(self) -> None:
+        unclassified: list[str] = []
+        for action in classified_actions(parser()):
+            if isinstance(action, argparse._SubParsersAction):
+                continue
+            if action.nargs == 0 or action.choices is not None:
+                continue
+            if not hasattr(action, "completion_kind"):
+                unclassified.append(action.dest)
+        self.assertEqual(unclassified, [])
+
+    def test_generated_scripts_are_deterministic_and_parse_when_shell_exists(self) -> None:
+        for shell in ("bash", "zsh", "fish"):
+            first = shell_script(shell)
+            self.assertEqual(first, shell_script(shell))
+            self.assertNotIn(".bashrc", first)
+            self.assertNotIn("config.fish", first)
+            executable = shutil.which(shell)
+            if executable is None:
+                continue
+            result = subprocess.run(
+                [executable, "-n"], input=first, text=True, capture_output=True
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+        shellcheck = shutil.which("shellcheck")
+        if shellcheck is not None:
+            result = subprocess.run(
+                [shellcheck, "--shell=bash", "-"],
+                input=shell_script("bash"),
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_bash_adapter_supports_an_absolute_invocation_path_with_spaces(self) -> None:
+        bash = shutil.which("bash")
+        if bash is None:
+            self.skipTest("Bash is unavailable")
+        directory = self.root / "absolute path with spaces"
+        directory.mkdir()
+        invocation = directory / "atrinik"
+        invocation.symlink_to(ROOT / "atrinik")
+        program = shell_script("bash") + "\n" + "\n".join(
+            [
+                f"COMP_WORDS=({shlex.quote(str(invocation))} profile '')",
+                "COMP_CWORD=2",
+                "_atrinik_completion",
+                "printf '%s\\n' \"${COMPREPLY[@]}\"",
+            ]
+        )
+        environment = {**os.environ, "PYTHONPATH": str(ROOT)}
+        result = subprocess.run(
+            [bash],
+            input=program,
+            text=True,
+            capture_output=True,
+            cwd=ROOT,
+            env=environment,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.splitlines(), ["create", "set", "show"])
+
+    def test_zsh_adapter_smoke(self) -> None:
+        zsh = shutil.which("zsh")
+        if zsh is None:
+            self.skipTest("Zsh is unavailable")
+        program = "\n".join(
+            [
+                "function compdef { : }",
+                "function compadd { print -l -- \"$@\" }",
+                "source <(./atrinik completion zsh)",
+                "words=(./atrinik profile '')",
+                "CURRENT=3",
+                "_atrinik_completion",
+            ]
+        )
+        result = subprocess.run(
+            [zsh, "-c", program], text=True, capture_output=True, cwd=ROOT
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            result.stdout.splitlines(), ["--", "create", "set", "show"]
+        )
+
+    def test_fish_adapter_smoke(self) -> None:
+        fish = shutil.which("fish")
+        if fish is None:
+            self.skipTest("Fish is unavailable")
+        program = " ".join(
+            [
+                "function commandline;",
+                "switch $argv[1];",
+                "case -opc; printf '%s\\n' ./atrinik profile;",
+                "case -ct; printf '\\n';",
+                "end; end;",
+                "./atrinik completion fish | source;",
+                "__atrinik_completion",
+            ]
+        )
+        environment = {
+            **os.environ,
+            "XDG_CONFIG_HOME": str(self.root / "fish-config"),
+            "XDG_DATA_HOME": str(self.root / "fish-data"),
+        }
+        result = subprocess.run(
+            [fish, "--no-config", "-c", program],
+            text=True,
+            capture_output=True,
+            cwd=ROOT,
+            env=environment,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.splitlines(), ["create", "set", "show"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -99,6 +99,10 @@ class CompletionTests(unittest.TestCase):
         }
 
     def test_commands_nested_commands_options_and_choices_follow_parser(self) -> None:
+        self.write_json(
+            self.workspace / "profiles" / "review.json",
+            self.profile_record("review", "classic"),
+        )
         mode, values = self.candidates("")
         self.assertEqual(mode, "candidates")
         self.assertIn("completion", values)
@@ -116,7 +120,9 @@ class CompletionTests(unittest.TestCase):
             self.candidates("init", "--with", "c"),
             ("candidates", ["classic"]),
         )
-        _, profile_values = self.candidates("profile", "set", "classic", "")
+        _, profile_names = self.candidates("profile", "set", "")
+        self.assertEqual(profile_names, ["review"])
+        _, profile_values = self.candidates("profile", "set", "review", "")
         self.assertIn("libatrinik", profile_values)
         mode, values = self.candidates("logs", "default", "server", "--f")
         self.assertEqual(mode, "candidates")
@@ -189,6 +195,29 @@ class CompletionTests(unittest.TestCase):
         _, after = self.candidates("profile", "show", "")
         self.assertNotIn("review", after)
 
+    def test_profiles_reject_cross_checkout_and_invalid_migration_selectors(self) -> None:
+        record = self.profile_record("broken", "classic")
+        record["components"]["classic-client"] = {
+            "kind": "worktree",
+            "value": "feature",
+        }
+        self.write_json(self.workspace / "profiles" / "broken.json", record)
+        _, names = self.candidates("profile", "show", "")
+        self.assertNotIn("broken", names)
+        self.assertEqual(
+            self.candidates("build", "--profile", "broken", ""),
+            ("candidates", []),
+        )
+
+        migrated = self.profile_record("migrated", "classic")
+        migrated["components"]["content-1x"] = {
+            "kind": "migrated-worktree",
+            "value": "/tmp/not-managed/content-1x",
+        }
+        self.write_json(self.workspace / "profiles" / "migrated.json", migrated)
+        _, names = self.candidates("profile", "show", "")
+        self.assertNotIn("migrated", names)
+
     def test_worktree_labels_are_filtered_by_selected_physical_checkout(self) -> None:
         (self.workspace / "worktrees" / "content" / "main-maps").mkdir(parents=True)
         (self.workspace / "worktrees" / "content-1x" / "classic-maps").mkdir(
@@ -235,7 +264,15 @@ class CompletionTests(unittest.TestCase):
     def test_state_scenario_and_topology_records_refresh_without_secrets(self) -> None:
         self.write_json(
             self.workspace / "states.json",
-            {"schema_version": 1, "states": {"review": "/tmp/review"}},
+            {
+                "schema_version": 1,
+                "states": {
+                    "review": "/tmp/review",
+                    "scenario-issue-292": str(
+                        self.workspace / "scenarios" / "issue-292" / "state"
+                    ),
+                },
+            },
         )
         self.write_json(
             self.workspace / "scenarios" / "issue-292" / "scenario.json",
@@ -305,7 +342,7 @@ class CompletionTests(unittest.TestCase):
 
         self.assertEqual(
             self.candidates("topology", "show", "default", "--state", ""),
-            ("candidates", ["default", "review"]),
+            ("candidates", ["default", "review", "scenario-issue-292"]),
         )
         with mock.patch(
             "atrinik_workspace.completion._json", wraps=completion._json
@@ -318,6 +355,45 @@ class CompletionTests(unittest.TestCase):
             self.workspace / "scenarios" / "issue-292" / "password",
             [call.args[0] for call in load_metadata.call_args_list],
         )
+        states = json.loads(
+            (self.workspace / "states.json").read_text(encoding="utf-8")
+        )
+        del states["states"]["scenario-issue-292"]
+        self.write_json(self.workspace / "states.json", states)
+        self.assertEqual(
+            self.candidates("scenario", "show", ""),
+            ("candidates", []),
+        )
+        self.assertEqual(
+            self.candidates("logs", ""),
+            ("candidates", ["completion-review"]),
+        )
+
+        broken_scenario = self.scenario_record("broken")
+        broken_scenario["providers"] = {}
+        broken_scenario["resolved"] = {}
+        self.write_json(
+            self.workspace / "scenarios" / "broken" / "scenario.json",
+            broken_scenario,
+        )
+        self.write_json(
+            self.workspace / "scenarios" / "broken" / completion.MANAGED_MARKER,
+            {"schema_version": 1, "purpose": "test-scenario"},
+        )
+        _, scenarios = self.candidates("scenario", "show", "")
+        self.assertNotIn("broken", scenarios)
+
+        status_path = self.workspace / "topologies" / "completion-review" / "status.json"
+        status = json.loads(status_path.read_text(encoding="utf-8"))
+        status["dependencies"] = [[]]
+        self.write_json(status_path, status)
+        self.assertEqual(self.candidates("logs", ""), ("candidates", []))
+
+        status["dependencies"] = ["server"]
+        status["services"] = {}
+        status["endpoint"] = None
+        status["error"] = "RuntimeError: startup failed"
+        self.write_json(status_path, status)
         self.assertEqual(
             self.candidates("logs", ""),
             ("candidates", ["completion-review"]),
@@ -352,6 +428,14 @@ class CompletionTests(unittest.TestCase):
             (root / f"label-{index:03d}").mkdir()
         self.assertEqual(
             self.candidates("worktree", "remove", "client", ""),
+            ("candidates", []),
+        )
+
+        scenarios = self.workspace / "scenarios"
+        for index in range(completion._MAX_RECORD_ENTRIES + 1):
+            (scenarios / f"scenario-{index:03d}").mkdir(parents=True)
+        self.assertEqual(
+            self.candidates("scenario", "show", ""),
             ("candidates", []),
         )
 


### PR DESCRIPTION
## Summary

- add deterministic Bash, Zsh, and Fish activation scripts backed by one parser-driven completion protocol
- complete nested commands, exact options, static choices, manifest identities, profiles, owning-checkout worktrees, states, scenarios, and topologies without workspace construction or mutation
- delegate filesystem values to native shell completion, stop at forwarding boundaries, reject unsafe records, and fail quietly when optional local metadata is absent or malformed
- document activation, per-user installation, the read-only architecture boundary, and the maintained agent contract

## Coordinates

- Base: `main` at `21971efece924cdb69ba9b812909ec171621df83`
- Head: `feat/shell-completion` at `edd7cc14a2e6c7cae6c78275372177f21d603574`
- Worktree: `workspace/worktrees/atrinik/issue-292-shell-completion`
- Commits: `242feba56 feat(cli): add native shell completion`; `1ea07c073 fix(cli): harden completion metadata discovery`; `ea2a62557 fix(cli): align completion with runtime records`; `0a8e55dca fix(cli): complete completion parity checks`; `edd7cc14a chore: merge latest main into shell completion`

Closes #292

## Validation

- complete wrapper suite: 326 tests passed under Coverage 7.15.3; 78% combined statement/branch coverage
- focused completion/CLI/model/cohort suite: 113 tests passed; completion module coverage is 83%
- Bash 5.3.9, Zsh 5.9, and Fish 4.2.1 syntax checks and adapter smoke tests passed
- generated Bash adapter passed ShellCheck
- Python compileall passed
- guidance inventory and changed-skill validation passed
- manifest and supply-chain validation passed (100 dependencies)
- `git diff --check` passed
- cold/warm top-level completion benchmark: 60 ms cold, 61 ms warm median in this Python 3.14 development container
- five iterative whole-diff review rounds completed; the final fresh current-base correctness, robustness, and tests/docs round found no actionable issues

## Verification

Runtime provisioning is not applicable: completion is an offline wrapper metadata path and tests prove it does not construct `Workspace`, invoke subprocess/network paths, read scenario passwords, or dispatch initialization, build, migration, cleanup, or runtime operations.

From the wrapper worktree, activate one target shell and type through nested commands, options, profiles, worktrees, states, scenarios, and topology names:

```sh
# Bash
source <(./atrinik completion bash)

# Zsh
autoload -Uz compinit && compinit
source <(./atrinik completion zsh)

# Fish
./atrinik completion fish | source
```

Expected: candidates refresh from current local metadata on each keypress; `--path`/`--output` use native path completion; wrapper suggestions stop after `./atrinik run server --`; no startup file or workspace state is changed. Repeat by starting a fresh shell and sourcing the generated adapter again. No shutdown or runtime cleanup is required.
