### PR TITLE
perf(build): select integrated Classic graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,11 @@ Add the complete currently playable classic stack explicitly:
 ./atrinik down classic-local
 ~~~
 
+`build all` configures the selected Classic monorepo through its root CMake
+project, so protocol and libatrinik are compiled once and shared by the client
+and server. A component-specific build such as `build client` or `build server`
+continues to exercise that module's supported standalone FetchContent path.
+
 Building the Classic server also runs its offline worldmaker and stages the
 generated region-map `.png`/`.def` pairs in the profile build. Generation uses
 the selected Classic, `content-1x`, and resource views, so it requires the same

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -1739,7 +1739,9 @@ class Workspace:
         targets: list[str], selected: dict[str, Path]
     ) -> bool:
         shared_roles = {"client", "server", "protocol", "libatrinik"}
-        if not shared_roles.issubset(targets) or not shared_roles.issubset(selected):
+        if not {"client", "server"}.issubset(targets) or not shared_roles.issubset(
+            selected
+        ):
             return False
         checkout = selected["client"].parent.resolve()
         return (checkout / "CMakeLists.txt").is_file() and all(
@@ -3158,8 +3160,6 @@ class Workspace:
                 for service in ("client", "server")
                 if service in selected_services
             ]
-            if set(targets) == {"client", "server"}:
-                targets = ["protocol", "libatrinik", *targets]
 
             with ExitStack() as stack:
                 state_location: Path | None = None

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -1387,14 +1387,21 @@ class Workspace:
                 self._collect_content(root, selected)
             if "server" in targets:
                 self._stage_resources(root, selected)
-            if "protocol" in targets:
-                self._build_protocol(root, selected, tests)
-            if "libatrinik" in targets:
-                self._build_library(root, selected, tests)
-            if "client" in targets:
-                self._build_client(root, selected, tests)
+            integrated_classic = self._uses_integrated_classic_build(
+                targets, selected
+            )
+            if integrated_classic:
+                self._build_integrated_classic(root, selected, tests)
+            else:
+                if "protocol" in targets:
+                    self._build_protocol(root, selected, tests)
+                if "libatrinik" in targets:
+                    self._build_library(root, selected, tests)
+                if "client" in targets:
+                    self._build_client(root, selected, tests)
+                if "server" in targets:
+                    self._build_server(root, selected, tests)
             if "server" in targets:
-                self._build_server(root, selected, tests)
                 self._generate_region_maps(root, profile_name, selected)
             if "metaserver-worker" in targets:
                 self._build_worker(root, selected)
@@ -1727,6 +1734,96 @@ class Workspace:
     def _build_protocol(self, root: Path, selected: dict[str, Path], tests: bool) -> None:
         self._cmake(selected["protocol"], root / "build" / "protocol", [], tests)
 
+    @staticmethod
+    def _uses_integrated_classic_build(
+        targets: list[str], selected: dict[str, Path]
+    ) -> bool:
+        shared_roles = {"client", "server", "protocol", "libatrinik"}
+        if not shared_roles.issubset(targets) or not shared_roles.issubset(selected):
+            return False
+        checkout = selected["client"].parent.resolve()
+        return (checkout / "CMakeLists.txt").is_file() and all(
+            selected[role].resolve() == checkout / role for role in shared_roles
+        )
+
+    @staticmethod
+    def _record_classic_graph(root: Path, roles: set[str], graph: str) -> None:
+        for role in roles:
+            atomic_json(
+                root / "build" / f".{role}-graph.json",
+                {
+                    "schema_version": 1,
+                    "purpose": "classic-build-graph",
+                    "graph": graph,
+                },
+            )
+
+    @staticmethod
+    def _classic_binary_directory(root: Path, role: str) -> Path:
+        marker = root / "build" / f".{role}-graph.json"
+        try:
+            record = load_json(marker)
+        except (OSError, ValueError, WorkspaceError):
+            record = {}
+        if (
+            record.get("schema_version") == 1
+            and record.get("purpose") == "classic-build-graph"
+            and record.get("graph") == "integrated"
+        ):
+            return root / "build" / "integrated" / role
+        return root / "build" / role
+
+    def _build_integrated_classic(
+        self, root: Path, selected: dict[str, Path], tests: bool
+    ) -> None:
+        checkout = selected["client"].parent.resolve()
+        view = self._profile_source_view(
+            root, "integrated", checkout, {"build", "client", "server"}
+        )
+        client = self._profile_source_view(
+            root,
+            "integrated/client",
+            selected["client"],
+            {"build", "sound"},
+        )
+        (client / "sound").symlink_to(selected["sound"], target_is_directory=True)
+        server = self._profile_source_view(
+            root,
+            "integrated/server",
+            selected["server"],
+            {
+                "atrinik-server",
+                "build",
+                "data",
+                "lib",
+                "maps",
+                "resources",
+                "runtime",
+                "libplugin_arena.so",
+                "libplugin_python.so",
+            },
+            {"install_data"},
+        )
+        runtime = server / "runtime"
+        runtime.mkdir()
+        (runtime / "content").symlink_to(
+            root / "runtime" / "content", target_is_directory=True
+        )
+        (server / "resources").symlink_to(
+            root / "runtime" / "resources", target_is_directory=True
+        )
+        self._cmake(
+            view,
+            root / "build" / "integrated",
+            [
+                "-DENABLE_WARNING_ERRORS=ON",
+                "-DPACKAGE_TYPE=none",
+                "-DENABLE_PYTHON_PLUGIN=ON",
+            ],
+            tests,
+        )
+        self._record_classic_graph(root, {"client", "server"}, "integrated")
+
     def _build_library(self, root: Path, selected: dict[str, Path], tests: bool) -> None:
         self._cmake(
             selected["libatrinik"],
@@ -1754,6 +1851,7 @@ class Workspace:
             ],
             tests,
         )
