### PR TITLE
fix(build): restore common Classic build roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,13 +693,17 @@ commands turn that selection into a Compose-like native development stack:
 ./atrinik down TOPOLOGY
 ~~~
 
-`up` resolves the selected providers for the `client`, `server`, `content`,
-`protocol`, `libatrinik`, `sound`, and `resources` roles automatically.
+For a complete Classic profile, `up`, scenarios, and individual builds resolve
+one manifest-derived build-root selection across the `client`, `server`,
+`content`, `protocol`, `libatrinik`, `sound`, `resources`, and
+`metaserver-worker` roles. Only the requested game service targets are built;
+the wider selection keeps their incremental outputs and recorded coordinates
+on one root. Partial profiles retain the requested service's dependency closure.
 Provider selection is stack-coherent: a classic service never binds a
 replacement protocol or `content@main`. Today the `classic` stack is the
 runnable implementation; the `default` replacement profile will become
 runnable as its component contracts land. For a runnable profile, `up` builds
-the required closure, collects content, stages resources/sound, prepares an
+the requested targets, collects content, stages resources/sound, prepares an
 isolated runtime, and starts both game processes under one supervisor. A server
 gets an available UDP port by default; use `--port` when a stable port is
 useful. The supervisor waits for both the QUIC certificate fingerprint and

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -1339,22 +1339,16 @@ class Workspace:
                 present_components.add(component.name)
             else:
                 complete = False
-        present_paths = (
-            self.resolve_profile(profile_name, present_components)
-            if present_components
-            else {}
+        roles = (
+            common_roles | requested_roles if complete else requested_roles
         )
-
-        roles = common_roles if complete else requested_roles
         component_names = {stack.providers[role].name for role in roles}
-        missing_required = component_names - set(present_paths)
-        if missing_required:
-            # This normally raises the precise missing-checkout/source error. If
-            # initialization completed after the existence snapshot, accept the
-            # newly valid checkout without revalidating already-present roots.
-            present_paths.update(
-                self.resolve_profile(profile_name, missing_required)
-            )
+        # Resolve present preferred components and the required selection in one
+        # pass. This both fails closed for malformed optional checkouts and keeps
+        # validation deduplicated if initialization races the existence snapshot.
+        present_paths = self.resolve_profile(
+            profile_name, present_components | component_names
+        )
         paths = {
             component_name: present_paths[component_name]
             for component_name in component_names
@@ -1808,10 +1802,12 @@ class Workspace:
     ) -> tuple[dict[str, Any], bool]:
         profile = self._load_profile(profile_name, require_file=False)
         stack = self.manifest.stack(profile["stack"])
+        required = self._dependency_roles(profile, {"server"})
         coordinates: dict[str, dict[str, str]] = {}
         cacheable = True
         checkout_states: dict[Path, tuple[bool, str]] = {}
-        for role, source in sorted(selected.items()):
+        for role in sorted(required & set(selected)):
+            source = selected[role]
             component = stack.providers[role]
             checkout = self._selector_root(profile, component).resolve()
             if checkout not in checkout_states:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -1022,12 +1022,15 @@ class Workspace:
                 for component in stack.components
                 if component.name in component_names
             ]
+        validated_checkouts: set[str] = set()
         for component in components:
             root = self._selector_root(profile, component)
-            selector = profile["components"][component.name]
-            self._validate_selected_checkout(
-                component, root, selector["kind"], trace=trace
-            )
+            if component.checkout_name not in validated_checkouts:
+                selector = profile["components"][component.name]
+                self._validate_selected_checkout(
+                    component, root, selector["kind"], trace=trace
+                )
+                validated_checkouts.add(component.checkout_name)
             result[component.name] = self._component_source(component, root)
         return result
 
@@ -1312,9 +1315,50 @@ class Workspace:
     ) -> dict[str, Path]:
         profile = self._load_profile(profile_name, require_file=False)
         stack = self.manifest.stack(profile["stack"])
-        roles = self._dependency_roles(profile, required)
+        requested_roles = self._dependency_roles(profile, required)
+        build_targets = {
+            role
+            for role, component in stack.providers.items()
+            if component.build != "none"
+        }
+        common_roles = self._dependency_roles(profile, build_targets)
+        common_components = {
+            stack.providers[role].name for role in common_roles
+        }
+
+        # Missing preferred checkouts identify a deliberately partial workspace.
+        # Any preferred checkout that is present must still pass full profile
+        # validation, so a malformed path cannot silently shrink the build key.
+        complete = True
+        present_components: set[str] = set()
+        for component in stack.components:
+            if component.name not in common_components:
+                continue
+            root = self._selector_root(profile, component)
+            if root.exists() or root.is_symlink():
+                present_components.add(component.name)
+            else:
+                complete = False
+        present_paths = (
+            self.resolve_profile(profile_name, present_components)
+            if present_components
+            else {}
+        )
+
+        roles = common_roles if complete else requested_roles
         component_names = {stack.providers[role].name for role in roles}
