### PR TITLE
chore(supply-chain): register crates.io publication

### DIFF
--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -1572,6 +1572,50 @@
       ]
     },
     {
+      "id": "external/crates-io",
+      "name": "crates.io registry publication and distribution",
+      "kind": "external-tool",
+      "owner": "protocol",
+      "scope": ["protocol"],
+      "required": true,
+      "version": "API v1; atrinik-protocol 0.1.0 bootstrap",
+      "version_source": "Fixed protocol bootstrap workflow and immutable v1.4.0 release provenance",
+      "license": "NOASSERTION",
+      "source_url": "https://crates.io/",
+      "locator": "pkg:cargo/atrinik-protocol@0.1.0",
+      "commit": null,
+      "checksum": "sha256:413c4da6c1b304d4a622065efe0d36c3f591041972f1a5ee76c538926f3c0b6b",
+      "acquisition": "A protected manual GitHub environment publishes only the byte-reproduced immutable release crate after required review",
+      "update_cadence_days": 30,
+      "update_mechanism": "Remove the one-time bootstrap after registration and replace it with a separately reviewed crate-scoped release policy",
+      "eol_response": "Stop registry publication and consumer rollout if ownership, integrity, availability, or supported Cargo compatibility cannot be maintained",
+      "validation": "Fixed workflow contract, offline package reproduction, GitHub release provenance and SHA-256 checks, and post-upload crates.io checksum verification",
+      "disposition": "retain",
+      "packages": ["atrinik-protocol"],
+      "evidence": [
+        {
+          "repository": "protocol",
+          "path": ".github/workflows/publish-crate.yml",
+          "contains": "CRATE_SHA256: 413c4da6c1b304d4a622065efe0d36c3f591041972f1a5ee76c538926f3c0b6b"
+        },
+        {
+          "repository": "protocol",
+          "path": ".github/workflows/publish-crate.yml",
+          "contains": "environment: crates-io-bootstrap"
+        },
+        {
+          "repository": "protocol",
+          "path": "crates/atrinik-protocol/Cargo.toml",
+          "contains": "publish = [\"crates-io\"]"
+        },
+        {
+          "repository": "protocol",
+          "path": "tools/check-crate-publication.py",
+          "contains": "bootstrap token must appear in exactly one step"
+        }
+      ]
+    },
+    {
       "id": "external/gridarta",
       "name": "Gridarta source checkout",
       "kind": "external-tool",


### PR DESCRIPTION
## Summary

- register crates.io as the protocol-owned external publication/distribution service
- pin the bootstrap coordinate to `atrinik-protocol` 0.1.0 and its immutable v1.4.0 release SHA-256
- link evidence to the merged fixed workflow, environment gate, manifest registry allowlist, and token-cardinality validator
- keep client scope absent until an actually published, locked client dependency exists

## Validation

- `python3 -m coverage run -m unittest discover -v` — 300 passed
- `python3 -m coverage report --show-missing` — 78% aggregate
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate` — 21 components
- `./atrinik supply-chain validate` — 100 dependencies
- complete `default` profile supply-chain audit with explicit overrides for all 13 replacement repositories
- `jq empty supply-chain/inventory.json`
- `git diff --check`

## Scope boundary

This is inventory evidence for merged protocol PR atrinik/protocol#27. It does not create a GitHub environment or secret, run the workflow, publish/register a crate, or authorize an irreversible registry mutation. Those remain separate explicit gates.

Refs atrinik/protocol#13.
Refs atrinik/client#41.
Refs atrinik/metaserver-worker#21.
