### PR TITLE
perf(runtime): cache content and resource staging

### DIFF
--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -90,9 +90,9 @@ wrapper replacement build/runtime closure yet.
 ./atrinik build COMPONENT --profile REVIEW --test
 ```
 
-Classic selection is checkout-wide; subdirectories are not worktrees. Content,
-resource, and region-map caches reuse only clean exact-coordinate inputs;
-runtimes copy independent topology-owned snapshots without overlays.
+Classic selection is checkout-wide; subdirectories are not worktrees. Clean
+exact-coordinate content, resource, and region-map caches are reused; runtimes
+copy independent topology-owned snapshots.
 
 Build, scenario, and topology records bind exact immutable coordinates;
 incomplete records are inert. Let the wrapper own generated paths, locks,

--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -89,8 +89,9 @@ wrapper replacement build/runtime closure yet.
 ./atrinik build COMPONENT --profile REVIEW --test
 ```
 
-Classic selection is checkout-wide; subdirectories are not worktrees. Region
-maps cache only clean matching inputs; runtimes copy snapshots without overlays.
+Classic selection is checkout-wide; subdirectories are not worktrees. Content,
+resource, and region-map caches reuse only clean exact-coordinate inputs;
+runtimes copy independent topology-owned snapshots without overlays.
 
 Build, scenario, and topology records bind exact immutable coordinates;
 incomplete records are inert. Let the wrapper own generated paths, locks,

--- a/README.md
+++ b/README.md
@@ -629,13 +629,18 @@ cd "$(./atrinik path classic-server --profile maps-review)"
 commands such as `status`, `sync`, and `worktree` when the full repository root
 is required.
 
-Before every server build or launch, the coordinator collects the selected
-content checkout into an isolated runtime tree and stages the selected resource
-repository. Only tracked files below the resource repository's
-`runtime-paths.txt` allowlist are staged; development metadata and untracked
-files cannot become server assets. Client builds similarly expose the selected
-sound checkout. These operations never write generated files into a component
-checkout.
+Before a server build or launch, the coordinator prepares marker-owned content
+and resource caches inside the exact profile build. A cache is reused only when
+its schema and provider, repository, branch, checkout, source path, checkout
+path, and clean `HEAD` metadata match and its required output structure remains
+valid. Dirty inputs rebuild every time and do not receive reusable metadata;
+inputs are checked again after generation so a concurrent checkout change
+cannot replace the previous valid cache. Only tracked files below the resource
+repository's `runtime-paths.txt` allowlist are staged; development metadata and
+untracked files cannot become server assets. Client builds similarly expose the
+selected sound checkout. These operations never write generated files into a
+component checkout. The caches remain under the marker-owned profile build, so
+ordinary build retention and preview-first cleanup cover them.
 
 ## Deterministic test scenarios
 
@@ -703,8 +708,9 @@ Provider selection is stack-coherent: a classic service never binds a
 replacement protocol or `content@main`. Today the `classic` stack is the
 runnable implementation; the `default` replacement profile will become
 runnable as its component contracts land. For a runnable profile, `up` builds
-the requested targets, collects content, stages resources/sound, prepares an
-isolated runtime, and starts both game processes under one supervisor. A server
+the requested targets, reuses or refreshes content and resource caches, stages
+sound, prepares an isolated runtime, and starts both game processes under one
+supervisor. A server
 gets an available UDP port by default; use `--port` when a stable port is
 useful. The supervisor waits for both the QUIC certificate fingerprint and
 completed server initialization, then gives the paired client an authenticated
@@ -719,10 +725,10 @@ start identities. `ps` without a name lists every recorded topology; a name
 selects one. It distinguishes a live process from a reused PID, `down` signals
 only the matching supervisor, and the server state remains locked for the
 complete supervised lifetime. Each topology also has a persistent isolated
-client configuration/cache root and its own collected content and resource
-snapshot, so a subsequent build cannot replace files underneath a running
-topology. Logs live below `workspace/topologies/` and rotate at 10 MiB with
-three backups.
+client configuration/cache root and its own copies of the collected content and
+resource caches, so changing or removing one topology cannot affect another
+topology or the retained build caches. Logs live below `workspace/topologies/`
+and rotate at 10 MiB with three backups.
 
 ### Use case: run the latest playable classic branches
 

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import ExitStack, contextmanager
 import ctypes
 from datetime import datetime, timezone
+import errno
 import fcntl
 import hashlib
 import os
@@ -266,14 +267,72 @@ def _open_owned_tree_directory(
     *,
     root: bool = False,
 ) -> int:
-    flags = os.O_DIRECTORY | os.O_NOFOLLOW
-    if sys.platform == "linux":
-        flags |= os.O_PATH
-    else:
-        flags |= os.O_RDONLY
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    try:
+        readable_descriptor = os.open(name, flags, dir_fd=parent_descriptor)
+    except OSError as error:
+        if sys.platform == "linux" and error.errno in (errno.EACCES, errno.EPERM):
+            return _open_unreadable_linux_owned_tree_directory(
+                parent_descriptor, name, before, mount_id, display, root=root
+            )
+        label = "root" if root else "directory"
+        raise WorkspaceError(
+            f"owned removal {label} changed: {display}"
+        ) from error
+    changed_mode = False
+    try:
+        opened = os.fstat(readable_descriptor)
+        if (
+            opened.st_dev != before.st_dev
+            or opened.st_ino != before.st_ino
+            or _descriptor_mount_id(readable_descriptor) != mount_id
+        ):
+            message = (
+                f"owned removal root changed or is mounted: {display}"
+                if root
+                else f"owned removal encountered a mount: {display}"
+            )
+            raise WorkspaceError(message)
+        os.fchmod(readable_descriptor, stat.S_IRWXU)
+        changed_mode = True
+        readable = os.fstat(readable_descriptor)
+        if (
+            readable.st_dev != before.st_dev
+            or readable.st_ino != before.st_ino
+            or _descriptor_mount_id(readable_descriptor) != mount_id
+        ):
+            raise WorkspaceError(
+                f"owned removal encountered a mount: {display}"
+            )
+        return readable_descriptor
+    except BaseException:
+        try:
+            if changed_mode:
+                os.fchmod(readable_descriptor, stat.S_IMODE(before.st_mode))
+        except OSError as restore_error:
+            raise WorkspaceError(
+                "cannot restore owned removal directory mode after "
+                f"open failure: {display}"
+            ) from restore_error
+        finally:
+            os.close(readable_descriptor)
+        raise
+
+
+def _open_unreadable_linux_owned_tree_directory(
+    parent_descriptor: int,
+    name: str,
+    before: os.stat_result,
+    mount_id: int | tuple[int, int],
+    display: Path,
+    *,
+    root: bool,
+) -> int:
     try:
         bound_descriptor = os.open(
-            name, flags, dir_fd=parent_descriptor
+            name,
+            os.O_PATH | os.O_DIRECTORY | os.O_NOFOLLOW,
+            dir_fd=parent_descriptor,
         )
     except OSError as error:
         label = "root" if root else "directory"
@@ -294,19 +353,13 @@ def _open_owned_tree_directory(
                 else f"owned removal encountered a mount: {display}"
             )
             raise WorkspaceError(message)
