### PR TITLE
fix(runtime): replace legacy HTTP asset staging

### DIFF
--- a/.agents/skills/atrinik-server-runtime/SKILL.md
+++ b/.agents/skills/atrinik-server-runtime/SKILL.md
@@ -5,15 +5,18 @@ description: Run or diagnose isolated classic servers and supervised topologies 
 
 # Atrinik server runtime
 
-Use the wrapper for build, collection, state locking, supervision, logs, and
-cleanup. Do not reconstruct internal paths or invoke generated binaries when a
-wrapper command owns the operation.
+The wrapper owns builds, collection, state locks, supervision, logs, and
+cleanup. Never reconstruct its paths or invoke generated binaries.
 
-1. Read the workspace and selected classic server/content/resource guides.
-2. Select a coherent classic-derived profile and inspect it with `profile show`
-   and `topology show`.
-3. Use a distinct registered state for each concurrent topology. Never replace
-   source, share live state, or edit wrapper-managed runtime files.
+Classic preparation owns disposable `assets` staging. Generated `data/*`,
+exact-profile `client-maps/*`, and resources use authenticated QUIC by default;
+`http_url` only names an optional external HTTP(S) origin. Never stage assets in
+state or restore a bundled HTTP listener.
+
+1. Read the workspace and selected server/content/resource guides.
+2. Inspect a coherent classic-derived profile and topology.
+3. Give concurrent topologies distinct registered states. Never replace source,
+   share live state, or edit managed runtime files.
 
 ```sh
 ./atrinik build server --profile PROFILE --test
@@ -24,9 +27,7 @@ wrapper command owns the operation.
 ./atrinik down NAME
 ```
 
-Let `up` allocate a port unless an exact distinct port is required. Separate
-build, collection, state, plugin, network, and gameplay failures before editing
-code. Use `atrinik-test-scenario` for a provisioned account/character; never
-handcraft saves. Inspect relevant service logs, state exact actions/results,
-always stop the topology, and reset only scenario-owned state with `scenario
-reset`. Finish with each changed repository's tests and `git diff --check`.
+Let `up` allocate a port unless a distinct fixed port is required. Diagnose
+build, state, plugin, network, and gameplay failures separately. Use
+`atrinik-test-scenario` for accounts; never handcraft saves. Record actions and
+logs, stop the topology, reset only scenario state, and run owner validation.

--- a/.agents/skills/atrinik-test-scenario/SKILL.md
+++ b/.agents/skills/atrinik-test-scenario/SKILL.md
@@ -5,9 +5,11 @@ description: Provision deterministic classic account/character scenarios with is
 
 # Atrinik test scenario
 
-Use scenarios for repeatable manual reproductions. Keep account creation inside
-the server API and orchestration inside the wrapper; never construct or edit
-account/player files.
+Use scenarios for repeatable reproductions. Keep account creation in the server
+API and orchestration in the wrapper; never edit account/player files.
+
+Fresh state comes from Classic `install_data`; the wrapper creates disposable
+asset staging. Never add generated assets to scenario state.
 
 1. Select the exact coherent classic-derived profile.
 2. Choose a lowercase issue/feature name and use `basic-player` unless a tested

--- a/README.md
+++ b/README.md
@@ -190,14 +190,16 @@ dirty inputs regenerate on every build. Missing `incuna_-1` output, incomplete
 pairs, malformed files, or generator failure stop the build while preserving
 the last valid cache.
 
