### PR TITLE
feat(runtime): label managed client launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -903,8 +903,13 @@ pattern; today only the classic command is runnable:
 This is useful for side-by-side regression checks, protocol experiments, and
 reviewing two pull-request combinations without stopping either one. Each
 client is pinned to its own server fingerprint and has separate settings and
-caches. Omit both `--port` options to have the coordinator choose two available
-ports. Two live servers may not use the same state directory; the state lock
+caches. A managed client's native window title includes both its topology and
+profile, for example `Atrinik Client — topology classic-side - profile classic`.
+Use the topology name shown there with `./atrinik ps NAME --json`,
+`./atrinik logs NAME client`, and `./atrinik down NAME`; clients from the same
+profile remain distinguishable by topology. Omit both `--port` options to have
+the coordinator choose two available ports. Two live servers may not use the
+same state directory; the state lock
 turns that mistake into an immediate error instead of mutable-data corruption.
 
 ### Use case: run only a headless server
@@ -977,7 +982,12 @@ The foreground commands are a paired local-development path: use the same
 `--state` and `--port` in both terminals. The server always starts with
 automatic port mapping and STUN discovery disabled. The client reads the
 state's generated QUIC certificate, adds its authenticated loopback endpoint,
-and starts with metaserver and STUN discovery disabled. Start the server first
+and starts with metaserver and STUN discovery disabled. Its native title shows
+`profile PROFILE (direct run)` so it cannot be confused with a supervised
+topology. The bounded launch identity exists only in the child process
+environment; it is not saved to client configuration or used as package,
+protocol, or network user-agent version data. Clients started outside the
+wrapper retain the ordinary package title. Start the server first
 so that its persistent `quic-identity.pem` exists. Additional arguments are
 appended after these defaults, and join-password arguments are redacted from
 command logging. Prefer `up` for routine use because it allocates a port,

--- a/atrinik_workspace/launch_identity.py
+++ b/atrinik_workspace/launch_identity.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from .model import WorkspaceError, validate_name
+
+
+CLIENT_LAUNCH_LABEL_ENV = "ATRINIK_LAUNCH_LABEL"
+CLIENT_LAUNCH_LABEL_MAX_SIZE = 96
+
+
+def client_launch_label(profile: str, topology: str | None = None) -> str:
+    validate_name(profile, "profile name")
+    if topology is None:
+        label = f"profile {profile} (direct run)"
+    else:
+        validate_name(topology, "topology name")
+        label = f"topology {topology} - profile {profile}"
+    if len(label.encode("ascii")) > CLIENT_LAUNCH_LABEL_MAX_SIZE:
+        raise WorkspaceError(
+            f"client launch label exceeds {CLIENT_LAUNCH_LABEL_MAX_SIZE} bytes"
+        )
+    return label

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -15,6 +15,8 @@ import threading
 import time
 from typing import Any, BinaryIO
 
+from .launch_identity import CLIENT_LAUNCH_LABEL_ENV, client_launch_label
+
 
 LOG_LIMIT = 10 * 1024 * 1024
 LOG_BACKUPS = 3
@@ -233,6 +235,10 @@ def supervise(spec_path: Path, lock_fd: int | None) -> int:
         command.extend(extra_arguments or [])
         environment = os.environ.copy()
         environment.update(service.get("environment", {}))
