### PR TITLE
perf(build): reuse local compiler and CMake state

### DIFF
--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -59,8 +59,9 @@ Reclaim review data only through preview-first cleanup:
 ./atrinik cleanup --scope all --older-than 7 --apply
 ```
 
-Default scope covers registered worktrees and marker-owned builds; npm cache is
-opt-in. Text uses IEC sizes; JSON keeps exact bytes. References, ambiguous Git,
+Default scope covers registered worktrees and marker-owned builds; shared npm
+and compiler caches are opt-in. Text uses IEC sizes; JSON keeps exact bytes.
+References, ambiguous Git,
 and unsafe paths/markers protect targets. Only an `atrinik/atrinik@main`
 worktree directly below `build/worktrees/` has the historical-base exception:
 its PR targets `master` and supplies head, base, and merge SHAs; the merge's

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,3 +72,8 @@ classic client and server with `--profile classic --test`. Replacement
 components use their repository-owned aggregate validation today and remain
 inspectable through wrapper manifest/profile contracts until wrapper build
 adapters are implemented.
+
+For CMake/cache changes, also repeat an unchanged build, exercise
+`--force-reconfigure` and `--no-ccache`, inspect `ccache --show-stats` when the
+command is installed, and preview shared-cache retention with
+`./atrinik cleanup --scope compiler-cache --dry-run --json`.

--- a/README.md
+++ b/README.md
@@ -248,8 +248,10 @@ continues to exercise that module's supported standalone FetchContent path.
 
 Managed source views are reconciled in place, so unchanged links and copied
 files retain their identity while changed, retargeted, and stale entries are
-updated without following unsafe symlinks. CMake configuration is skipped only
-when the source-view state and a fingerprint of the generator, CMake/compiler
+updated without following unsafe symlinks. Linked-directory structure and
+symlink targets participate in view identity; a dirty Git source conservatively
+runs configure on every build. CMake configuration is skipped only when the
+source-view state and a fingerprint of the generator, CMake/compiler
 toolchain, cache arguments, test mode, and relevant environment still match.
 Ninja may still run CMake's dependency regeneration during the build. Use
 `--force-reconfigure` to run the explicit configure step regardless. A skip

--- a/README.md
+++ b/README.md
@@ -260,9 +260,12 @@ the shared compiler cache.
 
 When `ccache` is available, native C and C++ builds automatically use the
 marker-owned shared `workspace/build/compiler-cache`, bounded at 5 GiB. Debug
-and source prefixes are normalized across equivalent profile roots. Pass
-`--no-ccache` for an explicit uncached build; an unavailable cache command is
-reported with the same opt-out guidance.
+and source prefixes are normalized across equivalent profile roots when the
+selected environment compiler proves support for the required prefix-map
+switches. Opaque toolchain-selected compilers retain their own flag contract
+instead of receiving incompatible GCC-style switches. Pass `--no-ccache` for
+an explicit uncached build; an unavailable cache command is reported with the
+same opt-out guidance.
 
 Building the Classic server also runs its offline worldmaker and stages the
 generated region-map `.png`/`.def` pairs in the profile build. Generation uses

--- a/README.md
+++ b/README.md
@@ -246,6 +246,20 @@ project, so protocol and libatrinik are compiled once and shared by the client
 and server. A component-specific build such as `build client` or `build server`
 continues to exercise that module's supported standalone FetchContent path.
 
+Managed source views are reconciled in place, so unchanged links and copied
+files retain their identity while changed, retargeted, and stale entries are
+updated without following unsafe symlinks. CMake configuration is skipped only
+when the source-view state and a fingerprint of the generator, CMake/compiler
+toolchain, cache arguments, test mode, and relevant environment still match.
+Ninja may still run CMake's dependency regeneration during the build. Use
+`--force-reconfigure` to run the explicit configure step regardless.
+
+When `ccache` is available, native C and C++ builds automatically use the
+marker-owned shared `workspace/build/compiler-cache`, bounded at 5 GiB. Debug
+and source prefixes are normalized across equivalent profile roots. Pass
+`--no-ccache` for an explicit uncached build; an unavailable cache command is
+reported with the same opt-out guidance.
+
 Building the Classic server also runs its offline worldmaker and stages the
 generated region-map `.png`/`.def` pairs in the profile build. Generation uses
 the selected Classic, `content-1x`, and resource views, so it requires the same
@@ -481,13 +495,13 @@ seven days without changing the filesystem:
 ./atrinik cleanup
 ./atrinik cleanup --dry-run --json
 ./atrinik cleanup --scope worktrees classic-server --older-than 14
-./atrinik cleanup --scope builds --scope npm-cache --older-than 0
+./atrinik cleanup --scope builds --scope npm-cache --scope compiler-cache --older-than 0
 ./atrinik cleanup --scope all --older-than 7 --apply
 ~~~
 
 `--dry-run` is the explicit spelling of the default mode; only `--apply`
 mutates. Repeated `--scope` options combine `worktrees`, `builds`, and the
-opt-in `npm-cache`; `all` selects all three. Positional checkout or logical
+opt-in `npm-cache` and `compiler-cache`; `all` selects all four. Positional checkout or logical
 component names narrow only the worktree inventory and still deduplicate
 aliases to one physical checkout. The special `atrinik` filter selects wrapper
 worktrees. JSON output is stable schema-versioned data and keeps Git/GitHub
@@ -542,10 +556,11 @@ schema 1 and contains exactly `schema_version` plus an absolute `build_roots`
 array. A build sourced from a worktree eligible in the same plan may be
 reclaimed regardless of age unless another protection applies.
 
-The shared `workspace/build/npm-cache` is never part of default cleanup. Its
-explicit scope accepts the exact marker-owned path or the one legacy known
-cache at that fixed location after proving the workspace marker, path shape,
-age, and absence of an active build. Unmarked profile roots, other
+The shared `workspace/build/npm-cache` and `workspace/build/compiler-cache`
+are never part of default cleanup. Their explicit scopes require exact
+marker-owned paths, valid last-use metadata, safe fixed containment, age, and
+absence of an active build. Only the npm path admits one legacy known cache
+after the same proof. Unmarked profile roots, other
 `workspace/build` children, and all remaining mixed top-level `build/`
 entries are report-only `unmanaged-build` items. Deep-review reports, ad hoc
 builds, packages, archives, and unregistered siblings are never recursively

--- a/README.md
+++ b/README.md
@@ -265,9 +265,10 @@ marker-owned shared `workspace/build/compiler-cache`, bounded at 5 GiB. Debug
 and source prefixes are normalized across equivalent profile roots when the
 selected environment compiler proves support for the required prefix-map
 switches. Opaque toolchain-selected compilers retain their own flag contract
-instead of receiving incompatible GCC-style switches. Pass `--no-ccache` for
-an explicit uncached build; an unavailable cache command is reported with the
-same opt-out guidance.
+instead of receiving incompatible GCC-style switches, and retain directory
+hashing so objects with profile-specific debug paths cannot cross profile
+roots. Pass `--no-ccache` for an explicit uncached build; an unavailable cache
+command is reported with the same opt-out guidance.
 
 Building the Classic server also runs its offline worldmaker and stages the
 generated region-map `.png`/`.def` pairs in the profile build. Generation uses

--- a/README.md
+++ b/README.md
@@ -252,7 +252,11 @@ updated without following unsafe symlinks. CMake configuration is skipped only
 when the source-view state and a fingerprint of the generator, CMake/compiler
 toolchain, cache arguments, test mode, and relevant environment still match.
 Ninja may still run CMake's dependency regeneration during the build. Use
-`--force-reconfigure` to run the explicit configure step regardless.
+`--force-reconfigure` to run the explicit configure step regardless. A skip
+also requires the expected CMake cache and Ninja graph to identify the current
+source and generator. Compiler, toolchain-file, or initialization-environment
+changes safely reinitialize only that marker-owned binary tree while retaining
+the shared compiler cache.
 
 When `ccache` is available, native C and C++ builds automatically use the
 marker-owned shared `workspace/build/compiler-cache`, bounded at 5 GiB. Debug

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -2040,8 +2040,13 @@ class Cleanup:
                 item["error"] = str(error)
                 used_at = None
         else:
-            used_at = observed
-            item["age_basis"] = "legacy-tree-mtime"
+            if legacy_allowed:
+                used_at = observed
+                item["age_basis"] = "legacy-tree-mtime"
+            else:
+                used_at = None
+                item["reasons"].append("invalid_cache_metadata")
+                item["error"] = f"cache metadata is missing: {metadata_path}"
         if used_at is None:
             item["reasons"].append("cache_age_unavailable")
         else:

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -25,6 +25,8 @@ from .workspace import (
     BUILD_METADATA,
     BUILD_METADATA_SCHEMA_VERSION,
     CACHE_METADATA,
+    COMPILER_CACHE_MAX_SIZE,
+    COMPILER_CACHE_PURPOSE,
     _remote_matches,
     exclusive_lock,
 )
@@ -32,7 +34,7 @@ from .workspace import (
 
 CLEANUP_SCHEMA_VERSION = 1
 DEFAULT_SCOPES = ("worktrees", "builds")
-ALL_SCOPES = (*DEFAULT_SCOPES, "npm-cache")
+ALL_SCOPES = (*DEFAULT_SCOPES, "npm-cache", "compiler-cache")
 BUILD_RETENTION_RECORD = "retention.json"
 BUILD_METADATA_KEYS = {
     "schema_version",
@@ -445,6 +447,12 @@ class Cleanup:
             cache = self._npm_cache(older_than_days, references, reference_errors)
             if cache is not None:
                 items.append(cache)
+        if "compiler-cache" in scopes:
+            cache = self._compiler_cache(
+                older_than_days, references, reference_errors
+            )
+            if cache is not None:
+                items.append(cache)
         items.sort(key=lambda item: (item["kind"], item["owner"], item["path"]))
         self._credit_sizes(items)
         for item in items:
@@ -520,8 +528,11 @@ class Cleanup:
                 references,
                 reference_errors,
             )
-        elif kind == "npm-cache":
-            item = self._npm_cache(
+        elif kind in {"npm-cache", "compiler-cache"}:
+            cache_method = (
+                self._npm_cache if kind == "npm-cache" else self._compiler_cache
+            )
+            item = cache_method(
                 older_than_days,
                 references,
                 reference_errors,
@@ -1896,7 +1907,7 @@ class Cleanup:
         if self.paths.builds.is_dir() and not self.paths.builds.is_symlink():
             try:
                 for path in sorted(self.paths.builds.iterdir()):
-                    if path.name in {"profiles", "npm-cache"}:
+                    if path.name in {"profiles", "npm-cache", "compiler-cache"}:
                         continue
                     roots.append((path, []))
             except OSError:
@@ -1922,11 +1933,42 @@ class Cleanup:
         references: dict[str, Any],
         reference_errors: set[str],
     ) -> dict[str, Any] | None:
-        path = self.paths.builds / "npm-cache"
+        return self._shared_cache(
+            "npm-cache",
+            "npm-cache",
+            older_than_days,
+            reference_errors,
+            legacy_allowed=True,
+        )
+
+    def _compiler_cache(
+        self,
+        older_than_days: int,
+        references: dict[str, Any],
+        reference_errors: set[str],
+    ) -> dict[str, Any] | None:
+        return self._shared_cache(
+            "compiler-cache",
+            COMPILER_CACHE_PURPOSE,
+            older_than_days,
+            reference_errors,
+            legacy_allowed=False,
+        )
+
+    def _shared_cache(
+        self,
+        kind: str,
+        purpose: str,
+        older_than_days: int,
+        reference_errors: set[str],
+        *,
+        legacy_allowed: bool,
+    ) -> dict[str, Any] | None:
+        path = self.paths.builds / kind
         if not path.exists() and not path.is_symlink():
             return None
-        item = _base_item("npm-cache", "atrinik", "atrinik/atrinik", path)
-        item["_purpose"] = "npm-cache"
+        item = _base_item(kind, "atrinik", "atrinik/atrinik", path)
+        item["_purpose"] = purpose
         if self.paths.builds.is_symlink() or not self.paths.builds.is_dir():
             item["reasons"] = ["invalid_cache_path"]
             item["legacy_known_cache"] = False
@@ -1946,21 +1988,21 @@ class Cleanup:
                 and not path.is_symlink()
                 and path.is_dir()
                 and path.resolve(strict=False)
-                == self.paths.builds.resolve(strict=False) / "npm-cache"
+                == self.paths.builds.resolve(strict=False) / kind
             )
         except (OSError, RuntimeError):
             valid_path = False
         if not valid_path:
             item["reasons"].append("invalid_cache_path")
         marker = path / MANAGED_MARKER
-        legacy = not marker.exists() and not marker.is_symlink()
+        legacy = legacy_allowed and not marker.exists() and not marker.is_symlink()
         if not legacy:
             try:
                 if marker.is_symlink() or load_json(marker) != {
                     "schema_version": SCHEMA_VERSION,
-                    "purpose": "npm-cache",
+                    "purpose": purpose,
                 }:
-                    raise WorkspaceError("npm cache marker is invalid")
+                    raise WorkspaceError(f"{kind} marker is invalid")
             except WorkspaceError as error:
                 item["reasons"].append("invalid_managed_marker")
                 item["error"] = str(error)
@@ -1977,11 +2019,18 @@ class Cleanup:
                 if metadata_path.is_symlink() or not metadata_path.is_file():
                     raise WorkspaceError("cache metadata is not a regular file")
                 metadata = load_json(metadata_path)
+                expected_fields = {"schema_version", "purpose", "last_used_at"}
+                if kind == "compiler-cache":
+                    expected_fields.add("max_size")
                 if (
                     not isinstance(metadata, dict)
-                    or set(metadata) != {"schema_version", "purpose", "last_used_at"}
+                    or set(metadata) != expected_fields
                     or metadata.get("schema_version") != BUILD_METADATA_SCHEMA_VERSION
-                    or metadata.get("purpose") != "npm-cache"
+                    or metadata.get("purpose") != purpose
+                    or (
+                        kind == "compiler-cache"
+                        and metadata.get("max_size") != COMPILER_CACHE_MAX_SIZE
+                    )
                 ):
                     raise WorkspaceError("cache metadata fields are invalid")
                 used_at = _parse_time(metadata["last_used_at"], "cache last_used_at")
@@ -2005,7 +2054,7 @@ class Cleanup:
         item["reasons"] = sorted(set(item["reasons"]))
         if not item["reasons"]:
             item["disposition"] = "eligible"
-            item["reasons"] = ["stale_npm_cache"]
+            item["reasons"] = [f"stale_{kind.replace('-', '_')}"]
         return item
 
     def _any_build_lock_busy(self) -> tuple[bool, str | None]:
@@ -2061,6 +2110,7 @@ class Cleanup:
             "profile-build": 0,
             "worktree": 1,
             "npm-cache": 2,
+            "compiler-cache": 2,
             "prunable-metadata": 3,
         }
         return order.get(item["kind"], 99), item["path"]
@@ -2082,16 +2132,17 @@ class Cleanup:
         elif item["kind"] == "worktree":
             primary = self._repositories[item["owner"]]
             _command(primary, "worktree", "remove", "--", str(path))
-        elif item["kind"] == "npm-cache":
+        elif item["kind"] in {"npm-cache", "compiler-cache"}:
+            purpose = item["kind"]
             if item.get("legacy_known_cache"):
                 marker = path / MANAGED_MARKER
                 if marker.exists() or marker.is_symlink():
                     raise WorkspaceError("legacy npm cache marker appeared before removal")
                 atomic_json(
                     marker,
-                    {"schema_version": SCHEMA_VERSION, "purpose": "npm-cache"},
+                    {"schema_version": SCHEMA_VERSION, "purpose": purpose},
                 )
-            managed_remove(path, self.paths.builds, "npm-cache")
+            managed_remove(path, self.paths.builds, purpose)
         elif item["kind"] == "prunable-metadata":
             primary = self._repositories[item["owner"]]
             _command(primary, "worktree", "prune", "--expire", "now")

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -166,7 +166,7 @@ def parser() -> argparse.ArgumentParser:
     cleanup.add_argument(
         "--scope",
         action="append",
-        choices=["worktrees", "builds", "npm-cache", "all"],
+        choices=["worktrees", "builds", "npm-cache", "compiler-cache", "all"],
         default=[],
     )
     mark(cleanup.add_argument("--older-than", type=int, default=7, metavar="DAYS"), "none")
@@ -201,6 +201,16 @@ def parser() -> argparse.ArgumentParser:
     mark(build.add_argument("target", help="all or a component name"), "build_target")
     mark(build.add_argument("--profile", default="default"), "profile")
     build.add_argument("--test", action="store_true")
+    build.add_argument(
+        "--force-reconfigure",
+        action="store_true",
+        help="run CMake configure even when its managed fingerprint is unchanged",
+    )
+    build.add_argument(
+        "--no-ccache",
+        action="store_true",
+        help="disable automatic C/C++ compiler caching",
+    )
 
     topology = commands.add_parser(
         "topology", help="inspect a resolved multi-component topology"
@@ -597,7 +607,15 @@ def main(arguments: list[str] | None = None) -> int:
         elif options.command == "path":
             print(workspace.component_path(options.component, options.profile))
         elif options.command == "build":
-            print(workspace.build(options.target, options.profile, options.test))
+            print(
+                workspace.build(
+                    options.target,
+                    options.profile,
+                    options.test,
+                    force_reconfigure=options.force_reconfigure,
+                    use_ccache=not options.no_ccache,
+                )
+            )
         elif options.command == "topology":
             summary = workspace.topology_summary(
                 options.profile, options.state, options.service

--- a/atrinik_workspace/model.py
+++ b/atrinik_workspace/model.py
@@ -1092,13 +1092,42 @@ class Paths:
                 os.close(descriptor)
 
 
+def _managed_path_no_symlinks(path: Path, workspace_builds: Path) -> Path:
+    if workspace_builds.exists() or workspace_builds.is_symlink():
+        if workspace_builds.is_symlink() or not workspace_builds.is_dir():
+            raise WorkspaceError(
+                f"workspace builds path is not a regular directory: {workspace_builds}"
+            )
+    builds = Path(os.path.abspath(workspace_builds))
+    candidate = Path(os.path.abspath(path))
+    try:
+        relative = candidate.relative_to(builds)
+    except ValueError as error:
+        raise WorkspaceError(
+            f"managed build path is outside workspace builds: {candidate}"
+        ) from error
+    current = builds
+    for part in relative.parts:
+        current /= part
+        try:
+            mode = current.lstat().st_mode
+        except FileNotFoundError:
+            break
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot inspect managed build path {current}: {error}"
+            ) from error
+        if stat.S_ISLNK(mode):
+            raise WorkspaceError(f"refusing symlinked managed build path: {current}")
+        if current != candidate and not stat.S_ISDIR(mode):
+            raise WorkspaceError(
+                f"managed build parent is not a directory: {current}"
+            )
+    return candidate
+
+
 def managed_reset(path: Path, workspace_builds: Path, purpose: str) -> None:
-    builds = workspace_builds.resolve()
-    if path.is_symlink():
-        raise WorkspaceError(f"refusing symlinked managed build path: {path}")
-    path = path.parent.resolve() / path.name
-    if builds not in path.parents:
-        raise WorkspaceError(f"refusing to replace path outside workspace builds: {path}")
+    path = _managed_path_no_symlinks(path, workspace_builds)
     marker = path / MANAGED_MARKER
     if path.exists():
         if not path.is_dir() or not marker.is_file() or marker.is_symlink():
@@ -1112,12 +1141,7 @@ def managed_reset(path: Path, workspace_builds: Path, purpose: str) -> None:
 
 
 def managed_directory(path: Path, workspace_builds: Path, purpose: str) -> None:
-    builds = workspace_builds.resolve()
-    if path.is_symlink():
-        raise WorkspaceError(f"refusing symlinked managed build path: {path}")
-    path = path.parent.resolve() / path.name
-    if builds != path and builds not in path.parents:
-        raise WorkspaceError(f"refusing build path outside workspace builds: {path}")
+    path = _managed_path_no_symlinks(path, workspace_builds)
     marker = path / MANAGED_MARKER
     if path.exists():
         if not path.is_dir() or not marker.is_file() or marker.is_symlink():
@@ -1137,12 +1161,7 @@ def managed_remove(path: Path, workspace_builds: Path, purpose: str) -> None:
         raise WorkspaceError(
             f"workspace builds path is not a regular directory: {workspace_builds}"
         )
-    builds = workspace_builds.resolve()
-    if path.is_symlink():
-        raise WorkspaceError(f"refusing symlinked managed build path: {path}")
-    path = path.parent.resolve() / path.name
-    if builds not in path.parents:
-        raise WorkspaceError(f"refusing to remove path outside workspace builds: {path}")
+    path = _managed_path_no_symlinks(path, workspace_builds)
     marker = path / MANAGED_MARKER
     if not path.is_dir() or not marker.is_file() or marker.is_symlink():
         raise WorkspaceError(f"refusing to remove unmanaged build path: {path}")

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -35,6 +35,7 @@ from .model import (
     WorkspaceError,
     atomic_json,
     load_json,
+    _managed_path_no_symlinks,
     managed_directory,
     managed_reset,
     profile_key,
@@ -1602,6 +1603,7 @@ class Workspace:
                         entry,
                         destination,
                         entry,
+                        source,
                         exclusions if copy_all else set(),
                     )
                 elif stat.S_ISREG(mode):
@@ -1741,6 +1743,7 @@ class Workspace:
         source: Path,
         destination: Path,
         root: Path,
+        safety_root: Path,
         exclusions: set[str],
     ) -> str:
         if destination.is_symlink() or (destination.exists() and not destination.is_dir()):
@@ -1770,7 +1773,7 @@ class Workspace:
                 digest.update(b"\0directory\0")
                 digest.update(
                     self._reconcile_source_tree(
-                        entry, output, root, exclusions
+                        entry, output, root, safety_root, exclusions
                     ).encode()
                 )
             elif stat.S_ISREG(mode):
@@ -1804,7 +1807,7 @@ class Workspace:
                     self._remove_source_view_entry(output)
                     shutil.copy2(entry, output, follow_symlinks=False)
             elif stat.S_ISLNK(mode):
-                self._validate_source_symlink(entry, root)
+                self._validate_source_symlink(entry, safety_root)
                 target = os.readlink(entry)
                 digest.update(b"\0symlink\0")
                 digest.update(target.encode())
@@ -2055,6 +2058,9 @@ class Workspace:
             previous.get("build_tree_identity")
             != fingerprint["build_tree_identity"]
         )
+        toolchain_identity = fingerprint["build_tree_identity"]["toolchain_file"]
+        if toolchain_identity is not None and not toolchain_identity["complete"]:
+            build_tree_changed = True
         if build_tree_changed or not self._cmake_state_valid(source, binary):
             managed_reset(binary, self.paths.builds, "cmake-binary")
             configured = False
@@ -2064,6 +2070,9 @@ class Workspace:
             or not configured
         ):
             run(configure, env=environment)
+            fingerprint = self._configure_fingerprint(
+                source, binary, configure, tests, environment, ccache
+            )
             atomic_json(metadata_path, fingerprint)
         else:
             print(f"cmake: configure unchanged for {binary}; skipping", file=sys.stderr)
@@ -2075,14 +2084,7 @@ class Workspace:
             )
 
     def _prepare_cmake_binary(self, binary: Path) -> None:
-        if binary.is_symlink():
-            raise WorkspaceError(f"refusing symlinked CMake binary path: {binary}")
-        resolved_binary = binary.parent.resolve() / binary.name
-        builds = self.paths.builds.resolve()
-        if builds not in resolved_binary.parents:
-            raise WorkspaceError(
-                f"refusing CMake binary path outside workspace builds: {binary}"
-            )
+        binary = _managed_path_no_symlinks(binary, self.paths.builds)
         marker = binary / MANAGED_MARKER
         if not binary.exists():
             managed_directory(binary, self.paths.builds, "cmake-binary")
@@ -2141,7 +2143,17 @@ class Workspace:
             cached_source = Path(values["source"]).resolve(strict=True)
         except (KeyError, OSError, RuntimeError, UnicodeError):
             return False
-        return cached_source == source.resolve() and values.get("generator") == "Ninja"
+        if cached_source != source.resolve() or values.get("generator") != "Ninja":
+            return False
+        try:
+            graph = run(
+                ["ninja", "-C", str(binary), "-t", "query", "build.ninja"],
+                capture=True,
+                trace=False,
+            )
+        except WorkspaceError:
+            return False
+        return graph.startswith("build.ninja:\n  input: RERUN_CMAKE")
 
     @staticmethod
     def _add_debug_prefix_environment(
@@ -2150,14 +2162,15 @@ class Workspace:
         source_path = source.resolve()
         binary_path = binary.resolve()
         relative_source = os.path.relpath(source_path, binary_path)
-        mappings = (
-            f"-fdebug-prefix-map={source_path}=/atrinik/source "
-            f"-ffile-prefix-map={source_path}=/atrinik/source "
-            f"-fdebug-prefix-map={relative_source}=/atrinik/source "
-            f"-ffile-prefix-map={relative_source}=/atrinik/source "
-            f"-fdebug-prefix-map={binary_path}=/atrinik/build "
-            f"-ffile-prefix-map={binary_path}=/atrinik/build"
+        options = (
+            f"-fdebug-prefix-map={source_path}=/atrinik/source",
+            f"-ffile-prefix-map={source_path}=/atrinik/source",
+            f"-fdebug-prefix-map={relative_source}=/atrinik/source",
+            f"-ffile-prefix-map={relative_source}=/atrinik/source",
+            f"-fdebug-prefix-map={binary_path}=/atrinik/build",
+            f"-ffile-prefix-map={binary_path}=/atrinik/build",
         )
+        mappings = " ".join(shlex.quote(option) for option in options)
         environment["CFLAGS"] = " ".join(
             filter(None, (environment.get("CFLAGS", ""), mappings))
         )
@@ -2173,7 +2186,16 @@ class Workspace:
             words = [command]
         executable = shutil.which(words[0]) if words else None
         version = None
+        resolved = None
+        sha256 = None
         if executable is not None:
+            try:
+                resolved_path = Path(executable).resolve(strict=True)
+                resolved = str(resolved_path)
+                if resolved_path.is_file():
+                    sha256 = hashlib.sha256(resolved_path.read_bytes()).hexdigest()
+            except (OSError, RuntimeError):
+                pass
             try:
                 output = run(
                     [executable, *words[1:], "--version"],
@@ -2187,7 +2209,13 @@ class Workspace:
                 )
             except WorkspaceError as error:
                 version = f"unavailable: {error}"
-        return {"command": command, "path": executable, "version": version}
+        return {
+            "command": command,
+            "path": executable,
+            "resolved_path": resolved,
+            "sha256": sha256,
+            "version": version,
+        }
 
     def _configure_fingerprint(
         self,
@@ -2267,6 +2295,7 @@ class Workspace:
             "-DCMAKE_C_COMPILER=",
             "-DCMAKE_CXX_COMPILER=",
             "-DCMAKE_TOOLCHAIN_FILE=",
+            "-DCMAKE_TOOLCHAIN_FILE:FILEPATH=",
             "-DCMAKE_GENERATOR_PLATFORM=",
             "-DCMAKE_GENERATOR_TOOLSET=",
             "-DCMAKE_SYSROOT=",
@@ -2276,6 +2305,7 @@ class Workspace:
             "generator_tool": generator_tool,
             "cmake": cmake_tool,
             "compilers": compilers,
+            "configured_toolchain": self._cmake_configured_toolchain(binary),
             "environment": initialization_environment,
             "arguments": [
                 argument
@@ -2310,8 +2340,8 @@ class Workspace:
             ),
         }
 
-    @staticmethod
     def _cmake_toolchain_identity(
+        self,
         source: Path,
         binary: Path,
         configure: list[str],
@@ -2328,20 +2358,167 @@ class Workspace:
         if not value:
             return None
         raw = Path(value)
-        candidates = (
-            (raw,) if raw.is_absolute() else (binary / raw, source / raw)
-        )
+        candidates = (raw,) if raw.is_absolute() else (binary / raw, source / raw)
         for candidate in candidates:
             try:
-                if candidate.is_file() and not candidate.is_symlink():
-                    return {
-                        "value": value,
-                        "path": str(candidate.resolve()),
-                        "sha256": hashlib.sha256(candidate.read_bytes()).hexdigest(),
-                    }
-            except OSError:
+                resolved = candidate.resolve(strict=True)
+                if resolved.is_file() and not resolved.is_symlink():
+                    return self._cmake_toolchain_closure(value, candidate, resolved)
+            except (OSError, RuntimeError):
                 continue
-        return {"value": value, "path": None, "sha256": None}
+        return {
+            "value": value,
+            "path": None,
+            "files": [],
+            "complete": False,
+        }
+
+    @staticmethod
+    def _cmake_toolchain_closure(
+        value: str, requested: Path, resolved: Path
+    ) -> dict[str, Any]:
+        records: list[dict[str, Any]] = []
+        seen: set[Path] = set()
+        complete = True
+
+        def visit(path: Path, requested_path: Path) -> None:
+            nonlocal complete
+            try:
+                target = path.resolve(strict=True)
+            except (OSError, RuntimeError):
+                records.append(
+                    {
+                        "requested": str(requested_path),
+                        "path": None,
+                        "sha256": None,
+                    }
+                )
+                complete = False
+                return
+            if target in seen:
+                return
+            seen.add(target)
+            try:
+                data = target.read_bytes()
+                text = data.decode("utf-8")
+            except (OSError, UnicodeError):
+                records.append(
+                    {
+                        "requested": str(requested_path),
+                        "path": str(target),
+                        "sha256": None,
+                    }
+                )
+                complete = False
+                return
+            records.append(
+                {
+                    "requested": str(requested_path),
+                    "path": str(target),
+                    "symlink": (
+                        os.readlink(requested_path)
+                        if requested_path.is_symlink()
+                        else None
+                    ),
+                    "sha256": hashlib.sha256(data).hexdigest(),
+                }
+            )
+            if re.search(
+                r"(?im)^\s*(?:find_package|add_subdirectory|cmake_language)\s*\(",
+                text,
+            ):
+                complete = False
+            pattern = re.compile(
+                r"(?im)^\s*include\s*\(\s*(?:\"([^\"]+)\"|'([^']+)'|([^\s\)]+))"
+            )
+            for match in pattern.finditer(text):
+                included = next(group for group in match.groups() if group is not None)
+                if "$" in included:
+                    complete = False
+                    continue
+                child = Path(included)
+                if not child.is_absolute():
+                    child = target.parent / child
+                candidates = (child, child.with_suffix(".cmake"))
+                selected = next(
+                    (candidate for candidate in candidates if candidate.exists()),
+                    None,
+                )
+                if selected is None:
+                    records.append(
+                        {
+                            "requested": str(child),
+                            "path": None,
+                            "sha256": None,
+                        }
+                    )
+                    complete = False
+                    continue
+                visit(selected, child)
+
+        visit(resolved, requested)
+        return {
+            "value": value,
+            "path": str(resolved),
+            "files": records,
+            "complete": complete,
+        }
+
+    def _cmake_configured_toolchain(self, binary: Path) -> dict[str, Any] | None:
+        cache = binary / "CMakeCache.txt"
+        if cache.is_symlink() or not cache.is_file():
+            return None
+        values: dict[str, str] = {}
+        names = {
+            "CMAKE_C_COMPILER",
+            "CMAKE_CXX_COMPILER",
+            "CMAKE_C_COMPILER_TARGET",
+            "CMAKE_CXX_COMPILER_TARGET",
+            "CMAKE_SYSROOT",
+            "CMAKE_OSX_SYSROOT",
+        }
+        try:
+            for line in cache.read_text(encoding="utf-8").splitlines():
+                if "=" not in line or ":" not in line.split("=", 1)[0]:
+                    continue
+                key, value = line.split("=", 1)
+                name = key.split(":", 1)[0]
+                if name in names:
+                    values[name] = value
+            # CMake does not consistently expose the selected compiler as a
+            # cache entry.  Its generated platform files are the authoritative
+            # record after language detection, including toolchain-selected
+            # compilers.
+            compiler_patterns = {
+                "CMAKE_C_COMPILER": "CMakeCCompiler.cmake",
+                "CMAKE_CXX_COMPILER": "CMakeCXXCompiler.cmake",
+            }
+            for name, filename in compiler_patterns.items():
+                matches = sorted((binary / "CMakeFiles").glob(f"*/{filename}"))
+                if not matches:
+                    continue
+                compiler_file = matches[-1]
+                if compiler_file.is_symlink() or not compiler_file.is_file():
+                    return {"valid": False}
+                pattern = re.compile(
+                    rf'^set\({re.escape(name)}\s+"([^"]*)"\)\s*$'
+                )
+                for line in compiler_file.read_text(encoding="utf-8").splitlines():
+                    match = pattern.match(line)
+                    if match:
+                        values[name] = match.group(1)
+                        break
+        except (OSError, UnicodeError):
+            return {"valid": False}
+        return {
+            "valid": True,
+            "values": values,
+            "compilers": {
+                name: self._tool_identity(values[name])
+                for name in ("CMAKE_C_COMPILER", "CMAKE_CXX_COMPILER")
+                if values.get(name)
+            },
+        }
 
     def _cmake_source_identity(self, source: Path) -> dict[str, Any]:
         source_metadata = source / SOURCE_VIEW_METADATA

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -1581,6 +1581,10 @@ class Workspace:
             SOURCE_VIEW_METADATA,
         }
         copied_directories = copied_directories or set()
+        try:
+            source_clean: bool | None = _is_clean(source, trace=False)
+        except WorkspaceError:
+            source_clean = None
         expected: dict[str, dict[str, Any]] = {}
         for entry in sorted(source.iterdir(), key=lambda path: path.name):
             if entry.name in exclusions:
@@ -1642,18 +1646,38 @@ class Workspace:
                     ) from error
                 if stat.S_ISLNK(mode):
                     self._validate_source_symlink(entry, source)
+                    source_symlinks = {".": os.readlink(entry)}
+                    source_structure = hashlib.sha256(
+                        f"symlink:{os.readlink(entry)}".encode()
+                    ).hexdigest()
                 elif not (stat.S_ISREG(mode) or stat.S_ISDIR(mode)):
                     raise WorkspaceError(
                         f"source-view input is not a file or directory: {entry}"
                     )
                 elif stat.S_ISDIR(mode):
-                    self._validate_source_tree_symlinks(entry, source)
+                    source_symlinks, source_structure = (
+                        self._validate_source_tree_symlinks(
+                            entry, source, hash_contents=source_clean is None
+                        )
+                    )
+                else:
+                    source_symlinks = {}
+                    source_structure = (
+                        hashlib.sha256(entry.read_bytes()).hexdigest()
+                        if source_clean is None
+                        else f"file:{stat.S_IMODE(mode):o}"
+                    )
                 target = str(entry)
                 if not destination.is_symlink() or os.readlink(destination) != target:
                     self._source_view_changed = True
                     self._remove_source_view_entry(destination)
                     destination.symlink_to(target, target_is_directory=stat.S_ISDIR(mode))
-                expected[entry.name] = {"kind": "link", "target": target}
+                expected[entry.name] = {
+                    "kind": "link",
+                    "target": target,
+                    "source_symlinks": source_symlinks,
+                    "source_structure": source_structure,
+                }
         reserved = {
             MANAGED_MARKER,
             SOURCE_VIEW_METADATA,
@@ -1675,6 +1699,7 @@ class Workspace:
                 unchanged = (
                     load_json(metadata_path) == metadata
                     and not self._source_view_changed
+                    and source_clean is not False
                 )
             except WorkspaceError:
                 unchanged = False
@@ -1741,23 +1766,48 @@ class Workspace:
             raise WorkspaceError(f"source-view symlink escapes its source root: {path}")
 
     @classmethod
-    def _validate_source_tree_symlinks(cls, path: Path, root: Path) -> None:
+    def _validate_source_tree_symlinks(
+        cls, path: Path, root: Path, *, hash_contents: bool
+    ) -> tuple[dict[str, str], str]:
         def traversal_error(error: OSError) -> None:
             raise error
 
+        symlinks: dict[str, str] = {}
+        structure = hashlib.sha256()
         try:
             for directory, directories, files in os.walk(
                 path, followlinks=False, onerror=traversal_error
             ):
                 parent = Path(directory)
+                directories.sort()
+                files.sort()
                 for name in (*directories, *files):
                     candidate = parent / name
+                    relative = candidate.relative_to(path).as_posix()
+                    mode = candidate.lstat().st_mode
+                    structure.update(relative.encode())
                     if candidate.is_symlink():
                         cls._validate_source_symlink(candidate, root)
+                        target = os.readlink(candidate)
+                        symlinks[relative] = target
+                        structure.update(f"\0symlink\0{target}\0".encode())
+                    elif stat.S_ISDIR(mode):
+                        structure.update(b"\0directory\0")
+                    elif stat.S_ISREG(mode):
+                        structure.update(b"\0file\0")
+                        if hash_contents:
+                            structure.update(
+                                hashlib.sha256(candidate.read_bytes()).digest()
+                            )
+                    else:
+                        raise WorkspaceError(
+                            f"source-view input is not a regular entry: {candidate}"
+                        )
         except OSError as error:
             raise WorkspaceError(
                 f"cannot inspect source-view directory {path}: {error}"
             ) from error
+        return symlinks, structure.hexdigest()
 
     def _reconcile_source_tree(
         self,
@@ -2358,28 +2408,11 @@ class Workspace:
             for name in relevant_names
             if name in environment
         }
-        initialization_names = {
-            "CC",
-            "CXX",
-            "CPPFLAGS",
-            "CFLAGS",
-            "CXXFLAGS",
-            "LDFLAGS",
-            "CPATH",
-            "C_INCLUDE_PATH",
-            "CPLUS_INCLUDE_PATH",
-            "LIBRARY_PATH",
-            "CMAKE_TOOLCHAIN_FILE",
-            "CMAKE_GENERATOR_PLATFORM",
-            "CMAKE_GENERATOR_TOOLSET",
-            "SDKROOT",
-            "MACOSX_DEPLOYMENT_TARGET",
-        }
-        initialization_environment = {
-            name: value
-            for name, value in environment_identity.items()
-            if name in initialization_names
-        }
+        # CMake caches discovery results from all of these inputs.  Re-running
+        # configure in the old tree does not reliably invalidate find_* or
+        # pkg-config cache entries, so every relevant environment change is a
+        # build-tree identity change.
+        initialization_environment = environment_identity
         generator_tool = self._tool_identity("ninja")
         cmake_tool = self._tool_identity("cmake")
         compilers = {

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -1646,6 +1646,8 @@ class Workspace:
                     raise WorkspaceError(
                         f"source-view input is not a file or directory: {entry}"
                     )
+                elif stat.S_ISDIR(mode):
+                    self._validate_source_tree_symlinks(entry, source)
                 target = str(entry)
                 if not destination.is_symlink() or os.readlink(destination) != target:
                     self._source_view_changed = True
@@ -1737,6 +1739,25 @@ class Workspace:
             raise WorkspaceError(f"unsafe source-view symlink {path}: {error}") from error
         if resolved != source and source not in resolved.parents:
             raise WorkspaceError(f"source-view symlink escapes its source root: {path}")
+
+    @classmethod
+    def _validate_source_tree_symlinks(cls, path: Path, root: Path) -> None:
+        def traversal_error(error: OSError) -> None:
+            raise error
+
+        try:
+            for directory, directories, files in os.walk(
+                path, followlinks=False, onerror=traversal_error
+            ):
+                parent = Path(directory)
+                for name in (*directories, *files):
+                    candidate = parent / name
+                    if candidate.is_symlink():
+                        cls._validate_source_symlink(candidate, root)
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot inspect source-view directory {path}: {error}"
+            ) from error
 
     def _reconcile_source_tree(
         self,
@@ -2021,7 +2042,9 @@ class Workspace:
                 file=sys.stderr,
             )
 
-        self._add_debug_prefix_environment(source, binary, environment)
+        self._add_debug_prefix_environment(
+            source, binary, environment, arguments
+        )
         configure = [
             "cmake",
             "-S",
@@ -2061,7 +2084,9 @@ class Workspace:
         toolchain_identity = fingerprint["build_tree_identity"]["toolchain_file"]
         if toolchain_identity is not None and not toolchain_identity["complete"]:
             build_tree_changed = True
-        if build_tree_changed or not self._cmake_state_valid(source, binary):
+        if build_tree_changed or not self._cmake_state_valid(
+            source, binary, configure
+        ):
             managed_reset(binary, self.paths.builds, "cmake-binary")
             configured = False
         if (
@@ -2123,7 +2148,9 @@ class Workspace:
         )
 
     @staticmethod
-    def _cmake_state_valid(source: Path, binary: Path) -> bool:
+    def _cmake_state_valid(
+        source: Path, binary: Path, configure: list[str]
+    ) -> bool:
         cache = binary / "CMakeCache.txt"
         ninja = binary / "build.ninja"
         if (
@@ -2136,6 +2163,9 @@ class Workspace:
         values: dict[str, str] = {}
         try:
             for line in cache.read_text(encoding="utf-8").splitlines():
+                if "=" in line and ":" in line.split("=", 1)[0]:
+                    key, value = line.split("=", 1)
+                    values[key.split(":", 1)[0]] = value
                 if line.startswith("CMAKE_HOME_DIRECTORY:INTERNAL="):
                     values["source"] = line.split("=", 1)[1]
                 elif line.startswith("CMAKE_GENERATOR:INTERNAL="):
@@ -2144,6 +2174,14 @@ class Workspace:
         except (KeyError, OSError, RuntimeError, UnicodeError):
             return False
         if cached_source != source.resolve() or values.get("generator") != "Ninja":
+            return False
+        expected: dict[str, str] = {}
+        for argument in configure:
+            if not argument.startswith("-D") or "=" not in argument:
+                continue
+            key, value = argument[2:].split("=", 1)
+            expected[key.split(":", 1)[0]] = value
+        if any(values.get(key) != value for key, value in expected.items()):
             return False
         try:
             graph = run(
@@ -2155,10 +2193,20 @@ class Workspace:
             return False
         return graph.startswith("build.ninja:\n  input: RERUN_CMAKE")
 
-    @staticmethod
     def _add_debug_prefix_environment(
-        source: Path, binary: Path, environment: dict[str, str]
+        self,
+        source: Path,
+        binary: Path,
+        environment: dict[str, str],
+        arguments: list[str],
     ) -> None:
+        if environment.get("CMAKE_TOOLCHAIN_FILE") or any(
+            argument.startswith(
+                ("-DCMAKE_TOOLCHAIN_FILE=", "-DCMAKE_TOOLCHAIN_FILE:FILEPATH=")
+            )
+            for argument in arguments
+        ):
+            return
         source_path = source.resolve()
         binary_path = binary.resolve()
         relative_source = os.path.relpath(source_path, binary_path)
@@ -2171,12 +2219,55 @@ class Workspace:
             f"-ffile-prefix-map={binary_path}=/atrinik/build",
         )
         mappings = " ".join(shlex.quote(option) for option in options)
-        environment["CFLAGS"] = " ".join(
-            filter(None, (environment.get("CFLAGS", ""), mappings))
-        )
-        environment["CXXFLAGS"] = " ".join(
-            filter(None, (environment.get("CXXFLAGS", ""), mappings))
-        )
+        for variable, command, language in (
+            ("CFLAGS", environment.get("CC", "cc"), "c"),
+            ("CXXFLAGS", environment.get("CXX", "c++"), "c++"),
+        ):
+            if self._compiler_supports_prefix_maps(command, language):
+                environment[variable] = " ".join(
+                    filter(None, (environment.get(variable, ""), mappings))
+                )
+
+    def _compiler_supports_prefix_maps(self, command: str, language: str) -> bool:
+        identity = self._tool_identity(command)
+        key = (command, language, identity.get("resolved_path"), identity.get("sha256"))
+        cached = getattr(self, "_prefix_map_support", {}).get(key)
+        if cached is not None:
+            return cached
+        try:
+            words = shlex.split(command)
+        except ValueError:
+            words = [command]
+        executable = shutil.which(words[0]) if words else None
+        supported = False
+        if executable is not None:
+            with tempfile.TemporaryDirectory(prefix="atrinik-prefix-probe-") as temporary:
+                root = Path(temporary)
+                source = root / ("probe.cc" if language == "c++" else "probe.c")
+                output = root / "probe.o"
+                source.write_text("int atrinik_prefix_probe;\n", encoding="utf-8")
+                try:
+                    run(
+                        [
+                            executable,
+                            *words[1:],
+                            "-x",
+                            language,
+                            "-fdebug-prefix-map=/atrinik-prefix-probe=/atrinik/probe",
+                            "-ffile-prefix-map=/atrinik-prefix-probe=/atrinik/probe",
+                            "-c",
+                            str(source),
+                            "-o",
+                            str(output),
+                        ],
+                        trace=False,
+                    )
+                    supported = output.is_file()
+                except WorkspaceError:
+                    supported = False
+        self._prefix_map_support = getattr(self, "_prefix_map_support", {})
+        self._prefix_map_support[key] = supported
+        return supported
 
     @staticmethod
     def _tool_identity(command: str) -> dict[str, str | None]:
@@ -2274,6 +2365,10 @@ class Workspace:
             "CFLAGS",
             "CXXFLAGS",
             "LDFLAGS",
+            "CPATH",
+            "C_INCLUDE_PATH",
+            "CPLUS_INCLUDE_PATH",
+            "LIBRARY_PATH",
             "CMAKE_TOOLCHAIN_FILE",
             "CMAKE_GENERATOR_PLATFORM",
             "CMAKE_GENERATOR_TOOLSET",
@@ -2423,16 +2518,22 @@ class Workspace:
                     "sha256": hashlib.sha256(data).hexdigest(),
                 }
             )
-            if re.search(
-                r"(?im)^\s*(?:find_package|add_subdirectory|cmake_language)\s*\(",
-                text,
+            command_names = re.findall(
+                r"(?im)^\s*([a-z_][a-z0-9_]*)\s*\(", text
+            )
+            if "$" in text or any(
+                name.lower() not in {"include", "set"} for name in command_names
             ):
                 complete = False
             pattern = re.compile(
-                r"(?im)^\s*include\s*\(\s*(?:\"([^\"]+)\"|'([^']+)'|([^\s\)]+))"
+                r"(?ims)^\s*include\s*\(\s*(?:\"([^\"]+)\"|"
+                r"\[(=*)\[(.*?)\]\2\]|([^\s\)]+))"
             )
-            for match in pattern.finditer(text):
-                included = next(group for group in match.groups() if group is not None)
+            matches = list(pattern.finditer(text))
+            if sum(name.lower() == "include" for name in command_names) != len(matches):
+                complete = False
+            for match in matches:
+                included = match.group(1) or match.group(3) or match.group(4)
                 if "$" in included:
                     complete = False
                     continue

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -7,7 +7,6 @@ from contextlib import ExitStack, contextmanager
 from datetime import datetime, timezone
 import fcntl
 import hashlib
-import json
 import os
 from pathlib import Path, PurePosixPath
 import re
@@ -70,7 +69,7 @@ ALL_BUILD_TARGETS = (
 )
 SOURCE_VIEW_METADATA = ".atrinik-source-view.json"
 CONFIGURE_METADATA = ".atrinik-configure.json"
-CONFIGURE_SCHEMA_VERSION = 1
+CONFIGURE_SCHEMA_VERSION = 2
 COMPILER_CACHE_PURPOSE = "compiler-cache"
 COMPILER_CACHE_MAX_SIZE = "5G"
 TOPOLOGY_SERVICES = ("server", "client")
@@ -1574,11 +1573,16 @@ class Workspace:
         purpose = f"source-view:{component}"
         managed_directory(view, self.paths.builds, purpose)
         self._source_view_changed = False
-        exclusions = {*exclusions, MANAGED_MARKER, SOURCE_VIEW_METADATA}
+        exclusions = {
+            *exclusions,
+            ".git",
+            MANAGED_MARKER,
+            SOURCE_VIEW_METADATA,
+        }
         copied_directories = copied_directories or set()
         expected: dict[str, dict[str, Any]] = {}
         for entry in sorted(source.iterdir(), key=lambda path: path.name):
-            if entry.name in exclusions or entry.name == ".git":
+            if entry.name in exclusions:
                 continue
             destination = view / entry.name
             copy_entry = copy_all or entry.name in copied_directories
@@ -1594,7 +1598,12 @@ class Workspace:
                         f"source-view copy input is not a directory: {entry}"
                     )
                 if stat.S_ISDIR(mode):
-                    digest = self._reconcile_source_tree(entry, destination, entry)
+                    digest = self._reconcile_source_tree(
+                        entry,
+                        destination,
+                        entry,
+                        exclusions if copy_all else set(),
+                    )
                 elif stat.S_ISREG(mode):
                     permissions = stat.S_IMODE(mode)
                     value = hashlib.sha256(entry.read_bytes()).hexdigest()
@@ -1665,7 +1674,8 @@ class Workspace:
                 )
             except WorkspaceError:
                 unchanged = False
-        atomic_json(metadata_path, metadata)
+        if not unchanged:
+            atomic_json(metadata_path, metadata)
         self._source_view_unchanged = getattr(self, "_source_view_unchanged", {})
         self._source_view_unchanged[str(view.resolve())] = unchanged
         return view
@@ -1687,7 +1697,12 @@ class Workspace:
             self._source_view_unchanged[str(view.resolve())] = False
         return destination
 
-    def _source_view_directory(self, view: Path, relative: str) -> Path:
+    def _source_view_directory(
+        self,
+        view: Path,
+        relative: str,
+        preserved_entries: set[str] | None = None,
+    ) -> Path:
         destination = view / relative
         if destination.is_symlink() or (
             destination.exists() and not destination.is_dir()
@@ -1696,6 +1711,10 @@ class Workspace:
         if not destination.exists():
             destination.mkdir(parents=True)
             self._source_view_unchanged[str(view.resolve())] = False
+        for entry in sorted(destination.iterdir(), key=lambda path: path.name):
+            if entry.name not in (preserved_entries or set()):
+                self._remove_source_view_entry(entry)
+                self._source_view_unchanged[str(view.resolve())] = False
         return destination
 
     def _remove_source_view_entry(self, path: Path) -> None:
@@ -1717,7 +1736,13 @@ class Workspace:
         if resolved != source and source not in resolved.parents:
             raise WorkspaceError(f"source-view symlink escapes its source root: {path}")
 
-    def _reconcile_source_tree(self, source: Path, destination: Path, root: Path) -> str:
+    def _reconcile_source_tree(
+        self,
+        source: Path,
+        destination: Path,
+        root: Path,
+        exclusions: set[str],
+    ) -> str:
         if destination.is_symlink() or (destination.exists() and not destination.is_dir()):
             self._remove_source_view_entry(destination)
         if not destination.exists():
@@ -1731,6 +1756,8 @@ class Workspace:
         digest.update(f"directory:{source_permissions:o}\0".encode())
         expected: set[str] = set()
         for entry in sorted(source.iterdir(), key=lambda path: path.name):
+            if entry.name in exclusions:
+                continue
             expected.add(entry.name)
             output = destination / entry.name
             relative = entry.relative_to(root).as_posix()
@@ -1741,7 +1768,11 @@ class Workspace:
             digest.update(relative.encode())
             if stat.S_ISDIR(mode):
                 digest.update(b"\0directory\0")
-                digest.update(self._reconcile_source_tree(entry, output, root).encode())
+                digest.update(
+                    self._reconcile_source_tree(
+                        entry, output, root, exclusions
+                    ).encode()
+                )
             elif stat.S_ISREG(mode):
                 permissions = stat.S_IMODE(mode)
                 file_digest = hashlib.sha256()
@@ -1945,7 +1976,7 @@ class Workspace:
         arguments: list[str],
         tests: bool,
     ) -> None:
-        binary.mkdir(parents=True, exist_ok=True)
+        self._prepare_cmake_binary(binary)
         environment = os.environ.copy()
         ccache = shutil.which("ccache") if getattr(self, "_use_ccache", True) else None
         cache_arguments = [
@@ -1987,7 +2018,7 @@ class Workspace:
                 file=sys.stderr,
             )
 
-        prefix_arguments = self._debug_prefix_arguments(source, binary, environment)
+        self._add_debug_prefix_environment(source, binary, environment)
         configure = [
             "cmake",
             "-S",
@@ -1999,7 +2030,6 @@ class Workspace:
             "-DCMAKE_BUILD_TYPE=Debug",
             f"-DBUILD_TESTING={'ON' if tests else 'OFF'}",
             *cache_arguments,
-            *prefix_arguments,
             *arguments,
         ]
         fingerprint = self._configure_fingerprint(
@@ -2012,12 +2042,22 @@ class Workspace:
             for view, unchanged in getattr(self, "_source_view_unchanged", {}).items()
             if Path(view) == source_resolved or source_resolved in Path(view).parents
         )
-        configured = False
+        previous: dict[str, Any] = {}
         if metadata_path.is_file() and not metadata_path.is_symlink():
             try:
-                configured = load_json(metadata_path) == fingerprint
+                loaded = load_json(metadata_path)
+                if isinstance(loaded, dict):
+                    previous = loaded
             except WorkspaceError:
-                configured = False
+                pass
+        configured = previous == fingerprint
+        build_tree_changed = (
+            previous.get("build_tree_identity")
+            != fingerprint["build_tree_identity"]
+        )
+        if build_tree_changed or not self._cmake_state_valid(source, binary):
+            managed_reset(binary, self.paths.builds, "cmake-binary")
+            configured = False
         if (
             getattr(self, "_force_reconfigure", False)
             or not unchanged_view
@@ -2034,21 +2074,96 @@ class Workspace:
                 env=environment,
             )
 
+    def _prepare_cmake_binary(self, binary: Path) -> None:
+        if binary.is_symlink():
+            raise WorkspaceError(f"refusing symlinked CMake binary path: {binary}")
+        resolved_binary = binary.parent.resolve() / binary.name
+        builds = self.paths.builds.resolve()
+        if builds not in resolved_binary.parents:
+            raise WorkspaceError(
+                f"refusing CMake binary path outside workspace builds: {binary}"
+            )
+        marker = binary / MANAGED_MARKER
+        if not binary.exists():
+            managed_directory(binary, self.paths.builds, "cmake-binary")
+            return
+        if not binary.is_dir():
+            raise WorkspaceError(f"CMake binary path is not a directory: {binary}")
+        if marker.exists() or marker.is_symlink():
+            managed_directory(binary, self.paths.builds, "cmake-binary")
+            return
+
+        # Adopt only the exact legacy location inside an already marker-owned
+        # profile build. Older wrapper releases created these CMake trees
+        # without a nested ownership marker.
+        profile_root = binary.parent.parent
+        profile_marker = profile_root / MANAGED_MARKER
+        try:
+            profile_metadata = load_json(profile_marker)
+        except WorkspaceError as error:
+            raise WorkspaceError(
+                f"refusing unmanaged CMake binary path: {binary}"
+            ) from error
+        if (
+            binary.parent.name != "build"
+            or profile_root.is_symlink()
+            or not profile_root.is_dir()
+            or profile_marker.is_symlink()
+            or not isinstance(profile_metadata, dict)
+            or profile_metadata.get("schema_version") != SCHEMA_VERSION
+            or not isinstance(profile_metadata.get("purpose"), str)
+            or not profile_metadata["purpose"].startswith("profile:")
+        ):
+            raise WorkspaceError(f"refusing unmanaged CMake binary path: {binary}")
+        atomic_json(
+            marker,
+            {"schema_version": SCHEMA_VERSION, "purpose": "cmake-binary"},
+        )
+
     @staticmethod
-    def _debug_prefix_arguments(
+    def _cmake_state_valid(source: Path, binary: Path) -> bool:
+        cache = binary / "CMakeCache.txt"
+        ninja = binary / "build.ninja"
+        if (
+            cache.is_symlink()
+            or not cache.is_file()
+            or ninja.is_symlink()
+            or not ninja.is_file()
+        ):
+            return False
+        values: dict[str, str] = {}
+        try:
+            for line in cache.read_text(encoding="utf-8").splitlines():
+                if line.startswith("CMAKE_HOME_DIRECTORY:INTERNAL="):
+                    values["source"] = line.split("=", 1)[1]
+                elif line.startswith("CMAKE_GENERATOR:INTERNAL="):
+                    values["generator"] = line.split("=", 1)[1]
+            cached_source = Path(values["source"]).resolve(strict=True)
+        except (KeyError, OSError, RuntimeError, UnicodeError):
+            return False
+        return cached_source == source.resolve() and values.get("generator") == "Ninja"
+
+    @staticmethod
+    def _add_debug_prefix_environment(
         source: Path, binary: Path, environment: dict[str, str]
-    ) -> list[str]:
+    ) -> None:
         source_path = source.resolve()
         binary_path = binary.resolve()
+        relative_source = os.path.relpath(source_path, binary_path)
         mappings = (
             f"-fdebug-prefix-map={source_path}=/atrinik/source "
             f"-ffile-prefix-map={source_path}=/atrinik/source "
+            f"-fdebug-prefix-map={relative_source}=/atrinik/source "
+            f"-ffile-prefix-map={relative_source}=/atrinik/source "
             f"-fdebug-prefix-map={binary_path}=/atrinik/build "
             f"-ffile-prefix-map={binary_path}=/atrinik/build"
         )
-        c_flags = " ".join(filter(None, (environment.get("CFLAGS", ""), mappings)))
-        cxx_flags = " ".join(filter(None, (environment.get("CXXFLAGS", ""), mappings)))
-        return [f"-DCMAKE_C_FLAGS={c_flags}", f"-DCMAKE_CXX_FLAGS={cxx_flags}"]
+        environment["CFLAGS"] = " ".join(
+            filter(None, (environment.get("CFLAGS", ""), mappings))
+        )
+        environment["CXXFLAGS"] = " ".join(
+            filter(None, (environment.get("CXXFLAGS", ""), mappings))
+        )
 
     @staticmethod
     def _tool_identity(command: str) -> dict[str, str | None]:
@@ -2060,9 +2175,16 @@ class Workspace:
         version = None
         if executable is not None:
             try:
-                version = run(
-                    [executable, "--version"], capture=True, trace=False
-                ).splitlines()[0]
+                output = run(
+                    [executable, *words[1:], "--version"],
+                    capture=True,
+                    trace=False,
+                )
+                version = (
+                    output.splitlines()[0]
+                    if output
+                    else "unavailable: empty --version output"
+                )
             except WorkspaceError as error:
                 version = f"unavailable: {error}"
         return {"command": command, "path": executable, "version": version}
@@ -2077,51 +2199,106 @@ class Workspace:
         ccache: str | None,
     ) -> dict[str, Any]:
         relevant_names = (
+            "ATRINIK_PACKAGE_VERSION",
             "CC",
             "CXX",
             "CPPFLAGS",
             "CFLAGS",
             "CXXFLAGS",
             "LDFLAGS",
+            "PATH",
+            "CPATH",
+            "C_INCLUDE_PATH",
+            "CPLUS_INCLUDE_PATH",
+            "LIBRARY_PATH",
             "CMAKE_PREFIX_PATH",
+            "CMAKE_INCLUDE_PATH",
+            "CMAKE_LIBRARY_PATH",
+            "CMAKE_FRAMEWORK_PATH",
+            "CMAKE_APPBUNDLE_PATH",
+            "CMAKE_PROGRAM_PATH",
+            "CMAKE_IGNORE_PATH",
+            "CMAKE_SYSTEM_IGNORE_PATH",
+            "CMAKE_FIND_ROOT_PATH",
+            "CMAKE_TOOLCHAIN_FILE",
+            "CMAKE_GENERATOR_PLATFORM",
+            "CMAKE_GENERATOR_TOOLSET",
+            "PKG_CONFIG_PATH",
+            "PKG_CONFIG_LIBDIR",
+            "PKG_CONFIG_SYSROOT_DIR",
+            "PKG_CONFIG_SYSTEM_INCLUDE_PATH",
+            "PKG_CONFIG_SYSTEM_LIBRARY_PATH",
+            "PKG_CONFIG_ALLOW_SYSTEM_CFLAGS",
+            "PKG_CONFIG_ALLOW_SYSTEM_LIBS",
+            "SDKROOT",
+            "MACOSX_DEPLOYMENT_TARGET",
+        )
+        identity = self._cmake_source_identity(source)
+        environment_identity = {
+            name: environment[name]
+            for name in relevant_names
+            if name in environment
+        }
+        initialization_names = {
+            "CC",
+            "CXX",
+            "CPPFLAGS",
+            "CFLAGS",
+            "CXXFLAGS",
+            "LDFLAGS",
             "CMAKE_TOOLCHAIN_FILE",
             "CMAKE_GENERATOR_PLATFORM",
             "CMAKE_GENERATOR_TOOLSET",
             "SDKROOT",
             "MACOSX_DEPLOYMENT_TARGET",
+        }
+        initialization_environment = {
+            name: value
+            for name, value in environment_identity.items()
+            if name in initialization_names
+        }
+        generator_tool = self._tool_identity("ninja")
+        cmake_tool = self._tool_identity("cmake")
+        compilers = {
+            "c": self._tool_identity(environment.get("CC", "cc")),
+            "cxx": self._tool_identity(environment.get("CXX", "c++")),
+        }
+        tree_argument_prefixes = (
+            "-DCMAKE_C_COMPILER=",
+            "-DCMAKE_CXX_COMPILER=",
+            "-DCMAKE_TOOLCHAIN_FILE=",
+            "-DCMAKE_GENERATOR_PLATFORM=",
+            "-DCMAKE_GENERATOR_TOOLSET=",
+            "-DCMAKE_SYSROOT=",
         )
-        source_metadata = source / SOURCE_VIEW_METADATA
-        if source_metadata.is_file() and not source_metadata.is_symlink():
-            identity: Any = load_json(source_metadata)
-        else:
-            cmakelists = source / "CMakeLists.txt"
-            identity = {
-                "path": str(source.resolve()),
-                "cmakelists": (
-                    hashlib.sha256(cmakelists.read_bytes()).hexdigest()
-                    if cmakelists.is_file() and not cmakelists.is_symlink()
-                    else None
-                ),
-            }
+        build_tree_identity = {
+            "generator": "Ninja",
+            "generator_tool": generator_tool,
+            "cmake": cmake_tool,
+            "compilers": compilers,
+            "environment": initialization_environment,
+            "arguments": [
+                argument
+                for argument in configure
+                if argument.startswith(tree_argument_prefixes)
+            ],
+            "toolchain_file": self._cmake_toolchain_identity(
+                source, binary, configure, environment
+            ),
+        }
         return {
             "schema_version": CONFIGURE_SCHEMA_VERSION,
             "purpose": "cmake-configure",
             "source": identity,
             "binary": str(binary.resolve()),
             "generator": "Ninja",
-            "generator_tool": self._tool_identity("ninja"),
-            "cmake": self._tool_identity("cmake"),
-            "compilers": {
-                "c": self._tool_identity(environment.get("CC", "cc")),
-                "cxx": self._tool_identity(environment.get("CXX", "c++")),
-            },
+            "generator_tool": generator_tool,
+            "cmake": cmake_tool,
+            "compilers": compilers,
             "configure_arguments": configure[1:],
             "build_testing": tests,
-            "environment": {
-                name: environment[name]
-                for name in relevant_names
-                if name in environment
-            },
+            "environment": environment_identity,
+            "build_tree_identity": build_tree_identity,
             "ccache": (
                 {
                     "path": ccache,
@@ -2129,6 +2306,79 @@ class Workspace:
                     "max_size": COMPILER_CACHE_MAX_SIZE,
                 }
                 if ccache is not None
+                else None
+            ),
+        }
+
+    @staticmethod
+    def _cmake_toolchain_identity(
+        source: Path,
+        binary: Path,
+        configure: list[str],
+        environment: dict[str, str],
+    ) -> dict[str, Any] | None:
+        value = environment.get("CMAKE_TOOLCHAIN_FILE")
+        for argument in configure:
+            for prefix in (
+                "-DCMAKE_TOOLCHAIN_FILE=",
+                "-DCMAKE_TOOLCHAIN_FILE:FILEPATH=",
+            ):
+                if argument.startswith(prefix):
+                    value = argument[len(prefix) :]
+        if not value:
+            return None
+        raw = Path(value)
+        candidates = (
+            (raw,) if raw.is_absolute() else (binary / raw, source / raw)
+        )
+        for candidate in candidates:
+            try:
+                if candidate.is_file() and not candidate.is_symlink():
+                    return {
+                        "value": value,
+                        "path": str(candidate.resolve()),
+                        "sha256": hashlib.sha256(candidate.read_bytes()).hexdigest(),
+                    }
+            except OSError:
+                continue
+        return {"value": value, "path": None, "sha256": None}
+
+    def _cmake_source_identity(self, source: Path) -> dict[str, Any]:
+        source_metadata = source / SOURCE_VIEW_METADATA
+        marker = source / MANAGED_MARKER
+        builds = self.paths.builds.resolve()
+        try:
+            resolved = source.resolve(strict=True)
+            metadata = load_json(source_metadata)
+            ownership = load_json(marker)
+            managed = builds in resolved.parents
+            valid = (
+                managed
+                and not source_metadata.is_symlink()
+                and not marker.is_symlink()
+                and isinstance(metadata, dict)
+                and set(metadata) == {"schema_version", "purpose", "source", "entries"}
+                and metadata.get("schema_version") == 1
+                and isinstance(metadata.get("purpose"), str)
+                and metadata["purpose"].startswith("source-view:")
+                and ownership
+                == {
+                    "schema_version": SCHEMA_VERSION,
+                    "purpose": metadata["purpose"],
+                }
+                and isinstance(metadata.get("source"), str)
+                and isinstance(metadata.get("entries"), dict)
+            )
+            if valid:
+                return metadata
+        except (OSError, RuntimeError, WorkspaceError):
+            pass
+        cmakelists = source / "CMakeLists.txt"
+        return {
+            "path": str(source.resolve()),
+            "cmakelists": (
+                hashlib.sha256(cmakelists.read_bytes()).hexdigest()
+                if cmakelists.is_file() and not cmakelists.is_symlink()
                 else None
             ),
         }
@@ -2216,7 +2466,7 @@ class Workspace:
             {"install_data"},
             preserved_entries={"runtime", "resources"},
         )
-        runtime = self._source_view_directory(server, "runtime")
+        self._source_view_directory(server, "runtime", {"content"})
         self._source_view_link(
             server,
             "runtime/content",
@@ -2298,7 +2548,7 @@ class Workspace:
             {"install_data"},
             preserved_entries={"runtime", "resources"},
         )
-        runtime = self._source_view_directory(view, "runtime")
+        self._source_view_directory(view, "runtime", {"content"})
         self._source_view_link(
             view,
             "runtime/content",

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -1609,6 +1609,8 @@ class Workspace:
                         entry,
                         source,
                         exclusions if copy_all else set(),
+                        view,
+                        exclusions,
                     )
                 elif stat.S_ISREG(mode):
                     permissions = stat.S_IMODE(mode)
@@ -1625,13 +1627,16 @@ class Workspace:
                         shutil.copy2(entry, destination, follow_symlinks=False)
                     digest = f"{permissions:o}:{value}"
                 elif stat.S_ISLNK(mode):
-                    self._validate_source_symlink(entry, source)
-                    target = os.readlink(entry)
+                    target, resolved_target = self._copied_source_symlink_target(
+                        entry, destination, source, view, exclusions, exclusions
+                    )
                     if not destination.is_symlink() or os.readlink(destination) != target:
                         self._source_view_changed = True
                         self._remove_source_view_entry(destination)
                         destination.symlink_to(target)
-                    digest = hashlib.sha256(f"symlink:{target}".encode()).hexdigest()
+                    digest = hashlib.sha256(
+                        f"symlink:{os.readlink(entry)}:{resolved_target}".encode()
+                    ).hexdigest()
                 else:
                     raise WorkspaceError(
                         f"source-view copy input is not a regular entry: {entry}"
@@ -1816,6 +1821,8 @@ class Workspace:
         root: Path,
         safety_root: Path,
         exclusions: set[str],
+        view: Path,
+        top_level_exclusions: set[str],
     ) -> str:
         if destination.is_symlink() or (destination.exists() and not destination.is_dir()):
             self._remove_source_view_entry(destination)
@@ -1844,7 +1851,13 @@ class Workspace:
                 digest.update(b"\0directory\0")
                 digest.update(
                     self._reconcile_source_tree(
-                        entry, output, root, safety_root, exclusions
+                        entry,
+                        output,
+                        root,
+                        safety_root,
+                        exclusions,
+                        view,
+                        top_level_exclusions,
                     ).encode()
                 )
             elif stat.S_ISREG(mode):
@@ -1878,10 +1891,18 @@ class Workspace:
                     self._remove_source_view_entry(output)
                     shutil.copy2(entry, output, follow_symlinks=False)
             elif stat.S_ISLNK(mode):
-                self._validate_source_symlink(entry, safety_root)
-                target = os.readlink(entry)
+                target, resolved_target = self._copied_source_symlink_target(
+                    entry,
+                    output,
+                    safety_root,
+                    view,
+                    exclusions,
+                    top_level_exclusions,
+                )
                 digest.update(b"\0symlink\0")
-                digest.update(target.encode())
+                digest.update(os.readlink(entry).encode())
+                digest.update(b"\0resolved\0")
+                digest.update(resolved_target.encode())
                 if not output.is_symlink() or os.readlink(output) != target:
                     self._source_view_changed = True
                     self._remove_source_view_entry(output)
@@ -1892,6 +1913,35 @@ class Workspace:
             if output.name not in expected:
                 self._remove_source_view_entry(output)
         return digest.hexdigest()
+
+    @classmethod
+    def _copied_source_symlink_target(
+        cls,
+        source: Path,
+        destination: Path,
+        safety_root: Path,
+        view: Path,
+        recursive_exclusions: set[str],
+        top_level_exclusions: set[str],
+    ) -> tuple[str, str]:
+        cls._validate_source_symlink(source, safety_root)
+        try:
+            relative = source.resolve(strict=True).relative_to(
+                safety_root.resolve(strict=True)
+            )
+        except (OSError, RuntimeError, ValueError) as error:
+            raise WorkspaceError(
+                f"unsafe copied source-view symlink {source}: {error}"
+            ) from error
+        if (
+            (relative.parts and relative.parts[0] in top_level_exclusions)
+            or any(part in recursive_exclusions for part in relative.parts)
+        ):
+            raise WorkspaceError(
+                f"copied source-view symlink targets an excluded entry: {source}"
+            )
+        mapped = view / relative
+        return os.path.relpath(mapped, destination.parent), relative.as_posix()
 
     def _collect_content(self, root: Path, selected: dict[str, Path]) -> Path:
         output = root / "runtime" / "content"
@@ -2057,6 +2107,9 @@ class Workspace:
             "-DCMAKE_C_COMPILER_LAUNCHER=",
             "-DCMAKE_CXX_COMPILER_LAUNCHER=",
         ]
+        prefix_map_support = self._add_debug_prefix_environment(
+            source, binary, environment, arguments
+        )
         if ccache is not None:
             cache = self.paths.builds / COMPILER_CACHE_PURPOSE
             managed_directory(cache, self.paths.builds, COMPILER_CACHE_PURPOSE)
@@ -2074,9 +2127,14 @@ class Workspace:
                     "CCACHE_DIR": str(cache),
                     "CCACHE_MAXSIZE": COMPILER_CACHE_MAX_SIZE,
                     "CCACHE_BASEDIR": str(binary.parent.parent.resolve()),
-                    "CCACHE_NOHASHDIR": "true",
                 }
             )
+            environment.pop("CCACHE_HASHDIR", None)
+            environment.pop("CCACHE_NOHASHDIR", None)
+            if all(prefix_map_support.values()):
+                environment["CCACHE_NOHASHDIR"] = "true"
+            else:
+                environment["CCACHE_HASHDIR"] = "true"
             cache_arguments = [
                 f"-DCMAKE_C_COMPILER_LAUNCHER={ccache}",
                 f"-DCMAKE_CXX_COMPILER_LAUNCHER={ccache}",
@@ -2092,9 +2150,6 @@ class Workspace:
                 file=sys.stderr,
             )
 
-        self._add_debug_prefix_environment(
-            source, binary, environment, arguments
-        )
         configure = [
             "cmake",
             "-S",
@@ -2142,6 +2197,7 @@ class Workspace:
         if (
             getattr(self, "_force_reconfigure", False)
             or not unchanged_view
+            or not fingerprint["source"].get("configure_skip_safe", True)
             or not configured
         ):
             run(configure, env=environment)
@@ -2249,14 +2305,14 @@ class Workspace:
         binary: Path,
         environment: dict[str, str],
         arguments: list[str],
-    ) -> None:
+    ) -> dict[str, bool]:
         if environment.get("CMAKE_TOOLCHAIN_FILE") or any(
             argument.startswith(
                 ("-DCMAKE_TOOLCHAIN_FILE=", "-DCMAKE_TOOLCHAIN_FILE:FILEPATH=")
             )
             for argument in arguments
         ):
-            return
+            return {"c": False, "cxx": False}
         source_path = source.resolve()
         binary_path = binary.resolve()
         relative_source = os.path.relpath(source_path, binary_path)
@@ -2269,14 +2325,20 @@ class Workspace:
             f"-ffile-prefix-map={binary_path}=/atrinik/build",
         )
         mappings = " ".join(shlex.quote(option) for option in options)
-        for variable, command, language in (
-            ("CFLAGS", environment.get("CC", "cc"), "c"),
-            ("CXXFLAGS", environment.get("CXX", "c++"), "c++"),
-        ):
-            if self._compiler_supports_prefix_maps(command, language):
+        compilers = (
+            ("c", "CFLAGS", environment.get("CC", "cc"), "c"),
+            ("cxx", "CXXFLAGS", environment.get("CXX", "c++"), "c++"),
+        )
+        support = {
+            name: self._compiler_supports_prefix_maps(command, language)
+            for name, _variable, command, language in compilers
+        }
+        for name, variable, _command, _language in compilers:
+            if support[name]:
                 environment[variable] = " ".join(
                     filter(None, (environment.get(variable, ""), mappings))
                 )
+        return support
 
     def _compiler_supports_prefix_maps(self, command: str, language: str) -> bool:
         identity = self._tool_identity(command)
@@ -2685,7 +2747,7 @@ class Workspace:
         except (OSError, RuntimeError, WorkspaceError):
             pass
         cmakelists = source / "CMakeLists.txt"
-        return {
+        identity: dict[str, Any] = {
             "path": str(source.resolve()),
             "cmakelists": (
                 hashlib.sha256(cmakelists.read_bytes()).hexdigest()
@@ -2693,6 +2755,28 @@ class Workspace:
                 else None
             ),
         }
+        try:
+            git_root = Path(
+                git(source, "rev-parse", "--show-toplevel", capture=True, trace=False)
+            ).resolve(strict=True)
+            head = git(source, "rev-parse", "HEAD", capture=True, trace=False)
+            if len(head) != 40 or any(
+                character not in "0123456789abcdef" for character in head
+            ):
+                raise WorkspaceError(
+                    f"invalid Git HEAD for direct CMake source: {source}"
+                )
+            clean = _is_clean(git_root, trace=False)
+            identity["git"] = {
+                "root": str(git_root),
+                "head": head,
+                "clean": clean,
+            }
+            identity["configure_skip_safe"] = clean
+        except (OSError, RuntimeError, WorkspaceError):
+            identity["git"] = None
+            identity["configure_skip_safe"] = False
+        return identity
 
     def _build_protocol(self, root: Path, selected: dict[str, Path], tests: bool) -> None:
         self._cmake(selected["protocol"], root / "build" / "protocol", [], tests)

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -7,6 +7,7 @@ from contextlib import ExitStack, contextmanager
 from datetime import datetime, timezone
 import fcntl
 import hashlib
+import json
 import os
 from pathlib import Path, PurePosixPath
 import re
@@ -67,6 +68,11 @@ ALL_BUILD_TARGETS = (
     "server",
     "metaserver-worker",
 )
+SOURCE_VIEW_METADATA = ".atrinik-source-view.json"
+CONFIGURE_METADATA = ".atrinik-configure.json"
+CONFIGURE_SCHEMA_VERSION = 1
+COMPILER_CACHE_PURPOSE = "compiler-cache"
+COMPILER_CACHE_MAX_SIZE = "5G"
 TOPOLOGY_SERVICES = ("server", "client")
 PRE_MONOREPO_REPOSITORIES = {
     "client": "legacy-client",
@@ -1355,19 +1361,49 @@ class Workspace:
         }
         return {role: paths[stack.providers[role].name] for role in roles}
 
-    def build(self, target: str, profile_name: str, tests: bool) -> Path:
+    def build(
+        self,
+        target: str,
+        profile_name: str,
+        tests: bool,
+        *,
+        force_reconfigure: bool = False,
+        use_ccache: bool = True,
+    ) -> Path:
         self.paths.ensure()
         with exclusive_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
         ):
-            return self._build(target, profile_name, tests)
+            return self._build(
+                target,
+                profile_name,
+                tests,
+                force_reconfigure=force_reconfigure,
+                use_ccache=use_ccache,
+            )
 
-    def _build(self, target: str, profile_name: str, tests: bool) -> Path:
+    def _build(
+        self,
+        target: str,
+        profile_name: str,
+        tests: bool,
+        *,
+        force_reconfigure: bool = False,
+        use_ccache: bool = True,
+    ) -> Path:
         targets = self._expand_build_target(target, profile_name)
         required = set(targets)
         selected = self._resolve_build_profile(profile_name, required)
-        return self._build_resolved(target, profile_name, tests, targets, selected)
+        return self._build_resolved(
+            target,
+            profile_name,
+            tests,
+            targets,
+            selected,
+            force_reconfigure=force_reconfigure,
+            use_ccache=use_ccache,
+        )
 
     def _build_resolved(
         self,
@@ -1376,11 +1412,16 @@ class Workspace:
         tests: bool,
         targets: list[str],
         selected: dict[str, Path],
+        *,
+        force_reconfigure: bool = False,
+        use_ccache: bool = True,
     ) -> Path:
         key = self._profile_build_key(profile_name, selected)
         root = self.paths.builds / "profiles" / f"{profile_name}-{key}"
         lock = self.paths.builds / "locks" / f"{profile_name}-{key}.lock"
         with exclusive_lock(lock, f"profile build {profile_name}"):
+            self._force_reconfigure = force_reconfigure
+            self._use_ccache = use_ccache
             managed_directory(root, self.paths.builds, f"profile:{profile_name}:{key}")
             self._refresh_build_metadata(root, profile_name, key, selected)
             if "content" in targets or "server" in targets:
@@ -1527,33 +1568,225 @@ class Workspace:
         exclusions: set[str],
         copied_directories: set[str] | None = None,
         copy_all: bool = False,
+        preserved_entries: set[str] | None = None,
     ) -> Path:
         view = root / "sources" / component
-        managed_reset(view, self.paths.builds, f"source-view:{component}")
-        exclusions = {*exclusions, MANAGED_MARKER}
-        if copy_all:
-            shutil.copytree(
-                source,
-                view,
-                dirs_exist_ok=True,
-                symlinks=True,
-                ignore=shutil.ignore_patterns(".git", *exclusions),
-            )
-            return view
+        purpose = f"source-view:{component}"
+        managed_directory(view, self.paths.builds, purpose)
+        self._source_view_changed = False
+        exclusions = {*exclusions, MANAGED_MARKER, SOURCE_VIEW_METADATA}
         copied_directories = copied_directories or set()
-        for entry in source.iterdir():
+        expected: dict[str, dict[str, Any]] = {}
+        for entry in sorted(source.iterdir(), key=lambda path: path.name):
             if entry.name in exclusions or entry.name == ".git":
                 continue
             destination = view / entry.name
-            if entry.name in copied_directories:
-                if not entry.is_dir():
+            copy_entry = copy_all or entry.name in copied_directories
+            if copy_entry:
+                try:
+                    mode = entry.lstat().st_mode
+                except OSError as error:
+                    raise WorkspaceError(
+                        f"cannot inspect source-view input {entry}: {error}"
+                    ) from error
+                if not stat.S_ISDIR(mode) and not copy_all:
                     raise WorkspaceError(
                         f"source-view copy input is not a directory: {entry}"
                     )
-                shutil.copytree(entry, destination, symlinks=True)
+                if stat.S_ISDIR(mode):
+                    digest = self._reconcile_source_tree(entry, destination, entry)
+                elif stat.S_ISREG(mode):
+                    permissions = stat.S_IMODE(mode)
+                    value = hashlib.sha256(entry.read_bytes()).hexdigest()
+                    same = (
+                        destination.is_file()
+                        and not destination.is_symlink()
+                        and hashlib.sha256(destination.read_bytes()).hexdigest() == value
+                        and stat.S_IMODE(destination.lstat().st_mode) == permissions
+                    )
+                    if not same:
+                        self._source_view_changed = True
+                        self._remove_source_view_entry(destination)
+                        shutil.copy2(entry, destination, follow_symlinks=False)
+                    digest = f"{permissions:o}:{value}"
+                elif stat.S_ISLNK(mode):
+                    self._validate_source_symlink(entry, source)
+                    target = os.readlink(entry)
+                    if not destination.is_symlink() or os.readlink(destination) != target:
+                        self._source_view_changed = True
+                        self._remove_source_view_entry(destination)
+                        destination.symlink_to(target)
+                    digest = hashlib.sha256(f"symlink:{target}".encode()).hexdigest()
+                else:
+                    raise WorkspaceError(
+                        f"source-view copy input is not a regular entry: {entry}"
+                    )
+                expected[entry.name] = {"kind": "copy", "digest": digest}
             else:
-                destination.symlink_to(entry, target_is_directory=entry.is_dir())
+                try:
+                    mode = entry.lstat().st_mode
+                except OSError as error:
+                    raise WorkspaceError(
+                        f"cannot inspect source-view input {entry}: {error}"
+                    ) from error
+                if stat.S_ISLNK(mode):
+                    self._validate_source_symlink(entry, source)
+                elif not (stat.S_ISREG(mode) or stat.S_ISDIR(mode)):
+                    raise WorkspaceError(
+                        f"source-view input is not a file or directory: {entry}"
+                    )
+                target = str(entry)
+                if not destination.is_symlink() or os.readlink(destination) != target:
+                    self._source_view_changed = True
+                    self._remove_source_view_entry(destination)
+                    destination.symlink_to(target, target_is_directory=stat.S_ISDIR(mode))
+                expected[entry.name] = {"kind": "link", "target": target}
+        reserved = {
+            MANAGED_MARKER,
+            SOURCE_VIEW_METADATA,
+            *(preserved_entries or set()),
+        }
+        for destination in sorted(view.iterdir(), key=lambda path: path.name):
+            if destination.name not in reserved and destination.name not in expected:
+                self._remove_source_view_entry(destination)
+        metadata = {
+            "schema_version": 1,
+            "purpose": purpose,
+            "source": str(source.resolve()),
+            "entries": expected,
+        }
+        metadata_path = view / SOURCE_VIEW_METADATA
+        unchanged = False
+        if metadata_path.is_file() and not metadata_path.is_symlink():
+            try:
+                unchanged = (
+                    load_json(metadata_path) == metadata
+                    and not self._source_view_changed
+                )
+            except WorkspaceError:
+                unchanged = False
+        atomic_json(metadata_path, metadata)
+        self._source_view_unchanged = getattr(self, "_source_view_unchanged", {})
+        self._source_view_unchanged[str(view.resolve())] = unchanged
         return view
+
+    def _source_view_link(
+        self,
+        view: Path,
+        relative: str,
+        target: Path,
+        *,
+        target_is_directory: bool,
+    ) -> Path:
+        destination = view / relative
+        expected = str(target)
+        if not destination.is_symlink() or os.readlink(destination) != expected:
+            self._remove_source_view_entry(destination)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.symlink_to(expected, target_is_directory=target_is_directory)
+            self._source_view_unchanged[str(view.resolve())] = False
+        return destination
+
+    def _source_view_directory(self, view: Path, relative: str) -> Path:
+        destination = view / relative
+        if destination.is_symlink() or (
+            destination.exists() and not destination.is_dir()
+        ):
+            self._remove_source_view_entry(destination)
+        if not destination.exists():
+            destination.mkdir(parents=True)
+            self._source_view_unchanged[str(view.resolve())] = False
+        return destination
+
+    def _remove_source_view_entry(self, path: Path) -> None:
+        if not path.exists() and not path.is_symlink():
+            return
+        self._source_view_changed = True
+        if path.is_symlink() or not path.is_dir():
+            path.unlink()
+        else:
+            shutil.rmtree(path)
+
+    @staticmethod
+    def _validate_source_symlink(path: Path, root: Path) -> None:
+        try:
+            resolved = path.resolve(strict=True)
+            source = root.resolve(strict=True)
+        except (OSError, RuntimeError) as error:
+            raise WorkspaceError(f"unsafe source-view symlink {path}: {error}") from error
+        if resolved != source and source not in resolved.parents:
+            raise WorkspaceError(f"source-view symlink escapes its source root: {path}")
+
+    def _reconcile_source_tree(self, source: Path, destination: Path, root: Path) -> str:
+        if destination.is_symlink() or (destination.exists() and not destination.is_dir()):
+            self._remove_source_view_entry(destination)
+        if not destination.exists():
+            self._source_view_changed = True
+        destination.mkdir(parents=True, exist_ok=True)
+        source_permissions = stat.S_IMODE(source.lstat().st_mode)
+        if stat.S_IMODE(destination.lstat().st_mode) != source_permissions:
+            destination.chmod(source_permissions)
+            self._source_view_changed = True
+        digest = hashlib.sha256()
+        digest.update(f"directory:{source_permissions:o}\0".encode())
+        expected: set[str] = set()
+        for entry in sorted(source.iterdir(), key=lambda path: path.name):
+            expected.add(entry.name)
+            output = destination / entry.name
+            relative = entry.relative_to(root).as_posix()
+            try:
+                mode = entry.lstat().st_mode
+            except OSError as error:
+                raise WorkspaceError(f"cannot inspect copied source {entry}: {error}") from error
+            digest.update(relative.encode())
+            if stat.S_ISDIR(mode):
+                digest.update(b"\0directory\0")
+                digest.update(self._reconcile_source_tree(entry, output, root).encode())
+            elif stat.S_ISREG(mode):
+                permissions = stat.S_IMODE(mode)
+                file_digest = hashlib.sha256()
+                try:
+                    with entry.open("rb") as stream:
+                        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                            file_digest.update(chunk)
+                except OSError as error:
+                    raise WorkspaceError(f"cannot read copied source {entry}: {error}") from error
+                value = file_digest.hexdigest()
+                digest.update(b"\0file\0")
+                digest.update(f"{permissions:o}\0".encode())
+                digest.update(value.encode())
+                same = False
+                if output.is_file() and not output.is_symlink():
+                    existing = hashlib.sha256()
+                    try:
+                        with output.open("rb") as stream:
+                            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                                existing.update(chunk)
+                        same = (
+                            existing.hexdigest() == value
+                            and stat.S_IMODE(output.lstat().st_mode) == permissions
+                        )
+                    except OSError:
+                        same = False
+                if not same:
+                    self._source_view_changed = True
+                    self._remove_source_view_entry(output)
+                    shutil.copy2(entry, output, follow_symlinks=False)
+            elif stat.S_ISLNK(mode):
+                self._validate_source_symlink(entry, root)
+                target = os.readlink(entry)
+                digest.update(b"\0symlink\0")
+                digest.update(target.encode())
+                if not output.is_symlink() or os.readlink(output) != target:
+                    self._source_view_changed = True
+                    self._remove_source_view_entry(output)
+                    output.symlink_to(target)
+            else:
+                raise WorkspaceError(f"copied source is not a regular entry: {entry}")
+        for output in sorted(destination.iterdir(), key=lambda path: path.name):
+            if output.name not in expected:
+                self._remove_source_view_entry(output)
+        return digest.hexdigest()
 
     def _collect_content(self, root: Path, selected: dict[str, Path]) -> Path:
         output = root / "runtime" / "content"
@@ -1713,23 +1946,192 @@ class Workspace:
         tests: bool,
     ) -> None:
         binary.mkdir(parents=True, exist_ok=True)
-        run(
-            [
-                "cmake",
-                "-S",
-                str(source),
-                "-B",
-                str(binary),
-                "-G",
-                "Ninja",
-                "-DCMAKE_BUILD_TYPE=Debug",
-                f"-DBUILD_TESTING={'ON' if tests else 'OFF'}",
-                *arguments,
+        environment = os.environ.copy()
+        ccache = shutil.which("ccache") if getattr(self, "_use_ccache", True) else None
+        cache_arguments = [
+            "-DCMAKE_C_COMPILER_LAUNCHER=",
+            "-DCMAKE_CXX_COMPILER_LAUNCHER=",
+        ]
+        if ccache is not None:
+            cache = self.paths.builds / COMPILER_CACHE_PURPOSE
+            managed_directory(cache, self.paths.builds, COMPILER_CACHE_PURPOSE)
+            atomic_json(
+                cache / CACHE_METADATA,
+                {
+                    "schema_version": BUILD_METADATA_SCHEMA_VERSION,
+                    "purpose": COMPILER_CACHE_PURPOSE,
+                    "last_used_at": datetime.now(timezone.utc).isoformat(),
+                    "max_size": COMPILER_CACHE_MAX_SIZE,
+                },
+            )
+            environment.update(
+                {
+                    "CCACHE_DIR": str(cache),
+                    "CCACHE_MAXSIZE": COMPILER_CACHE_MAX_SIZE,
+                    "CCACHE_BASEDIR": str(binary.parent.parent.resolve()),
+                    "CCACHE_NOHASHDIR": "true",
+                }
+            )
+            cache_arguments = [
+                f"-DCMAKE_C_COMPILER_LAUNCHER={ccache}",
+                f"-DCMAKE_CXX_COMPILER_LAUNCHER={ccache}",
             ]
+            print(
+                f"ccache: enabled at {cache} (maximum {COMPILER_CACHE_MAX_SIZE})",
+                file=sys.stderr,
+            )
+        elif getattr(self, "_use_ccache", True):
+            print(
+                "ccache: command not found; install ccache or pass --no-ccache "
+                "to disable this diagnostic",
+                file=sys.stderr,
+            )
+
+        prefix_arguments = self._debug_prefix_arguments(source, binary, environment)
+        configure = [
+            "cmake",
+            "-S",
+            str(source),
+            "-B",
+            str(binary),
+            "-G",
+            "Ninja",
+            "-DCMAKE_BUILD_TYPE=Debug",
+            f"-DBUILD_TESTING={'ON' if tests else 'OFF'}",
+            *cache_arguments,
+            *prefix_arguments,
+            *arguments,
+        ]
+        fingerprint = self._configure_fingerprint(
+            source, binary, configure, tests, environment, ccache
         )
-        run(["cmake", "--build", str(binary), "--parallel"])
+        metadata_path = binary / CONFIGURE_METADATA
+        source_resolved = source.resolve()
+        unchanged_view = all(
+            unchanged
+            for view, unchanged in getattr(self, "_source_view_unchanged", {}).items()
+            if Path(view) == source_resolved or source_resolved in Path(view).parents
+        )
+        configured = False
+        if metadata_path.is_file() and not metadata_path.is_symlink():
+            try:
+                configured = load_json(metadata_path) == fingerprint
+            except WorkspaceError:
+                configured = False
+        if (
+            getattr(self, "_force_reconfigure", False)
+            or not unchanged_view
+            or not configured
+        ):
+            run(configure, env=environment)
+            atomic_json(metadata_path, fingerprint)
+        else:
+            print(f"cmake: configure unchanged for {binary}; skipping", file=sys.stderr)
+        run(["cmake", "--build", str(binary), "--parallel"], env=environment)
         if tests:
-            run(["ctest", "--test-dir", str(binary), "--output-on-failure"])
+            run(
+                ["ctest", "--test-dir", str(binary), "--output-on-failure"],
+                env=environment,
+            )
+
+    @staticmethod
+    def _debug_prefix_arguments(
+        source: Path, binary: Path, environment: dict[str, str]
+    ) -> list[str]:
+        source_path = source.resolve()
+        binary_path = binary.resolve()
+        mappings = (
+            f"-fdebug-prefix-map={source_path}=/atrinik/source "
+            f"-ffile-prefix-map={source_path}=/atrinik/source "
+            f"-fdebug-prefix-map={binary_path}=/atrinik/build "
+            f"-ffile-prefix-map={binary_path}=/atrinik/build"
+        )
+        c_flags = " ".join(filter(None, (environment.get("CFLAGS", ""), mappings)))
+        cxx_flags = " ".join(filter(None, (environment.get("CXXFLAGS", ""), mappings)))
+        return [f"-DCMAKE_C_FLAGS={c_flags}", f"-DCMAKE_CXX_FLAGS={cxx_flags}"]
+
+    @staticmethod
+    def _tool_identity(command: str) -> dict[str, str | None]:
+        try:
+            words = shlex.split(command)
+        except ValueError:
+            words = [command]
+        executable = shutil.which(words[0]) if words else None
+        version = None
+        if executable is not None:
+            try:
+                version = run(
+                    [executable, "--version"], capture=True, trace=False
+                ).splitlines()[0]
+            except WorkspaceError as error:
+                version = f"unavailable: {error}"
+        return {"command": command, "path": executable, "version": version}
+
+    def _configure_fingerprint(
+        self,
+        source: Path,
+        binary: Path,
+        configure: list[str],
+        tests: bool,
+        environment: dict[str, str],
+        ccache: str | None,
+    ) -> dict[str, Any]:
+        relevant_names = (
+            "CC",
+            "CXX",
+            "CPPFLAGS",
+            "CFLAGS",
+            "CXXFLAGS",
+            "LDFLAGS",
+            "CMAKE_PREFIX_PATH",
+            "CMAKE_TOOLCHAIN_FILE",
+            "CMAKE_GENERATOR_PLATFORM",
+            "CMAKE_GENERATOR_TOOLSET",
+            "SDKROOT",
+            "MACOSX_DEPLOYMENT_TARGET",
+        )
+        source_metadata = source / SOURCE_VIEW_METADATA
+        if source_metadata.is_file() and not source_metadata.is_symlink():
+            identity: Any = load_json(source_metadata)
+        else:
+            cmakelists = source / "CMakeLists.txt"
+            identity = {
+                "path": str(source.resolve()),
+                "cmakelists": (
+                    hashlib.sha256(cmakelists.read_bytes()).hexdigest()
+                    if cmakelists.is_file() and not cmakelists.is_symlink()
+                    else None
+                ),
+            }
+        return {
+            "schema_version": CONFIGURE_SCHEMA_VERSION,
+            "purpose": "cmake-configure",
+            "source": identity,
+            "binary": str(binary.resolve()),
+            "generator": "Ninja",
+            "generator_tool": self._tool_identity("ninja"),
+            "cmake": self._tool_identity("cmake"),
+            "compilers": {
+                "c": self._tool_identity(environment.get("CC", "cc")),
+                "cxx": self._tool_identity(environment.get("CXX", "c++")),
+            },
+            "configure_arguments": configure[1:],
+            "build_testing": tests,
+            "environment": {
+                name: environment[name]
+                for name in relevant_names
+                if name in environment
+            },
+            "ccache": (
+                {
+                    "path": ccache,
+                    "version": self._tool_identity(ccache)["version"],
+                    "max_size": COMPILER_CACHE_MAX_SIZE,
+                }
+                if ccache is not None
+                else None
+            ),
+        }
 
     def _build_protocol(self, root: Path, selected: dict[str, Path], tests: bool) -> None:
         self._cmake(selected["protocol"], root / "build" / "protocol", [], tests)
@@ -1780,15 +2182,22 @@ class Workspace:
     ) -> None:
         checkout = selected["client"].parent.resolve()
         view = self._profile_source_view(
-            root, "integrated", checkout, {"build", "client", "server"}
+            root,
+            "integrated",
+            checkout,
+            {"build", "client", "server"},
+            preserved_entries={"client", "server"},
         )
         client = self._profile_source_view(
             root,
             "integrated/client",
             selected["client"],
             {"build", "sound"},
+            preserved_entries={"sound"},
         )
-        (client / "sound").symlink_to(selected["sound"], target_is_directory=True)
+        self._source_view_link(
+            client, "sound", selected["sound"], target_is_directory=True
+        )
         server = self._profile_source_view(
             root,
             "integrated/server",
@@ -1805,14 +2214,20 @@ class Workspace:
                 "libplugin_python.so",
             },
             {"install_data"},
+            preserved_entries={"runtime", "resources"},
         )
-        runtime = server / "runtime"
-        runtime.mkdir()
-        (runtime / "content").symlink_to(
-            root / "runtime" / "content", target_is_directory=True
+        runtime = self._source_view_directory(server, "runtime")
+        self._source_view_link(
+            server,
+            "runtime/content",
+            root / "runtime" / "content",
+            target_is_directory=True,
         )
-        (server / "resources").symlink_to(
-            root / "runtime" / "resources", target_is_directory=True
+        self._source_view_link(
+            server,
+            "resources",
+            root / "runtime" / "resources",
+            target_is_directory=True,
         )
         self._cmake(
             view,
@@ -1839,9 +2254,15 @@ class Workspace:
 
     def _build_client(self, root: Path, selected: dict[str, Path], tests: bool) -> None:
         view = self._profile_source_view(
-            root, "client", selected["client"], {"build", "sound"}
+            root,
+            "client",
+            selected["client"],
+            {"build", "sound"},
+            preserved_entries={"sound"},
         )
-        (view / "sound").symlink_to(selected["sound"], target_is_directory=True)
+        self._source_view_link(
+            view, "sound", selected["sound"], target_is_directory=True
+        )
         self._cmake(
             view,
             root / "build" / "client",
@@ -1875,14 +2296,20 @@ class Workspace:
             # CMake treats a top-level directory symlink as the object to copy,
             # which conflicts with the destination directory it just created.
             {"install_data"},
+            preserved_entries={"runtime", "resources"},
         )
-        runtime = view / "runtime"
-        runtime.mkdir()
-        (runtime / "content").symlink_to(
-            root / "runtime" / "content", target_is_directory=True
+        runtime = self._source_view_directory(view, "runtime")
+        self._source_view_link(
+            view,
+            "runtime/content",
+            root / "runtime" / "content",
+            target_is_directory=True,
         )
-        (view / "resources").symlink_to(
-            root / "runtime" / "resources", target_is_directory=True
+        self._source_view_link(
+            view,
+            "resources",
+            root / "runtime" / "resources",
+            target_is_directory=True,
         )
         self._cmake(
             view,

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -69,6 +69,7 @@ ALL_BUILD_TARGETS = (
     "metaserver-worker",
 )
 SOURCE_VIEW_METADATA = ".atrinik-source-view.json"
+SOURCE_VIEW_SCHEMA_VERSION = 2
 CONFIGURE_METADATA = ".atrinik-configure.json"
 CONFIGURE_SCHEMA_VERSION = 2
 COMPILER_CACHE_PURPOSE = "compiler-cache"
@@ -1582,8 +1583,16 @@ class Workspace:
         }
         copied_directories = copied_directories or set()
         try:
+            source_head: str | None = git(
+                source, "rev-parse", "HEAD", capture=True, trace=False
+            )
+            if not isinstance(source_head, str) or len(source_head) != 40 or any(
+                character not in "0123456789abcdef" for character in source_head
+            ):
+                raise WorkspaceError(f"invalid Git HEAD for source view: {source}")
             source_clean: bool | None = _is_clean(source, trace=False)
         except WorkspaceError:
+            source_head = None
             source_clean = None
         expected: dict[str, dict[str, Any]] = {}
         for entry in sorted(source.iterdir(), key=lambda path: path.name):
@@ -1692,9 +1701,10 @@ class Workspace:
             if destination.name not in reserved and destination.name not in expected:
                 self._remove_source_view_entry(destination)
         metadata = {
-            "schema_version": 1,
+            "schema_version": SOURCE_VIEW_SCHEMA_VERSION,
             "purpose": purpose,
             "source": str(source.resolve()),
+            "source_head": source_head,
             "entries": expected,
         }
         metadata_path = view / SOURCE_VIEW_METADATA
@@ -2730,8 +2740,9 @@ class Workspace:
                 and not source_metadata.is_symlink()
                 and not marker.is_symlink()
                 and isinstance(metadata, dict)
-                and set(metadata) == {"schema_version", "purpose", "source", "entries"}
-                and metadata.get("schema_version") == 1
+                and set(metadata)
+                == {"schema_version", "purpose", "source", "source_head", "entries"}
+                and metadata.get("schema_version") == SOURCE_VIEW_SCHEMA_VERSION
                 and isinstance(metadata.get("purpose"), str)
                 and metadata["purpose"].startswith("source-view:")
                 and ownership
@@ -2740,6 +2751,17 @@ class Workspace:
                     "purpose": metadata["purpose"],
                 }
                 and isinstance(metadata.get("source"), str)
+                and (
+                    metadata.get("source_head") is None
+                    or (
+                        isinstance(metadata["source_head"], str)
+                        and len(metadata["source_head"]) == 40
+                        and all(
+                            character in "0123456789abcdef"
+                            for character in metadata["source_head"]
+                        )
+                    )
+                )
                 and isinstance(metadata.get("entries"), dict)
             )
             if valid:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -121,6 +121,7 @@ workspace/
   profiles/<name>.json               logical component -> checkout selectors
   build/profiles/<name>-<key>/       isolated sources, builds, and runtime
   build/npm-cache/                   shared package download cache
+  build/compiler-cache/              bounded shared native compiler cache
   build/retention.json               optional strict build pin/rollback record
   topologies/<name>/                 supervised process state and rotated logs
   state/server/<name>/               persistent mutable server data
@@ -231,12 +232,13 @@ locks, registered Git worktrees, and exact absolute roots in strict schema-1
 helper repeats containment, symlink, marker, schema, and purpose validation
 immediately before deletion.
 
-The npm cache has an exact `npm-cache` purpose marker and atomically refreshed
-`.atrinik-cache.json` timestamp. Its scope is opt-in. One pre-marker cache at
-that fixed path can be treated as a legacy known cache only after the workspace
-marker, fixed containment, no-symlink shape, age, and inactive-build checks
-pass; apply adopts the marker before calling the common removal helper. No
-other unmarked path receives that exception. Unmarked profile roots, unknown
+The npm and compiler caches have exact purpose markers and atomically refreshed
+`.atrinik-cache.json` timestamps. The compiler cache metadata also fixes its
+5 GiB bound. Both scopes are opt-in. One pre-marker npm cache at its fixed path
+can be treated as a legacy known cache only after the workspace marker, fixed
+containment, no-symlink shape, age, and inactive-build checks pass; apply
+adopts the marker before calling the common removal helper. No other unmarked
+path receives that exception. Unmarked profile roots, unknown
 `workspace/build` children, and the mixed top-level `build/` tree remain
 visible report-only `unmanaged-build` records. Cleanup never targets profiles,
 scenarios, state, topology records/logs, migration archives/evidence, branches,
@@ -340,8 +342,10 @@ but malformed fails validation rather than silently shrinking that closure.
 This separates combinations across distinct physical checkouts while
 preserving compiler output when the same worktrees advance, and makes pre-split
 build trees inert rather than reinterpreting them under replacement identities.
-The coordinator creates disposable source views rather than writing dependency
-links or output into source checkouts.
+The coordinator reconciles marker-owned source views in place rather than
+writing dependency links or output into source checkouts. It retains unchanged
+safe links and copies, replaces changed or retargeted entries, removes stale
+entries, and rejects source symlinks that escape their selected source root.
 
 The currently playable classic build flow is:
 
@@ -383,6 +387,23 @@ The resources repository's `runtime-paths.txt` is the distribution boundary:
 only tracked regular files below those paths enter the runtime view. This keeps
 repository metadata, local untracked files, and symlinks out of the asset
 protocol.
+
+Each CMake binary tree stores an atomic configure fingerprint covering the
+source-view identity, Ninja generator, CMake and compiler identities, toolchain
+and cache arguments, `BUILD_TESTING`, and relevant compiler/platform
+environment. The wrapper skips only its explicit configure command when both
+that fingerprint and the reconciled view are unchanged; `cmake --build`
+remains able to invoke CMake/Ninja dependency regeneration. A forced configure
+is available through `--force-reconfigure`.
+
+When `ccache` is discoverable, the wrapper sets supported C and C++ CMake
+compiler launchers and a marker-owned shared cache with a fixed 5 GiB maximum.
+The per-build cache base and compiler prefix-map arguments normalize equivalent
+profile roots to stable `/atrinik/source` and `/atrinik/build` diagnostics
+without sharing mutable CMake binary trees. Compiler, toolchain, test-mode, or
+relevant environment changes invalidate configure state; source dependency
+changes continue through Ninja. `--no-ccache` explicitly opts out and clears
+any cached launcher setting.
 
 After a Classic server build, the coordinator runs the built server's offline
 worldmaker in a temporary runtime assembled from the selected server,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -408,10 +408,10 @@ The per-build cache base and compiler prefix-map arguments normalize equivalent
 profile roots to stable `/atrinik/source` and `/atrinik/build` diagnostics
 without sharing mutable CMake binary trees. Prefix-map flags are added only
 after the selected environment compiler proves support; opaque toolchain
-compilers retain their own flag syntax. Compiler, toolchain, test-mode, or
-relevant environment changes invalidate configure state; source dependency
-changes continue through Ninja. `--no-ccache` explicitly opts out and clears
-any cached launcher setting.
+compilers retain their own flag syntax and directory-sensitive cache keys.
+Compiler, toolchain, test-mode, or relevant environment changes invalidate
+configure state; source dependency changes continue through Ninja.
+`--no-ccache` explicitly opts out and clears any cached launcher setting.
 
 After a Classic server build, the coordinator runs the built server's offline
 worldmaker in a temporary runtime assembled from the selected server,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -392,9 +392,12 @@ Each CMake binary tree stores an atomic configure fingerprint covering the
 source-view identity, Ninja generator, CMake and compiler identities, toolchain
 and cache arguments, `BUILD_TESTING`, and relevant compiler/platform
 environment. The wrapper skips only its explicit configure command when both
-that fingerprint and the reconciled view are unchanged; `cmake --build`
-remains able to invoke CMake/Ninja dependency regeneration. A forced configure
-is available through `--force-reconfigure`.
+that fingerprint and the reconciled view are unchanged and the CMake cache and
+Ninja graph still identify the expected source/generator; `cmake --build`
+remains able to invoke CMake/Ninja dependency regeneration. Compiler,
+toolchain-file, and initialization-environment changes reinitialize only the
+marker-owned CMake binary tree. A forced configure is available through
+`--force-reconfigure` without resetting an otherwise matching tree.
 
 When `ccache` is discoverable, the wrapper sets supported C and C++ CMake
 compiler launchers and a marker-owned shared cache with a fixed 5 GiB maximum.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -403,7 +403,9 @@ When `ccache` is discoverable, the wrapper sets supported C and C++ CMake
 compiler launchers and a marker-owned shared cache with a fixed 5 GiB maximum.
 The per-build cache base and compiler prefix-map arguments normalize equivalent
 profile roots to stable `/atrinik/source` and `/atrinik/build` diagnostics
-without sharing mutable CMake binary trees. Compiler, toolchain, test-mode, or
+without sharing mutable CMake binary trees. Prefix-map flags are added only
+after the selected environment compiler proves support; opaque toolchain
+compilers retain their own flag syntax. Compiler, toolchain, test-mode, or
 relevant environment changes invalidate configure state; source dependency
 changes continue through Ninja. `--no-ccache` explicitly opts out and clears
 any cached launcher setting.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -346,6 +346,9 @@ The coordinator reconciles marker-owned source views in place rather than
 writing dependency links or output into source checkouts. It retains unchanged
 safe links and copies, replaces changed or retargeted entries, removes stale
 entries, and rejects source symlinks that escape their selected source root.
+Linked-tree structure and symlink targets participate in view identity; dirty
+Git sources conservatively force configure so untracked or otherwise unmodeled
+CMake inputs cannot remain hidden behind a warm graph.
 
 The currently playable classic build flow is:
 

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1839,6 +1839,36 @@ class CleanupTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "unsupported cleanup target"):
             cleanup._remove({"kind": "unknown", "path": str(cache)})
 
+    def test_compiler_cache_is_bounded_marker_owned_and_explicitly_reclaimed(
+        self,
+    ) -> None:
+        cache = self.workspace.paths.builds / "compiler-cache"
+        managed_directory(cache, self.workspace.paths.builds, "compiler-cache")
+        atomic_json(
+            cache / ".atrinik-cache.json",
+            {
+                "schema_version": 1,
+                "purpose": "compiler-cache",
+                "last_used_at": "2020-01-01T00:00:00+00:00",
+                "max_size": "5G",
+            },
+        )
+        (cache / "entry").write_text("cached\n", encoding="utf-8")
+
+        self.assertFalse(
+            any(row["kind"] == "compiler-cache" for row in self.plan([])["items"])
+        )
+        report = self.plan(["compiler-cache"])
+        item = next(
+            row for row in report["items"] if row["kind"] == "compiler-cache"
+        )
+        self.assertEqual(item["disposition"], "eligible")
+        self.assertEqual(item["reasons"], ["stale_compiler_cache"])
+
+        removed = self.workspace.cleanup(["compiler-cache"], 0, [], True)
+        self.assertEqual(removed["summary"]["removed_count"], 1)
+        self.assertFalse(cache.exists())
+
     def test_dry_run_does_not_create_an_absent_workspace(self) -> None:
         shutil.rmtree(self.workspace.paths.workspace)
         report = self.workspace.cleanup(["builds"], 7, [], False)
@@ -1852,7 +1882,8 @@ class CleanupTests(unittest.TestCase):
         actual_workspace = Workspace(repository)
         cleanup = Cleanup(actual_workspace)
         self.assertEqual(
-            cleanup._normalize_scopes(["all"]), ["worktrees", "builds", "npm-cache"]
+            cleanup._normalize_scopes(["all"]),
+            ["worktrees", "builds", "npm-cache", "compiler-cache"],
         )
         self.assertEqual(cleanup._normalize_names(["atrinik"]), {"atrinik"})
         with self.assertRaisesRegex(WorkspaceError, "unknown components"):

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1865,6 +1865,24 @@ class CleanupTests(unittest.TestCase):
         self.assertEqual(item["disposition"], "eligible")
         self.assertEqual(item["reasons"], ["stale_compiler_cache"])
 
+        (cache / ".atrinik-cache.json").unlink()
+        report = self.plan(["compiler-cache"])
+        item = next(
+            row for row in report["items"] if row["kind"] == "compiler-cache"
+        )
+        self.assertEqual(item["disposition"], "protected")
+        self.assertIn("invalid_cache_metadata", item["reasons"])
+        self.assertIn("cache_age_unavailable", item["reasons"])
+        atomic_json(
+            cache / ".atrinik-cache.json",
+            {
+                "schema_version": 1,
+                "purpose": "compiler-cache",
+                "last_used_at": "2020-01-01T00:00:00+00:00",
+                "max_size": "5G",
+            },
+        )
+
         removed = self.workspace.cleanup(["compiler-cache"], 0, [], True)
         self.assertEqual(removed["summary"]["removed_count"], 1)
         self.assertFalse(cache.exists())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -274,6 +274,30 @@ class ParserTests(unittest.TestCase):
             [], "none", include_classic=True
         )
 
+    def test_build_dispatches_cache_controls(self) -> None:
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.build.return_value = Path("/build")
+            result = main(
+                [
+                    "build",
+                    "client",
+                    "--profile",
+                    "review",
+                    "--test",
+                    "--force-reconfigure",
+                    "--no-ccache",
+                ]
+            )
+
+        self.assertEqual(result, 0)
+        workspace_type.return_value.build.assert_called_once_with(
+            "client",
+            "review",
+            True,
+            force_reconfigure=True,
+            use_ccache=False,
+        )
+
     def test_classic_cohort_option_rejects_abbreviated_spelling(self) -> None:
         for command in ("init", "sync"):
             with self.subTest(command=command):

--- a/tests/test_cohorts.py
+++ b/tests/test_cohorts.py
@@ -407,7 +407,12 @@ class CohortWorkspaceTests(unittest.TestCase):
             tests: bool,
             targets: list[str],
             selected: dict[str, Path],
+            *,
+            force_reconfigure: bool = False,
+            use_ccache: bool = True,
         ) -> Path:
+            self.assertFalse(force_reconfigure)
+            self.assertTrue(use_ccache)
             self.assertEqual(set(selected), expected_roles)
             root = self.workspace.paths.builds / "profiles" / (
                 f"{profile_name}-{self.workspace._profile_build_key(profile_name, selected)}"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -938,12 +938,16 @@ class WorkspaceTests(unittest.TestCase):
         (source_root / "CMakeLists.txt").write_text(
             "project(test C)\n", encoding="utf-8"
         )
+        command("git", "add", "CMakeLists.txt", cwd=source_root)
+        command("git", "commit", "-m", "test: add CMake project", cwd=source_root)
         root = self.workspace.paths.builds / "profiles" / "test"
         managed_directory(root, self.workspace.paths.builds, "test-profile")
         source = self.workspace._profile_source_view(root, "content", source_root, set())
         binary = root / "build" / "content"
 
         def configured(command: list[str], **kwargs: object) -> str | None:
+            if command[0] == "git":
+                return workspace_run(command, **kwargs)
             if command[:2] == ["ninja", "-C"]:
                 return "build.ninja:\n  input: RERUN_CMAKE\n"
             if command[:2] != ["cmake", "-S"]:
@@ -1572,6 +1576,49 @@ class WorkspaceTests(unittest.TestCase):
         (source / "src" / "b.c").write_text("int b;\n", encoding="utf-8")
         self.workspace._cmake(source, binary, [], tests=False)
         self.assertIn("b.c", (binary / "selected.txt").read_text(encoding="utf-8"))
+
+    @unittest.skipUnless(
+        all(shutil.which(tool) for tool in ("git", "cmake", "ninja")),
+        "real Git/CMake toolchain is unavailable",
+    )
+    def test_real_clean_source_commit_reconfigures_despite_older_mtime(self) -> None:
+        source = self.root / "clean-commit-source"
+        source.mkdir()
+        (source / "CMakeLists.txt").write_text(
+            "cmake_minimum_required(VERSION 3.20)\n"
+            "project(clean_commit NONE)\n"
+            "configure_file(value.in generated.txt COPYONLY)\n",
+            encoding="utf-8",
+        )
+        configured_input = source / "value.in"
+        configured_input.write_text("one\n", encoding="utf-8")
+        command("git", "init", "-b", "main", cwd=source)
+        command("git", "config", "user.name", "Tests", cwd=source)
+        command("git", "config", "user.email", "tests@example.invalid", cwd=source)
+        command("git", "add", ".", cwd=source)
+        command("git", "commit", "-m", "test: seed clean source", cwd=source)
+        root = self.workspace.paths.builds / "profiles" / "clean-commit"
+        managed_directory(root, self.workspace.paths.builds, "profile:clean-commit")
+        view = self.workspace._profile_source_view(root, "renamed", source, set())
+        binary = root / "build" / "sample"
+        self.workspace._use_ccache = False
+
+        self.workspace._cmake(view, binary, [], tests=False)
+        self.assertEqual((binary / "generated.txt").read_text(), "one\n")
+        sentinel = binary / "preserve-me"
+        sentinel.write_text("keep\n", encoding="utf-8")
+
+        configured_input.write_text("two\n", encoding="utf-8")
+        command("git", "add", "value.in", cwd=source)
+        command("git", "commit", "-m", "test: change configured input", cwd=source)
+        older = (binary / "build.ninja").stat().st_mtime - 60
+        os.utime(configured_input, (older, older))
+        self.workspace._profile_source_view(root, "renamed", source, set())
+        self.assertFalse(self.workspace._source_view_unchanged[str(view.resolve())])
+        self.workspace._cmake(view, binary, [], tests=False)
+
+        self.assertEqual((binary / "generated.txt").read_text(), "two\n")
+        self.assertTrue(sentinel.is_file())
 
     @unittest.skipUnless(
         all(shutil.which(tool) for tool in ("cc", "ccache", "cmake", "ninja")),

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -721,8 +721,6 @@ class WorkspaceTests(unittest.TestCase):
         )
         readme = view / "README"
         copied = view / "install_data" / "keys" / "test.pub"
-        readme_inode = readme.lstat().st_ino
-        copied_inode = copied.stat().st_ino
         (view / "stale").write_text("stale\n", encoding="utf-8")
         readme.unlink()
         readme.symlink_to(source / "install_data", target_is_directory=True)
@@ -735,9 +733,9 @@ class WorkspaceTests(unittest.TestCase):
 
         self.assertEqual(reconciled, view)
         self.assertFalse((view / "stale").exists())
+        self.assertTrue(readme.is_symlink())
+        self.assertEqual(os.readlink(readme), str(source / "README"))
         self.assertEqual(readme.resolve(), source / "README")
-        self.assertNotEqual(readme.lstat().st_ino, readme_inode)
-        self.assertNotEqual(copied.stat().st_ino, copied_inode)
         self.assertEqual(copied.read_text(encoding="utf-8"), "changed\n")
         self.assertTrue((view / "install_data" / "unique-items" / "new").is_file())
         self.assertFalse(self.workspace._source_view_unchanged[str(view.resolve())])

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -26,6 +26,8 @@ from atrinik_workspace.model import (
     profile_key,
 )
 from atrinik_workspace.workspace import (
+    CONFIGURE_METADATA,
+    SOURCE_VIEW_METADATA,
     Workspace,
     _remote_matches as real_remote_matches,
     display_arguments,
@@ -706,6 +708,178 @@ class WorkspaceTests(unittest.TestCase):
         )
         (copied / "README").write_text("changed in view\n", encoding="utf-8")
         self.assertEqual((source / "README").read_text(encoding="utf-8"), "content\n")
+
+    def test_source_view_reconciles_links_copies_and_stale_entries_in_place(self) -> None:
+        source = self.workspace.paths.repositories / "server"
+        copied_source = source / "install_data"
+        copied_file = copied_source / "keys" / "test.pub"
+        root = self.workspace.paths.builds / "profiles" / "test"
+        managed_directory(root, self.workspace.paths.builds, "test-profile")
+
+        view = self.workspace._profile_source_view(
+            root, "server", source, set(), {"install_data"}
+        )
+        readme = view / "README"
+        copied = view / "install_data" / "keys" / "test.pub"
+        readme_inode = readme.lstat().st_ino
+        copied_inode = copied.stat().st_ino
+        (view / "stale").write_text("stale\n", encoding="utf-8")
+        readme.unlink()
+        readme.symlink_to(source / "install_data", target_is_directory=True)
+        copied_file.write_text("changed\n", encoding="utf-8")
+        (copied_source / "unique-items" / "new").write_text("new\n", encoding="utf-8")
+
+        reconciled = self.workspace._profile_source_view(
+            root, "server", source, set(), {"install_data"}
+        )
+
+        self.assertEqual(reconciled, view)
+        self.assertFalse((view / "stale").exists())
+        self.assertEqual(readme.resolve(), source / "README")
+        self.assertNotEqual(readme.lstat().st_ino, readme_inode)
+        self.assertNotEqual(copied.stat().st_ino, copied_inode)
+        self.assertEqual(copied.read_text(encoding="utf-8"), "changed\n")
+        self.assertTrue((view / "install_data" / "unique-items" / "new").is_file())
+        self.assertFalse(self.workspace._source_view_unchanged[str(view.resolve())])
+        metadata = load_json(view / SOURCE_VIEW_METADATA)
+        self.assertEqual(metadata["purpose"], "source-view:server")
+
+        copied_file.chmod(0o700)
+        self.workspace._profile_source_view(
+            root, "server", source, set(), {"install_data"}
+        )
+        self.assertEqual(copied.stat().st_mode & 0o777, 0o700)
+        self.assertFalse(self.workspace._source_view_unchanged[str(view.resolve())])
+
+        (source / "README").unlink()
+        self.workspace._profile_source_view(
+            root, "server", source, set(), {"install_data"}
+        )
+        self.assertFalse(readme.exists())
+
+    def test_source_view_retains_unchanged_entries_and_rejects_escaping_symlink(
+        self,
+    ) -> None:
+        source = self.workspace.paths.repositories / "content"
+        root = self.workspace.paths.builds / "profiles" / "test"
+        managed_directory(root, self.workspace.paths.builds, "test-profile")
+        view = self.workspace._profile_source_view(root, "content", source, set())
+        inode = (view / "README").lstat().st_ino
+
+        self.workspace._profile_source_view(root, "content", source, set())
+        self.assertEqual((view / "README").lstat().st_ino, inode)
+        self.assertTrue(self.workspace._source_view_unchanged[str(view.resolve())])
+
+        outside_directory = self.root / "outside-directory"
+        outside_directory.mkdir()
+        sentinel = outside_directory / "sentinel"
+        sentinel.write_text("preserved\n", encoding="utf-8")
+        (view / "README").unlink()
+        (view / "README").symlink_to(outside_directory, target_is_directory=True)
+        self.workspace._profile_source_view(root, "content", source, set())
+        self.assertTrue(sentinel.is_file())
+        self.assertEqual((view / "README").resolve(), source / "README")
+        self.assertFalse(self.workspace._source_view_unchanged[str(view.resolve())])
+
+        outside = self.root / "outside"
+        outside.write_text("outside\n", encoding="utf-8")
+        (source / "escape").symlink_to(outside)
+        with self.assertRaisesRegex(WorkspaceError, "escapes its source root"):
+            self.workspace._profile_source_view(root, "content", source, set())
+
+    def test_cmake_skips_only_unchanged_fingerprint_and_honors_force(self) -> None:
+        source_root = self.workspace.paths.repositories / "content"
+        (source_root / "CMakeLists.txt").write_text(
+            "project(test C)\n", encoding="utf-8"
+        )
+        root = self.workspace.paths.builds / "profiles" / "test"
+        managed_directory(root, self.workspace.paths.builds, "test-profile")
+        source = self.workspace._profile_source_view(root, "content", source_root, set())
+        binary = root / "build" / "content"
+
+        with (
+            mock.patch("atrinik_workspace.workspace.shutil.which", return_value=None),
+            mock.patch.object(
+                self.workspace,
+                "_tool_identity",
+                return_value={"command": "tool", "path": "/tool", "version": "1"},
+            ),
+            mock.patch("atrinik_workspace.workspace.run") as run,
+        ):
+            self.workspace._cmake(source, binary, [], tests=False)
+            first_count = run.call_count
+            self.workspace._profile_source_view(root, "content", source_root, set())
+            self.workspace._cmake(source, binary, [], tests=False)
+            second_commands = [call.args[0] for call in run.call_args_list[first_count:]]
+            self.assertEqual(second_commands, [["cmake", "--build", str(binary), "--parallel"]])
+
+            self.workspace._force_reconfigure = True
+            self.workspace._cmake(source, binary, [], tests=False)
+            self.assertTrue(any(command[:2] == ["cmake", "-S"] for command in [
+                call.args[0] for call in run.call_args_list[first_count + 1 :]
+            ]))
+
+        self.assertTrue((binary / CONFIGURE_METADATA).is_file())
+
+    def test_cmake_fingerprint_invalidates_for_tests_environment_and_toolchain(self) -> None:
+        source = self.workspace.paths.repositories / "content"
+        (source / "CMakeLists.txt").write_text("project(test C)\n", encoding="utf-8")
+        binary = self.workspace.paths.builds / "profiles" / "test" / "build" / "content"
+        identities = {
+            "cmake": {"command": "cmake", "path": "/cmake", "version": "cmake 1"},
+            "ninja": {"command": "ninja", "path": "/ninja", "version": "ninja 1"},
+            "cc": {"command": "cc", "path": "/cc", "version": "cc 1"},
+            "c++": {"command": "c++", "path": "/c++", "version": "c++ 1"},
+        }
+        with (
+            mock.patch("atrinik_workspace.workspace.shutil.which", return_value=None),
+            mock.patch.object(
+                self.workspace, "_tool_identity", side_effect=lambda tool: identities[tool]
+            ),
+            mock.patch("atrinik_workspace.workspace.run") as run,
+        ):
+            self.workspace._cmake(source, binary, [], tests=False)
+            self.workspace._cmake(source, binary, [], tests=True)
+            with mock.patch.dict(os.environ, {"CFLAGS": "-DCHANGED"}):
+                self.workspace._cmake(source, binary, [], tests=True)
+            identities["cc"] = {"command": "cc", "path": "/cc", "version": "cc 2"}
+            self.workspace._cmake(source, binary, [], tests=True)
+
+        configure_calls = [
+            call for call in run.call_args_list if call.args[0][:2] == ["cmake", "-S"]
+        ]
+        self.assertEqual(len(configure_calls), 4)
+
+    def test_cmake_enables_bounded_marker_owned_ccache_with_normalized_paths(self) -> None:
+        source = self.workspace.paths.repositories / "content"
+        (source / "CMakeLists.txt").write_text("project(test CXX)\n", encoding="utf-8")
+        binary = self.workspace.paths.builds / "profiles" / "test" / "build" / "content"
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.shutil.which",
+                side_effect=lambda tool: "/usr/bin/ccache" if tool == "ccache" else f"/usr/bin/{tool}",
+            ),
+            mock.patch.object(
+                self.workspace,
+                "_tool_identity",
+                return_value={"command": "tool", "path": "/tool", "version": "1"},
+            ),
+            mock.patch("atrinik_workspace.workspace.run") as run,
+        ):
+            self.workspace._cmake(source, binary, [], tests=False)
+
+        configure = next(
+            call for call in run.call_args_list if call.args[0][:2] == ["cmake", "-S"]
+        )
+        arguments = configure.args[0]
+        environment = configure.kwargs["env"]
+        self.assertIn("-DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache", arguments)
+        self.assertIn("-fdebug-prefix-map=", " ".join(arguments))
+        self.assertEqual(environment["CCACHE_MAXSIZE"], "5G")
+        self.assertEqual(environment["CCACHE_BASEDIR"], str(binary.parent.parent.resolve()))
+        cache = self.workspace.paths.builds / "compiler-cache"
+        self.assertEqual(load_json(cache / MANAGED_MARKER)["purpose"], "compiler-cache")
+        self.assertEqual(load_json(cache / ".atrinik-cache.json")["max_size"], "5G")
 
     def test_resource_view_reserves_generated_metadata_names(self) -> None:
         source = self.workspace.paths.repositories / "resources"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -860,6 +860,27 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual(
             (view / "left" / "value-link").resolve(), view / "right" / "value"
         )
+        top_level_link = source / "top-level-link"
+        top_level_link.symlink_to(Path("../content/README"))
+        conflicting = root / "sources" / source.name
+        conflicting.mkdir()
+        (conflicting / "README").write_text("wrong\n", encoding="utf-8")
+        self.workspace._profile_source_view(
+            root, "worker", source, set(), copy_all=True
+        )
+        self.assertEqual((view / "top-level-link").resolve(), view / "README")
+        self.assertNotEqual(
+            (view / "top-level-link").resolve(), conflicting / "README"
+        )
+
+        (source / "build").mkdir()
+        (source / "build" / "generated").write_text("excluded\n", encoding="utf-8")
+        (source / "excluded-link").symlink_to(Path("build/generated"))
+        with self.assertRaisesRegex(WorkspaceError, "targets an excluded entry"):
+            self.workspace._profile_source_view(
+                root, "worker", source, {"build"}, copy_all=True
+            )
+        (source / "excluded-link").unlink()
         outside = self.root / "outside-copy-root"
         outside.write_text("unsafe\n", encoding="utf-8")
         (left / "escape-link").symlink_to(outside)
@@ -1053,6 +1074,57 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual(
             identity["cmakelists"], hashlib.sha256(cmakelists.read_bytes()).hexdigest()
         )
+        self.assertFalse(identity["configure_skip_safe"])
+
+    def test_direct_source_skip_requires_clean_git_identity(self) -> None:
+        source = self.workspace.paths.repositories / "protocol"
+        cmakelists = source / "CMakeLists.txt"
+        cmakelists.write_text("project(test C)\n", encoding="utf-8")
+        command("git", "add", "CMakeLists.txt", cwd=source)
+        command("git", "commit", "-m", "test: add CMake project", cwd=source)
+
+        clean = self.workspace._cmake_source_identity(source)
+        self.assertTrue(clean["configure_skip_safe"])
+        self.assertEqual(clean["git"]["root"], str(source.resolve()))
+        self.assertEqual(len(clean["git"]["head"]), 40)
+
+        (source / "new-input.c").write_text("int added;\n", encoding="utf-8")
+        dirty = self.workspace._cmake_source_identity(source)
+        self.assertFalse(dirty["configure_skip_safe"])
+        self.assertEqual(dirty["git"]["head"], clean["git"]["head"])
+
+        non_git = self.root / "non-git-cmake-source"
+        non_git.mkdir()
+        (non_git / "CMakeLists.txt").write_text(
+            "project(non_git NONE)\n", encoding="utf-8"
+        )
+        fallback = self.workspace._cmake_source_identity(non_git)
+        self.assertIsNone(fallback["git"])
+        self.assertFalse(fallback["configure_skip_safe"])
+
+    def test_dirty_direct_cmake_source_never_skips_explicit_configure(self) -> None:
+        source = self.workspace.paths.repositories / "protocol"
+        (source / "CMakeLists.txt").write_text("project(test C)\n", encoding="utf-8")
+        binary = (
+            self.workspace.paths.builds / "profiles" / "test" / "build" / "protocol"
+        )
+        with (
+            mock.patch("atrinik_workspace.workspace.shutil.which", return_value=None),
+            mock.patch.object(
+                self.workspace,
+                "_tool_identity",
+                return_value={"command": "tool", "path": "/tool", "version": "1"},
+            ),
+            mock.patch.object(self.workspace, "_cmake_state_valid", return_value=True),
+            mock.patch("atrinik_workspace.workspace.run") as run,
+        ):
+            self.workspace._cmake(source, binary, [], tests=False)
+            self.workspace._cmake(source, binary, [], tests=False)
+
+        configure_calls = [
+            call for call in run.call_args_list if call.args[0][:2] == ["cmake", "-S"]
+        ]
+        self.assertEqual(len(configure_calls), 2)
 
     def test_cmake_enables_bounded_marker_owned_ccache_with_normalized_paths(self) -> None:
         source = self.workspace.paths.repositories / "content"
@@ -1085,6 +1157,8 @@ class WorkspaceTests(unittest.TestCase):
         self.assertIn("-ffile-prefix-map=", environment["CXXFLAGS"])
         self.assertEqual(environment["CCACHE_MAXSIZE"], "5G")
         self.assertEqual(environment["CCACHE_BASEDIR"], str(binary.parent.parent.resolve()))
+        self.assertEqual(environment["CCACHE_NOHASHDIR"], "true")
+        self.assertNotIn("CCACHE_HASHDIR", environment)
         cache = self.workspace.paths.builds / "compiler-cache"
         self.assertEqual(load_json(cache / MANAGED_MARKER)["purpose"], "compiler-cache")
         self.assertEqual(load_json(cache / ".atrinik-cache.json")["max_size"], "5G")
@@ -1096,22 +1170,72 @@ class WorkspaceTests(unittest.TestCase):
         with mock.patch.object(
             self.workspace, "_compiler_supports_prefix_maps", return_value=False
         ):
-            self.workspace._add_debug_prefix_environment(
+            support = self.workspace._add_debug_prefix_environment(
                 source, binary, environment, []
             )
+        self.assertEqual(support, {"c": False, "cxx": False})
         self.assertEqual(environment["CFLAGS"], "/existing")
         self.assertEqual(environment["CXXFLAGS"], "/existing-cxx")
+
+        partial_environment = {"CFLAGS": "/c", "CXXFLAGS": "/cxx"}
+        with mock.patch.object(
+            self.workspace,
+            "_compiler_supports_prefix_maps",
+            side_effect=[True, False],
+        ):
+            support = self.workspace._add_debug_prefix_environment(
+                source, binary, partial_environment, []
+            )
+        self.assertEqual(support, {"c": True, "cxx": False})
+        self.assertIn("-fdebug-prefix-map=", partial_environment["CFLAGS"])
+        self.assertEqual(partial_environment["CXXFLAGS"], "/cxx")
 
         with mock.patch.object(
             self.workspace, "_compiler_supports_prefix_maps"
         ) as supported:
-            self.workspace._add_debug_prefix_environment(
+            support = self.workspace._add_debug_prefix_environment(
                 source,
                 binary,
                 environment,
                 ["-DCMAKE_TOOLCHAIN_FILE=/tmp/windows-toolchain.cmake"],
             )
+        self.assertEqual(support, {"c": False, "cxx": False})
         supported.assert_not_called()
+
+    def test_cmake_keeps_hash_directory_for_unproven_toolchain_compilers(self) -> None:
+        source = self.workspace.paths.repositories / "content"
+        (source / "CMakeLists.txt").write_text("project(test C)\n", encoding="utf-8")
+        binary = self.workspace.paths.builds / "profiles" / "test" / "build" / "content"
+        with (
+            mock.patch.dict(os.environ, {"CCACHE_NOHASHDIR": "true"}),
+            mock.patch(
+                "atrinik_workspace.workspace.shutil.which",
+                side_effect=lambda tool: f"/usr/bin/{tool}",
+            ),
+            mock.patch.object(
+                self.workspace,
+                "_tool_identity",
+                return_value={"command": "tool", "path": "/tool", "version": "1"},
+            ),
+            mock.patch.object(
+                self.workspace, "_compiler_supports_prefix_maps"
+            ) as supported,
+            mock.patch("atrinik_workspace.workspace.run") as run,
+        ):
+            self.workspace._cmake(
+                source,
+                binary,
+                ["-DCMAKE_TOOLCHAIN_FILE=/missing/toolchain.cmake"],
+                tests=False,
+            )
+
+        supported.assert_not_called()
+        configure = next(
+            call for call in run.call_args_list if call.args[0][:2] == ["cmake", "-S"]
+        )
+        environment = configure.kwargs["env"]
+        self.assertEqual(environment["CCACHE_HASHDIR"], "true")
+        self.assertNotIn("CCACHE_NOHASHDIR", environment)
 
     @unittest.skipUnless(
         all(shutil.which(tool) for tool in ("cc", "cmake", "ninja")),
@@ -1419,6 +1543,37 @@ class WorkspaceTests(unittest.TestCase):
         )
 
     @unittest.skipUnless(
+        all(shutil.which(tool) for tool in ("git", "cmake", "ninja")),
+        "real Git/CMake toolchain is unavailable",
+    )
+    def test_real_dirty_direct_source_reconfigures_plain_glob(self) -> None:
+        source = self.root / "direct-cmake-source"
+        (source / "src").mkdir(parents=True)
+        (source / "CMakeLists.txt").write_text(
+            "cmake_minimum_required(VERSION 3.20)\n"
+            "project(direct_dirty NONE)\n"
+            'file(GLOB SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.c")\n'
+            'file(WRITE "${CMAKE_BINARY_DIR}/selected.txt" "${SOURCES}")\n',
+            encoding="utf-8",
+        )
+        (source / "src" / "a.c").write_text("int a;\n", encoding="utf-8")
+        command("git", "init", "-b", "main", cwd=source)
+        command("git", "config", "user.name", "Tests", cwd=source)
+        command("git", "config", "user.email", "tests@example.invalid", cwd=source)
+        command("git", "add", ".", cwd=source)
+        command("git", "commit", "-m", "test: seed direct source", cwd=source)
+        root = self.workspace.paths.builds / "profiles" / "direct-dirty"
+        managed_directory(root, self.workspace.paths.builds, "profile:direct-dirty")
+        binary = root / "build" / "sample"
+        self.workspace._use_ccache = False
+
+        self.workspace._cmake(source, binary, [], tests=False)
+        self.assertNotIn("b.c", (binary / "selected.txt").read_text(encoding="utf-8"))
+        (source / "src" / "b.c").write_text("int b;\n", encoding="utf-8")
+        self.workspace._cmake(source, binary, [], tests=False)
+        self.assertIn("b.c", (binary / "selected.txt").read_text(encoding="utf-8"))
+
+    @unittest.skipUnless(
         all(shutil.which(tool) for tool in ("cc", "ccache", "cmake", "ninja")),
         "real ccache/CMake toolchain is unavailable",
     )
@@ -1495,6 +1650,89 @@ class WorkspaceTests(unittest.TestCase):
         object_data = object_file.read_bytes()
         self.assertIn(b"/atrinik/source/main.c", object_data)
         self.assertNotIn(str(roots[1]).encode(), object_data)
+
+    @unittest.skipUnless(
+        all(shutil.which(tool) for tool in ("cc", "ccache", "cmake", "ninja")),
+        "real ccache/CMake toolchain is unavailable",
+    )
+    def test_real_cmake_toolchain_keeps_profile_paths_out_of_shared_hits(self) -> None:
+        source = self.root / "opaque-toolchain-source"
+        source.mkdir()
+        (source / "CMakeLists.txt").write_text(
+            "cmake_minimum_required(VERSION 3.20)\n"
+            "project(wrapper_opaque_ccache C)\n"
+            "add_executable(opaque_sample opaque_unique_main.c)\n",
+            encoding="utf-8",
+        )
+        (source / "opaque_unique_main.c").write_text(
+            "const char *opaque_source_file = __FILE__;\n"
+            "int main(void) { return opaque_source_file[0] == 0; }\n",
+            encoding="utf-8",
+        )
+        toolchain = self.root / "opaque-toolchain.cmake"
+        toolchain.write_text(
+            f'set(CMAKE_C_COMPILER "{shutil.which("cc")}")\n', encoding="utf-8"
+        )
+        roots = [
+            self.workspace.paths.builds / "profiles" / name
+            for name in ("opaque-cache-a", "opaque-cache-b")
+        ]
+        views: list[Path] = []
+        for root in roots:
+            managed_directory(root, self.workspace.paths.builds, f"profile:{root.name}")
+            views.append(
+                self.workspace._profile_source_view(root, "opaque", source, set())
+            )
+
+        self.workspace._cmake(
+            views[0],
+            roots[0] / "build" / "opaque",
+            [f"-DCMAKE_TOOLCHAIN_FILE={toolchain}"],
+            tests=False,
+        )
+        cache = self.workspace.paths.builds / "compiler-cache"
+        statistics_environment = os.environ.copy()
+        statistics_environment["CCACHE_DIR"] = str(cache)
+        subprocess.run(
+            ["ccache", "--zero-stats"],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=statistics_environment,
+        )
+        self.workspace._cmake(
+            views[1],
+            roots[1] / "build" / "opaque",
+            [f"-DCMAKE_TOOLCHAIN_FILE={toolchain}"],
+            tests=False,
+        )
+
+        statistics = subprocess.run(
+            ["ccache", "--print-stats"],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=statistics_environment,
+        ).stdout
+        values = {
+            name: int(value)
+            for name, value in (
+                line.split("\t", 1) for line in statistics.splitlines() if "\t" in line
+            )
+            if value.isdigit()
+        }
+        self.assertEqual(
+            values.get("direct_cache_hit", 0)
+            + values.get("preprocessed_cache_hit", 0),
+            0,
+        )
+        self.assertGreater(values.get("cache_miss", 0), 0)
+        object_file = next(
+            (roots[1] / "build" / "opaque").rglob("opaque_unique_main.c.o")
+        )
+        object_data = object_file.read_bytes()
+        self.assertIn(str(roots[1]).encode(), object_data)
+        self.assertNotIn(str(roots[0]).encode(), object_data)
 
     def test_resource_view_reserves_generated_metadata_names(self) -> None:
         source = self.workspace.paths.repositories / "resources"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -769,6 +769,22 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual((view / "README").lstat().st_ino, inode)
         self.assertTrue(self.workspace._source_view_unchanged[str(view.resolve())])
 
+        internal_target = source / "internal-target"
+        internal_target.write_text("one\n", encoding="utf-8")
+        source_link = source / "internal-link"
+        source_link.symlink_to(internal_target.name)
+        self.workspace._profile_source_view(root, "content", source, set())
+        self.workspace._profile_source_view(root, "content", source, set())
+        self.assertFalse(self.workspace._source_view_unchanged[str(view.resolve())])
+        first_metadata = load_json(view / SOURCE_VIEW_METADATA)
+        second_target = source / "second-target"
+        second_target.write_text("two\n", encoding="utf-8")
+        source_link.unlink()
+        source_link.symlink_to(second_target.name)
+        self.workspace._profile_source_view(root, "content", source, set())
+        self.assertFalse(self.workspace._source_view_unchanged[str(view.resolve())])
+        self.assertNotEqual(first_metadata, load_json(view / SOURCE_VIEW_METADATA))
+
         outside_directory = self.root / "outside-directory"
         outside_directory.mkdir()
         sentinel = outside_directory / "sentinel"
@@ -935,7 +951,11 @@ class WorkspaceTests(unittest.TestCase):
             first_count = run.call_count
             self.workspace._profile_source_view(root, "content", source_root, set())
             self.workspace._cmake(source, binary, [], tests=False)
-            second_commands = [call.args[0] for call in run.call_args_list[first_count:]]
+            second_commands = [
+                call.args[0]
+                for call in run.call_args_list[first_count:]
+                if call.args[0][0] != "git"
+            ]
             self.assertEqual(
                 second_commands,
                 [
@@ -1256,6 +1276,8 @@ class WorkspaceTests(unittest.TestCase):
         (source / "CMakeLists.txt").write_text(
             "cmake_minimum_required(VERSION 3.20)\n"
             "project(environment_rebuild C)\n"
+            "find_program(SELECTED_TOOL selected-tool REQUIRED)\n"
+            'file(WRITE "${CMAKE_BINARY_DIR}/selected-tool.txt" "${SELECTED_TOOL}")\n'
             "add_executable(environment main.c)\n",
             encoding="utf-8",
         )
@@ -1268,6 +1290,14 @@ class WorkspaceTests(unittest.TestCase):
         include_two = self.root / "include-two"
         include_one.mkdir()
         include_two.mkdir()
+        tool_one = self.root / "tool-one"
+        tool_two = self.root / "tool-two"
+        tool_one.mkdir()
+        tool_two.mkdir()
+        for directory in (tool_one, tool_two):
+            tool = directory / "selected-tool"
+            tool.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            tool.chmod(0o755)
         (include_one / "selected-value.h").write_text(
             '#define SELECTED_VALUE "atrinik-environment-one"\n', encoding="utf-8"
         )
@@ -1277,8 +1307,16 @@ class WorkspaceTests(unittest.TestCase):
         binary = self.workspace.paths.builds / "profiles" / "environment" / "build" / "sample"
         self.workspace._use_ccache = False
 
-        with mock.patch.dict(os.environ, {"CPATH": str(include_one)}):
+        base_path = os.environ.get("PATH", "")
+        with mock.patch.dict(
+            os.environ,
+            {"CPATH": str(include_one), "PATH": f"{tool_one}{os.pathsep}{base_path}"},
+        ):
             self.workspace._cmake(source, binary, [], tests=False)
+            self.assertEqual(
+                (binary / "selected-tool.txt").read_text(encoding="utf-8"),
+                str(tool_one / "selected-tool"),
+            )
             preserved = binary / "preserved-on-unchanged-environment"
             preserved.write_text("current\n", encoding="utf-8")
             self.workspace._cmake(source, binary, [], tests=False)
@@ -1299,11 +1337,85 @@ class WorkspaceTests(unittest.TestCase):
 
         environment_sentinel = binary / "removed-on-implicit-environment-change"
         environment_sentinel.write_text("stale\n", encoding="utf-8")
-        with mock.patch.dict(os.environ, {"CPATH": str(include_two)}):
+        with mock.patch.dict(
+            os.environ,
+            {"CPATH": str(include_two), "PATH": f"{tool_two}{os.pathsep}{base_path}"},
+        ):
             self.workspace._cmake(source, binary, [], tests=False)
         self.assertFalse(environment_sentinel.exists())
         self.assertIn(
             b"atrinik-environment-two", (binary / "environment").read_bytes()
+        )
+        discovery_sentinel = binary / "removed-on-discovery-environment-change"
+        discovery_sentinel.write_text("stale\n", encoding="utf-8")
+        with mock.patch.dict(
+            os.environ,
+            {"CPATH": str(include_two), "PATH": f"{tool_one}{os.pathsep}{base_path}"},
+        ):
+            self.workspace._cmake(source, binary, [], tests=False)
+        self.assertFalse(discovery_sentinel.exists())
+        self.assertEqual(
+            (binary / "selected-tool.txt").read_text(encoding="utf-8"),
+            str(tool_one / "selected-tool"),
+        )
+
+    @unittest.skipUnless(
+        all(shutil.which(tool) for tool in ("cmake", "ninja")),
+        "real CMake/Ninja toolchain is unavailable",
+    )
+    def test_real_cmake_reconfigures_after_source_symlink_retarget(self) -> None:
+        source = self.root / "symlinked-cmake-source"
+        source.mkdir()
+        nested = source / "src"
+        nested.mkdir()
+        (nested / "a.c").write_text("int a;\n", encoding="utf-8")
+        first = source / "first.cmake"
+        second = source / "second.cmake"
+        first.write_text(
+            "cmake_minimum_required(VERSION 3.20)\n"
+            "project(first NONE)\n"
+            'file(GLOB SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.c")\n'
+            'file(WRITE "${CMAKE_BINARY_DIR}/selected.txt" "first:${SOURCES}")\n',
+            encoding="utf-8",
+        )
+        second.write_text(
+            "cmake_minimum_required(VERSION 3.20)\n"
+            "project(second NONE)\n"
+            'file(GLOB SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.c")\n'
+            'file(WRITE "${CMAKE_BINARY_DIR}/selected.txt" "second:${SOURCES}")\n',
+            encoding="utf-8",
+        )
+        older = first.stat().st_mtime - 60
+        os.utime(second, (older, older))
+        cmakelists = source / "CMakeLists.txt"
+        cmakelists.symlink_to(first.name)
+        root = self.workspace.paths.builds / "profiles" / "symlink-configure"
+        managed_directory(root, self.workspace.paths.builds, "profile:symlink")
+        view = self.workspace._profile_source_view(
+            root, "sample", source, set()
+        )
+        binary = root / "build" / "sample"
+        self.workspace._use_ccache = False
+
+        self.workspace._cmake(view, binary, [], tests=False)
+        self.assertIn(
+            "first:", (binary / "selected.txt").read_text(encoding="utf-8")
+        )
+        cmakelists.unlink()
+        cmakelists.symlink_to(second.name)
+        self.workspace._profile_source_view(root, "sample", source, set())
+        self.workspace._cmake(view, binary, [], tests=False)
+        selected = (binary / "selected.txt").read_text(encoding="utf-8")
+        self.assertIn("second:", selected)
+        self.assertNotIn("b.c", selected)
+
+        added = nested / "b.c"
+        added.write_text("int b;\n", encoding="utf-8")
+        os.utime(added, (older, older))
+        self.workspace._profile_source_view(root, "sample", source, set())
+        self.workspace._cmake(view, binary, [], tests=False)
+        self.assertIn(
+            "b.c", (binary / "selected.txt").read_text(encoding="utf-8")
         )
 
     @unittest.skipUnless(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 from concurrent.futures import ThreadPoolExecutor
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -785,6 +786,55 @@ class WorkspaceTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "escapes its source root"):
             self.workspace._profile_source_view(root, "content", source, set())
 
+    def test_copied_source_view_recursively_excludes_generated_entries(self) -> None:
+        source = self.workspace.paths.repositories / "content"
+        nested = source / "nested"
+        (nested / "kept").mkdir(parents=True)
+        (nested / "kept" / "input").write_text("kept\n", encoding="utf-8")
+        for excluded in (".git", "build", "dist", "node_modules", ".wrangler"):
+            (nested / excluded).mkdir()
+            (nested / excluded / "stale").write_text("excluded\n", encoding="utf-8")
+        root = self.workspace.paths.builds / "profiles" / "test"
+        managed_directory(root, self.workspace.paths.builds, "test-profile")
+
+        view = self.workspace._profile_source_view(
+            root,
+            "worker",
+            source,
+            {"build", "dist", "node_modules", ".wrangler"},
+            copy_all=True,
+        )
+
+        self.assertTrue((view / "nested" / "kept" / "input").is_file())
+        for excluded in (".git", "build", "dist", "node_modules", ".wrangler"):
+            self.assertFalse((view / "nested" / excluded).exists())
+        (view / "nested" / "node_modules").mkdir()
+        self.workspace._profile_source_view(
+            root,
+            "worker",
+            source,
+            {"build", "dist", "node_modules", ".wrangler"},
+            copy_all=True,
+        )
+        self.assertFalse((view / "nested" / "node_modules").exists())
+
+    def test_preserved_source_view_directory_removes_unexpected_children(self) -> None:
+        source = self.workspace.paths.repositories / "server"
+        root = self.workspace.paths.builds / "profiles" / "test"
+        managed_directory(root, self.workspace.paths.builds, "test-profile")
+        view = self.workspace._profile_source_view(
+            root, "server", source, {"runtime"}, preserved_entries={"runtime"}
+        )
+        runtime = view / "runtime"
+        runtime.mkdir()
+        (runtime / "content").symlink_to(source, target_is_directory=True)
+        (runtime / "stale").write_text("stale\n", encoding="utf-8")
+
+        self.workspace._source_view_directory(view, "runtime", {"content"})
+
+        self.assertTrue((runtime / "content").is_symlink())
+        self.assertFalse((runtime / "stale").exists())
+
     def test_cmake_skips_only_unchanged_fingerprint_and_honors_force(self) -> None:
         source_root = self.workspace.paths.repositories / "content"
         (source_root / "CMakeLists.txt").write_text(
@@ -795,6 +845,16 @@ class WorkspaceTests(unittest.TestCase):
         source = self.workspace._profile_source_view(root, "content", source_root, set())
         binary = root / "build" / "content"
 
+        def configured(command: list[str], **kwargs: object) -> None:
+            if command[:2] != ["cmake", "-S"]:
+                return
+            (binary / "CMakeCache.txt").write_text(
+                f"CMAKE_HOME_DIRECTORY:INTERNAL={source.resolve()}\n"
+                "CMAKE_GENERATOR:INTERNAL=Ninja\n",
+                encoding="utf-8",
+            )
+            (binary / "build.ninja").write_text("# generated\n", encoding="utf-8")
+
         with (
             mock.patch("atrinik_workspace.workspace.shutil.which", return_value=None),
             mock.patch.object(
@@ -802,7 +862,7 @@ class WorkspaceTests(unittest.TestCase):
                 "_tool_identity",
                 return_value={"command": "tool", "path": "/tool", "version": "1"},
             ),
-            mock.patch("atrinik_workspace.workspace.run") as run,
+            mock.patch("atrinik_workspace.workspace.run", side_effect=configured) as run,
         ):
             self.workspace._cmake(source, binary, [], tests=False)
             first_count = run.call_count
@@ -810,6 +870,16 @@ class WorkspaceTests(unittest.TestCase):
             self.workspace._cmake(source, binary, [], tests=False)
             second_commands = [call.args[0] for call in run.call_args_list[first_count:]]
             self.assertEqual(second_commands, [["cmake", "--build", str(binary), "--parallel"]])
+
+            (binary / "build.ninja").unlink()
+            repair_start = run.call_count
+            self.workspace._cmake(source, binary, [], tests=False)
+            repair_commands = [
+                call.args[0] for call in run.call_args_list[repair_start:]
+            ]
+            self.assertTrue(
+                any(command[:2] == ["cmake", "-S"] for command in repair_commands)
+            )
 
             self.workspace._force_reconfigure = True
             self.workspace._cmake(source, binary, [], tests=False)
@@ -840,13 +910,56 @@ class WorkspaceTests(unittest.TestCase):
             self.workspace._cmake(source, binary, [], tests=True)
             with mock.patch.dict(os.environ, {"CFLAGS": "-DCHANGED"}):
                 self.workspace._cmake(source, binary, [], tests=True)
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "ATRINIK_PACKAGE_VERSION": "review",
+                    "PKG_CONFIG_PATH": "/opt/review/pkgconfig",
+                },
+            ):
+                self.workspace._cmake(source, binary, [], tests=True)
             identities["cc"] = {"command": "cc", "path": "/cc", "version": "cc 2"}
             self.workspace._cmake(source, binary, [], tests=True)
 
         configure_calls = [
             call for call in run.call_args_list if call.args[0][:2] == ["cmake", "-S"]
         ]
-        self.assertEqual(len(configure_calls), 4)
+        self.assertEqual(len(configure_calls), 5)
+
+    def test_tool_identity_handles_wrappers_and_empty_version_output(self) -> None:
+        with (
+            mock.patch("atrinik_workspace.workspace.shutil.which", return_value="/tool"),
+            mock.patch("atrinik_workspace.workspace.run", return_value="") as run,
+        ):
+            identity = self.workspace._tool_identity("wrapper --compiler cc")
+
+        run.assert_called_once_with(
+            ["/tool", "--compiler", "cc", "--version"],
+            capture=True,
+            trace=False,
+        )
+        self.assertEqual(identity["version"], "unavailable: empty --version output")
+
+    def test_direct_source_does_not_trust_unowned_source_view_metadata(self) -> None:
+        source = self.workspace.paths.repositories / "content"
+        cmakelists = source / "CMakeLists.txt"
+        cmakelists.write_text("project(test C)\n", encoding="utf-8")
+        atomic_json(
+            source / SOURCE_VIEW_METADATA,
+            {
+                "schema_version": 1,
+                "purpose": "source-view:forged",
+                "source": "/forged",
+                "entries": {},
+            },
+        )
+
+        identity = self.workspace._cmake_source_identity(source)
+
+        self.assertEqual(identity["path"], str(source.resolve()))
+        self.assertEqual(
+            identity["cmakelists"], hashlib.sha256(cmakelists.read_bytes()).hexdigest()
+        )
 
     def test_cmake_enables_bounded_marker_owned_ccache_with_normalized_paths(self) -> None:
         source = self.workspace.paths.repositories / "content"
@@ -872,12 +985,142 @@ class WorkspaceTests(unittest.TestCase):
         arguments = configure.args[0]
         environment = configure.kwargs["env"]
         self.assertIn("-DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache", arguments)
-        self.assertIn("-fdebug-prefix-map=", " ".join(arguments))
+        self.assertIn("-fdebug-prefix-map=", environment["CFLAGS"])
+        self.assertIn("-ffile-prefix-map=", environment["CXXFLAGS"])
         self.assertEqual(environment["CCACHE_MAXSIZE"], "5G")
         self.assertEqual(environment["CCACHE_BASEDIR"], str(binary.parent.parent.resolve()))
         cache = self.workspace.paths.builds / "compiler-cache"
         self.assertEqual(load_json(cache / MANAGED_MARKER)["purpose"], "compiler-cache")
         self.assertEqual(load_json(cache / ".atrinik-cache.json")["max_size"], "5G")
+
+    @unittest.skipUnless(
+        all(shutil.which(tool) for tool in ("cc", "cmake", "ninja")),
+        "real CMake toolchain is unavailable",
+    )
+    def test_real_cmake_reinitializes_changed_toolchain_and_preserves_init_flags(
+        self,
+    ) -> None:
+        source = self.root / "cmake-source"
+        source.mkdir()
+        (source / "CMakeLists.txt").write_text(
+            "cmake_minimum_required(VERSION 3.20)\n"
+            "project(wrapper_toolchain C)\n"
+            "add_executable(sample main.c)\n",
+            encoding="utf-8",
+        )
+        (source / "main.c").write_text(
+            "#ifndef TOOLCHAIN_VALUE\n#error missing toolchain flag\n#endif\n"
+            "int main(void) { return 0; }\n",
+            encoding="utf-8",
+        )
+        toolchain = self.root / "toolchain.cmake"
+        toolchain.write_text(
+            'set(CMAKE_C_FLAGS_INIT "${CMAKE_C_FLAGS_INIT} -DTOOLCHAIN_VALUE=1")\n',
+            encoding="utf-8",
+        )
+        binary = self.workspace.paths.builds / "profiles" / "real" / "build" / "sample"
+        self.workspace._use_ccache = False
+
+        self.workspace._cmake(
+            source,
+            binary,
+            [f"-DCMAKE_TOOLCHAIN_FILE={toolchain}"],
+            tests=False,
+        )
+        cache = (binary / "CMakeCache.txt").read_text(encoding="utf-8")
+        self.assertIn("-DTOOLCHAIN_VALUE=1", cache)
+        self.assertIn("-fdebug-prefix-map=", cache)
+        sentinel = binary / "removed-on-toolchain-change"
+        sentinel.write_text("stale\n", encoding="utf-8")
+
+        toolchain.write_text(
+            'set(CMAKE_C_FLAGS_INIT "${CMAKE_C_FLAGS_INIT} -DTOOLCHAIN_VALUE=2")\n',
+            encoding="utf-8",
+        )
+        self.workspace._cmake(
+            source,
+            binary,
+            [f"-DCMAKE_TOOLCHAIN_FILE={toolchain}"],
+            tests=False,
+        )
+
+        self.assertFalse(sentinel.exists())
+        self.assertIn(
+            "-DTOOLCHAIN_VALUE=2",
+            (binary / "CMakeCache.txt").read_text(encoding="utf-8"),
+        )
+
+    @unittest.skipUnless(
+        all(shutil.which(tool) for tool in ("cc", "ccache", "cmake", "ninja")),
+        "real ccache/CMake toolchain is unavailable",
+    )
+    def test_real_cmake_reuses_ccache_across_equivalent_profile_views(self) -> None:
+        checkout = self.root / "shared-cmake-source"
+        checkout.mkdir()
+        (checkout / "CMakeLists.txt").write_text(
+            "cmake_minimum_required(VERSION 3.20)\n"
+            "project(wrapper_ccache C)\n"
+            "add_executable(sample main.c)\n",
+            encoding="utf-8",
+        )
+        (checkout / "main.c").write_text(
+            "const char *source_file = __FILE__;\n"
+            "int main(void) { return source_file[0] == 0; }\n",
+            encoding="utf-8",
+        )
+        roots = [
+            self.workspace.paths.builds / "profiles" / name
+            for name in ("cache-a", "cache-b")
+        ]
+        views: list[Path] = []
+        for root in roots:
+            managed_directory(root, self.workspace.paths.builds, f"profile:{root.name}")
+            views.append(
+                self.workspace._profile_source_view(
+                    root, "sample", checkout, set()
+                )
+            )
+
+        self.workspace._cmake(
+            views[0], roots[0] / "build" / "sample", [], tests=False
+        )
+        cache = self.workspace.paths.builds / "compiler-cache"
+        statistics_environment = os.environ.copy()
+        statistics_environment["CCACHE_DIR"] = str(cache)
+        subprocess.run(
+            ["ccache", "--zero-stats"],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=statistics_environment,
+        )
+        self.workspace._cmake(
+            views[1], roots[1] / "build" / "sample", [], tests=False
+        )
+
+        statistics = subprocess.run(
+            ["ccache", "--print-stats"],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=statistics_environment,
+        ).stdout
+        values = {
+            name: int(value)
+            for name, value in (
+                line.split("\t", 1) for line in statistics.splitlines() if "\t" in line
+            )
+            if value.isdigit()
+        }
+        self.assertGreater(
+            values.get("direct_cache_hit", 0)
+            + values.get("preprocessed_cache_hit", 0),
+            0,
+        )
+        object_file = next((roots[1] / "build" / "sample").rglob("main.c.o"))
+        object_data = object_file.read_bytes()
+        self.assertIn(b"/atrinik/source/main.c", object_data)
+        self.assertNotIn(str(roots[1]).encode(), object_data)
 
     def test_resource_view_reserves_generated_metadata_names(self) -> None:
         source = self.workspace.paths.repositories / "resources"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -818,6 +818,60 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertFalse((view / "nested" / "node_modules").exists())
 
+    def test_copied_source_view_allows_only_repository_internal_symlinks(self) -> None:
+        source = self.workspace.paths.repositories / "content"
+        left = source / "left"
+        right = source / "right"
+        left.mkdir()
+        right.mkdir()
+        (right / "value").write_text("safe\n", encoding="utf-8")
+        (left / "value-link").symlink_to(Path("../right/value"))
+        root = self.workspace.paths.builds / "profiles" / "test"
+        managed_directory(root, self.workspace.paths.builds, "test-profile")
+
+        view = self.workspace._profile_source_view(
+            root, "worker", source, set(), copy_all=True
+        )
+
+        self.assertTrue((view / "left" / "value-link").is_symlink())
+        self.assertEqual(
+            (view / "left" / "value-link").resolve(), view / "right" / "value"
+        )
+        outside = self.root / "outside-copy-root"
+        outside.write_text("unsafe\n", encoding="utf-8")
+        (left / "escape-link").symlink_to(outside)
+        with self.assertRaisesRegex(WorkspaceError, "escapes its source root"):
+            self.workspace._profile_source_view(
+                root, "worker", source, set(), copy_all=True
+            )
+
+    def test_profile_views_and_cmake_reject_intermediate_symlink_aliases(self) -> None:
+        builds = self.workspace.paths.builds
+        profile_a = builds / "profiles" / "a"
+        profile_z = builds / "profiles" / "z"
+        managed_directory(profile_a, builds, "profile:a")
+        managed_directory(profile_z, builds, "profile:z")
+        source = self.workspace.paths.repositories / "content"
+        target_view = self.workspace._profile_source_view(
+            profile_z, "content", source, set()
+        )
+        (profile_a / "sources").symlink_to(
+            profile_z / "sources", target_is_directory=True
+        )
+
+        with self.assertRaisesRegex(WorkspaceError, "symlinked managed build path"):
+            self.workspace._profile_source_view(profile_a, "content", source, set())
+        self.assertEqual((target_view / "README").resolve(), source / "README")
+
+        target_binary = profile_z / "build" / "sample"
+        managed_directory(target_binary, builds, "cmake-binary")
+        (profile_a / "build").symlink_to(
+            profile_z / "build", target_is_directory=True
+        )
+        with self.assertRaisesRegex(WorkspaceError, "symlinked managed build path"):
+            self.workspace._prepare_cmake_binary(profile_a / "build" / "sample")
+        self.assertTrue(target_binary.is_dir())
+
     def test_preserved_source_view_directory_removes_unexpected_children(self) -> None:
         source = self.workspace.paths.repositories / "server"
         root = self.workspace.paths.builds / "profiles" / "test"
@@ -845,7 +899,9 @@ class WorkspaceTests(unittest.TestCase):
         source = self.workspace._profile_source_view(root, "content", source_root, set())
         binary = root / "build" / "content"
 
-        def configured(command: list[str], **kwargs: object) -> None:
+        def configured(command: list[str], **kwargs: object) -> str | None:
+            if command[:2] == ["ninja", "-C"]:
+                return "build.ninja:\n  input: RERUN_CMAKE\n"
             if command[:2] != ["cmake", "-S"]:
                 return
             (binary / "CMakeCache.txt").write_text(
@@ -869,7 +925,13 @@ class WorkspaceTests(unittest.TestCase):
             self.workspace._profile_source_view(root, "content", source_root, set())
             self.workspace._cmake(source, binary, [], tests=False)
             second_commands = [call.args[0] for call in run.call_args_list[first_count:]]
-            self.assertEqual(second_commands, [["cmake", "--build", str(binary), "--parallel"]])
+            self.assertEqual(
+                second_commands,
+                [
+                    ["ninja", "-C", str(binary), "-t", "query", "build.ninja"],
+                    ["cmake", "--build", str(binary), "--parallel"],
+                ],
+            )
 
             (binary / "build.ninja").unlink()
             repair_start = run.call_count
@@ -1013,11 +1075,21 @@ class WorkspaceTests(unittest.TestCase):
             "int main(void) { return 0; }\n",
             encoding="utf-8",
         )
-        toolchain = self.root / "toolchain.cmake"
-        toolchain.write_text(
+        compiler = self.root / "compiler-wrapper"
+        compiler.write_text("#!/bin/sh\nexec /usr/bin/cc \"$@\"\n", encoding="utf-8")
+        compiler.chmod(0o755)
+        fragment = self.root / "toolchain-flags.cmake"
+        fragment.write_text(
             'set(CMAKE_C_FLAGS_INIT "${CMAKE_C_FLAGS_INIT} -DTOOLCHAIN_VALUE=1")\n',
             encoding="utf-8",
         )
+        toolchain_target = self.root / "toolchain-real.cmake"
+        toolchain_target.write_text(
+            f'include("{fragment}")\nset(CMAKE_C_COMPILER "{compiler}")\n',
+            encoding="utf-8",
+        )
+        toolchain = self.root / "toolchain.cmake"
+        toolchain.symlink_to(toolchain_target)
         binary = self.workspace.paths.builds / "profiles" / "real" / "build" / "sample"
         self.workspace._use_ccache = False
 
@@ -1033,7 +1105,7 @@ class WorkspaceTests(unittest.TestCase):
         sentinel = binary / "removed-on-toolchain-change"
         sentinel.write_text("stale\n", encoding="utf-8")
 
-        toolchain.write_text(
+        fragment.write_text(
             'set(CMAKE_C_FLAGS_INIT "${CMAKE_C_FLAGS_INIT} -DTOOLCHAIN_VALUE=2")\n',
             encoding="utf-8",
         )
@@ -1049,13 +1121,70 @@ class WorkspaceTests(unittest.TestCase):
             "-DTOOLCHAIN_VALUE=2",
             (binary / "CMakeCache.txt").read_text(encoding="utf-8"),
         )
+        compiler_sentinel = binary / "removed-on-compiler-change"
+        compiler_sentinel.write_text("stale\n", encoding="utf-8")
+        compiler.write_text(
+            "#!/bin/sh\n# updated wrapper\nexec /usr/bin/cc \"$@\"\n",
+            encoding="utf-8",
+        )
+        compiler.chmod(0o755)
+
+        self.workspace._cmake(
+            source,
+            binary,
+            [f"-DCMAKE_TOOLCHAIN_FILE={toolchain}"],
+            tests=False,
+        )
+
+        self.assertFalse(compiler_sentinel.exists())
+        link_sentinel = binary / "removed-on-toolchain-link-change"
+        link_sentinel.write_text("stale\n", encoding="utf-8")
+        second_target = self.root / "toolchain-second.cmake"
+        second_target.write_text(
+            f'include("{fragment}")\nset(CMAKE_C_COMPILER "{compiler}")\n'
+            "# second toolchain target\n",
+            encoding="utf-8",
+        )
+        toolchain.unlink()
+        toolchain.symlink_to(second_target)
+
+        self.workspace._cmake(
+            source,
+            binary,
+            [f"-DCMAKE_TOOLCHAIN_FILE={toolchain}"],
+            tests=False,
+        )
+
+        self.assertFalse(link_sentinel.exists())
+        (binary / "build.ninja").write_text("corrupt graph\n", encoding="utf-8")
+        self.workspace._cmake(
+            source,
+            binary,
+            [f"-DCMAKE_TOOLCHAIN_FILE={toolchain}"],
+            tests=False,
+        )
+        self.assertIn(
+            "RERUN_CMAKE",
+            subprocess.run(
+                ["ninja", "-C", str(binary), "-t", "query", "build.ninja"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout,
+        )
 
     @unittest.skipUnless(
         all(shutil.which(tool) for tool in ("cc", "ccache", "cmake", "ninja")),
         "real ccache/CMake toolchain is unavailable",
     )
     def test_real_cmake_reuses_ccache_across_equivalent_profile_views(self) -> None:
-        checkout = self.root / "shared-cmake-source"
+        with mock.patch.dict(
+            os.environ,
+            {"ATRINIK_WORKSPACE_DIR": str(self.root / "workspace with spaces")},
+        ):
+            workspace = Workspace(self.wrapper)
+            workspace.paths.ensure()
+        checkout = self.root / "shared cmake source"
         checkout.mkdir()
         (checkout / "CMakeLists.txt").write_text(
             "cmake_minimum_required(VERSION 3.20)\n"
@@ -1069,22 +1198,22 @@ class WorkspaceTests(unittest.TestCase):
             encoding="utf-8",
         )
         roots = [
-            self.workspace.paths.builds / "profiles" / name
+            workspace.paths.builds / "profiles" / name
             for name in ("cache-a", "cache-b")
         ]
         views: list[Path] = []
         for root in roots:
-            managed_directory(root, self.workspace.paths.builds, f"profile:{root.name}")
+            managed_directory(root, workspace.paths.builds, f"profile:{root.name}")
             views.append(
-                self.workspace._profile_source_view(
+                workspace._profile_source_view(
                     root, "sample", checkout, set()
                 )
             )
 
-        self.workspace._cmake(
+        workspace._cmake(
             views[0], roots[0] / "build" / "sample", [], tests=False
         )
-        cache = self.workspace.paths.builds / "compiler-cache"
+        cache = workspace.paths.builds / "compiler-cache"
         statistics_environment = os.environ.copy()
         statistics_environment["CCACHE_DIR"] = str(cache)
         subprocess.run(
@@ -1094,7 +1223,7 @@ class WorkspaceTests(unittest.TestCase):
             text=True,
             env=statistics_environment,
         )
-        self.workspace._cmake(
+        workspace._cmake(
             views[1], roots[1] / "build" / "sample", [], tests=False
         )
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -786,6 +786,13 @@ class WorkspaceTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "escapes its source root"):
             self.workspace._profile_source_view(root, "content", source, set())
 
+        (source / "escape").unlink()
+        nested = source / "nested-linked-directory"
+        nested.mkdir()
+        (nested / "escape").symlink_to(outside)
+        with self.assertRaisesRegex(WorkspaceError, "escapes its source root"):
+            self.workspace._profile_source_view(root, "content", source, set())
+
     def test_copied_source_view_recursively_excludes_generated_entries(self) -> None:
         source = self.workspace.paths.repositories / "content"
         nested = source / "nested"
@@ -906,7 +913,11 @@ class WorkspaceTests(unittest.TestCase):
                 return
             (binary / "CMakeCache.txt").write_text(
                 f"CMAKE_HOME_DIRECTORY:INTERNAL={source.resolve()}\n"
-                "CMAKE_GENERATOR:INTERNAL=Ninja\n",
+                "CMAKE_GENERATOR:INTERNAL=Ninja\n"
+                "CMAKE_BUILD_TYPE:STRING=Debug\n"
+                "BUILD_TESTING:UNINITIALIZED=OFF\n"
+                "CMAKE_C_COMPILER_LAUNCHER:UNINITIALIZED=\n"
+                "CMAKE_CXX_COMPILER_LAUNCHER:UNINITIALIZED=\n",
                 encoding="utf-8",
             )
             (binary / "build.ninja").write_text("# generated\n", encoding="utf-8")
@@ -1037,6 +1048,9 @@ class WorkspaceTests(unittest.TestCase):
                 "_tool_identity",
                 return_value={"command": "tool", "path": "/tool", "version": "1"},
             ),
+            mock.patch.object(
+                self.workspace, "_compiler_supports_prefix_maps", return_value=True
+            ),
             mock.patch("atrinik_workspace.workspace.run") as run,
         ):
             self.workspace._cmake(source, binary, [], tests=False)
@@ -1054,6 +1068,30 @@ class WorkspaceTests(unittest.TestCase):
         cache = self.workspace.paths.builds / "compiler-cache"
         self.assertEqual(load_json(cache / MANAGED_MARKER)["purpose"], "compiler-cache")
         self.assertEqual(load_json(cache / ".atrinik-cache.json")["max_size"], "5G")
+
+    def test_debug_prefix_flags_require_supported_non_toolchain_compilers(self) -> None:
+        source = self.workspace.paths.repositories / "content"
+        binary = self.workspace.paths.builds / "profiles" / "test" / "build" / "content"
+        environment = {"CFLAGS": "/existing", "CXXFLAGS": "/existing-cxx"}
+        with mock.patch.object(
+            self.workspace, "_compiler_supports_prefix_maps", return_value=False
+        ):
+            self.workspace._add_debug_prefix_environment(
+                source, binary, environment, []
+            )
+        self.assertEqual(environment["CFLAGS"], "/existing")
+        self.assertEqual(environment["CXXFLAGS"], "/existing-cxx")
+
+        with mock.patch.object(
+            self.workspace, "_compiler_supports_prefix_maps"
+        ) as supported:
+            self.workspace._add_debug_prefix_environment(
+                source,
+                binary,
+                environment,
+                ["-DCMAKE_TOOLCHAIN_FILE=/tmp/windows-toolchain.cmake"],
+            )
+        supported.assert_not_called()
 
     @unittest.skipUnless(
         all(shutil.which(tool) for tool in ("cc", "cmake", "ninja")),
@@ -1080,8 +1118,7 @@ class WorkspaceTests(unittest.TestCase):
         compiler.chmod(0o755)
         fragment = self.root / "toolchain-flags.cmake"
         fragment.write_text(
-            'set(CMAKE_C_FLAGS_INIT "${CMAKE_C_FLAGS_INIT} -DTOOLCHAIN_VALUE=1")\n',
-            encoding="utf-8",
+            'set(CMAKE_C_FLAGS_INIT "-DTOOLCHAIN_VALUE=1")\n', encoding="utf-8"
         )
         toolchain_target = self.root / "toolchain-real.cmake"
         toolchain_target.write_text(
@@ -1101,13 +1138,20 @@ class WorkspaceTests(unittest.TestCase):
         )
         cache = (binary / "CMakeCache.txt").read_text(encoding="utf-8")
         self.assertIn("-DTOOLCHAIN_VALUE=1", cache)
-        self.assertIn("-fdebug-prefix-map=", cache)
+        preserved = binary / "preserved-on-unchanged-toolchain"
+        preserved.write_text("current\n", encoding="utf-8")
+        self.workspace._cmake(
+            source,
+            binary,
+            [f"-DCMAKE_TOOLCHAIN_FILE={toolchain}"],
+            tests=False,
+        )
+        self.assertTrue(preserved.is_file())
         sentinel = binary / "removed-on-toolchain-change"
         sentinel.write_text("stale\n", encoding="utf-8")
 
         fragment.write_text(
-            'set(CMAKE_C_FLAGS_INIT "${CMAKE_C_FLAGS_INIT} -DTOOLCHAIN_VALUE=2")\n',
-            encoding="utf-8",
+            'set(CMAKE_C_FLAGS_INIT "-DTOOLCHAIN_VALUE=2")\n', encoding="utf-8"
         )
         self.workspace._cmake(
             source,
@@ -1141,7 +1185,7 @@ class WorkspaceTests(unittest.TestCase):
         link_sentinel.write_text("stale\n", encoding="utf-8")
         second_target = self.root / "toolchain-second.cmake"
         second_target.write_text(
-            f'include("{fragment}")\nset(CMAKE_C_COMPILER "{compiler}")\n'
+            f"include([[{fragment}]])\nset(CMAKE_C_COMPILER \"{compiler}\")\n"
             "# second toolchain target\n",
             encoding="utf-8",
         )
@@ -1171,6 +1215,95 @@ class WorkspaceTests(unittest.TestCase):
                 capture_output=True,
                 text=True,
             ).stdout,
+        )
+
+        compiler_path = self.root / "compiler-path.txt"
+        compiler_path.write_text(str(compiler), encoding="utf-8")
+        dynamic_target = self.root / "toolchain-dynamic.cmake"
+        dynamic_target.write_text(
+            f'include("{fragment}")\n'
+            f'file(READ "{compiler_path}" SELECTED_COMPILER)\n'
+            'set(CMAKE_C_COMPILER "${SELECTED_COMPILER}")\n',
+            encoding="utf-8",
+        )
+        toolchain.unlink()
+        toolchain.symlink_to(dynamic_target)
+        self.workspace._cmake(
+            source,
+            binary,
+            [f"-DCMAKE_TOOLCHAIN_FILE={toolchain}"],
+            tests=False,
+        )
+        incomplete_sentinel = binary / "removed-for-unproven-toolchain-inputs"
+        incomplete_sentinel.write_text("stale\n", encoding="utf-8")
+        self.workspace._cmake(
+            source,
+            binary,
+            [f"-DCMAKE_TOOLCHAIN_FILE={toolchain}"],
+            tests=False,
+        )
+        self.assertFalse(incomplete_sentinel.exists())
+
+    @unittest.skipUnless(
+        all(shutil.which(tool) for tool in ("cc", "cmake", "ninja")),
+        "real CMake toolchain is unavailable",
+    )
+    def test_real_cmake_repairs_cache_and_rebuilds_for_implicit_environment(
+        self,
+    ) -> None:
+        source = self.root / "environment-source"
+        source.mkdir()
+        (source / "CMakeLists.txt").write_text(
+            "cmake_minimum_required(VERSION 3.20)\n"
+            "project(environment_rebuild C)\n"
+            "add_executable(environment main.c)\n",
+            encoding="utf-8",
+        )
+        (source / "main.c").write_text(
+            '#include <stdio.h>\n#include "selected-value.h"\n'
+            "int main(void) { return puts(SELECTED_VALUE); }\n",
+            encoding="utf-8",
+        )
+        include_one = self.root / "include-one"
+        include_two = self.root / "include-two"
+        include_one.mkdir()
+        include_two.mkdir()
+        (include_one / "selected-value.h").write_text(
+            '#define SELECTED_VALUE "atrinik-environment-one"\n', encoding="utf-8"
+        )
+        (include_two / "selected-value.h").write_text(
+            '#define SELECTED_VALUE "atrinik-environment-two"\n', encoding="utf-8"
+        )
+        binary = self.workspace.paths.builds / "profiles" / "environment" / "build" / "sample"
+        self.workspace._use_ccache = False
+
+        with mock.patch.dict(os.environ, {"CPATH": str(include_one)}):
+            self.workspace._cmake(source, binary, [], tests=False)
+            preserved = binary / "preserved-on-unchanged-environment"
+            preserved.write_text("current\n", encoding="utf-8")
+            self.workspace._cmake(source, binary, [], tests=False)
+            self.assertTrue(preserved.is_file())
+            cache = binary / "CMakeCache.txt"
+            cache.write_text(
+                cache.read_text(encoding="utf-8").replace(
+                    "CMAKE_BUILD_TYPE:STRING=Debug",
+                    "CMAKE_BUILD_TYPE:STRING=Release",
+                ),
+                encoding="utf-8",
+            )
+            self.workspace._cmake(source, binary, [], tests=False)
+            self.assertFalse(preserved.exists())
+            self.assertIn(
+                "CMAKE_BUILD_TYPE:STRING=Debug", cache.read_text(encoding="utf-8")
+            )
+
+        environment_sentinel = binary / "removed-on-implicit-environment-change"
+        environment_sentinel.write_text("stale\n", encoding="utf-8")
+        with mock.patch.dict(os.environ, {"CPATH": str(include_two)}):
+            self.workspace._cmake(source, binary, [], tests=False)
+        self.assertFalse(environment_sentinel.exists())
+        self.assertIn(
+            b"atrinik-environment-two", (binary / "environment").read_bytes()
         )
 
     @unittest.skipUnless(


### PR DESCRIPTION
Closes #326.

## Summary

- reconcile marker-owned source views in place while removing stale/retargeted entries and rejecting escaping symlinks
- fingerprint CMake configuration state and skip only unchanged explicit configure steps, with `--force-reconfigure`
- automatically share a bounded, marker-owned ccache across equivalent profile builds, with normalized debug paths and `--no-ccache`
- add explicit preview-first `compiler-cache` cleanup and synchronize contributor, architecture, and agent guidance

## Validation

- `python3 -m coverage run -m unittest discover` — 365 tests passed
- `python3 -m coverage report --show-missing` — 79% total coverage
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `git diff --check`
- multi-repo workspace skill validation — valid
- Classic client in two equivalent profiles — 32/32 tests pass in each; second profile produced 74/78 ccache hits (94.87%)
- Classic server in two equivalent profiles — builds pass; second profile produced 85/86 ccache hits (98.84%)
- committed real-CMake tests prove included/dynamic toolchain, compiler-wrapper, direct and managed dirty-glob, clean-revision/clock-skew, source-symlink, discovery-environment, partial-cache, and corrupt-Ninja invalidation; equivalent normalized roots hit ccache, while opaque toolchain roots retain directory-sensitive keys and never reuse objects containing another profile's paths
- unchanged client/server repeats skip explicit configure while retaining Ninja no-op/dependency checks
- sampled objects contain `/atrinik/source` and `/atrinik/build`, not profile build roots
- `cleanup --scope compiler-cache --older-than 0 --dry-run --json` inventories only the exact marker-owned shared cache

### Timings

Wall-clock measurements on the preserved local Classic profiles (including wrapper resolution and tests/content staging where selected):

| Target | Fresh binary tree | Forced warm configure | No-op configure skip |
| --- | ---: | ---: | ---: |
| client `--test` | 8.32 s | 2.61 s | 2.26 s |
| server build | 26.08 s | 11.95 s | 10.37 s |

The final-head timing repeat used the fresh equivalent `issue-326-cache-d` profile with the warm shared compiler cache. The server fresh measurement includes completing its immutable dependency fetch after an initial sandboxed DNS failure. The earlier equivalent-profile client run passed all 32 tests and yielded 74 hits, 4 misses, 65 direct hits, and 9 preprocessed hits. During the final timing repeat, the current clean Classic client instead reproduced its external live-QUIC-listener initialization failure in `client-face-stream`; compilation and the other 31 tests passed. The server no-op remains dominated by content collection; its explicit configure is skipped and Ninja reports no work.

## External test baseline

Classic server `--test` reaches the component test suite but current clean Classic/content inputs reproduce two failures in both equivalent profiles: the existing object-merge expectations and a content Python `isinstance(delay, (int, None))` error under Python 3.14. A later clean client timing repeat also reproduced the external live-QUIC-listener initialization failure in `client-face-stream`; earlier equivalent profiles passed all 32 client tests. The wrapper client/server builds themselves pass, and repeated no-op/configure/cache behavior was verified. No component checkout was modified.

## Manual verification

Use the preserved `issue-326-cache-a`, `issue-326-cache-b`, `issue-326-cache-c`, and final timing `issue-326-cache-d` Classic profiles with `ATRINIK_WORKSPACE_DIR=/workspaces/atrinik/build/issue-326-workspace`. Repeat client/server builds, exercise `--force-reconfigure` and `--no-ccache`, inspect `ccache --show-stats`, and preview `cleanup --scope compiler-cache --dry-run --json`. No topology, scenario, or mutable server state is involved.