-Server launch uses a disposable HTTP asset root that combines the named
-state's existing `http/data` with those generated maps. It does not copy into
-or overlay an already registered state. A supervised topology copies the maps
-into its owned runtime snapshot before the server takes its immutable asset
-snapshot. Region maps are reclaimed with their marker-owned profile build by
-the normal preview-first `./atrinik cleanup --scope builds` lifecycle; topology
-snapshots remain with the retained topology record and are atomically replaced
-the next time that topology name is launched.
+Server launch uses a disposable `assets` staging root with a writable `data`
+directory and the selected generated `client-maps`. Generated game data never
+needs to exist in, copy into, or overlay a registered state. A supervised
+topology copies the maps into its owned runtime snapshot before the server
+takes its immutable asset snapshot. QUIC serves that snapshot by default;
+`http_url` only advertises an optional operator-managed HTTP(S) origin. Region
+maps are reclaimed with their marker-owned profile build by the normal
+preview-first `./atrinik cleanup --scope builds` lifecycle; topology snapshots
+remain with the retained topology record and are atomically replaced the next
+time that topology name is launched.
 
 `--with classic` has one exact meaning: add the complete classic initialization
 cohort to the replacement/default cohort. It is not a classic-only mode. The

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -3539,9 +3539,7 @@ class Workspace:
         assets = runtime / "assets"
         self._prepare_asset_staging_directory(assets)
         self._prepare_asset_staging_directory(assets / "data")
-        (assets / "client-maps").symlink_to(
-            client_maps, target_is_directory=True
-        )
+        shutil.copytree(client_maps, assets / "client-maps")
         return runtime
 
     @staticmethod

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -1880,9 +1880,9 @@ class Workspace:
             data = staging_root / "data"
             shutil.copytree(selected["server"] / "install_data", data)
             (data / "tmp").mkdir(exist_ok=True)
-            http = staging_root / "http"
-            http.mkdir()
-            generated = http / "client-maps"
+            assets = staging_root / "assets"
+            assets.mkdir()
+            generated = assets / "client-maps"
             content = root / "runtime" / "content"
             resources = root / "runtime" / "resources"
             self._link_server_runtime_inputs(
@@ -1894,7 +1894,7 @@ class Workspace:
                     str(executable),
                     "--worldmaker",
                     f"--datapath={data}",
-                    f"--httppath={http}",
+                    f"--assetspath={assets}",
                     f"--libpath={working / 'lib'}",
                     f"--mapspath={working / 'maps'}",
                     f"--resourcespath={working / 'resources'}",
@@ -2185,7 +2185,7 @@ class Workspace:
                 f"--provision_character={metadata['character']}",
                 f"--provision_archetype={metadata['archetype']}",
                 f"--provision_password_file={password_file}",
-                f"--httppath={runtime / 'http'}",
+                f"--assetspath={runtime / 'assets'}",
             ],
             cwd=runtime,
         )
@@ -3073,7 +3073,7 @@ class Workspace:
                             f"--port_quic={endpoint['port']}",
                             "--port_mapping=off",
                             "--stun_server=off",
-                            f"--httppath={runtime / 'http'}",
+                            f"--assetspath={runtime / 'assets'}",
                             "--no_console",
                         ],
                         "cwd": str(runtime),
@@ -3426,7 +3426,7 @@ class Workspace:
                 "--port_mapping=off",
                 "--stun_server=off",
                 *arguments,
-                f"--httppath={runtime / 'http'}",
+                f"--assetspath={runtime / 'assets'}",
             ]
             print(f"state: {state}")
             print(f"cwd: {runtime}")
@@ -3533,21 +3533,32 @@ class Workspace:
         resources = resources or root / "runtime" / "resources"
         client_maps = client_maps or root / "runtime" / "client-maps"
         self._validate_region_maps(client_maps)
-        http_data = state / "http" / "data"
-        if not http_data.is_dir() or http_data.is_symlink():
-            raise WorkspaceError(
-                f"server state lacks required HTTP data directory: {http_data}"
-            )
         self._link_server_runtime_inputs(
             runtime, root, selected, state, content, resources
         )