+        if name == "client":
+            environment[CLIENT_LAUNCH_LABEL_ENV] = client_launch_label(
+                spec["profile"], spec["name"]
+            )
         process = subprocess.Popen(
             command,
             cwd=service["cwd"],

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -23,6 +23,8 @@ import tempfile
 import time
 from typing import Any, Iterator, TextIO
 
+from .launch_identity import CLIENT_LAUNCH_LABEL_ENV, client_launch_label
+
 from .model import (
     MANAGED_MARKER,
     SCHEMA_VERSION,
@@ -98,8 +100,6 @@ CACHE_METADATA = ".atrinik-cache.json"
 REGION_MAP_METADATA = ".atrinik-region-maps.json"
 REGION_MAP_SCHEMA_VERSION = 1
 EXPECTED_REGION_MAP = "incuna_-1"
-CLIENT_LAUNCH_LABEL_ENV = "ATRINIK_LAUNCH_LABEL"
-CLIENT_LAUNCH_LABEL_MAX_SIZE = 96
 
 
 def display_arguments(arguments: list[str]) -> str:
@@ -117,20 +117,6 @@ def display_arguments(arguments: list[str]) -> str:
         else:
             displayed.append(argument)
     return shlex.join(displayed)
-
-
-def client_launch_label(profile: str, topology: str | None = None) -> str:
-    validate_name(profile, "profile name")
-    if topology is None:
-        label = f"profile {profile} (direct run)"
-    else:
-        validate_name(topology, "topology name")
-        label = f"topology {topology} - profile {profile}"
-    if len(label.encode("ascii")) > CLIENT_LAUNCH_LABEL_MAX_SIZE:
-        raise WorkspaceError(
-            f"client launch label exceeds {CLIENT_LAUNCH_LABEL_MAX_SIZE} bytes"
-        )
-    return label
 
 
 def run(
@@ -2985,11 +2971,8 @@ class Workspace:
         port: int | None = None,
     ) -> dict[str, Any]:
         selected_services = self._topology_services(services)
-        launch_label = (
+        if "client" in selected_services:
             client_launch_label(profile_name, name)
-            if "client" in selected_services
-            else None
-        )
         if "server" not in selected_services and port is not None:
             raise WorkspaceError("--port requires the server service")
         self._require_classic_contracts(profile_name, set(selected_services))
@@ -3101,7 +3084,6 @@ class Workspace:
                         "log": str(topology_root / "server.log"),
                     }
                 if "client" in selected_services:
-                    assert launch_label is not None
                     executable = root / "build" / "client" / "atrinik"
                     working = self._prepare_topology_client_runtime(
                         topology_root, selected
@@ -3121,8 +3103,7 @@ class Workspace:
                         "cwd": str(working),
                         "log": str(topology_root / "client.log"),
                         "environment": {
-                            "ATRINIK_CONFIG_DIR": str(client_config.resolve()),
-                            CLIENT_LAUNCH_LABEL_ENV: launch_label,
+                            "ATRINIK_CONFIG_DIR": str(client_config.resolve())
                         },
                     }
 

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -98,6 +98,8 @@ CACHE_METADATA = ".atrinik-cache.json"
 REGION_MAP_METADATA = ".atrinik-region-maps.json"
 REGION_MAP_SCHEMA_VERSION = 1
 EXPECTED_REGION_MAP = "incuna_-1"
+CLIENT_LAUNCH_LABEL_ENV = "ATRINIK_LAUNCH_LABEL"
+CLIENT_LAUNCH_LABEL_MAX_SIZE = 96
 
 
 def display_arguments(arguments: list[str]) -> str:
@@ -115,6 +117,20 @@ def display_arguments(arguments: list[str]) -> str:
         else:
             displayed.append(argument)
     return shlex.join(displayed)
+
+
+def client_launch_label(profile: str, topology: str | None = None) -> str:
+    validate_name(profile, "profile name")
+    if topology is None:
+        label = f"profile {profile} (direct run)"
+    else:
+        validate_name(topology, "topology name")
+        label = f"topology {topology} - profile {profile}"
+    if len(label.encode("ascii")) > CLIENT_LAUNCH_LABEL_MAX_SIZE:
+        raise WorkspaceError(
+            f"client launch label exceeds {CLIENT_LAUNCH_LABEL_MAX_SIZE} bytes"
+        )
+    return label
 
 
 def run(
@@ -2969,6 +2985,11 @@ class Workspace:
         port: int | None = None,
     ) -> dict[str, Any]:
         selected_services = self._topology_services(services)
+        launch_label = (
+            client_launch_label(profile_name, name)
+            if "client" in selected_services
+            else None
+        )
         if "server" not in selected_services and port is not None:
             raise WorkspaceError("--port requires the server service")
         self._require_classic_contracts(profile_name, set(selected_services))
@@ -3080,6 +3101,7 @@ class Workspace:
                         "log": str(topology_root / "server.log"),
                     }
                 if "client" in selected_services:
+                    assert launch_label is not None
                     executable = root / "build" / "client" / "atrinik"
                     working = self._prepare_topology_client_runtime(
                         topology_root, selected
@@ -3099,7 +3121,8 @@ class Workspace:
                         "cwd": str(working),
                         "log": str(topology_root / "client.log"),
                         "environment": {
-                            "ATRINIK_CONFIG_DIR": str(client_config.resolve())
+                            "ATRINIK_CONFIG_DIR": str(client_config.resolve()),
+                            CLIENT_LAUNCH_LABEL_ENV: launch_label,
                         },
                     }
 
@@ -3356,6 +3379,7 @@ class Workspace:
         dry_run: bool,
     ) -> Path:
         self._validate_run_port(port)
+        launch_label = client_launch_label(profile_name)
         self._require_classic_contracts(profile_name, {"client"})
         state = self._state_location(state_name)
         self._validate_state(state)