-        paths = self.resolve_profile(profile_name, component_names)
+        missing_required = component_names - set(present_paths)
+        if missing_required:
+            # This normally raises the precise missing-checkout/source error. If
+            # initialization completed after the existence snapshot, accept the
+            # newly valid checkout without revalidating already-present roots.
+            present_paths.update(
+                self.resolve_profile(profile_name, missing_required)
+            )
+        paths = {
+            component_name: present_paths[component_name]
+            for component_name in component_names
+        }
         return {role: paths[stack.providers[role].name] for role in roles}
 
     def build(self, target: str, profile_name: str, tests: bool) -> Path:
@@ -1373,10 +1417,14 @@ class Workspace:
     ) -> None:
         profile = self._load_profile(profile_name, require_file=False)
         stack = self.manifest.stack(profile["stack"])
+        checkout_states = self._selected_checkout_states(
+            profile, selected, include_dirty=False
+        )
         coordinates: dict[str, dict[str, str]] = {}
         for role in sorted(selected):
             component = stack.providers[role]
-            checkout_path = self._selector_root(profile, component).resolve()
+            checkout_state = checkout_states[component.checkout_name]
+            checkout_path = checkout_state["path"]
             coordinates[role] = {
                 "component": component.name,
                 "checkout": component.checkout_name,
@@ -1385,13 +1433,7 @@ class Workspace:
                 "source": component.source,
                 "checkout_path": str(checkout_path),
                 "source_path": str(selected[role].resolve()),
-                "head": git(
-                    checkout_path,
-                    "rev-parse",
-                    "HEAD",
-                    capture=True,
-                    trace=False,
-                ),
+                "head": checkout_state["head"],
             }
         atomic_json(
             root / BUILD_METADATA,
@@ -1404,6 +1446,35 @@ class Workspace:
                 "last_used_at": datetime.now(timezone.utc).isoformat(),
             },
         )
+
+    def _selected_checkout_states(
+        self,
+        profile: dict[str, Any],
+        selected: dict[str, Path],
+        *,
+        include_dirty: bool,
+    ) -> dict[str, dict[str, Any]]:
+        stack = self.manifest.stack(profile["stack"])
+        states: dict[str, dict[str, Any]] = {}
+        for role in sorted(selected):
+            component = stack.providers[role]
+            if component.checkout_name in states:
+                continue
+            checkout = self._selector_root(profile, component).resolve()
+            state: dict[str, Any] = {
+                "path": checkout,
+                "head": git(
+                    checkout,
+                    "rev-parse",
+                    "HEAD",
+                    capture=True,
+                    trace=False,
+                ),
+            }
+            if include_dirty:
+                state["dirty"] = not _is_clean(checkout, trace=False)
+            states[component.checkout_name] = state
+        return states
 
     def _profile_build_key(
         self, profile_name: str, selected: dict[str, Path]
@@ -2193,27 +2264,22 @@ class Workspace:
         )
         profile = self._load_profile(metadata["profile"], require_file=False)
         stack = self.manifest.stack(profile["stack"])
