### PR TITLE
docs(agents): require dual-line content delivery

### DIFF
--- a/.agents/skills/atrinik-content-change/SKILL.md
+++ b/.agents/skills/atrinik-content-change/SKILL.md
@@ -5,36 +5,35 @@ description: Change authored content on `main` or `1.x`, including maps, archety
 
 # Atrinik content change
 
-Use `content@main` for replacement forward authoring and `content-1x@1.x` for
-classic maintenance. Never assume a format or generated artifact belongs on
-both lines; cross-line changes use separate worktrees, validation, commits, and
-pull requests. Add `atrinik-multi-repo-workspace` when another checkout is
-affected.
+For issue fixes, assess both `content@main` and `content-1x@1.x`. Shared
+authored changes normally need separate worktrees, validation, commits, and
+linked PRs on both lines; record an evidence-backed format, consumer, runtime,
+or provenance reason for any single-line exception. Never merge lines wholesale
+or share generated output. Use `main` for replacement forward authoring and
+`1.x` for Classic maintenance; add `atrinik-multi-repo-workspace` for cross-line
+work.
 
 ## Establish the contract
 
-1. Select the exact content checkout/branch, then read its root guide and the
-   nearest `arch/` or `maps/` guide.
-2. Use `tools/content_catalog` for stable domain identities and references.
-   Trace every affected map, archetype, animation, image, artifact, treasure,
-   faction, interface, and script reference.
+1. Select the exact checkout/branch and read its root and nearest `arch/` or
+   `maps/` guides.
+2. Use `tools/content_catalog` for stable identities and references; trace each
+   affected map, archetype, animation, image, artifact, treasure, faction,
+   interface, and script.
 3. Preserve layout, formatting, case, attribution, and per-asset licenses.
-   Keep unrelated normalization out of the diff. Never mask a missing
-   reference with an absolute path or generated placeholder.
-4. Treat embedded Python as classic runtime code. Keep runtime output in an
-   isolated generated directory and never overwrite mutable server state.
+   Exclude unrelated normalization and never mask missing references.
+4. Treat embedded Python as Classic runtime code. Isolate generated runtime
+   output and never overwrite mutable server state.
 
 ## Validate
 
-Run the checkout's canonical aggregate validator; it already performs contract,
-schema, syntax, and runtime-build validation:
+Run the checkout's aggregate contract, schema, syntax, and runtime validator:
 
 ```sh
 python3 tools/validate.py
 git diff --check
 ```
 
-Run `python3 tools/world_content_audit.py all` only when its read-only report is
-relevant, plus focused commands named by the changed domain. For live behavior,
-select the exact content worktree in a coherent profile and use wrapper-native
-build/topology commands. Use `atrinik-test-scenario` for repeatable state.
+Run focused or read-only world audits only when relevant. For live behavior,
+select the exact worktree in a coherent profile and use wrapper-native
+build/topology commands plus `atrinik-test-scenario` for repeatable state.

--- a/.agents/skills/atrinik-issue-delivery/SKILL.md
+++ b/.agents/skills/atrinik-issue-delivery/SKILL.md
@@ -31,11 +31,12 @@ scenario procedures.
    when needed and set its existing Status to **In progress** per
    `github-settings/config/planning.json`; never invent an `in-progress` label.
    Use a status label only where an authorized repository makes it canonical.
-4. For content issues, assess `main` and `1.x`; normally give shared authored
-   fixes separate bases, worktrees, validation, commits, linked PRs, reviews,
-   and final-head checks. Record an evidence-backed single-line exception. For
-   paired delivery, only the canonical default-branch PR closes while companions
-   link; otherwise the sole applicable PR is canonical. Leave the issue open.
+4. For content, assess `main` and `1.x`. Give shared fixes separate bases,
+   worktrees, validation, commits, linked PRs, reviews, and final-head checks;
+   record an evidence-backed exception. Paired: only the default-branch PR
+   closes; companions link. A sole `main` PR closes. A sole `1.x` PR links
+   without a closing keyword; close its issue manually after merge. Leave
+   issues open.
 
 ## Resolve ownership and isolate work
 

--- a/.agents/skills/atrinik-issue-delivery/SKILL.md
+++ b/.agents/skills/atrinik-issue-delivery/SKILL.md
@@ -31,8 +31,11 @@ scenario procedures.
    when needed and set its existing Status to **In progress** per
    `github-settings/config/planning.json`; never invent an `in-progress` label.
    Use a status label only where an authorized repository makes it canonical.
