### PR TITLE
perf(worker): reuse lockfile-identical installations

### DIFF
--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -60,8 +60,8 @@ Reclaim review data only through preview-first cleanup:
 ```
 
 Default scope covers registered worktrees, profile builds, and individually
-marker-owned Worker dependency entries; the npm download cache is opt-in. Text
-uses IEC sizes; JSON keeps exact bytes. References, ambiguous Git,
+marker-owned Worker installs and stale transactions; npm downloads are opt-in.
+Text uses IEC sizes; JSON keeps bytes. References, ambiguous Git,
 and unsafe paths/markers protect targets. Only an `atrinik/atrinik@main`
 worktree directly below `build/worktrees/` has the historical-base exception:
 its PR targets `master` and supplies head, base, and merge SHAs; the merge's

--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -59,8 +59,9 @@ Reclaim review data only through preview-first cleanup:
 ./atrinik cleanup --scope all --older-than 7 --apply
 ```
 
-Default scope covers registered worktrees and marker-owned builds; npm cache is
-opt-in. Text uses IEC sizes; JSON keeps exact bytes. References, ambiguous Git,
+Default scope covers registered worktrees, profile builds, and individually
+marker-owned Worker dependency entries; the npm download cache is opt-in. Text
+uses IEC sizes; JSON keeps exact bytes. References, ambiguous Git,
 and unsafe paths/markers protect targets. Only an `atrinik/atrinik@main`
 worktree directly below `build/worktrees/` has the historical-base exception:
 its PR targets `master` and supplies head, base, and merge SHAs; the merge's

--- a/README.md
+++ b/README.md
@@ -281,7 +281,9 @@ modification times, filesystem flags, and extended metadata participate in the
 key while staging access times are normalized; the lifecycle source
 is authenticated before install; installed output that embeds its staging path
 is rejected; and project `.npmrc` content is provided as a restrictive
-temporary copy and never published in the shared cache. Every profile gets its
+temporary copy and never published in the shared cache. Wrapper transaction
+metadata is hidden while lifecycle scripts run and restored before publication.
+Every profile gets its
 own `node_modules` copy, so its checks cannot mutate the shared cache. A
 canonical no-follow digest covers
 the complete installed tree, including modes and bounded relative links. The

--- a/README.md
+++ b/README.md
@@ -266,6 +266,18 @@ preview-first `./atrinik cleanup --scope builds` lifecycle; topology snapshots
 remain with the retained topology record and are atomically replaced the next
 time that topology name is launched.
 
+Building `metaserver-worker` retains a validated dependency installation keyed
+by exact package and lockfile bytes, optional project `.npmrc`, Node/npm and
+platform identity, effective npm configuration, and the complete hashed
+lifecycle-script environment. `npm ci` remains the only installer. A second
+lockfile-identical build reuses that installation and an unchanged profile
+source view; application-only edits refresh the profile view without
+reinstalling dependencies unless the root package defines an install lifecycle
+hook, in which case the complete source digest participates in the dependency
+key. Every profile gets its own `node_modules` copy, so
+its checks cannot mutate the shared cache. Build output reports dependency
+installation/cache time and source-view preparation/reuse time.
+
 `--with classic` has one exact meaning: add the complete classic initialization
 cohort to the replacement/default cohort. It is not a classic-only mode. The
 cohort consists of one `atrinik/classic` checkout, a distinct `content-1x`
@@ -475,7 +487,8 @@ inside it.
 
 Cleanup is always operator-invoked and preview-first. With no options it
 inventories registered worktrees and marker-owned profile builds older than
-seven days without changing the filesystem:
+seven days, including individually marker-owned Worker dependency entries,
+without changing the filesystem:
 
 ~~~sh
 ./atrinik cleanup
@@ -542,10 +555,17 @@ schema 1 and contains exactly `schema_version` plus an absolute `build_roots`
 array. A build sourced from a worktree eligible in the same plan may be
 reclaimed regardless of age unless another protection applies.
 
+Worker dependency entries under `workspace/build/worker-dependencies/` use the
+same default `builds` scope and grace period. Cleanup requires the exact parent
+and entry markers, strict metadata and last-used time, a safe direct-child key,
+and an idle per-key build lock; uncertainty protects the entry. Removing a
+stale entry leaves the marker-owned container and npm download cache intact.
+
 The shared `workspace/build/npm-cache` is never part of default cleanup. Its
 explicit scope accepts the exact marker-owned path or the one legacy known
 cache at that fixed location after proving the workspace marker, path shape,
-age, and absence of an active build. Unmarked profile roots, other
+age, and absence of an active build. Unmarked profile roots, invalid Worker
+cache entries, other
 `workspace/build` children, and all remaining mixed top-level `build/`
 entries are report-only `unmanaged-build` items. Deep-review reports, ad hoc
 builds, packages, archives, and unregistered siblings are never recursively

--- a/README.md
+++ b/README.md
@@ -268,14 +268,17 @@ time that topology name is launched.
 
 Building `metaserver-worker` retains a validated dependency installation keyed
 by exact package and lockfile bytes, optional project `.npmrc`, Node/npm and
-platform identity, effective npm configuration plus its file-backed inputs,
-and the hashed lifecycle-script environment. `npm ci` remains the only
+platform identity and effective npm configuration. External file-backed npm
+configuration fails closed; project `.npmrc` is supported through an
+authenticated copy. The hashed lifecycle-script environment and source
+metadata also participate in the key. `npm ci` remains the only
 installer. A second
 input-identical build reuses that installation and an unchanged profile source
 view. Because enabled dependency lifecycle scripts can observe root files, the
 complete non-generated source digest participates in every dependency key and
 source symlinks fail closed. The install root is stable and hashed; copied
-timestamps and extended metadata participate in the key; the lifecycle source
+modification times, filesystem flags, and extended metadata participate in the
+key while staging access times are normalized; the lifecycle source
 is authenticated before install; installed output that embeds its staging path
 is rejected; and project `.npmrc` content is provided as a restrictive
 temporary copy and never published in the shared cache. Every profile gets its

--- a/README.md
+++ b/README.md
@@ -268,15 +268,19 @@ time that topology name is launched.
 
 Building `metaserver-worker` retains a validated dependency installation keyed
 by exact package and lockfile bytes, optional project `.npmrc`, Node/npm and
-platform identity, effective npm configuration, and the complete hashed
-lifecycle-script environment. `npm ci` remains the only installer. A second
+platform identity, effective npm configuration plus its file-backed inputs,
+and the hashed lifecycle-script environment. `npm ci` remains the only
+installer. A second
 input-identical build reuses that installation and an unchanged profile source
 view. Because enabled dependency lifecycle scripts can observe root files, the
 complete non-generated source digest participates in every dependency key and
-source symlinks fail closed. The install root is stable and hashed, installed
-output that embeds its staging path is rejected, and project `.npmrc` content
-is never published in the shared cache. Every profile gets its own `node_modules` copy, so
-its checks cannot mutate the shared cache. A canonical no-follow digest covers
+source symlinks fail closed. The install root is stable and hashed; staged
+timestamps and extended metadata are normalized; the copied lifecycle source
+is authenticated before install; installed output that embeds its staging path
+is rejected; and project `.npmrc` content is provided as a restrictive
+temporary copy and never published in the shared cache. Every profile gets its
+own `node_modules` copy, so its checks cannot mutate the shared cache. A
+canonical no-follow digest covers
 the complete installed tree, including modes and bounded relative links. The
 isolated view permits only Vite's profile-local `.vite`/`.vite-temp` outputs
 outside that immutable snapshot. Build output reports dependency installation/cache time and source-view

--- a/README.md
+++ b/README.md
@@ -267,10 +267,11 @@ remain with the retained topology record and are atomically replaced the next
 time that topology name is launched.
 
 Building `metaserver-worker` retains a validated dependency installation keyed
-by exact package and lockfile bytes, optional project `.npmrc`, Node/npm and
-platform identity and effective npm configuration. External file-backed npm
-configuration fails closed; project `.npmrc` is supported through an
-authenticated copy. The hashed lifecycle-script environment and source
+by exact package and lockfile bytes, optional project `.npmrc`, Node/npm, Node
+runtime and host platform identity, and effective npm configuration. External
+file-backed npm configuration and custom script shells fail closed; project
+`.npmrc` is supported through an authenticated copy. The hashed lifecycle-script
+environment and source
 metadata also participate in the key. `npm ci` remains the only
 installer. A second
 input-identical build reuses that installation and an unchanged profile source

--- a/README.md
+++ b/README.md
@@ -274,8 +274,8 @@ installer. A second
 input-identical build reuses that installation and an unchanged profile source
 view. Because enabled dependency lifecycle scripts can observe root files, the
 complete non-generated source digest participates in every dependency key and
-source symlinks fail closed. The install root is stable and hashed; staged
-timestamps and extended metadata are normalized; the copied lifecycle source
+source symlinks fail closed. The install root is stable and hashed; copied
+timestamps and extended metadata participate in the key; the lifecycle source
 is authenticated before install; installed output that embeds its staging path
 is rejected; and project `.npmrc` content is provided as a restrictive
 temporary copy and never published in the shared cache. Every profile gets its

--- a/README.md
+++ b/README.md
@@ -269,7 +269,8 @@ time that topology name is launched.
 Building `metaserver-worker` retains a validated dependency installation keyed
 by exact package and lockfile bytes, optional project `.npmrc`, Node/npm, Node
 runtime and host platform identity, and effective npm configuration. External
-file-backed npm configuration and custom script shells fail closed; project
+file-backed npm configuration, custom script shells, and external Node preload
+options fail closed; project
 `.npmrc` is supported through an authenticated copy. The hashed lifecycle-script
 environment and source
 metadata also participate in the key. `npm ci` remains the only
@@ -576,9 +577,10 @@ and an idle per-key build lock; uncertainty protects the entry. Removing a
 stale entry leaves the marker-owned container and npm download cache intact.
 Recognizable interrupted staging and backup directories live below the
 separately marker-owned `.transactions` container and are reclaimed by the
-same preview-first scope only after their grace period and per-key lock checks.
-A valid matching backup is restored under that lock before another install is
-attempted.
+same preview-first scope only after their conservative tree-mtime/root-ctime
+grace period and per-key lock checks. Apply repeats identity, ownership, and age
+validation while holding that lock through removal. A valid matching backup is
+restored under the lock before another install is attempted.
 
 The shared `workspace/build/npm-cache` is never part of default cleanup. Its
 explicit scope accepts the exact marker-owned path or the one legacy known

--- a/README.md
+++ b/README.md
@@ -270,13 +270,14 @@ Building `metaserver-worker` retains a validated dependency installation keyed
 by exact package and lockfile bytes, optional project `.npmrc`, Node/npm and
 platform identity, effective npm configuration, and the complete hashed
 lifecycle-script environment. `npm ci` remains the only installer. A second
-lockfile-identical build reuses that installation and an unchanged profile
-source view; application-only edits refresh the profile view without
-reinstalling dependencies unless the root package defines an install lifecycle
-hook, in which case the complete source digest participates in the dependency
-key. Every profile gets its own `node_modules` copy, so
-its checks cannot mutate the shared cache. Build output reports dependency
-installation/cache time and source-view preparation/reuse time.
+input-identical build reuses that installation and an unchanged profile source
+view. Because enabled dependency lifecycle scripts can observe root files, the
+complete non-generated source digest participates in every dependency key and
+source symlinks fail closed. Every profile gets its own `node_modules` copy, so
+its checks cannot mutate the shared cache. A canonical no-follow digest covers
+the complete installed tree, including modes and bounded relative links. Build
+output reports dependency installation/cache time and source-view
+preparation/reuse time.
 
 `--with classic` has one exact meaning: add the complete classic initialization
 cohort to the replacement/default cohort. It is not a classic-only mode. The
@@ -560,6 +561,9 @@ same default `builds` scope and grace period. Cleanup requires the exact parent
 and entry markers, strict metadata and last-used time, a safe direct-child key,
 and an idle per-key build lock; uncertainty protects the entry. Removing a
 stale entry leaves the marker-owned container and npm download cache intact.
+Recognizable interrupted staging and backup directories live below the
+separately marker-owned `.transactions` container and are reclaimed by the
+same preview-first scope only after their grace period and per-key lock checks.
 
 The shared `workspace/build/npm-cache` is never part of default cleanup. Its
 explicit scope accepts the exact marker-owned path or the one legacy known

--- a/README.md
+++ b/README.md
@@ -275,8 +275,9 @@ view. Because enabled dependency lifecycle scripts can observe root files, the
 complete non-generated source digest participates in every dependency key and
 source symlinks fail closed. Every profile gets its own `node_modules` copy, so
 its checks cannot mutate the shared cache. A canonical no-follow digest covers
-the complete installed tree, including modes and bounded relative links. Build
-output reports dependency installation/cache time and source-view
+the complete installed tree, including modes and bounded relative links. The
+isolated view permits only Vite's profile-local `.vite`/`.vite-temp` outputs
+outside that immutable snapshot. Build output reports dependency installation/cache time and source-view
 preparation/reuse time.
 
 `--with classic` has one exact meaning: add the complete classic initialization
@@ -564,6 +565,8 @@ stale entry leaves the marker-owned container and npm download cache intact.
 Recognizable interrupted staging and backup directories live below the
 separately marker-owned `.transactions` container and are reclaimed by the
 same preview-first scope only after their grace period and per-key lock checks.
+A valid matching backup is restored under that lock before another install is
+attempted.
 
 The shared `workspace/build/npm-cache` is never part of default cleanup. Its
 explicit scope accepts the exact marker-owned path or the one legacy known

--- a/README.md
+++ b/README.md
@@ -610,10 +610,10 @@ The shared `workspace/build/npm-cache` and `workspace/build/compiler-cache`
 are never part of default cleanup. Their explicit scopes require exact
 marker-owned paths, valid last-use metadata, safe fixed containment, age, and
 absence of an active build. Only the npm path admits one legacy known cache
-after the same proof. Unmarked profile roots, invalid Worker cache entries,
-other
-`workspace/build` children, and all remaining mixed top-level `build/`
-entries are report-only `unmanaged-build` items. Deep-review reports, ad hoc
+after the same proof. Invalid entries inside a valid Worker cache root remain
+protected `worker-dependencies` items. Unmarked profile roots, invalid Worker
+cache roots, other `workspace/build` children, and all remaining mixed
+top-level `build/` entries are report-only `unmanaged-build` items. Deep-review reports, ad hoc
 builds, packages, archives, and unregistered siblings are never recursively
 deleted.
 

--- a/README.md
+++ b/README.md
@@ -273,7 +273,9 @@ lifecycle-script environment. `npm ci` remains the only installer. A second
 input-identical build reuses that installation and an unchanged profile source
 view. Because enabled dependency lifecycle scripts can observe root files, the
 complete non-generated source digest participates in every dependency key and
-source symlinks fail closed. Every profile gets its own `node_modules` copy, so
+source symlinks fail closed. The install root is stable and hashed, installed
+output that embeds its staging path is rejected, and project `.npmrc` content
+is never published in the shared cache. Every profile gets its own `node_modules` copy, so
 its checks cannot mutate the shared cache. A canonical no-follow digest covers
 the complete installed tree, including modes and bounded relative links. The
 isolated view permits only Vite's profile-local `.vite`/`.vite-temp` outputs

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -32,6 +32,7 @@ from .workspace import (
     COMPILER_CACHE_PURPOSE,
     _remote_matches,
     exclusive_lock,
+    remove_owned_tree,
 )
 
 
@@ -2576,7 +2577,7 @@ class Cleanup:
                     raise WorkspaceError(
                         f"Worker dependency transaction changed before removal: {path}"
                     )
-                shutil.rmtree(path)
+                remove_owned_tree(path)
         elif item["kind"] == "worktree":
             primary = self._repositories[item["owner"]]
             _command(primary, "worktree", "remove", "--", str(path))

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -7,7 +7,6 @@ import json
 import os
 from pathlib import Path, PurePosixPath
 import re
-import shutil
 import stat
 import subprocess
 from typing import Any, Iterable
@@ -2526,11 +2525,22 @@ class Cleanup:
                     raise WorkspaceError(
                         "Worker dependency cache is no longer old enough to remove"
                     )