+        audited = {role: selected[role] for role in required}
+        checkout_states = self._selected_checkout_states(
+            profile, audited, include_dirty=True
+        )
         return {
             role: {
                 "path": str(path),
                 "checkout_path": str(
-                    self._selector_root(profile, stack.providers[role]).resolve()
+                    checkout_states[stack.providers[role].checkout_name]["path"]
                 ),
                 "checkout": stack.providers[role].checkout_name,
                 "repository": stack.providers[role].repository,
                 "branch": stack.providers[role].branch,
                 "source": stack.providers[role].source,
-                "head": git(
-                    self._selector_root(profile, stack.providers[role]).resolve(),
-                    "rev-parse",
-                    "HEAD",
-                    capture=True,
-                    trace=False,
-                ),
-                "dirty": not _is_clean(
-                    self._selector_root(profile, stack.providers[role]).resolve(),
-                    trace=False,
-                ),
+                "head": checkout_states[stack.providers[role].checkout_name]["head"],
+                "dirty": checkout_states[stack.providers[role].checkout_name]["dirty"],
             }
             for role, path in sorted(
                 (role, selected[role]) for role in required
@@ -2454,6 +2520,9 @@ class Workspace:
         resolved = self._resolve_build_profile(profile_name, requested)
         required = set(resolved)
         key = self._profile_build_key(profile_name, resolved)
+        checkout_states = self._selected_checkout_states(
+            profile, resolved, include_dirty=True
+        )
         state = (
             str(self._state_location(state_name))
             if "server" in selected_services
@@ -2480,25 +2549,10 @@ class Workspace:
                     "roles": sorted(stack.providers[role].provides),
                     "path": str(path),
                     "checkout_path": str(
-                        self._selector_root(
-                            profile, stack.providers[role]
-                        ).resolve()
+                        checkout_states[stack.providers[role].checkout_name]["path"]
                     ),
-                    "head": git(
-                        self._selector_root(
-                            profile, stack.providers[role]
-                        ).resolve(),
-                        "rev-parse",
-                        "HEAD",
-                        capture=True,
-                        trace=False,
-                    ),
-                    "dirty": not _is_clean(
-                        self._selector_root(
-                            profile, stack.providers[role]
-                        ).resolve(),
-                        trace=False,
-                    ),
+                    "head": checkout_states[stack.providers[role].checkout_name]["head"],
+                    "dirty": checkout_states[stack.providers[role].checkout_name]["dirty"],
                 }
                 for role, path in sorted(resolved.items())
             },
@@ -3109,33 +3163,27 @@ class Workspace:
 
                 profile = self._load_profile(profile_name, require_file=False)
                 selected_stack = self.manifest.stack(profile["stack"])
+                checkout_states = self._selected_checkout_states(
+                    profile, selected, include_dirty=True
+                )
                 resolved_status = {
                     selected_stack.providers[role].name: {
                         "path": str(path),
                         "checkout_path": str(
-                            self._selector_root(
-                                profile, selected_stack.providers[role]
-                            ).resolve()
+                            checkout_states[
+                                selected_stack.providers[role].checkout_name
+                            ]["path"]
                         ),
                         "checkout": selected_stack.providers[role].checkout_name,
                         "repository": selected_stack.providers[role].repository,
                         "branch": selected_stack.providers[role].branch,
                         "source": selected_stack.providers[role].source,
-                        "head": git(
-                            self._selector_root(
-                                profile, selected_stack.providers[role]
-                            ).resolve(),
-                            "rev-parse",
-                            "HEAD",
-                            capture=True,
-                            trace=False,
-                        ),
-                        "dirty": not _is_clean(
-                            self._selector_root(
-                                profile, selected_stack.providers[role]
-                            ).resolve(),
-                            trace=False,
-                        ),
+                        "head": checkout_states[
+                            selected_stack.providers[role].checkout_name
+                        ]["head"],
+                        "dirty": checkout_states[
+                            selected_stack.providers[role].checkout_name
+                        ]["dirty"],
                     }
                     for role, path in sorted(selected.items())
                 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -380,9 +380,11 @@ temporary directory; the coordinator accepts it only when every output is a
 nonempty regular `.png` or UTF-8 `.def`, the basename sets form complete pairs,
 and the expected `incuna_-1` pair exists. It then installs the marker-owned
 cache atomically, preserving the previous valid cache on failure. Cache
-metadata records all selected provider, repository, branch, checkout, source,
-path, and commit coordinates. It is reusable only for clean checkouts with an
-exact metadata match; dirty inputs deliberately regenerate.
+metadata records provider, repository, branch, checkout, source, path, and
+commit coordinates for the server dependency closure consumed by the
+worldmaker. Unrelated roles in the common profile build root do not invalidate
+that cache. It is reusable only for clean input checkouts with an exact metadata
+match; dirty inputs deliberately regenerate.
 
 ## Runtime and state
 
@@ -413,11 +415,13 @@ participate in the state lock, so operators must not point those processes at
 the same state concurrently.
 
 Profiles are stack-aware source-topology definitions for supervised runtime as
-well as builds. `up` resolves the requested service's logical provider closure
-once, records the exact paths/commits and build root, prepares the same isolated
-views used by foreground launches, and hands the state-lock file descriptor
-through a short forking bootstrap to a detached native supervisor and its
-server child. The lock remains held for the server lifetime without a
+well as builds. For a complete Classic profile, `up` resolves the common
+manifest-derived build-root selection once while building only the requested
+service targets; a partial profile retains the requested service's dependency
+closure. It records the exact paths, commits, and build root, prepares the same
+isolated views used by foreground launches, and hands the state-lock file
+descriptor through a short forking bootstrap to a detached native supervisor
+and its server child. The lock remains held for the server lifetime without a
 long-lived invoking CLI process.
 
 The supervisor owns child lifetimes and size-bounded rotating logs. Status

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -330,14 +330,18 @@ and role-provider identities, and normalized absolute roots are hashed into the
 profile build key. Topology and scenario records persist the same repository
 and branch coordinates; records from before that identity existed remain inert
 instead of being reinterpreted through a changed manifest. A fully initialized
-classic workspace uses the common buildable-component
-selection, so `build all --profile classic`, component builds, and classic
-launches share incremental output. A partial workspace uses only the requested
-target's dependency closure. This separates combinations across distinct
-physical checkouts while preserving compiler output when the same worktrees advance,
-and makes pre-split build trees inert rather than reinterpreting them under
-replacement identities. The coordinator creates disposable source views
-rather than writing dependency links or output into source checkouts.
+classic workspace derives one common buildable role set from the selected
+stack's providers and dependency graph, so `build all --profile classic`,
+component builds, scenarios, and classic launches share incremental output.
+Resolution validates each selected physical checkout once before deriving its
+logical role paths and coordinate records. A partial workspace uses only the
+requested target's dependency closure; a preferred checkout that is present
+but malformed fails validation rather than silently shrinking that closure.
+This separates combinations across distinct physical checkouts while
+preserving compiler output when the same worktrees advance, and makes pre-split
+build trees inert rather than reinterpreting them under replacement identities.
+The coordinator creates disposable source views rather than writing dependency
+links or output into source checkouts.
 
 The currently playable classic build flow is:
 

--- a/tests/test_cohorts.py
+++ b/tests/test_cohorts.py
@@ -398,6 +398,9 @@ class CohortWorkspaceTests(unittest.TestCase):
 
         roots: list[Path] = []
 
+        class StopTopology(Exception):
+            pass
+
         def build_resolved(
             target: str,
             profile_name: str,
@@ -410,6 +413,8 @@ class CohortWorkspaceTests(unittest.TestCase):
                 f"{profile_name}-{self.workspace._profile_build_key(profile_name, selected)}"
             )
             roots.append(root)
+            if target == "topology":
+                raise StopTopology
             return root
 
         with (
@@ -425,6 +430,16 @@ class CohortWorkspaceTests(unittest.TestCase):
             mock.patch(
                 "atrinik_workspace.workspace._is_clean", return_value=True
             ) as clean,
+            mock.patch.object(
+                self.workspace,
+                "_prepare_server_runtime",
+                return_value=self.root / "scenario-runtime",
+            ),
+            mock.patch.object(
+                self.workspace, "_state_location", return_value=self.root / "state"
+            ),
+            mock.patch.object(self.workspace, "_require_client_display"),
+            mock.patch("atrinik_workspace.workspace.run"),
         ):
             roots.extend(
                 [
@@ -438,11 +453,33 @@ class CohortWorkspaceTests(unittest.TestCase):
                     ),
                 ]
             )
+            audited = self.workspace._scenario_provision_state(
+                {
+                    "profile": "classic",
+                    "state": "scenario-common-root",
+                    "account": "scenario",
+                    "character": "Scenario",
+                    "archetype": "human_male",
+                },
+                self.root / "state",
+                self.root / "password",
+            )
+            with self.assertRaises(StopTopology):
+                self.workspace._topology_up(
+                    "common-root",
+                    "classic",
+                    "default",
+                    ["server", "client"],
+                )
 
         self.assertEqual(len(set(roots)), 1)
-        # Each of four resolutions validates the five selected physical
+        self.assertEqual(
+            set(audited),
+            {"server", "content", "resources", "libatrinik", "protocol"},
+        )
+        # Each of six resolutions validates the five selected physical
         # checkouts once; four Classic logical providers share one checkout.
-        self.assertEqual(validate.call_count, 20)
+        self.assertEqual(validate.call_count, 30)
         expected_checkouts = {
             "classic",
             "content-1x",
@@ -458,8 +495,42 @@ class CohortWorkspaceTests(unittest.TestCase):
                 set(validated[offset : offset + len(expected_checkouts)]),
                 expected_checkouts,
             )
-        self.assertEqual(git.call_count, 5)
-        self.assertEqual(clean.call_count, 5)
+        # Topology summary probes all five physical roots once. Scenario audit
+        # intentionally records only the three physical server-closure roots.
+        self.assertEqual(git.call_count, 8)
+        self.assertEqual(clean.call_count, 8)
+
+    def test_complete_default_selection_keeps_requested_service(self) -> None:
+        profile = self.workspace._load_profile("default", require_file=False)
+        stack = self.workspace.manifest.stack("default")
+        common = self.workspace._dependency_roles(
+            profile,
+            {
+                role
+                for role, component in stack.providers.items()
+                if component.build != "none"
+            },
+        )
+        requested = self.workspace._dependency_roles(profile, {"client"})
+        for role in common | requested:
+            component = stack.providers[role]
+            root = self.workspace._selector_root(profile, component)
+            source = root / component.source if component.source != "." else root
+            source.mkdir(parents=True, exist_ok=True)
+
+        with (
+            mock.patch.object(
+                self.workspace, "_validate_selected_checkout", return_value="origin"
+            ),
+            mock.patch("atrinik_workspace.workspace.git", return_value="a" * 40),
+            mock.patch("atrinik_workspace.workspace._is_clean", return_value=True),
+        ):
+            summary = self.workspace.topology_summary(
+                "default", "default", ["client"]
+            )
+
+        self.assertIn("client", summary["dependencies"])
+        self.assertEqual(summary["providers"]["client"], "client")
 
     def test_partial_classic_profile_keeps_requested_dependency_closure(self) -> None:
         self.make_classic_build_profile(include_worker=False)
@@ -486,14 +557,43 @@ class CohortWorkspaceTests(unittest.TestCase):
             ):
                 self.workspace._resolve_build_profile("classic", {"client"})
 