-        if sys.platform == "linux":
-            _linux_fchmod_path_descriptor(bound_descriptor, stat.S_IRWXU)
-            changed_mode = True
-            readable_descriptor = os.open(
-                ".",
-                os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
-                dir_fd=bound_descriptor,
-            )
-        else:
-            os.fchmod(bound_descriptor, stat.S_IRWXU)
-            changed_mode = True
-            readable_descriptor = bound_descriptor
-            bound_descriptor = -1
+        _linux_fchmod_path_descriptor(bound_descriptor, stat.S_IRWXU)
+        changed_mode = True
+        readable_descriptor = os.open(
+            ".",
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+            dir_fd=bound_descriptor,
+        )
         readable = os.fstat(readable_descriptor)
         if (
             readable.st_dev != before.st_dev
@@ -319,7 +372,7 @@ def _open_owned_tree_directory(
             )
         return readable_descriptor
     except BaseException:
-        if changed_mode and bound_descriptor >= 0:
+        if changed_mode:
             try:
                 _linux_fchmod_path_descriptor(
                     bound_descriptor, stat.S_IMODE(before.st_mode)
@@ -331,8 +384,7 @@ def _open_owned_tree_directory(
                 ) from restore_error
         raise
     finally:
-        if bound_descriptor >= 0:
-            os.close(bound_descriptor)
+        os.close(bound_descriptor)
 
 
 def _probe_owned_tree_entry_mount(

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -159,12 +159,19 @@ def git(
     return run(["git", "-C", str(path), *arguments], capture=capture, trace=trace)
 
 
-def replace_directory(
-    output: Path,
-    staging: Path,
-    backup_prefix: str,
-    verify_after_install: Callable[[], None] | None = None,
-) -> None:
+def remove_owned_tree(path: Path) -> None:
+    os.chmod(path, stat.S_IRWXU, follow_symlinks=False)
+    for directory, dirnames, _filenames in os.walk(path, followlinks=False):
+        directory_path = Path(directory)
+        os.chmod(directory_path, stat.S_IRWXU, follow_symlinks=False)
+        for name in dirnames:
+            child = directory_path / name
+            if not child.is_symlink():
+                os.chmod(child, stat.S_IRWXU, follow_symlinks=False)
+    shutil.rmtree(path)
+
+
+def recover_replaced_directory(output: Path, backup_prefix: str) -> None:
     backup_container = output.parent / f"{backup_prefix}pending"
     backup_metadata = {
         "schema_version": SCHEMA_VERSION,
@@ -180,7 +187,10 @@ def replace_directory(
             or not marker.is_file()
             or marker.is_symlink()
             or load_json(marker) != backup_metadata
-            or (not output.exists() and (not previous.is_dir() or previous.is_symlink()))
+            or (
+                not output.exists()
+                and (not previous.is_dir() or previous.is_symlink())
+            )
         ):
             raise WorkspaceError(
                 f"replaced-directory backup is not managed: {backup_container}"
@@ -188,12 +198,37 @@ def replace_directory(
         if not output.exists():
             previous.replace(output)
         try:
-            shutil.rmtree(backup_container)
+            if previous.exists() or previous.is_symlink():
+                if not previous.is_dir() or previous.is_symlink():
+                    raise WorkspaceError(
+                        "replaced-directory backup payload is invalid: "
+                        f"{previous}"
+                    )
+                remove_owned_tree(previous)
+            marker.unlink()
+            backup_container.rmdir()
         except OSError as error:
+            if backup_container.is_dir() and not marker.exists():
+                atomic_json(marker, backup_metadata)
             raise WorkspaceError(
                 f"cannot reclaim replaced-directory backup {backup_container}: "
                 f"{error}"
             ) from error
+
+
+def replace_directory(
+    output: Path,
+    staging: Path,
+    backup_prefix: str,
+    verify_after_install: Callable[[], None] | None = None,
+) -> None:
+    recover_replaced_directory(output, backup_prefix)
+    backup_container = output.parent / f"{backup_prefix}pending"
+    backup_metadata = {
+        "schema_version": SCHEMA_VERSION,
+        "purpose": "replaced-directory-backup",
+        "output": output.name,
+    }
 
     backup: Path | None = None
     if output.exists():
@@ -205,7 +240,9 @@ def replace_directory(
             staging.replace(output)
         except BaseException:
             backup.replace(output)
-            shutil.rmtree(backup_container)
+            marker = backup_container / MANAGED_MARKER
+            marker.unlink()
+            backup_container.rmdir()
             raise
     else:
         staging.replace(output)
@@ -216,11 +253,15 @@ def replace_directory(
         output.replace(staging)
         if backup is not None:
             backup.replace(output)
-            shutil.rmtree(backup_container)
+            marker = backup_container / MANAGED_MARKER
+            marker.unlink()
+            backup_container.rmdir()
         raise
     if backup is not None:
         try:
-            shutil.rmtree(backup_container)
+            remove_owned_tree(backup)
+            (backup_container / MANAGED_MARKER).unlink()
+            backup_container.rmdir()
         except OSError as error:
             print(
                 "warning: cannot remove managed replaced-directory backup "
@@ -2824,6 +2865,9 @@ class Workspace:
         root = self._scenario_directory(name)
         operation_lock = self.paths.scenarios / "operation.lock"
         with exclusive_lock(operation_lock, "scenario operation"):
+            recover_replaced_directory(
+                root / "state", f".{name}-state-previous-"
+            )
             metadata = self._load_scenario(name)
             state = root / "state"
             with exclusive_lock(
@@ -3034,6 +3078,159 @@ class Workspace:
             value.st_ctime_ns,
         )
 
+    def _compare_topology_runtime_directories(
+        self,
+        source_fd: int,
+        destination_fd: int,
+        source_display: Path,
+        destination_display: Path,
+    ) -> None:
+        source_before = os.fstat(source_fd)
+        destination_before = os.fstat(destination_fd)
+        if (
+            not stat.S_ISDIR(source_before.st_mode)
+            or not stat.S_ISDIR(destination_before.st_mode)
+            or stat.S_IMODE(source_before.st_mode)
+            != stat.S_IMODE(destination_before.st_mode)
+        ):
+            raise WorkspaceError(
+                "copied topology runtime directory metadata differs: "
+                f"{destination_display}"
+            )
+        try:
+            source_names = sorted(os.listdir(source_fd))
+            destination_names = sorted(os.listdir(destination_fd))
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot validate copied topology runtime input: {error}"
+            ) from error
+        if source_names != destination_names:
+            raise WorkspaceError(
+                f"copied topology runtime tree differs: {destination_display}"
+            )
+        for name in source_names:
+            source_child = source_display / name
+            destination_child = destination_display / name
+            try:
+                source_entry = os.stat(
+                    name, dir_fd=source_fd, follow_symlinks=False
+                )
+                destination_entry = os.stat(
+                    name, dir_fd=destination_fd, follow_symlinks=False
+                )
+            except OSError as error:
+                raise WorkspaceError(
+                    f"cannot validate copied topology runtime input: {error}"
+                ) from error
+            if (
+                stat.S_IFMT(source_entry.st_mode)
+                != stat.S_IFMT(destination_entry.st_mode)
+                or stat.S_IMODE(source_entry.st_mode)
+                != stat.S_IMODE(destination_entry.st_mode)
+            ):
+                raise WorkspaceError(
+                    f"copied topology runtime entry differs: {destination_child}"
+                )
+            if stat.S_ISDIR(source_entry.st_mode):
+                flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+                try:
+                    source_child_fd = os.open(name, flags, dir_fd=source_fd)
+                except OSError as error:
+                    raise WorkspaceError(
+                        "copied topology runtime source changed or contains a link: "
+                        f"{source_child}"
+                    ) from error
+                try:
+                    destination_child_fd = os.open(
+                        name, flags, dir_fd=destination_fd
+                    )
+                except OSError as error:
+                    os.close(source_child_fd)
+                    raise WorkspaceError(
+                        "copied topology runtime input changed or contains a link: "
+                        f"{destination_child}"
+                    ) from error
+                try:
+                    self._compare_topology_runtime_directories(
+                        source_child_fd,
+                        destination_child_fd,
+                        source_child,
+                        destination_child,
+                    )
+                finally:
+                    os.close(source_child_fd)
+                    os.close(destination_child_fd)
+            elif stat.S_ISREG(source_entry.st_mode):
+                flags = os.O_RDONLY | os.O_NOFOLLOW
+                try:
+                    source_child_fd = os.open(name, flags, dir_fd=source_fd)
+                except OSError as error:
+                    raise WorkspaceError(
+                        "copied topology runtime source changed or contains a link: "
+                        f"{source_child}"
+                    ) from error
+                try:
+                    destination_child_fd = os.open(
+                        name, flags, dir_fd=destination_fd
+                    )
+                except OSError as error:
+                    os.close(source_child_fd)
+                    raise WorkspaceError(
+                        "copied topology runtime input changed or contains a link: "
+                        f"{destination_child}"
+                    ) from error
+                try:
+                    source_file_before = os.fstat(source_child_fd)
+                    destination_file_before = os.fstat(destination_child_fd)
+                    if source_file_before.st_size != destination_file_before.st_size:
+                        raise WorkspaceError(
+                            f"copied topology runtime file differs: {destination_child}"
+                        )
+                    with os.fdopen(
+                        source_child_fd, "rb", closefd=False
+                    ) as source_file:
+                        with os.fdopen(
+                            destination_child_fd, "rb", closefd=False
+                        ) as destination_file:
+                            while True:
+                                source_chunk = source_file.read(1024 * 1024)
+                                destination_chunk = destination_file.read(1024 * 1024)
+                                if source_chunk != destination_chunk:
+                                    raise WorkspaceError(
+                                        "copied topology runtime file differs: "
+                                        f"{destination_child}"
+                                    )
+                                if not source_chunk:
+                                    break
+                    if (
+                        self._runtime_tree_identity(os.fstat(source_child_fd))
+                        != self._runtime_tree_identity(source_file_before)
+                        or self._runtime_tree_identity(os.fstat(destination_child_fd))
+                        != self._runtime_tree_identity(destination_file_before)
+                    ):
+                        raise WorkspaceError(
+                            "topology runtime input changed during validation: "
+                            f"{destination_child}"
+                        )
+                finally:
+                    os.close(source_child_fd)
+                    os.close(destination_child_fd)
+            else:
+                raise WorkspaceError(
+                    "copied topology runtime input contains a link or non-regular "
+                    f"file: {destination_child}"
+                )
+        if (
+            self._runtime_tree_identity(os.fstat(source_fd))
+            != self._runtime_tree_identity(source_before)
+            or self._runtime_tree_identity(os.fstat(destination_fd))
+            != self._runtime_tree_identity(destination_before)
+        ):
+            raise WorkspaceError(
+                "topology runtime input changed during validation: "
+                f"{destination_display}"
+            )
+
     def _copy_topology_runtime_directory(
         self,
         source_fd: int,
@@ -3182,8 +3379,9 @@ class Workspace:
 
     def _copy_topology_runtime_tree(
         self, source: Path, destination: Path
-    ) -> None:
+    ) -> int:
         flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        retained_destination_fd: int | None = None
         try:
             source_before = source.stat(follow_symlinks=False)
             source_fd = os.open(source, flags)
@@ -3246,6 +3444,8 @@ class Workspace:
                 raise WorkspaceError(
                     f"topology runtime input changed during copy: {source}"
                 )
+            retained_destination_fd = os.dup(destination_fd)
+            return retained_destination_fd
         finally:
             if destination_fd is not None:
                 os.close(destination_fd)
@@ -3286,6 +3486,7 @@ class Workspace:
         staging = Path(tempfile.mkdtemp(prefix=".runtime-", dir=topology_root))
         staging.rmdir()
         staging.mkdir()
+        copied_descriptors: dict[str, int] = {}
         try:
             for name, source, purpose in inputs:
                 metadata = expected[name]
@@ -3301,7 +3502,9 @@ class Workspace:
                         f"topology runtime input is not managed for {purpose}: {source}"
                     )
                 destination = staging / name
-                self._copy_topology_runtime_tree(source, destination)
+                copied_descriptors[name] = self._copy_topology_runtime_tree(
+                    source, destination
+                )
                 copied_marker = destination / MANAGED_MARKER
                 if (
                     not destination.is_dir()
@@ -3313,11 +3516,60 @@ class Workspace:
                     raise WorkspaceError(
                         f"copied topology runtime input is invalid: {destination}"
                     )
-            replace_directory(container, staging, ".runtime-previous-")
+
+            def verify_runtime_install() -> None:
+                flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+                for name, source, _purpose in inputs:
+                    retained_fd = copied_descriptors[name]
+                    try:
+                        installed_fd = os.open(container / name, flags)
+                    except OSError as error:
+                        raise WorkspaceError(
+                            "cannot validate installed topology runtime input "
+                            f"{container / name}: {error}"
+                        ) from error
+                    try:
+                        source_fd = os.open(source, flags)
+                    except OSError as error:
+                        os.close(installed_fd)
+                        raise WorkspaceError(
+                            "cannot validate topology runtime source "
+                            f"{source}: {error}"
+                        ) from error
+                    try:
+                        retained = os.fstat(retained_fd)
+                        installed = os.fstat(installed_fd)
+                        if (
+                            retained.st_dev != installed.st_dev
+                            or retained.st_ino != installed.st_ino
+                        ):
+                            raise WorkspaceError(
+                                "installed topology runtime input changed: "
+                                f"{container / name}"
+                            )
+                        self._compare_topology_runtime_directories(
+                            source_fd,
+                            installed_fd,
+                            source,
+                            container / name,
+                        )
+                    finally:
+                        os.close(source_fd)
+                        os.close(installed_fd)
+
+            replace_directory(
+                container,
+                staging,
+                ".runtime-previous-",
+                verify_runtime_install,
+            )
         except BaseException:
             if staging.exists():
-                shutil.rmtree(staging)
+                remove_owned_tree(staging)
             raise
+        finally:
+            for descriptor in copied_descriptors.values():
+                os.close(descriptor)
         return {name: container / name for name in expected}
 
     def _prepare_topology_client_runtime(

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -280,44 +280,52 @@ def _prepare_owned_tree_removal(
         or _descriptor_mount_id(descriptor) != mount_id
     ):
         raise WorkspaceError(f"owned removal crossed a filesystem boundary: {display}")
+    original_mode = stat.S_IMODE(root.st_mode)
     os.fchmod(descriptor, stat.S_IRWXU)
-    for name in sorted(os.listdir(descriptor)):
-        child_display = display / name
-        child = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
-        _probe_owned_tree_entry_mount(
-            descriptor, name, child, mount_id, child_display
-        )
-        if child.st_dev != device:
-            raise WorkspaceError(
-                f"owned removal encountered a mount: {child_display}"
+    try:
+        for name in sorted(os.listdir(descriptor)):
+            child_display = display / name
+            child = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
+            _probe_owned_tree_entry_mount(
+                descriptor, name, child, mount_id, child_display
             )
-        if stat.S_ISDIR(child.st_mode):
-            try:
-                child_descriptor = os.open(
-                    name,
-                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
-                    dir_fd=descriptor,
-                )
-            except OSError as error:
+            if child.st_dev != device:
                 raise WorkspaceError(
-                    f"owned removal directory changed: {child_display}"
-                ) from error
-            try:
-                opened = os.fstat(child_descriptor)
-                if (
-                    opened.st_dev != child.st_dev
-                    or opened.st_ino != child.st_ino
-                    or _descriptor_mount_id(child_descriptor) != mount_id
-                ):
-                    raise WorkspaceError(
-                        f"owned removal encountered a mount: {child_display}"
-                    )
-                os.fchmod(child_descriptor, stat.S_IRWXU)
-                _prepare_owned_tree_removal(
-                    child_descriptor, device, mount_id, child_display
+                    f"owned removal encountered a mount: {child_display}"
                 )
-            finally:
-                os.close(child_descriptor)
+            if stat.S_ISDIR(child.st_mode):
+                try:
+                    child_descriptor = os.open(
+                        name,
+                        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                        dir_fd=descriptor,
+                    )
+                except OSError as error:
+                    raise WorkspaceError(
+                        f"owned removal directory changed: {child_display}"
+                    ) from error
+                try:
+                    opened = os.fstat(child_descriptor)
+                    if (
+                        opened.st_dev != child.st_dev
+                        or opened.st_ino != child.st_ino
+                        or _descriptor_mount_id(child_descriptor) != mount_id
+                    ):
+                        raise WorkspaceError(
+                            f"owned removal encountered a mount: {child_display}"
+                        )
+                    _prepare_owned_tree_removal(
+                        child_descriptor, device, mount_id, child_display
+                    )
+                finally:
+                    os.close(child_descriptor)
+    finally:
+        try:
+            os.fchmod(descriptor, original_mode)
+        except OSError as restore_error:
+            raise WorkspaceError(
+                f"cannot restore owned removal directory mode: {display}"
+            ) from restore_error
 
 
 def _remove_owned_tree_contents(
@@ -357,6 +365,7 @@ def _remove_owned_tree_contents(
                     raise WorkspaceError(
                         f"owned removal encountered a mount: {child_display}"
                     )
+                os.fchmod(child_descriptor, stat.S_IRWXU)
                 _remove_owned_tree_contents(
                     child_descriptor, device, mount_id, child_display
                 )
@@ -390,10 +399,10 @@ def remove_owned_tree(path: Path) -> None:
             or root_mount_id != parent_mount_id
         ):
             raise WorkspaceError(f"owned removal root changed or is mounted: {path}")
-        os.fchmod(descriptor, stat.S_IRWXU)
         _prepare_owned_tree_removal(
             descriptor, opened.st_dev, root_mount_id, path
         )
+        os.fchmod(descriptor, stat.S_IRWXU)
         _remove_owned_tree_contents(
             descriptor, opened.st_dev, root_mount_id, path
         )

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -165,15 +165,43 @@ def replace_directory(
     backup_prefix: str,
     verify_after_install: Callable[[], None] | None = None,
 ) -> None:
+    backup_container = output.parent / f"{backup_prefix}pending"
+    backup_metadata = {
+        "schema_version": SCHEMA_VERSION,
+        "purpose": "replaced-directory-backup",
+        "output": output.name,
+    }
+    if backup_container.exists() or backup_container.is_symlink():
+        marker = backup_container / MANAGED_MARKER
+        if (
+            not backup_container.is_dir()
+            or backup_container.is_symlink()
+            or not marker.is_file()
+            or marker.is_symlink()
+            or load_json(marker) != backup_metadata
+        ):
+            raise WorkspaceError(
+                f"replaced-directory backup is not managed: {backup_container}"
+            )
+        try:
+            shutil.rmtree(backup_container)
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot reclaim replaced-directory backup {backup_container}: "
+                f"{error}"
+            ) from error
+
     backup: Path | None = None
     if output.exists():
-        backup = Path(tempfile.mkdtemp(prefix=backup_prefix, dir=output.parent))
-        backup.rmdir()
+        backup_container.mkdir()
+        atomic_json(backup_container / MANAGED_MARKER, backup_metadata)
+        backup = backup_container / "previous"
         output.replace(backup)
         try:
             staging.replace(output)
         except BaseException:
             backup.replace(output)
+            shutil.rmtree(backup_container)
             raise
     else:
         staging.replace(output)
@@ -184,13 +212,16 @@ def replace_directory(
         output.replace(staging)
         if backup is not None:
             backup.replace(output)
+            shutil.rmtree(backup_container)
         raise
     if backup is not None:
         try:
-            shutil.rmtree(backup)
+            shutil.rmtree(backup_container)
         except OSError as error:
             print(
-                f"warning: cannot remove replaced directory {backup}: {error}",
+                "warning: cannot remove managed replaced-directory backup "
+                f"{backup_container}: {error}; the next replacement will retry "
+                "before changing output",
                 file=sys.stderr,
             )
 
@@ -2989,28 +3020,159 @@ class Workspace:
         return path
 
     @staticmethod
-    def _validate_topology_runtime_tree(path: Path) -> None:
-        for directory, dirnames, filenames in os.walk(path, followlinks=False):
-            directory_path = Path(directory)
-            for name in dirnames:
-                child = directory_path / name
-                if child.is_symlink():
-                    raise WorkspaceError(
-                        f"topology runtime input contains a link: {child}"
-                    )
-            for name in filenames:
-                child = directory_path / name
+    def _runtime_tree_identity(value: os.stat_result) -> tuple[int, ...]:
+        return (
+            value.st_dev,
+            value.st_ino,
+            value.st_mode,
+            value.st_size,
+            value.st_mtime_ns,
+            value.st_ctime_ns,
+        )
+
+    def _copy_topology_runtime_directory(
+        self,
+        source_fd: int,
+        source_display: Path,
+        destination: Path,
+    ) -> None:
+        directory_before = os.fstat(source_fd)
+        if not stat.S_ISDIR(directory_before.st_mode):
+            raise WorkspaceError(
+                f"topology runtime input is not a directory: {source_display}"
+            )
+        destination.mkdir(mode=stat.S_IMODE(directory_before.st_mode))
+        try:
+            names = sorted(os.listdir(source_fd))
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot list topology runtime input {source_display}: {error}"
+            ) from error
+        for name in names:
+            source_child = source_display / name
+            destination_child = destination / name
+            try:
+                child_before = os.stat(name, dir_fd=source_fd, follow_symlinks=False)
+            except OSError as error:
+                raise WorkspaceError(
+                    f"cannot inspect topology runtime input {source_child}: {error}"
+                ) from error
+            if stat.S_ISDIR(child_before.st_mode):
+                flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
                 try:
-                    mode = child.lstat().st_mode
+                    child_fd = os.open(name, flags, dir_fd=source_fd)
                 except OSError as error:
                     raise WorkspaceError(
-                        f"cannot inspect topology runtime input {child}: {error}"
+                        "topology runtime input changed or contains a link: "
+                        f"{source_child}"
                     ) from error
-                if not stat.S_ISREG(mode):
-                    raise WorkspaceError(
-                        "topology runtime input contains a non-regular file: "
-                        f"{child}"
+                try:
+                    if self._runtime_tree_identity(os.fstat(child_fd)) != (
+                        self._runtime_tree_identity(child_before)
+                    ):
+                        raise WorkspaceError(
+                            f"topology runtime input changed during copy: {source_child}"
+                        )
+                    self._copy_topology_runtime_directory(
+                        child_fd, source_child, destination_child
                     )
+                finally:
+                    os.close(child_fd)
+            elif stat.S_ISREG(child_before.st_mode):
+                flags = os.O_RDONLY | os.O_NOFOLLOW
+                try:
+                    child_fd = os.open(name, flags, dir_fd=source_fd)
+                except OSError as error:
+                    raise WorkspaceError(
+                        "topology runtime input changed or contains a link: "
+                        f"{source_child}"
+                    ) from error
+                try:
+                    opened = os.fstat(child_fd)
+                    if (
+                        not stat.S_ISREG(opened.st_mode)
+                        or self._runtime_tree_identity(opened)
+                        != self._runtime_tree_identity(child_before)
+                    ):
+                        raise WorkspaceError(
+                            f"topology runtime input changed during copy: {source_child}"
+                        )
+                    destination_fd = os.open(
+                        destination_child,
+                        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                        stat.S_IMODE(opened.st_mode),
+                    )
+                    try:
+                        with os.fdopen(child_fd, "rb", closefd=False) as source_file:
+                            with os.fdopen(
+                                destination_fd, "wb", closefd=False
+                            ) as destination_file:
+                                shutil.copyfileobj(source_file, destination_file)
+                        copied = os.fstat(child_fd)
+                        if self._runtime_tree_identity(copied) != (
+                            self._runtime_tree_identity(opened)
+                        ):
+                            raise WorkspaceError(
+                                "topology runtime input changed during copy: "
+                                f"{source_child}"
+                            )
+                        os.fchmod(destination_fd, stat.S_IMODE(opened.st_mode))
+                    finally:
+                        os.close(destination_fd)
+                finally:
+                    os.close(child_fd)
+                os.utime(
+                    destination_child,
+                    ns=(opened.st_atime_ns, opened.st_mtime_ns),
+                    follow_symlinks=False,
+                )
+            else:
+                raise WorkspaceError(
+                    "topology runtime input contains a link or non-regular file: "
+                    f"{source_child}"
+                )
+        directory_after = os.fstat(source_fd)
+        if self._runtime_tree_identity(directory_after) != self._runtime_tree_identity(
+            directory_before
+        ):
+            raise WorkspaceError(
+                f"topology runtime input changed during copy: {source_display}"
+            )
+        destination.chmod(stat.S_IMODE(directory_before.st_mode))
+        os.utime(
+            destination,
+            ns=(directory_before.st_atime_ns, directory_before.st_mtime_ns),
+            follow_symlinks=False,
+        )
+
+    def _copy_topology_runtime_tree(
+        self, source: Path, destination: Path
+    ) -> None:
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        try:
+            source_before = source.stat(follow_symlinks=False)
+            source_fd = os.open(source, flags)
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot open topology runtime input {source}: {error}"
+            ) from error
+        try:
+            if self._runtime_tree_identity(os.fstat(source_fd)) != (
+                self._runtime_tree_identity(source_before)
+            ):
+                raise WorkspaceError(
+                    f"topology runtime input changed during copy: {source}"
+                )
+            self._copy_topology_runtime_directory(source_fd, source, destination)
+            source_after = source.stat(follow_symlinks=False)
+            if self._runtime_tree_identity(source_after) != (
+                self._runtime_tree_identity(source_before)
+            ):
+                raise WorkspaceError(
+                    f"topology runtime input changed during copy: {source}"
+                )
+        finally:
+            os.close(source_fd)
 
     def _copy_topology_runtime_inputs(
         self,
@@ -3059,9 +3221,8 @@ class Workspace:
                     raise WorkspaceError(
                         f"topology runtime input is not managed for {purpose}: {source}"
                     )
-                self._validate_topology_runtime_tree(source)
                 destination = staging / name
-                shutil.copytree(source, destination, symlinks=True)
+                self._copy_topology_runtime_tree(source, destination)
                 copied_marker = destination / MANAGED_MARKER
                 if (
                     not destination.is_dir()
@@ -3073,7 +3234,6 @@ class Workspace:
                     raise WorkspaceError(
                         f"copied topology runtime input is invalid: {destination}"
                     )
-                self._validate_topology_runtime_tree(destination)
             replace_directory(container, staging, ".runtime-previous-")
         except BaseException:
             if staging.exists():

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -160,6 +160,8 @@ def git(
 
 
 def _descriptor_mount_id(descriptor: int) -> int:
+    if sys.platform != "linux":
+        return os.fstat(descriptor).st_dev
     try:
         metadata = Path(f"/proc/self/fdinfo/{descriptor}").read_text(
             encoding="ascii"
@@ -190,28 +192,6 @@ def _prepare_owned_tree_removal(
     for name in sorted(os.listdir(descriptor)):
         child_display = display / name
         child = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
-        try:
-            child_probe = os.open(
-                name,
-                os.O_PATH | os.O_NOFOLLOW,
-                dir_fd=descriptor,
-            )
-        except OSError as error:
-            raise WorkspaceError(
-                f"owned removal entry changed: {child_display}"
-            ) from error
-        try:
-            probed = os.fstat(child_probe)
-            if (
-                probed.st_dev != child.st_dev
-                or probed.st_ino != child.st_ino
-                or _descriptor_mount_id(child_probe) != mount_id
-            ):
-                raise WorkspaceError(
-                    f"owned removal encountered a mount: {child_display}"
-                )
-        finally:
-            os.close(child_probe)
         if child.st_dev != device:
             raise WorkspaceError(
                 f"owned removal encountered a mount: {child_display}"
@@ -251,28 +231,6 @@ def _remove_owned_tree_contents(
     for name in sorted(os.listdir(descriptor)):
         child_display = display / name
         child = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
-        try:
-            child_probe = os.open(
-                name,
-                os.O_PATH | os.O_NOFOLLOW,
-                dir_fd=descriptor,
-            )
-        except OSError as error:
-            raise WorkspaceError(
-                f"owned removal entry changed: {child_display}"
-            ) from error
-        try:
-            probed = os.fstat(child_probe)
-            if (
-                probed.st_dev != child.st_dev
-                or probed.st_ino != child.st_ino
-                or _descriptor_mount_id(child_probe) != mount_id
-            ):
-                raise WorkspaceError(
-                    f"owned removal encountered a mount: {child_display}"
-                )
-        finally:
-            os.close(child_probe)
         if child.st_dev != device:
             raise WorkspaceError(
                 f"owned removal encountered a mount: {child_display}"
@@ -317,35 +275,18 @@ def remove_owned_tree(path: Path) -> None:
     descriptor: int | None = None
     try:
         before = os.stat(path.name, dir_fd=parent_descriptor, follow_symlinks=False)
-        root_probe = os.open(
-            path.name,
-            os.O_PATH | os.O_DIRECTORY | os.O_NOFOLLOW,
-            dir_fd=parent_descriptor,
-        )
-        try:
-            probed = os.fstat(root_probe)
-            parent_mount_id = _descriptor_mount_id(parent_descriptor)
-            root_mount_id = _descriptor_mount_id(root_probe)
-            if (
-                probed.st_dev != before.st_dev
-                or probed.st_ino != before.st_ino
-                or root_mount_id != parent_mount_id
-            ):
-                raise WorkspaceError(
-                    f"owned removal root changed or is mounted: {path}"
-                )
-        finally:
-            os.close(root_probe)
+        parent_mount_id = _descriptor_mount_id(parent_descriptor)
         descriptor = os.open(
             path.name,
             os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
             dir_fd=parent_descriptor,
         )
         opened = os.fstat(descriptor)
+        root_mount_id = _descriptor_mount_id(descriptor)
         if (
             opened.st_dev != before.st_dev
             or opened.st_ino != before.st_ino
-            or _descriptor_mount_id(descriptor) != root_mount_id
+            or root_mount_id != parent_mount_id
         ):
             raise WorkspaceError(f"owned removal root changed or is mounted: {path}")
         os.fchmod(descriptor, stat.S_IRWXU)
@@ -362,6 +303,51 @@ def remove_owned_tree(path: Path) -> None:
         if descriptor is not None:
             os.close(descriptor)
         os.close(parent_descriptor)
+
+
+def _create_replaced_directory_backup(
+    backup_container: Path, backup_metadata: dict[str, object], backup_prefix: str
+) -> None:
+    prepared = Path(
+        tempfile.mkdtemp(
+            prefix=f"{backup_prefix}prepared-", dir=backup_container.parent
+        )
+    )
+    marker = prepared / MANAGED_MARKER
+    try:
+        atomic_json(marker, backup_metadata)
+        prepared.replace(backup_container)
+    except BaseException:
+        if marker.is_file() and not marker.is_symlink():
+            remove_owned_tree(prepared)
+        else:
+            prepared.rmdir()
+        raise
+
+
+def _retire_replaced_directory_backup(
+    backup_container: Path, backup_prefix: str
+) -> None:
+    retired = backup_container.parent / (
+        f"{backup_prefix}retired-{secrets.token_hex(8)}"
+    )
+    try:
+        backup_container.replace(retired)
+    except OSError as error:
+        print(
+            "warning: cannot retire managed replaced-directory backup "
+            f"{backup_container}: {error}; the next replacement will retry",
+            file=sys.stderr,
+        )
+        return
+    try:
+        remove_owned_tree(retired)
+    except (OSError, WorkspaceError) as error:
+        print(
+            "warning: cannot remove retired managed replaced-directory backup "
+            f"{retired}: {error}; profile cleanup will retain or reclaim it",
+            file=sys.stderr,
+        )
 
 
 def recover_replaced_directory(output: Path, backup_prefix: str) -> None:
@@ -398,11 +384,8 @@ def recover_replaced_directory(output: Path, backup_prefix: str) -> None:
                         f"{previous}"
                     )
                 remove_owned_tree(previous)
-            marker.unlink()
-            backup_container.rmdir()
+            _retire_replaced_directory_backup(backup_container, backup_prefix)
         except OSError as error:
-            if backup_container.is_dir() and not marker.exists():
-                atomic_json(marker, backup_metadata)
             raise WorkspaceError(
                 f"cannot reclaim replaced-directory backup {backup_container}: "
                 f"{error}"
@@ -425,17 +408,16 @@ def replace_runtime_directory(
 
     backup: Path | None = None
     if output.exists():
-        backup_container.mkdir()
-        atomic_json(backup_container / MANAGED_MARKER, backup_metadata)
+        _create_replaced_directory_backup(
+            backup_container, backup_metadata, backup_prefix
+        )
         backup = backup_container / "previous"
         output.replace(backup)
         try:
             staging.replace(output)
         except BaseException:
             backup.replace(output)
-            marker = backup_container / MANAGED_MARKER
-            marker.unlink()
-            backup_container.rmdir()
+            _retire_replaced_directory_backup(backup_container, backup_prefix)
             raise
     else:
         staging.replace(output)
@@ -446,15 +428,11 @@ def replace_runtime_directory(
         output.replace(staging)
         if backup is not None:
             backup.replace(output)
-            marker = backup_container / MANAGED_MARKER
-            marker.unlink()
-            backup_container.rmdir()
+            _retire_replaced_directory_backup(backup_container, backup_prefix)
         raise
     if backup is not None:
         try:
             remove_owned_tree(backup)
-            (backup_container / MANAGED_MARKER).unlink()
-            backup_container.rmdir()
         except (OSError, WorkspaceError) as error:
             print(
                 "warning: cannot remove managed replaced-directory backup "
@@ -462,6 +440,8 @@ def replace_runtime_directory(
                 "before changing output",
                 file=sys.stderr,
             )
+        else:
+            _retire_replaced_directory_backup(backup_container, backup_prefix)
 
 
 def replace_directory(output: Path, staging: Path, backup_prefix: str) -> None:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -2428,6 +2428,8 @@ class Workspace:
                 working, root, selected, data, content, resources
             )
             executable = working / "atrinik-server"
+            environment = os.environ.copy()
+            environment["PYTHONDONTWRITEBYTECODE"] = "1"
             run(
                 [
                     str(executable),
@@ -2439,6 +2441,7 @@ class Workspace:
                     f"--resourcespath={working / 'resources'}",
                 ],
                 cwd=working,
+                env=environment,
             )
             self._validate_region_maps(generated)
             final_inputs, final_cacheable = self._region_map_inputs(

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -159,16 +159,143 @@ def git(
     return run(["git", "-C", str(path), *arguments], capture=capture, trace=trace)
 
 
+def _descriptor_is_mount(descriptor: int) -> bool:
+    return os.path.ismount(Path(f"/proc/self/fd/{descriptor}").resolve())
+
+
+def _prepare_owned_tree_removal(
+    descriptor: int, device: int, display: Path
+) -> None:
+    root = os.fstat(descriptor)
+    if not stat.S_ISDIR(root.st_mode) or root.st_dev != device:
+        raise WorkspaceError(f"owned removal crossed a filesystem boundary: {display}")
+    os.fchmod(descriptor, stat.S_IRWXU)
+    for name in sorted(os.listdir(descriptor)):
+        child_display = display / name
+        child = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
+        if os.path.ismount(child_display):
+            raise WorkspaceError(
+                f"owned removal encountered a mount: {child_display}"
+            )
+        if stat.S_ISDIR(child.st_mode):
+            if child.st_dev != device:
+                raise WorkspaceError(
+                    f"owned removal encountered a mount: {child_display}"
+                )
+            os.chmod(
+                name,
+                stat.S_IRWXU,
+                dir_fd=descriptor,
+                follow_symlinks=False,
+            )
+            try:
+                child_descriptor = os.open(
+                    name,
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                    dir_fd=descriptor,
+                )
+            except OSError as error:
+                raise WorkspaceError(
+                    f"owned removal directory changed: {child_display}"
+                ) from error
+            try:
+                opened = os.fstat(child_descriptor)
+                if (
+                    opened.st_dev != child.st_dev
+                    or opened.st_ino != child.st_ino
+                    or _descriptor_is_mount(child_descriptor)
+                ):
+                    raise WorkspaceError(
+                        f"owned removal encountered a mount: {child_display}"
+                    )
+                _prepare_owned_tree_removal(
+                    child_descriptor, device, child_display
+                )
+            finally:
+                os.close(child_descriptor)
+
+
+def _remove_owned_tree_contents(
+    descriptor: int, device: int, display: Path
+) -> None:
+    for name in sorted(os.listdir(descriptor)):
+        child_display = display / name
+        child = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
+        if os.path.ismount(child_display):
+            raise WorkspaceError(
+                f"owned removal encountered a mount: {child_display}"
+            )
+        if stat.S_ISDIR(child.st_mode):
+            if child.st_dev != device:
+                raise WorkspaceError(
+                    f"owned removal encountered a mount: {child_display}"
+                )
+            try:
+                child_descriptor = os.open(
+                    name,
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                    dir_fd=descriptor,
+                )
+            except OSError as error:
+                raise WorkspaceError(
+                    f"owned removal directory changed: {child_display}"
+                ) from error
+            try:
+                opened = os.fstat(child_descriptor)
+                if (
+                    opened.st_dev != child.st_dev
+                    or opened.st_ino != child.st_ino
+                    or _descriptor_is_mount(child_descriptor)
+                ):
+                    raise WorkspaceError(
+                        f"owned removal encountered a mount: {child_display}"
+                    )
+                _remove_owned_tree_contents(
+                    child_descriptor, device, child_display
+                )
+            finally:
+                os.close(child_descriptor)
+            os.rmdir(name, dir_fd=descriptor)
+        else:
+            os.unlink(name, dir_fd=descriptor)
+
+
 def remove_owned_tree(path: Path) -> None:
-    os.chmod(path, stat.S_IRWXU, follow_symlinks=False)
-    for directory, dirnames, _filenames in os.walk(path, followlinks=False):
-        directory_path = Path(directory)
-        os.chmod(directory_path, stat.S_IRWXU, follow_symlinks=False)
-        for name in dirnames:
-            child = directory_path / name
-            if not child.is_symlink():
-                os.chmod(child, stat.S_IRWXU, follow_symlinks=False)
-    shutil.rmtree(path)
+    if path.is_symlink() or not path.is_dir() or os.path.ismount(path):
+        raise WorkspaceError(f"owned removal root is invalid: {path}")
+    parent_descriptor = os.open(
+        path.parent, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    )
+    descriptor: int | None = None
+    try:
+        before = os.stat(path.name, dir_fd=parent_descriptor, follow_symlinks=False)
+        os.chmod(
+            path.name,
+            stat.S_IRWXU,
+            dir_fd=parent_descriptor,
+            follow_symlinks=False,
+        )
+        descriptor = os.open(
+            path.name,
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+            dir_fd=parent_descriptor,
+        )
+        opened = os.fstat(descriptor)
+        if (
+            opened.st_dev != before.st_dev
+            or opened.st_ino != before.st_ino
+            or _descriptor_is_mount(descriptor)
+        ):
+            raise WorkspaceError(f"owned removal root changed or is mounted: {path}")
+        _prepare_owned_tree_removal(descriptor, opened.st_dev, path)
+        _remove_owned_tree_contents(descriptor, opened.st_dev, path)
+        os.close(descriptor)
+        descriptor = None
+        os.rmdir(path.name, dir_fd=parent_descriptor)
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(parent_descriptor)
 
 
 def recover_replaced_directory(output: Path, backup_prefix: str) -> None:
@@ -216,7 +343,7 @@ def recover_replaced_directory(output: Path, backup_prefix: str) -> None:
             ) from error
 
 
-def replace_directory(
+def replace_runtime_directory(
     output: Path,
     staging: Path,
     backup_prefix: str,
@@ -269,6 +396,21 @@ def replace_directory(
                 "before changing output",
                 file=sys.stderr,
             )
+
+
+def replace_directory(output: Path, staging: Path, backup_prefix: str) -> None:
+    if output.exists():
+        backup = Path(tempfile.mkdtemp(prefix=backup_prefix, dir=output.parent))
+        backup.rmdir()
+        output.replace(backup)
+        try:
+            staging.replace(output)
+        except BaseException:
+            backup.replace(output)
+            raise
+        shutil.rmtree(backup)
+    else:
+        staging.replace(output)
 
 
 def _remote_matches(url: str, repository: str) -> bool:
@@ -2026,7 +2168,7 @@ class Workspace:
                         "selected content input changed during collection"
                     )
 
-            replace_directory(
+            replace_runtime_directory(
                 output,
                 staging,
                 ".content-previous-",
@@ -2155,7 +2297,7 @@ class Workspace:
                         "selected resource input changed during staging"
                     )
 
-            replace_directory(
+            replace_runtime_directory(
                 output,
                 staging,
                 ".resources-previous-",
@@ -2868,9 +3010,6 @@ class Workspace:
         root = self._scenario_directory(name)
         operation_lock = self.paths.scenarios / "operation.lock"
         with exclusive_lock(operation_lock, "scenario operation"):
-            recover_replaced_directory(
-                root / "state", f".{name}-state-previous-"
-            )
             metadata = self._load_scenario(name)
             state = root / "state"
             with exclusive_lock(
@@ -3560,7 +3699,7 @@ class Workspace:
                         os.close(source_fd)
                         os.close(installed_fd)
 
-            replace_directory(
+            replace_runtime_directory(
                 container,
                 staging,
                 ".runtime-previous-",

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -237,11 +237,13 @@ def _probe_owned_tree_entry_mount(
 ) -> None:
     if stat.S_ISLNK(child.st_mode):
         return
+    if not (stat.S_ISREG(child.st_mode) or stat.S_ISDIR(child.st_mode)):
+        raise WorkspaceError(f"owned removal entry is unsupported: {display}")
     flags = os.O_NOFOLLOW
     if sys.platform == "linux":
         flags |= os.O_PATH
     else:
-        flags |= os.O_RDONLY
+        flags |= os.O_RDONLY | os.O_NONBLOCK
     try:
         probe = os.open(name, flags, dir_fd=descriptor)
     except OSError as error:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -159,7 +159,13 @@ def git(
     return run(["git", "-C", str(path), *arguments], capture=capture, trace=trace)
 
 
-def replace_directory(output: Path, staging: Path, backup_prefix: str) -> None:
+def replace_directory(
+    output: Path,
+    staging: Path,
+    backup_prefix: str,
+    verify_after_install: Callable[[], None] | None = None,
+) -> None:
+    backup: Path | None = None
     if output.exists():
         backup = Path(tempfile.mkdtemp(prefix=backup_prefix, dir=output.parent))
         backup.rmdir()
@@ -169,9 +175,24 @@ def replace_directory(output: Path, staging: Path, backup_prefix: str) -> None:
         except BaseException:
             backup.replace(output)
             raise
-        shutil.rmtree(backup)
     else:
         staging.replace(output)
+    try:
+        if verify_after_install is not None:
+            verify_after_install()
+    except BaseException:
+        output.replace(staging)
+        if backup is not None:
+            backup.replace(output)
+        raise
+    if backup is not None:
+        try:
+            shutil.rmtree(backup)
+        except OSError as error:
+            print(
+                f"warning: cannot remove replaced directory {backup}: {error}",
+                file=sys.stderr,
+            )
 
 
 def _remote_matches(url: str, repository: str) -> bool:
@@ -1914,11 +1935,31 @@ class Workspace:
                 raise WorkspaceError("selected content input changed during collection")
             if cacheable:
                 atomic_json(staging / RUNTIME_INPUT_METADATA, inputs)
+
+            def verify_content_install() -> None:
+                installed_inputs, installed_cacheable = (
+                    self._runtime_input_coordinates(
+                        profile_name, selected, "content"
+                    )
+                )
+                if (
+                    installed_inputs != inputs
+                    or installed_cacheable != cacheable
+                ):
+                    raise WorkspaceError(
+                        "selected content input changed during collection"
+                    )
+
+            replace_directory(
+                output,
+                staging,
+                ".content-previous-",
+                verify_content_install,
+            )
         except BaseException:
             if staging.exists():
                 shutil.rmtree(staging)
             raise
-        replace_directory(output, staging, ".content-previous-")
         print(f"content: collected {output}")
         return output
 
@@ -2018,10 +2059,36 @@ class Workspace:
                 or installed_tracked != tracked
             ):
                 raise WorkspaceError("selected resource input changed during staging")
+
+            def verify_resource_install() -> None:
+                published_inputs, published_cacheable = (
+                    self._runtime_input_coordinates(
+                        profile_name, selected, "resources"
+                    )
+                )
+                published_runtime_paths, published_tracked = (
+                    self._resource_runtime_files(source)
+                )
+                if (
+                    published_inputs != inputs
+                    or published_cacheable != cacheable
+                    or published_runtime_paths != runtime_paths
+                    or published_tracked != tracked
+                ):
+                    raise WorkspaceError(
+                        "selected resource input changed during staging"
+                    )
+
+            replace_directory(
+                output,
+                staging,
+                ".resources-previous-",
+                verify_resource_install,
+            )
         except BaseException:
-            shutil.rmtree(staging)
+            if staging.exists():
+                shutil.rmtree(staging)
             raise
-        replace_directory(output, staging, ".resources-previous-")
         print(f"resources: staged {output}")
         return output
 
@@ -2921,73 +2988,29 @@ class Workspace:
         atomic_json(path / MANAGED_MARKER, metadata)
         return path
 
-    def _take_topology_runtime_input(
-        self,
-        topology_root: Path,
-        source: Path,
-        name: str,
-        purpose: str,
-        preserve_source: bool = False,
-    ) -> Path:
-        expected = {"schema_version": SCHEMA_VERSION, "purpose": purpose}
-        marker = source / MANAGED_MARKER
-        if (
-            not source.is_dir()
-            or source.is_symlink()
-            or not marker.is_file()
-            or marker.is_symlink()
-            or load_json(marker) != expected
-        ):
-            raise WorkspaceError(
-                f"topology runtime input is not managed for {purpose}: {source}"
-            )
-        container = topology_root / "runtime"
-        if container.exists() or container.is_symlink():
-            if not container.is_dir() or container.is_symlink():
-                raise WorkspaceError(
-                    f"topology runtime container is invalid: {container}"
-                )
-        else:
-            container.mkdir()
-        destination = container / name
-        if destination.exists() or destination.is_symlink():
-            destination_marker = destination / MANAGED_MARKER
-            if (
-                not destination.is_dir()
-                or destination.is_symlink()
-                or not destination_marker.is_file()
-                or destination_marker.is_symlink()
-                or load_json(destination_marker) != expected
-            ):
-                raise WorkspaceError(
-                    f"topology runtime destination is not managed: {destination}"
-                )
-        if preserve_source:
-            staging = Path(
-                tempfile.mkdtemp(prefix=f".{name}-", dir=container)
-            )
-            staging.rmdir()
-            try:
-                shutil.copytree(source, staging)
-                staging_marker = staging / MANAGED_MARKER
-                if (
-                    not staging.is_dir()
-                    or staging.is_symlink()
-                    or not staging_marker.is_file()
-                    or staging_marker.is_symlink()
-                    or load_json(staging_marker) != expected
-                ):
+    @staticmethod
+    def _validate_topology_runtime_tree(path: Path) -> None:
+        for directory, dirnames, filenames in os.walk(path, followlinks=False):
+            directory_path = Path(directory)
+            for name in dirnames:
+                child = directory_path / name
+                if child.is_symlink():
                     raise WorkspaceError(
-                        f"copied topology runtime input is invalid: {staging}"
+                        f"topology runtime input contains a link: {child}"
                     )
-                replace_directory(destination, staging, f".{name}-previous-")
-            except BaseException:
-                if staging.exists():
-                    shutil.rmtree(staging)
-                raise
-        else:
-            replace_directory(destination, source, f".{name}-previous-")
-        return destination
+            for name in filenames:
+                child = directory_path / name
+                try:
+                    mode = child.lstat().st_mode
+                except OSError as error:
+                    raise WorkspaceError(
+                        f"cannot inspect topology runtime input {child}: {error}"
+                    ) from error
+                if not stat.S_ISREG(mode):
+                    raise WorkspaceError(
+                        "topology runtime input contains a non-regular file: "
+                        f"{child}"
+                    )
 
     def _copy_topology_runtime_inputs(
         self,
@@ -3036,8 +3059,9 @@ class Workspace:
                     raise WorkspaceError(
                         f"topology runtime input is not managed for {purpose}: {source}"
                     )
+                self._validate_topology_runtime_tree(source)
                 destination = staging / name
-                shutil.copytree(source, destination)
+                shutil.copytree(source, destination, symlinks=True)
                 copied_marker = destination / MANAGED_MARKER
                 if (
                     not destination.is_dir()
@@ -3049,6 +3073,7 @@ class Workspace:
                     raise WorkspaceError(
                         f"copied topology runtime input is invalid: {destination}"
                     )
+                self._validate_topology_runtime_tree(destination)
             replace_directory(container, staging, ".runtime-previous-")
         except BaseException:
             if staging.exists():

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -173,16 +173,20 @@ def replace_directory(
     }
     if backup_container.exists() or backup_container.is_symlink():
         marker = backup_container / MANAGED_MARKER
+        previous = backup_container / "previous"
         if (
             not backup_container.is_dir()
             or backup_container.is_symlink()
             or not marker.is_file()
             or marker.is_symlink()
             or load_json(marker) != backup_metadata
+            or (not output.exists() and (not previous.is_dir() or previous.is_symlink()))
         ):
             raise WorkspaceError(
                 f"replaced-directory backup is not managed: {backup_container}"
             )
+        if not output.exists():
+            previous.replace(output)
         try:
             shutil.rmtree(backup_container)
         except OSError as error:
@@ -3034,14 +3038,14 @@ class Workspace:
         self,
         source_fd: int,
         source_display: Path,
-        destination: Path,
+        destination_fd: int,
+        destination_display: Path,
     ) -> None:
         directory_before = os.fstat(source_fd)
         if not stat.S_ISDIR(directory_before.st_mode):
             raise WorkspaceError(
                 f"topology runtime input is not a directory: {source_display}"
             )
-        destination.mkdir(mode=stat.S_IMODE(directory_before.st_mode))
         try:
             names = sorted(os.listdir(source_fd))
         except OSError as error:
@@ -3050,7 +3054,7 @@ class Workspace:
             ) from error
         for name in names:
             source_child = source_display / name
-            destination_child = destination / name
+            destination_child = destination_display / name
             try:
                 child_before = os.stat(name, dir_fd=source_fd, follow_symlinks=False)
             except OSError as error:
@@ -3058,9 +3062,9 @@ class Workspace:
                     f"cannot inspect topology runtime input {source_child}: {error}"
                 ) from error
             if stat.S_ISDIR(child_before.st_mode):
-                flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+                source_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
                 try:
-                    child_fd = os.open(name, flags, dir_fd=source_fd)
+                    child_fd = os.open(name, source_flags, dir_fd=source_fd)
                 except OSError as error:
                     raise WorkspaceError(
                         "topology runtime input changed or contains a link: "
@@ -3073,9 +3077,31 @@ class Workspace:
                         raise WorkspaceError(
                             f"topology runtime input changed during copy: {source_child}"
                         )
-                    self._copy_topology_runtime_directory(
-                        child_fd, source_child, destination_child
-                    )
+                    try:
+                        os.mkdir(
+                            name,
+                            stat.S_IMODE(child_before.st_mode) | 0o700,
+                            dir_fd=destination_fd,
+                        )
+                        destination_child_fd = os.open(
+                            name,
+                            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                            dir_fd=destination_fd,
+                        )
+                    except OSError as error:
+                        raise WorkspaceError(
+                            "topology runtime staging destination changed during "
+                            f"copy: {destination_child}"
+                        ) from error
+                    try:
+                        self._copy_topology_runtime_directory(
+                            child_fd,
+                            source_child,
+                            destination_child_fd,
+                            destination_child,
+                        )
+                    finally:
+                        os.close(destination_child_fd)
                 finally:
                     os.close(child_fd)
             elif stat.S_ISREG(child_before.st_mode):
@@ -3097,15 +3123,22 @@ class Workspace:
                         raise WorkspaceError(
                             f"topology runtime input changed during copy: {source_child}"
                         )
-                    destination_fd = os.open(
-                        destination_child,
-                        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
-                        stat.S_IMODE(opened.st_mode),
-                    )
+                    try:
+                        destination_file_fd = os.open(
+                            name,
+                            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                            stat.S_IMODE(opened.st_mode),
+                            dir_fd=destination_fd,
+                        )
+                    except OSError as error:
+                        raise WorkspaceError(
+                            "topology runtime staging destination changed during "
+                            f"copy: {destination_child}"
+                        ) from error
                     try:
                         with os.fdopen(child_fd, "rb", closefd=False) as source_file:
                             with os.fdopen(
-                                destination_fd, "wb", closefd=False
+                                destination_file_fd, "wb", closefd=False
                             ) as destination_file:
                                 shutil.copyfileobj(source_file, destination_file)
                         copied = os.fstat(child_fd)
@@ -3116,14 +3149,17 @@ class Workspace:
                                 "topology runtime input changed during copy: "
                                 f"{source_child}"
                             )
-                        os.fchmod(destination_fd, stat.S_IMODE(opened.st_mode))
+                        os.fchmod(
+                            destination_file_fd, stat.S_IMODE(opened.st_mode)
+                        )
                     finally:
-                        os.close(destination_fd)
+                        os.close(destination_file_fd)
                 finally:
                     os.close(child_fd)
                 os.utime(
-                    destination_child,
+                    name,
                     ns=(opened.st_atime_ns, opened.st_mtime_ns),
+                    dir_fd=destination_fd,
                     follow_symlinks=False,
                 )
             else:
@@ -3138,11 +3174,10 @@ class Workspace:
             raise WorkspaceError(
                 f"topology runtime input changed during copy: {source_display}"
             )
-        destination.chmod(stat.S_IMODE(directory_before.st_mode))
+        os.fchmod(destination_fd, stat.S_IMODE(directory_before.st_mode))
         os.utime(
-            destination,
+            destination_fd,
             ns=(directory_before.st_atime_ns, directory_before.st_mtime_ns),
-            follow_symlinks=False,
         )
 
     def _copy_topology_runtime_tree(
@@ -3156,6 +3191,8 @@ class Workspace:
             raise WorkspaceError(
                 f"cannot open topology runtime input {source}: {error}"
             ) from error
+        destination_parent_fd: int | None = None
+        destination_fd: int | None = None
         try:
             if self._runtime_tree_identity(os.fstat(source_fd)) != (
                 self._runtime_tree_identity(source_before)
@@ -3163,7 +3200,45 @@ class Workspace:
                 raise WorkspaceError(
                     f"topology runtime input changed during copy: {source}"
                 )
-            self._copy_topology_runtime_directory(source_fd, source, destination)
+            destination_parent_before = destination.parent.stat(
+                follow_symlinks=False
+            )
+            destination_parent_fd = os.open(destination.parent, flags)
+            if self._runtime_tree_identity(os.fstat(destination_parent_fd)) != (
+                self._runtime_tree_identity(destination_parent_before)
+            ):
+                raise WorkspaceError(
+                    "topology runtime staging directory changed during copy: "
+                    f"{destination.parent}"
+                )
+            try:
+                os.mkdir(
+                    destination.name,
+                    stat.S_IMODE(source_before.st_mode) | 0o700,
+                    dir_fd=destination_parent_fd,
+                )
+                destination_fd = os.open(
+                    destination.name,
+                    flags,
+                    dir_fd=destination_parent_fd,
+                )
+            except OSError as error:
+                raise WorkspaceError(
+                    "topology runtime staging destination changed during copy: "
+                    f"{destination}"
+                ) from error
+            self._copy_topology_runtime_directory(
+                source_fd, source, destination_fd, destination
+            )
+            destination_parent_after = os.fstat(destination_parent_fd)
+            if (
+                destination_parent_after.st_dev != destination_parent_before.st_dev
+                or destination_parent_after.st_ino != destination_parent_before.st_ino
+            ):
+                raise WorkspaceError(
+                    "topology runtime staging directory changed during copy: "
+                    f"{destination.parent}"
+                )
             source_after = source.stat(follow_symlinks=False)
             if self._runtime_tree_identity(source_after) != (
                 self._runtime_tree_identity(source_before)
@@ -3172,6 +3247,10 @@ class Workspace:
                     f"topology runtime input changed during copy: {source}"
                 )
         finally:
+            if destination_fd is not None:
+                os.close(destination_fd)
+            if destination_parent_fd is not None:
+                os.close(destination_parent_fd)
             os.close(source_fd)
 
     def _copy_topology_runtime_inputs(

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -235,6 +235,106 @@ def _descriptor_mount_id(descriptor: int) -> int | tuple[int, int]:
         )
 
 
+def _linux_fchmod_path_descriptor(descriptor: int, mode: int) -> None:
+    library = ctypes.CDLL(None, use_errno=True)
+    syscall = library.syscall
+    syscall.restype = ctypes.c_long
+    # fchmodat2 is syscall 452 on the Linux generic and x86-64 tables.
+    if (
+        syscall(
+            ctypes.c_long(452),
+            ctypes.c_int(descriptor),
+            ctypes.c_char_p(b""),
+            ctypes.c_uint(mode),
+            ctypes.c_int(0x1000),  # AT_EMPTY_PATH
+        )
+        != 0
+    ):
+        error = ctypes.get_errno()
+        raise WorkspaceError(
+            "cannot change owned removal directory mode for descriptor "
+            f"{descriptor}: {os.strerror(error)}"
+        )
+
+
+def _open_owned_tree_directory(
+    parent_descriptor: int,
+    name: str,
+    before: os.stat_result,
+    mount_id: int | tuple[int, int],
+    display: Path,
+    *,
+    root: bool = False,
+) -> int:
+    flags = os.O_DIRECTORY | os.O_NOFOLLOW
+    if sys.platform == "linux":
+        flags |= os.O_PATH
+    else:
+        flags |= os.O_RDONLY
+    try:
+        bound_descriptor = os.open(
+            name, flags, dir_fd=parent_descriptor
+        )
+    except OSError as error:
+        label = "root" if root else "directory"
+        raise WorkspaceError(
+            f"owned removal {label} changed: {display}"
+        ) from error
+    changed_mode = False
+    try:
+        opened = os.fstat(bound_descriptor)
+        if (
+            opened.st_dev != before.st_dev
+            or opened.st_ino != before.st_ino
+            or _descriptor_mount_id(bound_descriptor) != mount_id
+        ):
+            message = (
+                f"owned removal root changed or is mounted: {display}"
+                if root
+                else f"owned removal encountered a mount: {display}"
+            )
+            raise WorkspaceError(message)
+        if sys.platform == "linux":
+            _linux_fchmod_path_descriptor(bound_descriptor, stat.S_IRWXU)
+            changed_mode = True
+            readable_descriptor = os.open(
+                ".",
+                os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                dir_fd=bound_descriptor,
+            )
+        else:
+            os.fchmod(bound_descriptor, stat.S_IRWXU)
+            changed_mode = True
+            readable_descriptor = bound_descriptor
+            bound_descriptor = -1
+        readable = os.fstat(readable_descriptor)
+        if (
+            readable.st_dev != before.st_dev
+            or readable.st_ino != before.st_ino
+            or _descriptor_mount_id(readable_descriptor) != mount_id
+        ):
+            os.close(readable_descriptor)
+            raise WorkspaceError(
+                f"owned removal encountered a mount: {display}"
+            )
+        return readable_descriptor
+    except BaseException:
+        if changed_mode and bound_descriptor >= 0:
+            try:
+                _linux_fchmod_path_descriptor(
+                    bound_descriptor, stat.S_IMODE(before.st_mode)
+                )
+            except WorkspaceError as restore_error:
+                raise WorkspaceError(
+                    "cannot restore owned removal directory mode after "
+                    f"open failure: {display}"
+                ) from restore_error
+        raise
+    finally:
+        if bound_descriptor >= 0:
+            os.close(bound_descriptor)
+
+
 def _probe_owned_tree_entry_mount(
     descriptor: int,
     name: str,
@@ -272,6 +372,7 @@ def _prepare_owned_tree_removal(
     device: int,
     mount_id: int | tuple[int, int],
     display: Path,
+    original_mode: int | None = None,
 ) -> None:
     root = os.fstat(descriptor)
     if (
@@ -280,48 +381,39 @@ def _prepare_owned_tree_removal(
         or _descriptor_mount_id(descriptor) != mount_id
     ):
         raise WorkspaceError(f"owned removal crossed a filesystem boundary: {display}")
-    original_mode = stat.S_IMODE(root.st_mode)
+    restore_mode = (
+        stat.S_IMODE(root.st_mode) if original_mode is None else original_mode
+    )
     os.fchmod(descriptor, stat.S_IRWXU)
     try:
         for name in sorted(os.listdir(descriptor)):
             child_display = display / name
             child = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
-            _probe_owned_tree_entry_mount(
-                descriptor, name, child, mount_id, child_display
-            )
             if child.st_dev != device:
                 raise WorkspaceError(
                     f"owned removal encountered a mount: {child_display}"
                 )
             if stat.S_ISDIR(child.st_mode):
+                child_descriptor = _open_owned_tree_directory(
+                    descriptor, name, child, mount_id, child_display
+                )
                 try:
-                    child_descriptor = os.open(
-                        name,
-                        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
-                        dir_fd=descriptor,
-                    )
-                except OSError as error:
-                    raise WorkspaceError(
-                        f"owned removal directory changed: {child_display}"
-                    ) from error
-                try:
-                    opened = os.fstat(child_descriptor)
-                    if (
-                        opened.st_dev != child.st_dev
-                        or opened.st_ino != child.st_ino
-                        or _descriptor_mount_id(child_descriptor) != mount_id
-                    ):
-                        raise WorkspaceError(
-                            f"owned removal encountered a mount: {child_display}"
-                        )
                     _prepare_owned_tree_removal(
-                        child_descriptor, device, mount_id, child_display
+                        child_descriptor,
+                        device,
+                        mount_id,
+                        child_display,
+                        stat.S_IMODE(child.st_mode),
                     )
                 finally:
                     os.close(child_descriptor)
+            else:
+                _probe_owned_tree_entry_mount(
+                    descriptor, name, child, mount_id, child_display
+                )
     finally:
         try:
-            os.fchmod(descriptor, original_mode)
+            os.fchmod(descriptor, restore_mode)
         except OSError as restore_error:
             raise WorkspaceError(
                 f"cannot restore owned removal directory mode: {display}"
@@ -337,35 +429,15 @@ def _remove_owned_tree_contents(
     for name in sorted(os.listdir(descriptor)):
         child_display = display / name
         child = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
-        _probe_owned_tree_entry_mount(
-            descriptor, name, child, mount_id, child_display
-        )
         if child.st_dev != device:
             raise WorkspaceError(
                 f"owned removal encountered a mount: {child_display}"
             )
         if stat.S_ISDIR(child.st_mode):
+            child_descriptor = _open_owned_tree_directory(
+                descriptor, name, child, mount_id, child_display
+            )
             try:
-                child_descriptor = os.open(
-                    name,
-                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
-                    dir_fd=descriptor,
-                )
-            except OSError as error:
-                raise WorkspaceError(
-                    f"owned removal directory changed: {child_display}"
-                ) from error
-            try:
-                opened = os.fstat(child_descriptor)
-                if (
-                    opened.st_dev != child.st_dev
-                    or opened.st_ino != child.st_ino
-                    or _descriptor_mount_id(child_descriptor) != mount_id
-                ):
-                    raise WorkspaceError(
-                        f"owned removal encountered a mount: {child_display}"
-                    )
-                os.fchmod(child_descriptor, stat.S_IRWXU)
                 _remove_owned_tree_contents(
                     child_descriptor, device, mount_id, child_display
                 )
@@ -373,6 +445,9 @@ def _remove_owned_tree_contents(
                 os.close(child_descriptor)
             os.rmdir(name, dir_fd=descriptor)
         else:
+            _probe_owned_tree_entry_mount(
+                descriptor, name, child, mount_id, child_display
+            )
             os.unlink(name, dir_fd=descriptor)
 
 
@@ -386,21 +461,22 @@ def remove_owned_tree(path: Path) -> None:
     try:
         before = os.stat(path.name, dir_fd=parent_descriptor, follow_symlinks=False)
         parent_mount_id = _descriptor_mount_id(parent_descriptor)
-        descriptor = os.open(
+        descriptor = _open_owned_tree_directory(
+            parent_descriptor,
             path.name,
-            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
-            dir_fd=parent_descriptor,
+            before,
+            parent_mount_id,
+            path,
+            root=True,
         )
         opened = os.fstat(descriptor)
         root_mount_id = _descriptor_mount_id(descriptor)
-        if (
-            opened.st_dev != before.st_dev
-            or opened.st_ino != before.st_ino
-            or root_mount_id != parent_mount_id
-        ):
-            raise WorkspaceError(f"owned removal root changed or is mounted: {path}")
         _prepare_owned_tree_removal(
-            descriptor, opened.st_dev, root_mount_id, path
+            descriptor,
+            opened.st_dev,
+            root_mount_id,
+            path,
+            stat.S_IMODE(before.st_mode),
         )
         os.fchmod(descriptor, stat.S_IRWXU)
         _remove_owned_tree_contents(

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -21,7 +21,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from typing import Any, Iterator, TextIO
+from typing import Any, Callable, Iterator, TextIO
 
 from .launch_identity import CLIENT_LAUNCH_LABEL_ENV, client_launch_label
 
@@ -97,6 +97,8 @@ SCENARIO_PASSWORD_MAX_SIZE = 128
 BUILD_METADATA = ".atrinik-build.json"
 BUILD_METADATA_SCHEMA_VERSION = 1
 CACHE_METADATA = ".atrinik-cache.json"
+RUNTIME_INPUT_METADATA = ".atrinik-dependency.json"
+RUNTIME_INPUT_SCHEMA_VERSION = 1
 REGION_MAP_METADATA = ".atrinik-region-maps.json"
 REGION_MAP_SCHEMA_VERSION = 1
 EXPECTED_REGION_MAP = "incuna_-1"
@@ -1384,9 +1386,9 @@ class Workspace:
             managed_directory(root, self.paths.builds, f"profile:{profile_name}:{key}")
             self._refresh_build_metadata(root, profile_name, key, selected)
             if "content" in targets or "server" in targets:
-                self._collect_content(root, selected)
+                self._collect_content(root, selected, profile_name)
             if "server" in targets:
-                self._stage_resources(root, selected)
+                self._stage_resources(root, selected, profile_name)
             if "protocol" in targets:
                 self._build_protocol(root, selected, tests)
             if "libatrinik" in targets:
@@ -1548,55 +1550,213 @@ class Workspace:
                 destination.symlink_to(entry, target_is_directory=entry.is_dir())
         return view
 
-    def _collect_content(self, root: Path, selected: dict[str, Path]) -> Path:
-        output = root / "runtime" / "content"
-        output.parent.mkdir(parents=True, exist_ok=True)
-        if output.exists():
-            managed_directory(output, self.paths.builds, "collected-content")
-        staging = Path(tempfile.mkdtemp(prefix=".content-", dir=output.parent))
-        staging.rmdir()
-        source = selected["content"]
-        commit = git(source, "rev-parse", "HEAD", capture=True)
-        try:
-            run(
-                [
-                    sys.executable,
-                    str(source / "tools" / "build_runtime.py"),
-                    "--source",
-                    str(source),
-                    "--output",
-                    str(staging),
-                    "--source-commit",
-                    commit,
-                ]
-            )
-            atomic_json(
-                staging / MANAGED_MARKER,
-                {"schema_version": SCHEMA_VERSION, "purpose": "collected-content"},
-            )
-            atomic_json(
-                staging / ".atrinik-dependency.json",
-                {
-                    "schema_version": SCHEMA_VERSION,
-                    "workspace_source": str(source),
-                    "commit": commit,
-                },
-            )
-            if not (staging / "lib").is_dir() or not (staging / "maps").is_dir():
-                raise WorkspaceError("content collection did not produce lib and maps")
-        except BaseException:
-            if staging.exists():
-                shutil.rmtree(staging)
-            raise
-        replace_directory(output, staging, ".content-previous-")
-        return output
+    def _runtime_input_coordinates(
+        self,
+        profile_name: str,
+        selected: dict[str, Path],
+        role: str,
+    ) -> tuple[dict[str, Any], bool]:
+        profile = self._load_profile(profile_name, require_file=False)
+        component = self.manifest.stack(profile["stack"]).providers[role]
+        checkout = self._selector_root(profile, component).resolve()
+        clean = _is_clean(checkout, trace=False)
+        coordinate = {
+            "component": component.name,
+            "repository": component.repository,
+            "branch": component.branch,
+            "checkout": component.checkout_name,
+            "source": component.source,
+            "checkout_path": str(checkout),
+            "source_path": str(selected[role].resolve()),
+            "head": git(
+                checkout,
+                "rev-parse",
+                "HEAD",
+                capture=True,
+                trace=False,
+            ),
+        }
+        return (
+            {
+                "schema_version": RUNTIME_INPUT_SCHEMA_VERSION,
+                "cacheable": clean,
+                "coordinate": coordinate,
+            },
+            clean,
+        )
 
-    def _stage_resources(self, root: Path, selected: dict[str, Path]) -> Path:
-        output = root / "runtime" / "resources"
-        source = selected["resources"]
-        output.parent.mkdir(parents=True, exist_ok=True)
-        if output.exists() or output.is_symlink():
-            managed_directory(output, self.paths.builds, "resource-view")
+    @staticmethod
+    def _validate_collected_content(
+        path: Path,
+        coordinate: dict[str, str],
+        *,
+        require_metadata: bool = True,
+    ) -> None:
+        if not path.is_dir() or path.is_symlink():
+            raise WorkspaceError(f"collected content is not a directory: {path}")
+        for name in ("lib", "maps"):
+            required = path / name
+            if not required.is_dir() or required.is_symlink():
+                raise WorkspaceError(
+                    f"collected content lacks required directory: {required}"
+                )
+        for name in ("compatibility.json", "manifest.json"):
+            required = path / name
+            if not required.is_file() or required.is_symlink():
+                raise WorkspaceError(
+                    f"collected content lacks required file: {required}"
+                )
+        manifest = load_json(path / "manifest.json")
+        if (
+            not isinstance(manifest, dict)
+            or manifest.get("schema_version") != 2
+            or manifest.get("source")
+            != {
+                "repository": coordinate["repository"],
+                "branch": coordinate["branch"],
+                "commit": coordinate["head"],
+            }
+            or not isinstance(manifest.get("files"), list)
+        ):
+            raise WorkspaceError("collected content manifest is invalid")
+        expected = {MANAGED_MARKER, "manifest.json"}
+        if require_metadata:
+            expected.add(RUNTIME_INPUT_METADATA)
+        for entry in manifest["files"]:
+            if not isinstance(entry, dict) or set(entry) != {"path", "sha256", "size"}:
+                raise WorkspaceError("collected content manifest file entry is invalid")
+            relative = entry["path"]
+            relative_path = PurePosixPath(relative) if isinstance(relative, str) else None
+            if (
+                relative_path is None
+                or relative_path.is_absolute()
+                or relative != relative_path.as_posix()
+                or any(part in {"", ".", ".."} for part in relative_path.parts)
+                or relative in expected
+                or not isinstance(entry["size"], int)
+                or isinstance(entry["size"], bool)
+                or entry["size"] < 0
+                or not isinstance(entry["sha256"], str)
+                or re.fullmatch(r"[0-9a-f]{64}", entry["sha256"]) is None
+            ):
+                raise WorkspaceError("collected content manifest file entry is invalid")
+            expected.add(relative)
+        actual: set[str] = set()
+        for directory, dirnames, filenames in os.walk(path, followlinks=False):
+            directory_path = Path(directory)
+            for name in dirnames:
+                child = directory_path / name
+                if child.is_symlink():
+                    raise WorkspaceError(f"collected content contains a link: {child}")
+            for name in filenames:
+                child = directory_path / name
+                try:
+                    mode = child.lstat().st_mode
+                except OSError as error:
+                    raise WorkspaceError(
+                        f"cannot inspect collected content {child}: {error}"
+                    ) from error
+                if not stat.S_ISREG(mode):
+                    raise WorkspaceError(
+                        f"collected content contains a non-regular file: {child}"
+                    )
+                relative = child.relative_to(path).as_posix()
+                actual.add(relative)
+        if actual != expected:
+            raise WorkspaceError("collected content does not match its manifest")
+        entries = {entry["path"]: entry for entry in manifest["files"]}
+        for relative, entry in entries.items():
+            candidate = path.joinpath(*PurePosixPath(relative).parts)
+            digest = hashlib.sha256()
+            descriptor = open_regular_file(
+                candidate, os.O_RDONLY, "collected content file"
+            )
+            with os.fdopen(descriptor, "rb") as stream:
+                if os.fstat(stream.fileno()).st_size != entry["size"]:
+                    raise WorkspaceError(
+                        "collected content file size does not match manifest"
+                    )
+                while chunk := stream.read(1024 * 1024):
+                    digest.update(chunk)
+            if digest.hexdigest() != entry["sha256"]:
+                raise WorkspaceError(
+                    "collected content file digest does not match manifest"
+                )
+
+    @staticmethod
+    def _validate_resource_view(
+        path: Path, tracked: list[str], *, require_metadata: bool = True
+    ) -> None:
+        if not path.is_dir() or path.is_symlink():
+            raise WorkspaceError(f"resource view is not a directory: {path}")
+        expected = {MANAGED_MARKER, *tracked}
+        if require_metadata:
+            expected.add(RUNTIME_INPUT_METADATA)
+        actual: set[str] = set()
+        actual_directories: set[str] = set()
+        for directory, dirnames, filenames in os.walk(path, followlinks=False):
+            directory_path = Path(directory)
+            for name in dirnames:
+                child = directory_path / name
+                if child.is_symlink():
+                    raise WorkspaceError(f"resource view contains a link: {child}")
+                actual_directories.add(child.relative_to(path).as_posix())
+            for name in filenames:
+                child = directory_path / name
+                try:
+                    mode = child.lstat().st_mode
+                except OSError as error:
+                    raise WorkspaceError(
+                        f"cannot inspect staged resource {child}: {error}"
+                    ) from error
+                if not stat.S_ISREG(mode):
+                    raise WorkspaceError(
+                        f"resource view contains a non-regular file: {child}"
+                    )
+                actual.add(child.relative_to(path).as_posix())
+        if actual != expected:
+            raise WorkspaceError("resource view does not match its tracked file set")
+        expected_directories = {
+            parent.as_posix()
+            for relative in tracked
+            for parent in PurePosixPath(relative).parents
+            if parent != PurePosixPath(".")
+        }
+        if actual_directories != expected_directories:
+            raise WorkspaceError("resource view does not match its tracked directories")
+
+    def _runtime_input_cache_matches(
+        self,
+        output: Path,
+        purpose: str,
+        inputs: dict[str, Any],
+        cacheable: bool,
+        validate: Callable[[Path], None],
+    ) -> bool:
+        if not cacheable or not output.is_dir() or output.is_symlink():
+            return False
+        marker = output / MANAGED_MARKER
+        metadata = output / RUNTIME_INPUT_METADATA
+        if (
+            not marker.is_file()
+            or marker.is_symlink()
+            or not metadata.is_file()
+            or metadata.is_symlink()
+        ):
+            return False
+        try:
+            if load_json(marker) != {
+                "schema_version": SCHEMA_VERSION,
+                "purpose": purpose,
+            } or load_json(metadata) != inputs:
+                return False
+            validate(output)
+        except WorkspaceError:
+            return False
+        return True
+
+    @staticmethod
+    def _resource_runtime_files(source: Path) -> tuple[list[str], list[str]]:
         manifest = source / RESOURCE_PATHS_MANIFEST
         try:
             lines = manifest.read_text(encoding="utf-8").splitlines()
@@ -1642,7 +1802,9 @@ class Workspace:
         except subprocess.CalledProcessError as error:
             detail = error.stderr.decode("utf-8", errors="replace").strip()
             suffix = f": {detail}" if detail else ""
-            raise WorkspaceError(f"cannot list tracked runtime resources{suffix}") from error
+            raise WorkspaceError(
+                f"cannot list tracked runtime resources{suffix}"
+            ) from error
 
         try:
             tracked = [
@@ -1651,11 +1813,126 @@ class Workspace:
                 if item
             ]
         except UnicodeDecodeError as error:
-            raise WorkspaceError("runtime resource paths must use UTF-8 names") from error
+            raise WorkspaceError(
+                "runtime resource paths must use UTF-8 names"
+            ) from error
         if not tracked:
             raise WorkspaceError(
                 f"resource runtime manifest selects no tracked files: {manifest}"
             )
+        return runtime_paths, tracked
+
+    def _collect_content(
+        self,
+        root: Path,
+        selected: dict[str, Path],
+        profile_name: str = "default",
+    ) -> Path:
+        output = root / "runtime" / "content"
+        output.parent.mkdir(parents=True, exist_ok=True)
+        inputs, cacheable = self._runtime_input_coordinates(
+            profile_name, selected, "content"
+        )
+        matched = self._runtime_input_cache_matches(
+            output,
+            "collected-content",
+            inputs,
+            cacheable,
+            lambda path: self._validate_collected_content(
+                path, inputs["coordinate"]
+            ),
+        )
+        validated_inputs, validated_cacheable = self._runtime_input_coordinates(
+            profile_name, selected, "content"
+        )
+        if matched and (
+            validated_inputs == inputs
+            and validated_cacheable == cacheable
+            and validated_cacheable
+        ):
+            print(f"content: cached {output}")
+            return output
+        inputs, cacheable = validated_inputs, validated_cacheable
+        if output.exists() or output.is_symlink():
+            managed_directory(output, self.paths.builds, "collected-content")
+        staging = Path(tempfile.mkdtemp(prefix=".content-", dir=output.parent))
+        staging.rmdir()
+        source = selected["content"]
+        commit = inputs["coordinate"]["head"]
+        try:
+            run(
+                [
+                    sys.executable,
+                    str(source / "tools" / "build_runtime.py"),
+                    "--source",
+                    str(source),
+                    "--output",
+                    str(staging),
+                    "--source-commit",
+                    commit,
+                ]
+            )
+            atomic_json(
+                staging / MANAGED_MARKER,
+                {"schema_version": SCHEMA_VERSION, "purpose": "collected-content"},
+            )
+            self._validate_collected_content(
+                staging, inputs["coordinate"], require_metadata=False
+            )
+            final_inputs, final_cacheable = self._runtime_input_coordinates(
+                profile_name, selected, "content"
+            )
+            if final_inputs != inputs or final_cacheable != cacheable:
+                raise WorkspaceError("selected content input changed during collection")
+            if cacheable:
+                atomic_json(staging / RUNTIME_INPUT_METADATA, inputs)
+        except BaseException:
+            if staging.exists():
+                shutil.rmtree(staging)
+            raise
+        replace_directory(output, staging, ".content-previous-")
+        print(f"content: collected {output}")
+        return output
+
+    def _stage_resources(
+        self,
+        root: Path,
+        selected: dict[str, Path],
+        profile_name: str = "default",
+    ) -> Path:
+        output = root / "runtime" / "resources"
+        source = selected["resources"]
+        output.parent.mkdir(parents=True, exist_ok=True)
+        if output.exists() or output.is_symlink():
+            managed_directory(output, self.paths.builds, "resource-view")
+        inputs, cacheable = self._runtime_input_coordinates(
+            profile_name, selected, "resources"
+        )
+        runtime_paths, tracked = self._resource_runtime_files(source)
+        matched = self._runtime_input_cache_matches(
+            output,
+            "resource-view",
+            inputs,
+            cacheable,
+            lambda path: self._validate_resource_view(path, tracked),
+        )
+        validated_inputs, validated_cacheable = self._runtime_input_coordinates(
+            profile_name, selected, "resources"
+        )
+        validated_runtime_paths, validated_tracked = self._resource_runtime_files(
+            source
+        )
+        if matched and (
+            validated_inputs == inputs
+            and validated_cacheable == cacheable
+            and validated_cacheable
+            and validated_runtime_paths == runtime_paths
+            and validated_tracked == tracked
+        ):
+            print(f"resources: cached {output}")
+            return output
+        inputs, cacheable = validated_inputs, validated_cacheable
+        runtime_paths, tracked = validated_runtime_paths, validated_tracked
         staging = Path(tempfile.mkdtemp(prefix=".resources-", dir=output.parent))
         selected_roots = tuple(PurePosixPath(path) for path in runtime_paths)
         try:
@@ -1684,18 +1961,27 @@ class Workspace:
                 destination = staging.joinpath(*path.parts)
                 destination.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(source_path, destination, follow_symlinks=False)
-            atomic_json(
-                staging / ".atrinik-dependency.json",
-                {
-                    "schema_version": SCHEMA_VERSION,
-                    "workspace_source": str(source),
-                    "commit": git(source, "rev-parse", "HEAD", capture=True),
-                },
+            final_inputs, final_cacheable = self._runtime_input_coordinates(
+                profile_name, selected, "resources"
+            )
+            final_runtime_paths, final_tracked = self._resource_runtime_files(source)
+            if (
+                final_inputs != inputs
+                or final_cacheable != cacheable
+                or final_runtime_paths != runtime_paths
+                or final_tracked != tracked
+            ):
+                raise WorkspaceError("selected resource input changed during staging")
+            if cacheable:
+                atomic_json(staging / RUNTIME_INPUT_METADATA, inputs)
+            self._validate_resource_view(
+                staging, tracked, require_metadata=cacheable
             )
         except BaseException:
             shutil.rmtree(staging)
             raise
         replace_directory(output, staging, ".resources-previous-")
+        print(f"resources: staged {output}")
         return output
 
     def _cmake(
@@ -2635,11 +2921,31 @@ class Workspace:
                 raise WorkspaceError(
                     f"topology runtime destination is not managed: {destination}"
                 )
-            shutil.rmtree(destination)
         if preserve_source:
-            shutil.copytree(source, destination)
+            staging = Path(
+                tempfile.mkdtemp(prefix=f".{name}-", dir=container)
+            )
+            staging.rmdir()
+            try:
+                shutil.copytree(source, staging)
+                staging_marker = staging / MANAGED_MARKER
+                if (
+                    not staging.is_dir()
+                    or staging.is_symlink()
+                    or not staging_marker.is_file()
+                    or staging_marker.is_symlink()
+                    or load_json(staging_marker) != expected
+                ):
+                    raise WorkspaceError(
+                        f"copied topology runtime input is invalid: {staging}"
+                    )
+                replace_directory(destination, staging, f".{name}-previous-")
+            except BaseException:
+                if staging.exists():
+                    shutil.rmtree(staging)
+                raise
         else:
-            source.replace(destination)
+            replace_directory(destination, source, f".{name}-previous-")
         return destination
 
     def _prepare_topology_client_runtime(
@@ -3097,12 +3403,14 @@ class Workspace:
                         root / "runtime" / "content",
                         "content",
                         "collected-content",
+                        preserve_source=True,
                     )
                     resources = self._take_topology_runtime_input(
                         topology_root,
                         root / "runtime" / "resources",
                         "resources",
                         "resource-view",
+                        preserve_source=True,
                     )
                     client_maps = self._take_topology_runtime_input(
                         topology_root,

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -4,6 +4,7 @@ import binascii
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import ExitStack, contextmanager
+import ctypes
 from datetime import datetime, timezone
 import fcntl
 import hashlib
@@ -159,27 +160,109 @@ def git(
     return run(["git", "-C", str(path), *arguments], capture=capture, trace=trace)
 
 
-def _descriptor_mount_id(descriptor: int) -> int:
-    if sys.platform != "linux":
-        return os.fstat(descriptor).st_dev
+def _darwin_descriptor_mount_id(descriptor: int) -> tuple[int, int]:
+    buffer = ctypes.create_string_buffer(4096)
+    library = ctypes.CDLL(None, use_errno=True)
+    fstatfs = library.fstatfs
+    fstatfs.argtypes = [ctypes.c_int, ctypes.c_void_p]
+    fstatfs.restype = ctypes.c_int
+    if fstatfs(descriptor, ctypes.byref(buffer)) != 0:
+        error = ctypes.get_errno()
+        raise WorkspaceError(
+            "cannot inspect filesystem mount for descriptor "
+            f"{descriptor}: {os.strerror(error)}"
+        )
+    # Darwin's fsid_t is two signed 32-bit integers at byte offset 48 in
+    # struct statfs, after the size and block/file count fields.
+    first = ctypes.c_int32.from_buffer(buffer, 48).value
+    second = ctypes.c_int32.from_buffer(buffer, 52).value
+    return first, second
+
+
+def _linux_descriptor_mount_id(descriptor: int) -> int:
+    buffer = ctypes.create_string_buffer(256)
+    library = ctypes.CDLL(None, use_errno=True)
     try:
-        metadata = Path(f"/proc/self/fdinfo/{descriptor}").read_text(
-            encoding="ascii"
+        statx = library.statx
+    except AttributeError as error:
+        raise WorkspaceError("Linux statx mount identity is unavailable") from error
+    statx.argtypes = [
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_uint,
+        ctypes.c_void_p,
+    ]
+    statx.restype = ctypes.c_int
+    statx_mount_id = 0x1000
+    at_empty_path = 0x1000
+    if (
+        statx(
+            descriptor,
+            b"",
+            at_empty_path,
+            statx_mount_id,
+            ctypes.byref(buffer),
         )
-    except (OSError, UnicodeError) as error:
+        != 0
+    ):
+        error = ctypes.get_errno()
         raise WorkspaceError(
-            f"cannot inspect filesystem mount for descriptor {descriptor}: {error}"
-        ) from error
-    match = re.search(r"^mnt_id:\s+(\d+)$", metadata, re.MULTILINE)
-    if match is None:
-        raise WorkspaceError(
-            f"filesystem mount identity is unavailable for descriptor {descriptor}"
+            "cannot inspect filesystem mount for descriptor "
+            f"{descriptor}: {os.strerror(error)}"
         )
-    return int(match.group(1))
+    returned_mask = ctypes.c_uint32.from_buffer(buffer, 0).value
+    if returned_mask & statx_mount_id == 0:
+        raise WorkspaceError("Linux statx did not return a mount identity")
+    return ctypes.c_uint64.from_buffer(buffer, 144).value
+
+
+def _descriptor_mount_id(descriptor: int) -> int | tuple[int, int]:
+    if sys.platform == "darwin":
+        return _darwin_descriptor_mount_id(descriptor)
+    if sys.platform == "linux":
+        return _linux_descriptor_mount_id(descriptor)
+    else:
+        raise WorkspaceError(
+            f"filesystem mount identity is unavailable on {sys.platform}"
+        )
+
+
+def _probe_owned_tree_entry_mount(
+    descriptor: int,
+    name: str,
+    child: os.stat_result,
+    mount_id: int | tuple[int, int],
+    display: Path,
+) -> None:
+    if stat.S_ISLNK(child.st_mode):
+        return
+    flags = os.O_NOFOLLOW
+    if sys.platform == "linux":
+        flags |= os.O_PATH
+    else:
+        flags |= os.O_RDONLY
+    try:
+        probe = os.open(name, flags, dir_fd=descriptor)
+    except OSError as error:
+        raise WorkspaceError(f"owned removal entry changed: {display}") from error
+    try:
+        opened = os.fstat(probe)
+        if (
+            opened.st_dev != child.st_dev
+            or opened.st_ino != child.st_ino
+            or _descriptor_mount_id(probe) != mount_id
+        ):
+            raise WorkspaceError(f"owned removal encountered a mount: {display}")
+    finally:
+        os.close(probe)
 
 
 def _prepare_owned_tree_removal(
-    descriptor: int, device: int, mount_id: int, display: Path
+    descriptor: int,
+    device: int,
+    mount_id: int | tuple[int, int],
+    display: Path,
 ) -> None:
     root = os.fstat(descriptor)
     if (
@@ -192,6 +275,9 @@ def _prepare_owned_tree_removal(
     for name in sorted(os.listdir(descriptor)):
         child_display = display / name
         child = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
+        _probe_owned_tree_entry_mount(
+            descriptor, name, child, mount_id, child_display
+        )
         if child.st_dev != device:
             raise WorkspaceError(
                 f"owned removal encountered a mount: {child_display}"
@@ -226,11 +312,17 @@ def _prepare_owned_tree_removal(
 
 
 def _remove_owned_tree_contents(
-    descriptor: int, device: int, mount_id: int, display: Path
+    descriptor: int,
+    device: int,
+    mount_id: int | tuple[int, int],
+    display: Path,
 ) -> None:
     for name in sorted(os.listdir(descriptor)):
         child_display = display / name
         child = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
+        _probe_owned_tree_entry_mount(
+            descriptor, name, child, mount_id, child_display
+        )
         if child.st_dev != device:
             raise WorkspaceError(
                 f"owned removal encountered a mount: {child_display}"
@@ -305,91 +397,88 @@ def remove_owned_tree(path: Path) -> None:
         os.close(parent_descriptor)
 
 
-def _create_replaced_directory_backup(
-    backup_container: Path, backup_metadata: dict[str, object], backup_prefix: str
-) -> None:
-    prepared = Path(
-        tempfile.mkdtemp(
-            prefix=f"{backup_prefix}prepared-", dir=backup_container.parent
-        )
-    )
-    marker = prepared / MANAGED_MARKER
-    try:
-        atomic_json(marker, backup_metadata)
-        prepared.replace(backup_container)
-    except BaseException:
-        if marker.is_file() and not marker.is_symlink():
-            remove_owned_tree(prepared)
-        else:
-            prepared.rmdir()
-        raise
-
-
-def _retire_replaced_directory_backup(
-    backup_container: Path, backup_prefix: str
-) -> None:
-    retired = backup_container.parent / (
-        f"{backup_prefix}retired-{secrets.token_hex(8)}"
-    )
-    try:
-        backup_container.replace(retired)
-    except OSError as error:
-        print(
-            "warning: cannot retire managed replaced-directory backup "
-            f"{backup_container}: {error}; the next replacement will retry",
-            file=sys.stderr,
-        )
-        return
-    try:
-        remove_owned_tree(retired)
-    except (OSError, WorkspaceError) as error:
-        print(
-            "warning: cannot remove retired managed replaced-directory backup "
-            f"{retired}: {error}; profile cleanup will retain or reclaim it",
-            file=sys.stderr,
-        )
-
-
 def recover_replaced_directory(output: Path, backup_prefix: str) -> None:
     backup_container = output.parent / f"{backup_prefix}pending"
-    backup_metadata = {
+    journal = output.parent / f"{backup_prefix}pending.json"
+    expected_metadata = {
         "schema_version": SCHEMA_VERSION,
         "purpose": "replaced-directory-backup",
         "output": output.name,
     }
-    if backup_container.exists() or backup_container.is_symlink():
-        marker = backup_container / MANAGED_MARKER
-        previous = backup_container / "previous"
-        if (
-            not backup_container.is_dir()
-            or backup_container.is_symlink()
-            or not marker.is_file()
-            or marker.is_symlink()
-            or load_json(marker) != backup_metadata
-            or (
-                not output.exists()
-                and (not previous.is_dir() or previous.is_symlink())
-            )
-        ):
+    if not (journal.exists() or journal.is_symlink()):
+        if backup_container.exists() or backup_container.is_symlink():
             raise WorkspaceError(
                 f"replaced-directory backup is not managed: {backup_container}"
             )
-        if not output.exists():
-            previous.replace(output)
-        try:
+        return
+    if not journal.is_file() or journal.is_symlink():
+        raise WorkspaceError(f"replaced-directory journal is invalid: {journal}")
+    metadata = load_json(journal)
+    if not isinstance(metadata, dict):
+        raise WorkspaceError(f"replaced-directory journal is invalid: {journal}")
+    phase = metadata.pop("phase", None)
+    if metadata != expected_metadata or phase not in {"initializing", "prepared", "committed"}:
+        raise WorkspaceError(f"replaced-directory journal is invalid: {journal}")
+    previous = backup_container / "previous"
+    try:
+        if phase == "initializing":
+            if backup_container.exists() or backup_container.is_symlink():
+                if (
+                    not backup_container.is_dir()
+                    or backup_container.is_symlink()
+                    or any(backup_container.iterdir())
+                ):
+                    raise WorkspaceError(
+                        f"replaced-directory backup is invalid: {backup_container}"
+                    )
+                remove_owned_tree(backup_container)
+        else:
+            if not backup_container.is_dir() or backup_container.is_symlink():
+                if phase == "committed" and output.is_dir() and not output.is_symlink():
+                    journal.unlink()
+                    return
+                raise WorkspaceError(
+                    f"replaced-directory backup is invalid: {backup_container}"
+                )
             if previous.exists() or previous.is_symlink():
                 if not previous.is_dir() or previous.is_symlink():
                     raise WorkspaceError(
                         "replaced-directory backup payload is invalid: "
                         f"{previous}"
                     )
-                remove_owned_tree(previous)
-            _retire_replaced_directory_backup(backup_container, backup_prefix)
-        except OSError as error:
-            raise WorkspaceError(
-                f"cannot reclaim replaced-directory backup {backup_container}: "
-                f"{error}"
-            ) from error
+                if phase == "prepared":
+                    if output.exists() or output.is_symlink():
+                        if not output.is_dir() or output.is_symlink():
+                            raise WorkspaceError(
+                                f"uncommitted replacement is invalid: {output}"
+                            )
+                        remove_owned_tree(output)
+                    previous.replace(output)
+                else:
+                    if not output.is_dir() or output.is_symlink():
+                        raise WorkspaceError(
+                            f"committed replacement is invalid: {output}"
+                        )
+                    remove_owned_tree(previous)
+            elif phase == "committed":
+                if not output.is_dir() or output.is_symlink():
+                    raise WorkspaceError(
+                        f"committed replacement is invalid: {output}"
+                    )
+            elif not output.is_dir() or output.is_symlink():
+                raise WorkspaceError(
+                    f"uncommitted replacement is invalid: {output}"
+                )
+            if any(backup_container.iterdir()):
+                raise WorkspaceError(
+                    f"replaced-directory backup is not empty: {backup_container}"
+                )
+            remove_owned_tree(backup_container)
+        journal.unlink()
+    except OSError as error:
+        raise WorkspaceError(
+            f"cannot recover replaced-directory transaction {journal}: {error}"
+        ) from error
 
 
 def replace_runtime_directory(
@@ -400,24 +489,28 @@ def replace_runtime_directory(
 ) -> None:
     recover_replaced_directory(output, backup_prefix)
     backup_container = output.parent / f"{backup_prefix}pending"
-    backup_metadata = {
+    journal = output.parent / f"{backup_prefix}pending.json"
+    backup_metadata: dict[str, object] = {
         "schema_version": SCHEMA_VERSION,
         "purpose": "replaced-directory-backup",
         "output": output.name,
+        "phase": "initializing",
     }
 
     backup: Path | None = None
     if output.exists():
-        _create_replaced_directory_backup(
-            backup_container, backup_metadata, backup_prefix
-        )
+        atomic_json(journal, backup_metadata)
+        backup_container.mkdir()
+        backup_metadata["phase"] = "prepared"
+        atomic_json(journal, backup_metadata)
         backup = backup_container / "previous"
         output.replace(backup)
         try:
             staging.replace(output)
         except BaseException:
             backup.replace(output)
-            _retire_replaced_directory_backup(backup_container, backup_prefix)
+            remove_owned_tree(backup_container)
+            journal.unlink()
             raise
     else:
         staging.replace(output)
@@ -428,11 +521,16 @@ def replace_runtime_directory(
         output.replace(staging)
         if backup is not None:
             backup.replace(output)
-            _retire_replaced_directory_backup(backup_container, backup_prefix)
+            remove_owned_tree(backup_container)
+            journal.unlink()
         raise
     if backup is not None:
+        backup_metadata["phase"] = "committed"
+        atomic_json(journal, backup_metadata)
         try:
             remove_owned_tree(backup)
+            remove_owned_tree(backup_container)
+            journal.unlink()
         except (OSError, WorkspaceError) as error:
             print(
                 "warning: cannot remove managed replaced-directory backup "
@@ -440,8 +538,6 @@ def replace_runtime_directory(
                 "before changing output",
                 file=sys.stderr,
             )
-        else:
-            _retire_replaced_directory_backup(backup_container, backup_prefix)
 
 
 def replace_directory(output: Path, staging: Path, backup_prefix: str) -> None:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -1685,7 +1685,11 @@ class Workspace:
 
     @staticmethod
     def _validate_resource_view(
-        path: Path, tracked: list[str], *, require_metadata: bool = True
+        path: Path,
+        source: Path,
+        tracked: list[str],
+        *,
+        require_metadata: bool = True,
     ) -> None:
         if not path.is_dir() or path.is_symlink():
             raise WorkspaceError(f"resource view is not a directory: {path}")
@@ -1724,6 +1728,24 @@ class Workspace:
         }
         if actual_directories != expected_directories:
             raise WorkspaceError("resource view does not match its tracked directories")
+        for relative in tracked:
+            parts = PurePosixPath(relative).parts
+            identities: list[tuple[int, str]] = []
+            for candidate, label in (
+                (source.joinpath(*parts), "source resource"),
+                (path.joinpath(*parts), "staged resource"),
+            ):
+                digest = hashlib.sha256()
+                descriptor = open_regular_file(candidate, os.O_RDONLY, label)
+                with os.fdopen(descriptor, "rb") as stream:
+                    size = os.fstat(stream.fileno()).st_size
+                    while chunk := stream.read(1024 * 1024):
+                        digest.update(chunk)
+                identities.append((size, digest.hexdigest()))
+            if identities[0] != identities[1]:
+                raise WorkspaceError(
+                    f"staged resource does not match selected source: {relative}"
+                )
 
     def _runtime_input_cache_matches(
         self,
@@ -1820,6 +1842,12 @@ class Workspace:
             raise WorkspaceError(
                 f"resource runtime manifest selects no tracked files: {manifest}"
             )
+        reserved = {MANAGED_MARKER, RUNTIME_INPUT_METADATA}
+        if selected_reserved := sorted(reserved.intersection(tracked)):
+            raise WorkspaceError(
+                "resource runtime manifest selects reserved generated paths: "
+                + ", ".join(selected_reserved)
+            )
         return runtime_paths, tracked
 
     def _collect_content(
@@ -1914,7 +1942,7 @@ class Workspace:
             "resource-view",
             inputs,
             cacheable,
-            lambda path: self._validate_resource_view(path, tracked),
+            lambda path: self._validate_resource_view(path, source, tracked),
         )
         validated_inputs, validated_cacheable = self._runtime_input_coordinates(
             profile_name, selected, "resources"
@@ -1975,8 +2003,21 @@ class Workspace:
             if cacheable:
                 atomic_json(staging / RUNTIME_INPUT_METADATA, inputs)
             self._validate_resource_view(
-                staging, tracked, require_metadata=cacheable
+                staging, source, tracked, require_metadata=cacheable
             )
+            installed_inputs, installed_cacheable = self._runtime_input_coordinates(
+                profile_name, selected, "resources"
+            )
+            installed_runtime_paths, installed_tracked = (
+                self._resource_runtime_files(source)
+            )
+            if (
+                installed_inputs != inputs
+                or installed_cacheable != cacheable
+                or installed_runtime_paths != runtime_paths
+                or installed_tracked != tracked
+            ):
+                raise WorkspaceError("selected resource input changed during staging")
         except BaseException:
             shutil.rmtree(staging)
             raise
@@ -2948,6 +2989,73 @@ class Workspace:
             replace_directory(destination, source, f".{name}-previous-")
         return destination
 
+    def _copy_topology_runtime_inputs(
+        self,
+        topology_root: Path,
+        inputs: tuple[tuple[str, Path, str], ...],
+    ) -> dict[str, Path]:
+        container = topology_root / "runtime"
+        expected = {
+            name: {"schema_version": SCHEMA_VERSION, "purpose": purpose}
+            for name, _source, purpose in inputs
+        }
+        if container.exists() or container.is_symlink():
+            if not container.is_dir() or container.is_symlink():
+                raise WorkspaceError(
+                    f"topology runtime container is invalid: {container}"
+                )
+            for entry in container.iterdir():
+                metadata = expected.get(entry.name)
+                marker = entry / MANAGED_MARKER
+                if (
+                    metadata is None
+                    or not entry.is_dir()
+                    or entry.is_symlink()
+                    or not marker.is_file()
+                    or marker.is_symlink()
+                    or load_json(marker) != metadata
+                ):
+                    raise WorkspaceError(
+                        f"topology runtime container has an unmanaged entry: {entry}"
+                    )
+
+        staging = Path(tempfile.mkdtemp(prefix=".runtime-", dir=topology_root))
+        staging.rmdir()
+        staging.mkdir()
+        try:
+            for name, source, purpose in inputs:
+                metadata = expected[name]
+                marker = source / MANAGED_MARKER
+                if (
+                    not source.is_dir()
+                    or source.is_symlink()
+                    or not marker.is_file()
+                    or marker.is_symlink()
+                    or load_json(marker) != metadata
+                ):
+                    raise WorkspaceError(
+                        f"topology runtime input is not managed for {purpose}: {source}"
+                    )
+                destination = staging / name
+                shutil.copytree(source, destination)
+                copied_marker = destination / MANAGED_MARKER
+                if (
+                    not destination.is_dir()
+                    or destination.is_symlink()
+                    or not copied_marker.is_file()
+                    or copied_marker.is_symlink()
+                    or load_json(copied_marker) != metadata
+                ):
+                    raise WorkspaceError(
+                        f"copied topology runtime input is invalid: {destination}"
+                    )
+            replace_directory(container, staging, ".runtime-previous-")
+        except BaseException:
+            if staging.exists():
+                shutil.rmtree(staging)
+            raise
+        return {name: container / name for name in expected}
+
     def _prepare_topology_client_runtime(
         self, topology_root: Path, selected: dict[str, Path]
     ) -> Path:
@@ -3398,27 +3506,29 @@ class Workspace:
                         selected["server"],
                         resolved_path=state_location,
                     )
-                    content = self._take_topology_runtime_input(
+                    runtime_inputs = self._copy_topology_runtime_inputs(
                         topology_root,
-                        root / "runtime" / "content",
-                        "content",
-                        "collected-content",
-                        preserve_source=True,
+                        (
+                            (
+                                "content",
+                                root / "runtime" / "content",
+                                "collected-content",
+                            ),
+                            (
+                                "resources",
+                                root / "runtime" / "resources",
+                                "resource-view",
+                            ),
+                            (
+                                "client-maps",
+                                root / "runtime" / "client-maps",
+                                "region-map-cache",
+                            ),
+                        ),
                     )
-                    resources = self._take_topology_runtime_input(
-                        topology_root,
-                        root / "runtime" / "resources",
-                        "resources",
-                        "resource-view",
-                        preserve_source=True,
-                    )
-                    client_maps = self._take_topology_runtime_input(
-                        topology_root,
-                        root / "runtime" / "client-maps",
-                        "client-maps",
-                        "region-map-cache",
-                        preserve_source=True,
-                    )
+                    content = runtime_inputs["content"]
+                    resources = runtime_inputs["resources"]
+                    client_maps = runtime_inputs["client-maps"]
                     runtime = self._prepare_server_runtime(
                         root,
                         selected,

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -159,35 +159,64 @@ def git(
     return run(["git", "-C", str(path), *arguments], capture=capture, trace=trace)
 
 
-def _descriptor_is_mount(descriptor: int) -> bool:
-    return os.path.ismount(Path(f"/proc/self/fd/{descriptor}").resolve())
+def _descriptor_mount_id(descriptor: int) -> int:
+    try:
+        metadata = Path(f"/proc/self/fdinfo/{descriptor}").read_text(
+            encoding="ascii"
+        )
+    except (OSError, UnicodeError) as error:
+        raise WorkspaceError(
+            f"cannot inspect filesystem mount for descriptor {descriptor}: {error}"
+        ) from error
+    match = re.search(r"^mnt_id:\s+(\d+)$", metadata, re.MULTILINE)
+    if match is None:
+        raise WorkspaceError(
+            f"filesystem mount identity is unavailable for descriptor {descriptor}"
+        )
+    return int(match.group(1))
 
 
 def _prepare_owned_tree_removal(
-    descriptor: int, device: int, display: Path
+    descriptor: int, device: int, mount_id: int, display: Path
 ) -> None:
     root = os.fstat(descriptor)
-    if not stat.S_ISDIR(root.st_mode) or root.st_dev != device:
+    if (
+        not stat.S_ISDIR(root.st_mode)
+        or root.st_dev != device
+        or _descriptor_mount_id(descriptor) != mount_id
+    ):
         raise WorkspaceError(f"owned removal crossed a filesystem boundary: {display}")
     os.fchmod(descriptor, stat.S_IRWXU)
     for name in sorted(os.listdir(descriptor)):
         child_display = display / name
         child = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
-        if os.path.ismount(child_display):
+        try:
+            child_probe = os.open(
+                name,
+                os.O_PATH | os.O_NOFOLLOW,
+                dir_fd=descriptor,
+            )
+        except OSError as error:
+            raise WorkspaceError(
+                f"owned removal entry changed: {child_display}"
+            ) from error
+        try:
+            probed = os.fstat(child_probe)
+            if (
+                probed.st_dev != child.st_dev
+                or probed.st_ino != child.st_ino
+                or _descriptor_mount_id(child_probe) != mount_id
+            ):
+                raise WorkspaceError(
+                    f"owned removal encountered a mount: {child_display}"
+                )
+        finally:
+            os.close(child_probe)
+        if child.st_dev != device:
             raise WorkspaceError(
                 f"owned removal encountered a mount: {child_display}"
             )
         if stat.S_ISDIR(child.st_mode):
-            if child.st_dev != device:
-                raise WorkspaceError(
-                    f"owned removal encountered a mount: {child_display}"
-                )
-            os.chmod(
-                name,
-                stat.S_IRWXU,
-                dir_fd=descriptor,
-                follow_symlinks=False,
-            )
             try:
                 child_descriptor = os.open(
                     name,
@@ -203,33 +232,52 @@ def _prepare_owned_tree_removal(
                 if (
                     opened.st_dev != child.st_dev
                     or opened.st_ino != child.st_ino
-                    or _descriptor_is_mount(child_descriptor)
+                    or _descriptor_mount_id(child_descriptor) != mount_id
                 ):
                     raise WorkspaceError(
                         f"owned removal encountered a mount: {child_display}"
                     )
+                os.fchmod(child_descriptor, stat.S_IRWXU)
                 _prepare_owned_tree_removal(
-                    child_descriptor, device, child_display
+                    child_descriptor, device, mount_id, child_display
                 )
             finally:
                 os.close(child_descriptor)
 
 
 def _remove_owned_tree_contents(
-    descriptor: int, device: int, display: Path
+    descriptor: int, device: int, mount_id: int, display: Path
 ) -> None:
     for name in sorted(os.listdir(descriptor)):
         child_display = display / name
         child = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
-        if os.path.ismount(child_display):
+        try:
+            child_probe = os.open(
+                name,
+                os.O_PATH | os.O_NOFOLLOW,
+                dir_fd=descriptor,
+            )
+        except OSError as error:
+            raise WorkspaceError(
+                f"owned removal entry changed: {child_display}"
+            ) from error
+        try:
+            probed = os.fstat(child_probe)
+            if (
+                probed.st_dev != child.st_dev
+                or probed.st_ino != child.st_ino
+                or _descriptor_mount_id(child_probe) != mount_id
+            ):
+                raise WorkspaceError(
+                    f"owned removal encountered a mount: {child_display}"
+                )
+        finally:
+            os.close(child_probe)
+        if child.st_dev != device:
             raise WorkspaceError(
                 f"owned removal encountered a mount: {child_display}"
             )
         if stat.S_ISDIR(child.st_mode):
-            if child.st_dev != device:
-                raise WorkspaceError(
-                    f"owned removal encountered a mount: {child_display}"
-                )
             try:
                 child_descriptor = os.open(
                     name,
@@ -245,13 +293,13 @@ def _remove_owned_tree_contents(
                 if (
                     opened.st_dev != child.st_dev
                     or opened.st_ino != child.st_ino
-                    or _descriptor_is_mount(child_descriptor)
+                    or _descriptor_mount_id(child_descriptor) != mount_id
                 ):
                     raise WorkspaceError(
                         f"owned removal encountered a mount: {child_display}"
                     )
                 _remove_owned_tree_contents(
-                    child_descriptor, device, child_display
+                    child_descriptor, device, mount_id, child_display
                 )
             finally:
                 os.close(child_descriptor)
@@ -261,7 +309,7 @@ def _remove_owned_tree_contents(
 
 
 def remove_owned_tree(path: Path) -> None:
-    if path.is_symlink() or not path.is_dir() or os.path.ismount(path):
+    if path.is_symlink() or not path.is_dir():
         raise WorkspaceError(f"owned removal root is invalid: {path}")
     parent_descriptor = os.open(
         path.parent, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
@@ -269,12 +317,25 @@ def remove_owned_tree(path: Path) -> None:
     descriptor: int | None = None
     try:
         before = os.stat(path.name, dir_fd=parent_descriptor, follow_symlinks=False)
-        os.chmod(
+        root_probe = os.open(
             path.name,
-            stat.S_IRWXU,
+            os.O_PATH | os.O_DIRECTORY | os.O_NOFOLLOW,
             dir_fd=parent_descriptor,
-            follow_symlinks=False,
         )
+        try:
+            probed = os.fstat(root_probe)
+            parent_mount_id = _descriptor_mount_id(parent_descriptor)
+            root_mount_id = _descriptor_mount_id(root_probe)
+            if (
+                probed.st_dev != before.st_dev
+                or probed.st_ino != before.st_ino
+                or root_mount_id != parent_mount_id
+            ):
+                raise WorkspaceError(
+                    f"owned removal root changed or is mounted: {path}"
+                )
+        finally:
+            os.close(root_probe)
         descriptor = os.open(
             path.name,
             os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
@@ -284,11 +345,16 @@ def remove_owned_tree(path: Path) -> None:
         if (
             opened.st_dev != before.st_dev
             or opened.st_ino != before.st_ino
-            or _descriptor_is_mount(descriptor)
+            or _descriptor_mount_id(descriptor) != root_mount_id
         ):
             raise WorkspaceError(f"owned removal root changed or is mounted: {path}")
-        _prepare_owned_tree_removal(descriptor, opened.st_dev, path)
-        _remove_owned_tree_contents(descriptor, opened.st_dev, path)
+        os.fchmod(descriptor, stat.S_IRWXU)
+        _prepare_owned_tree_removal(
+            descriptor, opened.st_dev, root_mount_id, path
+        )
+        _remove_owned_tree_contents(
+            descriptor, opened.st_dev, root_mount_id, path
+        )
         os.close(descriptor)
         descriptor = None
         os.rmdir(path.name, dir_fd=parent_descriptor)
@@ -389,7 +455,7 @@ def replace_runtime_directory(
             remove_owned_tree(backup)
             (backup_container / MANAGED_MARKER).unlink()
             backup_container.rmdir()
-        except OSError as error:
+        except (OSError, WorkspaceError) as error:
             print(
                 "warning: cannot remove managed replaced-directory backup "
                 f"{backup_container}: {error}; the next replacement will retry "

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -449,9 +449,11 @@ A server topology copies the collected-content and staged-resource caches after
 the shared incremental build. The profile build retains its source caches, and
 each topology owns independent immutable-at-startup copies, so later builds and
 other topology removal or mutation cannot change the filesystem seen by a
-running process. Because the caches remain below the marker-owned profile build,
-existing build retention and marker-safe cleanup own their lifecycle; topology
-copies follow topology retention.
+running process. Content, resources, and generated client maps are staged and
+installed as one runtime-input transaction, so a failed restart retains the
+complete previous snapshot set and status. Because the caches remain below the
+marker-owned profile build, existing build retention and marker-safe cleanup
+own their lifecycle; topology copies follow topology retention.
 A topology may select one service, and distinct runtime names permit concurrent
 combinations as long as their server ports and mutable state directories do not
 conflict. When replacement runtime support lands, a concurrent `classic` and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -453,7 +453,9 @@ running process. Content, resources, and generated client maps are staged and
 installed as one runtime-input transaction, so a copy or validation failure
 before installation retains the complete previous snapshot set and status.
 Snapshot traversal opens every directory and regular file descriptor-relative
-with no-follow semantics and rejects identity changes, links, and special files.
+with no-follow semantics and rejects identity changes, links, and special files;
+retained descriptors bind a complete source/destination comparison through
+installation.
 Atomic replacement keeps at most one marker-owned prior-output backup; failed
 reclamation is retried before another replacement may change the output, and
 an interrupted move is restored before a later replacement attempt.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -455,7 +455,8 @@ before installation retains the complete previous snapshot set and status.
 Snapshot traversal opens every directory and regular file descriptor-relative
 with no-follow semantics and rejects identity changes, links, and special files.
 Atomic replacement keeps at most one marker-owned prior-output backup; failed
-reclamation is retried before another replacement may change the output.
+reclamation is retried before another replacement may change the output, and
+an interrupted move is restored before a later replacement attempt.
 Because the caches remain below the marker-owned profile build, existing build
 retention and marker-safe cleanup own their lifecycle; topology copies follow
 topology retention.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -450,10 +450,11 @@ the shared incremental build. The profile build retains its source caches, and
 each topology owns independent immutable-at-startup copies, so later builds and
 other topology removal or mutation cannot change the filesystem seen by a
 running process. Content, resources, and generated client maps are staged and
-installed as one runtime-input transaction, so a failed restart retains the
-complete previous snapshot set and status. Because the caches remain below the
-marker-owned profile build, existing build retention and marker-safe cleanup
-own their lifecycle; topology copies follow topology retention.
+installed as one runtime-input transaction, so a copy or validation failure
+before installation retains the complete previous snapshot set and status.
+Because the caches remain below the marker-owned profile build, existing build
+retention and marker-safe cleanup own their lifecycle; topology copies follow
+topology retention.
 A topology may select one service, and distinct runtime names permit concurrent
 combinations as long as their server ports and mutable state directories do not
 conflict. When replacement runtime support lands, a concurrent `classic` and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -375,8 +375,15 @@ protocol.
 
 After a Classic server build, the coordinator runs the built server's offline
 worldmaker in a temporary runtime assembled from the selected server,
-collected content, and staged resources. The generator writes into a sibling
-temporary directory; the coordinator accepts it only when every output is a
+collected content, and staged resources. Content and resources are themselves
+marker-owned caches within the profile build. Their schema-versioned metadata
+binds the exact provider, repository, branch, checkout, source, resolved paths,
+and clean commit. Reuse also validates the content manifest/compatibility files,
+`lib` and `maps` directories, or the resource allowlist's exact regular-file
+set. Dirty inputs always regenerate without cache metadata. Each generator
+rechecks cleanliness and `HEAD` before atomic installation, preserving the
+previous cache if a clean input changes during generation. The generator writes into a sibling
+temporary directory. The coordinator accepts it only when every output is a
 nonempty regular `.png` or UTF-8 `.def`, the basename sets form complete pairs,
 and the expected `incuna_-1` pair exists. It then installs the marker-owned
 cache atomically, preserving the previous valid cache on failure. Cache
@@ -438,9 +445,13 @@ its topology and profile; a foreground client receives its profile and direct
 run mode. The client uses this label only for its native window title. It is
 not part of persisted settings, package or protocol identity, or network
 metadata, and unmanaged launches receive no label.
-A server topology takes ownership of its collected content and staged resource
-directories after the shared incremental build, so later builds cannot mutate
-the filesystem seen by a running process.
+A server topology copies the collected-content and staged-resource caches after
+the shared incremental build. The profile build retains its source caches, and
+each topology owns independent immutable-at-startup copies, so later builds and
+other topology removal or mutation cannot change the filesystem seen by a
+running process. Because the caches remain below the marker-owned profile build,
+existing build retention and marker-safe cleanup own their lifecycle; topology
+copies follow topology retention.
 A topology may select one service, and distinct runtime names permit concurrent
 combinations as long as their server ports and mutable state directories do not
 conflict. When replacement runtime support lands, a concurrent `classic` and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -452,6 +452,10 @@ other topology removal or mutation cannot change the filesystem seen by a
 running process. Content, resources, and generated client maps are staged and
 installed as one runtime-input transaction, so a copy or validation failure
 before installation retains the complete previous snapshot set and status.
+Snapshot traversal opens every directory and regular file descriptor-relative
+with no-follow semantics and rejects identity changes, links, and special files.
+Atomic replacement keeps at most one marker-owned prior-output backup; failed
+reclamation is retried before another replacement may change the output.
 Because the caches remain below the marker-owned profile build, existing build
 retention and marker-safe cleanup own their lifecycle; topology copies follow
 topology retention.

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1528,11 +1528,14 @@ class WorkspaceTests(unittest.TestCase):
         executable.write_text(
             "#!/usr/bin/env python3\n"
             "from pathlib import Path\n"
+            "import os\n"
             "import sys\n"
             "binary = Path(__file__).resolve()\n"
             "counter = binary.with_name('worldmaker-count')\n"
             "count = int(counter.read_text()) + 1 if counter.exists() else 1\n"
             "counter.write_text(str(count))\n"
+            "binary.with_name('worldmaker-bytecode').write_text("
+            "os.environ.get('PYTHONDONTWRITEBYTECODE', ''))\n"
             "assets = Path(next(arg.split('=', 1)[1] for arg in sys.argv "
             "if arg.startswith('--assetspath=')))\n"
             "output = assets / 'client-maps'\n"
@@ -1559,6 +1562,7 @@ class WorkspaceTests(unittest.TestCase):
         self.workspace._generate_region_maps(root, "default", selected)
 
         self.assertEqual((binary / "worldmaker-count").read_text(), "1")
+        self.assertEqual((binary / "worldmaker-bytecode").read_text(), "1")
         self.assertTrue((output / "incuna_-1.png").is_file())
         previous = (output / "incuna_-1.def").read_text(encoding="utf-8")
         atomic_json(output / ".atrinik-region-maps.json", {"stale": True})

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -12,6 +12,7 @@ import shutil
 import signal
 import stat
 import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -2734,7 +2735,7 @@ class WorkspaceTests(unittest.TestCase):
 
         with mock.patch(
             "atrinik_workspace.workspace._descriptor_mount_id",
-            side_effect=[1, 1, 1, 1, 1, 1, 1, 2],
+            side_effect=[1] * 9 + [2],
         ):
             with self.assertRaisesRegex(WorkspaceError, "encountered a mount"):
                 remove_owned_tree(owned)
@@ -2773,7 +2774,7 @@ class WorkspaceTests(unittest.TestCase):
 
         with mock.patch(
             "atrinik_workspace.workspace._descriptor_mount_id",
-            side_effect=[1, 1, 1, 1, 2],
+            side_effect=[1] * 6 + [2],
         ):
             with self.assertRaisesRegex(WorkspaceError, "encountered a mount"):
                 remove_owned_tree(owned)
@@ -2793,6 +2794,19 @@ class WorkspaceTests(unittest.TestCase):
             side_effect=FileNotFoundError("no procfs"),
         ):
             remove_owned_tree(owned)
+
+        self.assertFalse(owned.exists())
+
+    @unittest.skipUnless(sys.platform == "linux", "requires Linux O_PATH")
+    def test_owned_tree_removal_handles_unreadable_directories(self) -> None:
+        owned = self.root / "owned"
+        nested = owned / "nested"
+        nested.mkdir(parents=True)
+        (nested / "payload").write_text("remove\n", encoding="utf-8")
+        nested.chmod(0)
+        owned.chmod(0)
+
+        remove_owned_tree(owned)
 
         self.assertFalse(owned.exists())
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import copy
 from concurrent.futures import ThreadPoolExecutor
+import ctypes
+import errno
 import hashlib
 import json
 import os
@@ -15,6 +17,7 @@ import time
 import unittest
 from unittest import mock
 
+from atrinik_workspace import workspace as workspace_module
 from atrinik_workspace.migration import rename_no_replace as real_rename_no_replace
 from atrinik_workspace.launch_identity import client_launch_label
 from atrinik_workspace.model import (
@@ -2797,6 +2800,653 @@ class WorkspaceTests(unittest.TestCase):
                 remove_owned_tree(owned)
 
         self.assertTrue(fifo.exists())
+
+    def test_mount_identity_probes_fail_closed(self) -> None:
+        class FakeFunction:
+            def __init__(self, result: int, values: tuple[int, int] | None = None):
+                self.result = result
+                self.values = values
+
+            def __call__(self, *arguments: object) -> int:
+                if self.values is not None:
+                    buffer = arguments[-1]._obj  # type: ignore[attr-defined]
+                    ctypes.c_int32.from_buffer(buffer, 48).value = self.values[0]
+                    ctypes.c_int32.from_buffer(buffer, 52).value = self.values[1]
+                return self.result
+
+        class FakeLibrary:
+            def __init__(self, function: FakeFunction):
+                self.fstatfs = function
+                self.statx = function
+
+        with mock.patch(
+            "atrinik_workspace.workspace.ctypes.CDLL",
+            return_value=FakeLibrary(FakeFunction(0, (7, 9))),
+        ):
+            self.assertEqual(workspace_module._darwin_descriptor_mount_id(1), (7, 9))
+
+        ctypes.set_errno(errno.EIO)
+        with mock.patch(
+            "atrinik_workspace.workspace.ctypes.CDLL",
+            return_value=FakeLibrary(FakeFunction(-1)),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "cannot inspect filesystem"):
+                workspace_module._darwin_descriptor_mount_id(1)
+
+        with mock.patch(
+            "atrinik_workspace.workspace.ctypes.CDLL", return_value=object()
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "statx mount identity"):
+                workspace_module._linux_descriptor_mount_id(1)
+
+        ctypes.set_errno(errno.EIO)
+        with mock.patch(
+            "atrinik_workspace.workspace.ctypes.CDLL",
+            return_value=FakeLibrary(FakeFunction(-1)),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "cannot inspect filesystem"):
+                workspace_module._linux_descriptor_mount_id(1)
+
+        with mock.patch(
+            "atrinik_workspace.workspace.ctypes.CDLL",
+            return_value=FakeLibrary(FakeFunction(0)),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "did not return"):
+                workspace_module._linux_descriptor_mount_id(1)
+
+        class SuccessfulStatx(FakeFunction):
+            def __call__(self, *arguments: object) -> int:
+                buffer = arguments[-1]._obj  # type: ignore[attr-defined]
+                ctypes.c_uint32.from_buffer(buffer, 0).value = 0x1000
+                ctypes.c_uint64.from_buffer(buffer, 144).value = 8675309
+                return 0
+
+        with mock.patch(
+            "atrinik_workspace.workspace.ctypes.CDLL",
+            return_value=FakeLibrary(SuccessfulStatx(0)),
+        ):
+            self.assertEqual(
+                workspace_module._linux_descriptor_mount_id(1), 8675309
+            )
+
+        with mock.patch("atrinik_workspace.workspace.sys.platform", "freebsd"):
+            with self.assertRaisesRegex(WorkspaceError, "unavailable on freebsd"):
+                workspace_module._descriptor_mount_id(1)
+
+    def test_owned_tree_removal_detects_descriptor_races(self) -> None:
+        invalid = self.root / "invalid-removal-root"
+        invalid.write_text("file\n", encoding="utf-8")
+        with self.assertRaisesRegex(WorkspaceError, "root is invalid"):
+            remove_owned_tree(invalid)
+
+        mounted = self.root / "mounted-removal-root"
+        mounted.mkdir()
+        mounted_payload = mounted / "payload"
+        mounted_payload.write_text("preserve\n", encoding="utf-8")
+        mounted_identity = mounted_payload.lstat()
+        with mock.patch(
+            "atrinik_workspace.workspace._descriptor_mount_id",
+            side_effect=[1, 2],
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "root changed or is mounted"):
+                remove_owned_tree(mounted)
+        self.assertEqual(
+            (mounted_payload.read_text(encoding="utf-8"), mounted_payload.lstat().st_ino),
+            ("preserve\n", mounted_identity.st_ino),
+        )
+
+        probe_root = self.root / "probe-open-race"
+        probe_root.mkdir()
+        probe_file = probe_root / "payload"
+        probe_file.write_text("data\n", encoding="utf-8")
+        probe_identity = probe_file.lstat()
+        probe_descriptor = os.open(probe_root, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            with mock.patch(
+                "atrinik_workspace.workspace.os.open",
+                side_effect=OSError("changed"),
+            ):
+                with self.assertRaisesRegex(WorkspaceError, "entry changed"):
+                    workspace_module._probe_owned_tree_entry_mount(
+                        probe_descriptor,
+                        "payload",
+                        probe_file.stat(),
+                        1,
+                        probe_file,
+                    )
+        finally:
+            os.close(probe_descriptor)
+        self.assertEqual(
+            (probe_file.read_text(encoding="utf-8"), probe_file.lstat().st_ino),
+            ("data\n", probe_identity.st_ino),
+        )
+
+        boundary = self.root / "prepare-boundary"
+        boundary.mkdir()
+        boundary_payload = boundary / "payload"
+        boundary_payload.write_text("preserve\n", encoding="utf-8")
+        boundary_identity = boundary_payload.lstat()
+        boundary_descriptor = os.open(boundary, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            boundary_stat = os.fstat(boundary_descriptor)
+            with self.assertRaisesRegex(WorkspaceError, "crossed a filesystem"):
+                workspace_module._prepare_owned_tree_removal(
+                    boundary_descriptor,
+                    boundary_stat.st_dev + 1,
+                    1,
+                    boundary,
+                )
+        finally:
+            os.close(boundary_descriptor)
+        self.assertEqual(
+            (
+                boundary_payload.read_text(encoding="utf-8"),
+                boundary_payload.lstat().st_ino,
+            ),
+            ("preserve\n", boundary_identity.st_ino),
+        )
+
+        def changed_device(result: os.stat_result) -> os.stat_result:
+            fields = list(result)
+            fields[2] += 1
+            return os.stat_result(fields)
+
+        for operation in (
+            workspace_module._prepare_owned_tree_removal,
+            workspace_module._remove_owned_tree_contents,
+        ):
+            root = self.root / f"device-race-{operation.__name__}"
+            root.mkdir()
+            child = root / "payload"
+            child.write_text("data\n", encoding="utf-8")
+            descriptor = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+            try:
+                root_stat = os.fstat(descriptor)
+                with (
+                    mock.patch(
+                        "atrinik_workspace.workspace._descriptor_mount_id",
+                        return_value=1,
+                    ),
+                    mock.patch(
+                        "atrinik_workspace.workspace._probe_owned_tree_entry_mount"
+                    ),
+                    mock.patch(
+                        "atrinik_workspace.workspace.os.stat",
+                        return_value=changed_device(child.stat()),
+                    ),
+                ):
+                    with self.assertRaisesRegex(WorkspaceError, "encountered a mount"):
+                        operation(descriptor, root_stat.st_dev, 1, root)
+            finally:
+                os.close(descriptor)
+            self.assertEqual(child.read_text(encoding="utf-8"), "data\n")
+
+        real_open = os.open
+        for operation in (
+            workspace_module._prepare_owned_tree_removal,
+            workspace_module._remove_owned_tree_contents,
+        ):
+            root = self.root / f"open-race-{operation.__name__}"
+            nested = root / "nested"
+            nested.mkdir(parents=True)
+            nested_payload = nested / "payload"
+            nested_payload.write_text("preserve\n", encoding="utf-8")
+            nested_identity = nested_payload.lstat()
+            descriptor = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+            root_stat = os.fstat(descriptor)
+
+            def fail_nested_open(
+                path: object, flags: int, *args: object, **kwargs: object
+            ) -> int:
+                if path == "nested" and kwargs.get("dir_fd") == descriptor:
+                    raise OSError("changed")
+                return real_open(path, flags, *args, **kwargs)
+
+            try:
+                with (
+                    mock.patch(
+                        "atrinik_workspace.workspace._descriptor_mount_id",
+                        return_value=1,
+                    ),
+                    mock.patch(
+                        "atrinik_workspace.workspace._probe_owned_tree_entry_mount"
+                    ),
+                    mock.patch(
+                        "atrinik_workspace.workspace.os.open",
+                        side_effect=fail_nested_open,
+                    ),
+                ):
+                    with self.assertRaisesRegex(WorkspaceError, "directory changed"):
+                        operation(descriptor, root_stat.st_dev, 1, root)
+            finally:
+                os.close(descriptor)
+            self.assertEqual(
+                (
+                    nested_payload.read_text(encoding="utf-8"),
+                    nested_payload.lstat().st_ino,
+                ),
+                ("preserve\n", nested_identity.st_ino),
+            )
+
+        for operation in (
+            workspace_module._prepare_owned_tree_removal,
+            workspace_module._remove_owned_tree_contents,
+        ):
+            root = self.root / f"identity-race-{operation.__name__}"
+            nested = root / "nested"
+            nested.mkdir(parents=True)
+            nested_payload = nested / "payload"
+            nested_payload.write_text("preserve\n", encoding="utf-8")
+            nested_identity = nested_payload.lstat()
+            descriptor = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+            root_stat = os.fstat(descriptor)
+            mount_ids = (
+                [1, 2]
+                if operation is workspace_module._prepare_owned_tree_removal
+                else [2]
+            )
+            try:
+                with (
+                    mock.patch(
+                        "atrinik_workspace.workspace._descriptor_mount_id",
+                        side_effect=mount_ids,
+                    ),
+                    mock.patch(
+                        "atrinik_workspace.workspace._probe_owned_tree_entry_mount"
+                    ),
+                ):
+                    with self.assertRaisesRegex(WorkspaceError, "encountered a mount"):
+                        operation(descriptor, root_stat.st_dev, 1, root)
+            finally:
+                os.close(descriptor)
+            self.assertEqual(
+                (
+                    nested_payload.read_text(encoding="utf-8"),
+                    nested_payload.lstat().st_ino,
+                ),
+                ("preserve\n", nested_identity.st_ino),
+            )
+
+    def test_replaced_directory_recovery_rejects_invalid_states(self) -> None:
+        def snapshot(parent: Path) -> dict[str, tuple[object, ...]]:
+            result: dict[str, tuple[object, ...]] = {}
+            for directory, dirnames, filenames in os.walk(
+                parent, followlinks=False
+            ):
+                directory_path = Path(directory)
+                for name in sorted([*dirnames, *filenames]):
+                    entry = directory_path / name
+                    relative = entry.relative_to(parent).as_posix()
+                    metadata = entry.lstat()
+                    if entry.is_symlink():
+                        value: object = os.readlink(entry)
+                    elif entry.is_file():
+                        value = entry.read_bytes()
+                    else:
+                        value = None
+                    result[relative] = (
+                        stat.S_IFMT(metadata.st_mode),
+                        stat.S_IMODE(metadata.st_mode),
+                        metadata.st_ino,
+                        value,
+                    )
+            return result
+
+        def prepare(
+            name: str,
+            phase: str,
+            *,
+            output: str = "absent",
+            backup: str = "absent",
+        ) -> tuple[Path, Path, Path]:
+            parent = self.root / name
+            parent.mkdir()
+            target = parent / "output"
+            pending = parent / ".previous-pending"
+            if output == "directory":
+                target.mkdir()
+            elif output == "symlink":
+                external = parent / "external"
+                external.mkdir()
+                target.symlink_to(external, target_is_directory=True)
+            if backup != "absent":
+                pending.mkdir()
+                if backup == "previous":
+                    (pending / "previous").mkdir()
+                elif backup == "previous-symlink":
+                    external = parent / "backup-external"
+                    external.mkdir()
+                    (pending / "previous").symlink_to(
+                        external, target_is_directory=True
+                    )
+                elif backup == "other":
+                    (pending / "other").write_text("unexpected\n", encoding="utf-8")
+            atomic_json(
+                parent / ".previous-pending.json",
+                {
+                    "schema_version": 1,
+                    "purpose": "replaced-directory-backup",
+                    "output": "output",
+                    "phase": phase,
+                },
+            )
+            return target, pending, parent / ".previous-pending.json"
+
+        unmanaged = self.root / "unmanaged"
+        unmanaged.mkdir()
+        (unmanaged / ".previous-pending").mkdir()
+        unmanaged_before = snapshot(unmanaged)
+        with self.assertRaisesRegex(WorkspaceError, "is not managed"):
+            workspace_module.recover_replaced_directory(
+                unmanaged / "output", ".previous-"
+            )
+        self.assertEqual(snapshot(unmanaged), unmanaged_before)
+
+        invalid_link = self.root / "invalid-link"
+        invalid_link.mkdir()
+        link_target = invalid_link / "journal-target"
+        link_target.write_text("{}", encoding="utf-8")
+        (invalid_link / ".previous-pending.json").symlink_to(link_target)
+        invalid_link_before = snapshot(invalid_link)
+        with self.assertRaisesRegex(WorkspaceError, "journal is invalid"):
+            workspace_module.recover_replaced_directory(
+                invalid_link / "output", ".previous-"
+            )
+        self.assertEqual(snapshot(invalid_link), invalid_link_before)
+
+        invalid_json = self.root / "invalid-json"
+        invalid_json.mkdir()
+        atomic_json(invalid_json / ".previous-pending.json", [])
+        invalid_json_before = snapshot(invalid_json)
+        with self.assertRaisesRegex(WorkspaceError, "journal is invalid"):
+            workspace_module.recover_replaced_directory(
+                invalid_json / "output", ".previous-"
+            )
+        self.assertEqual(snapshot(invalid_json), invalid_json_before)
+
+        invalid_phase = self.root / "invalid-phase"
+        invalid_phase.mkdir()
+        atomic_json(
+            invalid_phase / ".previous-pending.json",
+            {
+                "schema_version": 1,
+                "purpose": "replaced-directory-backup",
+                "output": "output",
+                "phase": "unknown",
+            },
+        )
+        invalid_phase_before = snapshot(invalid_phase)
+        with self.assertRaisesRegex(WorkspaceError, "journal is invalid"):
+            workspace_module.recover_replaced_directory(
+                invalid_phase / "output", ".previous-"
+            )
+        self.assertEqual(snapshot(invalid_phase), invalid_phase_before)
+
+        cases = (
+            (
+                "initializing-nonempty",
+                "initializing",
+                "absent",
+                "other",
+                "backup is invalid",
+            ),
+            ("prepared-no-backup", "prepared", "absent", "absent", "backup is invalid"),
+            (
+                "previous-link",
+                "prepared",
+                "absent",
+                "previous-symlink",
+                "payload is invalid",
+            ),
+            (
+                "prepared-output-link",
+                "prepared",
+                "symlink",
+                "previous",
+                "replacement is invalid",
+            ),
+            (
+                "committed-no-output",
+                "committed",
+                "absent",
+                "previous",
+                "replacement is invalid",
+            ),
+            (
+                "committed-empty",
+                "committed",
+                "absent",
+                "empty",
+                "replacement is invalid",
+            ),
+            ("prepared-empty", "prepared", "absent", "empty", "replacement is invalid"),
+            ("unexpected-payload", "prepared", "directory", "other", "not empty"),
+        )
+        for name, phase, output, backup, message in cases:
+            with self.subTest(name=name):
+                target, _pending, _journal = prepare(
+                    name, phase, output=output, backup=backup
+                )
+                before = snapshot(target.parent)
+                with self.assertRaisesRegex(WorkspaceError, message):
+                    workspace_module.recover_replaced_directory(
+                        target, ".previous-"
+                    )
+                self.assertEqual(snapshot(target.parent), before)
+
+        target, pending, journal = prepare(
+            "committed-clean", "committed", output="directory"
+        )
+        workspace_module.recover_replaced_directory(target, ".previous-")
+        self.assertFalse(pending.exists())
+        self.assertFalse(journal.exists())
+
+    def test_content_and_resource_validators_reject_malformed_trees(self) -> None:
+        coordinate = {
+            "repository": "atrinik/content",
+            "branch": "main",
+            "head": "a" * 40,
+        }
+
+        def content(name: str) -> Path:
+            path = self.root / name
+            path.mkdir()
+            self.make_content_candidate(path, coordinate["head"], "content\n")
+            atomic_json(
+                path / MANAGED_MARKER,
+                {"schema_version": 1, "purpose": "collected-content"},
+            )
+            return path
+
+        root_file = self.root / "content-file"
+        root_file.write_text("bad\n", encoding="utf-8")
+        with self.assertRaisesRegex(WorkspaceError, "not a directory"):
+            self.workspace._validate_collected_content(
+                root_file, coordinate, require_metadata=False
+            )
+
+        missing_directory = content("content-missing-directory")
+        shutil.rmtree(missing_directory / "lib")
+        with self.assertRaisesRegex(WorkspaceError, "required directory"):
+            self.workspace._validate_collected_content(
+                missing_directory, coordinate, require_metadata=False
+            )
+
+        invalid_manifest = content("content-invalid-manifest")
+        atomic_json(invalid_manifest / "manifest.json", [])
+        with self.assertRaisesRegex(WorkspaceError, "manifest is invalid"):
+            self.workspace._validate_collected_content(
+                invalid_manifest, coordinate, require_metadata=False
+            )
+
+        invalid_entry = content("content-invalid-entry")
+        manifest = load_json(invalid_entry / "manifest.json")
+        manifest["files"][0]["path"] = "../escape"
+        atomic_json(invalid_entry / "manifest.json", manifest)
+        with self.assertRaisesRegex(WorkspaceError, "file entry is invalid"):
+            self.workspace._validate_collected_content(
+                invalid_entry, coordinate, require_metadata=False
+            )
+
+        linked = content("content-link")
+        (linked / "linked").symlink_to(self.root, target_is_directory=True)
+        with self.assertRaisesRegex(WorkspaceError, "contains a link"):
+            self.workspace._validate_collected_content(
+                linked, coordinate, require_metadata=False
+            )
+
+        extra = content("content-extra")
+        (extra / "extra").write_text("extra\n", encoding="utf-8")
+        with self.assertRaisesRegex(WorkspaceError, "does not match"):
+            self.workspace._validate_collected_content(
+                extra, coordinate, require_metadata=False
+            )
+
+        wrong_size = content("content-size")
+        manifest = load_json(wrong_size / "manifest.json")
+        manifest["files"][0]["size"] += 1
+        atomic_json(wrong_size / "manifest.json", manifest)
+        with self.assertRaisesRegex(WorkspaceError, "size does not match"):
+            self.workspace._validate_collected_content(
+                wrong_size, coordinate, require_metadata=False
+            )
+
+        unreadable = content("content-unreadable")
+        real_lstat = Path.lstat
+        walking = False
+
+        def fail_content_lstat(candidate: Path) -> os.stat_result:
+            if walking and candidate == unreadable / "compatibility.json":
+                raise OSError("changed")
+            return real_lstat(candidate)
+
+        real_walk = os.walk
+
+        def activate_content_walk(
+            *arguments: object, **kwargs: object
+        ) -> object:
+            nonlocal walking
+            walking = True
+            yield from real_walk(*arguments, **kwargs)
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.Path.lstat",
+                autospec=True,
+                side_effect=fail_content_lstat,
+            ),
+            mock.patch(
+                "atrinik_workspace.workspace.os.walk",
+                side_effect=activate_content_walk,
+            ),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "cannot inspect collected"):
+                self.workspace._validate_collected_content(
+                    unreadable, coordinate, require_metadata=False
+                )
+
+        special_content = content("content-special")
+        fifo = special_content / "fifo"
+        os.mkfifo(fifo)
+        manifest = load_json(special_content / "manifest.json")
+        manifest["files"].append(
+            {"path": "fifo", "sha256": "0" * 64, "size": 0}
+        )
+        atomic_json(special_content / "manifest.json", manifest)
+        with self.assertRaisesRegex(WorkspaceError, "non-regular file"):
+            self.workspace._validate_collected_content(
+                special_content, coordinate, require_metadata=False
+            )
+
+        source = self.workspace.paths.repositories / "resources"
+
+        def resource(name: str) -> Path:
+            path = self.root / name
+            (path / "paintings").mkdir(parents=True)
+            shutil.copy2(
+                source / "paintings" / "scene.jpg",
+                path / "paintings" / "scene.jpg",
+            )
+            atomic_json(
+                path / MANAGED_MARKER,
+                {"schema_version": 1, "purpose": "resource-view"},
+            )
+            return path
+
+        resource_file = self.root / "resource-file"
+        resource_file.write_text("bad\n", encoding="utf-8")
+        with self.assertRaisesRegex(WorkspaceError, "not a directory"):
+            self.workspace._validate_resource_view(
+                resource_file,
+                source,
+                ["paintings/scene.jpg"],
+                require_metadata=False,
+            )
+
+        resource_link = resource("resource-link")
+        (resource_link / "linked").symlink_to(self.root, target_is_directory=True)
+        with self.assertRaisesRegex(WorkspaceError, "contains a link"):
+            self.workspace._validate_resource_view(
+                resource_link,
+                source,
+                ["paintings/scene.jpg"],
+                require_metadata=False,
+            )
+
+        resource_extra = resource("resource-extra")
+        (resource_extra / "extra").write_text("extra\n", encoding="utf-8")
+        with self.assertRaisesRegex(WorkspaceError, "tracked file set"):
+            self.workspace._validate_resource_view(
+                resource_extra,
+                source,
+                ["paintings/scene.jpg"],
+                require_metadata=False,
+            )
+
+        resource_directory = resource("resource-directory")
+        (resource_directory / "extra").mkdir()
+        with self.assertRaisesRegex(WorkspaceError, "tracked directories"):
+            self.workspace._validate_resource_view(
+                resource_directory,
+                source,
+                ["paintings/scene.jpg"],
+                require_metadata=False,
+            )
+
+        unreadable_resource = resource("resource-unreadable")
+
+        def fail_resource_lstat(candidate: Path) -> os.stat_result:
+            if candidate == unreadable_resource / "paintings" / "scene.jpg":
+                raise OSError("changed")
+            return real_lstat(candidate)
+
+        with mock.patch(
+            "atrinik_workspace.workspace.Path.lstat",
+            autospec=True,
+            side_effect=fail_resource_lstat,
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "cannot inspect staged"):
+                self.workspace._validate_resource_view(
+                    unreadable_resource,
+                    source,
+                    ["paintings/scene.jpg"],
+                    require_metadata=False,
+                )
+
+        special_resource = self.root / "resource-special"
+        (special_resource / "paintings").mkdir(parents=True)
+        os.mkfifo(special_resource / "paintings" / "fifo")
+        atomic_json(
+            special_resource / MANAGED_MARKER,
+            {"schema_version": 1, "purpose": "resource-view"},
+        )
+        with self.assertRaisesRegex(WorkspaceError, "non-regular file"):
+            self.workspace._validate_resource_view(
+                special_resource,
+                source,
+                ["paintings/fifo"],
+                require_metadata=False,
+            )
 
     def test_replace_directory_interrupted_journal_publish_is_retryable(
         self,

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -32,7 +32,8 @@ from atrinik_workspace.workspace import (
     _remote_matches as real_remote_matches,
     display_arguments,
     exclusive_lock,
-    replace_directory as workspace_replace_directory,
+    remove_owned_tree,
+    replace_runtime_directory as workspace_replace_directory,
     run as workspace_run,
 )
 
@@ -829,7 +830,7 @@ class WorkspaceTests(unittest.TestCase):
             )
 
         with mock.patch(
-            "atrinik_workspace.workspace.replace_directory",
+            "atrinik_workspace.workspace.replace_runtime_directory",
             side_effect=replace_then_advance,
         ):
             with self.assertRaisesRegex(WorkspaceError, "changed during staging"):
@@ -1390,22 +1391,28 @@ class WorkspaceTests(unittest.TestCase):
     def test_replace_directory_cleanup_failure_keeps_committed_output(self) -> None:
         output = self.root / "output"
         output.mkdir()
+        (output / "first").write_text("delete first\n", encoding="utf-8")
         (output / "payload").write_text("previous\n", encoding="utf-8")
         staging = self.root / "staging"
         staging.mkdir()
         (staging / "payload").write_text("new\n", encoding="utf-8")
-        real_remove = shutil.rmtree
+        real_unlink = os.unlink
 
-        def fail_backup_cleanup(path: Path, **kwargs: object) -> None:
-            if Path(path).name == "previous" and Path(path).parent.name.startswith(
-                ".previous-"
-            ):
-                (Path(path) / "payload").unlink(missing_ok=True)
+        def fail_backup_cleanup(
+            path: object, *args: object, **kwargs: object
+        ) -> None:
+            directory_fd = kwargs.get("dir_fd")
+            parent = (
+                Path(f"/proc/self/fd/{directory_fd}").resolve()
+                if isinstance(directory_fd, int)
+                else None
+            )
+            if path == "payload" and parent is not None and parent.name == "previous":
                 raise PermissionError("read only")
-            real_remove(path, **kwargs)
+            real_unlink(path, *args, **kwargs)
 
         with mock.patch(
-            "atrinik_workspace.workspace.shutil.rmtree",
+            "atrinik_workspace.workspace.os.unlink",
             side_effect=fail_backup_cleanup,
         ):
             workspace_replace_directory(output, staging, ".previous-")
@@ -1470,6 +1477,22 @@ class WorkspaceTests(unittest.TestCase):
             (output / "payload").read_text(encoding="utf-8"), "previous\n"
         )
         self.assertFalse(pending.exists())
+
+    def test_owned_tree_removal_refuses_nested_mount_before_deletion(self) -> None:
+        owned = self.root / "owned"
+        nested = owned / "nested"
+        nested.mkdir(parents=True)
+        payload = nested / "payload"
+        payload.write_text("preserve\n", encoding="utf-8")
+
+        with mock.patch(
+            "atrinik_workspace.workspace._descriptor_is_mount",
+            side_effect=[False, True],
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "encountered a mount"):
+                remove_owned_tree(owned)
+
+        self.assertEqual(payload.read_text(encoding="utf-8"), "preserve\n")
 
     def test_topology_runtime_install_rejects_post_copy_replacement(self) -> None:
         topology = self.root / "topology"
@@ -2566,39 +2589,6 @@ class WorkspaceTests(unittest.TestCase):
         with exclusive_lock(Path(f"{state}.lock"), "test state"):
             with self.assertRaisesRegex(WorkspaceError, "already in use"):
                 self.workspace.scenario_reset("locked")
-
-    def test_scenario_reset_recovers_state_before_loading_scenario(self) -> None:
-        root = self.workspace.paths.scenarios / "recovery"
-        pending = root / ".recovery-state-previous-pending"
-        previous = pending / "previous"
-        previous.mkdir(parents=True)
-        (previous / "payload").write_text("previous\n", encoding="utf-8")
-        atomic_json(
-            pending / MANAGED_MARKER,
-            {
-                "schema_version": 1,
-                "purpose": "replaced-directory-backup",
-                "output": "state",
-            },
-        )
-
-        def observe_recovered_state(name: str) -> dict[str, object]:
-            self.assertEqual(name, "recovery")
-            self.assertEqual(
-                (root / "state" / "payload").read_text(encoding="utf-8"),
-                "previous\n",
-            )
-            raise WorkspaceError("stop after recovery")
-
-        with mock.patch.object(
-            self.workspace,
-            "_load_scenario",
-            side_effect=observe_recovered_state,
-        ):
-            with self.assertRaisesRegex(WorkspaceError, "stop after recovery"):
-                self.workspace._scenario_reset("recovery")
-
-        self.assertFalse(pending.exists())
 
     def test_foreground_client_pins_matching_server_state(self) -> None:
         server = self.workspace.paths.repositories / "server"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2799,6 +2799,17 @@ class WorkspaceTests(unittest.TestCase):
 
     @unittest.skipUnless(sys.platform == "linux", "requires Linux O_PATH")
     def test_owned_tree_removal_handles_unreadable_directories(self) -> None:
+        readable = self.root / "readable"
+        readable.mkdir()
+        (readable / "payload").write_text("remove\n", encoding="utf-8")
+        with mock.patch(
+            "atrinik_workspace.workspace._linux_fchmod_path_descriptor",
+            side_effect=WorkspaceError("fchmodat2 unavailable"),
+        ) as fallback:
+            remove_owned_tree(readable)
+        fallback.assert_not_called()
+        self.assertFalse(readable.exists())
+
         owned = self.root / "owned"
         nested = owned / "nested"
         nested.mkdir(parents=True)
@@ -2809,6 +2820,24 @@ class WorkspaceTests(unittest.TestCase):
         remove_owned_tree(owned)
 
         self.assertFalse(owned.exists())
+
+        unsupported = self.root / "unsupported"
+        unsupported.mkdir()
+        payload = unsupported / "payload"
+        payload.write_text("preserve\n", encoding="utf-8")
+        unsupported.chmod(0)
+        try:
+            with mock.patch(
+                "atrinik_workspace.workspace._linux_fchmod_path_descriptor",
+                side_effect=WorkspaceError("fchmodat2 unavailable"),
+            ):
+                with self.assertRaisesRegex(WorkspaceError, "unavailable"):
+                    remove_owned_tree(unsupported)
+            self.assertEqual(stat.S_IMODE(unsupported.stat().st_mode), 0)
+            unsupported.chmod(0o700)
+            self.assertEqual(payload.read_text(encoding="utf-8"), "preserve\n")
+        finally:
+            unsupported.chmod(0o700)
 
     def test_owned_tree_removal_rejects_special_nodes_without_opening(self) -> None:
         owned = self.root / "owned"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1489,13 +1489,49 @@ class WorkspaceTests(unittest.TestCase):
 
         with mock.patch(
             "atrinik_workspace.workspace._descriptor_mount_id",
-            side_effect=[1, 1, 1, 1, 2],
+            side_effect=[1, 1, 1, 2],
         ):
             with self.assertRaisesRegex(WorkspaceError, "encountered a mount"):
                 remove_owned_tree(owned)
 
         self.assertEqual(payload.read_text(encoding="utf-8"), "preserve\n")
         self.assertEqual(stat.S_IMODE(nested.stat().st_mode), original_mode)
+
+    def test_owned_tree_removal_uses_portable_mount_fallback(self) -> None:
+        owned = self.root / "owned"
+        owned.mkdir()
+        (owned / "payload").write_text("remove\n", encoding="utf-8")
+
+        with mock.patch("atrinik_workspace.workspace.sys.platform", "darwin"):
+            remove_owned_tree(owned)
+
+        self.assertFalse(owned.exists())
+
+    def test_replace_directory_interrupted_journal_publish_is_retryable(
+        self,
+    ) -> None:
+        output = self.root / "output"
+        output.mkdir()
+        (output / "payload").write_text("previous\n", encoding="utf-8")
+        staging = self.root / "staging"
+        staging.mkdir()
+        (staging / "payload").write_text("new\n", encoding="utf-8")
+
+        with mock.patch(
+            "atrinik_workspace.workspace.atomic_json",
+            side_effect=KeyboardInterrupt("interrupted"),
+        ):
+            with self.assertRaises(KeyboardInterrupt):
+                workspace_replace_directory(output, staging, ".previous-")
+
+        self.assertEqual(
+            (output / "payload").read_text(encoding="utf-8"), "previous\n"
+        )
+        self.assertFalse((self.root / ".previous-pending").exists())
+        workspace_replace_directory(output, staging, ".previous-")
+        self.assertEqual(
+            (output / "payload").read_text(encoding="utf-8"), "new\n"
+        )
 
     def test_topology_runtime_install_rejects_post_copy_replacement(self) -> None:
         topology = self.root / "topology"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1575,6 +1575,24 @@ class WorkspaceTests(unittest.TestCase):
 
         self.assertFalse(owned.exists())
 
+    def test_owned_tree_removal_rejects_special_nodes_without_opening(self) -> None:
+        owned = self.root / "owned"
+        owned.mkdir()
+        fifo = owned / "fifo"
+        os.mkfifo(fifo)
+
+        with (
+            mock.patch("atrinik_workspace.workspace.sys.platform", "darwin"),
+            mock.patch(
+                "atrinik_workspace.workspace._darwin_descriptor_mount_id",
+                return_value=(1, 2),
+            ),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "entry is unsupported"):
+                remove_owned_tree(owned)
+
+        self.assertTrue(fifo.exists())
+
     def test_replace_directory_interrupted_journal_publish_is_retryable(
         self,
     ) -> None:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -641,6 +641,20 @@ class WorkspaceTests(unittest.TestCase):
 
         self.assertFalse((output / "paintings" / "private.txt").exists())
 
+    def test_resource_view_rejects_tracked_generated_metadata_names(self) -> None:
+        source = self.workspace.paths.repositories / "resources"
+        (source / MANAGED_MARKER).write_text("payload\n", encoding="utf-8")
+        (source / "runtime-paths.txt").write_text(
+            f"{MANAGED_MARKER}\n", encoding="utf-8"
+        )
+        command("git", "add", ".", cwd=source)
+        command("git", "commit", "-m", "test: select reserved resource", cwd=source)
+        root = self.workspace.paths.builds / "profiles" / "test"
+        managed_directory(root, self.workspace.paths.builds, "test-profile")
+
+        with self.assertRaisesRegex(WorkspaceError, "reserved generated paths"):
+            self.workspace._stage_resources(root, {"resources": source})
+
     def test_resource_view_rejects_unsafe_manifest_path(self) -> None:
         source = self.workspace.paths.repositories / "resources"
         (source / "runtime-paths.txt").write_text("../outside\n", encoding="utf-8")
@@ -719,6 +733,16 @@ class WorkspaceTests(unittest.TestCase):
             self.workspace._stage_resources(root, {"resources": source})
             self.assertEqual(copied, 7)
             self.assertFalse((output / "unexpected").exists())
+
+            (output / "paintings" / "scene.jpg").write_text(
+                "bad cache!\n", encoding="utf-8"
+            )
+            self.workspace._stage_resources(root, {"resources": source})
+            self.assertEqual(copied, 8)
+            self.assertEqual(
+                (output / "paintings" / "scene.jpg").read_text(encoding="utf-8"),
+                "new commit\n",
+            )
 
     def test_resource_view_race_preserves_previous_cache(self) -> None:
         source = self.workspace.paths.repositories / "resources"
@@ -805,10 +829,19 @@ class WorkspaceTests(unittest.TestCase):
         mutated = False
 
         def mutate_after_validation(
-            path: Path, tracked: list[str], *, require_metadata: bool = True
+            path: Path,
+            selected_source: Path,
+            tracked: list[str],
+            *,
+            require_metadata: bool = True,
         ) -> None:
             nonlocal mutated
-            real_validate(path, tracked, require_metadata=require_metadata)
+            real_validate(
+                path,
+                selected_source,
+                tracked,
+                require_metadata=require_metadata,
+            )
             if not mutated:
                 mutated = True
                 (source / "local-race").write_text("dirty\n", encoding="utf-8")
@@ -1074,6 +1107,65 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertEqual(
             [entry.name for entry in destination.parent.iterdir()], ["resources"]
+        )
+
+    def test_topology_runtime_set_copy_failure_preserves_all_snapshots(self) -> None:
+        topology = self.root / "topology"
+        runtime = topology / "runtime"
+        runtime.mkdir(parents=True)
+        sources: list[tuple[str, Path, str]] = []
+        for name, purpose in (
+            ("content", "collected-content"),
+            ("resources", "resource-view"),
+            ("client-maps", "region-map-cache"),
+        ):
+            source = self.root / f"shared-{name}"
+            source.mkdir()
+            (source / "payload").write_text("new\n", encoding="utf-8")
+            atomic_json(
+                source / MANAGED_MARKER,
+                {"schema_version": 1, "purpose": purpose},
+            )
+            destination = runtime / name
+            destination.mkdir()
+            (destination / "payload").write_text("previous\n", encoding="utf-8")
+            atomic_json(
+                destination / MANAGED_MARKER,
+                {"schema_version": 1, "purpose": purpose},
+            )
+            sources.append((name, source, purpose))
+        status = topology / "status.json"
+        status.write_text("previous status\n", encoding="utf-8")
+        real_copy = shutil.copytree
+        copied = 0
+
+        def fail_second_copy(
+            source_path: Path, destination: Path, **kwargs: object
+        ) -> Path:
+            nonlocal copied
+            copied += 1
+            if copied == 2:
+                raise OSError("disk full")
+            return real_copy(source_path, destination, **kwargs)
+
+        with mock.patch(
+            "atrinik_workspace.workspace.shutil.copytree",
+            side_effect=fail_second_copy,
+        ):
+            with self.assertRaisesRegex(OSError, "disk full"):
+                self.workspace._copy_topology_runtime_inputs(
+                    topology, tuple(sources)
+                )
+
+        for name, _source, _purpose in sources:
+            self.assertEqual(
+                (runtime / name / "payload").read_text(encoding="utf-8"),
+                "previous\n",
+            )
+        self.assertEqual(status.read_text(encoding="utf-8"), "previous status\n")
+        self.assertEqual(
+            sorted(entry.name for entry in topology.iterdir()),
+            ["runtime", "status.json"],
         )
 
     def test_region_maps_are_atomic_cached_and_keyed_by_clean_inputs(self) -> None:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1482,17 +1482,20 @@ class WorkspaceTests(unittest.TestCase):
         owned = self.root / "owned"
         nested = owned / "nested"
         nested.mkdir(parents=True)
+        nested.chmod(0o755)
         payload = nested / "payload"
         payload.write_text("preserve\n", encoding="utf-8")
+        original_mode = stat.S_IMODE(nested.stat().st_mode)
 
         with mock.patch(
-            "atrinik_workspace.workspace._descriptor_is_mount",
-            side_effect=[False, True],
+            "atrinik_workspace.workspace._descriptor_mount_id",
+            side_effect=[1, 1, 1, 1, 2],
         ):
             with self.assertRaisesRegex(WorkspaceError, "encountered a mount"):
                 remove_owned_tree(owned)
 
         self.assertEqual(payload.read_text(encoding="utf-8"), "preserve\n")
+        self.assertEqual(stat.S_IMODE(nested.stat().st_mode), original_mode)
 
     def test_topology_runtime_install_rejects_post_copy_replacement(self) -> None:
         topology = self.root / "topology"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 from concurrent.futures import ThreadPoolExecutor
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -26,6 +27,7 @@ from atrinik_workspace.model import (
     profile_key,
 )
 from atrinik_workspace.workspace import (
+    RUNTIME_INPUT_METADATA,
     Workspace,
     _remote_matches as real_remote_matches,
     display_arguments,
@@ -174,6 +176,33 @@ class WorkspaceTests(unittest.TestCase):
             {"schema_version": 1, "purpose": "region-map-cache"},
         )
         return output
+
+    @staticmethod
+    def make_content_candidate(output: Path, commit: str, payload: str) -> None:
+        (output / "lib").mkdir(parents=True)
+        (output / "maps").mkdir()
+        compatibility = output / "compatibility.json"
+        compatibility.write_text(payload, encoding="utf-8")
+        atomic_json(
+            output / "manifest.json",
+            {
+                "schema_version": 2,
+                "source": {
+                    "repository": "atrinik/content",
+                    "branch": "main",
+                    "commit": commit,
+                },
+                "files": [
+                    {
+                        "path": "compatibility.json",
+                        "sha256": hashlib.sha256(
+                            compatibility.read_bytes()
+                        ).hexdigest(),
+                        "size": compatibility.stat().st_size,
+                    }
+                ],
+            },
+        )
 
     def advance_origin(self, name: str, filename: str) -> str:
         seed = self.seeds[name]
@@ -587,10 +616,7 @@ class WorkspaceTests(unittest.TestCase):
         output = self.workspace._stage_resources(root, {"resources": source})
 
         self.assertEqual(load_json(output / MANAGED_MARKER)["purpose"], "resource-view")
-        self.assertEqual(
-            load_json(output / ".atrinik-dependency.json")["workspace_source"],
-            str(source),
-        )
+        self.assertFalse((output / RUNTIME_INPUT_METADATA).exists())
         self.assertEqual(
             (source / ".atrinik-dependency.json").read_text(encoding="utf-8"),
             "component metadata\n",
@@ -639,6 +665,163 @@ class WorkspaceTests(unittest.TestCase):
             "resource\n",
         )
 
+    def test_resource_view_reuses_only_exact_clean_valid_inputs(self) -> None:
+        source = self.workspace.paths.repositories / "resources"
+        root = self.workspace.paths.builds / "profiles" / "test"
+        managed_directory(root, self.workspace.paths.builds, "test-profile")
+        copied = 0
+        real_copy = shutil.copy2
+
+        def counting_copy(source_path: Path, destination: Path, **kwargs: object) -> None:
+            nonlocal copied
+            copied += 1
+            real_copy(source_path, destination, **kwargs)
+
+        with mock.patch(
+            "atrinik_workspace.workspace.shutil.copy2", side_effect=counting_copy
+        ):
+            output = self.workspace._stage_resources(root, {"resources": source})
+            self.workspace._stage_resources(root, {"resources": source})
+            self.assertEqual(copied, 1)
+
+            (source / "paintings" / "scene.jpg").write_text(
+                "new commit\n", encoding="utf-8"
+            )
+            command("git", "add", ".", cwd=source)
+            command("git", "commit", "-m", "test: change resource", cwd=source)
+            self.workspace._stage_resources(root, {"resources": source})
+            self.assertEqual(copied, 2)
+
+            dirty = source / "local-only"
+            dirty.write_text("dirty\n", encoding="utf-8")
+            self.workspace._stage_resources(root, {"resources": source})
+            self.workspace._stage_resources(root, {"resources": source})
+            self.assertEqual(copied, 4)
+            self.assertFalse((output / RUNTIME_INPUT_METADATA).exists())
+            dirty.unlink()
+
+            self.workspace._stage_resources(root, {"resources": source})
+            self.assertEqual(copied, 5)
+            (output / RUNTIME_INPUT_METADATA).write_text("{", encoding="utf-8")
+            self.workspace._stage_resources(root, {"resources": source})
+            self.assertEqual(copied, 6)
+
+            (output / MANAGED_MARKER).write_text("{", encoding="utf-8")
+            with self.assertRaisesRegex(WorkspaceError, "cannot read"):
+                self.workspace._stage_resources(root, {"resources": source})
+            self.assertEqual(copied, 6)
+            atomic_json(
+                output / MANAGED_MARKER,
+                {"schema_version": 1, "purpose": "resource-view"},
+            )
+
+            (output / "unexpected").write_text("corrupt\n", encoding="utf-8")
+            self.workspace._stage_resources(root, {"resources": source})
+            self.assertEqual(copied, 7)
+            self.assertFalse((output / "unexpected").exists())
+
+    def test_resource_view_race_preserves_previous_cache(self) -> None:
+        source = self.workspace.paths.repositories / "resources"
+        root = self.workspace.paths.builds / "profiles" / "test"
+        managed_directory(root, self.workspace.paths.builds, "test-profile")
+        output = self.workspace._stage_resources(root, {"resources": source})
+        previous = (output / "paintings" / "scene.jpg").read_text(encoding="utf-8")
+
+        (source / "paintings" / "scene.jpg").write_text(
+            "next commit\n", encoding="utf-8"
+        )
+        command("git", "add", ".", cwd=source)
+        command("git", "commit", "-m", "test: advance resource", cwd=source)
+        real_copy = shutil.copy2
+        mutated = False
+
+        def mutate_after_copy(source_path: Path, destination: Path, **kwargs: object) -> None:
+            nonlocal mutated
+            real_copy(source_path, destination, **kwargs)
+            if not mutated:
+                mutated = True
+                (source / "README").write_text("changed during staging\n", encoding="utf-8")
+
+        try:
+            with mock.patch(
+                "atrinik_workspace.workspace.shutil.copy2",
+                side_effect=mutate_after_copy,
+            ):
+                with self.assertRaisesRegex(WorkspaceError, "changed during staging"):
+                    self.workspace._stage_resources(root, {"resources": source})
+        finally:
+            command("git", "checkout", "--", "README", cwd=source)
+
+        self.assertEqual(
+            (output / "paintings" / "scene.jpg").read_text(encoding="utf-8"),
+            previous,
+        )
+
+    def test_resource_view_resamples_coordinates_before_staging(self) -> None:
+        source = self.workspace.paths.repositories / "resources"
+        root = self.workspace.paths.builds / "profiles" / "test"
+        managed_directory(root, self.workspace.paths.builds, "test-profile")
+        real_files = self.workspace._resource_runtime_files
+        sampled = False
+
+        def advance_after_first_sample(path: Path) -> tuple[list[str], list[str]]:
+            nonlocal sampled
+            result = real_files(path)
+            if not sampled:
+                sampled = True
+                (source / "catalog").mkdir()
+                (source / "catalog" / "resources.json").write_text(
+                    "new resource\n", encoding="utf-8"
+                )
+                (source / "runtime-paths.txt").write_text(
+                    "catalog\n", encoding="utf-8"
+                )
+                command("git", "add", ".", cwd=source)
+                command(
+                    "git", "commit", "-m", "test: change resource allowlist", cwd=source
+                )
+            return result
+
+        with mock.patch.object(
+            self.workspace,
+            "_resource_runtime_files",
+            side_effect=advance_after_first_sample,
+        ):
+            output = self.workspace._stage_resources(root, {"resources": source})
+
+        self.assertTrue((output / "catalog" / "resources.json").is_file())
+        self.assertFalse((output / "paintings").exists())
+        self.assertEqual(
+            load_json(output / RUNTIME_INPUT_METADATA)["coordinate"]["head"],
+            command("git", "rev-parse", "HEAD", cwd=source),
+        )
+
+    def test_resource_cache_hit_rechecks_source_after_validation(self) -> None:
+        source = self.workspace.paths.repositories / "resources"
+        root = self.workspace.paths.builds / "profiles" / "test"
+        managed_directory(root, self.workspace.paths.builds, "test-profile")
+        output = self.workspace._stage_resources(root, {"resources": source})
+        real_validate = self.workspace._validate_resource_view
+        mutated = False
+
+        def mutate_after_validation(
+            path: Path, tracked: list[str], *, require_metadata: bool = True
+        ) -> None:
+            nonlocal mutated
+            real_validate(path, tracked, require_metadata=require_metadata)
+            if not mutated:
+                mutated = True
+                (source / "local-race").write_text("dirty\n", encoding="utf-8")
+
+        with mock.patch.object(
+            self.workspace,
+            "_validate_resource_view",
+            side_effect=mutate_after_validation,
+        ):
+            self.workspace._stage_resources(root, {"resources": source})
+
+        self.assertFalse((output / RUNTIME_INPUT_METADATA).exists())
+
     def test_content_collection_failure_preserves_previous_output(self) -> None:
         root = self.workspace.paths.builds / "profiles" / "test"
         managed_directory(root, self.workspace.paths.builds, "test-profile")
@@ -659,6 +842,239 @@ class WorkspaceTests(unittest.TestCase):
                 )
 
         self.assertEqual((output / "sentinel").read_text(encoding="utf-8"), "last good\n")
+
+    def test_content_collection_reuses_only_exact_clean_valid_inputs(self) -> None:
+        source = self.workspace.paths.repositories / "content"
+        root = self.workspace.paths.builds / "profiles" / "test"
+        managed_directory(root, self.workspace.paths.builds, "test-profile")
+        collections = 0
+
+        def collect(arguments: list[str], **kwargs: object) -> str:
+            nonlocal collections
+            if arguments[0] != os.sys.executable:
+                return workspace_run(arguments, **kwargs)
+            collections += 1
+            output = Path(arguments[arguments.index("--output") + 1])
+            self.make_content_candidate(
+                output,
+                arguments[arguments.index("--source-commit") + 1],
+                f"collection {collections}\n",
+            )
+            return ""
+
+        with mock.patch("atrinik_workspace.workspace.run", side_effect=collect):
+            output = self.workspace._collect_content(root, {"content": source})
+            self.workspace._collect_content(root, {"content": source})
+            self.assertEqual(collections, 1)
+
+            (source / "README").write_text("new commit\n", encoding="utf-8")
+            command("git", "add", ".", cwd=source)
+            command("git", "commit", "-m", "test: change content", cwd=source)
+            self.workspace._collect_content(root, {"content": source})
+            self.assertEqual(collections, 2)
+
+            dirty = source / "local-only"
+            dirty.write_text("dirty\n", encoding="utf-8")
+            self.workspace._collect_content(root, {"content": source})
+            self.workspace._collect_content(root, {"content": source})
+            self.assertEqual(collections, 4)
+            self.assertFalse((output / RUNTIME_INPUT_METADATA).exists())
+            dirty.unlink()
+
+            self.workspace._collect_content(root, {"content": source})
+            self.assertEqual(collections, 5)
+            (output / RUNTIME_INPUT_METADATA).write_text("{", encoding="utf-8")
+            self.workspace._collect_content(root, {"content": source})
+            self.assertEqual(collections, 6)
+            compatibility = output / "compatibility.json"
+            corrupted = compatibility.read_bytes()
+            compatibility.write_bytes(b"X" + corrupted[1:])
+            self.workspace._collect_content(root, {"content": source})
+            self.assertEqual(collections, 7)
+            (output / MANAGED_MARKER).write_text("{", encoding="utf-8")
+            with self.assertRaisesRegex(WorkspaceError, "cannot read"):
+                self.workspace._collect_content(root, {"content": source})
+            self.assertEqual(collections, 7)
+            atomic_json(
+                output / MANAGED_MARKER,
+                {"schema_version": 1, "purpose": "collected-content"},
+            )
+            (output / "manifest.json").unlink()
+            self.workspace._collect_content(root, {"content": source})
+            self.assertEqual(collections, 8)
+
+    def test_content_collection_race_preserves_previous_cache(self) -> None:
+        source = self.workspace.paths.repositories / "content"
+        root = self.workspace.paths.builds / "profiles" / "test"
+        managed_directory(root, self.workspace.paths.builds, "test-profile")
+        mutate = False
+
+        def collect(arguments: list[str], **kwargs: object) -> str:
+            if arguments[0] != os.sys.executable:
+                return workspace_run(arguments, **kwargs)
+            output = Path(arguments[arguments.index("--output") + 1])
+            self.make_content_candidate(
+                output,
+                arguments[arguments.index("--source-commit") + 1],
+                "generated\n",
+            )
+            if mutate:
+                (source / "README").write_text(
+                    "changed during collection\n", encoding="utf-8"
+                )
+            return ""
+
+        with mock.patch("atrinik_workspace.workspace.run", side_effect=collect):
+            output = self.workspace._collect_content(root, {"content": source})
+            previous = (output / "manifest.json").read_text(encoding="utf-8")
+            (source / "README").write_text("next commit\n", encoding="utf-8")
+            command("git", "add", ".", cwd=source)
+            command("git", "commit", "-m", "test: advance content", cwd=source)
+            mutate = True
+            try:
+                with self.assertRaisesRegex(
+                    WorkspaceError, "changed during collection"
+                ):
+                    self.workspace._collect_content(root, {"content": source})
+            finally:
+                command("git", "checkout", "--", "README", cwd=source)
+
+        self.assertEqual(
+            (output / "manifest.json").read_text(encoding="utf-8"), previous
+        )
+
+    def test_content_cache_hit_rechecks_source_after_validation(self) -> None:
+        source = self.workspace.paths.repositories / "content"
+        root = self.workspace.paths.builds / "profiles" / "test"
+        managed_directory(root, self.workspace.paths.builds, "test-profile")
+
+        def collect(arguments: list[str], **kwargs: object) -> str:
+            if arguments[0] != os.sys.executable:
+                return workspace_run(arguments, **kwargs)
+            output = Path(arguments[arguments.index("--output") + 1])
+            self.make_content_candidate(
+                output,
+                arguments[arguments.index("--source-commit") + 1],
+                "content\n",
+            )
+            return ""
+
+        with mock.patch("atrinik_workspace.workspace.run", side_effect=collect):
+            output = self.workspace._collect_content(root, {"content": source})
+            real_validate = self.workspace._validate_collected_content
+            mutated = False
+
+            def mutate_after_validation(
+                path: Path,
+                coordinate: dict[str, str],
+                *,
+                require_metadata: bool = True,
+            ) -> None:
+                nonlocal mutated
+                real_validate(
+                    path, coordinate, require_metadata=require_metadata
+                )
+                if not mutated:
+                    mutated = True
+                    (source / "local-race").write_text("dirty\n", encoding="utf-8")
+
+            with mock.patch.object(
+                self.workspace,
+                "_validate_collected_content",
+                side_effect=mutate_after_validation,
+            ):
+                self.workspace._collect_content(root, {"content": source})
+
+        self.assertFalse((output / RUNTIME_INPUT_METADATA).exists())
+
+    def test_topology_runtime_copies_are_independent_from_shared_cache(self) -> None:
+        sources: dict[str, Path] = {}
+        for name, purpose in (
+            ("content", "collected-content"),
+            ("resources", "resource-view"),
+        ):
+            source = self.root / f"shared-{name}-cache"
+            source.mkdir()
+            (source / "payload").write_text("shared\n", encoding="utf-8")
+            atomic_json(
+                source / MANAGED_MARKER,
+                {"schema_version": 1, "purpose": purpose},
+            )
+            sources[name] = source
+        first_root = self.root / "first-topology"
+        second_root = self.root / "second-topology"
+        first_root.mkdir()
+        second_root.mkdir()
+
+        for name, purpose in (
+            ("content", "collected-content"),
+            ("resources", "resource-view"),
+        ):
+            first = self.workspace._take_topology_runtime_input(
+                first_root,
+                sources[name],
+                name,
+                purpose,
+                preserve_source=True,
+            )
+            second = self.workspace._take_topology_runtime_input(
+                second_root,
+                sources[name],
+                name,
+                purpose,
+                preserve_source=True,
+            )
+            (first / "payload").write_text("first changed\n", encoding="utf-8")
+            shutil.rmtree(first)
+
+            self.assertEqual(
+                (sources[name] / "payload").read_text(encoding="utf-8"),
+                "shared\n",
+            )
+            self.assertEqual(
+                (second / "payload").read_text(encoding="utf-8"), "shared\n"
+            )
+
+    def test_topology_runtime_copy_failure_preserves_previous_snapshot(self) -> None:
+        source = self.root / "shared-cache"
+        source.mkdir()
+        (source / "payload").write_text("new\n", encoding="utf-8")
+        atomic_json(
+            source / MANAGED_MARKER,
+            {"schema_version": 1, "purpose": "resource-view"},
+        )
+        topology = self.root / "topology"
+        destination = topology / "runtime" / "resources"
+        destination.mkdir(parents=True)
+        (destination / "payload").write_text("previous\n", encoding="utf-8")
+        atomic_json(
+            destination / MANAGED_MARKER,
+            {"schema_version": 1, "purpose": "resource-view"},
+        )
+
+        def fail_copy(source_path: Path, staging: Path, **kwargs: object) -> None:
+            staging.mkdir()
+            (staging / "partial").write_text("partial\n", encoding="utf-8")
+            raise OSError("disk full")
+
+        with mock.patch(
+            "atrinik_workspace.workspace.shutil.copytree", side_effect=fail_copy
+        ):
+            with self.assertRaisesRegex(OSError, "disk full"):
+                self.workspace._take_topology_runtime_input(
+                    topology,
+                    source,
+                    "resources",
+                    "resource-view",
+                    preserve_source=True,
+                )
+
+        self.assertEqual(
+            (destination / "payload").read_text(encoding="utf-8"), "previous\n"
+        )
+        self.assertEqual(
+            [entry.name for entry in destination.parent.iterdir()], ["resources"]
+        )
 
     def test_region_maps_are_atomic_cached_and_keyed_by_clean_inputs(self) -> None:
         source = self.workspace.paths.repositories / "server"
@@ -1144,6 +1560,12 @@ class WorkspaceTests(unittest.TestCase):
             build_root / "runtime" / "resources",
         ):
             path.mkdir(parents=True, exist_ok=True)
+        (build_root / "runtime" / "content" / "maps" / "map").write_text(
+            "shared content\n", encoding="utf-8"
+        )
+        (build_root / "runtime" / "resources" / "resource").write_text(
+            "shared resource\n", encoding="utf-8"
+        )
         atomic_json(
             build_root / "runtime" / "content" / MANAGED_MARKER,
             {"schema_version": 1, "purpose": "collected-content"},
@@ -1205,6 +1627,12 @@ class WorkspaceTests(unittest.TestCase):
         self.assertTrue(
             (build_root / "runtime" / "client-maps" / "incuna_-1.png").is_file()
         )
+        self.assertTrue(
+            (build_root / "runtime" / "content" / "maps" / "map").is_file()
+        )
+        self.assertTrue(
+            (build_root / "runtime" / "resources" / "resource").is_file()
+        )
         self.assertEqual(
             Path(status["services"]["client"]["cwd"]),
             self.workspace.paths.topologies
@@ -1243,7 +1671,54 @@ class WorkspaceTests(unittest.TestCase):
             client_log.read_text(),
         )
         state = self.workspace._state_location("default")
+        second_state = self.workspace.state_add("second", None)
         try:
+            with (
+                mock.patch.object(
+                    self.workspace, "_build_resolved", return_value=build_root
+                ),
+                mock.patch.object(
+                    self.workspace, "_select_topology_port", return_value=17301
+                ),
+            ):
+                second = self.workspace.topology_up(
+                    "server-review-two", "default", "second", ["server"], 17301
+                )
+            self.assertTrue(second["ready"])
+            self.assertEqual(second["endpoint"]["port"], 17301)
+            for topology in ("server-review", "server-review-two"):
+                snapshot = self.workspace.paths.topologies / topology / "runtime"
+                self.assertEqual(
+                    (snapshot / "content" / "maps" / "map").read_text(),
+                    "shared content\n",
+                )
+                self.assertEqual(
+                    (snapshot / "resources" / "resource").read_text(),
+                    "shared resource\n",
+                )
+            self.workspace.topology_down("server-review-two", timeout=5)
+            second_content = (
+                self.workspace.paths.topologies
+                / "server-review-two"
+                / "runtime"
+                / "content"
+            )
+            shutil.rmtree(second_content)
+            self.assertEqual(
+                (
+                    self.workspace.paths.topologies
+                    / "server-review"
+                    / "runtime"
+                    / "content"
+                    / "maps"
+                    / "map"
+                ).read_text(),
+                "shared content\n",
+            )
+            self.assertEqual(
+                (build_root / "runtime" / "content" / "maps" / "map").read_text(),
+                "shared content\n",
+            )
             with self.assertRaisesRegex(WorkspaceError, "already in use"):
                 with exclusive_lock(
                     Path(f"{state}.lock"), "server state", nonblocking=True
@@ -1282,6 +1757,12 @@ class WorkspaceTests(unittest.TestCase):
                 any(service["running"] for service in recovered["services"].values())
             )
         finally:
+            second_remaining = self.workspace.topology_status("server-review-two")
+            if second_remaining["supervisor"]["running"] or any(
+                service["running"]
+                for service in second_remaining["services"].values()
+            ):
+                self.workspace.topology_down("server-review-two", timeout=5)
             remaining = self.workspace.topology_status("server-review")
             if remaining["supervisor"]["running"] or any(
                 service["running"] for service in remaining["services"].values()
@@ -1289,6 +1770,10 @@ class WorkspaceTests(unittest.TestCase):
                 self.workspace.topology_down("server-review", timeout=5)
 
         with exclusive_lock(Path(f"{state}.lock"), "server state", nonblocking=True):
+            pass
+        with exclusive_lock(
+            Path(f"{second_state}.lock"), "server state", nonblocking=True
+        ):
             pass
 
     def test_topology_port_selection_rejects_unavailable_port(self) -> None:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -32,6 +32,7 @@ from atrinik_workspace.workspace import (
     _remote_matches as real_remote_matches,
     display_arguments,
     exclusive_lock,
+    replace_directory as workspace_replace_directory,
     run as workspace_run,
 )
 
@@ -781,6 +782,64 @@ class WorkspaceTests(unittest.TestCase):
             previous,
         )
 
+    def test_resource_install_race_rolls_back_previous_cache(self) -> None:
+        source = self.workspace.paths.repositories / "resources"
+        root = self.workspace.paths.builds / "profiles" / "test"
+        managed_directory(root, self.workspace.paths.builds, "test-profile")
+        output = self.workspace._stage_resources(root, {"resources": source})
+        previous = (output / "paintings" / "scene.jpg").read_text(encoding="utf-8")
+        (source / "paintings" / "scene.jpg").write_text(
+            "next commit\n", encoding="utf-8"
+        )
+        command("git", "add", ".", cwd=source)
+        command("git", "commit", "-m", "test: advance resource", cwd=source)
+        advanced = False
+
+        def replace_then_advance(
+            destination: Path,
+            staging: Path,
+            backup_prefix: str,
+            verify_after_install: object = None,
+        ) -> None:
+            nonlocal advanced
+
+            def advance_and_verify() -> None:
+                nonlocal advanced
+                if not advanced:
+                    advanced = True
+                    (source / "paintings" / "scene.jpg").write_text(
+                        "commit after install\n", encoding="utf-8"
+                    )
+                    command("git", "add", ".", cwd=source)
+                    command(
+                        "git",
+                        "commit",
+                        "-m",
+                        "test: race after install",
+                        cwd=source,
+                    )
+                assert callable(verify_after_install)
+                verify_after_install()
+
+            workspace_replace_directory(
+                destination,
+                staging,
+                backup_prefix,
+                advance_and_verify,
+            )
+
+        with mock.patch(
+            "atrinik_workspace.workspace.replace_directory",
+            side_effect=replace_then_advance,
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "changed during staging"):
+                self.workspace._stage_resources(root, {"resources": source})
+
+        self.assertEqual(
+            (output / "paintings" / "scene.jpg").read_text(encoding="utf-8"),
+            previous,
+        )
+
     def test_resource_view_resamples_coordinates_before_staging(self) -> None:
         source = self.workspace.paths.repositories / "resources"
         root = self.workspace.paths.builds / "profiles" / "test"
@@ -1020,11 +1079,66 @@ class WorkspaceTests(unittest.TestCase):
 
         self.assertFalse((output / RUNTIME_INPUT_METADATA).exists())
 
+    def test_content_install_race_rolls_back_previous_cache(self) -> None:
+        source = self.workspace.paths.repositories / "content"
+        root = self.workspace.paths.builds / "profiles" / "test"
+        managed_directory(root, self.workspace.paths.builds, "test-profile")
+
+        def collect(arguments: list[str], **kwargs: object) -> str:
+            if arguments[0] != os.sys.executable:
+                return workspace_run(arguments, **kwargs)
+            output = Path(arguments[arguments.index("--output") + 1])
+            self.make_content_candidate(
+                output,
+                arguments[arguments.index("--source-commit") + 1],
+                "content\n",
+            )
+            return ""
+
+        with mock.patch("atrinik_workspace.workspace.run", side_effect=collect):
+            output = self.workspace._collect_content(root, {"content": source})
+            previous = (output / "manifest.json").read_text(encoding="utf-8")
+            (source / "README").write_text("next commit\n", encoding="utf-8")
+            command("git", "add", ".", cwd=source)
+            command("git", "commit", "-m", "test: advance content", cwd=source)
+            advanced = False
+
+            def advance_after_metadata(path: Path, value: object) -> None:
+                nonlocal advanced
+                atomic_json(path, value)
+                if path.name == RUNTIME_INPUT_METADATA and not advanced:
+                    advanced = True
+                    (source / "README").write_text(
+                        "commit after metadata\n", encoding="utf-8"
+                    )
+                    command("git", "add", ".", cwd=source)
+                    command(
+                        "git",
+                        "commit",
+                        "-m",
+                        "test: race after metadata",
+                        cwd=source,
+                    )
+
+            with mock.patch(
+                "atrinik_workspace.workspace.atomic_json",
+                side_effect=advance_after_metadata,
+            ):
+                with self.assertRaisesRegex(
+                    WorkspaceError, "changed during collection"
+                ):
+                    self.workspace._collect_content(root, {"content": source})
+
+        self.assertEqual(
+            (output / "manifest.json").read_text(encoding="utf-8"), previous
+        )
+
     def test_topology_runtime_copies_are_independent_from_shared_cache(self) -> None:
         sources: dict[str, Path] = {}
         for name, purpose in (
             ("content", "collected-content"),
             ("resources", "resource-view"),
+            ("client-maps", "region-map-cache"),
         ):
             source = self.root / f"shared-{name}-cache"
             source.mkdir()
@@ -1038,25 +1152,24 @@ class WorkspaceTests(unittest.TestCase):
         second_root = self.root / "second-topology"
         first_root.mkdir()
         second_root.mkdir()
+        specifications = tuple(
+            (name, sources[name], purpose)
+            for name, purpose in (
+                ("content", "collected-content"),
+                ("resources", "resource-view"),
+                ("client-maps", "region-map-cache"),
+            )
+        )
+        first_inputs = self.workspace._copy_topology_runtime_inputs(
+            first_root, specifications
+        )
+        second_inputs = self.workspace._copy_topology_runtime_inputs(
+            second_root, specifications
+        )
 
-        for name, purpose in (
-            ("content", "collected-content"),
-            ("resources", "resource-view"),
-        ):
-            first = self.workspace._take_topology_runtime_input(
-                first_root,
-                sources[name],
-                name,
-                purpose,
-                preserve_source=True,
-            )
-            second = self.workspace._take_topology_runtime_input(
-                second_root,
-                sources[name],
-                name,
-                purpose,
-                preserve_source=True,
-            )
+        for name in sources:
+            first = first_inputs[name]
+            second = second_inputs[name]
             (first / "payload").write_text("first changed\n", encoding="utf-8")
             shutil.rmtree(first)
 
@@ -1067,47 +1180,6 @@ class WorkspaceTests(unittest.TestCase):
             self.assertEqual(
                 (second / "payload").read_text(encoding="utf-8"), "shared\n"
             )
-
-    def test_topology_runtime_copy_failure_preserves_previous_snapshot(self) -> None:
-        source = self.root / "shared-cache"
-        source.mkdir()
-        (source / "payload").write_text("new\n", encoding="utf-8")
-        atomic_json(
-            source / MANAGED_MARKER,
-            {"schema_version": 1, "purpose": "resource-view"},
-        )
-        topology = self.root / "topology"
-        destination = topology / "runtime" / "resources"
-        destination.mkdir(parents=True)
-        (destination / "payload").write_text("previous\n", encoding="utf-8")
-        atomic_json(
-            destination / MANAGED_MARKER,
-            {"schema_version": 1, "purpose": "resource-view"},
-        )
-
-        def fail_copy(source_path: Path, staging: Path, **kwargs: object) -> None:
-            staging.mkdir()
-            (staging / "partial").write_text("partial\n", encoding="utf-8")
-            raise OSError("disk full")
-
-        with mock.patch(
-            "atrinik_workspace.workspace.shutil.copytree", side_effect=fail_copy
-        ):
-            with self.assertRaisesRegex(OSError, "disk full"):
-                self.workspace._take_topology_runtime_input(
-                    topology,
-                    source,
-                    "resources",
-                    "resource-view",
-                    preserve_source=True,
-                )
-
-        self.assertEqual(
-            (destination / "payload").read_text(encoding="utf-8"), "previous\n"
-        )
-        self.assertEqual(
-            [entry.name for entry in destination.parent.iterdir()], ["resources"]
-        )
 
     def test_topology_runtime_set_copy_failure_preserves_all_snapshots(self) -> None:
         topology = self.root / "topology"
@@ -1166,6 +1238,61 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual(
             sorted(entry.name for entry in topology.iterdir()),
             ["runtime", "status.json"],
+        )
+
+    def test_topology_runtime_set_rejects_internal_links(self) -> None:
+        topology = self.root / "topology"
+        topology.mkdir()
+        source = self.root / "shared-content"
+        source.mkdir()
+        external = self.root / "external"
+        external.write_text("private\n", encoding="utf-8")
+        (source / "payload").symlink_to(external)
+        atomic_json(
+            source / MANAGED_MARKER,
+            {"schema_version": 1, "purpose": "collected-content"},
+        )
+
+        with self.assertRaisesRegex(WorkspaceError, "contains a"):
+            self.workspace._copy_topology_runtime_inputs(
+                topology,
+                (("content", source, "collected-content"),),
+            )
+
+        self.assertEqual(list(topology.iterdir()), [])
+
+    def test_replace_directory_cleanup_failure_keeps_committed_output(self) -> None:
+        output = self.root / "output"
+        output.mkdir()
+        (output / "payload").write_text("previous\n", encoding="utf-8")
+        staging = self.root / "staging"
+        staging.mkdir()
+        (staging / "payload").write_text("new\n", encoding="utf-8")
+        real_remove = shutil.rmtree
+
+        def fail_backup_cleanup(path: Path, **kwargs: object) -> None:
+            if Path(path).name.startswith(".previous-"):
+                raise PermissionError("read only")
+            real_remove(path, **kwargs)
+
+        with mock.patch(
+            "atrinik_workspace.workspace.shutil.rmtree",
+            side_effect=fail_backup_cleanup,
+        ):
+            workspace_replace_directory(output, staging, ".previous-")
+
+        self.assertEqual(
+            (output / "payload").read_text(encoding="utf-8"), "new\n"
+        )
+        self.assertEqual(
+            len(
+                [
+                    path
+                    for path in self.root.iterdir()
+                    if path.name.startswith(".previous-")
+                ]
+            ),
+            1,
         )
 
     def test_region_maps_are_atomic_cached_and_keyed_by_clean_inputs(self) -> None:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1208,20 +1208,21 @@ class WorkspaceTests(unittest.TestCase):
             sources.append((name, source, purpose))
         status = topology / "status.json"
         status.write_text("previous status\n", encoding="utf-8")
-        real_copy = shutil.copytree
+        real_copy = self.workspace._copy_topology_runtime_tree
         copied = 0
 
         def fail_second_copy(
-            source_path: Path, destination: Path, **kwargs: object
-        ) -> Path:
+            source_path: Path, destination: Path
+        ) -> None:
             nonlocal copied
             copied += 1
             if copied == 2:
                 raise OSError("disk full")
-            return real_copy(source_path, destination, **kwargs)
+            real_copy(source_path, destination)
 
-        with mock.patch(
-            "atrinik_workspace.workspace.shutil.copytree",
+        with mock.patch.object(
+            self.workspace,
+            "_copy_topology_runtime_tree",
             side_effect=fail_second_copy,
         ):
             with self.assertRaisesRegex(OSError, "disk full"):
@@ -1261,6 +1262,46 @@ class WorkspaceTests(unittest.TestCase):
 
         self.assertEqual(list(topology.iterdir()), [])
 
+    def test_topology_runtime_set_rejects_file_changed_to_link_during_copy(
+        self,
+    ) -> None:
+        topology = self.root / "topology"
+        topology.mkdir()
+        source = self.root / "shared-content"
+        source.mkdir()
+        payload = source / "payload"
+        payload.write_text("shared\n", encoding="utf-8")
+        external = self.root / "external"
+        external.write_text("private\n", encoding="utf-8")
+        atomic_json(
+            source / MANAGED_MARKER,
+            {"schema_version": 1, "purpose": "collected-content"},
+        )
+        real_stat = os.stat
+        changed = False
+
+        def stat_then_change(
+            path: object, *args: object, **kwargs: object
+        ) -> os.stat_result:
+            nonlocal changed
+            result = real_stat(path, *args, **kwargs)
+            if path == "payload" and kwargs.get("dir_fd") is not None and not changed:
+                changed = True
+                payload.unlink()
+                payload.symlink_to(external)
+            return result
+
+        with mock.patch(
+            "atrinik_workspace.workspace.os.stat", side_effect=stat_then_change
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "changed or contains a link"):
+                self.workspace._copy_topology_runtime_inputs(
+                    topology,
+                    (("content", source, "collected-content"),),
+                )
+
+        self.assertEqual(list(topology.iterdir()), [])
+
     def test_replace_directory_cleanup_failure_keeps_committed_output(self) -> None:
         output = self.root / "output"
         output.mkdir()
@@ -1281,6 +1322,14 @@ class WorkspaceTests(unittest.TestCase):
         ):
             workspace_replace_directory(output, staging, ".previous-")
 
+            next_staging = self.root / "next-staging"
+            next_staging.mkdir()
+            (next_staging / "payload").write_text("next\n", encoding="utf-8")
+            with self.assertRaisesRegex(
+                WorkspaceError, "cannot reclaim replaced-directory backup"
+            ):
+                workspace_replace_directory(output, next_staging, ".previous-")
+
         self.assertEqual(
             (output / "payload").read_text(encoding="utf-8"), "new\n"
         )
@@ -1293,6 +1342,18 @@ class WorkspaceTests(unittest.TestCase):
                 ]
             ),
             1,
+        )
+        workspace_replace_directory(output, next_staging, ".previous-")
+        self.assertEqual(
+            (output / "payload").read_text(encoding="utf-8"), "next\n"
+        )
+        self.assertEqual(
+            [
+                path
+                for path in self.root.iterdir()
+                if path.name.startswith(".previous-")
+            ],
+            [],
         )
 
     def test_region_maps_are_atomic_cached_and_keyed_by_clean_inputs(self) -> None:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1302,6 +1302,87 @@ class WorkspaceTests(unittest.TestCase):
 
         self.assertEqual(list(topology.iterdir()), [])
 
+    def test_topology_runtime_set_rejects_destination_directory_link_race(
+        self,
+    ) -> None:
+        topology = self.root / "topology"
+        topology.mkdir()
+        source = self.root / "shared-content"
+        nested = source / "nested"
+        nested.mkdir(parents=True)
+        (nested / "payload").write_text("shared\n", encoding="utf-8")
+        atomic_json(
+            source / MANAGED_MARKER,
+            {"schema_version": 1, "purpose": "collected-content"},
+        )
+        external = self.root / "external"
+        external.mkdir()
+        (external / "sentinel").write_text("private\n", encoding="utf-8")
+        real_open = os.open
+        changed = False
+
+        def open_after_change(
+            path: object, flags: int, *args: object, **kwargs: object
+        ) -> int:
+            nonlocal changed
+            directory_fd = kwargs.get("dir_fd")
+            if (
+                path == "nested"
+                and isinstance(directory_fd, int)
+                and flags & os.O_DIRECTORY
+                and not changed
+            ):
+                parent = Path(f"/proc/self/fd/{directory_fd}").resolve()
+                if ".runtime-" in str(parent):
+                    changed = True
+                    (parent / "nested").rmdir()
+                    (parent / "nested").symlink_to(external, target_is_directory=True)
+            return real_open(path, flags, *args, **kwargs)
+
+        with mock.patch(
+            "atrinik_workspace.workspace.os.open", side_effect=open_after_change
+        ):
+            with self.assertRaisesRegex(
+                WorkspaceError, "staging destination changed"
+            ):
+                self.workspace._copy_topology_runtime_inputs(
+                    topology,
+                    (("content", source, "collected-content"),),
+                )
+
+        self.assertTrue(changed)
+        self.assertEqual(
+            (external / "sentinel").read_text(encoding="utf-8"), "private\n"
+        )
+        self.assertEqual(sorted(path.name for path in external.iterdir()), ["sentinel"])
+        self.assertEqual(list(topology.iterdir()), [])
+
+    def test_topology_runtime_set_copies_read_only_directories(self) -> None:
+        topology = self.root / "topology"
+        topology.mkdir()
+        source = self.root / "shared-content"
+        nested = source / "nested"
+        nested.mkdir(parents=True)
+        (nested / "payload").write_text("shared\n", encoding="utf-8")
+        atomic_json(
+            source / MANAGED_MARKER,
+            {"schema_version": 1, "purpose": "collected-content"},
+        )
+        nested.chmod(0o555)
+        source.chmod(0o555)
+
+        copied = self.workspace._copy_topology_runtime_inputs(
+            topology,
+            (("content", source, "collected-content"),),
+        )["content"]
+
+        self.assertEqual(
+            (copied / "nested" / "payload").read_text(encoding="utf-8"),
+            "shared\n",
+        )
+        self.assertEqual(stat.S_IMODE(copied.stat().st_mode), 0o555)
+        self.assertEqual(stat.S_IMODE((copied / "nested").stat().st_mode), 0o555)
+
     def test_replace_directory_cleanup_failure_keeps_committed_output(self) -> None:
         output = self.root / "output"
         output.mkdir()
@@ -1355,6 +1436,30 @@ class WorkspaceTests(unittest.TestCase):
             ],
             [],
         )
+
+    def test_replace_directory_restores_interrupted_pending_output(self) -> None:
+        output = self.root / "output"
+        pending = self.root / ".previous-pending"
+        previous = pending / "previous"
+        previous.mkdir(parents=True)
+        (previous / "payload").write_text("previous\n", encoding="utf-8")
+        atomic_json(
+            pending / MANAGED_MARKER,
+            {
+                "schema_version": 1,
+                "purpose": "replaced-directory-backup",
+                "output": "output",
+            },
+        )
+        missing_staging = self.root / "missing-staging"
+
+        with self.assertRaises(FileNotFoundError):
+            workspace_replace_directory(output, missing_staging, ".previous-")
+
+        self.assertEqual(
+            (output / "payload").read_text(encoding="utf-8"), "previous\n"
+        )
+        self.assertFalse(pending.exists())
 
     def test_region_maps_are_atomic_cached_and_keyed_by_clean_inputs(self) -> None:
         source = self.workspace.paths.repositories / "server"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1213,12 +1213,12 @@ class WorkspaceTests(unittest.TestCase):
 
         def fail_second_copy(
             source_path: Path, destination: Path
-        ) -> None:
+        ) -> int:
             nonlocal copied
             copied += 1
             if copied == 2:
                 raise OSError("disk full")
-            real_copy(source_path, destination)
+            return real_copy(source_path, destination)
 
         with mock.patch.object(
             self.workspace,
@@ -1375,6 +1375,10 @@ class WorkspaceTests(unittest.TestCase):
             topology,
             (("content", source, "collected-content"),),
         )["content"]
+        copied = self.workspace._copy_topology_runtime_inputs(
+            topology,
+            (("content", source, "collected-content"),),
+        )["content"]
 
         self.assertEqual(
             (copied / "nested" / "payload").read_text(encoding="utf-8"),
@@ -1393,7 +1397,10 @@ class WorkspaceTests(unittest.TestCase):
         real_remove = shutil.rmtree
 
         def fail_backup_cleanup(path: Path, **kwargs: object) -> None:
-            if Path(path).name.startswith(".previous-"):
+            if Path(path).name == "previous" and Path(path).parent.name.startswith(
+                ".previous-"
+            ):
+                (Path(path) / "payload").unlink(missing_ok=True)
                 raise PermissionError("read only")
             real_remove(path, **kwargs)
 
@@ -1423,6 +1430,9 @@ class WorkspaceTests(unittest.TestCase):
                 ]
             ),
             1,
+        )
+        self.assertTrue(
+            (self.root / ".previous-pending" / MANAGED_MARKER).is_file()
         )
         workspace_replace_directory(output, next_staging, ".previous-")
         self.assertEqual(
@@ -1460,6 +1470,47 @@ class WorkspaceTests(unittest.TestCase):
             (output / "payload").read_text(encoding="utf-8"), "previous\n"
         )
         self.assertFalse(pending.exists())
+
+    def test_topology_runtime_install_rejects_post_copy_replacement(self) -> None:
+        topology = self.root / "topology"
+        topology.mkdir()
+        source = self.root / "shared-content"
+        source.mkdir()
+        (source / "payload").write_text("shared\n", encoding="utf-8")
+        atomic_json(
+            source / MANAGED_MARKER,
+            {"schema_version": 1, "purpose": "collected-content"},
+        )
+        external = self.root / "external"
+        external.write_text("private\n", encoding="utf-8")
+        real_copy = self.workspace._copy_topology_runtime_tree
+
+        def copy_then_replace(source_path: Path, destination: Path) -> int:
+            descriptor = real_copy(source_path, destination)
+            destination.replace(destination.with_name("copied-original"))
+            destination.mkdir()
+            (destination / "payload").symlink_to(external)
+            atomic_json(
+                destination / MANAGED_MARKER,
+                {"schema_version": 1, "purpose": "collected-content"},
+            )
+            return descriptor
+
+        with mock.patch.object(
+            self.workspace,
+            "_copy_topology_runtime_tree",
+            side_effect=copy_then_replace,
+        ):
+            with self.assertRaisesRegex(
+                WorkspaceError, "installed topology runtime input changed"
+            ):
+                self.workspace._copy_topology_runtime_inputs(
+                    topology,
+                    (("content", source, "collected-content"),),
+                )
+
+        self.assertEqual(list(topology.iterdir()), [])
+        self.assertEqual(external.read_text(encoding="utf-8"), "private\n")
 
     def test_region_maps_are_atomic_cached_and_keyed_by_clean_inputs(self) -> None:
         source = self.workspace.paths.repositories / "server"
@@ -2511,6 +2562,39 @@ class WorkspaceTests(unittest.TestCase):
         with exclusive_lock(Path(f"{state}.lock"), "test state"):
             with self.assertRaisesRegex(WorkspaceError, "already in use"):
                 self.workspace.scenario_reset("locked")
+
+    def test_scenario_reset_recovers_state_before_loading_scenario(self) -> None:
+        root = self.workspace.paths.scenarios / "recovery"
+        pending = root / ".recovery-state-previous-pending"
+        previous = pending / "previous"
+        previous.mkdir(parents=True)
+        (previous / "payload").write_text("previous\n", encoding="utf-8")
+        atomic_json(
+            pending / MANAGED_MARKER,
+            {
+                "schema_version": 1,
+                "purpose": "replaced-directory-backup",
+                "output": "state",
+            },
+        )
+
+        def observe_recovered_state(name: str) -> dict[str, object]:
+            self.assertEqual(name, "recovery")
+            self.assertEqual(
+                (root / "state" / "payload").read_text(encoding="utf-8"),
+                "previous\n",
+            )
+            raise WorkspaceError("stop after recovery")
+
+        with mock.patch.object(
+            self.workspace,
+            "_load_scenario",
+            side_effect=observe_recovered_state,
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "stop after recovery"):
+                self.workspace._scenario_reset("recovery")
+
+        self.assertFalse(pending.exists())
 
     def test_foreground_client_pins_matching_server_state(self) -> None:
         server = self.workspace.paths.repositories / "server"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2799,6 +2799,17 @@ class WorkspaceTests(unittest.TestCase):
 
     @unittest.skipUnless(sys.platform == "linux", "requires Linux O_PATH")
     def test_owned_tree_removal_handles_unreadable_directories(self) -> None:
+        real_open = os.open
+
+        def deny_initial_read(
+            path: object, flags: int, *args: object, **kwargs: object
+        ) -> int:
+            if path in {"owned", "nested", "unsupported"} and not (
+                flags & os.O_PATH
+            ):
+                raise PermissionError(errno.EACCES, "permission denied")
+            return real_open(path, flags, *args, **kwargs)
+
         readable = self.root / "readable"
         readable.mkdir()
         (readable / "payload").write_text("remove\n", encoding="utf-8")
@@ -2817,7 +2828,10 @@ class WorkspaceTests(unittest.TestCase):
         nested.chmod(0)
         owned.chmod(0)
 
-        remove_owned_tree(owned)
+        with mock.patch(
+            "atrinik_workspace.workspace.os.open", side_effect=deny_initial_read
+        ):
+            remove_owned_tree(owned)
 
         self.assertFalse(owned.exists())
 
@@ -2827,9 +2841,15 @@ class WorkspaceTests(unittest.TestCase):
         payload.write_text("preserve\n", encoding="utf-8")
         unsupported.chmod(0)
         try:
-            with mock.patch(
-                "atrinik_workspace.workspace._linux_fchmod_path_descriptor",
-                side_effect=WorkspaceError("fchmodat2 unavailable"),
+            with (
+                mock.patch(
+                    "atrinik_workspace.workspace.os.open",
+                    side_effect=deny_initial_read,
+                ),
+                mock.patch(
+                    "atrinik_workspace.workspace._linux_fchmod_path_descriptor",
+                    side_effect=WorkspaceError("fchmodat2 unavailable"),
+                ),
             ):
                 with self.assertRaisesRegex(WorkspaceError, "unavailable"):
                     remove_owned_tree(unsupported)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2717,21 +2717,34 @@ class WorkspaceTests(unittest.TestCase):
 
     def test_owned_tree_removal_refuses_nested_mount_before_deletion(self) -> None:
         owned = self.root / "owned"
+        first = owned / "a-first"
+        first.mkdir(parents=True)
+        first_payload = first / "payload"
+        first_payload.write_text("preserve first\n", encoding="utf-8")
         nested = owned / "nested"
-        nested.mkdir(parents=True)
+        nested.mkdir()
         nested.chmod(0o755)
         payload = nested / "payload"
         payload.write_text("preserve\n", encoding="utf-8")
+        first.chmod(0o555)
+        owned.chmod(0o555)
+        owned_mode = stat.S_IMODE(owned.stat().st_mode)
+        first_mode = stat.S_IMODE(first.stat().st_mode)
         original_mode = stat.S_IMODE(nested.stat().st_mode)
 
         with mock.patch(
             "atrinik_workspace.workspace._descriptor_mount_id",
-            side_effect=[1, 1, 1, 2],
+            side_effect=[1, 1, 1, 1, 1, 1, 1, 2],
         ):
             with self.assertRaisesRegex(WorkspaceError, "encountered a mount"):
                 remove_owned_tree(owned)
 
         self.assertEqual(payload.read_text(encoding="utf-8"), "preserve\n")
+        self.assertEqual(
+            first_payload.read_text(encoding="utf-8"), "preserve first\n"
+        )
+        self.assertEqual(stat.S_IMODE(owned.stat().st_mode), owned_mode)
+        self.assertEqual(stat.S_IMODE(first.stat().st_mode), first_mode)
         self.assertEqual(stat.S_IMODE(nested.stat().st_mode), original_mode)
 
     def test_owned_tree_removal_uses_portable_mount_fallback(self) -> None:
@@ -2925,6 +2938,8 @@ class WorkspaceTests(unittest.TestCase):
         boundary.mkdir()
         boundary_payload = boundary / "payload"
         boundary_payload.write_text("preserve\n", encoding="utf-8")
+        boundary.chmod(0o555)
+        boundary_mode = stat.S_IMODE(boundary.stat().st_mode)
         boundary_identity = boundary_payload.lstat()
         boundary_descriptor = os.open(boundary, os.O_RDONLY | os.O_DIRECTORY)
         try:
@@ -2945,6 +2960,7 @@ class WorkspaceTests(unittest.TestCase):
             ),
             ("preserve\n", boundary_identity.st_ino),
         )
+        self.assertEqual(stat.S_IMODE(boundary.stat().st_mode), boundary_mode)
 
         def changed_device(result: os.stat_result) -> os.stat_result:
             fields = list(result)
@@ -2959,6 +2975,8 @@ class WorkspaceTests(unittest.TestCase):
             root.mkdir()
             child = root / "payload"
             child.write_text("data\n", encoding="utf-8")
+            root.chmod(0o555)
+            root_mode = stat.S_IMODE(root.stat().st_mode)
             descriptor = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
             try:
                 root_stat = os.fstat(descriptor)
@@ -2980,6 +2998,7 @@ class WorkspaceTests(unittest.TestCase):
             finally:
                 os.close(descriptor)
             self.assertEqual(child.read_text(encoding="utf-8"), "data\n")
+            self.assertEqual(stat.S_IMODE(root.stat().st_mode), root_mode)
 
         real_open = os.open
         for operation in (
@@ -2991,6 +3010,10 @@ class WorkspaceTests(unittest.TestCase):
             nested.mkdir(parents=True)
             nested_payload = nested / "payload"
             nested_payload.write_text("preserve\n", encoding="utf-8")
+            nested.chmod(0o555)
+            root.chmod(0o555)
+            root_mode = stat.S_IMODE(root.stat().st_mode)
+            nested_mode = stat.S_IMODE(nested.stat().st_mode)
             nested_identity = nested_payload.lstat()
             descriptor = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
             root_stat = os.fstat(descriptor)
@@ -3027,6 +3050,8 @@ class WorkspaceTests(unittest.TestCase):
                 ),
                 ("preserve\n", nested_identity.st_ino),
             )
+            self.assertEqual(stat.S_IMODE(root.stat().st_mode), root_mode)
+            self.assertEqual(stat.S_IMODE(nested.stat().st_mode), nested_mode)
 
         for operation in (
             workspace_module._prepare_owned_tree_removal,
@@ -3037,6 +3062,10 @@ class WorkspaceTests(unittest.TestCase):
             nested.mkdir(parents=True)
             nested_payload = nested / "payload"
             nested_payload.write_text("preserve\n", encoding="utf-8")
+            nested.chmod(0o555)
+            root.chmod(0o555)
+            root_mode = stat.S_IMODE(root.stat().st_mode)
+            nested_mode = stat.S_IMODE(nested.stat().st_mode)
             nested_identity = nested_payload.lstat()
             descriptor = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
             root_stat = os.fstat(descriptor)
@@ -3066,6 +3095,8 @@ class WorkspaceTests(unittest.TestCase):
                 ),
                 ("preserve\n", nested_identity.st_ino),
             )
+            self.assertEqual(stat.S_IMODE(root.stat().st_mode), root_mode)
+            self.assertEqual(stat.S_IMODE(nested.stat().st_mode), nested_mode)
 
     def test_replaced_directory_recovery_rejects_invalid_states(self) -> None:
         def snapshot(parent: Path) -> dict[str, tuple[object, ...]]:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1421,7 +1421,7 @@ class WorkspaceTests(unittest.TestCase):
             next_staging.mkdir()
             (next_staging / "payload").write_text("next\n", encoding="utf-8")
             with self.assertRaisesRegex(
-                WorkspaceError, "cannot reclaim replaced-directory backup"
+                WorkspaceError, "cannot recover replaced-directory transaction"
             ):
                 workspace_replace_directory(output, next_staging, ".previous-")
 
@@ -1436,11 +1436,9 @@ class WorkspaceTests(unittest.TestCase):
                     if path.name.startswith(".previous-")
                 ]
             ),
-            1,
+            2,
         )
-        self.assertTrue(
-            (self.root / ".previous-pending" / MANAGED_MARKER).is_file()
-        )
+        self.assertTrue((self.root / ".previous-pending.json").is_file())
         workspace_replace_directory(output, next_staging, ".previous-")
         self.assertEqual(
             (output / "payload").read_text(encoding="utf-8"), "next\n"
@@ -1461,11 +1459,12 @@ class WorkspaceTests(unittest.TestCase):
         previous.mkdir(parents=True)
         (previous / "payload").write_text("previous\n", encoding="utf-8")
         atomic_json(
-            pending / MANAGED_MARKER,
+            self.root / ".previous-pending.json",
             {
                 "schema_version": 1,
                 "purpose": "replaced-directory-backup",
                 "output": "output",
+                "phase": "prepared",
             },
         )
         missing_staging = self.root / "missing-staging"
@@ -1477,6 +1476,36 @@ class WorkspaceTests(unittest.TestCase):
             (output / "payload").read_text(encoding="utf-8"), "previous\n"
         )
         self.assertFalse(pending.exists())
+        self.assertFalse((self.root / ".previous-pending.json").exists())
+
+    def test_replace_directory_restores_unverified_installed_output(self) -> None:
+        output = self.root / "output"
+        output.mkdir()
+        (output / "payload").write_text("unverified\n", encoding="utf-8")
+        pending = self.root / ".previous-pending"
+        previous = pending / "previous"
+        previous.mkdir(parents=True)
+        (previous / "payload").write_text("previous\n", encoding="utf-8")
+        atomic_json(
+            self.root / ".previous-pending.json",
+            {
+                "schema_version": 1,
+                "purpose": "replaced-directory-backup",
+                "output": "output",
+                "phase": "prepared",
+            },
+        )
+
+        with self.assertRaises(FileNotFoundError):
+            workspace_replace_directory(
+                output, self.root / "missing-staging", ".previous-"
+            )
+
+        self.assertEqual(
+            (output / "payload").read_text(encoding="utf-8"), "previous\n"
+        )
+        self.assertFalse(pending.exists())
+        self.assertFalse((self.root / ".previous-pending.json").exists())
 
     def test_owned_tree_removal_refuses_nested_mount_before_deletion(self) -> None:
         owned = self.root / "owned"
@@ -1502,7 +1531,46 @@ class WorkspaceTests(unittest.TestCase):
         owned.mkdir()
         (owned / "payload").write_text("remove\n", encoding="utf-8")
 
-        with mock.patch("atrinik_workspace.workspace.sys.platform", "darwin"):
+        with (
+            mock.patch("atrinik_workspace.workspace.sys.platform", "darwin"),
+            mock.patch(
+                "atrinik_workspace.workspace._darwin_descriptor_mount_id",
+                return_value=(1, 2),
+            ),
+        ):
+            remove_owned_tree(owned)
+
+        self.assertFalse(owned.exists())
+
+    def test_owned_tree_removal_checks_file_mounts_before_deletion(self) -> None:
+        owned = self.root / "owned"
+        owned.mkdir()
+        first = owned / "a-first"
+        mounted = owned / "z-mounted"
+        first.write_text("preserve first\n", encoding="utf-8")
+        mounted.write_text("preserve mounted\n", encoding="utf-8")
+
+        with mock.patch(
+            "atrinik_workspace.workspace._descriptor_mount_id",
+            side_effect=[1, 1, 1, 1, 2],
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "encountered a mount"):
+                remove_owned_tree(owned)
+
+        self.assertEqual(first.read_text(encoding="utf-8"), "preserve first\n")
+        self.assertEqual(
+            mounted.read_text(encoding="utf-8"), "preserve mounted\n"
+        )
+
+    def test_owned_tree_removal_does_not_require_procfs(self) -> None:
+        owned = self.root / "owned"
+        owned.mkdir()
+        (owned / "payload").write_text("remove\n", encoding="utf-8")
+
+        with mock.patch(
+            "atrinik_workspace.workspace.Path.read_text",
+            side_effect=FileNotFoundError("no procfs"),
+        ):
             remove_owned_tree(owned)
 
         self.assertFalse(owned.exists())


### PR DESCRIPTION
Closes #325.

## Summary

- reuse collected content and staged resources only for exact clean provider, repository, branch, checkout, path, HEAD, schema, and output coordinates
- retain shared build caches while transactionally copying/reflinking independent content, resource, and client-map snapshots for every topology
- preserve the last verified output through input races, copy failures, interruptions, and cleanup retries with marker-, mount-, mode-, and phase-safe replacement journals
- synchronize runtime-cache, topology-ownership, retention, cleanup, and portability guidance

## Safety and correctness

- content manifests validate file size and SHA-256; resource caches validate selected source bytes and the tracked allowlist
- cache hits and generation resample clean coordinates, so dirty or advancing sources rebuild or fail without publishing misleading metadata
- topology copies use descriptor-relative no-follow traversal, validate retained destination descriptors through installation, preserve read-only modes, and reject links or special nodes
- replacement cleanup fails closed across mount boundaries, restores restrictive modes on rejection, keeps ordinary cleanup compatible with older Linux kernels, and recovers uncommitted versus verified-committed journal phases deterministically

## Verification

- complete wrapper suite: 396 tests passed; 80% aggregate coverage
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- workspace skill quick validation: `Skill is valid!`
- `./atrinik manifest validate` (21 components)
- `./atrinik supply-chain validate` (103 dependencies)
- `git diff --check`; clean committed tree
- cleanup dry run: zero candidates, no mutation
- three independent fresh whole-diff reviews at final head: zero actionable findings
- latest-head checks: Integration validation, Conventional PR title, and `codecov/patch` passed

## Runtime and performance

Exact-head profile `issue-325-benchmark-5` used clean Classic `796f9ac2d682101d8d9cf7a60e76a190e21383e3`, content `3da37c25c9cc2c9d8bf6cd9761d15d6e73ecb1be`, resources `266ac693e5567e1c253384bff1d490f1e37fedca`, sound `acb29ba84c0d85d124c7b245c594c0fac1298c0c`, and metaserver worker `ee1218e42f90db72a1d06175a7bfc44078dc1670`.

- cold full-profile build: 69.87 s
- warm full-profile build: 34.20 s, with content/resources/client maps cached, configure skipped, and Ninja reporting no work
- two topology starts: 1.78 s and 1.85 s
- retained cache inputs: 77,158,811 apparent bytes; each topology snapshot was 77,168,193 bytes after runtime `__pycache__`
- both servers reached ready on distinct states, UDP ports, and certificate fingerprints; cache-to-snapshot and snapshot-to-snapshot comparisons passed, and both topologies were stopped

The Classic `--test` path is separately blocked by an existing locked-content Python compatibility fixture in this environment after native compilation; the complete wrapper suite and exact-profile non-test build/runtime verification pass.

## Coordinates

- base / merge base: `b7ae3877fb70824a43d208f4416bffe187b5a24b`
- head: `708afea99e4d234572b293b5de89a5a108333a23`
- branch: `zoeyrose:perf/cache-content-resource-staging`
- worktree: `/workspaces/atrinik/workspace/worktrees/atrinik/issue-325-cache-staging`