-                managed_remove(
-                    path,
-                    self.paths.builds,
-                    f"worker-dependencies:{item['key']}",
-                )
+                marker = path / MANAGED_MARKER
+                if (
+                    path.is_symlink()
+                    or not path.is_dir()
+                    or marker.is_symlink()
+                    or not marker.is_file()
+                    or load_json(marker)
+                    != {
+                        "schema_version": SCHEMA_VERSION,
+                        "purpose": f"worker-dependencies:{item['key']}",
+                    }
+                ):
+                    raise WorkspaceError(
+                        "Worker dependency cache ownership changed before removal"
+                    )
+                remove_owned_tree(path)
         elif item["kind"] == "worker-dependency-transaction":
             key = item["key"]
             lock = (

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -7,6 +7,7 @@ import json
 import os
 from pathlib import Path, PurePosixPath
 import re
+import shutil
 import stat
 import subprocess
 from typing import Any, Iterable
@@ -353,7 +354,7 @@ class Cleanup:
                 target.update(credited)
                 report["mutation_attempted"] = True
                 try:
-                    self._remove(match)
+                    self._remove(match, older_than_days)
                 except (OSError, RuntimeError, WorkspaceError) as error:
                     target["disposition"] = "error"
                     target["reasons"] = ["removal_failed"]
@@ -475,6 +476,7 @@ class Cleanup:
         item.pop("_inodes", None)
         item.pop("_primary", None)
         item.pop("_purpose", None)
+        item.pop("_older_than_days", None)
 
     def _revalidate_target(
         self,
@@ -521,6 +523,8 @@ class Cleanup:
                 references,
                 reference_errors,
             )
+        elif kind == "worker-dependency-transaction":
+            item = self._worker_dependency_transaction_item(path, older_than_days)
         elif kind in {"worktree", "prunable-metadata"}:
             item = self._revalidate_worktree(
                 target["owner"],
@@ -1726,7 +1730,9 @@ class Cleanup:
                     "Worker dependency cache root is not marker-owned"
                 )
             paths = sorted(
-                path for path in root.iterdir() if path.name != MANAGED_MARKER
+                path
+                for path in root.iterdir()
+                if path.name not in {MANAGED_MARKER, ".transactions"}
             )
         except (OSError, WorkspaceError) as error:
             item = _base_item(
@@ -1739,7 +1745,7 @@ class Cleanup:
             if walk_error:
                 item["reasons"].append("filesystem_traversal_error")
             return [item]
-        return [
+        items = [
             self._worker_dependency_item(
                 path,
                 older_than_days,
@@ -1749,6 +1755,114 @@ class Cleanup:
             )
             for path in paths
         ]
+        transactions = root / ".transactions"
+        if transactions.exists() or transactions.is_symlink():
+            try:
+                marker = transactions / MANAGED_MARKER
+                if (
+                    transactions.is_symlink()
+                    or not transactions.is_dir()
+                    or marker.is_symlink()
+                    or load_json(marker)
+                    != {
+                        "schema_version": SCHEMA_VERSION,
+                        "purpose": "worker-dependency-transactions",
+                    }
+                ):
+                    raise WorkspaceError(
+                        "Worker dependency transaction root is not marker-owned"
+                    )
+                transaction_paths = sorted(
+                    path
+                    for path in transactions.iterdir()
+                    if path.name != MANAGED_MARKER
+                )
+            except (OSError, WorkspaceError) as error:
+                item = _base_item(
+                    "unmanaged-build",
+                    "atrinik",
+                    "atrinik/atrinik",
+                    transactions,
+                )
+                item["reasons"] = ["invalid_worker_dependency_transactions"]
+                item["error"] = str(error)
+                inodes, _, walk_error = _tree_usage(transactions)
+                item["_inodes"] = inodes
+                if walk_error:
+                    item["reasons"].append("filesystem_traversal_error")
+                items.append(item)
+            else:
+                items.extend(
+                    self._worker_dependency_transaction_item(
+                        path, older_than_days
+                    )
+                    for path in transaction_paths
+                )
+        return items
+
+    def _worker_dependency_transaction_item(
+        self, path: Path, older_than_days: int
+    ) -> dict[str, Any]:
+        item = _base_item(
+            "worker-dependency-transaction", "atrinik", "atrinik/atrinik", path
+        )
+        inodes, observed, walk_error = _tree_usage(path)
+        item["_inodes"] = inodes
+        match = re.fullmatch(
+            r"([0-9a-f]{64})-(staging|backup)-([0-9a-f]+)", path.name
+        )
+        if walk_error:
+            item["reasons"].append("filesystem_traversal_error")
+            item["error"] = walk_error
+        if match is None or path.is_symlink() or not path.is_dir():
+            item["reasons"].append("invalid_worker_dependency_transaction")
+        else:
+            key, transaction_type, _suffix = match.groups()
+            item["key"] = key
+            marker = path / MANAGED_MARKER
+            allowed_purposes = {f"worker-dependencies:{key}"}
+            if transaction_type == "staging":
+                allowed_purposes.add(f"worker-dependency-transaction:{key}")
+            try:
+                if marker.exists() or marker.is_symlink():
+                    metadata = load_json(marker)
+                    if marker.is_symlink() or metadata not in (
+                        {
+                            "schema_version": SCHEMA_VERSION,
+                            "purpose": purpose,
+                        }
+                        for purpose in allowed_purposes
+                    ):
+                        raise WorkspaceError(
+                            "Worker dependency transaction marker is invalid"
+                        )
+            except (OSError, WorkspaceError) as error:
+                item["reasons"].append("invalid_worker_dependency_transaction")
+                item["error"] = str(error)
+            lock = (
+                self.paths.builds / "locks" / f"worker-dependencies-{key}.lock"
+            )
+            busy, lock_error = self._lock_busy(lock)
+            if lock_error:
+                item["reasons"].append("build_lock_error")
+                item["error"] = lock_error
+            elif busy:
+                item["reasons"].append("build_lock_busy")
+        item["age_basis"] = "tree-mtime" if observed else None
+        if observed is None:
+            item["reasons"].append("build_age_unavailable")
+        else:
+            age = max(0, int((self.now - observed).total_seconds()))
+            item["age_seconds"] = age
+            if observed > self.now:
+                item["reasons"].append("future_tree_mtime")
+            elif age < older_than_days * 86400:
+                item["reasons"].append("younger_than_grace_period")
+        item["reasons"] = sorted(set(item["reasons"]))
+        if not item["reasons"]:
+            item["disposition"] = "eligible"
+            item["reasons"] = ["stale_worker_dependency_transaction"]
+        return item
 
     def _worker_dependency_item(
         self,
@@ -1770,6 +1884,7 @@ class Cleanup:
         purpose = f"worker-dependencies:{key}"
         item["key"] = key
         item["_purpose"] = purpose
+        item["_older_than_days"] = older_than_days
         try:
             if not re.fullmatch(r"[0-9a-f]{64}", key):
                 raise WorkspaceError("Worker dependency cache key is invalid")
@@ -1797,6 +1912,7 @@ class Cleanup:
                     "key",
                     "inputs",
                     "node_modules_lock_sha256",
+                    "node_modules_sha256",
                     "last_used_at",
                 }
                 or metadata.get("schema_version")
@@ -1808,6 +1924,8 @@ class Cleanup:
                 or not re.fullmatch(
                     r"[0-9a-f]{64}", metadata["node_modules_lock_sha256"]
                 )
+                or not isinstance(metadata.get("node_modules_sha256"), str)
+                or not re.fullmatch(r"[0-9a-f]{64}", metadata["node_modules_sha256"])
             ):
                 raise WorkspaceError(
                     "Worker dependency metadata fields are invalid"
@@ -1817,6 +1935,7 @@ class Cleanup:
                 "Worker dependencies last_used_at",
             )
             item["age_basis"] = "last-used-at"
+            item["last_used_at"] = metadata["last_used_at"]
         except (OSError, WorkspaceError) as error:
             item["reasons"].append("invalid_worker_dependency_cache")
             item["error"] = str(error)
@@ -2243,13 +2362,14 @@ class Cleanup:
         order = {
             "profile-build": 0,
             "worker-dependencies": 0,
+            "worker-dependency-transaction": 0,
             "worktree": 1,
             "npm-cache": 2,
             "prunable-metadata": 3,
         }
         return order.get(item["kind"], 99), item["path"]
 
-    def _remove(self, item: dict[str, Any]) -> None:
+    def _remove(self, item: dict[str, Any], older_than_days: int = 0) -> None:
         path = Path(item["path"])
         if item["kind"] == "profile-build":
             lock = self.paths.builds / "locks" / f"{item['profile']}-{item['key']}.lock"
@@ -2274,11 +2394,69 @@ class Cleanup:
                 f"Worker dependencies {item['key']}",
                 nonblocking=True,
             ):
+                expected = (
+                    self.paths.builds / "worker-dependencies" / item["key"]
+                ).resolve(strict=False)
+                if path.resolve(strict=False) != expected:
+                    raise WorkspaceError(
+                        f"Worker dependency cache path changed before removal: {path}"
+                    )
+                metadata = load_json(path / WORKER_DEPENDENCY_METADATA)
+                if (
+                    not isinstance(metadata, dict)
+                    or metadata.get("last_used_at") != item.get("last_used_at")
+                ):
+                    raise WorkspaceError(
+                        "Worker dependency cache was refreshed before removal"
+                    )
+                used_at = _parse_time(
+                    metadata["last_used_at"], "Worker dependencies last_used_at"
+                )
+                age = max(0, int((self.now - used_at).total_seconds()))
+                if used_at > self.now or age < older_than_days * 86400:
+                    raise WorkspaceError(
+                        "Worker dependency cache is no longer old enough to remove"
+                    )
                 managed_remove(
                     path,
                     self.paths.builds,
                     f"worker-dependencies:{item['key']}",
                 )
+        elif item["kind"] == "worker-dependency-transaction":
+            key = item["key"]
+            lock = (
+                self.paths.builds / "locks" / f"worker-dependencies-{key}.lock"
+            )
+            with exclusive_lock(
+                lock,
+                f"Worker dependencies {key}",
+                nonblocking=True,
+            ):
+                transaction_root = (
+                    self.paths.builds / "worker-dependencies" / ".transactions"
+                )
+                marker = transaction_root / MANAGED_MARKER
+                if (
+                    transaction_root.is_symlink()
+                    or not transaction_root.is_dir()
+                    or marker.is_symlink()
+                    or load_json(marker)
+                    != {
+                        "schema_version": SCHEMA_VERSION,
+                        "purpose": "worker-dependency-transactions",
+                    }
+                    or path.parent.resolve(strict=False)
+                    != transaction_root.resolve(strict=False)
+                    or not re.fullmatch(
+                        rf"{key}-(?:staging|backup)-[0-9a-f]+", path.name
+                    )
+                    or path.is_symlink()
+                    or not path.is_dir()
+                ):
+                    raise WorkspaceError(
+                        f"Worker dependency transaction changed before removal: {path}"
+                    )
+                shutil.rmtree(path)
         elif item["kind"] == "worktree":
             primary = self._repositories[item["owner"]]
             _command(primary, "worktree", "remove", "--", str(path))

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -35,7 +35,7 @@ from .workspace import (
 
 CLEANUP_SCHEMA_VERSION = 1
 WORKER_DEPENDENCY_CLEANUP_SCHEMA_VERSIONS = frozenset(
-    {2, WORKER_DEPENDENCY_SCHEMA_VERSION}
+    {1, 2, 3, WORKER_DEPENDENCY_SCHEMA_VERSION}
 )
 DEFAULT_SCOPES = ("worktrees", "builds")
 ALL_SCOPES = (*DEFAULT_SCOPES, "npm-cache")
@@ -480,6 +480,7 @@ class Cleanup:
         item.pop("_primary", None)
         item.pop("_purpose", None)
         item.pop("_older_than_days", None)
+        item.pop("_identity", None)
 
     def _revalidate_target(
         self,
@@ -548,7 +549,10 @@ class Cleanup:
         else:
             raise WorkspaceError(f"unsupported cleanup target: {kind}")
         if item is not None:
+            filesystem_identity = item.get("_identity")
             self._strip_internal(item)
+            if kind == "worker-dependency-transaction":
+                item["_identity"] = filesystem_identity
         return item
 
     def _revalidate_build_sources(
@@ -1803,14 +1807,30 @@ class Cleanup:
                 )
         return items
 
+    @staticmethod
+    def _worker_dependency_transaction_created_at(path: Path) -> datetime:
+        return datetime.fromtimestamp(path.lstat().st_ctime, timezone.utc)
+
     def _worker_dependency_transaction_item(
-        self, path: Path, older_than_days: int
+        self,
+        path: Path,
+        older_than_days: int,
+        *,
+        check_lock: bool = True,
     ) -> dict[str, Any]:
         item = _base_item(
             "worker-dependency-transaction", "atrinik", "atrinik/atrinik", path
         )
         inodes, observed, walk_error = _tree_usage(path)
         item["_inodes"] = inodes
+        try:
+            path_status = path.lstat()
+            item["_identity"] = (path_status.st_dev, path_status.st_ino)
+            created = self._worker_dependency_transaction_created_at(path)
+            observed = created if observed is None else max(observed, created)
+        except OSError as error:
+            item["reasons"].append("filesystem_traversal_error")
+            item["error"] = str(error)
         match = re.fullmatch(
             r"([0-9a-f]{64})-(staging|backup)-([a-z0-9_]+)", path.name
         )
@@ -1842,16 +1862,17 @@ class Cleanup:
             except (OSError, WorkspaceError) as error:
                 item["reasons"].append("invalid_worker_dependency_transaction")
                 item["error"] = str(error)
-            lock = (
-                self.paths.builds / "locks" / f"worker-dependencies-{key}.lock"
-            )
-            busy, lock_error = self._lock_busy(lock)
-            if lock_error:
-                item["reasons"].append("build_lock_error")
-                item["error"] = lock_error
-            elif busy:
-                item["reasons"].append("build_lock_busy")
-        item["age_basis"] = "tree-mtime" if observed else None
+            if check_lock:
+                lock = (
+                    self.paths.builds / "locks" / f"worker-dependencies-{key}.lock"
+                )
+                busy, lock_error = self._lock_busy(lock)
+                if lock_error:
+                    item["reasons"].append("build_lock_error")
+                    item["error"] = lock_error
+                elif busy:
+                    item["reasons"].append("build_lock_busy")
+        item["age_basis"] = "tree-mtime-or-root-ctime" if observed else None
         if observed is None:
             item["reasons"].append("build_age_unavailable")
         else:
@@ -1906,19 +1927,29 @@ class Cleanup:
                     "Worker dependency metadata is not a regular file"
                 )
             metadata = load_json(metadata_path)
+            schema_version = (
+                metadata.get("schema_version")
+                if isinstance(metadata, dict)
+                else None
+            )
+            metadata_keys = {
+                "schema_version",
+                "purpose",
+                "key",
+                "inputs",
+                "node_modules_lock_sha256",
+                "last_used_at",
+            }
+            if schema_version != 1:
+                metadata_keys.add("node_modules_sha256")
+            if schema_version == WORKER_DEPENDENCY_SCHEMA_VERSION:
+                metadata_keys.add("node_modules_view_sha256")
             if (
                 not isinstance(metadata, dict)
-                or set(metadata)
-                != {
-                    "schema_version",
-                    "purpose",
-                    "key",
-                    "inputs",
-                    "node_modules_lock_sha256",
-                    "node_modules_sha256",
-                    "last_used_at",
-                }
-                or metadata.get("schema_version")
+                or set(metadata) != metadata_keys
+                or not isinstance(schema_version, int)
+                or isinstance(schema_version, bool)
+                or schema_version
                 not in WORKER_DEPENDENCY_CLEANUP_SCHEMA_VERSIONS
                 or metadata.get("purpose") != "worker-dependencies"
                 or metadata.get("key") != key
@@ -1927,8 +1958,20 @@ class Cleanup:
                 or not re.fullmatch(
                     r"[0-9a-f]{64}", metadata["node_modules_lock_sha256"]
                 )
-                or not isinstance(metadata.get("node_modules_sha256"), str)
-                or not re.fullmatch(r"[0-9a-f]{64}", metadata["node_modules_sha256"])
+                or schema_version != 1
+                and (
+                    not isinstance(metadata.get("node_modules_sha256"), str)
+                    or not re.fullmatch(
+                        r"[0-9a-f]{64}", metadata["node_modules_sha256"]
+                    )
+                )
+                or schema_version == WORKER_DEPENDENCY_SCHEMA_VERSION
+                and (
+                    not isinstance(metadata.get("node_modules_view_sha256"), str)
+                    or not re.fullmatch(
+                        r"[0-9a-f]{64}", metadata["node_modules_view_sha256"]
+                    )
+                )
             ):
                 raise WorkspaceError(
                     "Worker dependency metadata fields are invalid"
@@ -2455,6 +2498,18 @@ class Cleanup:
                     )
                     or path.is_symlink()
                     or not path.is_dir()
+                ):
+                    raise WorkspaceError(
+                        f"Worker dependency transaction changed before removal: {path}"
+                    )
+                current = self._worker_dependency_transaction_item(
+                    path,
+                    older_than_days,
+                    check_lock=False,
+                )
+                if (
+                    current.get("_identity") != item.get("_identity")
+                    or current["disposition"] != "eligible"
                 ):
                     raise WorkspaceError(
                         f"Worker dependency transaction changed before removal: {path}"

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -1809,7 +1809,7 @@ class Cleanup:
         inodes, observed, walk_error = _tree_usage(path)
         item["_inodes"] = inodes
         match = re.fullmatch(
-            r"([0-9a-f]{64})-(staging|backup)-([0-9a-f]+)", path.name
+            r"([0-9a-f]{64})-(staging|backup)-([a-z0-9_]+)", path.name
         )
         if walk_error:
             item["reasons"].append("filesystem_traversal_error")
@@ -2448,7 +2448,7 @@ class Cleanup:
                     or path.parent.resolve(strict=False)
                     != transaction_root.resolve(strict=False)
                     or not re.fullmatch(
-                        rf"{key}-(?:staging|backup)-[0-9a-f]+", path.name
+                        rf"{key}-(?:staging|backup)-[a-z0-9_]+", path.name
                     )
                     or path.is_symlink()
                     or not path.is_dir()

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -1825,7 +1825,13 @@ class Cleanup:
         item["_inodes"] = inodes
         try:
             path_status = path.lstat()
-            item["_identity"] = (path_status.st_dev, path_status.st_ino)
+            item["_identity"] = (
+                path_status.st_dev,
+                path_status.st_ino,
+                path_status.st_ctime_ns,
+                stat.S_IFMT(path_status.st_mode),
+                stat.S_IMODE(path_status.st_mode),
+            )
             created = self._worker_dependency_transaction_created_at(path)
             observed = created if observed is None else max(observed, created)
         except OSError as error:

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -34,6 +34,9 @@ from .workspace import (
 
 
 CLEANUP_SCHEMA_VERSION = 1
+WORKER_DEPENDENCY_CLEANUP_SCHEMA_VERSIONS = frozenset(
+    {2, WORKER_DEPENDENCY_SCHEMA_VERSION}
+)
 DEFAULT_SCOPES = ("worktrees", "builds")
 ALL_SCOPES = (*DEFAULT_SCOPES, "npm-cache")
 BUILD_RETENTION_RECORD = "retention.json"
@@ -1916,7 +1919,7 @@ class Cleanup:
                     "last_used_at",
                 }
                 or metadata.get("schema_version")
-                != WORKER_DEPENDENCY_SCHEMA_VERSION
+                not in WORKER_DEPENDENCY_CLEANUP_SCHEMA_VERSIONS
                 or metadata.get("purpose") != "worker-dependencies"
                 or metadata.get("key") != key
                 or not isinstance(metadata.get("inputs"), dict)

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -25,6 +25,8 @@ from .workspace import (
     BUILD_METADATA,
     BUILD_METADATA_SCHEMA_VERSION,
     CACHE_METADATA,
+    WORKER_DEPENDENCY_METADATA,
+    WORKER_DEPENDENCY_SCHEMA_VERSION,
     _remote_matches,
     exclusive_lock,
 )
@@ -508,6 +510,14 @@ class Cleanup:
                 older_than_days,
                 registered,
                 removable_worktrees,
+                references,
+                reference_errors,
+            )
+        elif kind == "worker-dependencies":
+            item = self._worker_dependency_item(
+                path,
+                older_than_days,
+                registered,
                 references,
                 reference_errors,
             )
@@ -1649,6 +1659,7 @@ class Cleanup:
                 item["error"] = error
             return [item]
         profiles = self.paths.builds / "profiles"
+        items: list[dict[str, Any]] = []
         if not profiles.is_dir() or profiles.is_symlink():
             if profiles.exists() or profiles.is_symlink():
                 item = _base_item(
@@ -1659,28 +1670,196 @@ class Cleanup:
                 item["_inodes"] = inodes
                 if error:
                     item["error"] = error
-                return [item]
+                items.append(item)
+        else:
+            try:
+                profile_roots = sorted(profiles.iterdir())
+            except OSError as error:
+                item = _base_item(
+                    "unmanaged-build", "atrinik", "atrinik/atrinik", profiles
+                )
+                item["reasons"] = ["profiles_inventory_error"]
+                item["error"] = str(error)
+                items.append(item)
+            else:
+                items.extend(
+                    self._build_item(
+                        path,
+                        older_than_days,
+                        registered,
+                        removable_worktrees,
+                        references,
+                        reference_errors,
+                    )
+                    for path in profile_roots
+                )
+        items.extend(
+            self._worker_dependency_caches(
+                older_than_days, registered, references, reference_errors
+            )
+        )
+        return items
+
+    def _worker_dependency_caches(
+        self,
+        older_than_days: int,
+        registered: set[Path],
+        references: dict[str, Any],
+        reference_errors: set[str],
+    ) -> list[dict[str, Any]]:
+        root = self.paths.builds / "worker-dependencies"
+        if not root.exists() and not root.is_symlink():
             return []
         try:
-            profile_roots = sorted(profiles.iterdir())
-        except OSError as error:
-            item = _base_item(
-                "unmanaged-build", "atrinik", "atrinik/atrinik", profiles
+            marker = root / MANAGED_MARKER
+            if (
+                root.is_symlink()
+                or not root.is_dir()
+                or marker.is_symlink()
+                or load_json(marker)
+                != {
+                    "schema_version": SCHEMA_VERSION,
+                    "purpose": "worker-dependency-cache",
+                }
+            ):
+                raise WorkspaceError(
+                    "Worker dependency cache root is not marker-owned"
+                )
+            paths = sorted(
+                path for path in root.iterdir() if path.name != MANAGED_MARKER
             )
-            item["reasons"] = ["profiles_inventory_error"]
+        except (OSError, WorkspaceError) as error:
+            item = _base_item(
+                "unmanaged-build", "atrinik", "atrinik/atrinik", root
+            )
+            item["reasons"] = ["invalid_worker_dependency_cache"]
             item["error"] = str(error)
+            inodes, _, walk_error = _tree_usage(root)
+            item["_inodes"] = inodes
+            if walk_error:
+                item["reasons"].append("filesystem_traversal_error")
             return [item]
         return [
-            self._build_item(
+            self._worker_dependency_item(
                 path,
                 older_than_days,
                 registered,
-                removable_worktrees,
                 references,
                 reference_errors,
             )
-            for path in profile_roots
+            for path in paths
         ]
+
+    def _worker_dependency_item(
+        self,
+        path: Path,
+        older_than_days: int,
+        registered: set[Path],
+        references: dict[str, Any],
+        reference_errors: set[str],
+    ) -> dict[str, Any]:
+        item = _base_item(
+            "worker-dependencies", "atrinik", "atrinik/atrinik", path
+        )
+        inodes, _, walk_error = _tree_usage(path)
+        item["_inodes"] = inodes
+        if walk_error:
+            item["reasons"].append("filesystem_traversal_error")
+            item["error"] = walk_error
+        key = path.name
+        purpose = f"worker-dependencies:{key}"
+        item["key"] = key
+        item["_purpose"] = purpose
+        try:
+            if not re.fullmatch(r"[0-9a-f]{64}", key):
+                raise WorkspaceError("Worker dependency cache key is invalid")
+            marker = path / MANAGED_MARKER
+            if (
+                path.is_symlink()
+                or not path.is_dir()
+                or marker.is_symlink()
+                or load_json(marker)
+                != {"schema_version": SCHEMA_VERSION, "purpose": purpose}
+            ):
+                raise WorkspaceError("Worker dependency cache marker is invalid")
+            metadata_path = path / WORKER_DEPENDENCY_METADATA
+            if metadata_path.is_symlink() or not metadata_path.is_file():
+                raise WorkspaceError(
+                    "Worker dependency metadata is not a regular file"
+                )
+            metadata = load_json(metadata_path)
+            if (
+                not isinstance(metadata, dict)
+                or set(metadata)
+                != {
+                    "schema_version",
+                    "purpose",
+                    "key",
+                    "inputs",
+                    "node_modules_lock_sha256",
+                    "last_used_at",
+                }
+                or metadata.get("schema_version")
+                != WORKER_DEPENDENCY_SCHEMA_VERSION
+                or metadata.get("purpose") != "worker-dependencies"
+                or metadata.get("key") != key
+                or not isinstance(metadata.get("inputs"), dict)
+                or not isinstance(metadata.get("node_modules_lock_sha256"), str)
+                or not re.fullmatch(
+                    r"[0-9a-f]{64}", metadata["node_modules_lock_sha256"]
+                )
+            ):
+                raise WorkspaceError(
+                    "Worker dependency metadata fields are invalid"
+                )
+            used_at = _parse_time(
+                metadata.get("last_used_at"),
+                "Worker dependencies last_used_at",
+            )
+            item["age_basis"] = "last-used-at"
+        except (OSError, WorkspaceError) as error:
+            item["reasons"].append("invalid_worker_dependency_cache")
+            item["error"] = str(error)
+            used_at = None
+        normalized = path.resolve(strict=False)
+        if any(_path_relation(normalized, worktree) for worktree in registered):
+            item["reasons"].append("contains_registered_worktree")
+        for category, reason in (
+            ("live_builds", "live_topology"),
+            ("retention", "retention_reference"),
+        ):
+            values = references[category].get(normalized, [])
+            if values:
+                target = (
+                    "topologies" if category == "live_builds" else "retention"
+                )
+                item["references"][target] = sorted(set(values))
+                item["reasons"].append(reason)
+        item["reasons"].extend(sorted(reference_errors))
+        if re.fullmatch(r"[0-9a-f]{64}", key):
+            lock = (
+                self.paths.builds / "locks" / f"worker-dependencies-{key}.lock"
+            )
+            busy, lock_error = self._lock_busy(lock)
+            if lock_error:
+                item["reasons"].append("build_lock_error")
+                item["error"] = lock_error
+            elif busy:
+                item["reasons"].append("build_lock_busy")
+        if used_at is None:
+            item["reasons"].append("build_age_unavailable")
+        else:
+            age = max(0, int((self.now - used_at).total_seconds()))
+            item["age_seconds"] = age
+            if used_at > self.now:
+                item["reasons"].append("future_last_used")
+            elif age < older_than_days * 86400:
+                item["reasons"].append("younger_than_grace_period")
+        item["reasons"] = sorted(set(item["reasons"]))
+        if not item["reasons"]:
+            item["disposition"] = "eligible"
+            item["reasons"] = ["stale_worker_dependencies"]
+        return item
 
     def _build_item(
         self,
@@ -1896,7 +2075,11 @@ class Cleanup:
         if self.paths.builds.is_dir() and not self.paths.builds.is_symlink():
             try:
                 for path in sorted(self.paths.builds.iterdir()):
-                    if path.name in {"profiles", "npm-cache"}:
+                    if path.name in {
+                        "profiles",
+                        "npm-cache",
+                        "worker-dependencies",
+                    }:
                         continue
                     roots.append((path, []))
             except OSError:
@@ -2059,6 +2242,7 @@ class Cleanup:
     def _apply_order(item: dict[str, Any]) -> tuple[int, str]:
         order = {
             "profile-build": 0,
+            "worker-dependencies": 0,
             "worktree": 1,
             "npm-cache": 2,
             "prunable-metadata": 3,
@@ -2078,6 +2262,22 @@ class Cleanup:
                     path,
                     self.paths.builds,
                     f"profile:{item['profile']}:{item['key']}",
+                )
+        elif item["kind"] == "worker-dependencies":
+            lock = (
+                self.paths.builds
+                / "locks"
+                / f"worker-dependencies-{item['key']}.lock"
+            )
+            with exclusive_lock(
+                lock,
+                f"Worker dependencies {item['key']}",
+                nonblocking=True,
+            ):
+                managed_remove(
+                    path,
+                    self.paths.builds,
+                    f"worker-dependencies:{item['key']}",
                 )
         elif item["kind"] == "worktree":
             primary = self._repositories[item["owner"]]

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -101,7 +101,7 @@ BUILD_METADATA_SCHEMA_VERSION = 1
 CACHE_METADATA = ".atrinik-cache.json"
 WORKER_DEPENDENCY_METADATA = ".atrinik-worker-dependencies.json"
 WORKER_VIEW_METADATA = ".atrinik-worker-view.json"
-WORKER_DEPENDENCY_SCHEMA_VERSION = 2
+WORKER_DEPENDENCY_SCHEMA_VERSION = 3
 WORKER_VIEW_SCHEMA_VERSION = 1
 WORKER_DEPENDENCY_FILES = ("package.json", "package-lock.json")
 WORKER_SOURCE_EXCLUSIONS = {
@@ -2815,6 +2815,10 @@ class Workspace:
                 f"worker-dependency-transaction:{key}",
             )
             try:
+                # Ownership is proven by the marker-owned transaction parent,
+                # exact per-key name, and held key lock. Keep wrapper metadata
+                # outside the lifecycle-visible input tree while npm runs.
+                (staging / MANAGED_MARKER).unlink()
                 _copy_worker_source(
                     source,
                     staging,
@@ -2850,6 +2854,12 @@ class Workspace:
                         )
                 _normalize_worker_atime(staging)
                 run(["npm", "ci"], cwd=staging, env=environment)
+                if (staging / MANAGED_MARKER).exists() or (
+                    staging / MANAGED_MARKER
+                ).is_symlink():
+                    raise WorkspaceError(
+                        "Worker lifecycle created reserved workspace metadata"
+                    )
                 if _tree_references_path(staging / "node_modules", staging):
                     raise WorkspaceError(
                         "Worker dependency output embeds its install path"

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -4469,6 +4469,24 @@ class Workspace:
         finally:
             os.close(descriptor)
 
+    def _reconcile_worker_view_after_checks(
+        self,
+        source: Path,
+        view: Path,
+        dependency_key: str,
+        dependency_metadata: dict[str, Any],
+    ) -> None:
+        self._reconcile_worker_view_source(
+            source, view, dependency_key, dependency_metadata
+        )
+        self._validate_worker_node_modules(
+            view / "node_modules",
+            dependency_metadata["node_modules_lock_sha256"],
+            dependency_metadata["node_modules_view_sha256"],
+            self._worker_required_packages(source),
+            WORKER_VIEW_NODE_MODULES_EXCLUSIONS,
+        )
+
     def _build_worker(self, root: Path, selected: dict[str, Path]) -> None:
         source = selected["metaserver-worker"]
         environment = os.environ.copy()
@@ -4491,7 +4509,7 @@ class Workspace:
             f"({view_seconds:.2f}s)"
         )
         self._run_worker_checks(view, environment, key, metadata)
-        self._reconcile_worker_view_source(source, view, key, metadata)
+        self._reconcile_worker_view_after_checks(source, view, key, metadata)
 
     def state_add(self, name: str, path: Path | None) -> Path:
         self.paths.ensure()

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -299,13 +299,18 @@ def _tree_digest(
     return digest.hexdigest()
 
 
-def _copy_worker_source(source: Path, destination: Path) -> None:
+def _copy_worker_source(
+    source: Path, destination: Path, *, include_npmrc: bool = True
+) -> None:
     """Copy Worker source while excluding generated names only at its root."""
 
     def ignore(directory: str, names: list[str]) -> list[str]:
         if Path(directory) != source:
             return []
-        return sorted(set(names) & WORKER_SOURCE_EXCLUSIONS)
+        excluded = set(names) & WORKER_SOURCE_EXCLUSIONS
+        if not include_npmrc and Path(directory) == source and ".npmrc" in names:
+            excluded.add(".npmrc")
+        return sorted(excluded)
 
     shutil.copytree(
         source,
@@ -314,6 +319,34 @@ def _copy_worker_source(source: Path, destination: Path) -> None:
         symlinks=True,
         ignore=ignore,
     )
+
+
+def _tree_references_path(root: Path, referenced: Path) -> bool:
+    """Return whether a no-follow tree stores one absolute path literally."""
+
+    needle = str(referenced).encode()
+    for directory, directories, files in os.walk(root, followlinks=False):
+        parent = Path(directory)
+        for name in (*directories, *files):
+            path = parent / name
+            status = path.lstat()
+            if stat.S_ISLNK(status.st_mode):
+                if needle in os.readlink(path).encode(
+                    "utf-8", "surrogateescape"
+                ):
+                    return True
+            elif stat.S_ISREG(status.st_mode):
+                descriptor = open_regular_file(
+                    path, os.O_RDONLY, "Worker installed file"
+                )
+                with os.fdopen(descriptor, "rb") as stream:
+                    previous = b""
+                    while chunk := stream.read(1024 * 1024):
+                        combined = previous + chunk
+                        if needle in combined:
+                            return True
+                        previous = combined[-max(0, len(needle) - 1) :]
+    return False
 
 
 def _remote_matches(url: str, repository: str) -> bool:
@@ -2350,6 +2383,13 @@ class Workspace:
             "lifecycle_source_sha256": _tree_digest(
                 source, WORKER_SOURCE_EXCLUSIONS, reject_symlinks=True
             ),
+            "install_root_sha256": hashlib.sha256(
+                str(
+                    self.paths.builds
+                    / "worker-dependencies"
+                    / ".transactions"
+                ).encode()
+            ).hexdigest(),
         }
 
     @staticmethod
@@ -2459,6 +2499,10 @@ class Workspace:
                 return None
             for name, expected in inputs["files"].items():
                 path = entry / name
+                if name == ".npmrc":
+                    if path.exists() or path.is_symlink():
+                        return None
+                    continue
                 if expected is None:
                     if path.exists() or path.is_symlink():
                         return None
@@ -2522,8 +2566,11 @@ class Workspace:
         lock = self.paths.builds / "locks" / f"worker-dependencies-{key}.lock"
         started = time.monotonic()
         with exclusive_lock(lock, f"Worker dependencies {key}"):
-            if not entry.exists() and not entry.is_symlink():
-                recoverable: list[Path] = []
+            metadata = self._worker_dependency_cache_matches(
+                entry, key, inputs, required
+            )
+            recoverable: list[Path] = []
+            if metadata is None:
                 for candidate in transactions.iterdir():
                     if not re.fullmatch(
                         rf"{key}-(?:staging|backup)-[a-z0-9_]+",
@@ -2534,18 +2581,29 @@ class Workspace:
                         candidate, key, inputs, required
                     ) is not None:
                         recoverable.append(candidate)
-                if recoverable:
-                    recovered = max(
-                        recoverable,
-                        key=lambda candidate: (
-                            candidate.stat().st_mtime_ns,
-                            candidate.name,
-                        ),
+            if recoverable:
+                if entry.exists() or entry.is_symlink():
+                    managed_directory(
+                        entry,
+                        self.paths.builds,
+                        f"worker-dependencies:{key}",
                     )
-                    recovered.replace(entry)
-            metadata = self._worker_dependency_cache_matches(
-                entry, key, inputs, required
-            )
+                recovered = max(
+                    recoverable,
+                    key=lambda candidate: (
+                        candidate.stat().st_mtime_ns,
+                        candidate.name,
+                    ),
+                )
+                replace_directory(
+                    entry,
+                    recovered,
+                    f"{key}-backup-",
+                    backup_parent=transactions,
+                )
+                metadata = self._worker_dependency_cache_matches(
+                    entry, key, inputs, required
+                )
             if metadata is not None:
                 metadata["last_used_at"] = datetime.now(timezone.utc).isoformat()
                 atomic_json(entry / WORKER_DEPENDENCY_METADATA, metadata)
@@ -2564,15 +2622,35 @@ class Workspace:
                     self.paths.builds,
                     f"worker-dependencies:{key}",
                 )
-            staging = transactions / f"{key}-staging-{secrets.token_hex(8)}"
+            staging = transactions / f"{key}-staging-install"
+            if staging.exists() or staging.is_symlink():
+                try:
+                    managed_directory(
+                        staging,
+                        self.paths.builds,
+                        f"worker-dependency-transaction:{key}",
+                    )
+                except WorkspaceError:
+                    managed_directory(
+                        staging,
+                        self.paths.builds,
+                        f"worker-dependencies:{key}",
+                    )
+                shutil.rmtree(staging)
             managed_directory(
                 staging,
                 self.paths.builds,
                 f"worker-dependency-transaction:{key}",
             )
             try:
-                _copy_worker_source(source, staging)
+                _copy_worker_source(source, staging, include_npmrc=False)
+                if inputs["files"][".npmrc"] is not None:
+                    (staging / ".npmrc").symlink_to(source / ".npmrc")
                 run(["npm", "ci"], cwd=staging, env=environment)
+                if _tree_references_path(staging / "node_modules", staging):
+                    raise WorkspaceError(
+                        "Worker dependency output embeds its install path"
+                    )
                 final_inputs = self._worker_dependency_inputs(source, environment)
                 if final_inputs != inputs:
                     raise WorkspaceError(
@@ -2586,7 +2664,7 @@ class Workspace:
                     else:
                         shutil.rmtree(child)
                 for name, expected in inputs["files"].items():
-                    if expected is not None:
+                    if expected is not None and name != ".npmrc":
                         shutil.copy2(source / name, staging / name)
                 hidden_digest = _file_digest(
                     staging / "node_modules" / ".package-lock.json",
@@ -2627,6 +2705,7 @@ class Workspace:
             finally:
                 if staging.exists():
                     shutil.rmtree(staging)
+            elapsed = time.monotonic() - started
             consumed = (
                 consume(entry / "node_modules", key, metadata)
                 if consume is not None
@@ -2637,7 +2716,7 @@ class Workspace:
             key,
             metadata,
             False,
-            time.monotonic() - started,
+            elapsed,
             consumed,
         )
 

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -273,7 +273,11 @@ def _tree_digest(
                 status = entry.lstat()
                 mode = stat.S_IMODE(status.st_mode)
                 metadata: tuple[object, ...] = (
-                    (status.st_mtime_ns, extended_attributes(entry))
+                    (
+                        status.st_mtime_ns,
+                        getattr(status, "st_flags", 0),
+                        extended_attributes(entry),
+                    )
                     if copied_metadata
                     else ()
                 )
@@ -338,7 +342,11 @@ def _tree_digest(
         raise WorkspaceError(f"Worker source is not a regular directory: {root}")
     root_status = root.lstat()
     root_metadata: tuple[object, ...] = (
-        (root_status.st_mtime_ns, extended_attributes(root))
+        (
+            root_status.st_mtime_ns,
+            getattr(root_status, "st_flags", 0),
+            extended_attributes(root),
+        )
         if copied_metadata
         else ()
     )
@@ -403,6 +411,27 @@ def _copy_regular_file(source: Path, destination: Path, description: str) -> Non
             os.close(source_descriptor)
         if destination_descriptor is not None:
             os.close(destination_descriptor)
+
+
+def _normalize_worker_atime(root: Path) -> None:
+    """Give lifecycle staging a deterministic initial access time."""
+
+    paths = [root]
+    for directory, directories, files in os.walk(root, followlinks=False):
+        parent = Path(directory)
+        paths.extend(parent / name for name in (*directories, *files))
+    for path in reversed(paths):
+        try:
+            status = path.lstat()
+            os.utime(
+                path,
+                ns=(0, status.st_mtime_ns),
+                follow_symlinks=False,
+            )
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot normalize Worker lifecycle access time {path}: {error}"
+            ) from error
 
 
 def _tree_references_path(root: Path, referenced: Path) -> bool:
@@ -2426,7 +2455,11 @@ class Workspace:
             path = Path(os.path.abspath(path))
             path_digest = hashlib.sha256(str(path).encode()).hexdigest()
             if path.exists() or path.is_symlink():
-                content_digest = _file_digest(path, f"npm {name}")
+                _file_digest(path, f"npm {name}")
+                raise WorkspaceError(
+                    "external file-backed npm configuration is unsupported; "
+                    "use the project .npmrc"
+                )
             else:
                 content_digest = None
             records.append((name, path_digest, content_digest))
@@ -2808,6 +2841,14 @@ class Workspace:
                     )
                 if (staging / ".npmrc").exists():
                     (staging / ".npmrc").chmod(0o600)
+                    if (
+                        _file_digest(staging / ".npmrc", "staged Worker .npmrc")
+                        != inputs["files"][".npmrc"]
+                    ):
+                        raise WorkspaceError(
+                            "staged Worker .npmrc does not match its cache key"
+                        )
+                _normalize_worker_atime(staging)
                 run(["npm", "ci"], cwd=staging, env=environment)
                 if _tree_references_path(staging / "node_modules", staging):
                     raise WorkspaceError(

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -102,7 +102,7 @@ CACHE_METADATA = ".atrinik-cache.json"
 WORKER_DEPENDENCY_METADATA = ".atrinik-worker-dependencies.json"
 WORKER_VIEW_METADATA = ".atrinik-worker-view.json"
 WORKER_DEPENDENCY_SCHEMA_VERSION = 4
-WORKER_VIEW_SCHEMA_VERSION = 1
+WORKER_VIEW_SCHEMA_VERSION = 2
 WORKER_DEPENDENCY_FILES = ("package.json", "package-lock.json")
 WORKER_SOURCE_EXCLUSIONS = {
     ".git",
@@ -3048,6 +3048,13 @@ class Workspace:
         source_digest = _tree_digest(
             source, WORKER_SOURCE_EXCLUSIONS, reject_symlinks=True
         )
+        source_view_digest = _tree_digest(
+            source,
+            WORKER_SOURCE_EXCLUSIONS,
+            reject_symlinks=True,
+            copied_metadata=True,
+            ignore_root_mtime=True,
+        )
         dependency_source_digest = dependency_metadata.get("inputs", {}).get(
             "lifecycle_source_sha256"
         )
@@ -3059,22 +3066,36 @@ class Workspace:
             "schema_version": WORKER_VIEW_SCHEMA_VERSION,
             "purpose": "worker-view",
             "source_sha256": source_digest,
+            "source_view_sha256": source_view_digest,
             "dependency_key": dependency_key,
             "node_modules_lock_sha256": dependency_metadata[
                 "node_modules_lock_sha256"
             ],
         }
+        marker_path = view / MANAGED_MARKER
+        metadata_path = view / WORKER_VIEW_METADATA
         try:
             if (
                 not view.is_symlink()
                 and view.is_dir()
-                and load_json(view / MANAGED_MARKER)
+                and marker_path.is_file()
+                and not marker_path.is_symlink()
+                and metadata_path.is_file()
+                and not metadata_path.is_symlink()
+                and load_json(marker_path)
                 == {
                     "schema_version": SCHEMA_VERSION,
                     "purpose": "source-view:metaserver-worker",
                 }
-                and load_json(view / WORKER_VIEW_METADATA) == expected
+                and load_json(metadata_path) == expected
                 and _tree_digest(view, WORKER_SOURCE_EXCLUSIONS) == source_digest
+                and _tree_digest(
+                    view,
+                    WORKER_SOURCE_EXCLUSIONS,
+                    copied_metadata=True,
+                    ignore_root_mtime=True,
+                )
+                == source_view_digest
             ):
                 self._validate_worker_node_modules(
                     view / "node_modules",
@@ -3140,6 +3161,59 @@ class Workspace:
                 shutil.rmtree(staging)
         return view, False, time.monotonic() - started
 
+    @staticmethod
+    def _reconcile_worker_view_source(
+        source: Path,
+        view: Path,
+        dependency_metadata: dict[str, Any],
+    ) -> None:
+        lifecycle_source_digest = dependency_metadata.get("inputs", {}).get(
+            "lifecycle_source_sha256"
+        )
+        source_digest = _tree_digest(
+            source, WORKER_SOURCE_EXCLUSIONS, reject_symlinks=True
+        )
+        if (
+            _tree_digest(
+                source,
+                WORKER_SOURCE_EXCLUSIONS,
+                reject_symlinks=True,
+                copied_metadata=True,
+            )
+            != lifecycle_source_digest
+            or _tree_digest(
+                view, WORKER_SOURCE_EXCLUSIONS, reject_symlinks=True
+            )
+            != source_digest
+        ):
+            raise WorkspaceError("Worker source changed while running checks")
+        _copy_worker_source(source, view)
+        source_view_digest = _tree_digest(
+            source,
+            WORKER_SOURCE_EXCLUSIONS,
+            reject_symlinks=True,
+            copied_metadata=True,
+            ignore_root_mtime=True,
+        )
+        if (
+            _tree_digest(
+                source,
+                WORKER_SOURCE_EXCLUSIONS,
+                reject_symlinks=True,
+                copied_metadata=True,
+            )
+            != lifecycle_source_digest
+            or _tree_digest(
+                view,
+                WORKER_SOURCE_EXCLUSIONS,
+                reject_symlinks=True,
+                copied_metadata=True,
+                ignore_root_mtime=True,
+            )
+            != source_view_digest
+        ):
+            raise WorkspaceError("Worker source changed during view reconciliation")
+
     def _build_worker(self, root: Path, selected: dict[str, Path]) -> None:
         source = selected["metaserver-worker"]
         environment = os.environ.copy()
@@ -3162,6 +3236,7 @@ class Workspace:
             f"({view_seconds:.2f}s)"
         )
         run(["npm", "run", "check"], cwd=view, env=environment)
+        self._reconcile_worker_view_source(source, view, metadata)
 
     def state_add(self, name: str, path: Path | None) -> Path:
         self.paths.ensure()

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -228,6 +228,7 @@ def _tree_digest(
     *,
     bounded_symlinks: bool = False,
     reject_symlinks: bool = False,
+    copied_metadata: bool = False,
 ) -> str:
     """Hash a tree as framed records without following links."""
 
@@ -240,6 +241,22 @@ def _tree_digest(
         ).encode()
         digest.update(len(encoded).to_bytes(8, "big"))
         digest.update(encoded)
+
+    def extended_attributes(path: Path) -> tuple[tuple[str, int, str], ...]:
+        if not hasattr(os, "listxattr"):
+            return ()
+        try:
+            values = []
+            for name in sorted(os.listxattr(path, follow_symlinks=False)):
+                value = os.getxattr(path, name, follow_symlinks=False)
+                values.append(
+                    (name, len(value), hashlib.sha256(value).hexdigest())
+                )
+            return tuple(values)
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot inspect Worker source metadata {path}: {error}"
+            ) from error
 
     def visit(directory: Path, relative: PurePosixPath) -> None:
         try:
@@ -255,8 +272,18 @@ def _tree_digest(
             try:
                 status = entry.lstat()
                 mode = stat.S_IMODE(status.st_mode)
+                metadata: tuple[object, ...] = (
+                    (status.st_mtime_ns, extended_attributes(entry))
+                    if copied_metadata
+                    else ()
+                )
                 if stat.S_ISDIR(status.st_mode):
-                    record("directory", child.as_posix(), mode)
+                    record(
+                        "directory",
+                        child.as_posix(),
+                        mode,
+                        *metadata,
+                    )
                     visit(entry, child)
                 elif stat.S_ISREG(status.st_mode):
                     record(
@@ -265,6 +292,7 @@ def _tree_digest(
                         mode,
                         status.st_size,
                         _file_digest(entry, "Worker tree file"),
+                        *metadata,
                     )
                 elif stat.S_ISLNK(status.st_mode):
                     target = os.readlink(entry)
@@ -288,7 +316,13 @@ def _tree_digest(
                             raise WorkspaceError(
                                 f"Worker dependencies contain a dangling link: {entry}"
                             )
-                    record("symlink", child.as_posix(), mode, target)
+                    record(
+                        "symlink",
+                        child.as_posix(),
+                        mode,
+                        target,
+                        *metadata,
+                    )
                 else:
                     raise WorkspaceError(
                         f"Worker source contains an unsupported file type: {entry}"
@@ -302,6 +336,13 @@ def _tree_digest(
 
     if root.is_symlink() or not root.is_dir():
         raise WorkspaceError(f"Worker source is not a regular directory: {root}")
+    root_status = root.lstat()
+    root_metadata: tuple[object, ...] = (
+        (root_status.st_mtime_ns, extended_attributes(root))
+        if copied_metadata
+        else ()
+    )
+    record("root", stat.S_IMODE(root_status.st_mode), *root_metadata)
     visit(root, PurePosixPath())
     return digest.hexdigest()
 
@@ -311,7 +352,6 @@ def _copy_worker_source(
     destination: Path,
     *,
     include_npmrc: bool = True,
-    preserve_metadata: bool = True,
 ) -> None:
     """Copy Worker source while excluding generated names only at its root."""
 
@@ -329,7 +369,6 @@ def _copy_worker_source(
         dirs_exist_ok=True,
         symlinks=True,
         ignore=ignore,
-        copy_function=shutil.copy2 if preserve_metadata else shutil.copy,
     )
 
 
@@ -339,7 +378,8 @@ def _copy_regular_file(source: Path, destination: Path, description: str) -> Non
     source_descriptor = open_regular_file(source, os.O_RDONLY, description)
     destination_descriptor: int | None = None
     try:
-        mode = stat.S_IMODE(os.fstat(source_descriptor).st_mode)
+        source_status = os.fstat(source_descriptor)
+        mode = stat.S_IMODE(source_status.st_mode)
         destination_descriptor = os.open(
             destination,
             os.O_WRONLY | os.O_CREAT | os.O_EXCL,
@@ -351,6 +391,11 @@ def _copy_regular_file(source: Path, destination: Path, description: str) -> Non
             with os.fdopen(destination_descriptor, "wb") as destination_stream:
                 destination_descriptor = None
                 shutil.copyfileobj(source_stream, destination_stream)
+        os.utime(
+            destination,
+            ns=(source_status.st_atime_ns, source_status.st_mtime_ns),
+            follow_symlinks=False,
+        )
     except OSError as error:
         raise WorkspaceError(f"cannot stage {description} {source}: {error}") from error
     finally:
@@ -358,25 +403,6 @@ def _copy_regular_file(source: Path, destination: Path, description: str) -> Non
             os.close(source_descriptor)
         if destination_descriptor is not None:
             os.close(destination_descriptor)
-
-
-def _normalize_worker_staging(root: Path) -> None:
-    """Remove unkeyed copied metadata before lifecycle scripts can observe it."""
-
-    paths = [root]
-    for directory, directories, files in os.walk(root, followlinks=False):
-        parent = Path(directory)
-        paths.extend(parent / name for name in (*directories, *files))
-    for path in reversed(paths):
-        try:
-            if hasattr(os, "listxattr"):
-                for attribute in os.listxattr(path, follow_symlinks=False):
-                    os.removexattr(path, attribute, follow_symlinks=False)
-            os.utime(path, ns=(0, 0), follow_symlinks=False)
-        except OSError as error:
-            raise WorkspaceError(
-                f"cannot normalize Worker lifecycle staging path {path}: {error}"
-            ) from error
 
 
 def _tree_references_path(root: Path, referenced: Path) -> bool:
@@ -2485,7 +2511,16 @@ class Workspace:
             # root files even when package.json has no root hook. Preserve npm's
             # enabled-script semantics by staging and keying the complete source.
             "lifecycle_source_sha256": _tree_digest(
-                source, WORKER_SOURCE_EXCLUSIONS, reject_symlinks=True
+                source,
+                WORKER_SOURCE_EXCLUSIONS,
+                reject_symlinks=True,
+                copied_metadata=True,
+            ),
+            "lifecycle_source_without_npmrc_sha256": _tree_digest(
+                source,
+                WORKER_SOURCE_EXCLUSIONS | {".npmrc"},
+                reject_symlinks=True,
+                copied_metadata=True,
             ),
             "install_root_sha256": hashlib.sha256(
                 str(
@@ -2751,7 +2786,6 @@ class Workspace:
                     source,
                     staging,
                     include_npmrc=False,
-                    preserve_metadata=False,
                 )
                 if inputs["files"][".npmrc"] is not None:
                     _copy_regular_file(
@@ -2759,20 +2793,21 @@ class Workspace:
                         staging / ".npmrc",
                         "Worker .npmrc",
                     )
+                shutil.copystat(source, staging, follow_symlinks=False)
                 if (
                     _tree_digest(
                         staging,
-                        WORKER_SOURCE_EXCLUSIONS,
+                        WORKER_SOURCE_EXCLUSIONS | {".npmrc"},
                         reject_symlinks=True,
+                        copied_metadata=True,
                     )
-                    != inputs["lifecycle_source_sha256"]
+                    != inputs["lifecycle_source_without_npmrc_sha256"]
                 ):
                     raise WorkspaceError(
                         "staged Worker lifecycle source does not match its cache key"
                     )
                 if (staging / ".npmrc").exists():
                     (staging / ".npmrc").chmod(0o600)
-                _normalize_worker_staging(staging)
                 run(["npm", "ci"], cwd=staging, env=environment)
                 if _tree_references_path(staging / "node_modules", staging):
                     raise WorkspaceError(
@@ -2857,13 +2892,19 @@ class Workspace:
     ) -> tuple[Path, bool, float]:
         started = time.monotonic()
         view = root / "sources" / "metaserver-worker"
+        lifecycle_source_digest = _tree_digest(
+            source,
+            WORKER_SOURCE_EXCLUSIONS,
+            reject_symlinks=True,
+            copied_metadata=True,
+        )
         source_digest = _tree_digest(
             source, WORKER_SOURCE_EXCLUSIONS, reject_symlinks=True
         )
         dependency_source_digest = dependency_metadata.get("inputs", {}).get(
             "lifecycle_source_sha256"
         )
-        if source_digest != dependency_source_digest:
+        if lifecycle_source_digest != dependency_source_digest:
             raise WorkspaceError(
                 "Worker source does not match dependency lifecycle inputs"
             )
@@ -2907,25 +2948,28 @@ class Workspace:
             tempfile.mkdtemp(prefix=".metaserver-worker-", dir=view.parent)
         )
         try:
-            _copy_worker_source(source, staging, preserve_metadata=False)
+            _copy_worker_source(source, staging)
             if (
                 _tree_digest(
                     staging,
                     WORKER_SOURCE_EXCLUSIONS,
                     reject_symlinks=True,
+                    copied_metadata=True,
                 )
-                != source_digest
+                != lifecycle_source_digest
             ):
                 raise WorkspaceError(
                     "staged Worker view source does not match its fingerprint"
                 )
-            _normalize_worker_staging(staging)
             shutil.copytree(dependencies, staging / "node_modules", symlinks=True)
             if (
                 _tree_digest(
-                    source, WORKER_SOURCE_EXCLUSIONS, reject_symlinks=True
+                    source,
+                    WORKER_SOURCE_EXCLUSIONS,
+                    reject_symlinks=True,
+                    copied_metadata=True,
                 )
-                != source_digest
+                != lifecycle_source_digest
             ):
                 raise WorkspaceError("Worker source changed during view preparation")
             self._validate_worker_node_modules(

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -2796,18 +2796,29 @@ class Workspace:
                 )
             staging = transactions / f"{key}-staging-install"
             if staging.exists() or staging.is_symlink():
-                try:
-                    managed_directory(
-                        staging,
-                        self.paths.builds,
-                        f"worker-dependency-transaction:{key}",
+                marker = staging / MANAGED_MARKER
+                if marker.exists() or marker.is_symlink():
+                    try:
+                        managed_directory(
+                            staging,
+                            self.paths.builds,
+                            f"worker-dependency-transaction:{key}",
+                        )
+                    except WorkspaceError:
+                        managed_directory(
+                            staging,
+                            self.paths.builds,
+                            f"worker-dependencies:{key}",
+                        )
+                elif staging.is_symlink() or not staging.is_dir():
+                    raise WorkspaceError(
+                        f"Worker dependency transaction path is unsafe: {staging}"
                     )
-                except WorkspaceError:
-                    managed_directory(
-                        staging,
-                        self.paths.builds,
-                        f"worker-dependencies:{key}",
-                    )
+                # npm runs without the marker so lifecycle scripts cannot
+                # observe wrapper-created metadata. A crash can therefore
+                # leave this one exact unmarked path behind. Its marker-owned
+                # parent, deterministic key-derived name, and held key lock
+                # provide the ownership proof needed to recover it safely.
                 shutil.rmtree(staging)
             managed_directory(
                 staging,

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -194,6 +194,11 @@ def replace_directory(
         backup.rmdir()
         output.replace(backup)
         try:
+            # Rename preserves the old tree's timestamps. Refresh the backup
+            # root so cleanup's no-follow tree age measures when this
+            # transaction was created, not when the replaced output last
+            # changed.
+            os.utime(backup, None, follow_symlinks=False)
             staging.replace(output)
         except BaseException:
             backup.replace(output)
@@ -2429,6 +2434,20 @@ class Workspace:
     ) -> str:
         """Hash file-backed effective npm configuration without storing secrets."""
 
+        script_shells = {
+            name: value
+            for name, value in config.items()
+            if name == "script-shell" or name.rsplit(":", 1)[-1] == "script-shell"
+        }
+        for name, value in sorted(script_shells.items()):
+            if value is None or value == "":
+                continue
+            if not isinstance(value, str) or "\0" in value:
+                raise WorkspaceError(f"npm configuration {name} path is invalid")
+            raise WorkspaceError(
+                "custom npm script-shell configuration is unsupported"
+            )
+
         records: list[tuple[str, str, str | None]] = []
         file_values = {
             name: value
@@ -2491,6 +2510,46 @@ class Workspace:
             if not value or "\n" in value or len(value) > 256:
                 raise WorkspaceError(f"{command} returned an invalid version")
             versions[command] = value
+        raw_node_runtime = run(
+            [
+                "node",
+                "-p",
+                "JSON.stringify({platform:process.platform,arch:process.arch,"
+                "versions:process.versions})",
+            ],
+            cwd=source,
+            capture=True,
+            env=environment,
+            trace=False,
+        )
+        try:
+            node_runtime = json.loads(raw_node_runtime)
+        except json.JSONDecodeError as error:
+            raise WorkspaceError("Node runtime identity is not valid JSON") from error
+        if (
+            not isinstance(node_runtime, dict)
+            or set(node_runtime) != {"platform", "arch", "versions"}
+            or not isinstance(node_runtime.get("platform"), str)
+            or not re.fullmatch(r"[a-z0-9._-]{1,64}", node_runtime["platform"])
+            or not isinstance(node_runtime.get("arch"), str)
+            or not re.fullmatch(r"[a-z0-9._-]{1,64}", node_runtime["arch"])
+            or not isinstance(node_runtime.get("versions"), dict)
+            or not node_runtime["versions"]
+            or not all(
+                isinstance(name, str)
+                and re.fullmatch(r"[a-z0-9._-]{1,64}", name)
+                and isinstance(value, str)
+                and len(value) <= 256
+                and "\n" not in value
+                for name, value in node_runtime["versions"].items()
+            )
+        ):
+            raise WorkspaceError("Node runtime identity is invalid")
+        node_versions_digest = hashlib.sha256(
+            json.dumps(
+                node_runtime["versions"], sort_keys=True, separators=(",", ":")
+            ).encode()
+        ).hexdigest()
         raw_config = run(
             ["npm", "config", "list", "--json"],
             cwd=source,
@@ -2529,6 +2588,9 @@ class Workspace:
             "files": files,
             "node_version": versions["node"],
             "npm_version": versions["npm"],
+            "node_platform": node_runtime["platform"],
+            "node_architecture": node_runtime["arch"],
+            "node_versions_sha256": node_versions_digest,
             "os": platform.system(),
             "architecture": platform.machine(),
             "python_platform": sys.platform,

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -113,6 +113,7 @@ WORKER_SOURCE_EXCLUSIONS = {
     "node_modules",
     ".wrangler",
 }
+WORKER_VIEW_NODE_MODULES_EXCLUSIONS = {".vite", ".vite-temp"}
 REGION_MAP_METADATA = ".atrinik-region-maps.json"
 REGION_MAP_SCHEMA_VERSION = 1
 EXPECTED_REGION_MAP = "incuna_-1"
@@ -296,6 +297,23 @@ def _tree_digest(
         raise WorkspaceError(f"Worker source is not a regular directory: {root}")
     visit(root, PurePosixPath())
     return digest.hexdigest()
+
+
+def _copy_worker_source(source: Path, destination: Path) -> None:
+    """Copy Worker source while excluding generated names only at its root."""
+
+    def ignore(directory: str, names: list[str]) -> list[str]:
+        if Path(directory) != source:
+            return []
+        return sorted(set(names) & WORKER_SOURCE_EXCLUSIONS)
+
+    shutil.copytree(
+        source,
+        destination,
+        dirs_exist_ok=True,
+        symlinks=True,
+        ignore=ignore,
+    )
 
 
 def _remote_matches(url: str, repository: str) -> bool:
@@ -2345,6 +2363,7 @@ class Workspace:
         hidden_lock_digest: str,
         tree_digest: str,
         required: tuple[str, ...],
+        generated_exclusions: set[str] | None = None,
     ) -> None:
         if node_modules.is_symlink() or not node_modules.is_dir():
             raise WorkspaceError("Worker node_modules is not a regular directory")
@@ -2380,7 +2399,11 @@ class Workspace:
             if dependency.is_symlink() or not dependency.is_dir():
                 raise WorkspaceError(f"Worker dependency is missing or unsafe: {name}")
         if (
-            _tree_digest(node_modules, set(), bounded_symlinks=True)
+            _tree_digest(
+                node_modules,
+                generated_exclusions or set(),
+                bounded_symlinks=True,
+            )
             != tree_digest
         ):
             raise WorkspaceError("Worker node_modules does not match cache metadata")
@@ -2499,6 +2522,27 @@ class Workspace:
         lock = self.paths.builds / "locks" / f"worker-dependencies-{key}.lock"
         started = time.monotonic()
         with exclusive_lock(lock, f"Worker dependencies {key}"):
+            if not entry.exists() and not entry.is_symlink():
+                recoverable: list[Path] = []
+                for candidate in transactions.iterdir():
+                    if not re.fullmatch(
+                        rf"{key}-(?:staging|backup)-[a-z0-9_]+",
+                        candidate.name,
+                    ):
+                        continue
+                    if self._worker_dependency_cache_matches(
+                        candidate, key, inputs, required
+                    ) is not None:
+                        recoverable.append(candidate)
+                if recoverable:
+                    recovered = max(
+                        recoverable,
+                        key=lambda candidate: (
+                            candidate.stat().st_mtime_ns,
+                            candidate.name,
+                        ),
+                    )
+                    recovered.replace(entry)
             metadata = self._worker_dependency_cache_matches(
                 entry, key, inputs, required
             )
@@ -2527,13 +2571,7 @@ class Workspace:
                 f"worker-dependency-transaction:{key}",
             )
             try:
-                shutil.copytree(
-                    source,
-                    staging,
-                    dirs_exist_ok=True,
-                    symlinks=True,
-                    ignore=shutil.ignore_patterns(*WORKER_SOURCE_EXCLUSIONS),
-                )
+                _copy_worker_source(source, staging)
                 run(["npm", "ci"], cwd=staging, env=environment)
                 final_inputs = self._worker_dependency_inputs(source, environment)
                 if final_inputs != inputs:
@@ -2613,7 +2651,16 @@ class Workspace:
     ) -> tuple[Path, bool, float]:
         started = time.monotonic()
         view = root / "sources" / "metaserver-worker"
-        source_digest = _tree_digest(source, WORKER_SOURCE_EXCLUSIONS)
+        source_digest = _tree_digest(
+            source, WORKER_SOURCE_EXCLUSIONS, reject_symlinks=True
+        )
+        dependency_source_digest = dependency_metadata.get("inputs", {}).get(
+            "lifecycle_source_sha256"
+        )
+        if source_digest != dependency_source_digest:
+            raise WorkspaceError(
+                "Worker source does not match dependency lifecycle inputs"
+            )
         expected = {
             "schema_version": WORKER_VIEW_SCHEMA_VERSION,
             "purpose": "worker-view",
@@ -2640,6 +2687,7 @@ class Workspace:
                     dependency_metadata["node_modules_lock_sha256"],
                     dependency_metadata["node_modules_sha256"],
                     self._worker_required_packages(source),
+                    WORKER_VIEW_NODE_MODULES_EXCLUSIONS,
                 )
                 return view, True, time.monotonic() - started
         except (OSError, WorkspaceError):
@@ -2653,21 +2701,21 @@ class Workspace:
             tempfile.mkdtemp(prefix=".metaserver-worker-", dir=view.parent)
         )
         try:
-            shutil.copytree(
-                source,
-                staging,
-                dirs_exist_ok=True,
-                symlinks=True,
-                ignore=shutil.ignore_patterns(*WORKER_SOURCE_EXCLUSIONS),
-            )
+            _copy_worker_source(source, staging)
             shutil.copytree(dependencies, staging / "node_modules", symlinks=True)
-            if _tree_digest(source, WORKER_SOURCE_EXCLUSIONS) != source_digest:
+            if (
+                _tree_digest(
+                    source, WORKER_SOURCE_EXCLUSIONS, reject_symlinks=True
+                )
+                != source_digest
+            ):
                 raise WorkspaceError("Worker source changed during view preparation")
             self._validate_worker_node_modules(
                 staging / "node_modules",
                 dependency_metadata["node_modules_lock_sha256"],
                 dependency_metadata["node_modules_sha256"],
                 self._worker_required_packages(source),
+                WORKER_VIEW_NODE_MODULES_EXCLUSIONS,
             )
             atomic_json(
                 staging / MANAGED_MARKER,

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -101,7 +101,7 @@ BUILD_METADATA_SCHEMA_VERSION = 1
 CACHE_METADATA = ".atrinik-cache.json"
 WORKER_DEPENDENCY_METADATA = ".atrinik-worker-dependencies.json"
 WORKER_VIEW_METADATA = ".atrinik-worker-view.json"
-WORKER_DEPENDENCY_SCHEMA_VERSION = 3
+WORKER_DEPENDENCY_SCHEMA_VERSION = 4
 WORKER_VIEW_SCHEMA_VERSION = 1
 WORKER_DEPENDENCY_FILES = ("package.json", "package-lock.json")
 WORKER_SOURCE_EXCLUSIONS = {
@@ -234,6 +234,7 @@ def _tree_digest(
     bounded_symlinks: bool = False,
     reject_symlinks: bool = False,
     copied_metadata: bool = False,
+    ignore_root_mtime: bool = False,
 ) -> str:
     """Hash a tree as framed records without following links."""
 
@@ -348,7 +349,7 @@ def _tree_digest(
     root_status = root.lstat()
     root_metadata: tuple[object, ...] = (
         (
-            root_status.st_mtime_ns,
+            0 if ignore_root_mtime else root_status.st_mtime_ns,
             getattr(root_status, "st_flags", 0),
             extended_attributes(root),
         )
@@ -2434,19 +2435,18 @@ class Workspace:
     ) -> str:
         """Hash file-backed effective npm configuration without storing secrets."""
 
-        script_shells = {
+        execution_options = {
             name: value
             for name, value in config.items()
-            if name == "script-shell" or name.rsplit(":", 1)[-1] == "script-shell"
+            if name in {"node-options", "script-shell"}
+            or name.rsplit(":", 1)[-1] in {"node-options", "script-shell"}
         }
-        for name, value in sorted(script_shells.items()):
+        for name, value in sorted(execution_options.items()):
             if value is None or value == "":
                 continue
             if not isinstance(value, str) or "\0" in value:
                 raise WorkspaceError(f"npm configuration {name} path is invalid")
-            raise WorkspaceError(
-                "custom npm script-shell configuration is unsupported"
-            )
+            raise WorkspaceError(f"custom npm {name} configuration is unsupported")
 
         records: list[tuple[str, str, str | None]] = []
         file_values = {
@@ -2488,6 +2488,11 @@ class Workspace:
     def _worker_dependency_inputs(
         self, source: Path, environment: dict[str, str]
     ) -> dict[str, Any]:
+        for name in ("NODE_OPTIONS", "npm_config_node_options"):
+            if environment.get(name):
+                raise WorkspaceError(
+                    f"custom Node execution options in {name} are unsupported"
+                )
         files = {
             name: _file_digest(source / name, f"Worker {name}")
             for name in WORKER_DEPENDENCY_FILES
@@ -2677,6 +2682,8 @@ class Workspace:
                 node_modules,
                 generated_exclusions or set(),
                 bounded_symlinks=True,
+                copied_metadata=True,
+                ignore_root_mtime=bool(generated_exclusions),
             )
             != tree_digest
         ):
@@ -2716,6 +2723,7 @@ class Workspace:
                     "inputs",
                     "node_modules_lock_sha256",
                     "node_modules_sha256",
+                    "node_modules_view_sha256",
                     "last_used_at",
                 }
                 or metadata.get("schema_version") != WORKER_DEPENDENCY_SCHEMA_VERSION
@@ -2728,6 +2736,10 @@ class Workspace:
                 )
                 or not isinstance(metadata.get("node_modules_sha256"), str)
                 or not re.fullmatch(r"[0-9a-f]{64}", metadata["node_modules_sha256"])
+                or not isinstance(metadata.get("node_modules_view_sha256"), str)
+                or not re.fullmatch(
+                    r"[0-9a-f]{64}", metadata["node_modules_view_sha256"]
+                )
                 or not isinstance(metadata.get("last_used_at"), str)
             ):
                 return None
@@ -2957,7 +2969,17 @@ class Workspace:
                     "Worker installed lockfile",
                 )
                 modules_digest = _tree_digest(
-                    staging / "node_modules", set(), bounded_symlinks=True
+                    staging / "node_modules",
+                    set(),
+                    bounded_symlinks=True,
+                    copied_metadata=True,
+                )
+                modules_view_digest = _tree_digest(
+                    staging / "node_modules",
+                    WORKER_VIEW_NODE_MODULES_EXCLUSIONS,
+                    bounded_symlinks=True,
+                    copied_metadata=True,
+                    ignore_root_mtime=True,
                 )
                 self._validate_worker_node_modules(
                     staging / "node_modules",
@@ -2972,6 +2994,7 @@ class Workspace:
                     "inputs": inputs,
                     "node_modules_lock_sha256": hidden_digest,
                     "node_modules_sha256": modules_digest,
+                    "node_modules_view_sha256": modules_view_digest,
                     "last_used_at": datetime.now(timezone.utc).isoformat(),
                 }
                 atomic_json(
@@ -3056,7 +3079,7 @@ class Workspace:
                 self._validate_worker_node_modules(
                     view / "node_modules",
                     dependency_metadata["node_modules_lock_sha256"],
-                    dependency_metadata["node_modules_sha256"],
+                    dependency_metadata["node_modules_view_sha256"],
                     self._worker_required_packages(source),
                     WORKER_VIEW_NODE_MODULES_EXCLUSIONS,
                 )
@@ -3099,7 +3122,7 @@ class Workspace:
             self._validate_worker_node_modules(
                 staging / "node_modules",
                 dependency_metadata["node_modules_lock_sha256"],
-                dependency_metadata["node_modules_sha256"],
+                dependency_metadata["node_modules_view_sha256"],
                 self._worker_required_packages(source),
                 WORKER_VIEW_NODE_MODULES_EXCLUSIONS,
             )

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -7,7 +7,9 @@ from contextlib import ExitStack, contextmanager
 from datetime import datetime, timezone
 import fcntl
 import hashlib
+import json
 import os
+import platform
 from pathlib import Path, PurePosixPath
 import re
 import secrets
@@ -97,6 +99,20 @@ SCENARIO_PASSWORD_MAX_SIZE = 128
 BUILD_METADATA = ".atrinik-build.json"
 BUILD_METADATA_SCHEMA_VERSION = 1
 CACHE_METADATA = ".atrinik-cache.json"
+WORKER_DEPENDENCY_METADATA = ".atrinik-worker-dependencies.json"
+WORKER_VIEW_METADATA = ".atrinik-worker-view.json"
+WORKER_DEPENDENCY_SCHEMA_VERSION = 1
+WORKER_VIEW_SCHEMA_VERSION = 1
+WORKER_DEPENDENCY_FILES = ("package.json", "package-lock.json")
+WORKER_SOURCE_EXCLUSIONS = {
+    ".git",
+    MANAGED_MARKER,
+    WORKER_VIEW_METADATA,
+    "build",
+    "dist",
+    "node_modules",
+    ".wrangler",
+}
 REGION_MAP_METADATA = ".atrinik-region-maps.json"
 REGION_MAP_SCHEMA_VERSION = 1
 EXPECTED_REGION_MAP = "incuna_-1"
@@ -170,6 +186,77 @@ def replace_directory(output: Path, staging: Path, backup_prefix: str) -> None:
         shutil.rmtree(backup)
     else:
         staging.replace(output)
+
+
+def _file_digest(path: Path, description: str) -> str:
+    descriptor: int | None = None
+    try:
+        descriptor = open_regular_file(path, os.O_RDONLY, description)
+        digest = hashlib.sha256()
+        with os.fdopen(descriptor, "rb") as stream:
+            descriptor = None
+            while chunk := stream.read(1024 * 1024):
+                digest.update(chunk)
+        return digest.hexdigest()
+    except WorkspaceError:
+        raise
+    except OSError as error:
+        raise WorkspaceError(f"cannot read {description} {path}: {error}") from error
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def _tree_digest(root: Path, exclusions: set[str]) -> str:
+    """Hash one source tree without following links or generated top-level roots."""
+
+    digest = hashlib.sha256()
+
+    def visit(directory: Path, relative: PurePosixPath) -> None:
+        try:
+            entries = sorted(directory.iterdir(), key=lambda entry: entry.name)
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot inventory Worker source {directory}: {error}"
+            ) from error
+        for entry in entries:
+            if not relative.parts and entry.name in exclusions:
+                continue
+            child = relative / entry.name
+            encoded = child.as_posix().encode("utf-8", "surrogateescape")
+            try:
+                status = entry.lstat()
+                if stat.S_ISDIR(status.st_mode):
+                    digest.update(b"d\0" + encoded + b"\0")
+                    visit(entry, child)
+                elif stat.S_ISREG(status.st_mode):
+                    digest.update(b"f\0" + encoded + b"\0")
+                    with entry.open("rb") as stream:
+                        while chunk := stream.read(1024 * 1024):
+                            digest.update(chunk)
+                elif stat.S_ISLNK(status.st_mode):
+                    digest.update(
+                        b"l\0"
+                        + encoded
+                        + b"\0"
+                        + os.readlink(entry).encode("utf-8", "surrogateescape")
+                        + b"\0"
+                    )
+                else:
+                    raise WorkspaceError(
+                        f"Worker source contains an unsupported file type: {entry}"
+                    )
+            except WorkspaceError:
+                raise
+            except OSError as error:
+                raise WorkspaceError(
+                    f"cannot inspect Worker source {entry}: {error}"
+                ) from error
+
+    if root.is_symlink() or not root.is_dir():
+        raise WorkspaceError(f"Worker source is not a regular directory: {root}")
+    visit(root, PurePosixPath())
+    return digest.hexdigest()
 
 
 def _remote_matches(url: str, repository: str) -> bool:
@@ -2094,35 +2181,412 @@ class Workspace:
         print(f"region maps: generated {output}")
         return output
 
-    def _build_worker(self, root: Path, selected: dict[str, Path]) -> None:
-        view = self._profile_source_view(
-            root,
-            "metaserver-worker",
-            selected["metaserver-worker"],
-            {"build", "dist", "node_modules", ".wrangler"},
-            copy_all=True,
+    @staticmethod
+    def _worker_required_packages(source: Path) -> tuple[str, ...]:
+        try:
+            package = load_json(source / "package.json")
+        except WorkspaceError:
+            raise
+        if not isinstance(package, dict):
+            raise WorkspaceError("Worker package.json root is not an object")
+        names: set[str] = set()
+        for field in ("dependencies", "devDependencies"):
+            value = package.get(field, {})
+            if not isinstance(value, dict) or not all(
+                isinstance(name, str) and isinstance(version, str)
+                for name, version in value.items()
+            ):
+                raise WorkspaceError(f"Worker package.json {field} is invalid")
+            names.update(value)
+        for name in names:
+            if not re.fullmatch(
+                r"(?:@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*",
+                name,
+            ):
+                raise WorkspaceError(f"Worker package name is unsafe: {name}")
+        return tuple(sorted(names))
+
+    @staticmethod
+    def _worker_environment_digest(environment: dict[str, str]) -> str:
+        # Lifecycle scripts can observe arbitrary environment variables. Hash the
+        # complete install environment, without persisting names or values, so an
+        # unrepresented input fails closed as a cache miss.
+        payload = json.dumps(
+            sorted(environment.items()),
+            ensure_ascii=True,
+            separators=(",", ":"),
         )
-        environment = os.environ.copy()
-        npm_cache = self.paths.builds / "npm-cache"
-        marker = npm_cache / MANAGED_MARKER
-        if npm_cache.exists() and not marker.exists() and not marker.is_symlink():
-            if npm_cache.is_symlink() or not npm_cache.is_dir():
-                raise WorkspaceError(f"npm cache path is invalid: {npm_cache}")
-            atomic_json(
-                marker,
-                {"schema_version": SCHEMA_VERSION, "purpose": "npm-cache"},
+        return hashlib.sha256(payload.encode()).hexdigest()
+
+    def _worker_dependency_inputs(
+        self, source: Path, environment: dict[str, str]
+    ) -> dict[str, Any]:
+        files = {
+            name: _file_digest(source / name, f"Worker {name}")
+            for name in WORKER_DEPENDENCY_FILES
+        }
+        npmrc = source / ".npmrc"
+        files[".npmrc"] = (
+            _file_digest(npmrc, "Worker .npmrc")
+            if npmrc.exists() or npmrc.is_symlink()
+            else None
+        )
+        versions: dict[str, str] = {}
+        for command in ("node", "npm"):
+            value = run(
+                [command, "--version"],
+                cwd=source,
+                capture=True,
+                env=environment,
+                trace=False,
             )
-        managed_directory(npm_cache, self.paths.builds, "npm-cache")
-        atomic_json(
-            npm_cache / CACHE_METADATA,
-            {
-                "schema_version": BUILD_METADATA_SCHEMA_VERSION,
-                "purpose": "npm-cache",
-                "last_used_at": datetime.now(timezone.utc).isoformat(),
-            },
+            if not value or "\n" in value or len(value) > 256:
+                raise WorkspaceError(f"{command} returned an invalid version")
+            versions[command] = value
+        raw_config = run(
+            ["npm", "config", "list", "--json"],
+            cwd=source,
+            capture=True,
+            env=environment,
+            trace=False,
         )
+        try:
+            config = json.loads(raw_config)
+        except json.JSONDecodeError as error:
+            raise WorkspaceError("npm configuration is not valid JSON") from error
+        config_digest = hashlib.sha256(
+            json.dumps(config, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+        package = load_json(source / "package.json")
+        scripts = package.get("scripts", {}) if isinstance(package, dict) else None
+        if not isinstance(scripts, dict) or not all(
+            isinstance(name, str) and isinstance(value, str)
+            for name, value in scripts.items()
+        ):
+            raise WorkspaceError("Worker package.json scripts are invalid")
+        lifecycle_names = (
+            "preinstall",
+            "install",
+            "postinstall",
+            "prepublish",
+            "preprepare",
+            "prepare",
+            "postprepare",
+        )
+        root_lifecycle = tuple(name for name in lifecycle_names if name in scripts)
+        return {
+            "schema_version": WORKER_DEPENDENCY_SCHEMA_VERSION,
+            "files": files,
+            "node_version": versions["node"],
+            "npm_version": versions["npm"],
+            "os": platform.system(),
+            "architecture": platform.machine(),
+            "python_platform": sys.platform,
+            "npm_config_sha256": config_digest,
+            "environment_sha256": self._worker_environment_digest(environment),
+            "install_command": ["npm", "ci"],
+            "lifecycle_scripts": "enabled; complete environment participates in key",
+            "root_lifecycle_scripts": list(root_lifecycle),
+            "root_lifecycle_source_sha256": (
+                _tree_digest(source, WORKER_SOURCE_EXCLUSIONS)
+                if root_lifecycle
+                else None
+            ),
+        }
+
+    @staticmethod
+    def _worker_dependency_key(inputs: dict[str, Any]) -> str:
+        payload = json.dumps(inputs, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(payload.encode()).hexdigest()
+
+    @staticmethod
+    def _validate_worker_node_modules(
+        node_modules: Path, hidden_lock_digest: str, required: tuple[str, ...]
+    ) -> None:
+        if node_modules.is_symlink() or not node_modules.is_dir():
+            raise WorkspaceError("Worker node_modules is not a regular directory")
+        hidden_lock = node_modules / ".package-lock.json"
+        if _file_digest(hidden_lock, "Worker installed lockfile") != hidden_lock_digest:
+            raise WorkspaceError(
+                "Worker installed lockfile does not match cache metadata"
+            )
+        installed = load_json(hidden_lock)
+        packages = installed.get("packages") if isinstance(installed, dict) else None
+        if not isinstance(packages, dict):
+            raise WorkspaceError("Worker installed lockfile packages are invalid")
+        for relative in packages:
+            if not isinstance(relative, str) or not relative.startswith(
+                "node_modules/"
+            ):
+                raise WorkspaceError("Worker installed package path is invalid")
+            package_path = PurePosixPath(relative)
+            if (
+                package_path.is_absolute()
+                or ".." in package_path.parts
+                or "\\" in relative
+                or len(package_path.parts) < 2
+            ):
+                raise WorkspaceError("Worker installed package path is unsafe")
+            dependency = node_modules.joinpath(*package_path.parts[1:])
+            if dependency.is_symlink() or not dependency.is_dir():
+                raise WorkspaceError(
+                    f"Worker installed package is missing or unsafe: {relative}"
+                )
+        for name in required:
+            dependency = node_modules.joinpath(*name.split("/"))
+            if dependency.is_symlink() or not dependency.is_dir():
+                raise WorkspaceError(f"Worker dependency is missing or unsafe: {name}")
+
+    def _worker_dependency_cache_matches(
+        self,
+        entry: Path,
+        key: str,
+        inputs: dict[str, Any],
+        required: tuple[str, ...],
+    ) -> dict[str, Any] | None:
+        marker = entry / MANAGED_MARKER
+        metadata_path = entry / WORKER_DEPENDENCY_METADATA
+        try:
+            if (
+                entry.is_symlink()
+                or not entry.is_dir()
+                or marker.is_symlink()
+                or load_json(marker)
+                != {
+                    "schema_version": SCHEMA_VERSION,
+                    "purpose": f"worker-dependencies:{key}",
+                }
+                or metadata_path.is_symlink()
+                or not metadata_path.is_file()
+            ):
+                return None
+            metadata = load_json(metadata_path)
+            if (
+                not isinstance(metadata, dict)
+                or set(metadata)
+                != {
+                    "schema_version",
+                    "purpose",
+                    "key",
+                    "inputs",
+                    "node_modules_lock_sha256",
+                    "last_used_at",
+                }
+                or metadata.get("schema_version") != WORKER_DEPENDENCY_SCHEMA_VERSION
+                or metadata.get("purpose") != "worker-dependencies"
+                or metadata.get("key") != key
+                or metadata.get("inputs") != inputs
+                or not isinstance(metadata.get("node_modules_lock_sha256"), str)
+                or not re.fullmatch(
+                    r"[0-9a-f]{64}", metadata["node_modules_lock_sha256"]
+                )
+                or not isinstance(metadata.get("last_used_at"), str)
+            ):
+                return None
+            for name, expected in inputs["files"].items():
+                path = entry / name
+                if expected is None:
+                    if path.exists() or path.is_symlink():
+                        return None
+                elif _file_digest(path, f"cached Worker {name}") != expected:
+                    return None
+            self._validate_worker_node_modules(
+                entry / "node_modules",
+                metadata["node_modules_lock_sha256"],
+                required,
+            )
+            return metadata
+        except (OSError, WorkspaceError):
+            return None
+
+    def _worker_dependencies(
+        self, source: Path, environment: dict[str, str]
+    ) -> tuple[Path, str, dict[str, Any], bool, float]:
+        npm_cache = self.paths.builds / "npm-cache"
+        npm_cache_lock = self.paths.builds / "locks" / "npm-cache.lock"
+        with exclusive_lock(npm_cache_lock, "npm download cache"):
+            marker = npm_cache / MANAGED_MARKER
+            if npm_cache.exists() and not marker.exists() and not marker.is_symlink():
+                if npm_cache.is_symlink() or not npm_cache.is_dir():
+                    raise WorkspaceError(f"npm cache path is invalid: {npm_cache}")
+                atomic_json(
+                    marker,
+                    {"schema_version": SCHEMA_VERSION, "purpose": "npm-cache"},
+                )
+            managed_directory(npm_cache, self.paths.builds, "npm-cache")
+            atomic_json(
+                npm_cache / CACHE_METADATA,
+                {
+                    "schema_version": BUILD_METADATA_SCHEMA_VERSION,
+                    "purpose": "npm-cache",
+                    "last_used_at": datetime.now(timezone.utc).isoformat(),
+                },
+            )
         environment["npm_config_cache"] = str(npm_cache)
-        run(["npm", "ci"], cwd=view, env=environment)
+        inputs = self._worker_dependency_inputs(source, environment)
+        key = self._worker_dependency_key(inputs)
+        required = self._worker_required_packages(source)
+        cache_root = self.paths.builds / "worker-dependencies"
+        with exclusive_lock(
+            self.paths.builds / "locks" / "worker-dependency-cache.lock",
+            "Worker dependency cache",
+        ):
+            managed_directory(
+                cache_root, self.paths.builds, "worker-dependency-cache"
+            )
+        entry = cache_root / key
+        lock = self.paths.builds / "locks" / f"worker-dependencies-{key}.lock"
+        started = time.monotonic()
+        with exclusive_lock(lock, f"Worker dependencies {key}"):
+            metadata = self._worker_dependency_cache_matches(
+                entry, key, inputs, required
+            )
+            if metadata is not None:
+                metadata["last_used_at"] = datetime.now(timezone.utc).isoformat()
+                atomic_json(entry / WORKER_DEPENDENCY_METADATA, metadata)
+                elapsed = time.monotonic() - started
+                return entry / "node_modules", key, metadata, True, elapsed
+            if entry.is_symlink() or entry.exists() and not entry.is_dir():
+                raise WorkspaceError(f"Worker dependency cache path is unsafe: {entry}")
+            staging = Path(tempfile.mkdtemp(prefix=f".{key}-", dir=cache_root))
+            try:
+                if inputs["root_lifecycle_scripts"]:
+                    shutil.copytree(
+                        source,
+                        staging,
+                        dirs_exist_ok=True,
+                        symlinks=True,
+                        ignore=shutil.ignore_patterns(*WORKER_SOURCE_EXCLUSIONS),
+                    )
+                else:
+                    for name, expected in inputs["files"].items():
+                        if expected is not None:
+                            shutil.copy2(source / name, staging / name)
+                run(["npm", "ci"], cwd=staging, env=environment)
+                final_inputs = self._worker_dependency_inputs(source, environment)
+                if final_inputs != inputs:
+                    raise WorkspaceError(
+                        "Worker dependency inputs changed during installation"
+                    )
+                hidden_digest = _file_digest(
+                    staging / "node_modules" / ".package-lock.json",
+                    "Worker installed lockfile",
+                )
+                self._validate_worker_node_modules(
+                    staging / "node_modules", hidden_digest, required
+                )
+                metadata = {
+                    "schema_version": WORKER_DEPENDENCY_SCHEMA_VERSION,
+                    "purpose": "worker-dependencies",
+                    "key": key,
+                    "inputs": inputs,
+                    "node_modules_lock_sha256": hidden_digest,
+                    "last_used_at": datetime.now(timezone.utc).isoformat(),
+                }
+                atomic_json(
+                    staging / MANAGED_MARKER,
+                    {
+                        "schema_version": SCHEMA_VERSION,
+                        "purpose": f"worker-dependencies:{key}",
+                    },
+                )
+                atomic_json(staging / WORKER_DEPENDENCY_METADATA, metadata)
+                replace_directory(entry, staging, f".{key}-previous-")
+            finally:
+                if staging.exists():
+                    shutil.rmtree(staging)
+        return entry / "node_modules", key, metadata, False, time.monotonic() - started
+
+    def _worker_view(
+        self,
+        root: Path,
+        source: Path,
+        dependencies: Path,
+        dependency_key: str,
+        dependency_metadata: dict[str, Any],
+    ) -> tuple[Path, bool, float]:
+        started = time.monotonic()
+        view = root / "sources" / "metaserver-worker"
+        source_digest = _tree_digest(source, WORKER_SOURCE_EXCLUSIONS)
+        expected = {
+            "schema_version": WORKER_VIEW_SCHEMA_VERSION,
+            "purpose": "worker-view",
+            "source_sha256": source_digest,
+            "dependency_key": dependency_key,
+            "node_modules_lock_sha256": dependency_metadata[
+                "node_modules_lock_sha256"
+            ],
+        }
+        try:
+            if (
+                not view.is_symlink()
+                and view.is_dir()
+                and load_json(view / MANAGED_MARKER)
+                == {
+                    "schema_version": SCHEMA_VERSION,
+                    "purpose": "source-view:metaserver-worker",
+                }
+                and load_json(view / WORKER_VIEW_METADATA) == expected
+                and _tree_digest(view, WORKER_SOURCE_EXCLUSIONS) == source_digest
+            ):
+                self._validate_worker_node_modules(
+                    view / "node_modules",
+                    dependency_metadata["node_modules_lock_sha256"],
+                    self._worker_required_packages(source),
+                )
+                return view, True, time.monotonic() - started
+        except (OSError, WorkspaceError):
+            pass
+        if view.exists() or view.is_symlink():
+            managed_directory(
+                view, self.paths.builds, "source-view:metaserver-worker"
+            )
+        view.parent.mkdir(parents=True, exist_ok=True)
+        staging = Path(
+            tempfile.mkdtemp(prefix=".metaserver-worker-", dir=view.parent)
+        )
+        try:
+            shutil.copytree(
+                source,
+                staging,
+                dirs_exist_ok=True,
+                symlinks=True,
+                ignore=shutil.ignore_patterns(*WORKER_SOURCE_EXCLUSIONS),
+            )
+            shutil.copytree(dependencies, staging / "node_modules", symlinks=True)
+            if _tree_digest(source, WORKER_SOURCE_EXCLUSIONS) != source_digest:
+                raise WorkspaceError("Worker source changed during view preparation")
+            atomic_json(
+                staging / MANAGED_MARKER,
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "purpose": "source-view:metaserver-worker",
+                },
+            )
+            atomic_json(staging / WORKER_VIEW_METADATA, expected)
+            replace_directory(view, staging, ".metaserver-worker-previous-")
+        finally:
+            if staging.exists():
+                shutil.rmtree(staging)
+        return view, False, time.monotonic() - started
+
+    def _build_worker(self, root: Path, selected: dict[str, Path]) -> None:
+        source = selected["metaserver-worker"]
+        environment = os.environ.copy()
+        dependencies, key, metadata, cache_hit, install_seconds = (
+            self._worker_dependencies(source, environment)
+        )
+        view, view_hit, view_seconds = self._worker_view(
+            root, source, dependencies, key, metadata
+        )
+        print(
+            f"worker dependencies: {'cached' if cache_hit else 'installed'} "
+            f"{key} ({install_seconds:.2f}s)"
+        )
+        print(
+            f"worker view: {'reused' if view_hit else 'prepared'} {view} "
+            f"({view_seconds:.2f}s)"
+        )
         run(["npm", "run", "check"], cwd=view, env=environment)
 
     def state_add(self, name: str, path: Path | None) -> Path:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -393,6 +393,38 @@ def _copy_worker_source(
     )
 
 
+def _copy_worker_source_metadata(source: Path, destination: Path) -> None:
+    """Reapply copied Worker metadata without copying file contents."""
+
+    def visit(source_directory: Path, destination_directory: Path, root: bool) -> None:
+        for source_entry in sorted(
+            source_directory.iterdir(), key=lambda entry: entry.name
+        ):
+            if root and source_entry.name in WORKER_SOURCE_EXCLUSIONS:
+                continue
+            destination_entry = destination_directory / source_entry.name
+            source_status = source_entry.lstat()
+            destination_status = destination_entry.lstat()
+            if stat.S_IFMT(source_status.st_mode) != stat.S_IFMT(
+                destination_status.st_mode
+            ):
+                raise WorkspaceError(
+                    f"Worker view entry type changed during checks: {destination_entry}"
+                )
+            if stat.S_ISDIR(source_status.st_mode):
+                visit(source_entry, destination_entry, False)
+            elif not stat.S_ISREG(source_status.st_mode):
+                raise WorkspaceError(
+                    f"Worker source contains an unsupported entry: {source_entry}"
+                )
+            shutil.copystat(source_entry, destination_entry, follow_symlinks=False)
+        shutil.copystat(
+            source_directory, destination_directory, follow_symlinks=False
+        )
+
+    visit(source, destination, True)
+
+
 def _copy_regular_file(source: Path, destination: Path, description: str) -> None:
     """Copy one no-follow regular file without inheriting extended metadata."""
 
@@ -3854,6 +3886,17 @@ class Workspace:
                 metadata["node_modules_sha256"],
                 required,
             )
+            if (
+                _tree_digest(
+                    entry / "node_modules",
+                    WORKER_VIEW_NODE_MODULES_EXCLUSIONS,
+                    bounded_symlinks=True,
+                    copied_metadata=True,
+                    ignore_root_mtime=True,
+                )
+                != metadata["node_modules_view_sha256"]
+            ):
+                return None
             return metadata
         except (OSError, WorkspaceError):
             return None
@@ -4318,7 +4361,17 @@ class Workspace:
             != source_digest
         ):
             raise WorkspaceError("Worker source changed while running checks")
-        _copy_worker_source(source, view)
+        if (
+            _tree_digest(
+                view,
+                WORKER_SOURCE_EXCLUSIONS,
+                reject_symlinks=True,
+                copied_metadata=True,
+                ignore_root_mtime=True,
+            )
+            != source_view_digest
+        ):
+            _copy_worker_source_metadata(source, view)
         validate_controls()
         if (
             _tree_digest(
@@ -4406,6 +4459,11 @@ class Workspace:
                     and (current_status.st_dev, current_status.st_ino)
                     == (opened_status.st_dev, opened_status.st_ino)
                 ):
+                    for control_path in (marker_path, metadata_path):
+                        if control_path.is_symlink() or not control_path.is_dir():
+                            control_path.unlink(missing_ok=True)
+                        else:
+                            shutil.rmtree(control_path)
                     atomic_json(marker_path, expected_marker)
                     atomic_json(metadata_path, control_metadata)
         finally:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -965,14 +965,23 @@ def _copy_worker_source_metadata(source: Path, destination: Path) -> None:
     visit(source, destination, True)
 
 
-def _copy_regular_file(source: Path, destination: Path, description: str) -> None:
+def _copy_regular_file(
+    source: Path,
+    destination: Path,
+    description: str,
+    destination_mode: int | None = None,
+) -> None:
     """Copy one no-follow regular file without inheriting extended metadata."""
 
     source_descriptor = open_regular_file(source, os.O_RDONLY, description)
     destination_descriptor: int | None = None
     try:
         source_status = os.fstat(source_descriptor)
-        mode = stat.S_IMODE(source_status.st_mode)
+        mode = (
+            stat.S_IMODE(source_status.st_mode)
+            if destination_mode is None
+            else destination_mode
+        )
         destination_descriptor = os.open(
             destination,
             os.O_WRONLY | os.O_CREAT | os.O_EXCL,
@@ -4965,6 +4974,7 @@ class Workspace:
                         source / ".npmrc",
                         staging / ".npmrc",
                         "Worker .npmrc",
+                        0o600,
                     )
                 shutil.copystat(source, staging, follow_symlinks=False)
                 if (

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -715,7 +715,9 @@ def replace_directory(
     staging: Path,
     backup_prefix: str,
     backup_parent: Path | None = None,
+    verify_after_install: Callable[[], None] | None = None,
 ) -> None:
+    backup: Path | None = None
     if output.exists():
         backup = Path(
             tempfile.mkdtemp(prefix=backup_prefix, dir=backup_parent or output.parent)
@@ -732,9 +734,25 @@ def replace_directory(
         except BaseException:
             backup.replace(output)
             raise
-        shutil.rmtree(backup)
     else:
         staging.replace(output)
+    try:
+        if verify_after_install is not None:
+            verify_after_install()
+    except BaseException:
+        output.replace(staging)
+        if backup is not None:
+            backup.replace(output)
+        raise
+    if backup is not None:
+        try:
+            remove_owned_tree(backup)
+        except (OSError, WorkspaceError) as error:
+            print(
+                f"warning: cannot remove managed replacement backup {backup}: "
+                f"{error}; cleanup will retry after its grace period",
+                file=sys.stderr,
+            )
 
 
 def _file_digest(path: Path, description: str) -> str:
@@ -4926,7 +4944,7 @@ class Workspace:
                 # leave this one exact unmarked path behind. Its marker-owned
                 # parent, deterministic key-derived name, and held key lock
                 # provide the ownership proof needed to recover it safely.
-                shutil.rmtree(staging)
+                remove_owned_tree(staging)
             managed_directory(
                 staging,
                 self.paths.builds,
@@ -4993,7 +5011,7 @@ class Workspace:
                     if child.is_symlink() or not child.is_dir():
                         child.unlink()
                     else:
-                        shutil.rmtree(child)
+                        remove_owned_tree(child)
                 for name, expected in inputs["files"].items():
                     if expected is not None and name != ".npmrc":
                         shutil.copy2(source / name, staging / name)
@@ -5038,15 +5056,26 @@ class Workspace:
                     },
                 )
                 atomic_json(staging / WORKER_DEPENDENCY_METADATA, metadata)
+
+                def verify_dependency_install() -> None:
+                    installed = self._worker_dependency_cache_matches(
+                        entry, key, inputs, required
+                    )
+                    if installed != metadata:
+                        raise WorkspaceError(
+                            "published Worker dependencies failed validation"
+                        )
+
                 replace_directory(
                     entry,
                     staging,
                     f"{key}-backup-",
                     backup_parent=transactions,
+                    verify_after_install=verify_dependency_install,
                 )
             finally:
                 if staging.exists():
-                    shutil.rmtree(staging)
+                    remove_owned_tree(staging)
             elapsed = time.monotonic() - started
             consumed = (
                 consume(entry / "node_modules", key, metadata)
@@ -5107,37 +5136,42 @@ class Workspace:
         }
         marker_path = view / MANAGED_MARKER
         metadata_path = view / WORKER_VIEW_METADATA
-        try:
+
+        def validate_installed_view() -> None:
             if (
-                not view.is_symlink()
-                and view.is_dir()
-                and marker_path.is_file()
-                and not marker_path.is_symlink()
-                and metadata_path.is_file()
-                and not metadata_path.is_symlink()
-                and load_json(marker_path)
-                == {
+                view.is_symlink()
+                or not view.is_dir()
+                or not marker_path.is_file()
+                or marker_path.is_symlink()
+                or not metadata_path.is_file()
+                or metadata_path.is_symlink()
+                or load_json(marker_path)
+                != {
                     "schema_version": SCHEMA_VERSION,
                     "purpose": "source-view:metaserver-worker",
                 }
-                and load_json(metadata_path) == expected
-                and _tree_digest(view, WORKER_SOURCE_EXCLUSIONS) == source_digest
-                and _tree_digest(
+                or load_json(metadata_path) != expected
+                or _tree_digest(view, WORKER_SOURCE_EXCLUSIONS) != source_digest
+                or _tree_digest(
                     view,
                     WORKER_SOURCE_EXCLUSIONS,
                     copied_metadata=True,
                     ignore_root_mtime=True,
                 )
-                == source_view_digest
+                != source_view_digest
             ):
-                self._validate_worker_node_modules(
-                    view / "node_modules",
-                    dependency_metadata["node_modules_lock_sha256"],
-                    dependency_metadata["node_modules_view_sha256"],
-                    self._worker_required_packages(source),
-                    WORKER_VIEW_NODE_MODULES_EXCLUSIONS,
-                )
-                return view, True, time.monotonic() - started
+                raise WorkspaceError("published Worker view failed validation")
+            self._validate_worker_node_modules(
+                view / "node_modules",
+                dependency_metadata["node_modules_lock_sha256"],
+                dependency_metadata["node_modules_view_sha256"],
+                self._worker_required_packages(source),
+                WORKER_VIEW_NODE_MODULES_EXCLUSIONS,
+            )
+
+        try:
+            validate_installed_view()
+            return view, True, time.monotonic() - started
         except (OSError, WorkspaceError):
             pass
         if view.exists() or view.is_symlink():
@@ -5188,10 +5222,15 @@ class Workspace:
                 },
             )
             atomic_json(staging / WORKER_VIEW_METADATA, expected)
-            replace_directory(view, staging, ".metaserver-worker-previous-")
+            replace_directory(
+                view,
+                staging,
+                ".metaserver-worker-previous-",
+                verify_after_install=validate_installed_view,
+            )
         finally:
             if staging.exists():
-                shutil.rmtree(staging)
+                remove_owned_tree(staging)
         return view, False, time.monotonic() - started
 
     @staticmethod
@@ -5359,7 +5398,7 @@ class Workspace:
                         if control_path.is_symlink() or not control_path.is_dir():
                             control_path.unlink(missing_ok=True)
                         else:
-                            shutil.rmtree(control_path)
+                            remove_owned_tree(control_path)
                     atomic_json(marker_path, expected_marker)
                     atomic_json(metadata_path, control_metadata)
         finally:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -114,6 +114,13 @@ WORKER_SOURCE_EXCLUSIONS = {
     ".wrangler",
 }
 WORKER_VIEW_NODE_MODULES_EXCLUSIONS = {".vite", ".vite-temp"}
+WORKER_NPM_FILE_CONFIG_KEYS = {
+    "cafile",
+    "certfile",
+    "globalconfig",
+    "keyfile",
+    "userconfig",
+}
 REGION_MAP_METADATA = ".atrinik-region-maps.json"
 REGION_MAP_SCHEMA_VERSION = 1
 EXPECTED_REGION_MAP = "incuna_-1"
@@ -300,7 +307,11 @@ def _tree_digest(
 
 
 def _copy_worker_source(
-    source: Path, destination: Path, *, include_npmrc: bool = True
+    source: Path,
+    destination: Path,
+    *,
+    include_npmrc: bool = True,
+    preserve_metadata: bool = True,
 ) -> None:
     """Copy Worker source while excluding generated names only at its root."""
 
@@ -318,7 +329,54 @@ def _copy_worker_source(
         dirs_exist_ok=True,
         symlinks=True,
         ignore=ignore,
+        copy_function=shutil.copy2 if preserve_metadata else shutil.copy,
     )
+
+
+def _copy_regular_file(source: Path, destination: Path, description: str) -> None:
+    """Copy one no-follow regular file without inheriting extended metadata."""
+
+    source_descriptor = open_regular_file(source, os.O_RDONLY, description)
+    destination_descriptor: int | None = None
+    try:
+        mode = stat.S_IMODE(os.fstat(source_descriptor).st_mode)
+        destination_descriptor = os.open(
+            destination,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            mode,
+        )
+        os.fchmod(destination_descriptor, mode)
+        with os.fdopen(source_descriptor, "rb") as source_stream:
+            source_descriptor = -1
+            with os.fdopen(destination_descriptor, "wb") as destination_stream:
+                destination_descriptor = None
+                shutil.copyfileobj(source_stream, destination_stream)
+    except OSError as error:
+        raise WorkspaceError(f"cannot stage {description} {source}: {error}") from error
+    finally:
+        if source_descriptor >= 0:
+            os.close(source_descriptor)
+        if destination_descriptor is not None:
+            os.close(destination_descriptor)
+
+
+def _normalize_worker_staging(root: Path) -> None:
+    """Remove unkeyed copied metadata before lifecycle scripts can observe it."""
+
+    paths = [root]
+    for directory, directories, files in os.walk(root, followlinks=False):
+        parent = Path(directory)
+        paths.extend(parent / name for name in (*directories, *files))
+    for path in reversed(paths):
+        try:
+            if hasattr(os, "listxattr"):
+                for attribute in os.listxattr(path, follow_symlinks=False):
+                    os.removexattr(path, attribute, follow_symlinks=False)
+            os.utime(path, ns=(0, 0), follow_symlinks=False)
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot normalize Worker lifecycle staging path {path}: {error}"
+            ) from error
 
 
 def _tree_references_path(root: Path, referenced: Path) -> bool:
@@ -2308,6 +2366,47 @@ class Workspace:
         )
         return hashlib.sha256(payload.encode()).hexdigest()
 
+    @staticmethod
+    def _worker_npm_file_config_digest(
+        source: Path,
+        environment: dict[str, str],
+        config: dict[str, Any],
+    ) -> str:
+        """Hash file-backed effective npm configuration without storing secrets."""
+
+        records: list[tuple[str, str, str | None]] = []
+        file_values = {
+            name: value
+            for name, value in config.items()
+            if name in WORKER_NPM_FILE_CONFIG_KEYS
+            or name.rsplit(":", 1)[-1] in {"cafile", "certfile", "keyfile"}
+        }
+        for name, value in sorted(file_values.items()):
+            if value is None or value == "":
+                continue
+            if not isinstance(value, str) or "\0" in value:
+                raise WorkspaceError(f"npm configuration {name} path is invalid")
+            if value == "~" or value.startswith("~/"):
+                home = environment.get("HOME")
+                if not home:
+                    raise WorkspaceError(
+                        f"npm configuration {name} requires HOME to resolve"
+                    )
+                path = Path(home) / value.removeprefix("~/")
+            else:
+                path = Path(value)
+            if not path.is_absolute():
+                path = source / path
+            path = Path(os.path.abspath(path))
+            path_digest = hashlib.sha256(str(path).encode()).hexdigest()
+            if path.exists() or path.is_symlink():
+                content_digest = _file_digest(path, f"npm {name}")
+            else:
+                content_digest = None
+            records.append((name, path_digest, content_digest))
+        payload = json.dumps(records, separators=(",", ":"))
+        return hashlib.sha256(payload.encode()).hexdigest()
+
     def _worker_dependency_inputs(
         self, source: Path, environment: dict[str, str]
     ) -> dict[str, Any]:
@@ -2344,6 +2443,8 @@ class Workspace:
             config = json.loads(raw_config)
         except json.JSONDecodeError as error:
             raise WorkspaceError("npm configuration is not valid JSON") from error
+        if not isinstance(config, dict):
+            raise WorkspaceError("npm configuration root is not an object")
         config_digest = hashlib.sha256(
             json.dumps(config, sort_keys=True, separators=(",", ":")).encode()
         ).hexdigest()
@@ -2373,6 +2474,9 @@ class Workspace:
             "architecture": platform.machine(),
             "python_platform": sys.platform,
             "npm_config_sha256": config_digest,
+            "npm_file_config_sha256": self._worker_npm_file_config_digest(
+                source, environment, config
+            ),
             "environment_sha256": self._worker_environment_digest(environment),
             "install_command": ["npm", "ci"],
             "lifecycle_scripts": "enabled; complete environment participates in key",
@@ -2643,9 +2747,32 @@ class Workspace:
                 f"worker-dependency-transaction:{key}",
             )
             try:
-                _copy_worker_source(source, staging, include_npmrc=False)
+                _copy_worker_source(
+                    source,
+                    staging,
+                    include_npmrc=False,
+                    preserve_metadata=False,
+                )
                 if inputs["files"][".npmrc"] is not None:
-                    (staging / ".npmrc").symlink_to(source / ".npmrc")
+                    _copy_regular_file(
+                        source / ".npmrc",
+                        staging / ".npmrc",
+                        "Worker .npmrc",
+                    )
+                if (
+                    _tree_digest(
+                        staging,
+                        WORKER_SOURCE_EXCLUSIONS,
+                        reject_symlinks=True,
+                    )
+                    != inputs["lifecycle_source_sha256"]
+                ):
+                    raise WorkspaceError(
+                        "staged Worker lifecycle source does not match its cache key"
+                    )
+                if (staging / ".npmrc").exists():
+                    (staging / ".npmrc").chmod(0o600)
+                _normalize_worker_staging(staging)
                 run(["npm", "ci"], cwd=staging, env=environment)
                 if _tree_references_path(staging / "node_modules", staging):
                     raise WorkspaceError(
@@ -2780,7 +2907,19 @@ class Workspace:
             tempfile.mkdtemp(prefix=".metaserver-worker-", dir=view.parent)
         )
         try:
-            _copy_worker_source(source, staging)
+            _copy_worker_source(source, staging, preserve_metadata=False)
+            if (
+                _tree_digest(
+                    staging,
+                    WORKER_SOURCE_EXCLUSIONS,
+                    reject_symlinks=True,
+                )
+                != source_digest
+            ):
+                raise WorkspaceError(
+                    "staged Worker view source does not match its fingerprint"
+                )
+            _normalize_worker_staging(staging)
             shutil.copytree(dependencies, staging / "node_modules", symlinks=True)
             if (
                 _tree_digest(

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -23,7 +23,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from typing import Any, Iterator, TextIO
+from typing import Any, Callable, Iterator, TextIO
 
 from .launch_identity import CLIENT_LAUNCH_LABEL_ENV, client_launch_label
 
@@ -101,7 +101,7 @@ BUILD_METADATA_SCHEMA_VERSION = 1
 CACHE_METADATA = ".atrinik-cache.json"
 WORKER_DEPENDENCY_METADATA = ".atrinik-worker-dependencies.json"
 WORKER_VIEW_METADATA = ".atrinik-worker-view.json"
-WORKER_DEPENDENCY_SCHEMA_VERSION = 1
+WORKER_DEPENDENCY_SCHEMA_VERSION = 2
 WORKER_VIEW_SCHEMA_VERSION = 1
 WORKER_DEPENDENCY_FILES = ("package.json", "package-lock.json")
 WORKER_SOURCE_EXCLUSIONS = {
@@ -173,9 +173,16 @@ def git(
     return run(["git", "-C", str(path), *arguments], capture=capture, trace=trace)
 
 
-def replace_directory(output: Path, staging: Path, backup_prefix: str) -> None:
+def replace_directory(
+    output: Path,
+    staging: Path,
+    backup_prefix: str,
+    backup_parent: Path | None = None,
+) -> None:
     if output.exists():
-        backup = Path(tempfile.mkdtemp(prefix=backup_prefix, dir=output.parent))
+        backup = Path(
+            tempfile.mkdtemp(prefix=backup_prefix, dir=backup_parent or output.parent)
+        )
         backup.rmdir()
         output.replace(backup)
         try:
@@ -207,10 +214,24 @@ def _file_digest(path: Path, description: str) -> str:
             os.close(descriptor)
 
 
-def _tree_digest(root: Path, exclusions: set[str]) -> str:
-    """Hash one source tree without following links or generated top-level roots."""
+def _tree_digest(
+    root: Path,
+    exclusions: set[str],
+    *,
+    bounded_symlinks: bool = False,
+    reject_symlinks: bool = False,
+) -> str:
+    """Hash a tree as framed records without following links."""
 
     digest = hashlib.sha256()
+    resolved_root = root.resolve()
+
+    def record(*fields: object) -> None:
+        encoded = json.dumps(
+            fields, ensure_ascii=True, separators=(",", ":")
+        ).encode()
+        digest.update(len(encoded).to_bytes(8, "big"))
+        digest.update(encoded)
 
     def visit(directory: Path, relative: PurePosixPath) -> None:
         try:
@@ -223,25 +244,43 @@ def _tree_digest(root: Path, exclusions: set[str]) -> str:
             if not relative.parts and entry.name in exclusions:
                 continue
             child = relative / entry.name
-            encoded = child.as_posix().encode("utf-8", "surrogateescape")
             try:
                 status = entry.lstat()
+                mode = stat.S_IMODE(status.st_mode)
                 if stat.S_ISDIR(status.st_mode):
-                    digest.update(b"d\0" + encoded + b"\0")
+                    record("directory", child.as_posix(), mode)
                     visit(entry, child)
                 elif stat.S_ISREG(status.st_mode):
-                    digest.update(b"f\0" + encoded + b"\0")
-                    with entry.open("rb") as stream:
-                        while chunk := stream.read(1024 * 1024):
-                            digest.update(chunk)
-                elif stat.S_ISLNK(status.st_mode):
-                    digest.update(
-                        b"l\0"
-                        + encoded
-                        + b"\0"
-                        + os.readlink(entry).encode("utf-8", "surrogateescape")
-                        + b"\0"
+                    record(
+                        "file",
+                        child.as_posix(),
+                        mode,
+                        status.st_size,
+                        _file_digest(entry, "Worker tree file"),
                     )
+                elif stat.S_ISLNK(status.st_mode):
+                    target = os.readlink(entry)
+                    if reject_symlinks:
+                        raise WorkspaceError(
+                            f"Worker source contains a symbolic link: {entry}"
+                        )
+                    if bounded_symlinks:
+                        if Path(target).is_absolute():
+                            raise WorkspaceError(
+                                f"Worker dependencies contain an absolute link: {entry}"
+                            )
+                        resolved = entry.parent.joinpath(target).resolve(strict=False)
+                        try:
+                            resolved.relative_to(resolved_root)
+                        except ValueError as error:
+                            raise WorkspaceError(
+                                f"Worker dependencies contain an escaping link: {entry}"
+                            ) from error
+                        if not resolved.exists():
+                            raise WorkspaceError(
+                                f"Worker dependencies contain a dangling link: {entry}"
+                            )
+                    record("symlink", child.as_posix(), mode, target)
                 else:
                     raise WorkspaceError(
                         f"Worker source contains an unsupported file type: {entry}"
@@ -2287,10 +2326,11 @@ class Workspace:
             "install_command": ["npm", "ci"],
             "lifecycle_scripts": "enabled; complete environment participates in key",
             "root_lifecycle_scripts": list(root_lifecycle),
-            "root_lifecycle_source_sha256": (
-                _tree_digest(source, WORKER_SOURCE_EXCLUSIONS)
-                if root_lifecycle
-                else None
+            # Dependency lifecycle scripts can observe INIT_CWD and arbitrary
+            # root files even when package.json has no root hook. Preserve npm's
+            # enabled-script semantics by staging and keying the complete source.
+            "lifecycle_source_sha256": _tree_digest(
+                source, WORKER_SOURCE_EXCLUSIONS, reject_symlinks=True
             ),
         }
 
@@ -2301,7 +2341,10 @@ class Workspace:
 
     @staticmethod
     def _validate_worker_node_modules(
-        node_modules: Path, hidden_lock_digest: str, required: tuple[str, ...]
+        node_modules: Path,
+        hidden_lock_digest: str,
+        tree_digest: str,
+        required: tuple[str, ...],
     ) -> None:
         if node_modules.is_symlink() or not node_modules.is_dir():
             raise WorkspaceError("Worker node_modules is not a regular directory")
@@ -2336,6 +2379,11 @@ class Workspace:
             dependency = node_modules.joinpath(*name.split("/"))
             if dependency.is_symlink() or not dependency.is_dir():
                 raise WorkspaceError(f"Worker dependency is missing or unsafe: {name}")
+        if (
+            _tree_digest(node_modules, set(), bounded_symlinks=True)
+            != tree_digest
+        ):
+            raise WorkspaceError("Worker node_modules does not match cache metadata")
 
     def _worker_dependency_cache_matches(
         self,
@@ -2370,6 +2418,7 @@ class Workspace:
                     "key",
                     "inputs",
                     "node_modules_lock_sha256",
+                    "node_modules_sha256",
                     "last_used_at",
                 }
                 or metadata.get("schema_version") != WORKER_DEPENDENCY_SCHEMA_VERSION
@@ -2380,6 +2429,8 @@ class Workspace:
                 or not re.fullmatch(
                     r"[0-9a-f]{64}", metadata["node_modules_lock_sha256"]
                 )
+                or not isinstance(metadata.get("node_modules_sha256"), str)
+                or not re.fullmatch(r"[0-9a-f]{64}", metadata["node_modules_sha256"])
                 or not isinstance(metadata.get("last_used_at"), str)
             ):
                 return None
@@ -2393,6 +2444,7 @@ class Workspace:
             self._validate_worker_node_modules(
                 entry / "node_modules",
                 metadata["node_modules_lock_sha256"],
+                metadata["node_modules_sha256"],
                 required,
             )
             return metadata
@@ -2400,8 +2452,11 @@ class Workspace:
             return None
 
     def _worker_dependencies(
-        self, source: Path, environment: dict[str, str]
-    ) -> tuple[Path, str, dict[str, Any], bool, float]:
+        self,
+        source: Path,
+        environment: dict[str, str],
+        consume: Callable[[Path, str, dict[str, Any]], Any] | None = None,
+    ) -> tuple[Path, str, dict[str, Any], bool, float, Any]:
         npm_cache = self.paths.builds / "npm-cache"
         npm_cache_lock = self.paths.builds / "locks" / "npm-cache.lock"
         with exclusive_lock(npm_cache_lock, "npm download cache"):
@@ -2434,6 +2489,12 @@ class Workspace:
             managed_directory(
                 cache_root, self.paths.builds, "worker-dependency-cache"
             )
+            transactions = cache_root / ".transactions"
+            managed_directory(
+                transactions,
+                self.paths.builds,
+                "worker-dependency-transactions",
+            )
         entry = cache_root / key
         lock = self.paths.builds / "locks" / f"worker-dependencies-{key}.lock"
         started = time.monotonic()
@@ -2445,35 +2506,62 @@ class Workspace:
                 metadata["last_used_at"] = datetime.now(timezone.utc).isoformat()
                 atomic_json(entry / WORKER_DEPENDENCY_METADATA, metadata)
                 elapsed = time.monotonic() - started
-                return entry / "node_modules", key, metadata, True, elapsed
+                consumed = (
+                    consume(entry / "node_modules", key, metadata)
+                    if consume is not None
+                    else None
+                )
+                return entry / "node_modules", key, metadata, True, elapsed, consumed
             if entry.is_symlink() or entry.exists() and not entry.is_dir():
                 raise WorkspaceError(f"Worker dependency cache path is unsafe: {entry}")
-            staging = Path(tempfile.mkdtemp(prefix=f".{key}-", dir=cache_root))
+            if entry.exists():
+                managed_directory(
+                    entry,
+                    self.paths.builds,
+                    f"worker-dependencies:{key}",
+                )
+            staging = transactions / f"{key}-staging-{secrets.token_hex(8)}"
+            managed_directory(
+                staging,
+                self.paths.builds,
+                f"worker-dependency-transaction:{key}",
+            )
             try:
-                if inputs["root_lifecycle_scripts"]:
-                    shutil.copytree(
-                        source,
-                        staging,
-                        dirs_exist_ok=True,
-                        symlinks=True,
-                        ignore=shutil.ignore_patterns(*WORKER_SOURCE_EXCLUSIONS),
-                    )
-                else:
-                    for name, expected in inputs["files"].items():
-                        if expected is not None:
-                            shutil.copy2(source / name, staging / name)
+                shutil.copytree(
+                    source,
+                    staging,
+                    dirs_exist_ok=True,
+                    symlinks=True,
+                    ignore=shutil.ignore_patterns(*WORKER_SOURCE_EXCLUSIONS),
+                )
                 run(["npm", "ci"], cwd=staging, env=environment)
                 final_inputs = self._worker_dependency_inputs(source, environment)
                 if final_inputs != inputs:
                     raise WorkspaceError(
                         "Worker dependency inputs changed during installation"
                     )
+                for child in staging.iterdir():
+                    if child.name == "node_modules":
+                        continue
+                    if child.is_symlink() or not child.is_dir():
+                        child.unlink()
+                    else:
+                        shutil.rmtree(child)
+                for name, expected in inputs["files"].items():
+                    if expected is not None:
+                        shutil.copy2(source / name, staging / name)
                 hidden_digest = _file_digest(
                     staging / "node_modules" / ".package-lock.json",
                     "Worker installed lockfile",
                 )
+                modules_digest = _tree_digest(
+                    staging / "node_modules", set(), bounded_symlinks=True
+                )
                 self._validate_worker_node_modules(
-                    staging / "node_modules", hidden_digest, required
+                    staging / "node_modules",
+                    hidden_digest,
+                    modules_digest,
+                    required,
                 )
                 metadata = {
                     "schema_version": WORKER_DEPENDENCY_SCHEMA_VERSION,
@@ -2481,6 +2569,7 @@ class Workspace:
                     "key": key,
                     "inputs": inputs,
                     "node_modules_lock_sha256": hidden_digest,
+                    "node_modules_sha256": modules_digest,
                     "last_used_at": datetime.now(timezone.utc).isoformat(),
                 }
                 atomic_json(
@@ -2491,11 +2580,28 @@ class Workspace:
                     },
                 )
                 atomic_json(staging / WORKER_DEPENDENCY_METADATA, metadata)
-                replace_directory(entry, staging, f".{key}-previous-")
+                replace_directory(
+                    entry,
+                    staging,
+                    f"{key}-backup-",
+                    backup_parent=transactions,
+                )
             finally:
                 if staging.exists():
                     shutil.rmtree(staging)
-        return entry / "node_modules", key, metadata, False, time.monotonic() - started
+            consumed = (
+                consume(entry / "node_modules", key, metadata)
+                if consume is not None
+                else None
+            )
+        return (
+            entry / "node_modules",
+            key,
+            metadata,
+            False,
+            time.monotonic() - started,
+            consumed,
+        )
 
     def _worker_view(
         self,
@@ -2532,6 +2638,7 @@ class Workspace:
                 self._validate_worker_node_modules(
                     view / "node_modules",
                     dependency_metadata["node_modules_lock_sha256"],
+                    dependency_metadata["node_modules_sha256"],
                     self._worker_required_packages(source),
                 )
                 return view, True, time.monotonic() - started
@@ -2556,6 +2663,12 @@ class Workspace:
             shutil.copytree(dependencies, staging / "node_modules", symlinks=True)
             if _tree_digest(source, WORKER_SOURCE_EXCLUSIONS) != source_digest:
                 raise WorkspaceError("Worker source changed during view preparation")
+            self._validate_worker_node_modules(
+                staging / "node_modules",
+                dependency_metadata["node_modules_lock_sha256"],
+                dependency_metadata["node_modules_sha256"],
+                self._worker_required_packages(source),
+            )
             atomic_json(
                 staging / MANAGED_MARKER,
                 {
@@ -2573,12 +2686,16 @@ class Workspace:
     def _build_worker(self, root: Path, selected: dict[str, Path]) -> None:
         source = selected["metaserver-worker"]
         environment = os.environ.copy()
-        dependencies, key, metadata, cache_hit, install_seconds = (
-            self._worker_dependencies(source, environment)
+        dependencies, key, metadata, cache_hit, install_seconds, view_result = (
+            self._worker_dependencies(
+                source,
+                environment,
+                lambda dependencies, key, metadata: self._worker_view(
+                    root, source, dependencies, key, metadata
+                ),
+            )
         )
-        view, view_hit, view_seconds = self._worker_view(
-            root, source, dependencies, key, metadata
-        )
+        view, view_hit, view_seconds = view_result
         print(
             f"worker dependencies: {'cached' if cache_hit else 'installed'} "
             f"{key} ({install_seconds:.2f}s)"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -265,7 +265,9 @@ is hashed. Copied modification times, filesystem flags, and extended metadata
 are keyed; staging access times are normalized; and the
 staged source snapshot is authenticated before installation. A project `.npmrc`
 is a restrictive no-follow temporary copy that is removed before publication;
-installed output containing the staging path is rejected as non-relocatable.
+the transaction marker is hidden during lifecycle execution and restored before
+publication; installed output containing the staging path is rejected as
+non-relocatable.
 A missing canonical entry recovers the newest structurally valid matching
 backup under the per-key lock before falling back to a new `npm ci`.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -250,8 +250,9 @@ recoverable staging and backup artifacts. Each key covers exact `package.json`,
 Node runtime platform, architecture, and ABI identity; host OS and architecture;
 the effective npm configuration; and a digest of the
 complete lifecycle-script environment. Only digests, never configuration or
-environment values, enter metadata. External file-backed npm configuration and
-custom script shells fail closed rather than remaining live during install;
+environment values, enter metadata. External file-backed npm configuration,
+custom script shells, and external Node preload options fail closed rather than
+remaining live during install;
 project `.npmrc` uses an authenticated temporary copy. Each entry has its own
 lock, ownership marker, installed-lockfile digest, canonical complete-tree
 digest, required top-level dependency checks, and atomically refreshed
@@ -272,6 +273,9 @@ publication; installed output containing the staging path is rejected as
 non-relocatable.
 A missing canonical entry recovers the newest structurally valid matching
 backup under the per-key lock before falling back to a new `npm ci`.
+Cleanup ages transaction artifacts from the newer of their no-follow tree
+mtime and root ctime, then repeats inode identity, marker, age, and path checks
+while holding the per-key lock through deletion.
 
 ## Classic monorepo migration
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -258,6 +258,8 @@ scripts can observe root files, the complete non-generated source digest always
 enters the key, the source is staged, and source symlinks fail closed. Installed
 relative links must resolve within `node_modules`; absolute, escaping, dangling,
 or unsupported entries invalidate the installation.
+A missing canonical entry recovers the newest structurally valid matching
+backup under the per-key lock before falling back to a new `npm ci`.
 
 ## Classic monorepo migration
 
@@ -401,6 +403,8 @@ both the view and dependency key because dependency lifecycle scripts remain
 enabled; package or project npm configuration edits do the same. The profile
 receives a real, revalidated copy of cached `node_modules`, never a link or
 shared inode contract, so its checks cannot mutate the shared installation.
+View reuse excludes only Vite's profile-local `.vite` and `.vite-temp` outputs
+from the immutable dependency digest.
 Collected
 content and resource dependency metadata identify the selected path and commit.
 The resources repository's `runtime-paths.txt` is the distribution boundary:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -247,13 +247,15 @@ Worker dependency entries are direct key children of the marker-owned
 `worker-dependencies` container; its reserved `.transactions` child owns
 recoverable staging and backup artifacts. Each key covers exact `package.json`,
 `package-lock.json`, and optional project `.npmrc` bytes; Node and npm versions;
-OS and architecture; the effective npm configuration; and a digest of the
+Node runtime platform, architecture, and ABI identity; host OS and architecture;
+the effective npm configuration; and a digest of the
 complete lifecycle-script environment. Only digests, never configuration or
-environment values, enter metadata. External file-backed npm configuration
-fails closed rather than remaining live during install; project `.npmrc` uses
-an authenticated temporary copy. Each entry has its own lock, ownership
-marker, installed-lockfile digest, canonical complete-tree digest, required
-top-level dependency checks, and atomically refreshed `last_used_at`. Invalid
+environment values, enter metadata. External file-backed npm configuration and
+custom script shells fail closed rather than remaining live during install;
+project `.npmrc` uses an authenticated temporary copy. Each entry has its own
+lock, ownership marker, installed-lockfile digest, canonical complete-tree
+digest, required top-level dependency checks, and atomically refreshed
+`last_used_at`. Invalid
 ownership fails closed; corruption of an exactly owned entry is replaced only
 after a clean staged `npm ci` succeeds. Because enabled dependency lifecycle
 scripts can observe root files, the complete non-generated source digest always

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -121,6 +121,7 @@ workspace/
   profiles/<name>.json               logical component -> checkout selectors
   build/profiles/<name>-<key>/       isolated sources, builds, and runtime
   build/npm-cache/                   shared package download cache
+  build/worker-dependencies/<key>/   shared validated Worker installations
   build/retention.json               optional strict build pin/rollback record
   topologies/<name>/                 supervised process state and rotated logs
   state/server/<name>/               persistent mutable server data
@@ -242,6 +243,19 @@ visible report-only `unmanaged-build` records. Cleanup never targets profiles,
 scenarios, state, topology records/logs, migration archives/evidence, branches,
 Git objects, or arbitrary unmarked paths.
 
+Worker dependency entries are direct children of the marker-owned
+`worker-dependencies` container. Each key covers exact `package.json`,
+`package-lock.json`, and optional project `.npmrc` bytes; Node and npm versions;
+OS and architecture; the effective npm configuration; and a digest of the
+complete lifecycle-script environment. Only digests, never configuration or
+environment values, enter metadata. Each entry has its own lock, ownership
+marker, installed-lockfile digest, required top-level dependency checks, and
+atomically refreshed `last_used_at`. Marker or structural corruption is a
+cache miss and is replaced only after a clean staged `npm ci` succeeds. When
+the root package defines an install lifecycle hook, the complete non-generated
+source digest also enters the key and its source is staged for that hook;
+otherwise application-only edits do not invalidate dependencies.
+
 ## Classic monorepo migration
 
 `migrate repositories` is a checked transaction for workspaces that still
@@ -353,7 +367,7 @@ full Classic closure -> integrated source view -> one protocol/libatrinik graph
                                              +-> server targets -> CMake/Ninja
 component-only client/server request -> standalone source view -> CMake/Ninja
 selected Classic + content + resources ---> offline worldmaker -> region-map cache
-selected Worker -------------------------> npm source view -> npm run check
+selected Worker -> keyed npm ci cache -> isolated reconciled view -> npm run check
 ~~~
 
 The integrated graph is selected only when client, server, protocol, and
@@ -377,7 +391,13 @@ The server source view uses a copied `install_data` directory because its CTest
 preparation uses CMake directory-copy semantics. Other authored inputs remain
 links to their selected worktrees. The Worker view is copied because Node's
 module resolver follows configuration-file links and would otherwise search the
-Worker checkout instead of the isolated dependency directory. Collected
+Worker checkout instead of the isolated dependency directory. The coordinator
+fingerprints all non-generated source entries, so an unchanged profile view is
+reused without another source copy. Application-only clean or dirty edits
+invalidate that view but keep lockfile-identical dependencies; package or
+project npm configuration edits invalidate both. The profile receives a real
+copy of cached `node_modules`, never a link or shared inode contract, so its
+checks cannot mutate the shared installation. Collected
 content and resource dependency metadata identify the selected path and commit.
 The resources repository's `runtime-paths.txt` is the distribution boundary:
 only tracked regular files below those paths enter the runtime view. This keeps

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -243,18 +243,21 @@ visible report-only `unmanaged-build` records. Cleanup never targets profiles,
 scenarios, state, topology records/logs, migration archives/evidence, branches,
 Git objects, or arbitrary unmarked paths.
 
-Worker dependency entries are direct children of the marker-owned
-`worker-dependencies` container. Each key covers exact `package.json`,
+Worker dependency entries are direct key children of the marker-owned
+`worker-dependencies` container; its reserved `.transactions` child owns
+recoverable staging and backup artifacts. Each key covers exact `package.json`,
 `package-lock.json`, and optional project `.npmrc` bytes; Node and npm versions;
 OS and architecture; the effective npm configuration; and a digest of the
 complete lifecycle-script environment. Only digests, never configuration or
 environment values, enter metadata. Each entry has its own lock, ownership
-marker, installed-lockfile digest, required top-level dependency checks, and
-atomically refreshed `last_used_at`. Marker or structural corruption is a
-cache miss and is replaced only after a clean staged `npm ci` succeeds. When
-the root package defines an install lifecycle hook, the complete non-generated
-source digest also enters the key and its source is staged for that hook;
-otherwise application-only edits do not invalidate dependencies.
+marker, installed-lockfile digest, canonical complete-tree digest, required
+top-level dependency checks, and atomically refreshed `last_used_at`. Invalid
+ownership fails closed; corruption of an exactly owned entry is replaced only
+after a clean staged `npm ci` succeeds. Because enabled dependency lifecycle
+scripts can observe root files, the complete non-generated source digest always
+enters the key, the source is staged, and source symlinks fail closed. Installed
+relative links must resolve within `node_modules`; absolute, escaping, dangling,
+or unsupported entries invalidate the installation.
 
 ## Classic monorepo migration
 
@@ -393,11 +396,12 @@ links to their selected worktrees. The Worker view is copied because Node's
 module resolver follows configuration-file links and would otherwise search the
 Worker checkout instead of the isolated dependency directory. The coordinator
 fingerprints all non-generated source entries, so an unchanged profile view is
-reused without another source copy. Application-only clean or dirty edits
-invalidate that view but keep lockfile-identical dependencies; package or
-project npm configuration edits invalidate both. The profile receives a real
-copy of cached `node_modules`, never a link or shared inode contract, so its
-checks cannot mutate the shared installation. Collected
+reused without another source copy. Any clean or dirty source edit invalidates
+both the view and dependency key because dependency lifecycle scripts remain
+enabled; package or project npm configuration edits do the same. The profile
+receives a real, revalidated copy of cached `node_modules`, never a link or
+shared inode contract, so its checks cannot mutate the shared installation.
+Collected
 content and resource dependency metadata identify the selected path and commit.
 The resources repository's `runtime-paths.txt` is the distribution boundary:
 only tracked regular files below those paths enter the runtime view. This keeps

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -260,7 +260,7 @@ enters the key, the source is staged, and source symlinks fail closed. Installed
 relative links must resolve within `node_modules`; absolute, escaping, dangling,
 or unsupported entries invalidate the installation.
 The per-key staging path is stable within the workspace and its parent identity
-is hashed. Copied timestamps and extended metadata are normalized, and the
+is hashed. Copied modification times and extended metadata are keyed, and the
 staged source snapshot is authenticated before installation. A project `.npmrc`
 is a restrictive no-follow temporary copy that is removed before publication;
 installed output containing the staging path is rejected as non-relocatable.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -258,6 +258,10 @@ scripts can observe root files, the complete non-generated source digest always
 enters the key, the source is staged, and source symlinks fail closed. Installed
 relative links must resolve within `node_modules`; absolute, escaping, dangling,
 or unsupported entries invalidate the installation.
+The per-key staging path is stable within the workspace and its parent identity
+is hashed. A project `.npmrc` is exposed to npm through a temporary link but is
+removed before publication, and installed output containing the staging path is
+rejected as non-relocatable.
 A missing canonical entry recovers the newest structurally valid matching
 backup under the per-key lock before falling back to a new `npm ci`.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -247,10 +247,11 @@ Worker dependency entries are direct key children of the marker-owned
 `worker-dependencies` container; its reserved `.transactions` child owns
 recoverable staging and backup artifacts. Each key covers exact `package.json`,
 `package-lock.json`, and optional project `.npmrc` bytes; Node and npm versions;
-OS and architecture; the effective npm configuration and path/content digests
-for every file-backed configuration input; and a digest of the
+OS and architecture; the effective npm configuration; and a digest of the
 complete lifecycle-script environment. Only digests, never configuration or
-environment values, enter metadata. Each entry has its own lock, ownership
+environment values, enter metadata. External file-backed npm configuration
+fails closed rather than remaining live during install; project `.npmrc` uses
+an authenticated temporary copy. Each entry has its own lock, ownership
 marker, installed-lockfile digest, canonical complete-tree digest, required
 top-level dependency checks, and atomically refreshed `last_used_at`. Invalid
 ownership fails closed; corruption of an exactly owned entry is replaced only
@@ -260,7 +261,8 @@ enters the key, the source is staged, and source symlinks fail closed. Installed
 relative links must resolve within `node_modules`; absolute, escaping, dangling,
 or unsupported entries invalidate the installation.
 The per-key staging path is stable within the workspace and its parent identity
-is hashed. Copied modification times and extended metadata are keyed, and the
+is hashed. Copied modification times, filesystem flags, and extended metadata
+are keyed; staging access times are normalized; and the
 staged source snapshot is authenticated before installation. A project `.npmrc`
 is a restrictive no-follow temporary copy that is removed before publication;
 installed output containing the staging path is rejected as non-relocatable.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -247,7 +247,8 @@ Worker dependency entries are direct key children of the marker-owned
 `worker-dependencies` container; its reserved `.transactions` child owns
 recoverable staging and backup artifacts. Each key covers exact `package.json`,
 `package-lock.json`, and optional project `.npmrc` bytes; Node and npm versions;
-OS and architecture; the effective npm configuration; and a digest of the
+OS and architecture; the effective npm configuration and path/content digests
+for every file-backed configuration input; and a digest of the
 complete lifecycle-script environment. Only digests, never configuration or
 environment values, enter metadata. Each entry has its own lock, ownership
 marker, installed-lockfile digest, canonical complete-tree digest, required
@@ -259,9 +260,10 @@ enters the key, the source is staged, and source symlinks fail closed. Installed
 relative links must resolve within `node_modules`; absolute, escaping, dangling,
 or unsupported entries invalidate the installation.
 The per-key staging path is stable within the workspace and its parent identity
-is hashed. A project `.npmrc` is exposed to npm through a temporary link but is
-removed before publication, and installed output containing the staging path is
-rejected as non-relocatable.
+is hashed. Copied timestamps and extended metadata are normalized, and the
+staged source snapshot is authenticated before installation. A project `.npmrc`
+is a restrictive no-follow temporary copy that is removed before publication;
+installed output containing the staging path is rejected as non-relocatable.
 A missing canonical entry recovers the newest structurally valid matching
 backup under the per-key lock before falling back to a new `npm ci`.
 

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1913,6 +1913,27 @@ class CleanupTests(unittest.TestCase):
         self.assertFalse(entry.exists())
         self.assertTrue((self.workspace.paths.builds / "worker-dependencies").exists())
 
+    def test_worker_dependency_cache_removal_is_mount_bounded(self) -> None:
+        entry = self.make_worker_dependency_cache()
+        payload = entry / "node_modules" / "package.js"
+        payload.write_text("preserve\n", encoding="utf-8")
+
+        with mock.patch(
+            "atrinik_workspace.cleanup.remove_owned_tree",
+            side_effect=WorkspaceError("owned removal encountered a mount boundary"),
+        ):
+            report = self.workspace.cleanup(["builds"], 7, [], True)
+
+        item = next(
+            row
+            for row in report["items"]
+            if row["kind"] == "worker-dependencies"
+        )
+        self.assertEqual(item["disposition"], "error")
+        self.assertEqual(item["reasons"], ["removal_failed"])
+        self.assertIn("mount boundary", item["error"])
+        self.assertEqual(payload.read_text(encoding="utf-8"), "preserve\n")
+
     def test_prior_worker_dependency_schema_is_reclaimable(self) -> None:
         for schema_version, key in ((1, "1" * 64), (2, "2" * 64), (3, "3" * 64)):
             with self.subTest(schema_version=schema_version):

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1851,11 +1851,12 @@ class CleanupTests(unittest.TestCase):
         atomic_json(
             entry / ".atrinik-worker-dependencies.json",
             {
-                "schema_version": 1,
+                "schema_version": 2,
                 "purpose": "worker-dependencies",
                 "key": key,
                 "inputs": {"lock": "exact"},
                 "node_modules_lock_sha256": "b" * 64,
+                "node_modules_sha256": "c" * 64,
                 "last_used_at": self.old.isoformat(),
             },
         )
@@ -1917,6 +1918,178 @@ class CleanupTests(unittest.TestCase):
         self.assertEqual(item["disposition"], "protected")
         self.assertIn("invalid_worker_dependency_cache", item["reasons"])
         self.assertTrue(entry.exists())
+
+    def test_worker_dependency_cleanup_rejects_concurrent_refresh(self) -> None:
+        entry = self.make_worker_dependency_cache()
+        original_remove = Cleanup._remove
+
+        def refresh_before_remove(
+            cleanup: Cleanup, item: dict[str, object], older_than_days: int = 0
+        ) -> None:
+            if item["kind"] == "worker-dependencies":
+                metadata_path = entry / ".atrinik-worker-dependencies.json"
+                metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+                metadata["last_used_at"] = cleanup.now.isoformat()
+                atomic_json(metadata_path, metadata)
+            original_remove(cleanup, item, older_than_days)
+
+        with mock.patch.object(Cleanup, "_remove", new=refresh_before_remove):
+            report = self.workspace.cleanup(["builds"], 7, [], True)
+        item = next(
+            row
+            for row in report["items"]
+            if row["kind"] == "worker-dependencies"
+        )
+        self.assertEqual(item["disposition"], "error")
+        self.assertEqual(item["reasons"], ["removal_failed"])
+        self.assertIn("refreshed", item["error"])
+        self.assertTrue(entry.exists())
+
+    def test_worker_dependency_transactions_are_previewed_and_bounded(self) -> None:
+        key = "d" * 64
+        root = self.workspace.paths.builds / "worker-dependencies"
+        managed_directory(root, self.workspace.paths.builds, "worker-dependency-cache")
+        transactions = root / ".transactions"
+        managed_directory(
+            transactions,
+            self.workspace.paths.builds,
+            "worker-dependency-transactions",
+        )
+        transaction = transactions / f"{key}-staging-deadbeef"
+        transaction.mkdir()
+        (transaction / "partial-package").write_text("partial\n", encoding="utf-8")
+        old_timestamp = self.old.timestamp()
+        os.utime(transaction / "partial-package", (old_timestamp, old_timestamp))
+        os.utime(transaction, (old_timestamp, old_timestamp))
+
+        preview = self.workspace.cleanup(["builds"], 7, [], False)
+        item = next(
+            row
+            for row in preview["items"]
+            if row["kind"] == "worker-dependency-transaction"
+        )
+        self.assertEqual(item["disposition"], "eligible")
+        self.assertEqual(item["reasons"], ["stale_worker_dependency_transaction"])
+        self.assertTrue(transaction.exists())
+
+        applied = self.workspace.cleanup(["builds"], 7, [], True)
+        item = next(
+            row
+            for row in applied["items"]
+            if row["kind"] == "worker-dependency-transaction"
+        )
+        self.assertEqual(item["disposition"], "removed")
+        self.assertFalse(transaction.exists())
+        self.assertTrue(transactions.exists())
+
+    def test_worker_dependency_transaction_uncertainty_protects_artifacts(self) -> None:
+        key = "e" * 64
+        root = self.workspace.paths.builds / "worker-dependencies"
+        managed_directory(root, self.workspace.paths.builds, "worker-dependency-cache")
+        transactions = root / ".transactions"
+        managed_directory(
+            transactions,
+            self.workspace.paths.builds,
+            "worker-dependency-transactions",
+        )
+        old_timestamp = self.old.timestamp()
+
+        invalid_name = transactions / "unrecognized"
+        invalid_name.mkdir()
+        os.utime(invalid_name, (old_timestamp, old_timestamp))
+
+        wrong_marker = transactions / f"{key}-staging-bad"
+        wrong_marker.mkdir()
+        atomic_json(
+            wrong_marker / MANAGED_MARKER,
+            {"schema_version": SCHEMA_VERSION, "purpose": "unrelated"},
+        )
+        os.utime(wrong_marker, (old_timestamp, old_timestamp))
+
+        future = transactions / f"{key}-backup-feed"
+        future.mkdir()
+        now = datetime.now(timezone.utc)
+        future_timestamp = (now + timedelta(days=1)).timestamp()
+        os.utime(future, (future_timestamp, future_timestamp))
+
+        young = transactions / f"{key}-staging-cafe"
+        young.mkdir()
+
+        busy = transactions / f"{key}-staging-dead"
+        busy.mkdir()
+        os.utime(busy, (old_timestamp, old_timestamp))
+        lock = (
+            self.workspace.paths.builds
+            / "locks"
+            / f"worker-dependencies-{key}.lock"
+        )
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        with lock.open("w", encoding="utf-8") as stream:
+            import fcntl
+
+            fcntl.flock(stream, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            report = self.workspace.cleanup(["builds"], 7, [], False)
+
+        items = {
+            Path(row["path"]).name: row
+            for row in report["items"]
+            if row["kind"] == "worker-dependency-transaction"
+        }
+        self.assertIn(
+            "invalid_worker_dependency_transaction",
+            items[invalid_name.name]["reasons"],
+        )
+        self.assertIn(
+            "invalid_worker_dependency_transaction",
+            items[wrong_marker.name]["reasons"],
+        )
+        self.assertIn("future_tree_mtime", items[future.name]["reasons"])
+        self.assertIn("younger_than_grace_period", items[young.name]["reasons"])
+        self.assertIn("build_lock_busy", items[busy.name]["reasons"])
+
+    def test_invalid_worker_dependency_transaction_root_is_protected(self) -> None:
+        root = self.workspace.paths.builds / "worker-dependencies"
+        managed_directory(root, self.workspace.paths.builds, "worker-dependency-cache")
+        transactions = root / ".transactions"
+        transactions.mkdir()
+        atomic_json(
+            transactions / MANAGED_MARKER,
+            {"schema_version": SCHEMA_VERSION, "purpose": "unrelated"},
+        )
+        report = self.workspace.cleanup(["builds"], 0, [], False)
+        item = next(
+            row
+            for row in report["items"]
+            if row["path"] == str(transactions)
+        )
+        self.assertEqual(item["disposition"], "protected")
+        self.assertEqual(item["reasons"], ["invalid_worker_dependency_transactions"])
+
+    def test_worker_dependency_cache_age_and_key_fail_closed(self) -> None:
+        entry = self.make_worker_dependency_cache()
+        metadata_path = entry / ".atrinik-worker-dependencies.json"
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        now = datetime.now(timezone.utc)
+        metadata["last_used_at"] = (now + timedelta(days=1)).isoformat()
+        atomic_json(metadata_path, metadata)
+        report = self.workspace.cleanup(["builds"], 7, [], False)
+        item = next(
+            row for row in report["items"] if row["kind"] == "worker-dependencies"
+        )
+        self.assertIn("future_last_used", item["reasons"])
+
+        metadata["last_used_at"] = now.isoformat()
+        atomic_json(metadata_path, metadata)
+        report = self.workspace.cleanup(["builds"], 7, [], False)
+        item = next(
+            row for row in report["items"] if row["kind"] == "worker-dependencies"
+        )
+        self.assertIn("younger_than_grace_period", item["reasons"])
+
+        invalid = self.make_worker_dependency_cache("not-a-key")
+        report = self.workspace.cleanup(["builds"], 0, [], False)
+        item = next(row for row in report["items"] if row["path"] == str(invalid))
+        self.assertIn("invalid_worker_dependency_cache", item["reasons"])
 
     def test_dry_run_does_not_create_an_absent_workspace(self) -> None:
         shutil.rmtree(self.workspace.paths.workspace)

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1955,7 +1955,7 @@ class CleanupTests(unittest.TestCase):
             self.workspace.paths.builds,
             "worker-dependency-transactions",
         )
-        transaction = transactions / f"{key}-staging-deadbeef"
+        transaction = transactions / f"{key}-backup-_n056r1s"
         transaction.mkdir()
         (transaction / "partial-package").write_text("partial\n", encoding="utf-8")
         old_timestamp = self.old.timestamp()

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1856,18 +1856,19 @@ class CleanupTests(unittest.TestCase):
             self.workspace.paths.builds,
             f"worker-dependencies:{key}",
         )
-        atomic_json(
-            entry / ".atrinik-worker-dependencies.json",
-            {
-                "schema_version": schema_version,
-                "purpose": "worker-dependencies",
-                "key": key,
-                "inputs": {"lock": "exact"},
-                "node_modules_lock_sha256": "b" * 64,
-                "node_modules_sha256": "c" * 64,
-                "last_used_at": self.old.isoformat(),
-            },
-        )
+        metadata = {
+            "schema_version": schema_version,
+            "purpose": "worker-dependencies",
+            "key": key,
+            "inputs": {"lock": "exact"},
+            "node_modules_lock_sha256": "b" * 64,
+            "last_used_at": self.old.isoformat(),
+        }
+        if schema_version != 1:
+            metadata["node_modules_sha256"] = "c" * 64
+        if schema_version == WORKER_DEPENDENCY_SCHEMA_VERSION:
+            metadata["node_modules_view_sha256"] = "d" * 64
+        atomic_json(entry / ".atrinik-worker-dependencies.json", metadata)
         (entry / "node_modules").mkdir()
         return entry
 
@@ -1913,25 +1914,27 @@ class CleanupTests(unittest.TestCase):
         self.assertTrue((self.workspace.paths.builds / "worker-dependencies").exists())
 
     def test_prior_worker_dependency_schema_is_reclaimable(self) -> None:
-        entry = self.make_worker_dependency_cache(schema_version=2)
-        preview = self.workspace.cleanup(["builds"], 7, [], False)
-        item = next(
-            row
-            for row in preview["items"]
-            if row["kind"] == "worker-dependencies"
-        )
-        self.assertEqual(item["disposition"], "eligible")
-        self.assertEqual(item["reasons"], ["stale_worker_dependencies"])
-        self.assertTrue(entry.exists())
+        for schema_version, key in ((1, "1" * 64), (2, "2" * 64), (3, "3" * 64)):
+            with self.subTest(schema_version=schema_version):
+                entry = self.make_worker_dependency_cache(key, schema_version)
+                preview = self.workspace.cleanup(["builds"], 7, [], False)
+                item = next(
+                    row
+                    for row in preview["items"]
+                    if row["path"] == str(entry)
+                )
+                self.assertEqual(item["disposition"], "eligible")
+                self.assertEqual(item["reasons"], ["stale_worker_dependencies"])
+                self.assertTrue(entry.exists())
 
-        applied = self.workspace.cleanup(["builds"], 7, [], True)
-        item = next(
-            row
-            for row in applied["items"]
-            if row["kind"] == "worker-dependencies"
-        )
-        self.assertEqual(item["disposition"], "removed")
-        self.assertFalse(entry.exists())
+                applied = self.workspace.cleanup(["builds"], 7, [], True)
+                item = next(
+                    row
+                    for row in applied["items"]
+                    if row["path"] == str(entry)
+                )
+                self.assertEqual(item["disposition"], "removed")
+                self.assertFalse(entry.exists())
 
     def test_invalid_worker_dependency_cache_is_protected(self) -> None:
         entry = self.make_worker_dependency_cache()
@@ -1991,7 +1994,12 @@ class CleanupTests(unittest.TestCase):
         os.utime(transaction / "partial-package", (old_timestamp, old_timestamp))
         os.utime(transaction, (old_timestamp, old_timestamp))
 
-        preview = self.workspace.cleanup(["builds"], 7, [], False)
+        with mock.patch.object(
+            Cleanup,
+            "_worker_dependency_transaction_created_at",
+            return_value=self.old,
+        ):
+            preview = self.workspace.cleanup(["builds"], 7, [], False)
         item = next(
             row
             for row in preview["items"]
@@ -2001,7 +2009,12 @@ class CleanupTests(unittest.TestCase):
         self.assertEqual(item["reasons"], ["stale_worker_dependency_transaction"])
         self.assertTrue(transaction.exists())
 
-        applied = self.workspace.cleanup(["builds"], 7, [], True)
+        with mock.patch.object(
+            Cleanup,
+            "_worker_dependency_transaction_created_at",
+            return_value=self.old,
+        ):
+            applied = self.workspace.cleanup(["builds"], 7, [], True)
         item = next(
             row
             for row in applied["items"]
@@ -2049,6 +2062,84 @@ class CleanupTests(unittest.TestCase):
         )
         self.assertEqual(backup["disposition"], "protected")
         self.assertIn("younger_than_grace_period", backup["reasons"])
+
+    def test_new_staging_with_old_source_mtimes_gets_a_fresh_grace_period(
+        self,
+    ) -> None:
+        key = "9" * 64
+        root = self.workspace.paths.builds / "worker-dependencies"
+        managed_directory(root, self.workspace.paths.builds, "worker-dependency-cache")
+        transactions = root / ".transactions"
+        managed_directory(
+            transactions,
+            self.workspace.paths.builds,
+            "worker-dependency-transactions",
+        )
+        source = self.root / "old-worker-source"
+        source.mkdir()
+        (source / "worker.ts").write_text("old\n", encoding="utf-8")
+        old_timestamp = self.old.timestamp()
+        os.utime(source / "worker.ts", (old_timestamp, old_timestamp))
+        os.utime(source, (old_timestamp, old_timestamp))
+        staging = transactions / f"{key}-staging-install"
+        managed_directory(
+            staging,
+            self.workspace.paths.builds,
+            f"worker-dependency-transaction:{key}",
+        )
+        (staging / MANAGED_MARKER).unlink()
+        shutil.copy2(source / "worker.ts", staging / "worker.ts")
+        shutil.copystat(source, staging, follow_symlinks=False)
+
+        preview = self.workspace.cleanup(["builds"], 7, [], False)
+        item = next(row for row in preview["items"] if row["path"] == str(staging))
+        self.assertEqual(item["disposition"], "protected")
+        self.assertEqual(item["age_basis"], "tree-mtime-or-root-ctime")
+        self.assertIn("younger_than_grace_period", item["reasons"])
+
+    def test_worker_dependency_transaction_removal_rejects_aba(self) -> None:
+        key = "8" * 64
+        root = self.workspace.paths.builds / "worker-dependencies"
+        managed_directory(root, self.workspace.paths.builds, "worker-dependency-cache")
+        transactions = root / ".transactions"
+        managed_directory(
+            transactions,
+            self.workspace.paths.builds,
+            "worker-dependency-transactions",
+        )
+        transaction = transactions / f"{key}-staging-install"
+        transaction.mkdir()
+        old_timestamp = self.old.timestamp()
+        os.utime(transaction, (old_timestamp, old_timestamp))
+        original_remove = Cleanup._remove
+
+        def replace_before_remove(
+            cleanup: Cleanup, item: dict[str, object], older_than_days: int = 0
+        ) -> None:
+            if item["kind"] == "worker-dependency-transaction":
+                shutil.rmtree(transaction)
+                transaction.mkdir()
+                os.utime(transaction, (old_timestamp, old_timestamp))
+            original_remove(cleanup, item, older_than_days)
+
+        with (
+            mock.patch.object(
+                Cleanup,
+                "_worker_dependency_transaction_created_at",
+                return_value=self.old,
+            ),
+            mock.patch.object(Cleanup, "_remove", new=replace_before_remove),
+        ):
+            applied = self.workspace.cleanup(["builds"], 7, [], True)
+        item = next(
+            row
+            for row in applied["items"]
+            if row["path"] == str(transaction)
+        )
+        self.assertEqual(item["disposition"], "error")
+        self.assertEqual(item["reasons"], ["removal_failed"])
+        self.assertIn("changed before removal", item["error"])
+        self.assertTrue(transaction.exists())
 
     def test_worker_dependency_transaction_uncertainty_protects_artifacts(self) -> None:
         key = "e" * 64

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1839,6 +1839,85 @@ class CleanupTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "unsupported cleanup target"):
             cleanup._remove({"kind": "unknown", "path": str(cache)})
 
+    def make_worker_dependency_cache(self, key: str = "a" * 64) -> Path:
+        root = self.workspace.paths.builds / "worker-dependencies"
+        managed_directory(root, self.workspace.paths.builds, "worker-dependency-cache")
+        entry = root / key
+        managed_directory(
+            entry,
+            self.workspace.paths.builds,
+            f"worker-dependencies:{key}",
+        )
+        atomic_json(
+            entry / ".atrinik-worker-dependencies.json",
+            {
+                "schema_version": 1,
+                "purpose": "worker-dependencies",
+                "key": key,
+                "inputs": {"lock": "exact"},
+                "node_modules_lock_sha256": "b" * 64,
+                "last_used_at": self.old.isoformat(),
+            },
+        )
+        (entry / "node_modules").mkdir()
+        return entry
+
+    def test_worker_dependency_cache_is_bounded_preview_first_and_locked(self) -> None:
+        entry = self.make_worker_dependency_cache()
+        preview = self.workspace.cleanup(["builds"], 7, [], False)
+        item = next(
+            row
+            for row in preview["items"]
+            if row["kind"] == "worker-dependencies"
+        )
+        self.assertEqual(item["disposition"], "eligible")
+        self.assertEqual(item["reasons"], ["stale_worker_dependencies"])
+        self.assertEqual(item["age_basis"], "last-used-at")
+        self.assertTrue(entry.exists())
+
+        lock = (
+            self.workspace.paths.builds
+            / "locks"
+            / f"worker-dependencies-{'a' * 64}.lock"
+        )
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        with lock.open("w", encoding="utf-8") as stream:
+            import fcntl
+
+            fcntl.flock(stream, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            protected = self.workspace.cleanup(["builds"], 7, [], False)
+        item = next(
+            row
+            for row in protected["items"]
+            if row["kind"] == "worker-dependencies"
+        )
+        self.assertIn("build_lock_busy", item["reasons"])
+
+        applied = self.workspace.cleanup(["builds"], 7, [], True)
+        item = next(
+            row
+            for row in applied["items"]
+            if row["kind"] == "worker-dependencies"
+        )
+        self.assertEqual(item["disposition"], "removed")
+        self.assertFalse(entry.exists())
+        self.assertTrue((self.workspace.paths.builds / "worker-dependencies").exists())
+
+    def test_invalid_worker_dependency_cache_is_protected(self) -> None:
+        entry = self.make_worker_dependency_cache()
+        (entry / ".atrinik-worker-dependencies.json").write_text(
+            "{}\n", encoding="utf-8"
+        )
+        report = self.workspace.cleanup(["builds"], 0, [], False)
+        item = next(
+            row
+            for row in report["items"]
+            if row["kind"] == "worker-dependencies"
+        )
+        self.assertEqual(item["disposition"], "protected")
+        self.assertIn("invalid_worker_dependency_cache", item["reasons"])
+        self.assertTrue(entry.exists())
+
     def test_dry_run_does_not_create_an_absent_workspace(self) -> None:
         shutil.rmtree(self.workspace.paths.workspace)
         report = self.workspace.cleanup(["builds"], 7, [], False)

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -29,7 +29,11 @@ from atrinik_workspace.model import (
     managed_directory,
     managed_remove as real_managed_remove,
 )
-from atrinik_workspace.workspace import WORKER_DEPENDENCY_SCHEMA_VERSION, Workspace
+from atrinik_workspace.workspace import (
+    WORKER_DEPENDENCY_SCHEMA_VERSION,
+    Workspace,
+    replace_directory,
+)
 
 
 def command(*arguments: str, cwd: Path) -> str:
@@ -2006,6 +2010,45 @@ class CleanupTests(unittest.TestCase):
         self.assertEqual(item["disposition"], "removed")
         self.assertFalse(transaction.exists())
         self.assertTrue(transactions.exists())
+
+    def test_new_worker_dependency_backup_gets_a_fresh_grace_period(self) -> None:
+        key = "f" * 64
+        entry = self.make_worker_dependency_cache(key)
+        transactions = entry.parent / ".transactions"
+        managed_directory(
+            transactions,
+            self.workspace.paths.builds,
+            "worker-dependency-transactions",
+        )
+        old_timestamp = self.old.timestamp()
+        for path in sorted(entry.rglob("*"), reverse=True):
+            os.utime(path, (old_timestamp, old_timestamp), follow_symlinks=False)
+        os.utime(entry, (old_timestamp, old_timestamp), follow_symlinks=False)
+        staging = transactions / f"{key}-staging-install"
+        staging.mkdir()
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.shutil.rmtree",
+                side_effect=WorkspaceError("simulated interruption"),
+            ),
+            self.assertRaisesRegex(WorkspaceError, "simulated interruption"),
+        ):
+            replace_directory(
+                entry,
+                staging,
+                f"{key}-backup-",
+                backup_parent=transactions,
+            )
+
+        preview = self.workspace.cleanup(["builds"], 7, [], False)
+        backup = next(
+            row
+            for row in preview["items"]
+            if row["kind"] == "worker-dependency-transaction"
+        )
+        self.assertEqual(backup["disposition"], "protected")
+        self.assertIn("younger_than_grace_period", backup["reasons"])
 
     def test_worker_dependency_transaction_uncertainty_protects_artifacts(self) -> None:
         key = "e" * 64

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1839,7 +1839,11 @@ class CleanupTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "unsupported cleanup target"):
             cleanup._remove({"kind": "unknown", "path": str(cache)})
 
-    def make_worker_dependency_cache(self, key: str = "a" * 64) -> Path:
+    def make_worker_dependency_cache(
+        self,
+        key: str = "a" * 64,
+        schema_version: int = WORKER_DEPENDENCY_SCHEMA_VERSION,
+    ) -> Path:
         root = self.workspace.paths.builds / "worker-dependencies"
         managed_directory(root, self.workspace.paths.builds, "worker-dependency-cache")
         entry = root / key
@@ -1851,7 +1855,7 @@ class CleanupTests(unittest.TestCase):
         atomic_json(
             entry / ".atrinik-worker-dependencies.json",
             {
-                "schema_version": WORKER_DEPENDENCY_SCHEMA_VERSION,
+                "schema_version": schema_version,
                 "purpose": "worker-dependencies",
                 "key": key,
                 "inputs": {"lock": "exact"},
@@ -1903,6 +1907,27 @@ class CleanupTests(unittest.TestCase):
         self.assertEqual(item["disposition"], "removed")
         self.assertFalse(entry.exists())
         self.assertTrue((self.workspace.paths.builds / "worker-dependencies").exists())
+
+    def test_prior_worker_dependency_schema_is_reclaimable(self) -> None:
+        entry = self.make_worker_dependency_cache(schema_version=2)
+        preview = self.workspace.cleanup(["builds"], 7, [], False)
+        item = next(
+            row
+            for row in preview["items"]
+            if row["kind"] == "worker-dependencies"
+        )
+        self.assertEqual(item["disposition"], "eligible")
+        self.assertEqual(item["reasons"], ["stale_worker_dependencies"])
+        self.assertTrue(entry.exists())
+
+        applied = self.workspace.cleanup(["builds"], 7, [], True)
+        item = next(
+            row
+            for row in applied["items"]
+            if row["kind"] == "worker-dependencies"
+        )
+        self.assertEqual(item["disposition"], "removed")
+        self.assertFalse(entry.exists())
 
     def test_invalid_worker_dependency_cache_is_protected(self) -> None:
         entry = self.make_worker_dependency_cache()

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -2040,12 +2040,9 @@ class CleanupTests(unittest.TestCase):
         staging = transactions / f"{key}-staging-install"
         staging.mkdir()
 
-        with (
-            mock.patch(
-                "atrinik_workspace.workspace.shutil.rmtree",
-                side_effect=WorkspaceError("simulated interruption"),
-            ),
-            self.assertRaisesRegex(WorkspaceError, "simulated interruption"),
+        with mock.patch(
+            "atrinik_workspace.workspace.remove_owned_tree",
+            side_effect=WorkspaceError("simulated interruption"),
         ):
             replace_directory(
                 entry,

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -29,7 +29,7 @@ from atrinik_workspace.model import (
     managed_directory,
     managed_remove as real_managed_remove,
 )
-from atrinik_workspace.workspace import Workspace
+from atrinik_workspace.workspace import WORKER_DEPENDENCY_SCHEMA_VERSION, Workspace
 
 
 def command(*arguments: str, cwd: Path) -> str:
@@ -1851,7 +1851,7 @@ class CleanupTests(unittest.TestCase):
         atomic_json(
             entry / ".atrinik-worker-dependencies.json",
             {
-                "schema_version": 2,
+                "schema_version": WORKER_DEPENDENCY_SCHEMA_VERSION,
                 "purpose": "worker-dependencies",
                 "key": key,
                 "inputs": {"lock": "exact"},

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -2112,15 +2112,20 @@ class CleanupTests(unittest.TestCase):
         old_timestamp = self.old.timestamp()
         os.utime(transaction, (old_timestamp, old_timestamp))
         original_remove = Cleanup._remove
+        original_transaction = transactions / f".{transaction.name}-original"
 
         def replace_before_remove(
             cleanup: Cleanup, item: dict[str, object], older_than_days: int = 0
         ) -> None:
             if item["kind"] == "worker-dependency-transaction":
-                shutil.rmtree(transaction)
+                transaction.replace(original_transaction)
                 transaction.mkdir()
                 os.utime(transaction, (old_timestamp, old_timestamp))
-            original_remove(cleanup, item, older_than_days)
+            try:
+                original_remove(cleanup, item, older_than_days)
+            finally:
+                if original_transaction.exists():
+                    shutil.rmtree(original_transaction)
 
         with (
             mock.patch.object(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1287,6 +1287,7 @@ class WorkspaceTests(unittest.TestCase):
             real_copy_regular_file(*args, **kwargs)
             destination = args[1]
             assert isinstance(destination, Path)
+            self.assertEqual(stat.S_IMODE(destination.stat().st_mode), 0o600)
             destination.write_text("strict-peer-deps=false\n", encoding="utf-8")
 
         with (

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -848,6 +848,7 @@ class WorkspaceTests(unittest.TestCase):
             )
             self.assertNotEqual(config_changed[1], invalidated[1])
             self.assertEqual(len(installs), 5)
+            self.assertFalse((config_changed[0].parent / ".npmrc").exists())
 
             (source / "package-lock.json").write_text(
                 '{"lockfileVersion":3,"changed":true}\n', encoding="utf-8"
@@ -1001,6 +1002,49 @@ class WorkspaceTests(unittest.TestCase):
                 source, {"PATH": "/bin"}, consume
             )
         self.assertEqual(result[5], "consumed")
+
+    def test_worker_dependency_timing_excludes_view_consumption(self) -> None:
+        source = self.make_worker_source()
+        versions = {"node": "v22.0.0", "npm": "11.0.0"}
+        consumed: list[Path] = []
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.run",
+                side_effect=self.fake_worker_run([], versions, threading.Lock()),
+            ),
+            mock.patch(
+                "atrinik_workspace.workspace.time.monotonic",
+                side_effect=(10.0, 12.5),
+            ),
+        ):
+            result = self.workspace._worker_dependencies(
+                source,
+                {"PATH": "/bin"},
+                lambda modules, _key, _metadata: consumed.append(modules),
+            )
+        self.assertEqual(result[4], 2.5)
+        self.assertEqual(consumed, [result[0]])
+
+    def test_worker_dependency_rejects_embedded_install_path(self) -> None:
+        source = self.make_worker_source()
+        versions = {"node": "v22.0.0", "npm": "11.0.0"}
+        runner = self.fake_worker_run([], versions, threading.Lock())
+
+        def path_embedding_run(arguments: list[str], **kwargs: object) -> str:
+            result = runner(arguments, **kwargs)
+            if arguments == ["npm", "ci"]:
+                cwd = kwargs["cwd"]
+                assert isinstance(cwd, Path)
+                (cwd / "node_modules" / "alpha" / "embedded").write_text(
+                    str(cwd), encoding="utf-8"
+                )
+            return result
+
+        with mock.patch(
+            "atrinik_workspace.workspace.run", side_effect=path_embedding_run
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "embeds its install path"):
+                self.workspace._worker_dependencies(source, {"PATH": "/bin"})
 
     def test_worker_package_and_tool_metadata_fail_closed(self) -> None:
         source = self.make_worker_source()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -771,6 +771,10 @@ class WorkspaceTests(unittest.TestCase):
                 )
             if arguments == ["npm", "ci"]:
                 assert cwd is not None
+                if (cwd / MANAGED_MARKER).exists() or (
+                    cwd / MANAGED_MARKER
+                ).is_symlink():
+                    raise AssertionError("workspace metadata was exposed to npm")
                 if not (cwd / "worker.ts").is_file():
                     raise AssertionError("npm lifecycle source was not staged")
                 if (cwd / "worker.ts").stat().st_atime_ns != 0:
@@ -1142,6 +1146,25 @@ class WorkspaceTests(unittest.TestCase):
             "atrinik_workspace.workspace.run", side_effect=path_embedding_run
         ):
             with self.assertRaisesRegex(WorkspaceError, "embeds its install path"):
+                self.workspace._worker_dependencies(source, {"PATH": "/bin"})
+
+    def test_worker_dependency_hides_reserved_metadata_from_lifecycle(self) -> None:
+        source = self.make_worker_source()
+        versions = {"node": "v22.0.0", "npm": "11.0.0"}
+        runner = self.fake_worker_run([], versions, threading.Lock())
+
+        def marker_creating_run(arguments: list[str], **kwargs: object) -> str:
+            result = runner(arguments, **kwargs)
+            if arguments == ["npm", "ci"]:
+                cwd = kwargs["cwd"]
+                assert isinstance(cwd, Path)
+                atomic_json(cwd / MANAGED_MARKER, {"lifecycle": "unexpected"})
+            return result
+
+        with mock.patch(
+            "atrinik_workspace.workspace.run", side_effect=marker_creating_run
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "reserved workspace metadata"):
                 self.workspace._worker_dependencies(source, {"PATH": "/bin"})
 
     def test_worker_package_and_tool_metadata_fail_closed(self) -> None:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -951,19 +951,31 @@ class WorkspaceTests(unittest.TestCase):
             self.assertFalse(rebuilt_content[3])
             self.assertEqual(len(installs), 2)
 
+            entry_metadata_path = (
+                rebuilt_content[0].parent / ".atrinik-worker-dependencies.json"
+            )
+            entry_metadata = load_json(entry_metadata_path)
+            entry_metadata["node_modules_view_sha256"] = "0" * 64
+            atomic_json(entry_metadata_path, entry_metadata)
+            rebuilt_view_digest = self.workspace._worker_dependencies(
+                source, {"PATH": "/bin"}
+            )
+            self.assertFalse(rebuilt_view_digest[3])
+            self.assertEqual(len(installs), 3)
+
             (modules / "unexpected.txt").write_text("unexpected\n", encoding="utf-8")
             rebuilt_addition = self.workspace._worker_dependencies(
                 source, {"PATH": "/bin"}
             )
             self.assertFalse(rebuilt_addition[3])
-            self.assertEqual(len(installs), 3)
+            self.assertEqual(len(installs), 4)
 
             (modules / "escape").symlink_to("../../outside")
             rebuilt_link = self.workspace._worker_dependencies(
                 source, {"PATH": "/bin"}
             )
             self.assertFalse(rebuilt_link[3])
-            self.assertEqual(len(installs), 4)
+            self.assertEqual(len(installs), 5)
 
     def test_worker_dependency_cache_authenticates_copied_metadata(self) -> None:
         source = self.make_worker_source()
@@ -1619,9 +1631,13 @@ class WorkspaceTests(unittest.TestCase):
             copied_source,
             ns=(copied_status.st_atime_ns, copied_status.st_mtime_ns + 1),
         )
-        self.workspace._reconcile_worker_view_source(
-            source, reconciled_control[0], "a" * 64, metadata
-        )
+        with mock.patch(
+            "atrinik_workspace.workspace._copy_worker_source",
+            side_effect=AssertionError("post-check reconciliation copied source bytes"),
+        ):
+            self.workspace._reconcile_worker_view_source(
+                source, reconciled_control[0], "a" * 64, metadata
+            )
         reconciled_after_check = self.workspace._worker_view(
             root, source, dependencies, "a" * 64, metadata
         )
@@ -1656,6 +1672,30 @@ class WorkspaceTests(unittest.TestCase):
             },
         )
         self.assertFalse(view_metadata.is_symlink())
+
+        def fail_after_replacing_controls_with_directories(
+            *args: object, **kwargs: object
+        ) -> None:
+            marker.unlink()
+            marker.mkdir()
+            (marker / "nested").write_text("corrupt\n", encoding="utf-8")
+            view_metadata.unlink()
+            view_metadata.mkdir()
+            (view_metadata / "nested").write_text("corrupt\n", encoding="utf-8")
+            raise subprocess.CalledProcessError(1, ["npm", "run", "check"])
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.run",
+                side_effect=fail_after_replacing_controls_with_directories,
+            ),
+            self.assertRaises(subprocess.CalledProcessError),
+        ):
+            self.workspace._run_worker_checks(
+                reconciled_after_check[0], {}, "a" * 64, metadata
+            )
+        self.assertTrue(marker.is_file())
+        self.assertTrue(view_metadata.is_file())
 
         atomic_json(marker, {"schema_version": 1, "purpose": "wrong"})
         with self.assertRaisesRegex(WorkspaceError, "control metadata"):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 from concurrent.futures import ThreadPoolExecutor
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -10,6 +11,7 @@ import signal
 import stat
 import subprocess
 import tempfile
+import threading
 import time
 import unittest
 from unittest import mock
@@ -706,6 +708,242 @@ class WorkspaceTests(unittest.TestCase):
         )
         (copied / "README").write_text("changed in view\n", encoding="utf-8")
         self.assertEqual((source / "README").read_text(encoding="utf-8"), "content\n")
+
+    def make_worker_source(self) -> Path:
+        source = self.root / "worker-source"
+        source.mkdir()
+        (source / "package.json").write_text(
+            json.dumps(
+                {
+                    "name": "worker-test",
+                    "version": "1.0.0",
+                    "scripts": {"check": "node check.js"},
+                    "dependencies": {"alpha": "1.0.0"},
+                    "devDependencies": {"@scope/beta": "2.0.0"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        (source / "package-lock.json").write_text(
+            json.dumps(
+                {
+                    "name": "worker-test",
+                    "version": "1.0.0",
+                    "lockfileVersion": 3,
+                    "packages": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+        (source / "worker.ts").write_text("export const value = 1;\n", encoding="utf-8")
+        return source
+
+    @staticmethod
+    def fake_worker_run(
+        installs: list[Path], versions: dict[str, str], install_lock: threading.Lock
+    ):
+        def invoke(
+            arguments: list[str],
+            *,
+            cwd: Path | None = None,
+            capture: bool = False,
+            env: dict[str, str] | None = None,
+            **_kwargs: object,
+        ) -> str:
+            if arguments == ["node", "--version"]:
+                return versions["node"]
+            if arguments == ["npm", "--version"]:
+                return versions["npm"]
+            if arguments == ["npm", "config", "list", "--json"]:
+                return json.dumps(
+                    {
+                        "cache": (env or {}).get("npm_config_cache"),
+                        "ignore-scripts": False,
+                    }
+                )
+            if arguments == ["npm", "ci"]:
+                assert cwd is not None
+                with install_lock:
+                    installs.append(cwd)
+                modules = cwd / "node_modules"
+                (modules / "alpha").mkdir(parents=True)
+                (modules / "@scope" / "beta").mkdir(parents=True)
+                (modules / ".package-lock.json").write_text(
+                    json.dumps(
+                        {
+                            "lockfileVersion": 3,
+                            "packages": {
+                                "node_modules/alpha": {},
+                                "node_modules/@scope/beta": {},
+                            },
+                        }
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+                return ""
+            raise AssertionError(f"unexpected command: {arguments}")
+
+        return invoke
+
+    def test_worker_dependencies_reuse_exact_inputs_and_rebuild_corruption(self) -> None:
+        source = self.make_worker_source()
+        installs: list[Path] = []
+        versions = {"node": "v22.0.0", "npm": "11.0.0"}
+        with mock.patch(
+            "atrinik_workspace.workspace.run",
+            side_effect=self.fake_worker_run(installs, versions, threading.Lock()),
+        ):
+            first = self.workspace._worker_dependencies(source, {"PATH": "/bin"})
+            second = self.workspace._worker_dependencies(source, {"PATH": "/bin"})
+            self.assertFalse(first[3])
+            self.assertTrue(second[3])
+            self.assertEqual(first[1], second[1])
+            self.assertEqual(len(installs), 1)
+
+            (source / "worker.ts").write_text(
+                "export const value = 2;\n", encoding="utf-8"
+            )
+            application_changed = self.workspace._worker_dependencies(
+                source, {"PATH": "/bin"}
+            )
+            self.assertTrue(application_changed[3])
+            self.assertEqual(application_changed[1], first[1])
+            self.assertEqual(len(installs), 1)
+
+            (application_changed[0] / "alpha").rename(
+                application_changed[0] / "alpha-corrupt"
+            )
+            rebuilt = self.workspace._worker_dependencies(source, {"PATH": "/bin"})
+            self.assertFalse(rebuilt[3])
+            self.assertEqual(rebuilt[1], first[1])
+            self.assertEqual(len(installs), 2)
+
+            versions["npm"] = "11.1.0"
+            invalidated = self.workspace._worker_dependencies(
+                source, {"PATH": "/bin"}
+            )
+            self.assertNotEqual(invalidated[1], first[1])
+            self.assertEqual(len(installs), 3)
+
+            (source / ".npmrc").write_text("strict-peer-deps=true\n", encoding="utf-8")
+            config_changed = self.workspace._worker_dependencies(
+                source, {"PATH": "/bin"}
+            )
+            self.assertNotEqual(config_changed[1], invalidated[1])
+            self.assertEqual(len(installs), 4)
+
+            (source / "package-lock.json").write_text(
+                '{"lockfileVersion":3,"changed":true}\n', encoding="utf-8"
+            )
+            lock_changed = self.workspace._worker_dependencies(
+                source, {"PATH": "/bin"}
+            )
+            self.assertNotEqual(lock_changed[1], config_changed[1])
+            self.assertEqual(len(installs), 5)
+
+    def test_worker_root_lifecycle_scripts_key_complete_source(self) -> None:
+        source = self.make_worker_source()
+        package = json.loads((source / "package.json").read_text(encoding="utf-8"))
+        package["scripts"]["postinstall"] = "node worker.ts"
+        (source / "package.json").write_text(json.dumps(package), encoding="utf-8")
+        installs: list[Path] = []
+        versions = {"node": "v22.0.0", "npm": "11.0.0"}
+        with mock.patch(
+            "atrinik_workspace.workspace.run",
+            side_effect=self.fake_worker_run(installs, versions, threading.Lock()),
+        ):
+            environment = {"PATH": "/bin", "BUILD_MODE": "one"}
+            environment["npm_config_cache"] = "/cache"
+            first = self.workspace._worker_dependency_inputs(source, environment)
+            (source / "worker.ts").write_text(
+                "export const value = 2;\n", encoding="utf-8"
+            )
+            second = self.workspace._worker_dependency_inputs(source, environment)
+            changed_environment = dict(environment, BUILD_MODE="two")
+            third = self.workspace._worker_dependency_inputs(
+                source, changed_environment
+            )
+        self.assertEqual(first["root_lifecycle_scripts"], ["postinstall"])
+        self.assertNotEqual(
+            first["root_lifecycle_source_sha256"],
+            second["root_lifecycle_source_sha256"],
+        )
+        self.assertNotEqual(
+            second["environment_sha256"], third["environment_sha256"]
+        )
+
+    def test_worker_dependency_concurrency_installs_once(self) -> None:
+        source = self.make_worker_source()
+        installs: list[Path] = []
+        versions = {"node": "v22.0.0", "npm": "11.0.0"}
+        install_lock = threading.Lock()
+        with mock.patch(
+            "atrinik_workspace.workspace.run",
+            side_effect=self.fake_worker_run(installs, versions, install_lock),
+        ):
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                results = list(
+                    executor.map(
+                        lambda _value: self.workspace._worker_dependencies(
+                            source, {"PATH": "/bin"}
+                        ),
+                        range(2),
+                    )
+                )
+        self.assertEqual(len(installs), 1)
+        self.assertEqual(results[0][1], results[1][1])
+        self.assertEqual(sorted(result[3] for result in results), [False, True])
+
+    def test_worker_view_reuses_application_and_isolates_dependencies(self) -> None:
+        source = self.make_worker_source()
+        dependencies = self.root / "cached-node-modules"
+        (dependencies / "alpha").mkdir(parents=True)
+        (dependencies / "@scope" / "beta").mkdir(parents=True)
+        hidden = dependencies / ".package-lock.json"
+        hidden.write_text(
+            json.dumps(
+                {
+                    "lockfileVersion": 3,
+                    "packages": {
+                        "node_modules/alpha": {},
+                        "node_modules/@scope/beta": {},
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        hidden_digest = hashlib.sha256(hidden.read_bytes()).hexdigest()
+        metadata = {"node_modules_lock_sha256": hidden_digest}
+        root = self.workspace.paths.builds / "profiles" / "worker-test"
+        managed_directory(root, self.workspace.paths.builds, "worker-test")
+
+        first = self.workspace._worker_view(
+            root, source, dependencies, "a" * 64, metadata
+        )
+        second = self.workspace._worker_view(
+            root, source, dependencies, "a" * 64, metadata
+        )
+        self.assertFalse(first[1])
+        self.assertTrue(second[1])
+        (second[0] / "node_modules" / "alpha" / "local").write_text(
+            "profile only\n", encoding="utf-8"
+        )
+        self.assertFalse((dependencies / "alpha" / "local").exists())
+
+        (source / "worker.ts").write_text(
+            "export const value = 2;\n", encoding="utf-8"
+        )
+        changed = self.workspace._worker_view(
+            root, source, dependencies, "a" * 64, metadata
+        )
+        self.assertFalse(changed[1])
+        self.assertEqual(
+            (changed[0] / "worker.ts").read_text(encoding="utf-8"),
+            "export const value = 2;\n",
+        )
+        self.assertFalse((changed[0] / "node_modules" / "alpha" / "local").exists())
 
     def test_resource_view_reserves_generated_metadata_names(self) -> None:
         source = self.workspace.paths.repositories / "resources"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1568,6 +1568,72 @@ class WorkspaceTests(unittest.TestCase):
         self.assertFalse(first[1])
         self.assertTrue(second[1])
         self.assertTrue((second[0] / "src" / "build" / "nested.ts").is_file())
+
+        copied_source = second[0] / "worker.ts"
+        copied_status = copied_source.stat()
+        os.utime(
+            copied_source,
+            ns=(copied_status.st_atime_ns, copied_status.st_mtime_ns + 1),
+        )
+        reconciled_metadata = self.workspace._worker_view(
+            root, source, dependencies, "a" * 64, metadata
+        )
+        self.assertFalse(reconciled_metadata[1])
+        if hasattr(os, "setxattr"):
+            try:
+                os.setxattr(
+                    reconciled_metadata[0] / "worker.ts",
+                    "user.atrinik-view-test",
+                    b"changed",
+                )
+            except OSError:
+                pass
+            else:
+                reconciled_metadata = self.workspace._worker_view(
+                    root, source, dependencies, "a" * 64, metadata
+                )
+                self.assertFalse(reconciled_metadata[1])
+
+        external_metadata = self.root / "matching-worker-view.json"
+        view_metadata = reconciled_metadata[0] / ".atrinik-worker-view.json"
+        shutil.copy2(view_metadata, external_metadata)
+        view_metadata.unlink()
+        view_metadata.symlink_to(external_metadata)
+        reconciled_control = self.workspace._worker_view(
+            root, source, dependencies, "a" * 64, metadata
+        )
+        self.assertFalse(reconciled_control[1])
+        self.assertFalse(
+            (reconciled_control[0] / ".atrinik-worker-view.json").is_symlink()
+        )
+
+        copied_source = reconciled_control[0] / "worker.ts"
+        copied_status = copied_source.stat()
+        os.utime(
+            copied_source,
+            ns=(copied_status.st_atime_ns, copied_status.st_mtime_ns + 1),
+        )
+        self.workspace._reconcile_worker_view_source(
+            source, reconciled_control[0], metadata
+        )
+        reconciled_after_check = self.workspace._worker_view(
+            root, source, dependencies, "a" * 64, metadata
+        )
+        self.assertTrue(reconciled_after_check[1])
+
+        external_marker = self.root / "matching-worker-marker.json"
+        marker = reconciled_after_check[0] / MANAGED_MARKER
+        shutil.copy2(marker, external_marker)
+        marker.unlink()
+        marker.symlink_to(external_marker)
+        with self.assertRaises(WorkspaceError):
+            self.workspace._worker_view(
+                root, source, dependencies, "a" * 64, metadata
+            )
+        self.assertTrue(marker.is_symlink())
+        marker.unlink()
+        shutil.copy2(external_marker, marker)
+
         (second[0] / "node_modules" / "alpha" / "local").write_text(
             "profile only\n", encoding="utf-8"
         )

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -30,6 +30,7 @@ from atrinik_workspace.model import (
 from atrinik_workspace.workspace import (
     WORKER_SOURCE_EXCLUSIONS,
     Workspace,
+    _copy_worker_source as real_copy_worker_source,
     _tree_digest,
     _remote_matches as real_remote_matches,
     display_arguments,
@@ -771,6 +772,15 @@ class WorkspaceTests(unittest.TestCase):
                 assert cwd is not None
                 if not (cwd / "worker.ts").is_file():
                     raise AssertionError("npm lifecycle source was not staged")
+                if (cwd / "worker.ts").stat().st_mtime_ns != 0:
+                    raise AssertionError("lifecycle source metadata was not normalized")
+                npmrc = cwd / ".npmrc"
+                if npmrc.exists():
+                    if (
+                        npmrc.is_symlink()
+                        or stat.S_IMODE(npmrc.stat().st_mode) != 0o600
+                    ):
+                        raise AssertionError("project npm configuration is not isolated")
                 if not (cwd / "src" / "build" / "nested.ts").is_file():
                     raise AssertionError("nested generated-name source was omitted")
                 with install_lock:
@@ -978,6 +988,65 @@ class WorkspaceTests(unittest.TestCase):
                 self.workspace._worker_dependency_inputs(
                     source, {"PATH": "/bin", "npm_config_cache": "/cache"}
                 )
+
+    def test_worker_dependency_keys_file_backed_npm_configuration(self) -> None:
+        source = self.make_worker_source()
+        userconfig = self.root / "user.npmrc"
+        userconfig.write_text(
+            "//registry.example/:_authToken=first\n", encoding="utf-8"
+        )
+        versions = {"node": "v22.0.0", "npm": "11.0.0"}
+        runner = self.fake_worker_run([], versions, threading.Lock())
+
+        def configured_run(arguments: list[str], **kwargs: object) -> str:
+            if arguments == ["npm", "config", "list", "--json"]:
+                return json.dumps({"userconfig": str(userconfig)})
+            return runner(arguments, **kwargs)
+
+        environment = {"PATH": "/bin", "npm_config_cache": "/cache"}
+        with mock.patch(
+            "atrinik_workspace.workspace.run", side_effect=configured_run
+        ):
+            first = self.workspace._worker_dependency_inputs(source, environment)
+            userconfig.write_text(
+                "//registry.example/:_authToken=second\n", encoding="utf-8"
+            )
+            second = self.workspace._worker_dependency_inputs(source, environment)
+        self.assertEqual(first["npm_config_sha256"], second["npm_config_sha256"])
+        self.assertNotEqual(
+            first["npm_file_config_sha256"],
+            second["npm_file_config_sha256"],
+        )
+        self.assertNotIn("_authToken", json.dumps(second))
+
+    def test_worker_dependency_authenticates_staged_source_snapshot(self) -> None:
+        source = self.make_worker_source()
+        versions = {"node": "v22.0.0", "npm": "11.0.0"}
+        installs: list[Path] = []
+
+        def corrupt_copy(*args: object, **kwargs: object) -> None:
+            real_copy_worker_source(*args, **kwargs)
+            destination = args[1]
+            assert isinstance(destination, Path)
+            (destination / "worker.ts").write_text(
+                "mixed snapshot\n", encoding="utf-8"
+            )
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.run",
+                side_effect=self.fake_worker_run(
+                    installs, versions, threading.Lock()
+                ),
+            ),
+            mock.patch(
+                "atrinik_workspace.workspace._copy_worker_source",
+                side_effect=corrupt_copy,
+            ),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "does not match its cache key"):
+                self.workspace._worker_dependencies(source, {"PATH": "/bin"})
+        self.assertEqual(installs, [])
 
     def test_worker_dependency_consumer_holds_key_lock(self) -> None:
         source = self.make_worker_source()
@@ -1225,6 +1294,25 @@ class WorkspaceTests(unittest.TestCase):
         }
         root = self.workspace.paths.builds / "profiles" / "worker-test"
         managed_directory(root, self.workspace.paths.builds, "worker-test")
+
+        def corrupt_copy(*args: object, **kwargs: object) -> None:
+            real_copy_worker_source(*args, **kwargs)
+            destination = args[1]
+            assert isinstance(destination, Path)
+            (destination / "worker.ts").write_text(
+                "mixed view snapshot\n", encoding="utf-8"
+            )
+
+        with mock.patch(
+            "atrinik_workspace.workspace._copy_worker_source",
+            side_effect=corrupt_copy,
+        ):
+            with self.assertRaisesRegex(
+                WorkspaceError, "does not match its fingerprint"
+            ):
+                self.workspace._worker_view(
+                    root, source, dependencies, "a" * 64, metadata
+                )
 
         first = self.workspace._worker_view(
             root, source, dependencies, "a" * 64, metadata

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -29,6 +29,7 @@ from atrinik_workspace.model import (
 )
 from atrinik_workspace.workspace import (
     WORKER_SOURCE_EXCLUSIONS,
+    WORKER_VIEW_NODE_MODULES_EXCLUSIONS,
     Workspace,
     _copy_regular_file as real_copy_regular_file,
     _copy_worker_source as real_copy_worker_source,
@@ -962,6 +963,35 @@ class WorkspaceTests(unittest.TestCase):
             self.assertFalse(rebuilt_link[3])
             self.assertEqual(len(installs), 4)
 
+    def test_worker_dependency_cache_authenticates_copied_metadata(self) -> None:
+        source = self.make_worker_source()
+        installs: list[Path] = []
+        versions = {"node": "v22.0.0", "npm": "11.0.0"}
+        runner = self.fake_worker_run(installs, versions, threading.Lock())
+        with mock.patch("atrinik_workspace.workspace.run", side_effect=runner):
+            first = self.workspace._worker_dependencies(source, {"PATH": "/bin"})
+            installed = first[0] / "alpha" / "bin.js"
+            status = installed.stat()
+            os.utime(
+                installed,
+                ns=(status.st_atime_ns, status.st_mtime_ns + 1),
+            )
+            rebuilt = self.workspace._worker_dependencies(source, {"PATH": "/bin"})
+            self.assertFalse(rebuilt[3])
+            self.assertEqual(len(installs), 2)
+
+            installed = rebuilt[0] / "alpha" / "bin.js"
+            if hasattr(os, "setxattr"):
+                try:
+                    os.setxattr(installed, "user.atrinik-test", b"changed")
+                except OSError:
+                    return
+                rebuilt_xattr = self.workspace._worker_dependencies(
+                    source, {"PATH": "/bin"}
+                )
+                self.assertFalse(rebuilt_xattr[3])
+                self.assertEqual(len(installs), 3)
+
     def test_worker_dependency_failed_rebuild_preserves_owned_cache(self) -> None:
         source = self.make_worker_source()
         installs: list[Path] = []
@@ -1112,6 +1142,40 @@ class WorkspaceTests(unittest.TestCase):
                     WorkspaceError, "custom npm script-shell"
                 ):
                     self.workspace._worker_dependencies(source, environment)
+        self.assertEqual(installs, [])
+
+    def test_worker_dependency_rejects_external_node_preload_options(self) -> None:
+        source = self.make_worker_source()
+        hook = self.root / "node-hook.cjs"
+        environment = {
+            "PATH": "/bin",
+            "NODE_OPTIONS": f"--require={hook}",
+        }
+        with mock.patch(
+            "atrinik_workspace.workspace.run",
+            side_effect=AssertionError("Node must not run with external preload code"),
+        ):
+            for contents in ("module.exports = 1;\n", "module.exports = 2;\n"):
+                hook.write_text(contents, encoding="utf-8")
+                with self.assertRaisesRegex(
+                    WorkspaceError, "custom Node execution options"
+                ):
+                    self.workspace._worker_dependencies(source, environment)
+
+        versions = {"node": "v22.0.0", "npm": "11.0.0"}
+        installs: list[Path] = []
+        runner = self.fake_worker_run(installs, versions, threading.Lock())
+
+        def configured_run(arguments: list[str], **kwargs: object) -> str:
+            if arguments == ["npm", "config", "list", "--json"]:
+                return json.dumps({"node-options": f"--require={hook}"})
+            return runner(arguments, **kwargs)
+
+        with mock.patch(
+            "atrinik_workspace.workspace.run", side_effect=configured_run
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "custom npm node-options"):
+                self.workspace._worker_dependencies(source, {"PATH": "/bin"})
         self.assertEqual(installs, [])
 
     def test_worker_dependency_authenticates_staged_project_npmrc(self) -> None:
@@ -1448,7 +1512,17 @@ class WorkspaceTests(unittest.TestCase):
         metadata = {
             "node_modules_lock_sha256": hidden_digest,
             "node_modules_sha256": _tree_digest(
-                dependencies, set(), bounded_symlinks=True
+                dependencies,
+                set(),
+                bounded_symlinks=True,
+                copied_metadata=True,
+            ),
+            "node_modules_view_sha256": _tree_digest(
+                dependencies,
+                WORKER_VIEW_NODE_MODULES_EXCLUSIONS,
+                bounded_symlinks=True,
+                copied_metadata=True,
+                ignore_root_mtime=True,
             ),
             "inputs": {
                 "lifecycle_source_sha256": _tree_digest(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -45,6 +45,7 @@ from atrinik_workspace.workspace import (
     display_arguments,
     exclusive_lock,
     remove_owned_tree,
+    replace_directory as worker_replace_directory,
     replace_runtime_directory as workspace_replace_directory,
     run as workspace_run,
 )
@@ -867,6 +868,56 @@ class WorkspaceTests(unittest.TestCase):
             raise AssertionError(f"unexpected command: {arguments}")
 
         return invoke
+
+    def test_worker_dependency_publication_revalidates_after_rename(self) -> None:
+        source = self.make_worker_source()
+        installs: list[Path] = []
+        versions = {"node": "v22.0.0", "npm": "11.0.0"}
+
+        def mutate_before_verification(
+            output: Path,
+            staging: Path,
+            backup_prefix: str,
+            backup_parent: Path | None = None,
+            verify_after_install: object = None,
+        ) -> None:
+            assert callable(verify_after_install)
+
+            def corrupt_then_verify() -> None:
+                (output / "node_modules" / "alpha" / "bin.js").write_text(
+                    "post-rename corruption\n", encoding="utf-8"
+                )
+                verify_after_install()
+
+            worker_replace_directory(
+                output,
+                staging,
+                backup_prefix,
+                backup_parent,
+                corrupt_then_verify,
+            )
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.run",
+                side_effect=self.fake_worker_run(
+                    installs, versions, threading.Lock()
+                ),
+            ),
+            mock.patch(
+                "atrinik_workspace.workspace.replace_directory",
+                side_effect=mutate_before_verification,
+            ),
+            self.assertRaisesRegex(WorkspaceError, "published Worker dependencies"),
+        ):
+            self.workspace._worker_dependencies(source, {"PATH": "/bin"})
+        self.assertEqual(len(installs), 1)
+        entries = [
+            path
+            for path in (self.workspace.paths.builds / "worker-dependencies").iterdir()
+            if path.name not in {".transactions", MANAGED_MARKER}
+        ]
+        self.assertEqual(entries, [])
 
     def test_worker_dependencies_reuse_exact_inputs_and_rebuild_corruption(self) -> None:
         source = self.make_worker_source()
@@ -1786,6 +1837,44 @@ class WorkspaceTests(unittest.TestCase):
             WORKER_SOURCE_EXCLUSIONS,
             reject_symlinks=True,
             copied_metadata=True,
+        )
+
+        def corrupt_view_before_verification(
+            output: Path,
+            staging: Path,
+            backup_prefix: str,
+            backup_parent: Path | None = None,
+            verify_after_install: object = None,
+        ) -> None:
+            assert callable(verify_after_install)
+
+            def corrupt_then_verify() -> None:
+                (output / "worker.ts").write_text(
+                    "post-rename corruption\n", encoding="utf-8"
+                )
+                verify_after_install()
+
+            worker_replace_directory(
+                output,
+                staging,
+                backup_prefix,
+                backup_parent,
+                corrupt_then_verify,
+            )
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.replace_directory",
+                side_effect=corrupt_view_before_verification,
+            ),
+            self.assertRaisesRegex(WorkspaceError, "published Worker view"),
+        ):
+            self.workspace._worker_view(
+                root, source, dependencies, "b" * 64, metadata
+            )
+        self.assertEqual(
+            (first[0] / "worker.ts").read_text(encoding="utf-8"),
+            "export const value = 1;\n",
         )
         changed = self.workspace._worker_view(
             root, source, dependencies, "b" * 64, metadata

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -30,6 +30,7 @@ from atrinik_workspace.model import (
 from atrinik_workspace.workspace import (
     WORKER_SOURCE_EXCLUSIONS,
     Workspace,
+    _copy_regular_file as real_copy_regular_file,
     _copy_worker_source as real_copy_worker_source,
     _tree_digest,
     _remote_matches as real_remote_matches,
@@ -772,6 +773,10 @@ class WorkspaceTests(unittest.TestCase):
                 assert cwd is not None
                 if not (cwd / "worker.ts").is_file():
                     raise AssertionError("npm lifecycle source was not staged")
+                if (cwd / "worker.ts").stat().st_atime_ns != 0:
+                    raise AssertionError(
+                        "lifecycle source access time was not normalized"
+                    )
                 npmrc = cwd / ".npmrc"
                 if npmrc.exists():
                     if (
@@ -980,7 +985,6 @@ class WorkspaceTests(unittest.TestCase):
         self.assertNotEqual(
             before, _tree_digest(first, set(), copied_metadata=True)
         )
-
         source = self.make_worker_source()
         (source / "linked.ts").symlink_to("worker.ts")
         versions = {"node": "v22.0.0", "npm": "11.0.0"}
@@ -993,7 +997,7 @@ class WorkspaceTests(unittest.TestCase):
                     source, {"PATH": "/bin", "npm_config_cache": "/cache"}
                 )
 
-    def test_worker_dependency_keys_file_backed_npm_configuration(self) -> None:
+    def test_worker_dependency_rejects_external_npm_configuration(self) -> None:
         source = self.make_worker_source()
         userconfig = self.root / "user.npmrc"
         userconfig.write_text(
@@ -1011,17 +1015,38 @@ class WorkspaceTests(unittest.TestCase):
         with mock.patch(
             "atrinik_workspace.workspace.run", side_effect=configured_run
         ):
-            first = self.workspace._worker_dependency_inputs(source, environment)
-            userconfig.write_text(
-                "//registry.example/:_authToken=second\n", encoding="utf-8"
-            )
-            second = self.workspace._worker_dependency_inputs(source, environment)
-        self.assertEqual(first["npm_config_sha256"], second["npm_config_sha256"])
-        self.assertNotEqual(
-            first["npm_file_config_sha256"],
-            second["npm_file_config_sha256"],
-        )
-        self.assertNotIn("_authToken", json.dumps(second))
+            with self.assertRaisesRegex(
+                WorkspaceError, "external file-backed npm configuration"
+            ):
+                self.workspace._worker_dependency_inputs(source, environment)
+
+    def test_worker_dependency_authenticates_staged_project_npmrc(self) -> None:
+        source = self.make_worker_source()
+        (source / ".npmrc").write_text("strict-peer-deps=true\n", encoding="utf-8")
+        versions = {"node": "v22.0.0", "npm": "11.0.0"}
+        installs: list[Path] = []
+
+        def corrupt_copy(*args: object, **kwargs: object) -> None:
+            real_copy_regular_file(*args, **kwargs)
+            destination = args[1]
+            assert isinstance(destination, Path)
+            destination.write_text("strict-peer-deps=false\n", encoding="utf-8")
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.run",
+                side_effect=self.fake_worker_run(
+                    installs, versions, threading.Lock()
+                ),
+            ),
+            mock.patch(
+                "atrinik_workspace.workspace._copy_regular_file",
+                side_effect=corrupt_copy,
+            ),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "does not match its cache key"):
+                self.workspace._worker_dependencies(source, {"PATH": "/bin"})
+        self.assertEqual(installs, [])
 
     def test_worker_dependency_authenticates_staged_source_snapshot(self) -> None:
         source = self.make_worker_source()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -971,6 +971,32 @@ class WorkspaceTests(unittest.TestCase):
         self.assertTrue(entry.is_dir())
         self.assertFalse(transaction.exists())
 
+    def test_worker_dependency_recovers_unmarked_install_staging(self) -> None:
+        source = self.make_worker_source()
+        installs: list[Path] = []
+        versions = {"node": "v22.0.0", "npm": "11.0.0"}
+        runner = self.fake_worker_run(installs, versions, threading.Lock())
+        with mock.patch("atrinik_workspace.workspace.run", side_effect=runner):
+            first = self.workspace._worker_dependencies(source, {"PATH": "/bin"})
+            entry = first[0].parent
+            staging = (
+                entry.parent
+                / ".transactions"
+                / f"{first[1]}-staging-install"
+            )
+            shutil.rmtree(entry)
+            staging.mkdir()
+            (staging / "partial-install").write_text(
+                "interrupted\n", encoding="utf-8"
+            )
+            recovered = self.workspace._worker_dependencies(
+                source, {"PATH": "/bin"}
+            )
+        self.assertFalse(recovered[3])
+        self.assertEqual(len(installs), 2)
+        self.assertTrue(entry.is_dir())
+        self.assertFalse(staging.exists())
+
     def test_worker_tree_digest_is_canonical_and_lifecycle_rejects_links(self) -> None:
         first = self.root / "tree-first"
         second = self.root / "tree-second"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1582,6 +1582,16 @@ class WorkspaceTests(unittest.TestCase):
         self.assertFalse(first[1])
         self.assertTrue(second[1])
         self.assertTrue((second[0] / "src" / "build" / "nested.ts").is_file())
+        self.workspace._reconcile_worker_view_after_checks(
+            source, second[0], "a" * 64, metadata
+        )
+        unexpected_dependency_output = second[0] / "node_modules" / "alpha" / "changed"
+        unexpected_dependency_output.write_text("changed\n", encoding="utf-8")
+        with self.assertRaisesRegex(WorkspaceError, "does not match cache metadata"):
+            self.workspace._reconcile_worker_view_after_checks(
+                source, second[0], "a" * 64, metadata
+            )
+        unexpected_dependency_output.unlink()
 
         copied_source = second[0] / "worker.ts"
         copied_status = copied_source.stat()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -772,8 +772,6 @@ class WorkspaceTests(unittest.TestCase):
                 assert cwd is not None
                 if not (cwd / "worker.ts").is_file():
                     raise AssertionError("npm lifecycle source was not staged")
-                if (cwd / "worker.ts").stat().st_mtime_ns != 0:
-                    raise AssertionError("lifecycle source metadata was not normalized")
                 npmrc = cwd / ".npmrc"
                 if npmrc.exists():
                     if (
@@ -976,6 +974,12 @@ class WorkspaceTests(unittest.TestCase):
         before = _tree_digest(first, set())
         (first / "a").chmod(0o755)
         self.assertNotEqual(before, _tree_digest(first, set()))
+        before = _tree_digest(first, set(), copied_metadata=True)
+        status = (first / "a").stat()
+        os.utime(first / "a", ns=(status.st_atime_ns, status.st_mtime_ns + 1))
+        self.assertNotEqual(
+            before, _tree_digest(first, set(), copied_metadata=True)
+        )
 
         source = self.make_worker_source()
         (source / "linked.ts").symlink_to("worker.ts")
@@ -1288,7 +1292,10 @@ class WorkspaceTests(unittest.TestCase):
             ),
             "inputs": {
                 "lifecycle_source_sha256": _tree_digest(
-                    source, WORKER_SOURCE_EXCLUSIONS, reject_symlinks=True
+                    source,
+                    WORKER_SOURCE_EXCLUSIONS,
+                    reject_symlinks=True,
+                    copied_metadata=True,
                 )
             },
         }
@@ -1340,7 +1347,10 @@ class WorkspaceTests(unittest.TestCase):
                 root, source, dependencies, "a" * 64, metadata
             )
         metadata["inputs"]["lifecycle_source_sha256"] = _tree_digest(
-            source, WORKER_SOURCE_EXCLUSIONS, reject_symlinks=True
+            source,
+            WORKER_SOURCE_EXCLUSIONS,
+            reject_symlinks=True,
+            copied_metadata=True,
         )
         changed = self.workspace._worker_view(
             root, source, dependencies, "b" * 64, metadata

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -29,6 +29,7 @@ from atrinik_workspace.model import (
 )
 from atrinik_workspace.workspace import (
     Workspace,
+    _tree_digest,
     _remote_matches as real_remote_matches,
     display_arguments,
     exclusive_lock,
@@ -763,11 +764,18 @@ class WorkspaceTests(unittest.TestCase):
                 )
             if arguments == ["npm", "ci"]:
                 assert cwd is not None
+                if not (cwd / "worker.ts").is_file():
+                    raise AssertionError("npm lifecycle source was not staged")
                 with install_lock:
                     installs.append(cwd)
                 modules = cwd / "node_modules"
                 (modules / "alpha").mkdir(parents=True)
+                (modules / "alpha" / "bin.js").write_text(
+                    "console.log('alpha');\n", encoding="utf-8"
+                )
                 (modules / "@scope" / "beta").mkdir(parents=True)
+                (modules / ".bin").mkdir()
+                (modules / ".bin" / "alpha").symlink_to("../alpha/bin.js")
                 (modules / ".package-lock.json").write_text(
                     json.dumps(
                         {
@@ -800,6 +808,7 @@ class WorkspaceTests(unittest.TestCase):
             self.assertTrue(second[3])
             self.assertEqual(first[1], second[1])
             self.assertEqual(len(installs), 1)
+            self.assertFalse((first[0].parent / "worker.ts").exists())
 
             (source / "worker.ts").write_text(
                 "export const value = 2;\n", encoding="utf-8"
@@ -807,31 +816,31 @@ class WorkspaceTests(unittest.TestCase):
             application_changed = self.workspace._worker_dependencies(
                 source, {"PATH": "/bin"}
             )
-            self.assertTrue(application_changed[3])
-            self.assertEqual(application_changed[1], first[1])
-            self.assertEqual(len(installs), 1)
+            self.assertFalse(application_changed[3])
+            self.assertNotEqual(application_changed[1], first[1])
+            self.assertEqual(len(installs), 2)
 
             (application_changed[0] / "alpha").rename(
                 application_changed[0] / "alpha-corrupt"
             )
             rebuilt = self.workspace._worker_dependencies(source, {"PATH": "/bin"})
             self.assertFalse(rebuilt[3])
-            self.assertEqual(rebuilt[1], first[1])
-            self.assertEqual(len(installs), 2)
+            self.assertEqual(rebuilt[1], application_changed[1])
+            self.assertEqual(len(installs), 3)
 
             versions["npm"] = "11.1.0"
             invalidated = self.workspace._worker_dependencies(
                 source, {"PATH": "/bin"}
             )
             self.assertNotEqual(invalidated[1], first[1])
-            self.assertEqual(len(installs), 3)
+            self.assertEqual(len(installs), 4)
 
             (source / ".npmrc").write_text("strict-peer-deps=true\n", encoding="utf-8")
             config_changed = self.workspace._worker_dependencies(
                 source, {"PATH": "/bin"}
             )
             self.assertNotEqual(config_changed[1], invalidated[1])
-            self.assertEqual(len(installs), 4)
+            self.assertEqual(len(installs), 5)
 
             (source / "package-lock.json").write_text(
                 '{"lockfileVersion":3,"changed":true}\n', encoding="utf-8"
@@ -840,7 +849,224 @@ class WorkspaceTests(unittest.TestCase):
                 source, {"PATH": "/bin"}
             )
             self.assertNotEqual(lock_changed[1], config_changed[1])
-            self.assertEqual(len(installs), 5)
+            self.assertEqual(len(installs), 6)
+
+    def test_worker_dependency_cache_preserves_unowned_entries(self) -> None:
+        source = self.make_worker_source()
+        installs: list[Path] = []
+        versions = {"node": "v22.0.0", "npm": "11.0.0"}
+        runner = self.fake_worker_run(installs, versions, threading.Lock())
+        with mock.patch("atrinik_workspace.workspace.run", side_effect=runner):
+            first = self.workspace._worker_dependencies(source, {"PATH": "/bin"})
+            entry = first[0].parent
+            for marker in (None, {"schema_version": 1, "purpose": "unrelated"}):
+                with self.subTest(marker=marker):
+                    shutil.rmtree(entry)
+                    entry.mkdir()
+                    valuable = entry / "valuable.txt"
+                    valuable.write_text("preserve\n", encoding="utf-8")
+                    if marker is not None:
+                        atomic_json(entry / MANAGED_MARKER, marker)
+                    with self.assertRaisesRegex(
+                        WorkspaceError, "unmanaged|marker does not match"
+                    ):
+                        self.workspace._worker_dependencies(source, {"PATH": "/bin"})
+                    self.assertEqual(valuable.read_text(encoding="utf-8"), "preserve\n")
+
+    def test_worker_dependency_cache_authenticates_complete_tree(self) -> None:
+        source = self.make_worker_source()
+        installs: list[Path] = []
+        versions = {"node": "v22.0.0", "npm": "11.0.0"}
+        runner = self.fake_worker_run(installs, versions, threading.Lock())
+        with mock.patch("atrinik_workspace.workspace.run", side_effect=runner):
+            first = self.workspace._worker_dependencies(source, {"PATH": "/bin"})
+            modules = first[0]
+            (modules / "alpha" / "bin.js").write_text(
+                "corrupt\n", encoding="utf-8"
+            )
+            rebuilt_content = self.workspace._worker_dependencies(
+                source, {"PATH": "/bin"}
+            )
+            self.assertFalse(rebuilt_content[3])
+            self.assertEqual(len(installs), 2)
+
+            (modules / "unexpected.txt").write_text("unexpected\n", encoding="utf-8")
+            rebuilt_addition = self.workspace._worker_dependencies(
+                source, {"PATH": "/bin"}
+            )
+            self.assertFalse(rebuilt_addition[3])
+            self.assertEqual(len(installs), 3)
+
+            (modules / "escape").symlink_to("../../outside")
+            rebuilt_link = self.workspace._worker_dependencies(
+                source, {"PATH": "/bin"}
+            )
+            self.assertFalse(rebuilt_link[3])
+            self.assertEqual(len(installs), 4)
+
+    def test_worker_dependency_failed_rebuild_preserves_owned_cache(self) -> None:
+        source = self.make_worker_source()
+        installs: list[Path] = []
+        versions = {"node": "v22.0.0", "npm": "11.0.0"}
+        runner = self.fake_worker_run(installs, versions, threading.Lock())
+        with mock.patch("atrinik_workspace.workspace.run", side_effect=runner):
+            first = self.workspace._worker_dependencies(source, {"PATH": "/bin"})
+        damaged = first[0] / "alpha" / "bin.js"
+        damaged.write_text("valuable-corrupt-state\n", encoding="utf-8")
+
+        def failing_run(arguments: list[str], **kwargs: object) -> str:
+            if arguments == ["npm", "ci"]:
+                raise WorkspaceError("simulated install failure")
+            return runner(arguments, **kwargs)
+
+        with mock.patch("atrinik_workspace.workspace.run", side_effect=failing_run):
+            with self.assertRaisesRegex(WorkspaceError, "simulated install failure"):
+                self.workspace._worker_dependencies(source, {"PATH": "/bin"})
+        self.assertEqual(
+            damaged.read_text(encoding="utf-8"), "valuable-corrupt-state\n"
+        )
+
+    def test_worker_tree_digest_is_canonical_and_lifecycle_rejects_links(self) -> None:
+        first = self.root / "tree-first"
+        second = self.root / "tree-second"
+        first.mkdir()
+        second.mkdir()
+        (first / "a").write_bytes(b"Xf\0b\0Y")
+        (second / "a").write_bytes(b"X")
+        (second / "b").write_bytes(b"Y")
+        self.assertNotEqual(_tree_digest(first, set()), _tree_digest(second, set()))
+        before = _tree_digest(first, set())
+        (first / "a").chmod(0o755)
+        self.assertNotEqual(before, _tree_digest(first, set()))
+
+        source = self.make_worker_source()
+        (source / "linked.ts").symlink_to("worker.ts")
+        versions = {"node": "v22.0.0", "npm": "11.0.0"}
+        with mock.patch(
+            "atrinik_workspace.workspace.run",
+            side_effect=self.fake_worker_run([], versions, threading.Lock()),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "symbolic link"):
+                self.workspace._worker_dependency_inputs(
+                    source, {"PATH": "/bin", "npm_config_cache": "/cache"}
+                )
+
+    def test_worker_dependency_consumer_holds_key_lock(self) -> None:
+        source = self.make_worker_source()
+        versions = {"node": "v22.0.0", "npm": "11.0.0"}
+
+        def consume(_modules: Path, key: str, _metadata: dict[str, object]) -> str:
+            lock = (
+                self.workspace.paths.builds
+                / "locks"
+                / f"worker-dependencies-{key}.lock"
+            )
+            with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                with exclusive_lock(lock, "competing cleanup", nonblocking=True):
+                    self.fail("dependency lease was not held")
+            return "consumed"
+
+        with mock.patch(
+            "atrinik_workspace.workspace.run",
+            side_effect=self.fake_worker_run([], versions, threading.Lock()),
+        ):
+            result = self.workspace._worker_dependencies(
+                source, {"PATH": "/bin"}, consume
+            )
+        self.assertEqual(result[5], "consumed")
+
+    def test_worker_package_and_tool_metadata_fail_closed(self) -> None:
+        source = self.make_worker_source()
+        package_path = source / "package.json"
+        cases = (
+            ([], "root is not an object"),
+            ({"dependencies": []}, "dependencies is invalid"),
+            ({"dependencies": {"../escape": "1"}}, "package name is unsafe"),
+        )
+        for package, message in cases:
+            with self.subTest(message=message):
+                package_path.write_text(json.dumps(package), encoding="utf-8")
+                with self.assertRaisesRegex(WorkspaceError, message):
+                    self.workspace._worker_required_packages(source)
+
+        package_path.write_text(
+            json.dumps({"scripts": {"check": "node check.js"}}), encoding="utf-8"
+        )
+        environment = {"PATH": "/bin", "npm_config_cache": "/cache"}
+
+        def invalid_version(arguments: list[str], **_kwargs: object) -> str:
+            if arguments == ["node", "--version"]:
+                return "v22\ninvalid"
+            return "11.0.0"
+
+        with mock.patch("atrinik_workspace.workspace.run", side_effect=invalid_version):
+            with self.assertRaisesRegex(WorkspaceError, "invalid version"):
+                self.workspace._worker_dependency_inputs(source, environment)
+
+        def invalid_config(arguments: list[str], **_kwargs: object) -> str:
+            if arguments in (["node", "--version"], ["npm", "--version"]):
+                return "v22.0.0"
+            return "not-json"
+
+        with mock.patch("atrinik_workspace.workspace.run", side_effect=invalid_config):
+            with self.assertRaisesRegex(WorkspaceError, "not valid JSON"):
+                self.workspace._worker_dependency_inputs(source, environment)
+
+        package_path.write_text(json.dumps({"scripts": []}), encoding="utf-8")
+        with mock.patch(
+            "atrinik_workspace.workspace.run",
+            side_effect=lambda arguments, **_kwargs: (
+                "{}"
+                if arguments == ["npm", "config", "list", "--json"]
+                else "v22.0.0"
+            ),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "scripts are invalid"):
+                self.workspace._worker_dependency_inputs(source, environment)
+
+    def test_worker_installed_tree_validation_rejects_unsafe_shapes(self) -> None:
+        modules = self.root / "validation-node-modules"
+        with self.assertRaisesRegex(WorkspaceError, "not a regular directory"):
+            self.workspace._validate_worker_node_modules(
+                modules, "0" * 64, "0" * 64, ()
+            )
+        modules.mkdir()
+        hidden = modules / ".package-lock.json"
+
+        def write_hidden(packages: object) -> str:
+            hidden.write_text(json.dumps({"packages": packages}), encoding="utf-8")
+            return hashlib.sha256(hidden.read_bytes()).hexdigest()
+
+        digest = write_hidden({})
+        with self.assertRaisesRegex(WorkspaceError, "installed lockfile does not match"):
+            self.workspace._validate_worker_node_modules(
+                modules, "0" * 64, _tree_digest(modules, set()), ()
+            )
+        digest = write_hidden([])
+        with self.assertRaisesRegex(WorkspaceError, "packages are invalid"):
+            self.workspace._validate_worker_node_modules(
+                modules, digest, _tree_digest(modules, set()), ()
+            )
+        for packages, message in (
+            ({"invalid": {}}, "package path is invalid"),
+            ({"node_modules/../escape": {}}, "package path is unsafe"),
+            ({"node_modules/missing": {}}, "package is missing or unsafe"),
+        ):
+            with self.subTest(message=message):
+                digest = write_hidden(packages)
+                with self.assertRaisesRegex(WorkspaceError, message):
+                    self.workspace._validate_worker_node_modules(
+                        modules, digest, _tree_digest(modules, set()), ()
+                    )
+        digest = write_hidden({})
+        with self.assertRaisesRegex(WorkspaceError, "dependency is missing"):
+            self.workspace._validate_worker_node_modules(
+                modules, digest, _tree_digest(modules, set()), ("required",)
+            )
+        with self.assertRaisesRegex(WorkspaceError, "does not match cache metadata"):
+            self.workspace._validate_worker_node_modules(
+                modules, digest, "0" * 64, ()
+            )
 
     def test_worker_root_lifecycle_scripts_key_complete_source(self) -> None:
         source = self.make_worker_source()
@@ -866,8 +1092,8 @@ class WorkspaceTests(unittest.TestCase):
             )
         self.assertEqual(first["root_lifecycle_scripts"], ["postinstall"])
         self.assertNotEqual(
-            first["root_lifecycle_source_sha256"],
-            second["root_lifecycle_source_sha256"],
+            first["lifecycle_source_sha256"],
+            second["lifecycle_source_sha256"],
         )
         self.assertNotEqual(
             second["environment_sha256"], third["environment_sha256"]
@@ -915,7 +1141,12 @@ class WorkspaceTests(unittest.TestCase):
             encoding="utf-8",
         )
         hidden_digest = hashlib.sha256(hidden.read_bytes()).hexdigest()
-        metadata = {"node_modules_lock_sha256": hidden_digest}
+        metadata = {
+            "node_modules_lock_sha256": hidden_digest,
+            "node_modules_sha256": _tree_digest(
+                dependencies, set(), bounded_symlinks=True
+            ),
+        }
         root = self.workspace.paths.builds / "profiles" / "worker-test"
         managed_directory(root, self.workspace.paths.builds, "worker-test")
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -28,6 +28,7 @@ from atrinik_workspace.model import (
     profile_key,
 )
 from atrinik_workspace.workspace import (
+    WORKER_SOURCE_EXCLUSIONS,
     Workspace,
     _tree_digest,
     _remote_matches as real_remote_matches,
@@ -737,6 +738,10 @@ class WorkspaceTests(unittest.TestCase):
             encoding="utf-8",
         )
         (source / "worker.ts").write_text("export const value = 1;\n", encoding="utf-8")
+        (source / "src" / "build").mkdir(parents=True)
+        (source / "src" / "build" / "nested.ts").write_text(
+            "export const nested = true;\n", encoding="utf-8"
+        )
         return source
 
     @staticmethod
@@ -766,6 +771,8 @@ class WorkspaceTests(unittest.TestCase):
                 assert cwd is not None
                 if not (cwd / "worker.ts").is_file():
                     raise AssertionError("npm lifecycle source was not staged")
+                if not (cwd / "src" / "build" / "nested.ts").is_file():
+                    raise AssertionError("nested generated-name source was omitted")
                 with install_lock:
                     installs.append(cwd)
                 modules = cwd / "node_modules"
@@ -925,6 +932,26 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual(
             damaged.read_text(encoding="utf-8"), "valuable-corrupt-state\n"
         )
+
+    def test_worker_dependency_recovers_interrupted_atomic_backup(self) -> None:
+        source = self.make_worker_source()
+        installs: list[Path] = []
+        versions = {"node": "v22.0.0", "npm": "11.0.0"}
+        runner = self.fake_worker_run(installs, versions, threading.Lock())
+        with mock.patch("atrinik_workspace.workspace.run", side_effect=runner):
+            first = self.workspace._worker_dependencies(source, {"PATH": "/bin"})
+            entry = first[0].parent
+            transaction = (
+                entry.parent
+                / ".transactions"
+                / f"{first[1]}-backup-_interrupted"
+            )
+            entry.rename(transaction)
+            recovered = self.workspace._worker_dependencies(source, {"PATH": "/bin"})
+        self.assertTrue(recovered[3])
+        self.assertEqual(len(installs), 1)
+        self.assertTrue(entry.is_dir())
+        self.assertFalse(transaction.exists())
 
     def test_worker_tree_digest_is_canonical_and_lifecycle_rejects_links(self) -> None:
         first = self.root / "tree-first"
@@ -1146,6 +1173,11 @@ class WorkspaceTests(unittest.TestCase):
             "node_modules_sha256": _tree_digest(
                 dependencies, set(), bounded_symlinks=True
             ),
+            "inputs": {
+                "lifecycle_source_sha256": _tree_digest(
+                    source, WORKER_SOURCE_EXCLUSIONS, reject_symlinks=True
+                )
+            },
         }
         root = self.workspace.paths.builds / "profiles" / "worker-test"
         managed_directory(root, self.workspace.paths.builds, "worker-test")
@@ -1153,11 +1185,16 @@ class WorkspaceTests(unittest.TestCase):
         first = self.workspace._worker_view(
             root, source, dependencies, "a" * 64, metadata
         )
+        (first[0] / "node_modules" / ".vite").mkdir()
+        (first[0] / "node_modules" / ".vite" / "cache").write_text(
+            "profile generated\n", encoding="utf-8"
+        )
         second = self.workspace._worker_view(
             root, source, dependencies, "a" * 64, metadata
         )
         self.assertFalse(first[1])
         self.assertTrue(second[1])
+        self.assertTrue((second[0] / "src" / "build" / "nested.ts").is_file())
         (second[0] / "node_modules" / "alpha" / "local").write_text(
             "profile only\n", encoding="utf-8"
         )
@@ -1166,8 +1203,15 @@ class WorkspaceTests(unittest.TestCase):
         (source / "worker.ts").write_text(
             "export const value = 2;\n", encoding="utf-8"
         )
+        with self.assertRaisesRegex(WorkspaceError, "lifecycle inputs"):
+            self.workspace._worker_view(
+                root, source, dependencies, "a" * 64, metadata
+            )
+        metadata["inputs"]["lifecycle_source_sha256"] = _tree_digest(
+            source, WORKER_SOURCE_EXCLUSIONS, reject_symlinks=True
+        )
         changed = self.workspace._worker_view(
-            root, source, dependencies, "a" * 64, metadata
+            root, source, dependencies, "b" * 64, metadata
         )
         self.assertFalse(changed[1])
         self.assertEqual(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -762,6 +762,19 @@ class WorkspaceTests(unittest.TestCase):
                 return versions["node"]
             if arguments == ["npm", "--version"]:
                 return versions["npm"]
+            if arguments == [
+                "node",
+                "-p",
+                "JSON.stringify({platform:process.platform,arch:process.arch,"
+                "versions:process.versions})",
+            ]:
+                return json.dumps(
+                    {
+                        "platform": versions.get("node_platform", "linux"),
+                        "arch": versions.get("node_architecture", "x64"),
+                        "versions": {"modules": "127", "napi": "10"},
+                    }
+                )
             if arguments == ["npm", "config", "list", "--json"]:
                 return json.dumps(
                     {
@@ -875,6 +888,26 @@ class WorkspaceTests(unittest.TestCase):
             )
             self.assertNotEqual(lock_changed[1], config_changed[1])
             self.assertEqual(len(installs), 6)
+
+    def test_worker_dependency_keys_node_runtime_architecture(self) -> None:
+        source = self.make_worker_source()
+        installs: list[Path] = []
+        versions = {
+            "node": "v22.0.0",
+            "npm": "11.0.0",
+            "node_architecture": "x64",
+        }
+        with mock.patch(
+            "atrinik_workspace.workspace.run",
+            side_effect=self.fake_worker_run(
+                installs, versions, threading.Lock()
+            ),
+        ):
+            first = self.workspace._worker_dependencies(source, {"PATH": "/bin"})
+            versions["node_architecture"] = "arm64"
+            changed = self.workspace._worker_dependencies(source, {"PATH": "/bin"})
+        self.assertNotEqual(first[1], changed[1])
+        self.assertEqual(len(installs), 2)
 
     def test_worker_dependency_cache_preserves_unowned_entries(self) -> None:
         source = self.make_worker_source()
@@ -1050,6 +1083,37 @@ class WorkspaceTests(unittest.TestCase):
             ):
                 self.workspace._worker_dependency_inputs(source, environment)
 
+    def test_worker_dependency_rejects_custom_npm_script_shell(self) -> None:
+        source = self.make_worker_source()
+        script_shell = self.root / "npm-script-shell"
+        script_shell.write_text(
+            "#!/bin/sh\nexec /bin/sh \"$@\"\n", encoding="utf-8"
+        )
+        script_shell.chmod(0o755)
+        versions = {"node": "v22.0.0", "npm": "11.0.0"}
+        installs: list[Path] = []
+        runner = self.fake_worker_run(installs, versions, threading.Lock())
+
+        def configured_run(arguments: list[str], **kwargs: object) -> str:
+            if arguments == ["npm", "config", "list", "--json"]:
+                return json.dumps({"script-shell": str(script_shell)})
+            return runner(arguments, **kwargs)
+
+        environment = {"PATH": "/bin", "npm_config_cache": "/cache"}
+        with mock.patch(
+            "atrinik_workspace.workspace.run", side_effect=configured_run
+        ):
+            for contents in (
+                "#!/bin/sh\nexec /bin/sh \"$@\"\n",
+                "#!/bin/sh\nexit 99\n",
+            ):
+                script_shell.write_text(contents, encoding="utf-8")
+                with self.assertRaisesRegex(
+                    WorkspaceError, "custom npm script-shell"
+                ):
+                    self.workspace._worker_dependencies(source, environment)
+        self.assertEqual(installs, [])
+
     def test_worker_dependency_authenticates_staged_project_npmrc(self) -> None:
         source = self.make_worker_source()
         (source / ".npmrc").write_text("strict-peer-deps=true\n", encoding="utf-8")
@@ -1221,9 +1285,29 @@ class WorkspaceTests(unittest.TestCase):
             with self.assertRaisesRegex(WorkspaceError, "invalid version"):
                 self.workspace._worker_dependency_inputs(source, environment)
 
+        def valid_node_runtime() -> str:
+            return json.dumps(
+                {
+                    "platform": "linux",
+                    "arch": "x64",
+                    "versions": {"modules": "127", "napi": "10"},
+                }
+            )
+
+        def invalid_runtime(arguments: list[str], **_kwargs: object) -> str:
+            if arguments in (["node", "--version"], ["npm", "--version"]):
+                return "v22.0.0"
+            return "not-json"
+
+        with mock.patch("atrinik_workspace.workspace.run", side_effect=invalid_runtime):
+            with self.assertRaisesRegex(WorkspaceError, "runtime identity"):
+                self.workspace._worker_dependency_inputs(source, environment)
+
         def invalid_config(arguments: list[str], **_kwargs: object) -> str:
             if arguments in (["node", "--version"], ["npm", "--version"]):
                 return "v22.0.0"
+            if arguments[:2] == ["node", "-p"]:
+                return valid_node_runtime()
             return "not-json"
 
         with mock.patch("atrinik_workspace.workspace.run", side_effect=invalid_config):
@@ -1236,6 +1320,8 @@ class WorkspaceTests(unittest.TestCase):
             side_effect=lambda arguments, **_kwargs: (
                 "{}"
                 if arguments == ["npm", "config", "list", "--json"]
+                else valid_node_runtime()
+                if arguments[:2] == ["node", "-p"]
                 else "v22.0.0"
             ),
         ):


### PR DESCRIPTION
Closes #327.

## Summary

- reuse a marker-owned Worker dependency installation keyed by exact package metadata, Node/npm/runtime identity, effective npm configuration, and authenticated lifecycle inputs
- copy the authenticated installation into an isolated profile-owned source view, revalidate it after Worker checks, and never let builds mutate the shared cache
- fail closed on ownership or input ambiguity, atomically rebuild corruption with rollback/recovery, and use descriptor- and mount-bounded removal
- refresh last-used metadata and reclaim stale cache/transaction state through preview-first `builds` cleanup with per-key locking
- document deterministic source/dependency invalidation and cover reuse, invalidation, corruption, credentials, concurrency, isolation, recovery, and cleanup

## Coordinates

- Base and merge base: `atrinik/atrinik@main` at `d311e902994ee536dbe4905847ad05f4664794fd`
- Head: `zoeyrose:perf/worker-install-cache` at `d25e8efeef3efc1b39f684d491547346a3bb202d`
- Worktree: `/workspaces/atrinik/workspace/worktrees/atrinik/issue-327-worker-install-cache`
- Commits: `5938b49ae`, `5b54e6657`, `ad4c0e5f9`, `cfde9f47c`, `d6043c06c`, `f6a17eacb`, `a39d25062`, `f39fe9ff0`, `b075cfb14`, `dd28f8907`, `59c33363e`, `385734275`, `023a0cde0`, `fcb95317d`, `6012cd5d6`, `7d72a8412`, `185b0400b`, `e32a47d9d`, `d25e8efee`
- Diff: 7 modified authored files; 3,506 insertions and 50 deletions; no additions, deletions, renames, mode changes, binaries, or unrelated paths

## Validation

- `/workspaces/atrinik/.venv/bin/python -m coverage run -m unittest discover -q` — 432 passed
- `/workspaces/atrinik/.venv/bin/python -m coverage report --show-missing` — 81% total
- `/workspaces/atrinik/.venv/bin/python -m compileall -q atrinik atrinik_workspace tests`
- `/workspaces/atrinik/.venv/bin/python -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate` — 21 components
- `./atrinik supply-chain validate` — 103 dependencies
- `git diff --check`
- `./atrinik cleanup --scope all --older-than 7 --dry-run --json` — 0 candidates, errors, and removals
- three independent whole-diff reviews at the exact head — zero known actionable findings
- latest-head GitHub checks — Integration validation, Conventional PR title, and Codecov patch pass

## Worker verification and measurements

The issue-owned `issue-327-worker-cache` profile selects the clean primary `metaserver-worker` checkout at `ee1218e42f90`. Two complete exact-head builds passed 454 Vitest tests, 49 admin tests, two service-binding tests, type generation/checks, and all three Wrangler dry-run deployments.

| Build phase | New cache entry | Identical repeat |
| --- | ---: | ---: |
| Dependency installation/validation | 6.47 s installed | 1.05 s cached |
| Source-view preparation/validation | 2.97 s prepared | 0.59 s reused |

```sh
cd /workspaces/atrinik/workspace/worktrees/atrinik/issue-327-worker-install-cache
ATRINIK_ISSUE327_MEASUREMENT=final-d25e8efe ./atrinik build metaserver-worker --profile issue-327-worker-cache --test
ATRINIK_ISSUE327_MEASUREMENT=final-d25e8efe ./atrinik build metaserver-worker --profile issue-327-worker-cache --test
./atrinik cleanup --scope all --older-than 7 --dry-run --json
```

The first missing entry reports `installed` and `prepared`; the identical repeat reports `cached` and `reused`. Package, configuration, executable/runtime, platform, lifecycle environment, or authored source changes select another dependency key because enabled dependency lifecycle scripts can observe the complete source. Known generated roots remain profile-local and do not invalidate the immutable shared installation.

This is a replacement Worker build-only change. Game runtime, accounts, scenarios, credentials, services, shutdown, and state reset are not applicable. Preserve profile `issue-327-worker-cache`, build `issue-327-worker-cache-af57af4dcc8c`, the cache state, worktree, and ignored review report while this PR is open. Cleanup requires a separate post-merge request beginning with `./atrinik cleanup --dry-run --json`.