+    def test_initialization_race_validates_shared_checkout_once(self) -> None:
+        self.make_classic_build_profile()
+        classic = self.wrapper / "classic"
+        original_exists = Path.exists
+        first_classic_check = True
+
+        def racing_exists(path: Path) -> bool:
+            nonlocal first_classic_check
+            if path == classic and first_classic_check:
+                first_classic_check = False
+                return False
+            return original_exists(path)
+
+        with (
+            mock.patch.object(Path, "exists", racing_exists),
+            mock.patch.object(
+                self.workspace, "_validate_selected_checkout", return_value="origin"
+            ) as validate,
+        ):
+            self.workspace._resolve_build_profile("classic", {"client"})
+
+        validated = [call.args[0].checkout_name for call in validate.call_args_list]
+        self.assertEqual(validated.count("classic"), 1)
+
     def test_complete_classic_worktree_profile_uses_common_build_root(self) -> None:
         self.make_classic_build_profile()
         self.workspace.create_profile("classic-review", "classic")
         worktree = self.workspace.paths.worktrees / "classic" / "review"
         for source in ("client", "server", "protocol", "libatrinik", "editor"):
             (worktree / source).mkdir(parents=True, exist_ok=True)
-        with mock.patch.object(
-            self.workspace, "_validate_selected_checkout", return_value="origin"
+        with (
+            mock.patch.object(
+                self.workspace, "_validate_selected_checkout", return_value="origin"
+            ),
+            mock.patch(
+                "atrinik_workspace.workspace.git", return_value="a" * 40
+            ) as git,
         ):
             self.workspace.set_profile(
                 "classic-review", "classic", "worktree", "review"
@@ -504,6 +604,14 @@ class CohortWorkspaceTests(unittest.TestCase):
             server = self.workspace._resolve_build_profile(
                 "classic-review", {"server"}
             )
+            metadata_root = self.root / "worktree-build"
+            metadata_root.mkdir()
+            self.workspace._refresh_build_metadata(
+                metadata_root,
+                "classic-review",
+                self.workspace._profile_build_key("classic-review", client),
+                client,
+            )
 
         self.assertEqual(set(client), set(server))
         self.assertEqual(
@@ -512,6 +620,7 @@ class CohortWorkspaceTests(unittest.TestCase):
         )
         for role in ("client", "server", "protocol", "libatrinik"):
             self.assertEqual(client[role], worktree / role)
+        self.assertEqual(git.call_count, 5)
 
     def test_classic_component_source_rejects_symlinked_module(self) -> None:
         checkout = self.wrapper / "classic"

--- a/tests/test_cohorts.py
+++ b/tests/test_cohorts.py
@@ -34,6 +34,30 @@ class CohortWorkspaceTests(unittest.TestCase):
         self.environment.stop()
         self.temporary.cleanup()
 
+    def make_classic_build_profile(self, *, include_worker: bool = True) -> None:
+        profile = self.workspace._load_profile("classic", require_file=False)
+        stack = self.workspace.manifest.stack("classic")
+        build_targets = {
+            role
+            for role in (
+                "content",
+                "protocol",
+                "libatrinik",
+                "client",
+                "server",
+                "metaserver-worker",
+            )
+            if role in stack.providers and stack.providers[role].build != "none"
+        }
+        roles = self.workspace._dependency_roles(profile, build_targets)
+        for role in roles:
+            component = stack.providers[role]
+            if not include_worker and role == "metaserver-worker":
+                continue
+            root = self.workspace._selector_root(profile, component)
+            source = root / component.source if component.source != "." else root
+            source.mkdir(parents=True, exist_ok=True)
+
     def test_plain_init_selects_only_default_cohort(self) -> None:
         with mock.patch.object(
             self.workspace, "_ensure_repository", return_value=self.wrapper
@@ -358,6 +382,136 @@ class CohortWorkspaceTests(unittest.TestCase):
                 for name in names
             },
         )
+
+    def test_complete_classic_commands_share_common_build_root(self) -> None:
+        self.make_classic_build_profile()
+        expected_roles = {
+            "client",
+            "server",
+            "protocol",
+            "libatrinik",
+            "content",
+            "sound",
+            "resources",
+            "metaserver-worker",
+        }
+
+        roots: list[Path] = []
+
+        def build_resolved(
+            target: str,
+            profile_name: str,
+            tests: bool,
+            targets: list[str],
+            selected: dict[str, Path],
+        ) -> Path:
+            self.assertEqual(set(selected), expected_roles)
+            root = self.workspace.paths.builds / "profiles" / (
+                f"{profile_name}-{self.workspace._profile_build_key(profile_name, selected)}"
+            )
+            roots.append(root)
+            return root
+
+        with (
+            mock.patch.object(
+                self.workspace, "_validate_selected_checkout", return_value="origin"
+            ) as validate,
+            mock.patch.object(
+                self.workspace, "_build_resolved", side_effect=build_resolved
+            ),
+            mock.patch(
+                "atrinik_workspace.workspace.git", return_value="a" * 40
+            ) as git,
+            mock.patch(
+                "atrinik_workspace.workspace._is_clean", return_value=True
+            ) as clean,
+        ):
+            roots.extend(
+                [
+                    self.workspace.build("client", "classic", tests=False),
+                    self.workspace.build("server", "classic", tests=False),
+                    self.workspace.build("all", "classic", tests=False),
+                    Path(
+                        self.workspace.topology_summary(
+                            "classic", "default", ["server", "client"]
+                        )["build_root"]
+                    ),
+                ]
+            )
+
+        self.assertEqual(len(set(roots)), 1)
+        # Each of four resolutions validates the five selected physical
+        # checkouts once; four Classic logical providers share one checkout.
+        self.assertEqual(validate.call_count, 20)
+        expected_checkouts = {
+            "classic",
+            "content-1x",
+            "sound",
+            "resources",
+            "metaserver-worker",
+        }
+        validated = [
+            call.args[0].checkout_name for call in validate.call_args_list
+        ]
+        for offset in range(0, len(validated), len(expected_checkouts)):
+            self.assertEqual(
+                set(validated[offset : offset + len(expected_checkouts)]),
+                expected_checkouts,
+            )
+        self.assertEqual(git.call_count, 5)
+        self.assertEqual(clean.call_count, 5)
+
+    def test_partial_classic_profile_keeps_requested_dependency_closure(self) -> None:
+        self.make_classic_build_profile(include_worker=False)
+
+        with mock.patch.object(
+            self.workspace, "_validate_selected_checkout", return_value="origin"
+        ):
+            selected = self.workspace._resolve_build_profile("classic", {"client"})
+
+        self.assertEqual(
+            set(selected), {"client", "sound", "libatrinik", "protocol"}
+        )
+
+    def test_malformed_present_common_checkout_fails_closed(self) -> None:
+        self.make_classic_build_profile(include_worker=False)
+        worker = self.wrapper / "metaserver-worker"
+        worker.write_text("not a checkout\n", encoding="utf-8")
+
+        with mock.patch.object(
+            self.workspace, "_validate_selected_checkout", return_value="origin"
+        ):
+            with self.assertRaisesRegex(
+                WorkspaceError, "component checkout is not a directory"
+            ):
+                self.workspace._resolve_build_profile("classic", {"client"})
+
+    def test_complete_classic_worktree_profile_uses_common_build_root(self) -> None:
+        self.make_classic_build_profile()
+        self.workspace.create_profile("classic-review", "classic")
+        worktree = self.workspace.paths.worktrees / "classic" / "review"
+        for source in ("client", "server", "protocol", "libatrinik", "editor"):
+            (worktree / source).mkdir(parents=True, exist_ok=True)
+        with mock.patch.object(
+            self.workspace, "_validate_selected_checkout", return_value="origin"
+        ):
+            self.workspace.set_profile(
+                "classic-review", "classic", "worktree", "review"
+            )
+            client = self.workspace._resolve_build_profile(
+                "classic-review", {"client"}
+            )
+            server = self.workspace._resolve_build_profile(
+                "classic-review", {"server"}
+            )
+
+        self.assertEqual(set(client), set(server))
+        self.assertEqual(
+            self.workspace._profile_build_key("classic-review", client),
+            self.workspace._profile_build_key("classic-review", server),
+        )
+        for role in ("client", "server", "protocol", "libatrinik"):
+            self.assertEqual(client[role], worktree / role)
 
     def test_classic_component_source_rejects_symlinked_module(self) -> None:
         checkout = self.wrapper / "classic"

--- a/tests/test_cohorts.py
+++ b/tests/test_cohorts.py
@@ -9,7 +9,7 @@ import tempfile
 import unittest
 from unittest import mock
 
-from atrinik_workspace.model import WorkspaceError, atomic_json
+from atrinik_workspace.model import WorkspaceError, atomic_json, load_json
 from atrinik_workspace.workspace import Workspace
 
 
@@ -529,7 +529,8 @@ class CohortWorkspaceTests(unittest.TestCase):
                 "default", "default", ["client"]
             )
 