-4. Leave the issue open. Give only the canonical PR a closing reference; link
-   companion PRs without making them race to close it.
+4. For content issues, assess `main` and `1.x`; normally give shared authored
+   fixes separate bases, worktrees, validation, commits, linked PRs, reviews,
+   and final-head checks. Record an evidence-backed single-line exception. For
+   paired delivery, only the canonical default-branch PR closes while companions
+   link; otherwise the sole applicable PR is canonical. Leave the issue open.
 
 ## Resolve ownership and isolate work
 
@@ -52,11 +55,10 @@ scenario procedures.
 
 ## Implement and publish a draft
 
-Implement requirements with repository-owned tests and contract updates.
-Commit coherent Conventional Commit checkpoints; never rewrite published
-history without separate authority. Run focused validation, push normally, and
-open a draft PR against `TARGET_BRANCH` (for example, `--base TARGET_BRANCH`)
-once coherent; verify the returned PR base.
+Implement requirements with owner tests/contracts. Commit coherent Conventional
+Commit checkpoints; never rewrite published history without separate authority.
+Validate, push normally, and open a coherent draft against `TARGET_BRANCH`
+(for example, `--base TARGET_BRANCH`); verify the returned base.
 
 Use a Conventional Commit title and newline-preserving GitHub-Flavored Markdown
 body. Record issue linkage, base/head branches and SHAs, worktree, commits,
@@ -139,11 +141,10 @@ actionable feedback restarts the fix, validation, and whole-diff loop.
 Missing human approval blocks merging, not the ready transition after the stated
 exit conditions pass.
 
-Hand off issue/PR URLs; repositories; base/head SHAs; branches, commits, and
-worktrees; report path/rounds/findings; exact validation and check state;
-mergeability; runtime applicability; all reused/created/preserved profile,
-build, server/client, scenario, state, topology, and service data; prerequisites,
-actions, results, repeat/shutdown/cleanup commands; and blockers or `none`.
+Hand off issue/PR URLs; per-target bases, heads, branches, commits, worktrees,
+review findings, validation/checks, mergeability, runtime applicability,
+resources, verification/repeat/shutdown/cleanup commands, and blockers or
+`none`.
 
 Keep worktrees and reports while PRs are open. Stop before merge or closure.
 Cleanup requires a separate post-merge request beginning with

--- a/.agents/skills/atrinik-issue-delivery/assets/deep-review-report.md
+++ b/.agents/skills/atrinik-issue-delivery/assets/deep-review-report.md
@@ -8,7 +8,7 @@ vulnerability detail. Do not commit or publish this report.
 
 - Issue: `<URL>`
 - Pull request(s): `<URL(s)>`
-- Canonical closing PR: `<URL>`
+- Issue-closing path: `<default-branch PR URL or manual post-merge close>`
 - Review started / last refreshed: `<UTC timestamps>`
 
 | Release line / owner | Target / fetched base | Head branch / SHA | Merge base | Worktree | Commits reviewed |

--- a/.agents/skills/atrinik-issue-delivery/assets/deep-review-report.md
+++ b/.agents/skills/atrinik-issue-delivery/assets/deep-review-report.md
@@ -9,13 +9,11 @@ vulnerability detail. Do not commit or publish this report.
 - Issue: `<URL>`
 - Pull request(s): `<URL(s)>`
 - Canonical closing PR: `<URL>`
-- Repository: `<owner/repository>`
-- Target branch / fetched base SHA: `<branch>` / `<sha>`
-- Head branch / SHA: `<branch>` / `<sha>`
-- Merge base: `<sha>`
-- Worktree: `<absolute path>`
-- Commits reviewed: `<sha and subject list>`
 - Review started / last refreshed: `<UTC timestamps>`
+
+| Release line / owner | Target / fetched base | Head branch / SHA | Merge base | Worktree | Commits reviewed |
+| --- | --- | --- | --- | --- | --- |
+| `<repository@line>` | `<branch>` / `<sha>` | `<branch>` / `<sha>` | `<sha>` | `<absolute path>` | `<sha and subject list>` |
 
 ## Acceptance traceability
 
@@ -30,7 +28,7 @@ vulnerability detail. Do not commit or publish this report.
 - Added: `<paths or none>`
 - Modified: `<paths or none>`
 - Deleted/renamed/mode/binary: `<paths or none>`
-- Cross-repository consumers/contracts: `<impact or none>`
+- Cross-repository or cross-line consumers/contracts: `<impact or none>`
 - Generated versus authored files: `<inventory>`
 - Unrelated or formatting-only churn: `<none or explanation>`
 