-        http = runtime / "http"
-        http.mkdir()
-        (http / "data").symlink_to(http_data, target_is_directory=True)
-        (http / "client-maps").symlink_to(
+        assets = runtime / "assets"
+        self._prepare_asset_staging_directory(assets)
+        self._prepare_asset_staging_directory(assets / "data")
+        (assets / "client-maps").symlink_to(
             client_maps, target_is_directory=True
         )
         return runtime
+
+    @staticmethod
+    def _prepare_asset_staging_directory(path: Path) -> None:
+        if path.is_symlink():
+            raise WorkspaceError(f"server asset staging path is invalid: {path}")
+        try:
+            mode = path.lstat().st_mode
+        except FileNotFoundError:
+            path.mkdir()
+            return
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot inspect server asset staging path {path}: {error}"
+            ) from error
+        if not stat.S_ISDIR(mode):
+            raise WorkspaceError(f"server asset staging path is invalid: {path}")
 
     def _component(self, name: str) -> Component:
         try:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -393,7 +393,7 @@ remains unavailable until its native component contracts land.
 
 The server's configured `assetspath` is a disposable transport-neutral runtime
 view. Its real `data` directory receives generated core data, while its
-`client-maps` entry points at the validated generated cache. Neither belongs to
+`client-maps` directory copies the validated generated cache. Neither belongs to
 the named persistent state. A supervised topology copies the cache into its
 owned runtime before launch, so a later build cannot change the server's
 immutable startup asset snapshot. QUIC serves the snapshot by default;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -391,15 +391,15 @@ First use initializes a state atomically from the selected server's
 inside a server source worktree is rejected. Replacement runtime preparation
 remains unavailable until its native component contracts land.
 
-The server's configured HTTP asset root is a disposable runtime view. Its
-`data` entry points at the named state's existing `http/data`, while its
-`client-maps` entry points at the validated generated cache. A supervised
-topology copies that cache into its owned runtime before launch, so a later
-build cannot change the server's immutable startup asset snapshot. Fresh and
-registered states therefore receive the selected generated maps without
-writing them into mutable state. The cache follows marker-owned profile-build
-cleanup; topology copies follow topology retention and are replaced on the
-next launch of that topology name.
+The server's configured `assetspath` is a disposable transport-neutral runtime
+view. Its real `data` directory receives generated core data, while its
+`client-maps` entry points at the validated generated cache. Neither belongs to
+the named persistent state. A supervised topology copies the cache into its
+owned runtime before launch, so a later build cannot change the server's
+immutable startup asset snapshot. QUIC serves the snapshot by default;
+`http_url` separately advertises an optional operator-managed HTTP(S) origin.
+The cache follows marker-owned profile-build cleanup; topology copies follow
+topology retention and are replaced on the next launch of that topology name.
 
 The coordinator takes an advisory exclusive lock next to the state directory
 before build/runtime preparation and holds it for the lifetime of a launched

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -935,10 +935,9 @@ class WorkspaceTests(unittest.TestCase):
         self.assertTrue((first / "assets" / "data").is_dir())
         self.assertFalse((first / "assets" / "data").is_symlink())
         self.assertNotEqual(first / "assets", second / "assets")
-        self.assertEqual(
-            (first / "assets" / "client-maps").resolve(),
-            root / "runtime" / "client-maps",
-        )
+        staged_maps = first / "assets" / "client-maps"
+        self.assertTrue((staged_maps / "incuna_-1.png").is_file())
+        self.assertFalse(staged_maps.is_symlink())
 
         generated = first / "assets" / "data" / "listing.txt"
         generated.write_text("generated\n", encoding="utf-8")
@@ -1155,9 +1154,9 @@ class WorkspaceTests(unittest.TestCase):
             / "client-maps"
         )
         self.assertTrue((topology_maps / "incuna_-1.png").is_file())
-        self.assertEqual(
-            (server_runtime / "assets" / "client-maps").resolve(), topology_maps
-        )
+        staged_maps = server_runtime / "assets" / "client-maps"
+        self.assertTrue((staged_maps / "incuna_-1.png").is_file())
+        self.assertFalse(staged_maps.is_symlink())
         self.assertTrue(
             (build_root / "runtime" / "client-maps" / "incuna_-1.png").is_file()
         )
