### PR TITLE
chore(deps): update Windows build image to 1.2.1

### DIFF
--- a/.devcontainer/windows-cross/devcontainer.json
+++ b/.devcontainer/windows-cross/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Atrinik Windows cross-build (MXE)",
-  "image": "ghcr.io/atrinik/windows-build:1.0.5@sha256:9cc373f620a577328fc0a7a7fa823bddaca6d7dc75ac73bcf21be421c49676f7",
+  "image": "ghcr.io/atrinik/windows-build:1.2.1@sha256:d1f082eb28891600a9cf018a1d4310b9f3e1f985f82139fa48fbd4ac77b623bb",
   "workspaceFolder": "/workspaces/atrinik",
   "remoteUser": "vscode",
   "initializeCommand": "if [ ! -e \"${localEnv:HOME}/.gitconfig\" ]; then install -m 600 /dev/null \"${localEnv:HOME}/.gitconfig\"; fi",

--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -1502,13 +1502,13 @@
         "classic"
       ],
       "required": true,
-      "version": "1.0.5",
+      "version": "1.2.1",
       "version_source": "Immutable semantic-release image tag",
       "license": "LicenseRef-Atrinik-Image-Contents",
       "source_url": "https://github.com/atrinik/devcontainer/pkgs/container/windows-build",
       "locator": "ghcr.io/atrinik/windows-build",
       "commit": null,
-      "checksum": "sha256:9cc373f620a577328fc0a7a7fa823bddaca6d7dc75ac73bcf21be421c49676f7",
+      "checksum": "sha256:d1f082eb28891600a9cf018a1d4310b9f3e1f985f82139fa48fbd4ac77b623bb",
       "acquisition": "Dev Containers and GitHub Actions pull the release tag and immutable manifest digest",
       "update_cadence_days": 30,
       "update_mechanism": "Weekly audit plus reviewed devcontainer release update",
@@ -1520,17 +1520,17 @@
         {
           "repository": "atrinik",
           "path": ".devcontainer/windows-cross/devcontainer.json",
-          "contains": "ghcr.io/atrinik/windows-build:1.0.5@sha256:9cc373f620a577328fc0a7a7fa823bddaca6d7dc75ac73bcf21be421c49676f7"
+          "contains": "ghcr.io/atrinik/windows-build:1.2.1@sha256:d1f082eb28891600a9cf018a1d4310b9f3e1f985f82139fa48fbd4ac77b623bb"
         },
         {
           "repository": "classic",
           "path": ".github/workflows/build-release-candidate.yml",
-          "contains": "ghcr.io/atrinik/windows-build:1.0.5@sha256:9cc373f620a577328fc0a7a7fa823bddaca6d7dc75ac73bcf21be421c49676f7"
+          "contains": "ghcr.io/atrinik/windows-build:1.2.1@sha256:d1f082eb28891600a9cf018a1d4310b9f3e1f985f82139fa48fbd4ac77b623bb"
         },
         {
           "repository": "classic",
           "path": ".github/workflows/check.yml",
-          "contains": "ghcr.io/atrinik/windows-build:1.0.5@sha256:9cc373f620a577328fc0a7a7fa823bddaca6d7dc75ac73bcf21be421c49676f7"
+          "contains": "ghcr.io/atrinik/windows-build:1.2.1@sha256:d1f082eb28891600a9cf018a1d4310b9f3e1f985f82139fa48fbd4ac77b623bb"
         }
       ]
     },

--- a/tests/test_devcontainer.py
+++ b/tests/test_devcontainer.py
@@ -35,8 +35,8 @@ class DevcontainerTests(unittest.TestCase):
         )
         self.assertEqual(
             config["image"],
-            "ghcr.io/atrinik/windows-build:1.0.5@sha256:"
-            "9cc373f620a577328fc0a7a7fa823bddaca6d7dc75ac73bcf21be421c49676f7",
+            "ghcr.io/atrinik/windows-build:1.2.1@sha256:"
+            "d1f082eb28891600a9cf018a1d4310b9f3e1f985f82139fa48fbd4ac77b623bb",
         )
 
     def test_default_feature_lock_matches_configuration(self) -> None:


### PR DESCRIPTION
## Summary

- update the Windows cross-build devcontainer to the immutable `windows-build:1.2.1` OCI index
- update the supply-chain inventory version, checksum, and Classic evidence coordinates
- keep the exact devcontainer pin covered by the wrapper regression test

## Provenance

- source repository: `atrinik/devcontainer`
- source revision: `41d1d9c5445bef6891624954757dd01e6f6d65f4`
- package version ID: `1118090989`
- immutable index: `ghcr.io/atrinik/windows-build:1.2.1@sha256:d1f082eb28891600a9cf018a1d4310b9f3e1f985f82139fa48fbd4ac77b623bb`

## Validation

- complete wrapper unit and coverage suite
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- complete coordinated supply-chain audits for the `default` and `classic` profiles
- `git diff --check`
- independent latest-head whole-diff reviews: zero actionable findings

## Ordering

atrinik/classic#94 merged all six matching image references before this PR was opened, so every cross-repository evidence coordinate is already present on Classic `main`.