+        self._record_classic_graph(root, {"client"}, "standalone")
 
     def _build_server(self, root: Path, selected: dict[str, Path], tests: bool) -> None:
         view = self._profile_source_view(
@@ -1796,6 +1894,7 @@ class Workspace:
             ],
             tests,
         )
+        self._record_classic_graph(root, {"server"}, "standalone")
 
     def _region_map_inputs(
         self, profile_name: str, selected: dict[str, Path]
@@ -3134,7 +3233,9 @@ class Workspace:
                         "log": str(topology_root / "server.log"),
                     }
                 if "client" in selected_services:
-                    executable = root / "build" / "client" / "atrinik"
+                    executable = (
+                        self._classic_binary_directory(root, "client") / "atrinik"
+                    )
                     working = self._prepare_topology_client_runtime(
                         topology_root, selected
                     )
@@ -3410,7 +3511,7 @@ class Workspace:
         self._validate_state(state)
         fingerprint = self._server_identity_fingerprint(state)
         root = self.build("client", profile_name, tests=False)
-        executable = root / "build" / "client" / "atrinik"
+        executable = self._classic_binary_directory(root, "client") / "atrinik"
         working = root / "sources" / "client"
         if not executable.is_file():
             raise WorkspaceError(f"client executable is missing: {executable}")
@@ -3547,7 +3648,7 @@ class Workspace:
         resources: Path,
     ) -> None:
         source = selected["server"]
-        binary = root / "build" / "server"
+        binary = self._classic_binary_directory(root, "server")
         links = {
             "atrinik-server": binary / "atrinik-server",
             "libplugin_arena.so": binary / "libplugin_arena.so",

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -3153,7 +3153,13 @@ class Workspace:
                 profile_name, set(selected_services)
             )
             required = set(selected)
-            targets = [service for service in ("client", "server") if service in selected_services]
+            targets = [
+                service
+                for service in ("client", "server")
+                if service in selected_services
+            ]
+            if set(targets) == {"client", "server"}:
+                targets = ["protocol", "libatrinik", *targets]
 
             with ExitStack() as stack:
                 state_location: Path | None = None

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -348,11 +348,22 @@ The currently playable classic build flow is:
 ~~~text
 selected content-1x -> build_runtime.py -> isolated content/lib + content/maps
 selected tracked resource allowlist -> isolated resource view
-selected classic protocol/library + sound -> client source view -> CMake/Ninja
-selected classic protocol/library --------> server source view -> CMake/Ninja
+full Classic closure -> integrated source view -> one protocol/libatrinik graph
+                                             +-> client targets -> CMake/Ninja
+                                             +-> server targets -> CMake/Ninja
+component-only client/server request -> standalone source view -> CMake/Ninja
 selected Classic + content + resources ---> offline worldmaker -> region-map cache
 selected Worker -------------------------> npm source view -> npm run check
 ~~~