-        self.assertIn("client", summary["dependencies"])
+        self.assertEqual(set(summary["dependencies"]), common | requested)
+        self.assertEqual(set(summary["providers"]), common | requested)
         self.assertEqual(summary["providers"]["client"], "client")
 
     def test_partial_classic_profile_keeps_requested_dependency_closure(self) -> None:
@@ -594,6 +595,9 @@ class CohortWorkspaceTests(unittest.TestCase):
             mock.patch(
                 "atrinik_workspace.workspace.git", return_value="a" * 40
             ) as git,
+            mock.patch(
+                "atrinik_workspace.workspace._is_clean", return_value=True
+            ),
         ):
             self.workspace.set_profile(
                 "classic-review", "classic", "worktree", "review"
@@ -612,6 +616,9 @@ class CohortWorkspaceTests(unittest.TestCase):
                 self.workspace._profile_build_key("classic-review", client),
                 client,
             )
+            region_inputs, _ = self.workspace._region_map_inputs(
+                "classic-review", client
+            )
 
         self.assertEqual(set(client), set(server))
         self.assertEqual(
@@ -620,7 +627,23 @@ class CohortWorkspaceTests(unittest.TestCase):
         )
         for role in ("client", "server", "protocol", "libatrinik"):
             self.assertEqual(client[role], worktree / role)