--- a/.agents/skills/atrinik-issue-delivery/references/deep-review-checklist.md
+++ b/.agents/skills/atrinik-issue-delivery/references/deep-review-checklist.md
@@ -45,7 +45,8 @@ categories into invented findings.
   accidentally omitted files.
 - Confirm each file belongs to the physical repository that owns its contract.
 - Check cross-repository or cross-line changes have independent branches,
-  commits, PRs, and one unambiguous canonical issue-closing PR.
+  commits, PRs, and one unambiguous issue-closing path: a default-branch
+  closing keyword or documented manual post-merge close.
 - Verify the fetched target branch and recorded base SHA are current and correct.
 - Check public APIs, protocols, schemas, manifests, fixtures, docs, packages,
   release inputs, and generated consumers stay synchronized where applicable.

--- a/.agents/skills/atrinik-issue-delivery/references/deep-review-checklist.md
+++ b/.agents/skills/atrinik-issue-delivery/references/deep-review-checklist.md
@@ -44,8 +44,8 @@ categories into invented findings.
 - Identify unrequested behavior, scope creep, hidden compatibility changes, and
   accidentally omitted files.
 - Confirm each file belongs to the physical repository that owns its contract.
-- Check cross-repository changes have independent branches, commits, PRs, and
-  one unambiguous canonical issue-closing PR.
+- Check cross-repository or cross-line changes have independent branches,
+  commits, PRs, and one unambiguous canonical issue-closing PR.
 - Verify the fetched target branch and recorded base SHA are current and correct.
 - Check public APIs, protocols, schemas, manifests, fixtures, docs, packages,
   release inputs, and generated consumers stay synchronized where applicable.

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -236,9 +236,7 @@ class AgentGuidanceTests(unittest.TestCase):
             "final-head checks",
             "Paired: only the default-branch PR closes; companions link",
             "companions link",
-            "sole `main` PR closes",
-            "sole `1.x` PR links without a closing keyword",
-            "close its issue manually after merge",
+            "A sole `main` PR closes. A sole `1.x` PR links without a closing keyword; close its issue manually after merge",
             "per-target bases",
         }:
             with self.subTest(surface="delivery", marker=marker):

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -219,14 +219,15 @@ class AgentGuidanceTests(unittest.TestCase):
         ).read_text(encoding="utf-8")
 
         for marker in {
-            "content@main",
-            "content-1x@1.x",
-            "separate worktrees",
-            "validation",
-            "commits",
-            "linked PRs",
-            "evidence-backed",
-            "single-line exception",
+            "For issue fixes, assess both `content@main` and `content-1x@1.x`",
+            (
+                "Shared authored changes normally need separate worktrees, "
+                "validation, commits, and linked PRs on both lines"
+            ),
+            (
+                "record an evidence-backed format, consumer, runtime, or "
+                "provenance reason for any single-line exception"
+            ),
         }:
             with self.subTest(surface="content", marker=marker):
                 self.assertIn(marker, content)
@@ -236,7 +237,10 @@ class AgentGuidanceTests(unittest.TestCase):
             "final-head checks",
             "Paired: only the default-branch PR closes; companions link",
             "companions link",
-            "A sole `main` PR closes. A sole `1.x` PR links without a closing keyword; close its issue manually after merge",
+            (
+                "A sole `main` PR closes. A sole `1.x` PR links without a "
+                "closing keyword; close its issue manually after merge"
+            ),
             "per-target bases",
         }:
             with self.subTest(surface="delivery", marker=marker):

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -199,6 +199,50 @@ class AgentGuidanceTests(unittest.TestCase):
         self.assertIn("## Scale and performance", checklist)
         self.assertIn("## Safety, security, and supply chain", checklist)
 