+
+The integrated graph is selected only when client, server, protocol, and
+libatrinik resolve to sibling directories in one physical Classic checkout.
+Its binaries remain below a distinct `build/integrated` tree, and per-role
+marker records select those artifacts for later runtime staging. A successful
+standalone component build updates only that role's marker. This prevents an
+older graph from being selected merely because its output directory exists,
+while keeping partial Classic checkouts and component-specific FetchContent
+validation supported.
 
 The replacement MIT `server`, `client`, `editor`, `protocol`, `renderer`,
 `content-toolkit`, and `website` repositories have validated standalone M1

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -513,6 +513,111 @@ class WorkspaceTests(unittest.TestCase):
         selected = build_resolved.call_args.args[4]
         self.assertEqual(set(selected), {"content"})
 
+    def test_integrated_classic_build_requires_one_complete_monorepo(self) -> None:
+        checkout = self.root / "classic"
+        checkout.mkdir()
+        (checkout / "CMakeLists.txt").write_text("project(classic)\n", encoding="utf-8")
+        selected = {}
+        for role in ("client", "server", "protocol", "libatrinik"):
+            selected[role] = checkout / role
+            selected[role].mkdir()
+
+        self.assertTrue(
+            self.workspace._uses_integrated_classic_build(
+                ["protocol", "libatrinik", "client", "server"], selected
+            )
+        )
+        self.assertFalse(
+            self.workspace._uses_integrated_classic_build(
+                ["protocol", "libatrinik", "client"], selected
+            )
+        )
+        selected["server"] = self.root / "other" / "server"
+        self.assertFalse(
+            self.workspace._uses_integrated_classic_build(
+                ["protocol", "libatrinik", "client", "server"], selected
+            )
+        )
+
+    def test_integrated_classic_build_creates_one_nested_source_graph(self) -> None:
+        checkout = self.root / "classic"
+        for role in ("client", "server", "protocol", "libatrinik"):
+            (checkout / role).mkdir(parents=True)
+            (checkout / role / "README").write_text(role + "\n", encoding="utf-8")
+        (checkout / "CMakeLists.txt").write_text(
+            "project(classic)\n", encoding="utf-8"
+        )
+        (checkout / "server" / "install_data").mkdir()
+        sound = self.root / "sound"
+        sound.mkdir()
+        selected = {
+            role: checkout / role
+            for role in ("client", "server", "protocol", "libatrinik")
+        }
+        selected["sound"] = sound
+        root = self.workspace.paths.builds / "profiles" / "classic-test"
+        root.mkdir(parents=True)
+        (root / "runtime" / "content").mkdir(parents=True)
+        (root / "runtime" / "resources").mkdir()
+
+        with mock.patch.object(self.workspace, "_cmake") as cmake:
+            self.workspace._build_integrated_classic(root, selected, tests=True)
+
+        cmake.assert_called_once_with(
+            root / "sources" / "integrated",
+            root / "build" / "integrated",
+            [
+                "-DENABLE_WARNING_ERRORS=ON",
+                "-DPACKAGE_TYPE=none",
+                "-DENABLE_PYTHON_PLUGIN=ON",
+            ],
+            True,
+        )
+        self.assertEqual(
+            (root / "sources" / "integrated" / "client" / "sound").resolve(),
+            sound,
+        )
+        self.assertEqual(
+            (
+                root
+                / "sources"
+                / "integrated"
+                / "server"
+                / "runtime"
+                / "content"
+            ).resolve(),
+            root / "runtime" / "content",
+        )
+        self.assertEqual(
+            self.workspace._classic_binary_directory(root, "server"),
+            root / "build" / "integrated" / "server",
+        )
+
+    def test_classic_binary_directory_tracks_last_successful_graph(self) -> None:
+        root = self.workspace.paths.builds / "profiles" / "classic-test"
+        (root / "build").mkdir(parents=True)
+
+        self.assertEqual(
+            self.workspace._classic_binary_directory(root, "client"),
+            root / "build" / "client",
+        )
+        self.workspace._record_classic_graph(
+            root, {"client", "server"}, "integrated"
+        )
+        self.assertEqual(
+            self.workspace._classic_binary_directory(root, "client"),
+            root / "build" / "integrated" / "client",
+        )
+        self.workspace._record_classic_graph(root, {"client"}, "standalone")
+        self.assertEqual(
+            self.workspace._classic_binary_directory(root, "client"),
+            root / "build" / "client",
+        )
+        self.assertEqual(
+            self.workspace._classic_binary_directory(root, "server"),
+            root / "build" / "integrated" / "server",
+        )
+
     def test_profile_schema_namespace_leaves_old_partial_build_inert(self) -> None:
         selected = {
             "resources": self.workspace.paths.repositories / "resources"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -524,7 +524,7 @@ class WorkspaceTests(unittest.TestCase):
 
         self.assertTrue(
             self.workspace._uses_integrated_classic_build(
-                ["protocol", "libatrinik", "client", "server"], selected
+                ["client", "server"], selected
             )
         )
         self.assertFalse(
@@ -592,6 +592,33 @@ class WorkspaceTests(unittest.TestCase):
             self.workspace._classic_binary_directory(root, "server"),
             root / "build" / "integrated" / "server",
         )
+
+    def test_paired_classic_build_falls_back_without_shared_role_builds(self) -> None:
+        selected = {
+            role: self.workspace.paths.repositories / role
+            for role in ("client", "server", "protocol", "libatrinik")
+        }
+        with (
+            mock.patch.object(
+                self.workspace, "_profile_build_key", return_value="fallback"
+            ),
+            mock.patch.object(self.workspace, "_refresh_build_metadata"),
+            mock.patch.object(self.workspace, "_collect_content"),
+            mock.patch.object(self.workspace, "_stage_resources"),
+            mock.patch.object(self.workspace, "_build_protocol") as build_protocol,
+            mock.patch.object(self.workspace, "_build_library") as build_library,
+            mock.patch.object(self.workspace, "_build_client") as build_client,
+            mock.patch.object(self.workspace, "_build_server") as build_server,
+            mock.patch.object(self.workspace, "_generate_region_maps"),
+        ):
+            self.workspace._build_resolved(
+                "topology", "default", False, ["client", "server"], selected
+            )
+
+        build_protocol.assert_not_called()
+        build_library.assert_not_called()
+        build_client.assert_called_once()
+        build_server.assert_called_once()
 
     def test_classic_binary_directory_tracks_last_successful_graph(self) -> None:
         root = self.workspace.paths.builds / "profiles" / "classic-test"
@@ -1288,7 +1315,7 @@ class WorkspaceTests(unittest.TestCase):
             )
         self.assertEqual(
             build_resolved.call_args.args[3],
-            ["protocol", "libatrinik", "client", "server"],
+            ["client", "server"],
         )
         self.assertTrue(status["ready"])
         self.assertEqual(status["endpoint"]["port"], 17300)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1137,12 +1137,13 @@ class WorkspaceTests(unittest.TestCase):
         with (
             mock.patch.object(
                 self.workspace, "_build_resolved", return_value=build_root
-            ),
+            ) as build_resolved,
             mock.patch.object(self.workspace, "_require_client_display"),
         ):
             status = self.workspace.topology_up(
                 "review", "default", "default", ["client"]
             )