@@ -1391,6 +1390,85 @@ class WorkspaceTests(unittest.TestCase):
             self.assertGreater(reset["provisioned_at"], created["provisioned_at"])
 
         self.assertEqual(provision.call_count, 2)
+
+    def test_scenario_lifecycle_prepares_fresh_asset_staging(self) -> None:
+        selected = {
+            component: self.workspace.paths.repositories / component
+            for component in ("server", "content", "resources", "libatrinik", "protocol")
+        }
+        source = selected["server"]
+        (source / "tools").mkdir()
+        for name in ("ca-bundle.crt", "permissions.cfg", "server.cfg"):
+            (source / name).write_text("test\n", encoding="utf-8")
+
+        build_root = self.workspace.paths.builds / "profiles" / "scenario-assets"
+        managed_directory(build_root, self.workspace.paths.builds, "test-profile")
+        binary = build_root / "build" / "server"
+        binary.mkdir(parents=True)
+        for name in ("atrinik-server", "libplugin_arena.so", "libplugin_python.so"):
+            (binary / name).write_text("test\n", encoding="utf-8")
+        for path in (
+            build_root / "runtime" / "content" / "lib",
+            build_root / "runtime" / "content" / "maps",
+            build_root / "runtime" / "resources",
+        ):
+            path.mkdir(parents=True, exist_ok=True)
+        self.make_region_map_cache(build_root)
+
+        staged_assets: list[Path] = []
+
+        def provision(
+            arguments: list[str], *, cwd: Path | None = None, **kwargs: object
+        ) -> object:
+            if "--provision_scenario" not in arguments:
+                return workspace_run(arguments, cwd=cwd, **kwargs)
+            assert cwd is not None
+            assetspath = Path(
+                next(
+                    argument.split("=", 1)[1]
+                    for argument in arguments
+                    if argument.startswith("--assetspath=")
+                )
+            )
+            self.assertEqual(assetspath, cwd / "assets")
+            self.assertFalse(assetspath.is_symlink())
+            self.assertTrue((assetspath / "data").is_dir())
+            self.assertFalse((assetspath / "data").is_symlink())
+            self.assertTrue((assetspath / "client-maps" / "incuna_-1.png").is_file())
+            self.assertFalse((assetspath / "client-maps").is_symlink())
+            self.assertFalse((assetspath / "data" / "previous-run").exists())
+            self.assertFalse((cwd / "data" / "http").exists())
+            (assetspath / "data" / "previous-run").write_text(
+                "generated\n", encoding="utf-8"
+            )
+            staged_assets.append(assetspath)
+            return None
+
+        with (
+            mock.patch.object(
+                self.workspace, "_resolve_build_profile", return_value=selected
+            ),
+            mock.patch.object(
+                self.workspace, "_build_resolved", return_value=build_root
+            ),
+            mock.patch("atrinik_workspace.workspace.run", side_effect=provision),
+        ):
+            created = self.workspace.scenario_create(
+                "fresh-assets", "default", "basic-player"
+            )
+            self.assertEqual(
+                self.workspace.scenario_show("fresh-assets")["state"],
+                "scenario-fresh-assets",
+            )
+            reset = self.workspace.scenario_reset("fresh-assets")
+
+        self.assertEqual(created["state"], "scenario-fresh-assets")
+        self.assertEqual(reset["state"], "scenario-fresh-assets")
+        self.assertEqual(len(staged_assets), 2)
+        self.assertNotEqual(staged_assets[0], staged_assets[1])
+        state = self.workspace.paths.scenarios / "fresh-assets" / "state"
+        self.assertFalse((state / "assets").exists())
+        self.assertFalse((state / "http").exists())
 
     def test_scenario_create_rolls_back_failed_provisioning(self) -> None:
         with mock.patch.object(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -114,7 +114,6 @@ class WorkspaceTests(unittest.TestCase):
         if name == "server":
             (seed / "install_data" / "keys").mkdir(parents=True)
             (seed / "install_data" / "unique-items").mkdir()
-            (seed / "install_data" / "http" / "data").mkdir(parents=True)
             (seed / "install_data" / "keys" / "test.pub").write_text(
                 "key\n", encoding="utf-8"
             )
@@ -123,9 +122,6 @@ class WorkspaceTests(unittest.TestCase):
             )
             (seed / "install_data" / "bans").write_text("", encoding="utf-8")
             (seed / "install_data" / "motd").write_text("Welcome\n", encoding="utf-8")
