### PR TITLE
chore(supply-chain): retire crates.io bootstrap evidence

### DIFF
--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -1578,31 +1578,21 @@
       "owner": "protocol",
       "scope": ["protocol"],
       "required": true,
-      "version": "API v1; atrinik-protocol 0.1.0 bootstrap",
-      "version_source": "Fixed protocol bootstrap workflow and immutable v1.4.0 release provenance",
+      "version": "API v1; atrinik-protocol 0.1.0 canonical registry object",
+      "version_source": "Protocol registry/release policies and immutable v1.4.0 release provenance",
       "license": "NOASSERTION",
       "source_url": "https://crates.io/",
       "locator": "pkg:cargo/atrinik-protocol@0.1.0",
       "commit": null,
       "checksum": "sha256:413c4da6c1b304d4a622065efe0d36c3f591041972f1a5ee76c538926f3c0b6b",
-      "acquisition": "A protected manual GitHub environment publishes only the byte-reproduced immutable release crate after required review",
+      "acquisition": "Consumers acquire the immutable checksummed crate from crates.io; future publication remains disabled until a separately reviewed Trusted Publishing activation",
       "update_cadence_days": 30,
-      "update_mechanism": "Remove the one-time bootstrap after registration and replace it with a separately reviewed crate-scoped release policy",
+      "update_mechanism": "Review a new policy-owned crate release, exact GitHub OIDC identity, protected environment, and short-lived Trusted Publishing workflow before activation",
       "eol_response": "Stop registry publication and consumer rollout if ownership, integrity, availability, or supported Cargo compatibility cannot be maintained",
-      "validation": "Fixed workflow contract, offline package reproduction, GitHub release provenance and SHA-256 checks, and post-upload crates.io checksum verification",
+      "validation": "Fail-closed post-bootstrap policy, offline package reproduction, GitHub release provenance and SHA-256 checks, and public crates.io checksum verification",
       "disposition": "retain",
       "packages": ["atrinik-protocol"],
       "evidence": [
-        {
-          "repository": "protocol",
-          "path": ".github/workflows/publish-crate.yml",
-          "contains": "CRATE_SHA256: 413c4da6c1b304d4a622065efe0d36c3f591041972f1a5ee76c538926f3c0b6b"
-        },
-        {
-          "repository": "protocol",
-          "path": ".github/workflows/publish-crate.yml",
-          "contains": "environment: crates-io-bootstrap"
-        },
         {
           "repository": "protocol",
           "path": "crates/atrinik-protocol/Cargo.toml",
@@ -1610,8 +1600,18 @@
         },
         {
           "repository": "protocol",
-          "path": "tools/check-crate-publication.py",
-          "contains": "bootstrap token must appear in exactly one step"
+          "path": "policy/rust-crate-publishing.json",
+          "contains": "413c4da6c1b304d4a622065efe0d36c3f591041972f1a5ee76c538926f3c0b6b"
+        },
+        {
+          "repository": "protocol",
+          "path": "policy/rust-crate-publishing.json",
+          "contains": "disabled-until-reviewed-activation"
+        },
+        {
+          "repository": "protocol",
+          "path": "tools/check-crate-release-policy.py",
+          "contains": "Rust registry publication is not activated"
         }
       ]
     },


### PR DESCRIPTION
## Summary

- replace the retired one-use crates.io bootstrap workflow evidence with the canonical published registry object
- record future publication as disabled until a separately reviewed Trusted Publishing activation
- retain the independently verified atrinik-protocol 0.1.0 checksum and policy-owned validation path

## Validation

- 328 wrapper unit tests pass under coverage; aggregate coverage is 78%
- compileall, guidance inventory, 21-component manifest, and 100-dependency inventory checks pass
- classic profile supply-chain audit passes across 15 repositories, 17,689 version-controlled inputs, and 116 Action references
- jq validation and git diff check pass

## Ordering

Depends on merged atrinik/protocol#29. This PR changes only the wrapper dependency inventory and does not mutate crates.io or GitHub settings.