-        self.assertEqual(git.call_count, 5)
+        metadata = load_json(metadata_root / ".atrinik-build.json")
+        self.assertEqual(set(metadata["coordinates"]), set(client))
+        for role in ("client", "server", "protocol", "libatrinik"):
+            coordinate = metadata["coordinates"][role]
+            self.assertEqual(coordinate["component"], f"classic-{role}")
+            self.assertEqual(coordinate["source"], role)
+            self.assertEqual(coordinate["checkout_path"], str(worktree.resolve()))
+            self.assertEqual(
+                coordinate["source_path"], str((worktree / role).resolve())
+            )
+            self.assertEqual(coordinate["head"], "a" * 40)
+        profile = self.workspace._load_profile("classic-review", require_file=True)
+        server_roles = self.workspace._dependency_roles(profile, {"server"})
+        self.assertEqual(set(region_inputs["coordinates"]), server_roles)
+        # Five metadata checkouts plus the three physical server/worldmaker
+        # inputs (Classic, content, and resources) are each probed once.
+        self.assertEqual(git.call_count, 8)
 
     def test_classic_component_source_rejects_symlinked_module(self) -> None:
         checkout = self.wrapper / "classic"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -738,17 +738,17 @@ class WorkspaceTests(unittest.TestCase):
         )
 
     def test_region_map_inputs_ignore_unrelated_common_build_roles(self) -> None:
+        profile = self.workspace._load_profile("default", require_file=False)
+        required = self.workspace._dependency_roles(profile, {"server"})
         selected = {
             role: self.workspace.paths.repositories / role
-            for role in ("server", "content", "resources", "client", "sound")
+            for role in required | {"client", "sound"}
         }
 
         inputs, cacheable = self.workspace._region_map_inputs("default", selected)
 
         self.assertTrue(cacheable)
-        self.assertEqual(
-            set(inputs["coordinates"]), {"server", "content", "resources"}
-        )
+        self.assertEqual(set(inputs["coordinates"]), required)
 
     def test_region_map_validation_rejects_malformed_outputs(self) -> None:
         output = self.root / "client-maps"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -965,7 +965,7 @@ class WorkspaceTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "asset staging path is invalid"):
             self.workspace._prepare_asset_staging_directory(invalid_link)
 
-    def test_topology_summary_resolves_service_dependency_closure(self) -> None:
+    def test_topology_summary_uses_complete_profile_build_roles(self) -> None:
         summary = self.workspace.topology_summary(
             "default", "default", ["client"]
         )
@@ -974,13 +974,24 @@ class WorkspaceTests(unittest.TestCase):
         self.assertIsNone(summary["state"])
         self.assertEqual(
             set(summary["dependencies"]),
-            {"client", "sound", "libatrinik", "protocol"},
+            {
+                "client",
+                "server",
+                "sound",
+                "content",
+                "resources",
+                "libatrinik",
+                "protocol",
+            },
         )
         self.assertEqual(
             set(summary["components"]),
             {
                 "client",
+                "server",
                 "sound",
+                "content",
+                "resources",
                 "libatrinik",
                 "protocol",
             },

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -737,6 +737,19 @@ class WorkspaceTests(unittest.TestCase):
             (output / "incuna_-1.def").read_text(encoding="utf-8"), previous
         )
 