-            (seed / "install_data" / "http" / "data" / "listing.txt").write_text(
-                "assets\n", encoding="utf-8"
-            )
         command("git", "add", ".", cwd=seed)
         command("git", "commit", "-m", "feat: seed", cwd=seed)
         command("git", "remote", "add", "origin", str(origin), cwd=seed)
@@ -684,9 +680,9 @@ class WorkspaceTests(unittest.TestCase):
             "counter = binary.with_name('worldmaker-count')\n"
             "count = int(counter.read_text()) + 1 if counter.exists() else 1\n"
             "counter.write_text(str(count))\n"
-            "http = Path(next(arg.split('=', 1)[1] for arg in sys.argv "
-            "if arg.startswith('--httppath=')))\n"
-            "output = http / 'client-maps'\n"
+            "assets = Path(next(arg.split('=', 1)[1] for arg in sys.argv "
+            "if arg.startswith('--assetspath=')))\n"
+            "output = assets / 'client-maps'\n"
             "output.mkdir(parents=True)\n"
             "(output / 'incuna_-1.png').write_bytes(b'\\x89PNG\\r\\n\\x1a\\n')\n"
             "(output / 'incuna_-1.def').write_text('pixel_size 4\\n')\n",
@@ -921,26 +917,10 @@ class WorkspaceTests(unittest.TestCase):
         ):
             path.mkdir(parents=True, exist_ok=True)
         self.make_region_map_cache(root)
-        missing_http_state = self.root / "state-missing-http"
-        with self.assertRaisesRegex(WorkspaceError, "lacks required HTTP data"):
-            self.workspace._prepare_server_runtime(
-                root, {"server": source}, missing_http_state, "missing-http"
-            )
-        linked_http_state = self.root / "state-linked-http"
-        (linked_http_state / "http").mkdir(parents=True)
-        http_target = self.root / "http-target"
-        http_target.mkdir()
-        (linked_http_state / "http" / "data").symlink_to(
-            http_target, target_is_directory=True
-        )
-        with self.assertRaisesRegex(WorkspaceError, "lacks required HTTP data"):
-            self.workspace._prepare_server_runtime(
-                root, {"server": source}, linked_http_state, "linked-http"
-            )
         state_one = self.root / "state-one"
         state_two = self.root / "state-two"