@@ -3374,10 +3398,18 @@ class Workspace:
         ]
         print(f"state: {state}")
         print(f"cwd: {working}")
+        print(f"launch label: {launch_label}")
         print(f"command: {display_arguments(command)}")
         if not dry_run:
             self._require_client_display()
-            run(command, cwd=working, diagnostics_to_stderr=False)
+            environment = os.environ.copy()
+            environment[CLIENT_LAUNCH_LABEL_ENV] = launch_label
+            run(
+                command,
+                cwd=working,
+                env=environment,
+                diagnostics_to_stderr=False,
+            )
         return executable
 
     def run_server(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -425,6 +425,11 @@ first, waits for its fingerprint and final ready signal, and then pins the
 client to that authenticated loopback endpoint. Available UDP ports are
 allocated under a workspace-wide lock, or callers may request an explicit
 port. Each runtime name owns an isolated persistent client configuration base.
+A supervised client also receives a bounded, process-only launch label naming
+its topology and profile; a foreground client receives its profile and direct
+run mode. The client uses this label only for its native window title. It is
+not part of persisted settings, package or protocol identity, or network
+metadata, and unmanaged launches receive no label.
 A server topology takes ownership of its collected content and staged resource
 directories after the shared incremental build, so later builds cannot mutate
 the filesystem seen by a running process.

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -15,6 +15,7 @@ import unittest
 from unittest import mock
 
 from atrinik_workspace.migration import rename_no_replace as real_rename_no_replace
+from atrinik_workspace.launch_identity import client_launch_label
 from atrinik_workspace.model import (
     MANAGED_MARKER,
     WorkspaceError,
@@ -27,7 +28,6 @@ from atrinik_workspace.model import (
 from atrinik_workspace.workspace import (
     Workspace,
     _remote_matches as real_remote_matches,
-    client_launch_label,
     display_arguments,
     exclusive_lock,
     run as workspace_run,
@@ -1057,6 +1057,11 @@ class WorkspaceTests(unittest.TestCase):
                 log.read_text(),
             )
             self.assertIn("launch=topology review - profile default", log.read_text())
+            persisted_spec = (
+                self.workspace.paths.topologies / "review" / "spec.json"
+            ).read_text()
+            self.assertNotIn("ATRINIK_LAUNCH_LABEL", persisted_spec)
+            self.assertNotIn("topology review - profile default", persisted_spec)
 
             second_log = self.workspace.paths.topologies / "review-two" / "client.log"
             deadline = time.monotonic() + 5

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -27,6 +27,7 @@ from atrinik_workspace.model import (
 from atrinik_workspace.workspace import (
     Workspace,
     _remote_matches as real_remote_matches,
+    client_launch_label,
     display_arguments,
     exclusive_lock,
     run as workspace_run,
@@ -993,9 +994,11 @@ class WorkspaceTests(unittest.TestCase):
         (build_root / "sources" / "client").mkdir(parents=True)
         executable.write_text(
             "#!/usr/bin/env python3\n"
-            "import os, time\n"
+            "import os, sys, time\n"
             "print('client ready', flush=True)\n"
+            "print('arguments=' + repr(sys.argv[1:]), flush=True)\n"
             "print('config=' + os.environ['ATRINIK_CONFIG_DIR'], flush=True)\n"
+            "print('launch=' + os.environ['ATRINIK_LAUNCH_LABEL'], flush=True)\n"
             "while True:\n"
             "    time.sleep(0.1)\n",
             encoding="utf-8",
@@ -1052,6 +1055,18 @@ class WorkspaceTests(unittest.TestCase):
             self.assertIn(
                 str(self.workspace.paths.topologies / "review" / "client-config"),
                 log.read_text(),
+            )
+            self.assertIn("launch=topology review - profile default", log.read_text())
+
+            second_log = self.workspace.paths.topologies / "review-two" / "client.log"
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline and (
+                not second_log.is_file() or "launch=" not in second_log.read_text()
+            ):
+                time.sleep(0.05)
+            self.assertIn(
+                "launch=topology review-two - profile default",
+                second_log.read_text(),
             )
 
             with mock.patch("builtins.print") as output:
@@ -1117,6 +1132,7 @@ class WorkspaceTests(unittest.TestCase):
             "import os, sys, time\n"
             "print(repr(sys.argv[1:]), flush=True)\n"
             "print('config=' + os.environ['ATRINIK_CONFIG_DIR'], flush=True)\n"
+            "print('launch=' + os.environ['ATRINIK_LAUNCH_LABEL'], flush=True)\n"
             "while True:\n"
             "    time.sleep(0.1)\n",
             encoding="utf-8",
@@ -1185,6 +1201,10 @@ class WorkspaceTests(unittest.TestCase):
         self.assertIn("'--connect=127.0.0.1'", client_log.read_text())
         self.assertIn("'--stun_server=off'", client_log.read_text())
         self.assertIn("'--nometa'", client_log.read_text())
+        self.assertIn(
+            "launch=topology server-review - profile default",
+            client_log.read_text(),
+        )
         self.assertIn(
             str(
                 self.workspace.paths.topologies
@@ -1611,9 +1631,11 @@ class WorkspaceTests(unittest.TestCase):
         with (
             mock.patch.object(self.workspace, "build", return_value=build_root),
             mock.patch("builtins.print") as output,
+            mock.patch("atrinik_workspace.workspace.run") as execute,
+            mock.patch.object(self.workspace, "_require_client_display"),
         ):
             result = self.workspace.run_client(
-                "default", "default", 1731, ["--fullscreen"], True
+                "default", "default", 1731, ["--fullscreen"], False
             )
 
         self.assertEqual(result, executable)
@@ -1622,6 +1644,17 @@ class WorkspaceTests(unittest.TestCase):
         self.assertIn("--stun_server=off", rendered)
         self.assertIn("--nometa", rendered)
         self.assertIn("--fullscreen", rendered)
+        self.assertIn("launch label: profile default (direct run)", rendered)
+        environment = execute.call_args.kwargs["env"]
+        self.assertEqual(
+            environment["ATRINIK_LAUNCH_LABEL"],
+            "profile default (direct run)",
+        )
+
+    def test_client_launch_label_is_bounded(self) -> None:
+        long_profile = "p" * 96
+        with self.assertRaisesRegex(WorkspaceError, "launch label exceeds 96 bytes"):
+            client_launch_label(long_profile)
 
     def test_foreground_client_requires_initialized_server_identity(self) -> None:
         server = self.workspace.paths.repositories / "server"


### PR DESCRIPTION
## Summary

- propagate bounded process-only launch identity to supervised and foreground Classic clients
- include topology and profile for supervised clients, and profile plus direct-run mode for foreground clients
- keep concurrent same-profile clients distinguishable through the topology name used by `ps`, `logs`, and `down`
- document the runtime identity, persistence boundary, and operator mapping
- test supervised, paired, concurrent, direct-run, and length-boundary behavior

## Paired ownership

- Wrapper contract: this PR
- Classic native title support: atrinik/classic#92
- Replacement client support remains deferred until its runtime adapter lands; the current boundaries remain #266, #269, and #270

## Coordinates

- Base: `main` at `8be31b1d045fa7db03121e68ce4b32ee926a7f8c`
- Head: `feat/client-launch-identity` at `39a1b21d39bfd1d57c022ec0fbebafdd74d31e85`
- Validated implementation head before GitHub's non-overlapping branch update: `1d4f7549fd5ab9437b13070e3221613ed12fa359`
- Worktree: `/workspaces/atrinik/workspace/worktrees/atrinik/issue-329-client-identity`
- Commits: `54cc6d309 feat(runtime): label managed client launches`; `1d4f7549f fix(runtime): keep launch labels process-local`

## Validation

- `/tmp/atrinik-329-venv/bin/python -m coverage run -m unittest discover -v` — 329 tests passed
- `/tmp/atrinik-329-venv/bin/python -m coverage report --show-missing` — 78% total coverage
- `/tmp/atrinik-329-venv/bin/python -m compileall -q atrinik atrinik_workspace tests` — passed
- `/tmp/atrinik-329-venv/bin/python -m atrinik_workspace.guidance_inventory --check` — passed (`multi-selected=13,936/14,000`; `all-skills=28,695/28,750`)
- `./atrinik manifest validate` — passed
- `./atrinik supply-chain validate` — passed
- `git diff --check` — passed
- `./atrinik build client --profile issue-329-client-identity --test` — Classic companion 32/32 tests passed outside the sandbox
- GitHub branch update incorporated `docs(agents): require dual-line content delivery (#323)` with no changed-path overlap

## Runtime verification

Profile `issue-329-client-identity` selects the Classic companion worktree. For a supervised check, run a unique issue-owned topology and state; its client title should be `Atrinik Client — topology NAME - profile issue-329-client-identity`, and `NAME` must map to `./atrinik ps NAME --json`, `./atrinik logs NAME client`, and `./atrinik down NAME`. A foreground `run client` title should be `Atrinik Client — profile issue-329-client-identity (direct run)`. Unmanaged/package launches keep `Atrinik Client`.

Closes #329