+        self.assertEqual(build_resolved.call_args.args[3], ["client"])
         try:
             self.assertTrue(status["supervisor"]["running"])
             self.assertTrue(status["services"]["client"]["running"])
@@ -1276,7 +1277,7 @@ class WorkspaceTests(unittest.TestCase):
         with (
             mock.patch.object(
                 self.workspace, "_build_resolved", return_value=build_root
-            ),
+            ) as build_resolved,
             mock.patch.object(
                 self.workspace, "_select_topology_port", return_value=17300
             ),
@@ -1285,6 +1286,10 @@ class WorkspaceTests(unittest.TestCase):
             status = self.workspace.topology_up(
                 "server-review", "default", "default", None, 17300
             )
+        self.assertEqual(
+            build_resolved.call_args.args[3],
+            ["protocol", "libatrinik", "client", "server"],
+        )
         self.assertTrue(status["ready"])
         self.assertEqual(status["endpoint"]["port"], 17300)
         self.assertEqual(status["endpoint"]["fingerprint"], "a" * 64)


### PR DESCRIPTION
## Summary

- select the Classic monorepo root CMake project for complete `build all` closures
- preserve standalone component builds and track the last successful client/server graph atomically
- route runtime staging to the selected graph and document the integrated adapter

Companion implementation for atrinik/classic#82: https://github.com/atrinik/classic/pull/104

## Testing

- `python3 -m coverage run -m unittest discover`
- `python3 -m coverage report --show-missing`
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `git diff --check`
- full wrapper suite (341 tests, 79% coverage)
- wrapper-managed Classic `build all --test` integration (82 unique tests on the latest Classic main base; 80 pass outside the sandbox, with two current standalone-parity content/test failures documented in the companion PR)