-        (state_one / "http" / "data").mkdir(parents=True)
-        (state_two / "http" / "data").mkdir(parents=True)
+        state_one.mkdir()
+        state_two.mkdir()
 
         first = self.workspace._prepare_server_runtime(
             root, {"server": source}, state_one, "one"
@@ -952,10 +932,38 @@ class WorkspaceTests(unittest.TestCase):
         self.assertNotEqual(first, second)
         self.assertTrue((first / "data").is_symlink())
         self.assertEqual((second / "data").resolve(), state_two)
+        self.assertTrue((first / "assets" / "data").is_dir())
+        self.assertFalse((first / "assets" / "data").is_symlink())
+        self.assertNotEqual(first / "assets", second / "assets")
         self.assertEqual(
-            (first / "http" / "client-maps").resolve(),
+            (first / "assets" / "client-maps").resolve(),
             root / "runtime" / "client-maps",
         )
+
+        generated = first / "assets" / "data" / "listing.txt"
+        generated.write_text("generated\n", encoding="utf-8")
+        repeated = self.workspace._prepare_server_runtime(
+            root, {"server": source}, state_one, "one"
+        )
+        self.assertEqual(repeated, first)
+        self.assertFalse(generated.exists())
+
+    def test_asset_staging_directory_rejects_invalid_nodes(self) -> None:
+        missing = self.root / "missing-assets"
+        self.workspace._prepare_asset_staging_directory(missing)
+        self.assertTrue(missing.is_dir())
+
+        invalid_file = self.root / "asset-file"
+        invalid_file.write_text("invalid\n", encoding="utf-8")
+        with self.assertRaisesRegex(WorkspaceError, "asset staging path is invalid"):
+            self.workspace._prepare_asset_staging_directory(invalid_file)
+
+        target = self.root / "asset-target"
+        target.mkdir()
+        invalid_link = self.root / "asset-link"
+        invalid_link.symlink_to(target, target_is_directory=True)
+        with self.assertRaisesRegex(WorkspaceError, "asset staging path is invalid"):
+            self.workspace._prepare_asset_staging_directory(invalid_link)
 
     def test_topology_summary_resolves_service_dependency_closure(self) -> None:
         summary = self.workspace.topology_summary(
@@ -1148,7 +1156,7 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertTrue((topology_maps / "incuna_-1.png").is_file())
         self.assertEqual(
-            (server_runtime / "http" / "client-maps").resolve(), topology_maps
+            (server_runtime / "assets" / "client-maps").resolve(), topology_maps
         )
         self.assertTrue(
             (build_root / "runtime" / "client-maps" / "incuna_-1.png").is_file()
@@ -1170,7 +1178,7 @@ class WorkspaceTests(unittest.TestCase):
         self.assertIn("'--port_mapping=off'", server_log.read_text())
         self.assertIn("'--stun_server=off'", server_log.read_text())
         self.assertIn(
-            f"'--httppath={server_runtime / 'http'}'", server_log.read_text()
+            f"'--assetspath={server_runtime / 'assets'}'", server_log.read_text()
         )
         self.assertIn(
             f"'--server=127.0.0.1 17300 {'a' * 64}'", client_log.read_text()
@@ -1579,7 +1587,7 @@ class WorkspaceTests(unittest.TestCase):
                 "default",
                 "default",
                 1731,
-                ["--no_console", "--httppath=/tmp/untrusted"],
+                ["--no_console", "--assetspath=/tmp/untrusted"],
                 True,
             )
 
@@ -1590,8 +1598,8 @@ class WorkspaceTests(unittest.TestCase):
         self.assertIn("--stun_server=off", rendered)
         self.assertIn("--no_console", rendered)
         self.assertLess(
-            rendered.index("--httppath=/tmp/untrusted"),
-            rendered.index(f"--httppath={runtime / 'http'}"),
+            rendered.index("--assetspath=/tmp/untrusted"),
+            rendered.index(f"--assetspath={runtime / 'assets'}"),
         )
 
     def test_foreground_launch_rejects_invalid_port(self) -> None:


### PR DESCRIPTION
## Summary

- replace wrapper `runtime/http` staging with a disposable exact-profile `runtime/assets` view
- allow fresh Classic states without pre-created legacy directories and keep generated data outside persistent state
- preserve immutable topology snapshots and reject invalid owned staging nodes
- update wrapper tests, architecture, README, and runtime/scenario guidance

## Validation

- `python3 -m coverage run -m unittest discover -v`: 328 tests passed
- coverage report: 78%
- compileall, guidance inventory, manifest validation, and supply-chain validation
- focused fresh-state, topology snapshot, repeated-reset, file, and symlink tests
- runtime/scenario skill validation and `git diff --check`
- coordinated Classic build: 36/36 integrated tests, 37/37 sanitizer tests, 36/36 coverage tests
- fresh create/show, supervised server startup, 5,159,784-byte asset cache initialization, shutdown, and scenario reset passed on the final heads

## Coordination

- Companion Classic PR: https://github.com/atrinik/classic/pull/74
- Closes #317

The Classic companion owns the server option/settings rename, generated output, cache, packaging, and migration tests. This canonical wrapper PR owns state/scenario orchestration and runtime lifecycle.