+    def test_region_map_inputs_ignore_unrelated_common_build_roles(self) -> None:
+        selected = {
+            role: self.workspace.paths.repositories / role
+            for role in ("server", "content", "resources", "client", "sound")
+        }
+
+        inputs, cacheable = self.workspace._region_map_inputs("default", selected)
+
+        self.assertTrue(cacheable)
+        self.assertEqual(
+            set(inputs["coordinates"]), {"server", "content", "resources"}
+        )
+
     def test_region_map_validation_rejects_malformed_outputs(self) -> None:
         output = self.root / "client-maps"
 


### PR DESCRIPTION
## Summary

- derive a complete profile's common build role set from its stack providers and dependency graph so Classic builds, scenarios, and topologies share one root
- preserve requested dependency closures for partial profiles, retain requested non-buildable roles on other stacks, and fail closed on malformed present checkouts
- validate and snapshot each physical checkout once while retaining every logical role's exact build and runtime coordinates
- keep worldmaker caching scoped to the server dependency closure and synchronize operator/architecture guidance

## Coordinates

- issue: Fixes #324
- base: `main` at `9cb5b0419ba632ce7414ebf2d6d394442474d422`
- head: `fix/common-classic-build-roots` at `0ab6f97a9de5938578347f80075ecd25a9d1953a`
- commits: `69b4ae2b7`, `0fdec2bb7`, `0ab6f97a9`

## Validation

- `python -m coverage run -m unittest discover -v` — 337 tests passed
- `python -m coverage report --show-missing` — 79% aggregate coverage
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `git diff --check`
- three final independent whole-diff reviews — zero actionable findings

## Classic verification

Using isolated profile `issue-324-classic` and scenario `issue-324-common-build`:

- `build client --test` passed 31/31 at `issue-324-classic-789d38ad31e6`
- `build all` completed client, server, protocol, library, content, resources, and metaserver-worker checks at the same root
- scenario provisioning and topology resolution recorded all eight common roles at that root
- latest-head server-only `up` reached `ready: true`, retained the same root, and shut down cleanly
- paired `up` brought the server to ready; the client then exposed an environment limitation (`SDL: No available video device`) and the topology was stopped

The optional Classic server component test run passed 39/40. Its remaining failure is in the selected external `content-1x` checkout: `QuestManager.py` uses `isinstance(..., (int, None))` under Python 3.14. That file and repository are outside this wrapper diff; the wrapper's required validation and all latest-head PR checks pass.
