### PR TITLE
chore(supply-chain): own Classic Python coverage

### DIFF
--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -2411,25 +2411,26 @@
     },
     {
       "id": "language/wrapper-python-development",
-      "name": "Workspace Python development dependencies",
+      "name": "Workspace and Classic Python development dependencies",
       "kind": "language-package-set",
       "owner": "atrinik",
       "scope": [
-        "atrinik"
+        "atrinik",
+        "classic"
       ],
       "required": false,
       "version": "coverage=7.15.3",
-      "version_source": "requirements-dev.txt",
+      "version_source": "requirements-dev.txt and the Classic Check workflow",
       "license": "Apache-2.0",
       "source_url": "https://pypi.org/project/coverage/",
       "locator": "pkg:pypi/coverage@7.15.3",
       "commit": null,
       "checksum": null,
-      "acquisition": "pip installs the exact development requirement",
+      "acquisition": "pip installs the exact development or CI requirement",
       "update_cadence_days": 7,
       "update_mechanism": "Dependabot pip updates",
       "eol_response": "Upgrade with the supported Python line or retain stdlib test execution without coverage",
-      "validation": "Complete unittest suite and coverage report",
+      "validation": "Complete wrapper and Classic release-tool unittest suites and coverage reports",
       "disposition": "retain",
       "packages": [
         "coverage"
@@ -2439,6 +2440,11 @@
           "repository": "atrinik",
           "path": "requirements-dev.txt",
           "contains": "coverage==7.15.3"
+        },
+        {
+          "repository": "classic",
+          "path": ".github/workflows/check.yml",
+          "contains": "python3 -m pip install coverage==7.15.3"
         }
       ]
     },


### PR DESCRIPTION
## Summary

- extend the existing pinned coverage.py ownership to the Classic checkout
- bind aggregate evidence to the exact Classic Check workflow requirement
- document the shared wrapper/Classic validation and update mechanism

## Context

`atrinik/classic#97` now collects coverage for its already-executed Python release-tool tests so Codecov does not report those exercised policy lines as uncovered. The Classic workflow uses the same exact `coverage==7.15.3` coordinate already owned by the aggregate wrapper inventory.

This is a catalog-only companion change. It does not alter releases, credentials, runtime state, profiles, or topologies.

## Validation

- `./atrinik supply-chain validate` — 102 dependencies valid
- `python3 -m unittest discover -v` — 330 passed
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `git diff --check`