+    def test_content_issue_delivery_covers_both_release_lines(self) -> None:
+        content = " ".join(
+            (
+                ROOT / ".agents/skills/atrinik-content-change/SKILL.md"
+            ).read_text(encoding="utf-8").split()
+        )
+        delivery_root = ROOT / ".agents/skills/atrinik-issue-delivery"
+        delivery = " ".join(
+            (delivery_root / "SKILL.md").read_text(
+                encoding="utf-8"
+            ).split()
+        )
+        report = (delivery_root / "assets/deep-review-report.md").read_text(
+            encoding="utf-8"
+        )
+        checklist = (
+            delivery_root / "references/deep-review-checklist.md"
+        ).read_text(encoding="utf-8")
+
+        for marker in {
+            "content@main",
+            "content-1x@1.x",
+            "separate worktrees",
+            "validation",
+            "commits",
+            "linked PRs",
+            "evidence-backed",
+            "single-line exception",
+        }:
+            with self.subTest(surface="content", marker=marker):
+                self.assertIn(marker, content)
+        for marker in {
+            "assess `main` and `1.x`",
+            "separate bases",
+            "final-head checks",
+            "canonical default-branch PR",
+            "sole applicable PR is canonical",
+            "per-target bases",
+        }:
+            with self.subTest(surface="delivery", marker=marker):
+                self.assertIn(marker, delivery)
+        self.assertIn("| Release line / owner |", report)
+        self.assertIn("cross-repository or cross-line", checklist)
+
     def test_removed_stale_routes_do_not_return(self) -> None:
         paths = [ROOT / "AGENTS.md"]
         paths.extend(sorted((ROOT / ".agents/skills").glob("*/SKILL.md")))

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -234,15 +234,19 @@ class AgentGuidanceTests(unittest.TestCase):
             "assess `main` and `1.x`",
             "separate bases",
             "final-head checks",
-            "paired delivery, only the canonical default-branch PR closes while companions link",
+            "Paired: only the default-branch PR closes; companions link",
             "companions link",
-            "sole applicable PR is canonical",
+            "sole `main` PR closes",
+            "sole `1.x` PR links without a closing keyword",
+            "close its issue manually after merge",
             "per-target bases",
         }:
             with self.subTest(surface="delivery", marker=marker):
                 self.assertIn(marker, delivery)
         self.assertIn("| Release line / owner |", report)
         self.assertIn("cross-repository or cross-line", checklist)
+        self.assertIn("Issue-closing path", report)
+        self.assertIn("manual post-merge close", checklist)
 
     def test_removed_stale_routes_do_not_return(self) -> None:
         paths = [ROOT / "AGENTS.md"]

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -234,7 +234,8 @@ class AgentGuidanceTests(unittest.TestCase):
             "assess `main` and `1.x`",
             "separate bases",
             "final-head checks",
-            "canonical default-branch PR",
+            "paired delivery, only the canonical default-branch PR closes while companions link",
+            "companions link",
             "sole applicable PR is canonical",
             "per-target bases",
         }:


### PR DESCRIPTION
## Summary

- make dual-release-line assessment the default for issue-driven authored-content fixes
- require independent bases, worktrees, validation, commits, linked PRs, reviews, and final-head checks when both `main` and `1.x` apply
- require an evidence-backed rationale for a single-line exception
- define unambiguous closing behavior for paired delivery and legitimate single-line delivery
- extend the deep-review report/checklist and lock the contract with synchronized agent-guidance tests

## Closing and ownership contract

For paired delivery, the canonical default-branch PR is the only issue closer and companion PRs link without a closing keyword. For a documented single-line exception, a sole `main` PR uses a closing keyword; a sole `1.x` PR links without one and the issue is closed manually after merge. Release branches are never merged wholesale and generated output is never shared between their worktrees.

Repository-owned content guidance is tracked separately in atrinik/content#68.

## Coordinates

- Base: `main` at `616359b8d7c632ee1e2bef1e438b2dd7434bb7cc`
- Head: `docs/322-content-release-lines` at `486bed76b1db5a5eb28df54a7e838403bb28ae30`
- Worktree: `/workspaces/atrinik/workspace/worktrees/atrinik/issue-322-content-release-lines`
- Commits: `e7dd8dc16 docs(agents): require dual-line content delivery`; `9f1e621d9 test(agents): lock companion closing policy`; `66bee6b22 fix(agents): handle maintenance-only issue closure`; `44a084506 test(agents): lock maintenance closure path`; `486bed76b test(agents): lock dual-line delivery default`

## Validation

- `python3 .../skill-creator/scripts/quick_validate.py .agents/skills/atrinik-content-change`
- `python3 .../skill-creator/scripts/quick_validate.py .agents/skills/atrinik-issue-delivery`
- `python3 -m coverage run -m unittest discover -v` — 329 tests passed
- `python3 -m coverage report --show-missing` — 78% total coverage
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check` — `multi-selected=13,936/14,000`, `all-skills=28,651/28,750`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `git diff --check`

## Review

Independent whole-diff and test audits drove fixes for weak partial closing-policy assertions and the fact that GitHub ignores issue-closing keywords on `1.x`. The final policy distinguishes automatic default-branch closure from manual post-maintenance-merge closure. Follow-up final-head review reports zero remaining actionable findings.

Closes #322
