### PR TITLE
perf(workspace): allow independent builds

### DIFF
--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -95,11 +95,12 @@ Classic selection is checkout-wide; subdirectories are not worktrees. Clean
 exact-coordinate content, resource, and region-map caches are reused; runtimes
 copy independent topology-owned snapshots.
 
-Build/runtime readers share the outer layout lock: independent roots overlap,
-each exact root stays exclusive, and layout mutation is exclusive. Acquire it
-before finer locks and fail closed without reliable sharing. Incomplete
-immutable-coordinate records are inert; the wrapper owns generated paths,
-locks, state, PIDs, logs, content/resources, and process cleanup.
+Readers share the layout lock: roots overlap; exact roots and mutations
+stay exclusive. Take it before finer locks; fail closed without sharing.
+Incomplete coordinates are inert; wrapper owns paths, locks, state, PIDs, logs,
+content/resources and cleanup. Completion is bounded, local, read-only,
+secret-free and parser-driven before `Workspace`; stops at `--` or a `run`
+remainder.
 
 For classic server execution or diagnosis, load `atrinik-server-runtime`. For
 a ready account and character, also load `atrinik-test-scenario`; never

--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -95,12 +95,11 @@ Classic selection is checkout-wide; subdirectories are not worktrees. Clean
 exact-coordinate content, resource, and region-map caches are reused; runtimes
 copy independent topology-owned snapshots.
 
-Build, scenario, and topology records bind exact immutable coordinates;
-incomplete records are inert. Let the wrapper own generated paths, locks,
-state, PIDs, logs, content/resources, and process cleanup.
-
-Keep completion parser-driven, bounded, read-only, local-only, secret-free,
-before `Workspace`, and stopped at `--` or a `run` remainder.
+Build/runtime readers share the outer layout lock: independent roots overlap,
+each exact root stays exclusive, and layout mutation is exclusive. Acquire it
+before finer locks and fail closed without reliable sharing. Incomplete
+immutable-coordinate records are inert; the wrapper owns generated paths,
+locks, state, PIDs, logs, content/resources, and process cleanup.
 
 For classic server execution or diagnosis, load `atrinik-server-runtime`. For
 a ready account and character, also load `atrinik-test-scenario`; never

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,20 +44,19 @@
 - Cleanup is explicit and preview-first: run
   `./atrinik cleanup --dry-run --json` before the same scoped `--apply`; never
   invoke it implicitly. Preserve dirty, detached, locked, active, referenced,
-  or uncertain targets. Historical eligibility fails closed; the
-  multi-repository skill owns cleanup proof and retention.
+  or uncertain targets; historical proof fails closed.
 - Worktrees belong to physical checkouts. Selecting `classic`, a `classic-*`
   component, or one of its roles selects one root for all five; profiles append
   manifest source directories.
-- Use `./atrinik path`, `topology show`, `up`, `ps`, `logs`, and `down`. Do not
-  reconstruct managed build, PID, log, lock, runtime, or state paths. Give
+- Use wrapper path/topology commands; never reconstruct managed paths. Give
   concurrent topologies distinct names, states, ports, and client config.
 - Keep shell completion parser-driven, bounded, local-only, secret-free, and
   ahead of `Workspace` construction.
+- Build/runtime layout readers share the outer lock; layout mutation stays
+  exclusive. Fail closed without shared locking and take finer locks afterward.
 - Persisted records without current immutable coordinates are historical and inert.
-- Follow `docs/PROVENANCE.md` for historical MIT reuse; incomplete history,
-  mixed authorship, uncertain identity, or embedded third-party material fails
-  closed. Cite the exact wrapper registry revision used.
+- Historical MIT reuse follows `docs/PROVENANCE.md` and fails closed on
+  incomplete or uncertain evidence. Cite the exact registry revision.
 - Update `supply-chain/inventory.json` when dependency ownership or validation
   changes. Keep Actions/images immutable, add no submodules, and audit a
   complete profile. Only aggregate-root workflows and Dependabot are active.

--- a/README.md
+++ b/README.md
@@ -802,7 +802,9 @@ wrapper fails closed when advisory shared locking is unavailable. The layout
 lock is always acquired before topology, scenario, state, build-root, port,
 registry, or cache locks. Foreground processes inherit their layout and exact
 build-root leases. Supervised services inherit both leases through the daemon
-and keep them until every service exits or `down` completes.
+and keep them until every service exits or `down` completes. Build and scenario
+subprocesses inherit every active layout, build-root, state, registry, and cache
+lease so an orphan cannot outlive its reader protection.
 
 The supervisor records exact source commits, build and state paths, and process
 start identities. `ps` without a name lists every recorded topology; a name

--- a/README.md
+++ b/README.md
@@ -791,6 +791,15 @@ declaring the topology ready. Use
 `--service server` or `--service client` for a single service. Client startup
 requires a live forwarded display socket.
 
+Build and runtime-preparation commands hold a shared repository-layout lock.
+Different profile build roots may compile concurrently; an exclusive per-root
+lock still serializes the same root. Initialization, synchronization, worktree
+or profile changes, cleanup apply, and repository migration take the layout
+lock exclusively, so they wait until every build or startup reader finishes.
+The wrapper fails closed when advisory shared locking is unavailable. The
+layout lock is always acquired before topology, scenario, state, build-root,
+port, registry, or cache locks.
+
 The supervisor records exact source commits, build and state paths, and process
 start identities. `ps` without a name lists every recorded topology; a name
 selects one. It distinguishes a live process from a reused PID, `down` signals

--- a/README.md
+++ b/README.md
@@ -796,12 +796,13 @@ repository-layout lock.
 Different profile build roots may compile concurrently; an exclusive per-root
 lock still serializes the same root. Initialization, synchronization, worktree
 or profile changes, and cleanup apply take the layout lock exclusively, so they
-wait until every build or startup reader finishes. Repository migration uses
+wait until every build or runtime reader finishes. Repository migration uses
 the same exclusive mode but reports a busy result instead of waiting. The
 wrapper fails closed when advisory shared locking is unavailable. The layout
 lock is always acquired before topology, scenario, state, build-root, port,
-registry, or cache locks. A topology client inherits its shared lease through
-the supervisor and keeps it until the client exits or `down` completes.
+registry, or cache locks. Foreground processes inherit their layout and exact
+build-root leases. Supervised services inherit both leases through the daemon
+and keep them until every service exits or `down` completes.
 
 The supervisor records exact source commits, build and state paths, and process
 start identities. `ps` without a name lists every recorded topology; a name

--- a/README.md
+++ b/README.md
@@ -814,7 +814,9 @@ orphaned services and descendants. The server state remains locked for the
 complete supervised lifetime. Each topology also has a persistent isolated
 client configuration/cache root and its own copies of the collected content and
 resource caches, so changing or removing one topology cannot affect another
-topology or the retained build caches. Logs live below `workspace/topologies/`
+topology or the retained build caches. The inherited identity lease atomically
+prevents the same topology name from restarting while any generation remains.
+Logs live below `workspace/topologies/`
 and rotate at 10 MiB with three backups.
 
 ### Use case: run the latest playable classic branches

--- a/README.md
+++ b/README.md
@@ -808,8 +808,9 @@ lease so an orphan cannot outlive its reader protection.
 
 The supervisor records exact source commits, build and state paths, and process
 start identities. `ps` without a name lists every recorded topology; a name
-selects one. It distinguishes a live process from a reused PID, `down` signals
-only the matching supervisor, and the server state remains locked for the
+selects one. It distinguishes a live process from a reused PID, and `down`
+signals only processes holding that topology's identity lease, including
+orphaned services and descendants. The server state remains locked for the
 complete supervised lifetime. Each topology also has a persistent isolated
 client configuration/cache root and its own copies of the collected content and
 resource caches, so changing or removing one topology cannot affect another

--- a/README.md
+++ b/README.md
@@ -800,7 +800,8 @@ wait until every build or startup reader finishes. Repository migration uses
 the same exclusive mode but reports a busy result instead of waiting. The
 wrapper fails closed when advisory shared locking is unavailable. The layout
 lock is always acquired before topology, scenario, state, build-root, port,
-registry, or cache locks.
+registry, or cache locks. A topology client inherits its shared lease through
+the supervisor and keeps it until the client exits or `down` completes.
 
 The supervisor records exact source commits, build and state paths, and process
 start identities. `ps` without a name lists every recorded topology; a name

--- a/README.md
+++ b/README.md
@@ -791,14 +791,16 @@ declaring the topology ready. Use
 `--service server` or `--service client` for a single service. Client startup
 requires a live forwarded display socket.
 
-Build and runtime-preparation commands hold a shared repository-layout lock.
+Build, foreground run, and runtime-preparation commands hold a shared
+repository-layout lock.
 Different profile build roots may compile concurrently; an exclusive per-root
 lock still serializes the same root. Initialization, synchronization, worktree
-or profile changes, cleanup apply, and repository migration take the layout
-lock exclusively, so they wait until every build or startup reader finishes.
-The wrapper fails closed when advisory shared locking is unavailable. The
-layout lock is always acquired before topology, scenario, state, build-root,
-port, registry, or cache locks.
+or profile changes, and cleanup apply take the layout lock exclusively, so they
+wait until every build or startup reader finishes. Repository migration uses
+the same exclusive mode but reports a busy result instead of waiting. The
+wrapper fails closed when advisory shared locking is unavailable. The layout
+lock is always acquired before topology, scenario, state, build-root, port,
+registry, or cache locks.
 
 The supervisor records exact source commits, build and state paths, and process
 start identities. `ps` without a name lists every recorded topology; a name

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -11,6 +11,7 @@ import stat
 import subprocess
 from typing import Any, Iterable
 
+from .locking import active_lock_fds
 from .migration import MIGRATION_PENDING, MIGRATION_RECORD, OPERATION_PATHS
 from .model import (
     MANAGED_MARKER,
@@ -80,6 +81,7 @@ def _command(path: Path, *arguments: str) -> str:
             check=True,
             capture_output=True,
             text=True,
+            pass_fds=active_lock_fds(),
         )
     except FileNotFoundError as error:
         raise WorkspaceError("required command not found: git") from error
@@ -1543,6 +1545,7 @@ class Cleanup:
                 check=True,
                 capture_output=True,
                 text=True,
+                pass_fds=active_lock_fds(),
                 timeout=30,
             )
         except FileNotFoundError as error:

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextvars import copy_context
 from datetime import datetime, timezone
 import fcntl
 import json
@@ -1373,7 +1374,9 @@ class Cleanup:
         keys = sorted({(item["repository"], item["head"]) for item in pending})
         with ThreadPoolExecutor(max_workers=min(8, max(1, len(keys)))) as executor:
             futures = {
-                executor.submit(self._github_pulls, repository, head): (repository, head)
+                executor.submit(
+                    copy_context().run, self._github_pulls, repository, head
+                ): (repository, head)
                 for repository, head in keys
             }
             for future in as_completed(futures):

--- a/atrinik_workspace/locking.py
+++ b/atrinik_workspace/locking.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import BinaryIO, Iterator
+
+
+_ACTIVE_LOCK_FDS: ContextVar[tuple[int, ...]] = ContextVar(
+    "atrinik_active_lock_fds", default=()
+)
+
+
+def active_lock_fds() -> tuple[int, ...]:
+    return _ACTIVE_LOCK_FDS.get()
+
+
+@contextmanager
+def inherit_lock_fds(*leases: BinaryIO) -> Iterator[None]:
+    descriptors = tuple(lease.fileno() for lease in leases)
+    current = active_lock_fds()
+    token = _ACTIVE_LOCK_FDS.set(tuple(dict.fromkeys((*current, *descriptors))))
+    try:
+        yield
+    finally:
+        _ACTIVE_LOCK_FDS.reset(token)

--- a/atrinik_workspace/migration.py
+++ b/atrinik_workspace/migration.py
@@ -17,6 +17,7 @@ import subprocess
 import tempfile
 from typing import Any, Iterable
 
+from .locking import active_lock_fds, inherit_lock_fds
 from .model import WorkspaceError, atomic_json, load_json
 from .supervisor import process_matches
 
@@ -156,6 +157,7 @@ def classic_lineage(path: Path, canonical: str) -> bool:
                 stderr=subprocess.PIPE,
                 check=False,
                 env=environment,
+                pass_fds=active_lock_fds(),
             )
         except OSError as error:
             raise WorkspaceError(f"cannot inspect Git history: {error}") from error
@@ -415,7 +417,7 @@ class RepositoryMigration:
             raise WorkspaceError(
                 f"repository migration lock is not a regular file: {lock_path}"
             )
-        with os.fdopen(descriptor, "a+") as lock:
+        with os.fdopen(descriptor, "a+") as lock, inherit_lock_fds(lock):
             try:
                 fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
             except BlockingIOError:
@@ -3595,6 +3597,7 @@ class RepositoryMigration:
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             check=False,
+            pass_fds=active_lock_fds(),
         )
         if process.returncode == 0:
             return True
@@ -3614,6 +3617,7 @@ class RepositoryMigration:
                 stderr=subprocess.PIPE,
                 check=False,
                 env=environment,
+                pass_fds=active_lock_fds(),
             )
         except OSError as error:
             raise WorkspaceError(f"cannot run Git: {error}") from error
@@ -3656,6 +3660,7 @@ class RepositoryMigration:
                 stderr=subprocess.PIPE,
                 check=False,
                 env=environment,
+                pass_fds=active_lock_fds(),
             )
         except OSError as error:
             raise WorkspaceError(f"cannot run Git: {error}") from error

--- a/atrinik_workspace/process_tree.py
+++ b/atrinik_workspace/process_tree.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import signal
+from typing import Iterable
+
+
+def _holds_identity(pid: int, identity: tuple[int, int]) -> bool:
+    directory = Path("/proc") / str(pid) / "fd"
+    try:
+        descriptors = list(directory.iterdir())
+    except OSError:
+        return False
+    for descriptor in descriptors:
+        try:
+            metadata = descriptor.stat()
+        except OSError:
+            continue
+        if (metadata.st_dev, metadata.st_ino) == identity:
+            return True
+    return False
+
+
+def signal_holders(
+    lease_fd: int,
+    signum: signal.Signals,
+    *,
+    exclude: Iterable[int] = (),
+) -> int:
+    """Signal live holders of one inherited process-tree lease via pidfds."""
+    metadata = os.fstat(lease_fd)
+    identity = (metadata.st_dev, metadata.st_ino)
+    excluded = set(exclude)
+    signaled = 0
+    try:
+        entries = list(Path("/proc").iterdir())
+    except OSError:
+        return 0
+    for entry in entries:
+        if not entry.name.isdigit():
+            continue
+        pid = int(entry.name)
+        if pid in excluded or not _holds_identity(pid, identity):
+            continue
+        try:
+            pidfd = os.pidfd_open(pid)
+        except ProcessLookupError:
+            continue
+        try:
+            if not _holds_identity(pid, identity):
+                continue
+            try:
+                signal.pidfd_send_signal(pidfd, signum)
+            except ProcessLookupError:
+                continue
+            signaled += 1
+        finally:
+            os.close(pidfd)
+    return signaled
+
+
+def holders_exist(lease_fd: int, *, exclude: Iterable[int] = ()) -> bool:
+    metadata = os.fstat(lease_fd)
+    identity = (metadata.st_dev, metadata.st_ino)
+    excluded = set(exclude)
+    try:
+        entries = list(Path("/proc").iterdir())
+    except OSError:
+        return False
+    return any(
+        entry.name.isdigit()
+        and int(entry.name) not in excluded
+        and _holds_identity(int(entry.name), identity)
+        for entry in entries
+    )

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -78,47 +78,67 @@ def terminate(
     process_tree_fd: int | None,
     timeout: float = 10,
 ) -> None:
-    if process_tree_fd is None:
-        for process in processes.values():
-            if process.poll() is None:
-                try:
-                    os.killpg(process.pid, signal.SIGTERM)
-                except ProcessLookupError:
-                    pass
-    else:
+    # An unreaped session leader pins its numeric process-group identity, so
+    # these groups remain safe to signal until the final waits below. The lease
+    # additionally finds descendants whose recorded leader was already reaped.
+    process_groups = [
+        process.pid
+        for process in processes.values()
+        if process.returncode is None
+    ]
+
+    def signal_groups(signum: signal.Signals) -> None:
+        for process_group in process_groups:
+            try:
+                os.killpg(process_group, signum)
+            except ProcessLookupError:
+                pass
+
+    def groups_exist() -> bool:
+        groups = set(process_groups)
+        try:
+            entries = list(Path("/proc").iterdir())
+        except OSError:
+            entries = []
+        for entry in entries:
+            if not entry.name.isdigit():
+                continue
+            try:
+                fields = (entry / "stat").read_text().rsplit(")", 1)[1].split()
+                state = fields[0]
+                process_group = int(fields[2])
+            except (OSError, IndexError, ValueError):
+                continue
+            if process_group in groups and state != "Z":
+                return True
+        return False
+
+    signal_groups(signal.SIGTERM)
+    if process_tree_fd is not None:
         signal_holders(
             process_tree_fd, signal.SIGTERM, exclude=(os.getpid(),)
         )
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        for process in processes.values():
-            process.poll()
-        if process_tree_fd is None:
-            running = any(
-                process.poll() is None for process in processes.values()
-            )
-        else:
-            running = holders_exist(
+        running = groups_exist()
+        if process_tree_fd is not None:
+            running = running or holders_exist(
                 process_tree_fd, exclude=(os.getpid(),)
             )
         if not running:
             break
         time.sleep(0.1)
-    if process_tree_fd is None:
-        for process in processes.values():
-            if process.poll() is None:
-                try:
-                    os.killpg(process.pid, signal.SIGKILL)
-                except ProcessLookupError:
-                    pass
-    else:
+    signal_groups(signal.SIGKILL)
+    if process_tree_fd is not None:
         signal_holders(
             process_tree_fd, signal.SIGKILL, exclude=(os.getpid(),)
         )
         kill_deadline = time.monotonic() + 2
-        while time.monotonic() < kill_deadline and holders_exist(
-            process_tree_fd, exclude=(os.getpid(),)
+        while time.monotonic() < kill_deadline and (
+            groups_exist()
+            or holders_exist(process_tree_fd, exclude=(os.getpid(),))
         ):
+            signal_groups(signal.SIGKILL)
             signal_holders(
                 process_tree_fd, signal.SIGKILL, exclude=(os.getpid(),)
             )

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -16,6 +16,7 @@ import time
 from typing import Any, BinaryIO
 
 from .launch_identity import CLIENT_LAUNCH_LABEL_ENV, client_launch_label
+from .process_tree import holders_exist, signal_holders
 
 
 LOG_LIMIT = 10 * 1024 * 1024
@@ -72,47 +73,33 @@ def open_log(path: Path) -> BinaryIO:
     return os.fdopen(descriptor, "ab", buffering=0)
 
 
-def process_group_running(process_group: int) -> bool:
-    try:
-        os.killpg(process_group, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    return True
-
-
 def terminate(
     processes: dict[str, subprocess.Popen[bytes]],
-    pidfds: dict[str, int],
+    process_tree_fd: int | None,
     timeout: float = 10,
 ) -> None:
-    groups = [processes[name].pid for name in pidfds]
-    for process_group in groups:
-        try:
-            os.killpg(process_group, signal.SIGTERM)
-        except ProcessLookupError:
-            pass
+    if process_tree_fd is not None:
+        signal_holders(
+            process_tree_fd, signal.SIGTERM, exclude=(os.getpid(),)
+        )
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         for process in processes.values():
             process.poll()
-        if not any(process_group_running(process_group) for process_group in groups):
+        if process_tree_fd is None or not holders_exist(
+            process_tree_fd, exclude=(os.getpid(),)
+        ):
             break
         time.sleep(0.1)
-    for process_group in groups:
-        if process_group_running(process_group):
-            try:
-                os.killpg(process_group, signal.SIGKILL)
-            except ProcessLookupError:
-                pass
+    if process_tree_fd is not None:
+        signal_holders(
+            process_tree_fd, signal.SIGKILL, exclude=(os.getpid(),)
+        )
     for process in processes.values():
         try:
             process.wait(timeout=2)
         except subprocess.TimeoutExpired:
             pass
-    for descriptor in pidfds.values():
-        os.close(descriptor)
 
 
 class RotatingLog:
@@ -220,6 +207,7 @@ def supervise(
     lock_fd: int | None,
     layout_lock_fd: int | None,
     build_lock_fd: int | None,
+    process_tree_fd: int | None,
 ) -> int:
     with spec_path.open(encoding="utf-8") as stream:
         spec = json.load(stream)
@@ -238,7 +226,6 @@ def supervise(
         raise RuntimeError("cannot identify topology supervisor process")
     status = _initial_status(spec, supervisor_start_time)
     processes: dict[str, subprocess.Popen[bytes]] = {}
-    pidfds: dict[str, int] = {}
     logs: list[RotatingLog] = []
     pumps: list[threading.Thread] = []
 
@@ -270,6 +257,8 @@ def supervise(
             inherited_locks.append(layout_lock_fd)
         if build_lock_fd is not None:
             inherited_locks.append(build_lock_fd)
+        if process_tree_fd is not None:
+            inherited_locks.append(process_tree_fd)
         process = subprocess.Popen(
             command,
             cwd=service["cwd"],
@@ -281,10 +270,6 @@ def supervise(
             pass_fds=tuple(inherited_locks),
         )
         processes[name] = process
-        try:
-            pidfds[name] = os.pidfd_open(process.pid)
-        except ProcessLookupError as error:
-            raise RuntimeError(f"cannot identify {name} process") from error
         start_time = process_start_time(process.pid)
         if start_time is None:
             raise RuntimeError(f"cannot identify {name} process")
@@ -363,7 +348,7 @@ def supervise(
         atomic_status(status_path, status)
         return 1
     finally:
-        terminate(processes, pidfds)
+        terminate(processes, process_tree_fd)
         for pump in pumps:
             pump.join(timeout=2)
         for name, process in processes.items():
@@ -384,6 +369,8 @@ def supervise(
             os.close(layout_lock_fd)
         if build_lock_fd is not None:
             os.close(build_lock_fd)
+        if process_tree_fd is not None:
+            os.close(process_tree_fd)
     return 0
 
 
@@ -393,6 +380,7 @@ def main() -> int:
     parser.add_argument("--lock-fd", type=int)
     parser.add_argument("--layout-lock-fd", type=int)
     parser.add_argument("--build-lock-fd", type=int)
+    parser.add_argument("--process-tree-fd", type=int)
     parser.add_argument("--daemonize", action="store_true")
     options = parser.parse_args()
     if options.daemonize and os.fork() != 0:
@@ -403,6 +391,7 @@ def main() -> int:
             options.lock_fd,
             options.layout_lock_fd,
             options.build_lock_fd,
+            options.process_tree_fd,
         )
     except BaseException as error:
         message = f"{type(error).__name__}: {error}"
@@ -424,6 +413,11 @@ def main() -> int:
         if options.build_lock_fd is not None:
             try:
                 os.close(options.build_lock_fd)
+            except OSError:
+                pass
+        if options.process_tree_fd is not None:
+            try:
+                os.close(options.process_tree_fd)
             except OSError:
                 pass
         return 1

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -78,7 +78,14 @@ def terminate(
     process_tree_fd: int | None,
     timeout: float = 10,
 ) -> None:
-    if process_tree_fd is not None:
+    if process_tree_fd is None:
+        for process in processes.values():
+            if process.poll() is None:
+                try:
+                    os.killpg(process.pid, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+    else:
         signal_holders(
             process_tree_fd, signal.SIGTERM, exclude=(os.getpid(),)
         )
@@ -86,15 +93,36 @@ def terminate(
     while time.monotonic() < deadline:
         for process in processes.values():
             process.poll()
-        if process_tree_fd is None or not holders_exist(
-            process_tree_fd, exclude=(os.getpid(),)
-        ):
+        if process_tree_fd is None:
+            running = any(
+                process.poll() is None for process in processes.values()
+            )
+        else:
+            running = holders_exist(
+                process_tree_fd, exclude=(os.getpid(),)
+            )
+        if not running:
             break
         time.sleep(0.1)
-    if process_tree_fd is not None:
+    if process_tree_fd is None:
+        for process in processes.values():
+            if process.poll() is None:
+                try:
+                    os.killpg(process.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+    else:
         signal_holders(
             process_tree_fd, signal.SIGKILL, exclude=(os.getpid(),)
         )
+        kill_deadline = time.monotonic() + 2
+        while time.monotonic() < kill_deadline and holders_exist(
+            process_tree_fd, exclude=(os.getpid(),)
+        ):
+            signal_holders(
+                process_tree_fd, signal.SIGKILL, exclude=(os.getpid(),)
+            )
+            time.sleep(0.05)
     for process in processes.values():
         try:
             process.wait(timeout=2)

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -72,22 +72,38 @@ def open_log(path: Path) -> BinaryIO:
     return os.fdopen(descriptor, "ab", buffering=0)
 
 
-def terminate(processes: dict[str, subprocess.Popen[bytes]]) -> None:
-    for process in processes.values():
-        if process.poll() is None:
-            try:
-                os.killpg(process.pid, signal.SIGTERM)
-            except ProcessLookupError:
-                pass
-    deadline = time.monotonic() + 10
-    while time.monotonic() < deadline and any(
-        process.poll() is None for process in processes.values()
-    ):
+def process_group_running(process_group: int) -> bool:
+    try:
+        os.killpg(process_group, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def terminate(
+    processes: dict[str, subprocess.Popen[bytes]],
+    pidfds: dict[str, int],
+    timeout: float = 10,
+) -> None:
+    groups = [processes[name].pid for name in pidfds]
+    for process_group in groups:
+        try:
+            os.killpg(process_group, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        for process in processes.values():
+            process.poll()
+        if not any(process_group_running(process_group) for process_group in groups):
+            break
         time.sleep(0.1)
-    for process in processes.values():
-        if process.poll() is None:
+    for process_group in groups:
+        if process_group_running(process_group):
             try:
-                os.killpg(process.pid, signal.SIGKILL)
+                os.killpg(process_group, signal.SIGKILL)
             except ProcessLookupError:
                 pass
     for process in processes.values():
@@ -95,6 +111,8 @@ def terminate(processes: dict[str, subprocess.Popen[bytes]]) -> None:
             process.wait(timeout=2)
         except subprocess.TimeoutExpired:
             pass
+    for descriptor in pidfds.values():
+        os.close(descriptor)
 
 
 class RotatingLog:
@@ -220,6 +238,7 @@ def supervise(
         raise RuntimeError("cannot identify topology supervisor process")
     status = _initial_status(spec, supervisor_start_time)
     processes: dict[str, subprocess.Popen[bytes]] = {}
+    pidfds: dict[str, int] = {}
     logs: list[RotatingLog] = []
     pumps: list[threading.Thread] = []
 
@@ -262,6 +281,10 @@ def supervise(
             pass_fds=tuple(inherited_locks),
         )
         processes[name] = process
+        try:
+            pidfds[name] = os.pidfd_open(process.pid)
+        except ProcessLookupError as error:
+            raise RuntimeError(f"cannot identify {name} process") from error
         start_time = process_start_time(process.pid)
         if start_time is None:
             raise RuntimeError(f"cannot identify {name} process")
@@ -340,7 +363,7 @@ def supervise(
         atomic_status(status_path, status)
         return 1
     finally:
-        terminate(processes)
+        terminate(processes, pidfds)
         for pump in pumps:
             pump.join(timeout=2)
         for name, process in processes.items():

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -197,7 +197,11 @@ def _initial_status(spec: dict[str, Any], supervisor_start_time: str) -> dict[st
     return status
 
 
-def supervise(spec_path: Path, lock_fd: int | None) -> int:
+def supervise(
+    spec_path: Path,
+    lock_fd: int | None,
+    layout_lock_fd: int | None,
+) -> int:
     with spec_path.open(encoding="utf-8") as stream:
         spec = json.load(stream)
     status_path = spec_path.parent / "status.json"
@@ -239,6 +243,11 @@ def supervise(spec_path: Path, lock_fd: int | None) -> int:
             environment[CLIENT_LAUNCH_LABEL_ENV] = client_launch_label(
                 spec["profile"], spec["name"]
             )
+        inherited_locks: list[int] = []
+        if name == "server" and lock_fd is not None:
+            inherited_locks.append(lock_fd)
+        if name == "client" and layout_lock_fd is not None:
+            inherited_locks.append(layout_lock_fd)
         process = subprocess.Popen(
             command,
             cwd=service["cwd"],
@@ -247,7 +256,7 @@ def supervise(spec_path: Path, lock_fd: int | None) -> int:
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             start_new_session=True,
-            pass_fds=(lock_fd,) if name == "server" and lock_fd is not None else (),
+            pass_fds=tuple(inherited_locks),
         )
         start_time = process_start_time(process.pid)
         if start_time is None:
@@ -344,6 +353,8 @@ def supervise(spec_path: Path, lock_fd: int | None) -> int:
             output.close()
         if lock_fd is not None:
             os.close(lock_fd)
+        if layout_lock_fd is not None:
+            os.close(layout_lock_fd)
     return 0
 
 
@@ -351,12 +362,13 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--spec", type=Path, required=True)
     parser.add_argument("--lock-fd", type=int)
+    parser.add_argument("--layout-lock-fd", type=int)
     parser.add_argument("--daemonize", action="store_true")
     options = parser.parse_args()
     if options.daemonize and os.fork() != 0:
         return 0
     try:
-        return supervise(options.spec, options.lock_fd)
+        return supervise(options.spec, options.lock_fd, options.layout_lock_fd)
     except BaseException as error:
         message = f"{type(error).__name__}: {error}"
         print(f"topology supervisor failed during startup: {message}", file=sys.stderr)
@@ -367,6 +379,11 @@ def main() -> int:
         if options.lock_fd is not None:
             try:
                 os.close(options.lock_fd)
+            except OSError:
+                pass
+        if options.layout_lock_fd is not None:
+            try:
+                os.close(options.layout_lock_fd)
             except OSError:
                 pass
         return 1

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -201,6 +201,7 @@ def supervise(
     spec_path: Path,
     lock_fd: int | None,
     layout_lock_fd: int | None,
+    build_lock_fd: int | None,
 ) -> int:
     with spec_path.open(encoding="utf-8") as stream:
         spec = json.load(stream)
@@ -246,8 +247,10 @@ def supervise(
         inherited_locks: list[int] = []
         if name == "server" and lock_fd is not None:
             inherited_locks.append(lock_fd)
-        if name == "client" and layout_lock_fd is not None:
+        if layout_lock_fd is not None:
             inherited_locks.append(layout_lock_fd)
+        if build_lock_fd is not None:
+            inherited_locks.append(build_lock_fd)
         process = subprocess.Popen(
             command,
             cwd=service["cwd"],
@@ -258,11 +261,10 @@ def supervise(
             start_new_session=True,
             pass_fds=tuple(inherited_locks),
         )
+        processes[name] = process
         start_time = process_start_time(process.pid)
         if start_time is None:
-            process.terminate()
             raise RuntimeError(f"cannot identify {name} process")
-        processes[name] = process
         pump = threading.Thread(
             target=pump_output,
             args=(process, output, capture),
@@ -343,7 +345,9 @@ def supervise(
             pump.join(timeout=2)
         for name, process in processes.items():
             code = process.poll()
-            service_status = status["services"][name]
+            service_status = status["services"].get(name)
+            if service_status is None:
+                continue
             service_status["status"] = "exited"
             service_status["exit_code"] = code
         status["stopped_at"] = datetime.now(timezone.utc).isoformat()
@@ -355,6 +359,8 @@ def supervise(
             os.close(lock_fd)
         if layout_lock_fd is not None:
             os.close(layout_lock_fd)
+        if build_lock_fd is not None:
+            os.close(build_lock_fd)
     return 0
 
 
@@ -363,12 +369,18 @@ def main() -> int:
     parser.add_argument("--spec", type=Path, required=True)
     parser.add_argument("--lock-fd", type=int)
     parser.add_argument("--layout-lock-fd", type=int)
+    parser.add_argument("--build-lock-fd", type=int)
     parser.add_argument("--daemonize", action="store_true")
     options = parser.parse_args()
     if options.daemonize and os.fork() != 0:
         return 0
     try:
-        return supervise(options.spec, options.lock_fd, options.layout_lock_fd)
+        return supervise(
+            options.spec,
+            options.lock_fd,
+            options.layout_lock_fd,
+            options.build_lock_fd,
+        )
     except BaseException as error:
         message = f"{type(error).__name__}: {error}"
         print(f"topology supervisor failed during startup: {message}", file=sys.stderr)
@@ -384,6 +396,11 @@ def main() -> int:
         if options.layout_lock_fd is not None:
             try:
                 os.close(options.layout_lock_fd)
+            except OSError:
+                pass
+        if options.build_lock_fd is not None:
+            try:
+                os.close(options.build_lock_fd)
             except OSError:
                 pass
         return 1

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -73,6 +73,23 @@ def open_log(path: Path) -> BinaryIO:
     return os.fdopen(descriptor, "ab", buffering=0)
 
 
+def _peek_exit_code(process: subprocess.Popen[bytes]) -> int | None:
+    """Observe a child exit without reaping its process-group leader."""
+    try:
+        result = os.waitid(
+            os.P_PID,
+            process.pid,
+            os.WEXITED | os.WNOHANG | os.WNOWAIT,
+        )
+    except ChildProcessError:
+        return process.returncode
+    if result is None:
+        return None
+    if result.si_code == os.CLD_EXITED:
+        return result.si_status
+    return -result.si_status
+
+
 def terminate(
     processes: dict[str, subprocess.Popen[bytes]],
     process_tree_fd: int | None,
@@ -346,9 +363,10 @@ def supervise(
             server = start_service("server", capture=capture)
             deadline = time.monotonic() + SERVER_READY_TIMEOUT
             while not capture.event.wait(timeout=0.1):
-                if server.poll() is not None:
+                code = _peek_exit_code(server)
+                if code is not None:
                     raise RuntimeError(
-                        f"server exited before becoming ready with code {server.returncode}"
+                        f"server exited before becoming ready with code {code}"
                     )
                 if stop:
                     raise RuntimeError("topology stopped before the server became ready")
@@ -377,19 +395,21 @@ def supervise(
         status["ready"] = True
         atomic_status(status_path, status)
 
-        while not stop and all(
-            process.poll() is None for process in processes.values()
-        ):
+        while not stop:
             changed = False
+            running = True
             for name, process in processes.items():
-                code = process.poll()
+                code = _peek_exit_code(process)
                 service_status = status["services"][name]
                 if code is not None and service_status["status"] == "running":
                     service_status["status"] = "exited"
                     service_status["exit_code"] = code
                     changed = True
+                    running = False
             if changed:
                 atomic_status(status_path, status)
+            if not running:
+                break
             time.sleep(0.2)
     except BaseException as error:
         status["error"] = f"{type(error).__name__}: {error}"

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -4,7 +4,7 @@ import binascii
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import ExitStack, contextmanager
-from contextvars import ContextVar
+from contextvars import ContextVar, copy_context
 import ctypes
 from datetime import datetime, timezone
 import errno
@@ -1325,7 +1325,9 @@ class Workspace:
                 max_workers=max(1, min(jobs, len(checkouts)))
             ) as executor:
                 futures = {
-                    executor.submit(self._ensure_repository, checkout): checkout
+                    executor.submit(
+                        copy_context().run, self._ensure_repository, checkout
+                    ): checkout
                     for checkout in checkouts
                 }
                 for future in as_completed(futures):

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -7318,55 +7318,59 @@ class Workspace:
             targets = [supervisor] if supervisor_owned else orphaned
             if not targets:
                 return status
-            for record in targets:
-                pid = record["pid"]
-                start_time = record["start_time"]
-                try:
-                    pidfd = os.pidfd_open(pid)
-                except ProcessLookupError:
-                    continue
-                try:
-                    if process_matches(pid, start_time):
-                        if supervisor_owned:
-                            signal.pidfd_send_signal(pidfd, signal.SIGTERM)
-                        else:
-                            try:
-                                os.killpg(pid, signal.SIGTERM)
-                            except ProcessLookupError:
-                                pass
-                finally:
-                    os.close(pidfd)
-            deadline = time.monotonic() + timeout
-            while time.monotonic() < deadline:
-                if supervisor_owned:
-                    running = any(
-                        self._recorded_process_running(record) for record in targets
-                    )
-                else:
-                    running = any(
-                        self._process_group_running(record["pid"])
-                        for record in targets
-                    )
-                if not running:
-                    status = self.topology_status(name)
-                    return status
-                time.sleep(0.1)
-            if not supervisor_owned:
+            verified: list[tuple[dict[str, Any], int]] = []
+            try:
                 for record in targets:
-                    if not self._process_group_running(record["pid"]):
-                        continue
+                    pid = record["pid"]
                     try:
-                        os.killpg(record["pid"], signal.SIGKILL)
+                        pidfd = os.pidfd_open(pid)
                     except ProcessLookupError:
-                        pass
-                kill_deadline = time.monotonic() + min(max(timeout, 0.1), 2.0)
-                while time.monotonic() < kill_deadline:
-                    if not any(
-                        self._process_group_running(record["pid"])
-                        for record in targets
-                    ):
+                        continue
+                    if not process_matches(pid, record["start_time"]):
+                        os.close(pidfd)
+                        continue
+                    verified.append((record, pidfd))
+                    if supervisor_owned:
+                        signal.pidfd_send_signal(pidfd, signal.SIGTERM)
+                    else:
+                        try:
+                            os.killpg(pid, signal.SIGTERM)
+                        except ProcessLookupError:
+                            pass
+                deadline = time.monotonic() + timeout
+                while time.monotonic() < deadline:
+                    if supervisor_owned:
+                        running = any(
+                            self._recorded_process_running(record)
+                            for record, _pidfd in verified
+                        )
+                    else:
+                        running = any(
+                            self._process_group_running(record["pid"])
+                            for record, _pidfd in verified
+                        )
+                    if not running:
                         return self.topology_status(name)
-                    time.sleep(0.05)
+                    time.sleep(0.1)
+                if not supervisor_owned:
+                    for record, _pidfd in verified:
+                        if not self._process_group_running(record["pid"]):
+                            continue
+                        try:
+                            os.killpg(record["pid"], signal.SIGKILL)
+                        except ProcessLookupError:
+                            pass
+                    kill_deadline = time.monotonic() + min(max(timeout, 0.1), 2.0)
+                    while time.monotonic() < kill_deadline:
+                        if not any(
+                            self._process_group_running(record["pid"])
+                            for record, _pidfd in verified
+                        ):
+                            return self.topology_status(name)
+                        time.sleep(0.05)
+            finally:
+                for _record, pidfd in verified:
+                    os.close(pidfd)
             raise WorkspaceError(
                 f"topology did not stop within {timeout:g} seconds: {name}"
             )

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -6925,9 +6925,14 @@ class Workspace:
         with shared_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
-        ):
+        ) as layout_lock:
             return self._topology_up(
-                name, profile_name, state_name, services, port
+                name,
+                profile_name,
+                state_name,
+                services,
+                port,
+                layout_lock=layout_lock,
             )
 
     def _topology_up(
@@ -6937,6 +6942,8 @@ class Workspace:
         state_name: str,
         services: list[str] | None = None,
         port: int | None = None,
+        *,
+        layout_lock: TextIO | None = None,
     ) -> dict[str, Any]:
         selected_services = self._topology_services(services)
         if "client" in selected_services:
@@ -7151,10 +7158,15 @@ class Workspace:
                         "--spec",
                         str(spec_path),
                     ]
-                    pass_fds: tuple[int, ...] = ()
+                    inherited_locks: list[int] = []
                     if state_lock is not None:
                         command.extend(["--lock-fd", str(state_lock.fileno())])
-                        pass_fds = (state_lock.fileno(),)
+                        inherited_locks.append(state_lock.fileno())
+                    if "client" in selected_services and layout_lock is not None:
+                        command.extend(
+                            ["--layout-lock-fd", str(layout_lock.fileno())]
+                        )
+                        inherited_locks.append(layout_lock.fileno())
                     environment = os.environ.copy()
                     source_root = str(Path(__file__).resolve().parents[1])
                     python_path = environment.get("PYTHONPATH")
@@ -7171,7 +7183,7 @@ class Workspace:
                         stdout=supervisor_log,
                         stderr=subprocess.STDOUT,
                         start_new_session=True,
-                        pass_fds=pass_fds,
+                        pass_fds=tuple(inherited_locks),
                     )
                 except OSError as error:
                     raise WorkspaceError(f"cannot start topology supervisor: {error}") from error

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -1129,16 +1129,45 @@ def open_regular_file(
 def exclusive_lock(
     path: Path, description: str, nonblocking: bool = False
 ) -> Iterator[TextIO]:
+    with _advisory_lock(
+        path, description, fcntl.LOCK_EX, nonblocking=nonblocking
+    ) as lock:
+        yield lock
+
+
+@contextmanager
+def shared_lock(path: Path, description: str) -> Iterator[TextIO]:
+    operation = getattr(fcntl, "LOCK_SH", None)
+    if not isinstance(operation, int):
+        raise WorkspaceError(
+            f"shared locking is unavailable for {description}; refusing to continue"
+        )
+    with _advisory_lock(path, description, operation) as lock:
+        yield lock
+
+
+@contextmanager
+def _advisory_lock(
+    path: Path,
+    description: str,
+    operation: int,
+    *,
+    nonblocking: bool = False,
+) -> Iterator[TextIO]:
     path.parent.mkdir(parents=True, exist_ok=True)
     descriptor = open_regular_file(
         path, os.O_RDWR | os.O_CREAT, f"{description} lock"
     )
     with os.fdopen(descriptor, "a+") as lock:
-        operation = fcntl.LOCK_EX | (fcntl.LOCK_NB if nonblocking else 0)
+        operation |= fcntl.LOCK_NB if nonblocking else 0
         try:
             fcntl.flock(lock, operation)
         except BlockingIOError as error:
             raise WorkspaceError(f"{description} is already in use") from error
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot acquire {description} lock: {error}"
+            ) from error
         yield lock
 
 
@@ -2249,7 +2278,7 @@ class Workspace:
         use_ccache: bool = True,
     ) -> Path:
         self.paths.ensure()
-        with exclusive_lock(
+        with shared_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
         ):
@@ -5718,7 +5747,7 @@ class Workspace:
         self, name: str, profile: str, preset: str = "basic-player"
     ) -> dict[str, Any]:
         self.paths.ensure()
-        with exclusive_lock(
+        with shared_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
         ):
@@ -5816,7 +5845,7 @@ class Workspace:
 
     def scenario_reset(self, name: str) -> dict[str, Any]:
         self.paths.ensure()
-        with exclusive_lock(
+        with shared_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
         ):
@@ -6893,7 +6922,7 @@ class Workspace:
         port: int | None = None,
     ) -> dict[str, Any]:
         self.paths.ensure()
-        with exclusive_lock(
+        with shared_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
         ):
@@ -7345,7 +7374,7 @@ class Workspace:
         dry_run: bool,
     ) -> Path:
         self.paths.ensure()
-        with exclusive_lock(
+        with shared_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
         ):

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -7001,6 +7001,30 @@ class Workspace:
                 layout_lock=layout_lock,
             )
 
+    def _topology_resolved_status(
+        self, profile_name: str, selected: dict[str, Path]
+    ) -> dict[str, dict[str, Any]]:
+        profile = self._load_profile(profile_name, require_file=False)
+        stack = self.manifest.stack(profile["stack"])
+        checkout_states = self._selected_checkout_states(
+            profile, selected, include_dirty=True
+        )
+        return {
+            stack.providers[role].name: {
+                "path": str(path),
+                "checkout_path": str(
+                    checkout_states[stack.providers[role].checkout_name]["path"]
+                ),
+                "checkout": stack.providers[role].checkout_name,
+                "repository": stack.providers[role].repository,
+                "branch": stack.providers[role].branch,
+                "source": stack.providers[role].source,
+                "head": checkout_states[stack.providers[role].checkout_name]["head"],
+                "dirty": checkout_states[stack.providers[role].checkout_name]["dirty"],
+            }
+            for role, path in sorted(selected.items())
+        }
+
     def _topology_up(
         self,
         name: str,
@@ -7163,30 +7187,9 @@ class Workspace:
 
                 profile = self._load_profile(profile_name, require_file=False)
                 selected_stack = self.manifest.stack(profile["stack"])
-                checkout_states = self._selected_checkout_states(
-                    profile, selected, include_dirty=True
+                resolved_status = self._topology_resolved_status(
+                    profile_name, selected
                 )
-                resolved_status = {
-                    selected_stack.providers[role].name: {
-                        "path": str(path),
-                        "checkout_path": str(
-                            checkout_states[
-                                selected_stack.providers[role].checkout_name
-                            ]["path"]
-                        ),
-                        "checkout": selected_stack.providers[role].checkout_name,
-                        "repository": selected_stack.providers[role].repository,
-                        "branch": selected_stack.providers[role].branch,
-                        "source": selected_stack.providers[role].source,
-                        "head": checkout_states[
-                            selected_stack.providers[role].checkout_name
-                        ]["head"],
-                        "dirty": checkout_states[
-                            selected_stack.providers[role].checkout_name
-                        ]["dirty"],
-                    }
-                    for role, path in sorted(selected.items())
-                }
                 spec = {
                     "schema_version": SCHEMA_VERSION,
                     "name": name,
@@ -7311,7 +7314,8 @@ class Workspace:
                 for service in status["services"].values()
                 if service["running"]
             ]
-            targets = [supervisor] if supervisor["running"] else orphaned
+            supervisor_owned = supervisor["running"]
+            targets = [supervisor] if supervisor_owned else orphaned
             if not targets:
                 return status
             for record in targets:
@@ -7323,18 +7327,59 @@ class Workspace:
                     continue
                 try:
                     if process_matches(pid, start_time):
-                        signal.pidfd_send_signal(pidfd, signal.SIGTERM)
+                        if supervisor_owned:
+                            signal.pidfd_send_signal(pidfd, signal.SIGTERM)
+                        else:
+                            try:
+                                os.killpg(pid, signal.SIGTERM)
+                            except ProcessLookupError:
+                                pass
                 finally:
                     os.close(pidfd)
             deadline = time.monotonic() + timeout
             while time.monotonic() < deadline:
-                if not any(self._recorded_process_running(record) for record in targets):
+                if supervisor_owned:
+                    running = any(
+                        self._recorded_process_running(record) for record in targets
+                    )
+                else:
+                    running = any(
+                        self._process_group_running(record["pid"])
+                        for record in targets
+                    )
+                if not running:
                     status = self.topology_status(name)
                     return status
                 time.sleep(0.1)
+            if not supervisor_owned:
+                for record in targets:
+                    if not self._process_group_running(record["pid"]):
+                        continue
+                    try:
+                        os.killpg(record["pid"], signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+                kill_deadline = time.monotonic() + min(max(timeout, 0.1), 2.0)
+                while time.monotonic() < kill_deadline:
+                    if not any(
+                        self._process_group_running(record["pid"])
+                        for record in targets
+                    ):
+                        return self.topology_status(name)
+                    time.sleep(0.05)
             raise WorkspaceError(
                 f"topology did not stop within {timeout:g} seconds: {name}"
             )
+
+    @staticmethod
+    def _process_group_running(process_group: int) -> bool:
+        try:
+            os.killpg(process_group, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        return True
 
     def topology_logs(
         self,

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -7331,13 +7331,30 @@ class Workspace:
         arguments: list[str],
         dry_run: bool,
     ) -> Path:
+        self.paths.ensure()
+        with shared_lock(
+            self.paths.workspace / "repository-layout.lock",
+            "repository layout",
+        ):
+            return self._run_client(
+                profile_name, state_name, port, arguments, dry_run
+            )
+
+    def _run_client(
+        self,
+        profile_name: str,
+        state_name: str,
+        port: int,
+        arguments: list[str],
+        dry_run: bool,
+    ) -> Path:
         self._validate_run_port(port)
         launch_label = client_launch_label(profile_name)
         self._require_classic_contracts(profile_name, {"client"})
         state = self._state_location(state_name)
         self._validate_state(state)
         fingerprint = self._server_identity_fingerprint(state)
-        root = self.build("client", profile_name, tests=False)
+        root = self._build("client", profile_name, tests=False)
         executable = self._classic_binary_directory(root, "client") / "atrinik"
         working = root / "sources" / "client"
         if not executable.is_file():

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -162,6 +162,7 @@ def run(
     env: dict[str, str] | None = None,
     trace: bool = True,
     diagnostics_to_stderr: bool = True,
+    pass_fds: tuple[int, ...] = (),
 ) -> str:
     if trace:
         print(f"+ {display_arguments(arguments)}", file=sys.stderr)
@@ -174,6 +175,7 @@ def run(
             capture_output=capture,
             env=env,
             stdout=sys.stderr if diagnostics_to_stderr and not capture else None,
+            pass_fds=pass_fds,
         )
     except FileNotFoundError as error:
         raise WorkspaceError(f"required command not found: {arguments[0]}") from error
@@ -2325,8 +2327,7 @@ class Workspace:
     ) -> Path:
         key = self._profile_build_key(profile_name, selected)
         root = self.paths.builds / "profiles" / f"{profile_name}-{key}"
-        lock = self.paths.builds / "locks" / f"{profile_name}-{key}.lock"
-        with exclusive_lock(lock, f"profile build {profile_name}"):
+        with self._profile_build_lock(root, profile_name):
             self._force_reconfigure = force_reconfigure
             self._use_ccache = use_ccache
             managed_directory(root, self.paths.builds, f"profile:{profile_name}:{key}")
@@ -2356,6 +2357,14 @@ class Workspace:
             if target in {"sound", "resources"}:
                 print(f"{target}: selected {selected[target]}")
         return root
+
+    @contextmanager
+    def _profile_build_lock(
+        self, root: Path, profile_name: str
+    ) -> Iterator[TextIO]:
+        lock = self.paths.builds / "locks" / f"{root.name}.lock"
+        with exclusive_lock(lock, f"profile build {profile_name}") as lease:
+            yield lease
 
     def _refresh_build_metadata(
         self,
@@ -5703,22 +5712,23 @@ class Workspace:
         root = self._build_resolved(
             "server", metadata["profile"], False, ["server"], selected
         )
-        runtime = self._prepare_server_runtime(
-            root, selected, state, metadata["state"]
-        )
-        executable = runtime / "atrinik-server"
-        run(
-            [
-                str(executable),
-                "--provision_scenario",
-                f"--provision_account={metadata['account']}",
-                f"--provision_character={metadata['character']}",
-                f"--provision_archetype={metadata['archetype']}",
-                f"--provision_password_file={password_file}",
-                f"--assetspath={runtime / 'assets'}",
-            ],
-            cwd=runtime,
-        )
+        with self._profile_build_lock(root, metadata["profile"]):
+            runtime = self._prepare_server_runtime(
+                root, selected, state, metadata["state"]
+            )
+            executable = runtime / "atrinik-server"
+            run(
+                [
+                    str(executable),
+                    "--provision_scenario",
+                    f"--provision_account={metadata['account']}",
+                    f"--provision_character={metadata['character']}",
+                    f"--provision_archetype={metadata['archetype']}",
+                    f"--provision_password_file={password_file}",
+                    f"--assetspath={runtime / 'assets'}",
+                ],
+                cwd=runtime,
+            )
         profile = self._load_profile(metadata["profile"], require_file=False)
         stack = self.manifest.stack(profile["stack"])
         audited = {role: selected[role] for role in required}
@@ -7001,6 +7011,9 @@ class Workspace:
                 root = self._build_resolved(
                     "topology", profile_name, False, targets, selected
                 )
+                build_lock = stack.enter_context(
+                    self._profile_build_lock(root, profile_name)
+                )
                 endpoint: dict[str, Any] | None = None
                 if "server" in selected_services:
                     stack.enter_context(
@@ -7162,11 +7175,15 @@ class Workspace:
                     if state_lock is not None:
                         command.extend(["--lock-fd", str(state_lock.fileno())])
                         inherited_locks.append(state_lock.fileno())
-                    if "client" in selected_services and layout_lock is not None:
+                    if layout_lock is not None:
                         command.extend(
                             ["--layout-lock-fd", str(layout_lock.fileno())]
                         )
                         inherited_locks.append(layout_lock.fileno())
+                    command.extend(
+                        ["--build-lock-fd", str(build_lock.fileno())]
+                    )
+                    inherited_locks.append(build_lock.fileno())
                     environment = os.environ.copy()
                     source_root = str(Path(__file__).resolve().parents[1])
                     python_path = environment.get("PYTHONPATH")
@@ -7347,9 +7364,14 @@ class Workspace:
         with shared_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
-        ):
+        ) as layout_lock:
             return self._run_client(
-                profile_name, state_name, port, arguments, dry_run
+                profile_name,
+                state_name,
+                port,
+                arguments,
+                dry_run,
+                layout_lock=layout_lock,
             )
 
     def _run_client(
@@ -7359,6 +7381,8 @@ class Workspace:
         port: int,
         arguments: list[str],
         dry_run: bool,
+        *,
+        layout_lock: TextIO | None = None,
     ) -> Path:
         self._validate_run_port(port)
         launch_label = client_launch_label(profile_name)
@@ -7367,32 +7391,38 @@ class Workspace:
         self._validate_state(state)
         fingerprint = self._server_identity_fingerprint(state)
         root = self._build("client", profile_name, tests=False)
-        executable = self._classic_binary_directory(root, "client") / "atrinik"
-        working = root / "sources" / "client"
-        if not executable.is_file():
-            raise WorkspaceError(f"client executable is missing: {executable}")
-        command = [
-            str(executable),
-            f"--server=127.0.0.1 {port} {fingerprint}",
-            "--stun_server=off",
-            "--nometa",
-            *arguments,
-        ]
-        print(f"state: {state}")
-        print(f"cwd: {working}")
-        print(f"launch label: {launch_label}")
-        print(f"command: {display_arguments(command)}")
-        if not dry_run:
-            self._require_client_display()
-            environment = os.environ.copy()
-            environment[CLIENT_LAUNCH_LABEL_ENV] = launch_label
-            run(
-                command,
-                cwd=working,
-                env=environment,
-                diagnostics_to_stderr=False,
-            )
-        return executable
+        with self._profile_build_lock(root, profile_name) as build_lock:
+            executable = self._classic_binary_directory(root, "client") / "atrinik"
+            working = root / "sources" / "client"
+            if not executable.is_file():
+                raise WorkspaceError(f"client executable is missing: {executable}")
+            command = [
+                str(executable),
+                f"--server=127.0.0.1 {port} {fingerprint}",
+                "--stun_server=off",
+                "--nometa",
+                *arguments,
+            ]
+            print(f"state: {state}")
+            print(f"cwd: {working}")
+            print(f"launch label: {launch_label}")
+            print(f"command: {display_arguments(command)}")
+            if not dry_run:
+                self._require_client_display()
+                environment = os.environ.copy()
+                environment[CLIENT_LAUNCH_LABEL_ENV] = launch_label
+                run(
+                    command,
+                    cwd=working,
+                    env=environment,
+                    diagnostics_to_stderr=False,
+                    pass_fds=tuple(
+                        lease.fileno()
+                        for lease in (layout_lock, build_lock)
+                        if lease is not None
+                    ),
+                )
+            return executable
 
     def run_server(
         self,
@@ -7406,9 +7436,14 @@ class Workspace:
         with shared_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
-        ):
+        ) as layout_lock:
             return self._run_server(
-                profile_name, state_name, port, arguments, dry_run
+                profile_name,
+                state_name,
+                port,
+                arguments,
+                dry_run,
+                layout_lock=layout_lock,
             )
 
     def _run_server(
@@ -7418,6 +7453,8 @@ class Workspace:
         port: int,
         arguments: list[str],
         dry_run: bool,
+        *,
+        layout_lock: TextIO | None = None,
     ) -> Path:
         self._validate_run_port(port)
         self._require_classic_contracts(profile_name, {"server"})
@@ -7425,29 +7462,43 @@ class Workspace:
         selected = self._resolve_build_profile(profile_name, {"server"})
         state_location = self._state_location(state_name)
         lock_path = Path(f"{state_location}.lock")
-        with exclusive_lock(lock_path, f"server state {state_location}", nonblocking=True):
+        with exclusive_lock(
+            lock_path, f"server state {state_location}", nonblocking=True
+        ) as state_lock:
             root = self._build_resolved(
                 "server", profile_name, False, targets, selected
             )
-            state = self.state_path(
-                state_name, selected["server"], resolved_path=state_location
-            )
-            runtime = self._prepare_server_runtime(root, selected, state, state_name)
-            executable = runtime / "atrinik-server"
-            command = [
-                str(executable),
-                f"--port_quic={port}",
-                "--port_mapping=off",
-                "--stun_server=off",
-                *arguments,
-                f"--assetspath={runtime / 'assets'}",
-            ]
-            print(f"state: {state}")
-            print(f"cwd: {runtime}")
-            print(f"command: {display_arguments(command)}")
-            if not dry_run:
-                run(command, cwd=runtime, diagnostics_to_stderr=False)
-            return executable
+            with self._profile_build_lock(root, profile_name) as build_lock:
+                state = self.state_path(
+                    state_name, selected["server"], resolved_path=state_location
+                )
+                runtime = self._prepare_server_runtime(
+                    root, selected, state, state_name
+                )
+                executable = runtime / "atrinik-server"
+                command = [
+                    str(executable),
+                    f"--port_quic={port}",
+                    "--port_mapping=off",
+                    "--stun_server=off",
+                    *arguments,
+                    f"--assetspath={runtime / 'assets'}",
+                ]
+                print(f"state: {state}")
+                print(f"cwd: {runtime}")
+                print(f"command: {display_arguments(command)}")
+                if not dry_run:
+                    run(
+                        command,
+                        cwd=runtime,
+                        diagnostics_to_stderr=False,
+                        pass_fds=tuple(
+                            lease.fileno()
+                            for lease in (layout_lock, state_lock, build_lock)
+                            if lease is not None
+                        ),
+                    )
+                return executable
 
     @staticmethod
     def _validate_run_port(port: int) -> None:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -7332,8 +7332,12 @@ class Workspace:
         ):
             status = self.topology_status(name)
             process_tree_path = root / TOPOLOGY_PROCESS_TREE_LEASE
-            if not process_tree_path.is_file() or process_tree_path.is_symlink():
-                return status
+            if process_tree_path.is_symlink():
+                raise WorkspaceError(
+                    f"topology process-tree lease is invalid: {name}"
+                )
+            if not process_tree_path.is_file():
+                return self._legacy_topology_down(name, status, timeout)
             process_tree_fd = open_regular_file(
                 process_tree_path,
                 os.O_RDWR,
@@ -7344,6 +7348,12 @@ class Workspace:
                     process_tree_fd, exclude=(os.getpid(),)
                 )
                 if not active_holders:
+                    recorded_running = status["supervisor"]["running"] or any(
+                        service["running"]
+                        for service in status["services"].values()
+                    )
+                    if recorded_running:
+                        return self._legacy_topology_down(name, status, timeout)
                     return status
                 signal_holders(
                     process_tree_fd, signal.SIGTERM, exclude=(os.getpid(),)
@@ -7351,9 +7361,13 @@ class Workspace:
                 deadline = time.monotonic() + timeout
                 while time.monotonic() < deadline:
                     current = self.topology_status(name)
+                    recorded_running = current["supervisor"]["running"] or any(
+                        service["running"]
+                        for service in current["services"].values()
+                    )
                     if not holders_exist(
                         process_tree_fd, exclude=(os.getpid(),)
-                    ) and not current["supervisor"]["running"]:
+                    ) and not recorded_running:
                         return current
                     time.sleep(0.1)
                 signal_holders(
@@ -7361,10 +7375,19 @@ class Workspace:
                 )
                 kill_deadline = time.monotonic() + min(max(timeout, 0.1), 2.0)
                 while time.monotonic() < kill_deadline:
+                    signal_holders(
+                        process_tree_fd,
+                        signal.SIGKILL,
+                        exclude=(os.getpid(),),
+                    )
                     current = self.topology_status(name)
+                    recorded_running = current["supervisor"]["running"] or any(
+                        service["running"]
+                        for service in current["services"].values()
+                    )
                     if not holders_exist(
                         process_tree_fd, exclude=(os.getpid(),)
-                    ) and not current["supervisor"]["running"]:
+                    ) and not recorded_running:
                         return current
                     time.sleep(0.05)
             finally:
@@ -7372,6 +7395,82 @@ class Workspace:
             raise WorkspaceError(
                 f"topology did not stop within {timeout:g} seconds: {name}"
             )
+
+    def _legacy_topology_down(
+        self, name: str, status: dict[str, Any], timeout: float
+    ) -> dict[str, Any]:
+        supervisor = status["supervisor"]
+        supervisor_owned = supervisor["running"]
+        targets = [supervisor] if supervisor_owned else [
+            service
+            for service in status["services"].values()
+            if service["running"]
+        ]
+        verified: list[tuple[dict[str, Any], int]] = []
+        try:
+            for record in targets:
+                try:
+                    pidfd = os.pidfd_open(record["pid"])
+                except ProcessLookupError:
+                    continue
+                if not process_matches(record["pid"], record["start_time"]):
+                    os.close(pidfd)
+                    continue
+                verified.append((record, pidfd))
+                if supervisor_owned:
+                    signal.pidfd_send_signal(pidfd, signal.SIGTERM)
+                else:
+                    try:
+                        os.killpg(record["pid"], signal.SIGTERM)
+                    except ProcessLookupError:
+                        pass
+            deadline = time.monotonic() + timeout
+            while time.monotonic() < deadline:
+                if supervisor_owned:
+                    running = any(
+                        self._recorded_process_running(record)
+                        for record, _pidfd in verified
+                    )
+                else:
+                    running = any(
+                        self._process_group_running(record["pid"])
+                        for record, _pidfd in verified
+                    )
+                if not running:
+                    return self.topology_status(name)
+                time.sleep(0.1)
+            if not supervisor_owned:
+                for record, _pidfd in verified:
+                    if not self._process_group_running(record["pid"]):
+                        continue
+                    try:
+                        os.killpg(record["pid"], signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+                kill_deadline = time.monotonic() + min(max(timeout, 0.1), 2.0)
+                while time.monotonic() < kill_deadline:
+                    if not any(
+                        self._process_group_running(record["pid"])
+                        for record, _pidfd in verified
+                    ):
+                        return self.topology_status(name)
+                    time.sleep(0.05)
+        finally:
+            for _record, pidfd in verified:
+                os.close(pidfd)
+        raise WorkspaceError(
+            f"topology did not stop within {timeout:g} seconds: {name}"
+        )
+
+    @staticmethod
+    def _process_group_running(process_group: int) -> bool:
+        try:
+            os.killpg(process_group, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        return True
 
     def topology_logs(
         self,

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -4,7 +4,7 @@ import binascii
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import ExitStack, contextmanager
-from contextvars import ContextVar, copy_context
+from contextvars import copy_context
 import ctypes
 from datetime import datetime, timezone
 import errno
@@ -30,6 +30,7 @@ import time
 from typing import Any, Callable, Iterator, TextIO
 
 from .launch_identity import CLIENT_LAUNCH_LABEL_ENV, client_launch_label
+from .locking import active_lock_fds, inherit_lock_fds
 
 from .model import (
     MANAGED_MARKER,
@@ -137,20 +138,6 @@ RUNTIME_INPUT_SCHEMA_VERSION = 1
 REGION_MAP_METADATA = ".atrinik-region-maps.json"
 REGION_MAP_SCHEMA_VERSION = 1
 EXPECTED_REGION_MAP = "incuna_-1"
-_INHERITED_LOCK_FDS: ContextVar[tuple[int, ...]] = ContextVar(
-    "atrinik_inherited_lock_fds", default=()
-)
-
-
-@contextmanager
-def _inherit_lock_fds(*leases: TextIO) -> Iterator[None]:
-    descriptors = tuple(lease.fileno() for lease in leases)
-    current = _INHERITED_LOCK_FDS.get()
-    token = _INHERITED_LOCK_FDS.set(tuple(dict.fromkeys((*current, *descriptors))))
-    try:
-        yield
-    finally:
-        _INHERITED_LOCK_FDS.reset(token)
 
 
 def display_arguments(arguments: list[str]) -> str:
@@ -184,7 +171,7 @@ def run(
         print(f"+ {display_arguments(arguments)}", file=sys.stderr)
     try:
         inherited_fds = tuple(
-            dict.fromkeys((*_INHERITED_LOCK_FDS.get(), *pass_fds))
+            dict.fromkeys((*active_lock_fds(), *pass_fds))
         )
         result = subprocess.run(
             arguments,
@@ -1153,7 +1140,7 @@ def exclusive_lock(
     with _advisory_lock(
         path, description, fcntl.LOCK_EX, nonblocking=nonblocking
     ) as lock:
-        with _inherit_lock_fds(lock):
+        with inherit_lock_fds(lock):
             yield lock
 
 
@@ -1165,7 +1152,7 @@ def shared_lock(path: Path, description: str) -> Iterator[TextIO]:
             f"shared locking is unavailable for {description}; refusing to continue"
         )
     with _advisory_lock(path, description, operation) as lock:
-        with _inherit_lock_fds(lock):
+        with inherit_lock_fds(lock):
             yield lock
 
 
@@ -3200,6 +3187,7 @@ class Workspace:
                 check=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                pass_fds=active_lock_fds(),
             )
         except FileNotFoundError as error:
             raise WorkspaceError("required command not found: git") from error

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -7049,16 +7049,6 @@ class Workspace:
             operation_lock, f"topology {name} operation", nonblocking=True
         ):
             process_tree_path = topology_root / TOPOLOGY_PROCESS_TREE_LEASE
-            process_tree_probe = open_regular_file(
-                process_tree_path,
-                os.O_RDWR | os.O_CREAT,
-                "topology process-tree lease",
-            )
-            try:
-                if holders_exist(process_tree_probe, exclude=(os.getpid(),)):
-                    raise WorkspaceError(f"topology is already running: {name}")
-            finally:
-                os.close(process_tree_probe)
             status_path = topology_root / "status.json"
             startup_error_path = topology_root / "startup-error.json"
             if status_path.is_file():
@@ -7089,6 +7079,27 @@ class Workspace:
             ]
 
             with ExitStack() as stack:
+                process_tree_fd = open_regular_file(
+                    process_tree_path,
+                    os.O_RDWR | os.O_CREAT,
+                    "topology process-tree lease",
+                )
+                stack.callback(os.close, process_tree_fd)
+                try:
+                    fcntl.flock(
+                        process_tree_fd, fcntl.LOCK_EX | fcntl.LOCK_NB
+                    )
+                except BlockingIOError as error:
+                    raise WorkspaceError(
+                        f"topology is already running: {name}"
+                    ) from error
+                except OSError as error:
+                    raise WorkspaceError(
+                        f"cannot lock topology process-tree lease: {error}"
+                    ) from error
+                if holders_exist(process_tree_fd, exclude=(os.getpid(),)):
+                    raise WorkspaceError(f"topology is already running: {name}")
+
                 state_location: Path | None = None
                 state_lock: TextIO | None = None
                 if "server" in selected_services:
@@ -7234,11 +7245,6 @@ class Workspace:
                     "ab",
                     buffering=0,
                 )
-                process_tree_fd = open_regular_file(
-                    process_tree_path,
-                    os.O_RDWR,
-                    "topology process-tree lease",
-                )
                 try:
                     command = [
                         sys.executable,
@@ -7287,7 +7293,6 @@ class Workspace:
                     raise WorkspaceError(f"cannot start topology supervisor: {error}") from error
                 finally:
                     supervisor_log.close()
-                    os.close(process_tree_fd)
 
                 deadline = time.monotonic() + 45
                 while time.monotonic() < deadline:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -25,6 +25,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from typing import Any, Callable, Iterator, TextIO
 
@@ -1197,6 +1198,47 @@ class Workspace:
     def __init__(self, repository: Path):
         self.paths = Paths.discover(repository)
         self.manifest = Manifest.load(self.paths.repository / "components.json")
+        self._build_state = threading.local()
+        self._prefix_map_support: dict[
+            tuple[str, str, str | None, str | None], bool
+        ] = {}
+        self._prefix_map_support_lock = threading.Lock()
+
+    @property
+    def _force_reconfigure(self) -> bool:
+        return getattr(self._build_state, "force_reconfigure", False)
+
+    @_force_reconfigure.setter
+    def _force_reconfigure(self, value: bool) -> None:
+        self._build_state.force_reconfigure = value
+
+    @property
+    def _use_ccache(self) -> bool:
+        return getattr(self._build_state, "use_ccache", True)
+
+    @_use_ccache.setter
+    def _use_ccache(self, value: bool) -> None:
+        self._build_state.use_ccache = value
+
+    @property
+    def _source_view_changed(self) -> bool:
+        return getattr(self._build_state, "source_view_changed", False)
+
+    @_source_view_changed.setter
+    def _source_view_changed(self, value: bool) -> None:
+        self._build_state.source_view_changed = value
+
+    @property
+    def _source_view_unchanged(self) -> dict[str, bool]:
+        current = getattr(self._build_state, "source_view_unchanged", None)
+        if current is None:
+            current = {}
+            self._build_state.source_view_unchanged = current
+        return current
+
+    @_source_view_unchanged.setter
+    def _source_view_unchanged(self, value: dict[str, bool]) -> None:
+        self._build_state.source_view_unchanged = value
 
     def migrate_repositories(self, mode: str) -> dict[str, Any]:
         if mode == "apply":
@@ -2350,6 +2392,7 @@ class Workspace:
         with self._profile_build_lock(root, profile_name):
             self._force_reconfigure = force_reconfigure
             self._use_ccache = use_ccache
+            self._source_view_unchanged = {}
             managed_directory(root, self.paths.builds, f"profile:{profile_name}:{key}")
             self._refresh_build_metadata(root, profile_name, key, selected)
             if "content" in targets or "server" in targets:
@@ -2655,7 +2698,6 @@ class Workspace:
                 unchanged = False
         if not unchanged:
             atomic_json(metadata_path, metadata)
-        self._source_view_unchanged = getattr(self, "_source_view_unchanged", {})
         self._source_view_unchanged[str(view.resolve())] = unchanged
         return view
 
@@ -3418,7 +3460,7 @@ class Workspace:
     ) -> None:
         self._prepare_cmake_binary(binary)
         environment = os.environ.copy()
-        ccache = shutil.which("ccache") if getattr(self, "_use_ccache", True) else None
+        ccache = shutil.which("ccache") if self._use_ccache else None
         cache_arguments = [
             "-DCMAKE_C_COMPILER_LAUNCHER=",
             "-DCMAKE_CXX_COMPILER_LAUNCHER=",
@@ -3428,16 +3470,20 @@ class Workspace:
         )
         if ccache is not None:
             cache = self.paths.builds / COMPILER_CACHE_PURPOSE
-            managed_directory(cache, self.paths.builds, COMPILER_CACHE_PURPOSE)
-            atomic_json(
-                cache / CACHE_METADATA,
-                {
-                    "schema_version": BUILD_METADATA_SCHEMA_VERSION,
-                    "purpose": COMPILER_CACHE_PURPOSE,
-                    "last_used_at": datetime.now(timezone.utc).isoformat(),
-                    "max_size": COMPILER_CACHE_MAX_SIZE,
-                },
-            )
+            with exclusive_lock(
+                self.paths.builds / "locks" / "compiler-cache.lock",
+                "compiler cache initialization",
+            ):
+                managed_directory(cache, self.paths.builds, COMPILER_CACHE_PURPOSE)
+                atomic_json(
+                    cache / CACHE_METADATA,
+                    {
+                        "schema_version": BUILD_METADATA_SCHEMA_VERSION,
+                        "purpose": COMPILER_CACHE_PURPOSE,
+                        "last_used_at": datetime.now(timezone.utc).isoformat(),
+                        "max_size": COMPILER_CACHE_MAX_SIZE,
+                    },
+                )
             environment.update(
                 {
                     "CCACHE_DIR": str(cache),
@@ -3459,7 +3505,7 @@ class Workspace:
                 f"ccache: enabled at {cache} (maximum {COMPILER_CACHE_MAX_SIZE})",
                 file=sys.stderr,
             )
-        elif getattr(self, "_use_ccache", True):
+        elif self._use_ccache:
             print(
                 "ccache: command not found; install ccache or pass --no-ccache "
                 "to disable this diagnostic",
@@ -3486,7 +3532,7 @@ class Workspace:
         source_resolved = source.resolve()
         unchanged_view = all(
             unchanged
-            for view, unchanged in getattr(self, "_source_view_unchanged", {}).items()
+            for view, unchanged in self._source_view_unchanged.items()
             if Path(view) == source_resolved or source_resolved in Path(view).parents
         )
         previous: dict[str, Any] = {}
@@ -3511,7 +3557,7 @@ class Workspace:
             managed_reset(binary, self.paths.builds, "cmake-binary")
             configured = False
         if (
-            getattr(self, "_force_reconfigure", False)
+            self._force_reconfigure
             or not unchanged_view
             or not fingerprint["source"].get("configure_skip_safe", True)
             or not configured
@@ -3659,7 +3705,8 @@ class Workspace:
     def _compiler_supports_prefix_maps(self, command: str, language: str) -> bool:
         identity = self._tool_identity(command)
         key = (command, language, identity.get("resolved_path"), identity.get("sha256"))
-        cached = getattr(self, "_prefix_map_support", {}).get(key)
+        with self._prefix_map_support_lock:
+            cached = self._prefix_map_support.get(key)
         if cached is not None:
             return cached
         try:
@@ -3693,9 +3740,8 @@ class Workspace:
                     supported = output.is_file()
                 except WorkspaceError:
                     supported = False
-        self._prefix_map_support = getattr(self, "_prefix_map_support", {})
-        self._prefix_map_support[key] = supported
-        return supported
+        with self._prefix_map_support_lock:
+            return self._prefix_map_support.setdefault(key, supported)
 
     @staticmethod
     def _tool_identity(command: str) -> dict[str, str | None]:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -4,6 +4,7 @@ import binascii
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import ExitStack, contextmanager
+from contextvars import ContextVar
 import ctypes
 from datetime import datetime, timezone
 import errno
@@ -135,6 +136,20 @@ RUNTIME_INPUT_SCHEMA_VERSION = 1
 REGION_MAP_METADATA = ".atrinik-region-maps.json"
 REGION_MAP_SCHEMA_VERSION = 1
 EXPECTED_REGION_MAP = "incuna_-1"
+_INHERITED_LOCK_FDS: ContextVar[tuple[int, ...]] = ContextVar(
+    "atrinik_inherited_lock_fds", default=()
+)
+
+
+@contextmanager
+def _inherit_lock_fds(*leases: TextIO) -> Iterator[None]:
+    descriptors = tuple(lease.fileno() for lease in leases)
+    current = _INHERITED_LOCK_FDS.get()
+    token = _INHERITED_LOCK_FDS.set(tuple(dict.fromkeys((*current, *descriptors))))
+    try:
+        yield
+    finally:
+        _INHERITED_LOCK_FDS.reset(token)
 
 
 def display_arguments(arguments: list[str]) -> str:
@@ -167,6 +182,9 @@ def run(
     if trace:
         print(f"+ {display_arguments(arguments)}", file=sys.stderr)
     try:
+        inherited_fds = tuple(
+            dict.fromkeys((*_INHERITED_LOCK_FDS.get(), *pass_fds))
+        )
         result = subprocess.run(
             arguments,
             cwd=cwd,
@@ -175,7 +193,7 @@ def run(
             capture_output=capture,
             env=env,
             stdout=sys.stderr if diagnostics_to_stderr and not capture else None,
-            pass_fds=pass_fds,
+            pass_fds=inherited_fds,
         )
     except FileNotFoundError as error:
         raise WorkspaceError(f"required command not found: {arguments[0]}") from error
@@ -1134,7 +1152,8 @@ def exclusive_lock(
     with _advisory_lock(
         path, description, fcntl.LOCK_EX, nonblocking=nonblocking
     ) as lock:
-        yield lock
+        with _inherit_lock_fds(lock):
+            yield lock
 
 
 @contextmanager
@@ -1145,7 +1164,8 @@ def shared_lock(path: Path, description: str) -> Iterator[TextIO]:
             f"shared locking is unavailable for {description}; refusing to continue"
         )
     with _advisory_lock(path, description, operation) as lock:
-        yield lock
+        with _inherit_lock_fds(lock):
+            yield lock
 
 
 @contextmanager

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -31,6 +31,7 @@ from typing import Any, Callable, Iterator, TextIO
 
 from .launch_identity import CLIENT_LAUNCH_LABEL_ENV, client_launch_label
 from .locking import active_lock_fds, inherit_lock_fds
+from .process_tree import holders_exist, signal_holders
 
 from .model import (
     MANAGED_MARKER,
@@ -82,6 +83,7 @@ CONFIGURE_SCHEMA_VERSION = 2
 COMPILER_CACHE_PURPOSE = "compiler-cache"
 COMPILER_CACHE_MAX_SIZE = "5G"
 TOPOLOGY_SERVICES = ("server", "client")
+TOPOLOGY_PROCESS_TREE_LEASE = "process-tree.lease"
 PRE_MONOREPO_REPOSITORIES = {
     "client": "legacy-client",
     "server": "legacy-server",
@@ -7046,6 +7048,17 @@ class Workspace:
         with exclusive_lock(
             operation_lock, f"topology {name} operation", nonblocking=True
         ):
+            process_tree_path = topology_root / TOPOLOGY_PROCESS_TREE_LEASE
+            process_tree_probe = open_regular_file(
+                process_tree_path,
+                os.O_RDWR | os.O_CREAT,
+                "topology process-tree lease",
+            )
+            try:
+                if holders_exist(process_tree_probe, exclude=(os.getpid(),)):
+                    raise WorkspaceError(f"topology is already running: {name}")
+            finally:
+                os.close(process_tree_probe)
             status_path = topology_root / "status.json"
             startup_error_path = topology_root / "startup-error.json"
             if status_path.is_file():
@@ -7221,6 +7234,11 @@ class Workspace:
                     "ab",
                     buffering=0,
                 )
+                process_tree_fd = open_regular_file(
+                    process_tree_path,
+                    os.O_RDWR,
+                    "topology process-tree lease",
+                )
                 try:
                     command = [
                         sys.executable,
@@ -7243,6 +7261,10 @@ class Workspace:
                         ["--build-lock-fd", str(build_lock.fileno())]
                     )
                     inherited_locks.append(build_lock.fileno())
+                    command.extend(
+                        ["--process-tree-fd", str(process_tree_fd)]
+                    )
+                    inherited_locks.append(process_tree_fd)
                     environment = os.environ.copy()
                     source_root = str(Path(__file__).resolve().parents[1])
                     python_path = environment.get("PYTHONPATH")
@@ -7265,6 +7287,7 @@ class Workspace:
                     raise WorkspaceError(f"cannot start topology supervisor: {error}") from error
                 finally:
                     supervisor_log.close()
+                    os.close(process_tree_fd)
 
                 deadline = time.monotonic() + 45
                 while time.monotonic() < deadline:
@@ -7308,82 +7331,47 @@ class Workspace:
             root / "operation.lock", f"topology {name} operation", nonblocking=True
         ):
             status = self.topology_status(name)
-            supervisor = status["supervisor"]
-            orphaned = [
-                service
-                for service in status["services"].values()
-                if service["running"]
-            ]
-            supervisor_owned = supervisor["running"]
-            targets = [supervisor] if supervisor_owned else orphaned
-            if not targets:
+            process_tree_path = root / TOPOLOGY_PROCESS_TREE_LEASE
+            if not process_tree_path.is_file() or process_tree_path.is_symlink():
                 return status
-            verified: list[tuple[dict[str, Any], int]] = []
+            process_tree_fd = open_regular_file(
+                process_tree_path,
+                os.O_RDWR,
+                "topology process-tree lease",
+            )
             try:
-                for record in targets:
-                    pid = record["pid"]
-                    try:
-                        pidfd = os.pidfd_open(pid)
-                    except ProcessLookupError:
-                        continue
-                    if not process_matches(pid, record["start_time"]):
-                        os.close(pidfd)
-                        continue
-                    verified.append((record, pidfd))
-                    if supervisor_owned:
-                        signal.pidfd_send_signal(pidfd, signal.SIGTERM)
-                    else:
-                        try:
-                            os.killpg(pid, signal.SIGTERM)
-                        except ProcessLookupError:
-                            pass
+                active_holders = holders_exist(
+                    process_tree_fd, exclude=(os.getpid(),)
+                )
+                if not active_holders:
+                    return status
+                signal_holders(
+                    process_tree_fd, signal.SIGTERM, exclude=(os.getpid(),)
+                )
                 deadline = time.monotonic() + timeout
                 while time.monotonic() < deadline:
-                    if supervisor_owned:
-                        running = any(
-                            self._recorded_process_running(record)
-                            for record, _pidfd in verified
-                        )
-                    else:
-                        running = any(
-                            self._process_group_running(record["pid"])
-                            for record, _pidfd in verified
-                        )
-                    if not running:
-                        return self.topology_status(name)
+                    current = self.topology_status(name)
+                    if not holders_exist(
+                        process_tree_fd, exclude=(os.getpid(),)
+                    ) and not current["supervisor"]["running"]:
+                        return current
                     time.sleep(0.1)
-                if not supervisor_owned:
-                    for record, _pidfd in verified:
-                        if not self._process_group_running(record["pid"]):
-                            continue
-                        try:
-                            os.killpg(record["pid"], signal.SIGKILL)
-                        except ProcessLookupError:
-                            pass
-                    kill_deadline = time.monotonic() + min(max(timeout, 0.1), 2.0)
-                    while time.monotonic() < kill_deadline:
-                        if not any(
-                            self._process_group_running(record["pid"])
-                            for record, _pidfd in verified
-                        ):
-                            return self.topology_status(name)
-                        time.sleep(0.05)
+                signal_holders(
+                    process_tree_fd, signal.SIGKILL, exclude=(os.getpid(),)
+                )
+                kill_deadline = time.monotonic() + min(max(timeout, 0.1), 2.0)
+                while time.monotonic() < kill_deadline:
+                    current = self.topology_status(name)
+                    if not holders_exist(
+                        process_tree_fd, exclude=(os.getpid(),)
+                    ) and not current["supervisor"]["running"]:
+                        return current
+                    time.sleep(0.05)
             finally:
-                for _record, pidfd in verified:
-                    os.close(pidfd)
+                os.close(process_tree_fd)
             raise WorkspaceError(
                 f"topology did not stop within {timeout:g} seconds: {name}"
             )
-
-    @staticmethod
-    def _process_group_running(process_group: int) -> bool:
-        try:
-            os.killpg(process_group, 0)
-        except ProcessLookupError:
-            return False
-        except PermissionError:
-            return True
-        return True
 
     def topology_logs(
         self,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -185,17 +185,20 @@ serializes identical profile/key work. An exclusive writer cannot advance or
 remove a selected checkout until all readers exit. If the platform cannot provide
 a working advisory shared lock, the consuming operation fails closed.
 
-A supervised topology transfers its shared layout-lock descriptor through the
-daemon supervisor into its client process because the client runtime retains
-links to selected client and sound checkouts. This preserves the lease if the
-supervisor dies; topology shutdown terminates the client and releases the last
-descriptor. Server-only topologies release the layout lease after startup
-because they execute from topology-owned runtime snapshots.
+A supervised topology transfers its shared layout and exact build-root lock
+descriptors through the daemon supervisor into every service. Client runtimes
+retain links to selected client and sound checkouts, while server runtimes link
+selected server configuration and tool inputs. Inherited descriptors preserve
+both leases if the supervisor dies; topology shutdown terminates orphaned
+services and releases the last descriptors. Foreground client and server
+processes inherit the same applicable leases from the wrapper.
 
 The layout lock is always outermost; private helpers never reacquire it. A
 direct build or foreground client then takes its build-root lock and subordinate
-cache locks. Topology startup takes the topology-operation lock, the server-state
-lock when needed, the build-root lock, and finally the port-allocation lock.
+cache locks; the foreground process retains that root lease. Topology startup
+takes the topology-operation lock, the server-state lock when needed, the
+build-root lock, and finally the port-allocation lock, and transfers the layout
+and build-root leases into its services.
 Scenario create takes the scenario-operation lock, then build-root and
 state-registry locks; reset takes scenario-operation, state, and build-root locks.
 Foreground server launch takes state before build-root. Layout writers take the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -165,9 +165,8 @@ side effect.
 
 `cleanup` is an explicit garbage-collection boundary, never an implicit step
 of initialization, synchronization, build, or startup. Default and explicit
-`--dry-run` modes are read-only. `--apply` first takes the same
-repository-layout lock used by checkout, build, topology, foreground-run, and
-scenario operations, then performs one complete inventory and size
+`--dry-run` modes are read-only. `--apply` first takes the exclusive mode of the
+repository-layout lock, then performs one complete inventory and size
 recomputation. Immediately before each removal it freshly revalidates that
 target's safety dependencies without rescanning unrelated report-only
 payloads; any new ambiguity fails closed. Build roots are removed before Git
@@ -175,6 +174,27 @@ worktrees; the explicitly selected npm cache and safe prunable Git metadata
 come last. A race before the first mutation aborts the plan. A later failure
 stops the ordered sequence and reports completed reclamation without attempting
 to reconstruct generated data.
+
+The repository-layout lock is a process-wide read/write boundary. Initialization,
+synchronization, worktree and profile mutation, cleanup apply, and repository
+migration take it exclusively. Builds, topology startup, foreground server runs,
+and scenario create/reset take it in shared mode while they consume selected
+checkout and profile coordinates. Independent build roots can therefore compile
+concurrently, while each root's existing exclusive build lock still serializes
+identical profile/key work. An exclusive writer cannot advance or remove a
+selected checkout until all readers exit. If the platform cannot provide a
+working advisory shared lock, the consuming operation fails closed.
+
+The layout lock is always outermost; private helpers never reacquire it. A
+direct build then takes its build-root lock and subordinate cache locks. Topology
+startup takes the topology-operation lock, the server-state lock when needed,
+the build-root lock, and finally the port-allocation lock. Scenario create takes
+the scenario-operation lock, then build-root and state-registry locks; reset
+takes scenario-operation, state, and build-root locks. Foreground server launch
+takes state before build-root. Layout writers take the exclusive layout lock
+before any cleanup build-lock probes or mutation-specific work. Operations use
+only the applicable suffix of these orders and never acquire the layout lock
+from inside a finer-grained lock.
 
 Inventory records are stable-sorted and carry a kind, physical owner and
 repository, exact path, no-follow allocated size, age and age basis,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -191,7 +191,10 @@ retain links to selected client and sound checkouts, while server runtimes link
 selected server configuration and tool inputs. Inherited descriptors preserve
 both leases if the supervisor dies; topology shutdown terminates orphaned
 services and releases the last descriptors. Foreground client and server
-processes inherit the same applicable leases from the wrapper.
+processes inherit the same applicable leases from the wrapper. The common
+command runner also inherits every active advisory-lock descriptor into build
+and scenario subprocesses, preserving layout, build-root, state, registry, and
+cache protection if their wrapper exits unexpectedly.
 
 The layout lock is always outermost; private helpers never reacquire it. A
 direct build or foreground client then takes its build-root lock and subordinate

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -191,11 +191,13 @@ descriptors through the daemon supervisor into every service. Client runtimes
 retain links to selected client and sound checkouts, while server runtimes link
 selected server configuration and tool inputs. Inherited descriptors preserve
 both leases if the supervisor dies; topology shutdown terminates orphaned
-services and releases the last descriptors. Foreground client and server
-processes inherit the same applicable leases from the wrapper. The common
-command runner also inherits every active advisory-lock descriptor into build
-and scenario subprocesses, preserving layout, build-root, state, registry, and
-cache protection if their wrapper exits unexpectedly.
+services and releases the last descriptors. A topology-unique inherited
+process-tree lease lets shutdown find and pidfd-signal surviving descendants
+without trusting recycled process or process-group numbers. Foreground client
+and server processes inherit the same applicable leases from the wrapper. The
+common command runner also inherits every active advisory-lock descriptor into
+build and scenario subprocesses, preserving layout, build-root, state,
+registry, and cache protection if their wrapper exits unexpectedly.
 
 The layout lock is always outermost; private helpers never reacquire it. A
 direct build or foreground client then takes its build-root lock and subordinate

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -175,15 +175,16 @@ come last. A race before the first mutation aborts the plan. A later failure
 stops the ordered sequence and reports completed reclamation without attempting
 to reconstruct generated data.
 
-The repository-layout lock is a process-wide read/write boundary. Initialization,
-synchronization, worktree and profile mutation, cleanup apply, and repository
-migration take it exclusively. Builds, topology startup, foreground client and
-server runs, and scenario create/reset take it in shared mode while they consume
-selected checkout and profile coordinates. Independent build roots can therefore
-compile concurrently, while each root's existing exclusive build lock still
-serializes identical profile/key work. An exclusive writer cannot advance or
-remove a selected checkout until all readers exit. If the platform cannot provide
-a working advisory shared lock, the consuming operation fails closed.
+The repository-layout lock is a workspace-wide interprocess read/write boundary.
+Initialization, synchronization, worktree and profile mutation, cleanup apply,
+and repository migration take it exclusively. Builds, topology startup,
+foreground client and server runs, and scenario create/reset take it in shared
+mode while they consume selected checkout and profile coordinates. Independent
+build roots can therefore compile concurrently, while each root's existing
+exclusive build lock still serializes identical profile/key work. An exclusive
+writer cannot advance or remove a selected checkout until all readers exit. If
+the platform cannot provide a working advisory shared lock, the consuming
+operation fails closed.
 
 A supervised topology transfers its shared layout and exact build-root lock
 descriptors through the daemon supervisor into every service. Client runtimes

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -192,7 +192,9 @@ retain links to selected client and sound checkouts, while server runtimes link
 selected server configuration and tool inputs. Inherited descriptors preserve
 both leases if the supervisor dies; topology shutdown terminates orphaned
 services and releases the last descriptors. A topology-unique inherited
-process-tree lease lets shutdown find and pidfd-signal surviving descendants
+process-tree lease is also held as an advisory generation lock, so a topology
+name cannot restart until its prior process tree releases the lease. Shutdown
+uses the same lease identity to find and pidfd-signal surviving descendants
 without trusting recycled process or process-group numbers. Foreground client
 and server processes inherit the same applicable leases from the wrapper. The
 common command runner also inherits every active advisory-lock descriptor into

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -177,24 +177,24 @@ to reconstruct generated data.
 
 The repository-layout lock is a process-wide read/write boundary. Initialization,
 synchronization, worktree and profile mutation, cleanup apply, and repository
-migration take it exclusively. Builds, topology startup, foreground server runs,
-and scenario create/reset take it in shared mode while they consume selected
-checkout and profile coordinates. Independent build roots can therefore compile
-concurrently, while each root's existing exclusive build lock still serializes
-identical profile/key work. An exclusive writer cannot advance or remove a
-selected checkout until all readers exit. If the platform cannot provide a
-working advisory shared lock, the consuming operation fails closed.
+migration take it exclusively. Builds, topology startup, foreground client and
+server runs, and scenario create/reset take it in shared mode while they consume
+selected checkout and profile coordinates. Independent build roots can therefore
+compile concurrently, while each root's existing exclusive build lock still
+serializes identical profile/key work. An exclusive writer cannot advance or
+remove a selected checkout until all readers exit. If the platform cannot provide
+a working advisory shared lock, the consuming operation fails closed.
 
 The layout lock is always outermost; private helpers never reacquire it. A
-direct build then takes its build-root lock and subordinate cache locks. Topology
-startup takes the topology-operation lock, the server-state lock when needed,
-the build-root lock, and finally the port-allocation lock. Scenario create takes
-the scenario-operation lock, then build-root and state-registry locks; reset
-takes scenario-operation, state, and build-root locks. Foreground server launch
-takes state before build-root. Layout writers take the exclusive layout lock
-before any cleanup build-lock probes or mutation-specific work. Operations use
-only the applicable suffix of these orders and never acquire the layout lock
-from inside a finer-grained lock.
+direct build or foreground client then takes its build-root lock and subordinate
+cache locks. Topology startup takes the topology-operation lock, the server-state
+lock when needed, the build-root lock, and finally the port-allocation lock.
+Scenario create takes the scenario-operation lock, then build-root and
+state-registry locks; reset takes scenario-operation, state, and build-root locks.
+Foreground server launch takes state before build-root. Layout writers take the
+exclusive layout lock before any cleanup build-lock probes or mutation-specific
+work. Operations use only the applicable suffix of these orders and never acquire
+the layout lock from inside a finer-grained lock.
 
 Inventory records are stable-sorted and carry a kind, physical owner and
 repository, exact path, no-follow allocated size, age and age basis,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -202,6 +202,8 @@ cache locks; the foreground process retains that root lease. Topology startup
 takes the topology-operation lock, the server-state lock when needed, the
 build-root lock, and finally the port-allocation lock, and transfers the layout
 and build-root leases into its services.
+Independent CMake roots briefly serialize first-use compiler-cache marker and
+metadata publication, then release that cache lock before compilation.
 Scenario create takes the scenario-operation lock, then build-root and
 state-registry locks; reset takes scenario-operation, state, and build-root locks.
 Foreground server launch takes state before build-root. Layout writers take the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -185,6 +185,13 @@ serializes identical profile/key work. An exclusive writer cannot advance or
 remove a selected checkout until all readers exit. If the platform cannot provide
 a working advisory shared lock, the consuming operation fails closed.
 
+A supervised topology transfers its shared layout-lock descriptor through the
+daemon supervisor into its client process because the client runtime retains
+links to selected client and sound checkouts. This preserves the lease if the
+supervisor dies; topology shutdown terminates the client and releases the last
+descriptor. Server-only topologies release the layout lease after startup
+because they execute from topology-owned runtime snapshots.
+
 The layout lock is always outermost; private helpers never reacquire it. A
 direct build or foreground client then takes its build-root lock and subordinate
 cache locks. Topology startup takes the topology-operation lock, the server-state

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -21,6 +21,7 @@ from atrinik_workspace.cleanup import (
     _worktree_records,
     _workspace_owned,
 )
+from atrinik_workspace.locking import active_lock_fds, inherit_lock_fds
 from atrinik_workspace.model import (
     MANAGED_MARKER,
     SCHEMA_VERSION,
@@ -260,6 +261,30 @@ class CleanupTests(unittest.TestCase):
 
         with mock.patch.object(Cleanup, "_github_pulls", side_effect=pulls):
             return self.workspace.cleanup(scopes, older, [], False)
+
+    def test_github_workers_inherit_active_layout_descriptor(self) -> None:
+        observed: list[tuple[int, ...]] = []
+        cleanup = Cleanup(self.workspace)
+        item = {
+            "kind": "worktree",
+            "disposition": "skipped",
+            "reasons": ["github_pending"],
+            "repository": "atrinik/client",
+            "head": "a" * 40,
+            "base_branch": "main",
+        }
+
+        def inspect(_repository: str, _head: str) -> list[dict[str, object]]:
+            observed.append(active_lock_fds())
+            raise WorkspaceError("offline")
+
+        with (
+            tempfile.TemporaryFile(mode="w+") as lease,
+            inherit_lock_fds(lease),
+            mock.patch.object(Cleanup, "_github_pulls", side_effect=inspect),
+        ):
+            cleanup._resolve_github([item], 7)
+            self.assertEqual(observed, [(lease.fileno(),)])
 
     def test_low_level_inventory_helpers_report_invalid_inputs(self) -> None:
         with self.assertRaisesRegex(WorkspaceError, "zero or greater"):

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -13,6 +13,7 @@ import unittest
 from unittest import mock
 
 from atrinik_workspace import migration as migration_module
+from atrinik_workspace.locking import inherit_lock_fds
 from atrinik_workspace.migration import RepositoryMigration
 from atrinik_workspace.model import Paths, WorkspaceError
 
@@ -55,6 +56,19 @@ SHARED = (
 
 
 class RepositoryMigrationTests(unittest.TestCase):
+    def test_git_helpers_inherit_active_layout_descriptor(self) -> None:
+        completed = mock.MagicMock(returncode=0, stdout=b"", stderr=b"")
+        with (
+            tempfile.TemporaryFile(mode="w+") as lease,
+            inherit_lock_fds(lease),
+            mock.patch(
+                "atrinik_workspace.migration.subprocess.run",
+                return_value=completed,
+            ) as invoke,
+        ):
+            RepositoryMigration._git_process(Path("/tmp/repository"), "status")
+            self.assertEqual(invoke.call_args.kwargs["pass_fds"], (lease.fileno(),))
+
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory()
         self.root = Path(self.temporary.name)

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -111,6 +111,21 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                     except ProcessLookupError:
                         pass
 
+    def test_terminate_without_process_tree_lease_uses_group_fallback(self) -> None:
+        process = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            start_new_session=True,
+        )
+        try:
+            supervisor_module.terminate(
+                {"client": process}, None, timeout=0.1
+            )
+            self.assertIsNotNone(process.poll())
+        finally:
+            if process.poll() is None:
+                process.kill()
+                process.wait(timeout=2)
+
     def test_requires_fingerprint_and_finished_server_startup(self) -> None:
         capture = ServerReadinessCapture()
 

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -111,7 +111,9 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                     except ProcessLookupError:
                         pass
 
-    def test_terminate_cleans_descendant_that_closed_process_tree_lease(self) -> None:
+    def test_terminate_cleans_group_after_leader_exits_and_descendant_closes_lease(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as directory:
             descendant_path = Path(directory) / "descendant.pid"
             lease_fd = os.open(
@@ -128,7 +130,8 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                     "child == 0 and os.close(int(sys.argv[2])); "
                     "child == 0 and signal.signal(signal.SIGTERM, signal.SIG_IGN); "
                     "child == 0 and pathlib.Path(sys.argv[1]).write_text(str(os.getpid())); "
-                    "time.sleep(60)",
+                    "child == 0 and time.sleep(60); "
+                    "os._exit(0)",
                     str(descendant_path),
                     str(lease_fd),
                 ],
@@ -141,6 +144,14 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                 while time.monotonic() < deadline and not descendant_path.is_file():
                     time.sleep(0.05)
                 descendant = int(descendant_path.read_text(encoding="utf-8"))
+                deadline = time.monotonic() + 5
+                while (
+                    time.monotonic() < deadline
+                    and supervisor_module._peek_exit_code(process) is None
+                ):
+                    time.sleep(0.05)
+                self.assertIsNotNone(supervisor_module._peek_exit_code(process))
+                self.assertIsNone(process.returncode)
 
                 supervisor_module.terminate(
                     {"client": process}, lease_fd, timeout=0.1

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
+import signal
+import subprocess
+import sys
 import tempfile
+import time
 import unittest
 from unittest import mock
 
@@ -54,9 +59,57 @@ class ServerReadinessCaptureTests(unittest.TestCase):
 
             terminate.assert_called_once()
             self.assertEqual(terminate.call_args.args[0], {"client": process})
+            self.assertEqual(terminate.call_args.args[1], {})
             self.assertEqual(
                 {call.args[0] for call in close.call_args_list}, {7, 8}
             )
+
+    def test_terminate_cleans_group_after_service_leader_exits(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            descendant_path = Path(directory) / "descendant.pid"
+            process = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    "import os, pathlib, signal, sys, time; "
+                    "child = os.fork(); "
+                    "child == 0 and signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+                    "child == 0 and pathlib.Path(sys.argv[1]).write_text(str(os.getpid())); "
+                    "child == 0 and time.sleep(60); "
+                    "os._exit(0)",
+                    str(descendant_path),
+                ],
+                start_new_session=True,
+            )
+            pidfd = os.pidfd_open(process.pid)
+            descendant = None
+            try:
+                process.wait(timeout=5)
+                deadline = time.monotonic() + 5
+                while time.monotonic() < deadline and not descendant_path.is_file():
+                    time.sleep(0.05)
+                descendant = int(descendant_path.read_text(encoding="utf-8"))
+                self.assertTrue(Path(f"/proc/{descendant}").exists())
+
+                supervisor_module.terminate(
+                    {"client": process}, {"client": pidfd}, timeout=0.1
+                )
+                pidfd = -1
+                deadline = time.monotonic() + 2
+                while (
+                    time.monotonic() < deadline
+                    and Path(f"/proc/{descendant}").exists()
+                ):
+                    time.sleep(0.05)
+                self.assertFalse(Path(f"/proc/{descendant}").exists())
+            finally:
+                if pidfd >= 0:
+                    os.close(pidfd)
+                if descendant is not None and Path(f"/proc/{descendant}").exists():
+                    try:
+                        os.kill(descendant, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
 
     def test_requires_fingerprint_and_finished_server_startup(self) -> None:
         capture = ServerReadinessCapture()

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -55,11 +55,11 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                 mock.patch.object(supervisor_module, "terminate") as terminate,
                 mock.patch.object(supervisor_module.os, "close") as close,
             ):
-                self.assertEqual(supervise(spec_path, None, 7, 8), 1)
+                self.assertEqual(supervise(spec_path, None, 7, 8, None), 1)
 
             terminate.assert_called_once()
             self.assertEqual(terminate.call_args.args[0], {"client": process})
-            self.assertEqual(terminate.call_args.args[1], {})
+            self.assertIsNone(terminate.call_args.args[1])
             self.assertEqual(
                 {call.args[0] for call in close.call_args_list}, {7, 8}
             )
@@ -67,6 +67,8 @@ class ServerReadinessCaptureTests(unittest.TestCase):
     def test_terminate_cleans_group_after_service_leader_exits(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             descendant_path = Path(directory) / "descendant.pid"
+            lease = Path(directory) / "process-tree.lease"
+            lease_fd = os.open(lease, os.O_RDWR | os.O_CREAT, 0o600)
             process = subprocess.Popen(
                 [
                     sys.executable,
@@ -80,8 +82,8 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                     str(descendant_path),
                 ],
                 start_new_session=True,
+                pass_fds=(lease_fd,),
             )
-            pidfd = os.pidfd_open(process.pid)
             descendant = None
             try:
                 process.wait(timeout=5)
@@ -92,9 +94,8 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                 self.assertTrue(Path(f"/proc/{descendant}").exists())
 
                 supervisor_module.terminate(
-                    {"client": process}, {"client": pidfd}, timeout=0.1
+                    {"client": process}, lease_fd, timeout=0.1
                 )
-                pidfd = -1
                 deadline = time.monotonic() + 2
                 while (
                     time.monotonic() < deadline
@@ -103,8 +104,7 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                     time.sleep(0.05)
                 self.assertFalse(Path(f"/proc/{descendant}").exists())
             finally:
-                if pidfd >= 0:
-                    os.close(pidfd)
+                os.close(lease_fd)
                 if descendant is not None and Path(f"/proc/{descendant}").exists():
                     try:
                         os.kill(descendant, signal.SIGKILL)

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -20,6 +20,29 @@ from atrinik_workspace.supervisor import (
 
 
 class ServerReadinessCaptureTests(unittest.TestCase):
+    def test_peek_exit_code_observes_without_reaping(self) -> None:
+        process = mock.Mock(pid=1234, returncode=7)
+        with mock.patch.object(supervisor_module.os, "waitid", return_value=None):
+            self.assertIsNone(supervisor_module._peek_exit_code(process))
+        with mock.patch.object(
+            supervisor_module.os,
+            "waitid",
+            return_value=mock.Mock(si_code=os.CLD_EXITED, si_status=3),
+        ):
+            self.assertEqual(supervisor_module._peek_exit_code(process), 3)
+        with mock.patch.object(
+            supervisor_module.os,
+            "waitid",
+            return_value=mock.Mock(si_code=os.CLD_KILLED, si_status=signal.SIGTERM),
+        ):
+            self.assertEqual(
+                supervisor_module._peek_exit_code(process), -signal.SIGTERM
+            )
+        with mock.patch.object(
+            supervisor_module.os, "waitid", side_effect=ChildProcessError
+        ):
+            self.assertEqual(supervisor_module._peek_exit_code(process), 7)
+
     def test_unidentified_service_is_registered_for_bounded_cleanup(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -1,11 +1,63 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+import tempfile
 import unittest
+from unittest import mock
 
-from atrinik_workspace.supervisor import ServerReadinessCapture, _initial_status
+from atrinik_workspace import supervisor as supervisor_module
+from atrinik_workspace.supervisor import (
+    ServerReadinessCapture,
+    _initial_status,
+    supervise,
+)
 
 
 class ServerReadinessCaptureTests(unittest.TestCase):
+    def test_unidentified_service_is_registered_for_bounded_cleanup(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            spec = {
+                "name": "cleanup",
+                "profile": "default",
+                "dependencies": ["client"],
+                "state": None,
+                "build_root": "/tmp/build",
+                "resolved": {},
+                "endpoint": None,
+                "services": {
+                    "client": {
+                        "command": ["client"],
+                        "cwd": str(root),
+                        "log": str(root / "client.log"),
+                    }
+                },
+            }
+            spec_path = root / "spec.json"
+            spec_path.write_text(json.dumps(spec), encoding="utf-8")
+            process = mock.MagicMock(pid=1234)
+
+            with (
+                mock.patch.object(
+                    supervisor_module,
+                    "process_start_time",
+                    side_effect=["1", None],
+                ),
+                mock.patch.object(
+                    supervisor_module.subprocess, "Popen", return_value=process
+                ),
+                mock.patch.object(supervisor_module, "terminate") as terminate,
+                mock.patch.object(supervisor_module.os, "close") as close,
+            ):
+                self.assertEqual(supervise(spec_path, None, 7, 8), 1)
+
+            terminate.assert_called_once()
+            self.assertEqual(terminate.call_args.args[0], {"client": process})
+            self.assertEqual(
+                {call.args[0] for call in close.call_args_list}, {7, 8}
+            )
+
     def test_requires_fingerprint_and_finished_server_startup(self) -> None:
         capture = ServerReadinessCapture()
 

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -111,17 +111,81 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                     except ProcessLookupError:
                         pass
 
+    def test_terminate_cleans_descendant_that_closed_process_tree_lease(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            descendant_path = Path(directory) / "descendant.pid"
+            lease_fd = os.open(
+                Path(directory) / "process-tree.lease",
+                os.O_RDWR | os.O_CREAT,
+                0o600,
+            )
+            process = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    "import os, pathlib, signal, sys, time; "
+                    "child = os.fork(); "
+                    "child == 0 and os.close(int(sys.argv[2])); "
+                    "child == 0 and signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+                    "child == 0 and pathlib.Path(sys.argv[1]).write_text(str(os.getpid())); "
+                    "time.sleep(60)",
+                    str(descendant_path),
+                    str(lease_fd),
+                ],
+                start_new_session=True,
+                pass_fds=(lease_fd,),
+            )
+            descendant = None
+            try:
+                deadline = time.monotonic() + 5
+                while time.monotonic() < deadline and not descendant_path.is_file():
+                    time.sleep(0.05)
+                descendant = int(descendant_path.read_text(encoding="utf-8"))
+
+                supervisor_module.terminate(
+                    {"client": process}, lease_fd, timeout=0.1
+                )
+                deadline = time.monotonic() + 2
+                while (
+                    time.monotonic() < deadline
+                    and Path(f"/proc/{descendant}").exists()
+                ):
+                    time.sleep(0.05)
+                self.assertFalse(Path(f"/proc/{descendant}").exists())
+            finally:
+                os.close(lease_fd)
+                if process.poll() is None:
+                    process.kill()
+                    process.wait(timeout=2)
+                if descendant is not None and Path(f"/proc/{descendant}").exists():
+                    try:
+                        os.kill(descendant, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+
     def test_terminate_without_process_tree_lease_uses_group_fallback(self) -> None:
         process = subprocess.Popen(
-            [sys.executable, "-c", "import time; time.sleep(60)"],
+            [
+                sys.executable,
+                "-c",
+                "import signal, time; "
+                "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+                "print('ready', flush=True); "
+                "time.sleep(60)",
+            ],
             start_new_session=True,
+            stdout=subprocess.PIPE,
         )
         try:
+            assert process.stdout is not None
+            self.assertEqual(process.stdout.readline(), b"ready\n")
             supervisor_module.terminate(
                 {"client": process}, None, timeout=0.1
             )
             self.assertIsNotNone(process.poll())
         finally:
+            if process.stdout is not None:
+                process.stdout.close()
             if process.poll() is None:
                 process.kill()
                 process.wait(timeout=2)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -330,8 +330,6 @@ def mixed_layout_operation_process(
     wrapper: str,
     workspace_directory: str,
     operation: str,
-    build_root_value: str,
-    marker: dict[str, object],
     status: dict[str, object],
     ready: object,
     start: object,
@@ -344,7 +342,6 @@ def mixed_layout_operation_process(
             os.environ, {"ATRINIK_WORKSPACE_DIR": workspace_directory}
         ):
             workspace = Workspace(Path(wrapper))
-            build_root = Path(build_root_value)
             topology_root = workspace.paths.topologies / "stress"
             first_entry = True
             topology_generation = 0
@@ -358,35 +355,36 @@ def mixed_layout_operation_process(
                 if not release.wait(5):
                     raise TimeoutError("mixed operation was not released")
 
-            def refresh_build(*_arguments: object, **_keywords: object) -> Path:
-                with exclusive_lock(
-                    workspace.paths.builds / "locks" / "stress-a.lock",
-                    "stress build root",
-                ):
-                    rendezvous()
-                    atomic_json(build_root / MANAGED_MARKER, marker)
-                return build_root
+            def compile_client(*_arguments: object, **_keywords: object) -> None:
+                rendezvous()
 
             def refresh_topology(
                 *_arguments: object, **_keywords: object
             ) -> dict[str, object]:
                 nonlocal topology_generation
-                with exclusive_lock(
-                    topology_root / "operation.lock", "stress topology"
-                ):
-                    rendezvous()
-                    current = copy.deepcopy(status)
-                    current["error"] = f"stress generation {topology_generation}"
-                    topology_generation += 1
-                    atomic_json(topology_root / "status.json", current)
+                selected = workspace._resolve_build_profile("default", {"server"})
+                rendezvous()
+                current = copy.deepcopy(status)
+                current["resolved"] = workspace._topology_resolved_status(
+                    "default", selected
+                )
+                current["dependencies"] = sorted(selected)
+                current["error"] = f"stress generation {topology_generation}"
+                topology_generation += 1
+                atomic_json(topology_root / "status.json", current)
                 return current
 
             ready.put(operation)
             if not start.wait(5):
                 raise TimeoutError("mixed operation test did not start")
             if operation == "build":
-                with mock.patch.object(
-                    workspace, "_build", side_effect=refresh_build
+                with (
+                    mock.patch.object(
+                        workspace, "_expand_build_target", return_value=["client"]
+                    ),
+                    mock.patch.object(
+                        workspace, "_build_client", side_effect=compile_client
+                    ),
                 ):
                     for _ in range(20):
                         workspace.build("client", "stress", False)
@@ -405,8 +403,12 @@ def mixed_layout_operation_process(
                 ):
                     for index in range(20):
                         current = workspace.topology_status("stress")
-                        if current["resolved"] != status["resolved"]:
-                            raise AssertionError("topology coordinates changed")
+                        for coordinate in current["resolved"].values():
+                            checkout = Path(coordinate["checkout_path"])
+                            if coordinate["head"] != command(
+                                "git", "rev-parse", "HEAD", cwd=checkout
+                            ):
+                                raise AssertionError("topology coordinates changed")
                         if index == 0:
                             rendezvous()
             else:
@@ -5796,34 +5798,40 @@ class WorkspaceTests(unittest.TestCase):
                     operation.assert_called_once()
 
     def test_mixed_layout_readers_preserve_markers_and_coordinates(self) -> None:
-        build_root = self.workspace.paths.builds / "profiles" / "stress-a"
+        self.workspace.create_profile("stress")
+        selected_build = self.workspace._resolve_build_profile(
+            "stress", {"client"}
+        )
+        build_key = self.workspace._profile_build_key("stress", selected_build)
+        build_root = (
+            self.workspace.paths.builds / "profiles" / f"stress-{build_key}"
+        )
         managed_directory(
-            build_root, self.workspace.paths.builds, "profile:stress:a"
+            build_root,
+            self.workspace.paths.builds,
+            f"profile:stress:{build_key}",
         )
         marker = load_json(build_root / MANAGED_MARKER)
         topology_root = self.workspace._topology_directory("stress", create=True)
-        checkout = self.workspace.paths.repositories / "server"
+        selected_topology = self.workspace._resolve_build_profile(
+            "default", {"server"}
+        )
+        resolved = self.workspace._topology_resolved_status(
+            "default", selected_topology
+        )
         status = {
             "schema_version": 1,
             "name": "stress",
             "profile": "default",
             "stack": "default",
-            "providers": {"server": "server"},
-            "dependencies": ["server"],
+            "providers": {
+                role: self.workspace.manifest.stack("default").providers[role].name
+                for role in sorted(selected_topology)
+            },
+            "dependencies": sorted(selected_topology),
             "state": None,
             "build_root": str(build_root),
-            "resolved": {
-                "server": {
-                    "path": str(checkout),
-                    "checkout_path": str(checkout),
-                    "checkout": "server",
-                    "repository": "atrinik/server",
-                    "branch": "main",
-                    "source": ".",
-                    "head": command("git", "rev-parse", "HEAD", cwd=checkout),
-                    "dirty": False,
-                }
-            },
+            "resolved": resolved,
             "endpoint": None,
             "ready": False,
             "started_at": "2026-08-11T00:00:00+00:00",
@@ -5847,8 +5855,6 @@ class WorkspaceTests(unittest.TestCase):
                     str(self.wrapper),
                     str(self.workspace_directory),
                     operation,
-                    str(build_root),
-                    marker,
                     status,
                     ready,
                     start,
@@ -5876,6 +5882,18 @@ class WorkspaceTests(unittest.TestCase):
         outcomes = dict(results.get(timeout=2) for _ in processes)
         self.assertEqual(outcomes, {operation: None for operation in operations})
         self.assertEqual(load_json(build_root / MANAGED_MARKER), marker)
+        metadata = load_json(build_root / workspace_module.BUILD_METADATA)
+        self.assertEqual(metadata["profile"], "stress")
+        self.assertEqual(metadata["key"], build_key)
+        for role, coordinate in metadata["coordinates"].items():
+            self.assertEqual(
+                Path(coordinate["source_path"]), selected_build[role].resolve()
+            )
+            checkout_path = Path(coordinate["checkout_path"])
+            self.assertEqual(
+                coordinate["head"],
+                command("git", "rev-parse", "HEAD", cwd=checkout_path),
+            )
         expected_status = copy.deepcopy(status)
         expected_status["error"] = "stress generation 19"
         self.assertEqual(load_json(topology_root / "status.json"), expected_status)
@@ -6422,6 +6440,21 @@ class WorkspaceTests(unittest.TestCase):
                 self.workspace, "_select_topology_port", return_value=17302
             ),
         ):
+            executable.write_text(
+                "#!/usr/bin/env python3\n"
+                "import os, signal, time\n"
+                "child = os.fork()\n"
+                "if child == 0:\n"
+                "    signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+                "    while True:\n"
+                "        time.sleep(0.1)\n"
+                "open('descendant.pid', 'w', encoding='utf-8').write(str(child))\n"
+                f"print('QUIC certificate SHA-256: {'a' * 64}', flush=True)\n"
+                "print('Server ready. Waiting for connections...', flush=True)\n"
+                "while True:\n"
+                "    time.sleep(0.1)\n",
+                encoding="utf-8",
+            )
             server_only = self.workspace.topology_up(
                 "server-lease", "default", "default", ["server"], 17302
             )
@@ -6451,6 +6484,14 @@ class WorkspaceTests(unittest.TestCase):
             orphaned = self.workspace.topology_status("server-lease")
             self.assertFalse(orphaned["supervisor"]["running"])
             self.assertTrue(orphaned["services"]["server"]["running"])
+            descendant_path = Path(
+                orphaned["services"]["server"]["cwd"]
+            ) / "descendant.pid"
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline and not descendant_path.is_file():
+                time.sleep(0.05)
+            descendant_pid = int(descendant_path.read_text(encoding="utf-8"))
+            self.assertTrue(Path(f"/proc/{descendant_pid}").exists())
             for path, description in (
                 (layout_lock, "repository layout"),
                 (profile_lock, "profile build default"),
@@ -6458,7 +6499,14 @@ class WorkspaceTests(unittest.TestCase):
                 with self.assertRaisesRegex(WorkspaceError, "already in use"):
                     with exclusive_lock(path, description, nonblocking=True):
                         self.fail(f"orphaned server released {description}")
-            self.workspace.topology_down("server-lease", timeout=5)
+            self.workspace.topology_down("server-lease", timeout=0.5)
+            deadline = time.monotonic() + 2
+            while (
+                time.monotonic() < deadline
+                and Path(f"/proc/{descendant_pid}").exists()
+            ):
+                time.sleep(0.05)
+            self.assertFalse(Path(f"/proc/{descendant_pid}").exists())
         finally:
             remaining = self.workspace.topology_status("server-lease")
             if remaining["supervisor"]["running"] or any(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -216,13 +216,29 @@ def timed_layout_lock_process(
         raise
 
 
-def mixed_layout_operation_process(
+def inherited_leases_wrapper_process(
+    layout_path: str,
+    build_path: str,
+    state_path: str,
+    child_script: str,
+    child_pid_path: str,
+) -> None:
+    with (
+        shared_lock(Path(layout_path), "repository layout"),
+        exclusive_lock(Path(build_path), "profile build orphan"),
+        exclusive_lock(Path(state_path), "server state orphan"),
+    ):
+        workspace_run(
+            [sys.executable, child_script, child_pid_path],
+            diagnostics_to_stderr=False,
+        )
+
+
+def compiler_cache_first_use_process(
     wrapper: str,
     workspace_directory: str,
-    operation: str,
-    build_root_value: str,
-    marker: dict[str, object],
-    status: dict[str, object],
+    source_path: str,
+    binary_path: str,
     ready: object,
     start: object,
     results: object,
@@ -232,25 +248,86 @@ def mixed_layout_operation_process(
             os.environ, {"ATRINIK_WORKSPACE_DIR": workspace_directory}
         ):
             workspace = Workspace(Path(wrapper))
+            ready.put(binary_path)
+            if not start.wait(5):
+                raise TimeoutError("compiler-cache test did not start")
+            with (
+                mock.patch(
+                    "atrinik_workspace.workspace.shutil.which",
+                    side_effect=lambda tool: (
+                        "/usr/bin/ccache" if tool == "ccache" else None
+                    ),
+                ),
+                mock.patch.object(
+                    workspace,
+                    "_add_debug_prefix_environment",
+                    return_value={"c": False, "cxx": False},
+                ),
+                mock.patch("atrinik_workspace.workspace.run"),
+            ):
+                workspace._cmake(
+                    Path(source_path), Path(binary_path), [], False
+                )
+        results.put(None)
+    except BaseException as error:
+        results.put(f"{type(error).__name__}: {error}")
+        raise
+
+
+def mixed_layout_operation_process(
+    wrapper: str,
+    workspace_directory: str,
+    operation: str,
+    build_root_value: str,
+    marker: dict[str, object],
+    status: dict[str, object],
+    ready: object,
+    start: object,
+    entered: object,
+    release: object,
+    results: object,
+) -> None:
+    try:
+        with mock.patch.dict(
+            os.environ, {"ATRINIK_WORKSPACE_DIR": workspace_directory}
+        ):
+            workspace = Workspace(Path(wrapper))
             build_root = Path(build_root_value)
             topology_root = workspace.paths.topologies / "stress"
+            first_entry = True
+            topology_generation = 0
+
+            def rendezvous() -> None:
+                nonlocal first_entry
+                if not first_entry:
+                    return
+                first_entry = False
+                entered.put(operation)
+                if not release.wait(5):
+                    raise TimeoutError("mixed operation was not released")
 
             def refresh_build(*_arguments: object, **_keywords: object) -> Path:
                 with exclusive_lock(
                     workspace.paths.builds / "locks" / "stress-a.lock",
                     "stress build root",
                 ):
+                    rendezvous()
                     atomic_json(build_root / MANAGED_MARKER, marker)
                 return build_root
 
             def refresh_topology(
                 *_arguments: object, **_keywords: object
             ) -> dict[str, object]:
+                nonlocal topology_generation
                 with exclusive_lock(
                     topology_root / "operation.lock", "stress topology"
                 ):
-                    atomic_json(topology_root / "status.json", status)
-                return copy.deepcopy(status)
+                    rendezvous()
+                    current = copy.deepcopy(status)
+                    current["error"] = f"stress generation {topology_generation}"
+                    topology_generation += 1
+                    atomic_json(topology_root / "status.json", current)
+                return current
 
             ready.put(operation)
             if not start.wait(5):
@@ -274,19 +351,23 @@ def mixed_layout_operation_process(
                     "atrinik_workspace.workspace.process_matches",
                     return_value=False,
                 ):
-                    for _ in range(20):
+                    for index in range(20):
                         current = workspace.topology_status("stress")
                         if current["resolved"] != status["resolved"]:
                             raise AssertionError("topology coordinates changed")
+                        if index == 0:
+                            rendezvous()
             else:
                 with mock.patch(
                     "atrinik_workspace.cleanup.Cleanup._registered_worktree_paths",
                     return_value=(set(), None),
                 ):
-                    for _ in range(20):
+                    for index in range(20):
                         report = workspace.cleanup(["builds"], 7, [], False)
                         if report["inventory_errors"]:
                             raise AssertionError(report["inventory_errors"])
+                        if index == 0:
+                            rendezvous()
         results.put((operation, None))
     except BaseException as error:
         results.put((operation, f"{type(error).__name__}: {error}"))
@@ -2601,6 +2682,60 @@ class WorkspaceTests(unittest.TestCase):
         cache = self.workspace.paths.builds / "compiler-cache"
         self.assertEqual(load_json(cache / MANAGED_MARKER)["purpose"], "compiler-cache")
         self.assertEqual(load_json(cache / ".atrinik-cache.json")["max_size"], "5G")
+
+    def test_compiler_cache_first_use_is_serialized_across_processes(self) -> None:
+        context = multiprocessing.get_context("spawn")
+        ready = context.Queue()
+        start = context.Event()
+        results = context.Queue()
+        source = self.root / "cache-source"
+        source.mkdir()
+        (source / "CMakeLists.txt").write_text(
+            "project(cache_first_use NONE)\n", encoding="utf-8"
+        )
+        processes = [
+            context.Process(
+                target=compiler_cache_first_use_process,
+                args=(
+                    str(self.wrapper),
+                    str(self.workspace_directory),
+                    str(source),
+                    str(
+                        self.workspace.paths.builds
+                        / "profiles"
+                        / f"cache-first-{index}"
+                        / "build"
+                        / "sample"
+                    ),
+                    ready,
+                    start,
+                    results,
+                ),
+            )
+            for index in range(2)
+        ]
+        try:
+            for process in processes:
+                process.start()
+            self.assertEqual(len({ready.get(timeout=5) for _ in processes}), 2)
+            start.set()
+        finally:
+            join_or_stop_processes(processes, 10)
+        self.assertEqual([process.exitcode for process in processes], [0, 0])
+        self.assertEqual(
+            [results.get(timeout=2), results.get(timeout=2)], [None, None]
+        )
+        cache = (
+            self.workspace.paths.builds / workspace_module.COMPILER_CACHE_PURPOSE
+        )
+        self.assertEqual(
+            load_json(cache / MANAGED_MARKER)["purpose"],
+            workspace_module.COMPILER_CACHE_PURPOSE,
+        )
+        self.assertEqual(
+            load_json(cache / workspace_module.CACHE_METADATA)["max_size"],
+            workspace_module.COMPILER_CACHE_MAX_SIZE,
+        )
 
     def test_debug_prefix_flags_require_supported_non_toolchain_compilers(self) -> None:
         source = self.workspace.paths.repositories / "content"
@@ -5256,6 +5391,55 @@ class WorkspaceTests(unittest.TestCase):
             [results.get(timeout=2), results.get(timeout=2)], [None, None]
         )
 
+    def test_independent_build_options_are_thread_local(self) -> None:
+        self.workspace.create_profile("thread-a")
+        self.workspace.create_profile("thread-b")
+        selected = {"client": self.workspace.paths.repositories / "client"}
+        barrier = threading.Barrier(2)
+        observed: dict[str, tuple[bool, bool, set[str]]] = {}
+
+        def inspect_build(
+            root: Path, *_arguments: object, **_keywords: object
+        ) -> None:
+            self.workspace._source_view_unchanged[str(root)] = True
+            barrier.wait(timeout=5)
+            observed[root.name] = (
+                self.workspace._force_reconfigure,
+                self.workspace._use_ccache,
+                set(self.workspace._source_view_unchanged),
+            )
+
+        def build(profile: str, force: bool, ccache: bool) -> Path:
+            return self.workspace._build_resolved(
+                "client",
+                profile,
+                False,
+                ["client"],
+                selected,
+                force_reconfigure=force,
+                use_ccache=ccache,
+            )
+
+        with (
+            mock.patch.object(self.workspace, "_refresh_build_metadata"),
+            mock.patch.object(
+                self.workspace, "_build_client", side_effect=inspect_build
+            ),
+            ThreadPoolExecutor(max_workers=2) as executor,
+        ):
+            futures = (
+                executor.submit(build, "thread-a", True, False),
+                executor.submit(build, "thread-b", False, True),
+            )
+            roots = [future.result(timeout=10) for future in futures]
+
+        self.assertEqual(
+            observed[roots[0].name], (True, False, {str(roots[0])})
+        )
+        self.assertEqual(
+            observed[roots[1].name], (False, True, {str(roots[1])})
+        )
+
     def test_shared_layout_lock_improves_independent_elapsed_time(self) -> None:
         context = multiprocessing.get_context("spawn")
         lock = self.workspace.paths.workspace / "timed-layout.lock"
@@ -5541,7 +5725,7 @@ class WorkspaceTests(unittest.TestCase):
                     "repository": "atrinik/server",
                     "branch": "main",
                     "source": ".",
-                    "head": "a" * 40,
+                    "head": command("git", "rev-parse", "HEAD", cwd=checkout),
                     "dirty": False,
                 }
             },
@@ -5557,6 +5741,8 @@ class WorkspaceTests(unittest.TestCase):
         context = multiprocessing.get_context("spawn")
         ready = context.Queue()
         start = context.Event()
+        entered = context.Queue()
+        release = context.Event()
         results = context.Queue()
         operations = ("build", "topology", "status", "cleanup")
         processes = [
@@ -5571,6 +5757,8 @@ class WorkspaceTests(unittest.TestCase):
                     status,
                     ready,
                     start,
+                    entered,
+                    release,
                     results,
                 ),
             )
@@ -5583,13 +5771,19 @@ class WorkspaceTests(unittest.TestCase):
                 {ready.get(timeout=5) for _ in processes}, set(operations)
             )
             start.set()
+            self.assertEqual(
+                {entered.get(timeout=5) for _ in processes}, set(operations)
+            )
         finally:
+            release.set()
             join_or_stop_processes(processes, 20)
         self.assertEqual([process.exitcode for process in processes], [0] * 4)
         outcomes = dict(results.get(timeout=2) for _ in processes)
         self.assertEqual(outcomes, {operation: None for operation in operations})
         self.assertEqual(load_json(build_root / MANAGED_MARKER), marker)
-        self.assertEqual(load_json(topology_root / "status.json"), status)
+        expected_status = copy.deepcopy(status)
+        expected_status["error"] = "stress generation 19"
+        self.assertEqual(load_json(topology_root / "status.json"), expected_status)
 
     def test_layout_writer_waits_for_foreground_client_process(self) -> None:
         context = multiprocessing.get_context("spawn")
@@ -6732,6 +6926,76 @@ class WorkspaceTests(unittest.TestCase):
                 with self.assertRaisesRegex(WorkspaceError, "already in use"):
                     with exclusive_lock(path, description, nonblocking=True):
                         self.fail(f"subprocess lease did not protect {description}")
+
+    def test_orphaned_operational_subprocess_retains_active_leases(self) -> None:
+        child_script = self.root / "lease-child.py"
+        child_pid_path = self.root / "lease-child.pid"
+        child_script.write_text(
+            "import os, pathlib, sys, time\n"
+            "path = pathlib.Path(sys.argv[1])\n"
+            "path.write_text(str(os.getpid()), encoding='ascii')\n"
+            "while True:\n"
+            "    time.sleep(0.1)\n",
+            encoding="utf-8",
+        )
+        layout = self.workspace.paths.workspace / "repository-layout.lock"
+        build = self.workspace.paths.builds / "locks" / "orphan-build.lock"
+        state = self.workspace.paths.state / "orphan-state.lock"
+        context = multiprocessing.get_context("spawn")
+        wrapper = context.Process(
+            target=inherited_leases_wrapper_process,
+            args=(
+                str(layout),
+                str(build),
+                str(state),
+                str(child_script),
+                str(child_pid_path),
+            ),
+        )
+        child_pidfd: int | None = None
+        try:
+            wrapper.start()
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline and not child_pid_path.is_file():
+                time.sleep(0.05)
+            self.assertTrue(child_pid_path.is_file())
+            child_pid = int(child_pid_path.read_text(encoding="ascii"))
+            child_pidfd = os.pidfd_open(child_pid)
+            wrapper.kill()
+            wrapper.join(timeout=5)
+            self.assertFalse(wrapper.is_alive())
+            for path, description in (
+                (layout, "repository layout"),
+                (build, "profile build orphan"),
+                (state, "server state orphan"),
+            ):
+                with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                    with exclusive_lock(path, description, nonblocking=True):
+                        self.fail(f"orphaned child released {description}")
+        finally:
+            if wrapper.is_alive():
+                wrapper.kill()
+                wrapper.join(timeout=5)
+            if child_pidfd is not None:
+                try:
+                    signal.pidfd_send_signal(child_pidfd, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                os.close(child_pidfd)
+
+        deadline = time.monotonic() + 5
+        while True:
+            try:
+                with (
+                    exclusive_lock(layout, "repository layout", nonblocking=True),
+                    exclusive_lock(build, "profile build orphan", nonblocking=True),
+                    exclusive_lock(state, "server state orphan", nonblocking=True),
+                ):
+                    break
+            except WorkspaceError:
+                if time.monotonic() >= deadline:
+                    self.fail("orphaned child did not release inherited leases")
+                time.sleep(0.05)
 
 
 if __name__ == "__main__":

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -4,6 +4,7 @@ import copy
 from concurrent.futures import ThreadPoolExecutor
 import ctypes
 import errno
+import fcntl
 import hashlib
 import json
 import multiprocessing
@@ -6626,6 +6627,28 @@ class WorkspaceTests(unittest.TestCase):
             )
 
         fallback.assert_called_once_with("empty-lease", status, 0.1)
+
+    def test_topology_up_refuses_locked_process_tree_generation(self) -> None:
+        root = self.workspace._topology_directory("locked-generation", create=True)
+        descriptor = os.open(
+            root / workspace_module.TOPOLOGY_PROCESS_TREE_LEASE,
+            os.O_RDWR | os.O_CREAT,
+            0o600,
+        )
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            with (
+                mock.patch.object(self.workspace, "_require_classic_contracts"),
+                self.assertRaisesRegex(WorkspaceError, "already running"),
+            ):
+                self.workspace._topology_up(
+                    "locked-generation",
+                    "default",
+                    "default",
+                    ["server"],
+                )
+        finally:
+            os.close(descriptor)
 
     def test_topology_status_makes_pre_coordinate_records_inert(self) -> None:
         root = self.workspace._topology_directory("historical-coordinate", create=True)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -18,6 +18,7 @@ import sys
 import tempfile
 import threading
 import time
+from typing import Callable
 import unittest
 from unittest import mock
 
@@ -68,6 +69,12 @@ def synthetic_build_process(
             os.environ, {"ATRINIK_WORKSPACE_DIR": workspace_directory}
         ):
             workspace = Workspace(Path(wrapper))
+            real_flock = workspace_module.fcntl.flock
+
+            def observe_flock(lock: object, operation: int) -> None:
+                if operation & workspace_module.fcntl.LOCK_EX:
+                    attempting.set()
+                real_flock(lock, operation)
 
             def pause_build(*_arguments: object) -> None:
                 entered.put(profile)
@@ -93,8 +100,10 @@ def synthetic_build_process(
                     workspace, "_uses_integrated_classic_build", return_value=False
                 ),
                 mock.patch.object(workspace, "_build_client"),
+                mock.patch.object(
+                    workspace_module.fcntl, "flock", side_effect=observe_flock
+                ),
             ):
-                attempting.set()
                 workspace.build("client", profile, False)
         results.put(None)
     except BaseException as error:
@@ -115,21 +124,71 @@ def layout_writer_process(
             os.environ, {"ATRINIK_WORKSPACE_DIR": workspace_directory}
         ):
             workspace = Workspace(Path(wrapper))
-            attempting.set()
-            if operation == "sync":
-                with mock.patch.object(
-                    workspace,
-                    "_sync_components",
-                    side_effect=lambda *_: entered.set(),
-                ):
-                    workspace.sync([], "none")
-            else:
-                with mock.patch.object(
-                    workspace,
-                    "_remove_worktree",
-                    side_effect=lambda *_: entered.set(),
-                ):
-                    workspace.remove_worktree("client", "review")
+            real_flock = workspace_module.fcntl.flock
+
+            def observe_flock(lock: object, lock_operation: int) -> None:
+                if lock_operation & workspace_module.fcntl.LOCK_EX:
+                    attempting.set()
+                real_flock(lock, lock_operation)
+
+            with mock.patch.object(
+                workspace_module.fcntl, "flock", side_effect=observe_flock
+            ):
+                if operation == "sync":
+                    with mock.patch.object(
+                        workspace,
+                        "_sync_components",
+                        side_effect=lambda *_: entered.set(),
+                    ):
+                        workspace.sync([], "none")
+                else:
+                    with mock.patch.object(
+                        workspace,
+                        "_remove_worktree",
+                        side_effect=lambda *_: entered.set(),
+                    ):
+                        workspace.remove_worktree("client", "review")
+        results.put(None)
+    except BaseException as error:
+        results.put(f"{type(error).__name__}: {error}")
+        raise
+
+
+def synthetic_client_process(
+    wrapper: str,
+    workspace_directory: str,
+    attempting: object,
+    entered: object,
+    release: object,
+    results: object,
+) -> None:
+    try:
+        with mock.patch.dict(
+            os.environ, {"ATRINIK_WORKSPACE_DIR": workspace_directory}
+        ):
+            workspace = Workspace(Path(wrapper))
+            real_flock = workspace_module.fcntl.flock
+
+            def observe_flock(lock: object, operation: int) -> None:
+                if operation & workspace_module.fcntl.LOCK_SH:
+                    attempting.set()
+                real_flock(lock, operation)
+
+            def pause_client(*_arguments: object) -> Path:
+                entered.set()
+                if not release.wait(10):
+                    raise TimeoutError("test client was not released")
+                return Path(wrapper) / "client"
+
+            with (
+                mock.patch.object(
+                    workspace, "_run_client", side_effect=pause_client
+                ),
+                mock.patch.object(
+                    workspace_module.fcntl, "flock", side_effect=observe_flock
+                ),
+            ):
+                workspace.run_client("default", "default", 13327, [], True)
         results.put(None)
     except BaseException as error:
         results.put(f"{type(error).__name__}: {error}")
@@ -5108,6 +5167,16 @@ class WorkspaceTests(unittest.TestCase):
             self.assertEqual(entered.get(timeout=5), "same-root")
             processes[1].start()
             self.assertTrue(attempting[1].wait(timeout=5))
+            build_lock = (
+                self.workspace.paths.builds
+                / "locks"
+                / f"same-root-{'a' * 12}.lock"
+            )
+            with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                with exclusive_lock(
+                    build_lock, "profile build same-root", nonblocking=True
+                ):
+                    self.fail("held build-root lock unexpectedly available")
             with self.assertRaises(queue.Empty):
                 entered.get(timeout=0.25)
         finally:
@@ -5163,6 +5232,14 @@ class WorkspaceTests(unittest.TestCase):
                     )
                     writer.start()
                     self.assertTrue(writer_attempting.wait(timeout=5))
+                    with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                        with exclusive_lock(
+                            self.workspace.paths.workspace
+                            / "repository-layout.lock",
+                            "repository layout",
+                            nonblocking=True,
+                        ):
+                            self.fail("held layout lock unexpectedly available")
                     self.assertFalse(writer_entered.wait(timeout=0.25))
                 finally:
                     release.set()
@@ -5230,6 +5307,18 @@ class WorkspaceTests(unittest.TestCase):
                     "default", "review", 13327, [], True
                 ),
             ),
+            (
+                "_run_client",
+                lambda: self.workspace.run_client(
+                    "default", "review", 13327, [], True
+                ),
+            ),
+            (
+                "_run_client",
+                lambda: self.workspace.run_client(
+                    "default", "review", 13327, [], True
+                ),
+            ),
         )
         lock = self.workspace.paths.workspace / "repository-layout.lock"
         for private_name, invoke in operations:
@@ -5276,6 +5365,149 @@ class WorkspaceTests(unittest.TestCase):
                         with ThreadPoolExecutor(max_workers=1) as executor:
                             executor.submit(invoke).result(timeout=2)
                     operation.assert_called_once()
+
+    def test_mixed_layout_readers_preserve_markers_and_coordinates(self) -> None:
+        build_root = self.workspace.paths.builds / "profiles" / "stress-a"
+        managed_directory(
+            build_root, self.workspace.paths.builds, "profile:stress:a"
+        )
+        marker = load_json(build_root / MANAGED_MARKER)
+        topology_root = self.workspace._topology_directory("stress", create=True)
+        checkout = self.workspace.paths.repositories / "server"
+        status = {
+            "schema_version": 1,
+            "name": "stress",
+            "profile": "default",
+            "stack": "default",
+            "providers": {"server": "server"},
+            "dependencies": ["server"],
+            "state": None,
+            "build_root": str(build_root),
+            "resolved": {
+                "server": {
+                    "path": str(checkout),
+                    "checkout_path": str(checkout),
+                    "checkout": "server",
+                    "repository": "atrinik/server",
+                    "branch": "main",
+                    "source": ".",
+                    "head": "a" * 40,
+                    "dirty": False,
+                }
+            },
+            "endpoint": None,
+            "ready": False,
+            "started_at": "2026-08-11T00:00:00+00:00",
+            "stopped_at": None,
+            "supervisor": {"pid": 999, "start_time": "1"},
+            "services": {},
+            "error": "stress fixture",
+        }
+        atomic_json(topology_root / "status.json", status)
+        barrier = threading.Barrier(4)
+
+        def repeat(operation: Callable[[], object]) -> list[object]:
+            barrier.wait(timeout=5)
+            return [operation() for _ in range(20)]
+
+        operations = (
+            lambda: self.workspace.build("client", "stress", False),
+            lambda: self.workspace.topology_up(
+                "stress", "default", "default", ["server"], None
+            ),
+            lambda: self.workspace.topology_status("stress"),
+            lambda: self.workspace.cleanup(["builds"], 7, [], False),
+        )
+        with (
+            mock.patch.object(self.workspace, "_build", return_value=build_root),
+            mock.patch.object(
+                self.workspace, "_topology_up", return_value=copy.deepcopy(status)
+            ),
+            mock.patch(
+                "atrinik_workspace.workspace.process_matches", return_value=False
+            ),
+            mock.patch(
+                "atrinik_workspace.cleanup.Cleanup._registered_worktree_paths",
+                return_value=(set(), None),
+            ),
+            ThreadPoolExecutor(max_workers=4) as executor,
+        ):
+            results = [
+                future.result(timeout=15)
+                for future in [
+                    executor.submit(repeat, operation) for operation in operations
+                ]
+            ]
+
+        self.assertTrue(all(result == build_root for result in results[0]))
+        self.assertTrue(all(result == status for result in results[1]))
+        self.assertTrue(
+            all(
+                result["resolved"] == status["resolved"]
+                and "inert_historical_record" not in result
+                for result in results[2]
+            )
+        )
+        self.assertEqual(
+            [result["inventory_errors"] for result in results[3]],
+            [[] for _ in results[3]],
+        )
+        self.assertEqual(load_json(build_root / MANAGED_MARKER), marker)
+        self.assertEqual(load_json(topology_root / "status.json"), status)
+
+    def test_layout_writer_waits_for_foreground_client_process(self) -> None:
+        context = multiprocessing.get_context("spawn")
+        client_attempting = context.Event()
+        client_entered = context.Event()
+        release = context.Event()
+        client_results = context.Queue()
+        writer_attempting = context.Event()
+        writer_entered = context.Event()
+        writer_results = context.Queue()
+        client = context.Process(
+            target=synthetic_client_process,
+            args=(
+                str(self.wrapper),
+                str(self.workspace_directory),
+                client_attempting,
+                client_entered,
+                release,
+                client_results,
+            ),
+        )
+        writer = context.Process(
+            target=layout_writer_process,
+            args=(
+                str(self.wrapper),
+                str(self.workspace_directory),
+                "remove-worktree",
+                writer_attempting,
+                writer_entered,
+                writer_results,
+            ),
+        )
+        try:
+            client.start()
+            self.assertTrue(client_entered.wait(timeout=5))
+            writer.start()
+            self.assertTrue(writer_attempting.wait(timeout=5))
+            with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                with exclusive_lock(
+                    self.workspace.paths.workspace / "repository-layout.lock",
+                    "repository layout",
+                    nonblocking=True,
+                ):
+                    self.fail("held layout lock unexpectedly available")
+            self.assertFalse(writer_entered.wait(timeout=0.25))
+        finally:
+            release.set()
+            client.join(timeout=10)
+            writer.join(timeout=10)
+        self.assertTrue(writer_entered.is_set())
+        self.assertEqual(client.exitcode, 0)
+        self.assertEqual(writer.exitcode, 0)
+        self.assertIsNone(client_results.get(timeout=2))
+        self.assertIsNone(writer_results.get(timeout=2))
 
     def test_server_runtime_paths_are_isolated_by_state(self) -> None:
         source = self.workspace.paths.repositories / "server"
@@ -6096,7 +6328,7 @@ class WorkspaceTests(unittest.TestCase):
         (build_root / "sources" / "client").mkdir(parents=True)
         expected = "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81"
         with (
-            mock.patch.object(self.workspace, "build", return_value=build_root),
+            mock.patch.object(self.workspace, "_build", return_value=build_root),
             mock.patch("builtins.print") as output,
             mock.patch("atrinik_workspace.workspace.run") as execute,
             mock.patch.object(self.workspace, "_require_client_display"),

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -6,8 +6,10 @@ import ctypes
 import errno
 import hashlib
 import json
+import multiprocessing
 import os
 from pathlib import Path
+import queue
 import shutil
 import signal
 import stat
@@ -44,11 +46,94 @@ from atrinik_workspace.workspace import (
     _remote_matches as real_remote_matches,
     display_arguments,
     exclusive_lock,
+    shared_lock,
     remove_owned_tree,
     replace_directory as worker_replace_directory,
     replace_runtime_directory as workspace_replace_directory,
     run as workspace_run,
 )
+
+
+def synthetic_build_process(
+    wrapper: str,
+    workspace_directory: str,
+    profile: str,
+    attempting: object,
+    entered: object,
+    release: object,
+    results: object,
+) -> None:
+    try:
+        with mock.patch.dict(
+            os.environ, {"ATRINIK_WORKSPACE_DIR": workspace_directory}
+        ):
+            workspace = Workspace(Path(wrapper))
+
+            def pause_build(*_arguments: object) -> None:
+                entered.put(profile)
+                if not release.wait(10):
+                    raise TimeoutError("test build was not released")
+
+            with (
+                mock.patch.object(
+                    workspace, "_expand_build_target", return_value=["client"]
+                ),
+                mock.patch.object(
+                    workspace,
+                    "_resolve_build_profile",
+                    return_value={"client": Path(wrapper)},
+                ),
+                mock.patch.object(
+                    workspace, "_profile_build_key", return_value="a" * 12
+                ),
+                mock.patch.object(
+                    workspace, "_refresh_build_metadata", side_effect=pause_build
+                ),
+                mock.patch.object(
+                    workspace, "_uses_integrated_classic_build", return_value=False
+                ),
+                mock.patch.object(workspace, "_build_client"),
+            ):
+                attempting.set()
+                workspace.build("client", profile, False)
+        results.put(None)
+    except BaseException as error:
+        results.put(f"{type(error).__name__}: {error}")
+        raise
+
+
+def layout_writer_process(
+    wrapper: str,
+    workspace_directory: str,
+    operation: str,
+    attempting: object,
+    entered: object,
+    results: object,
+) -> None:
+    try:
+        with mock.patch.dict(
+            os.environ, {"ATRINIK_WORKSPACE_DIR": workspace_directory}
+        ):
+            workspace = Workspace(Path(wrapper))
+            attempting.set()
+            if operation == "sync":
+                with mock.patch.object(
+                    workspace,
+                    "_sync_components",
+                    side_effect=lambda *_: entered.set(),
+                ):
+                    workspace.sync([], "none")
+            else:
+                with mock.patch.object(
+                    workspace,
+                    "_remove_worktree",
+                    side_effect=lambda *_: entered.set(),
+                ):
+                    workspace.remove_worktree("client", "review")
+        results.put(None)
+    except BaseException as error:
+        results.put(f"{type(error).__name__}: {error}")
+        raise
 
 
 COMPONENTS = (
@@ -4938,6 +5023,157 @@ class WorkspaceTests(unittest.TestCase):
                 with exclusive_lock(lock, "test resource", nonblocking=True):
                     self.fail("concurrent lock unexpectedly succeeded")
 
+    def test_shared_lock_fails_closed_without_platform_primitive(self) -> None:
+        lock = self.workspace.paths.builds / "locks" / "test.lock"
+        with mock.patch.object(workspace_module.fcntl, "LOCK_SH", None):
+            with self.assertRaisesRegex(
+                WorkspaceError, "shared locking is unavailable"
+            ):
+                with shared_lock(lock, "test resource"):
+                    self.fail("shared lock unexpectedly succeeded")
+
+        with mock.patch.object(
+            workspace_module.fcntl,
+            "flock",
+            side_effect=OSError(errno.ENOTSUP, "operation not supported"),
+        ):
+            with self.assertRaisesRegex(
+                WorkspaceError, "cannot acquire test resource lock"
+            ):
+                with shared_lock(lock, "test resource"):
+                    self.fail("unsupported shared lock unexpectedly succeeded")
+
+    def test_independent_build_roots_overlap_across_processes(self) -> None:
+        context = multiprocessing.get_context("spawn")
+        entered = context.Queue()
+        release = context.Event()
+        results = context.Queue()
+        attempting = [context.Event(), context.Event()]
+        processes = [
+            context.Process(
+                target=synthetic_build_process,
+                args=(
+                    str(self.wrapper),
+                    str(self.workspace_directory),
+                    profile,
+                    attempting[index],
+                    entered,
+                    release,
+                    results,
+                ),
+            )
+            for index, profile in enumerate(("independent-a", "independent-b"))
+        ]
+        try:
+            for process in processes:
+                process.start()
+            self.assertEqual(
+                {entered.get(timeout=5), entered.get(timeout=5)},
+                {"independent-a", "independent-b"},
+            )
+        finally:
+            release.set()
+            for process in processes:
+                process.join(timeout=10)
+        self.assertEqual(
+            [process.exitcode for process in processes], [0, 0]
+        )
+        self.assertEqual(
+            [results.get(timeout=2), results.get(timeout=2)], [None, None]
+        )
+
+    def test_same_build_root_serializes_across_processes(self) -> None:
+        context = multiprocessing.get_context("spawn")
+        entered = context.Queue()
+        release = context.Event()
+        results = context.Queue()
+        attempting = [context.Event(), context.Event()]
+        processes = [
+            context.Process(
+                target=synthetic_build_process,
+                args=(
+                    str(self.wrapper),
+                    str(self.workspace_directory),
+                    "same-root",
+                    attempting[index],
+                    entered,
+                    release,
+                    results,
+                ),
+            )
+            for index in range(2)
+        ]
+        try:
+            processes[0].start()
+            self.assertEqual(entered.get(timeout=5), "same-root")
+            processes[1].start()
+            self.assertTrue(attempting[1].wait(timeout=5))
+            with self.assertRaises(queue.Empty):
+                entered.get(timeout=0.25)
+        finally:
+            release.set()
+            for process in processes:
+                process.join(timeout=10)
+        self.assertEqual(entered.get(timeout=2), "same-root")
+        self.assertEqual(
+            [process.exitcode for process in processes], [0, 0]
+        )
+        self.assertEqual(
+            [results.get(timeout=2), results.get(timeout=2)], [None, None]
+        )
+
+    def test_layout_writers_wait_for_build_readers_across_processes(self) -> None:
+        context = multiprocessing.get_context("spawn")
+        for operation in ("sync", "remove-worktree"):
+            with self.subTest(operation=operation):
+                entered = context.Queue()
+                release = context.Event()
+                reader_results = context.Queue()
+                reader_attempting = context.Event()
+                writer_attempting = context.Event()
+                writer_entered = context.Event()
+                writer_results = context.Queue()
+                reader = context.Process(
+                    target=synthetic_build_process,
+                    args=(
+                        str(self.wrapper),
+                        str(self.workspace_directory),
+                        f"reader-{operation}",
+                        reader_attempting,
+                        entered,
+                        release,
+                        reader_results,
+                    ),
+                )
+                writer = context.Process(
+                    target=layout_writer_process,
+                    args=(
+                        str(self.wrapper),
+                        str(self.workspace_directory),
+                        operation,
+                        writer_attempting,
+                        writer_entered,
+                        writer_results,
+                    ),
+                )
+                try:
+                    reader.start()
+                    self.assertEqual(
+                        entered.get(timeout=5), f"reader-{operation}"
+                    )
+                    writer.start()
+                    self.assertTrue(writer_attempting.wait(timeout=5))
+                    self.assertFalse(writer_entered.wait(timeout=0.25))
+                finally:
+                    release.set()
+                    reader.join(timeout=10)
+                    writer.join(timeout=10)
+                self.assertTrue(writer_entered.is_set())
+                self.assertEqual(reader.exitcode, 0)
+                self.assertEqual(writer.exitcode, 0)
+                self.assertIsNone(reader_results.get(timeout=2))
+                self.assertIsNone(writer_results.get(timeout=2))
+
     def test_exclusive_lock_refuses_symlink(self) -> None:
         target = self.root / "valuable"
         target.write_text("preserve\n", encoding="utf-8")
@@ -5006,6 +5242,39 @@ class WorkspaceTests(unittest.TestCase):
                             self.assertFalse(future.done())
                             operation.assert_not_called()
                         future.result(timeout=2)
+                    operation.assert_called_once()
+
+    def test_layout_readers_share_repository_lock(self) -> None:
+        operations = (
+            ("_build", lambda: self.workspace.build("client", "default", False)),
+            (
+                "_scenario_create",
+                lambda: self.workspace.scenario_create("review", "default"),
+            ),
+            (
+                "_scenario_reset",
+                lambda: self.workspace.scenario_reset("review"),
+            ),
+            (
+                "_topology_up",
+                lambda: self.workspace.topology_up(
+                    "review", "default", "review", ["server"], None
+                ),
+            ),
+            (
+                "_run_server",
+                lambda: self.workspace.run_server(
+                    "default", "review", 13327, [], True
+                ),
+            ),
+        )
+        lock = self.workspace.paths.workspace / "repository-layout.lock"
+        for private_name, invoke in operations:
+            with self.subTest(operation=private_name):
+                with mock.patch.object(self.workspace, private_name) as operation:
+                    with shared_lock(lock, "repository layout"):
+                        with ThreadPoolExecutor(max_workers=1) as executor:
+                            executor.submit(invoke).result(timeout=2)
                     operation.assert_called_once()
 
     def test_server_runtime_paths_are_isolated_by_state(self) -> None:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -6142,11 +6142,12 @@ class WorkspaceTests(unittest.TestCase):
             with mock.patch("builtins.print") as output:
                 self.workspace.topology_logs("review", "client", 10, False)
             self.assertIn("client ready", "".join(call.args[0] for call in output.call_args_list))
-            (
+            process_tree_path = (
                 self.workspace.paths.topologies
                 / "review"
                 / workspace_module.TOPOLOGY_PROCESS_TREE_LEASE
-            ).unlink()
+            )
+            process_tree_path.unlink()
         finally:
             try:
                 if self.workspace.topology_status("review-two")["supervisor"][
@@ -6594,6 +6595,37 @@ class WorkspaceTests(unittest.TestCase):
 
         with self.assertRaisesRegex(WorkspaceError, "supervisor status is invalid"):
             self.workspace.topology_status("invalid")
+
+    def test_topology_down_uses_legacy_fallback_for_empty_process_tree_lease(
+        self,
+    ) -> None:
+        root = self.workspace._topology_directory("empty-lease", create=True)
+        (root / workspace_module.TOPOLOGY_PROCESS_TREE_LEASE).touch(mode=0o600)
+        status = {
+            "supervisor": {"running": True},
+            "services": {},
+        }
+        stopped = {
+            "supervisor": {"running": False},
+            "services": {},
+        }
+
+        with (
+            mock.patch.object(
+                self.workspace, "topology_status", return_value=status
+            ),
+            mock.patch.object(
+                self.workspace,
+                "_legacy_topology_down",
+                return_value=stopped,
+            ) as fallback,
+        ):
+            self.assertEqual(
+                self.workspace.topology_down("empty-lease", timeout=0.1),
+                stopped,
+            )
+
+        fallback.assert_called_once_with("empty-lease", status, 0.1)
 
     def test_topology_status_makes_pre_coordinate_records_inert(self) -> None:
         root = self.workspace._topology_directory("historical-coordinate", create=True)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -5470,8 +5470,7 @@ class WorkspaceTests(unittest.TestCase):
             )
         finally:
             release.set()
-            for process in processes:
-                process.join(timeout=10)
+            join_or_stop_processes(processes, 10)
         self.assertEqual(
             [process.exitcode for process in processes], [0, 0]
         )
@@ -5612,8 +5611,7 @@ class WorkspaceTests(unittest.TestCase):
                 entered.get(timeout=0.25)
         finally:
             release.set()
-            for process in processes:
-                process.join(timeout=10)
+            join_or_stop_processes(processes, 10)
         self.assertEqual(entered.get(timeout=2), "same-root")
         self.assertEqual(
             [process.exitcode for process in processes], [0, 0]
@@ -5674,8 +5672,7 @@ class WorkspaceTests(unittest.TestCase):
                     self.assertFalse(writer_entered.wait(timeout=0.25))
                 finally:
                     release.set()
-                    reader.join(timeout=10)
-                    writer.join(timeout=10)
+                    join_or_stop_processes([reader, writer], 10)
                 self.assertTrue(writer_entered.is_set())
                 self.assertEqual(reader.exitcode, 0)
                 self.assertEqual(writer.exitcode, 0)
@@ -6467,6 +6464,32 @@ class WorkspaceTests(unittest.TestCase):
                 with self.assertRaisesRegex(WorkspaceError, "already in use"):
                     with exclusive_lock(path, description, nonblocking=True):
                         self.fail(f"server-only topology released {description}")
+            descendant_path = Path(
+                server_only["services"]["server"]["cwd"]
+            ) / "descendant.pid"
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline and not descendant_path.is_file():
+                time.sleep(0.05)
+            descendant_pid = int(descendant_path.read_text(encoding="utf-8"))
+            service = server_only["services"]["server"]
+            service_pidfd = os.pidfd_open(service["pid"])
+            try:
+                signal.pidfd_send_signal(service_pidfd, signal.SIGTERM)
+            finally:
+                os.close(service_pidfd)
+            deadline = time.monotonic() + 5
+            while (
+                time.monotonic() < deadline
+                and self.workspace.topology_status("server-lease")["services"][
+                    "server"
+                ]["running"]
+            ):
+                time.sleep(0.05)
+            self.assertTrue(
+                self.workspace.topology_status("server-lease")["supervisor"][
+                    "running"
+                ]
+            )
             supervisor = server_only["supervisor"]
             pidfd = os.pidfd_open(supervisor["pid"])
             try:
@@ -6483,14 +6506,7 @@ class WorkspaceTests(unittest.TestCase):
                 time.sleep(0.05)
             orphaned = self.workspace.topology_status("server-lease")
             self.assertFalse(orphaned["supervisor"]["running"])
-            self.assertTrue(orphaned["services"]["server"]["running"])
-            descendant_path = Path(
-                orphaned["services"]["server"]["cwd"]
-            ) / "descendant.pid"
-            deadline = time.monotonic() + 5
-            while time.monotonic() < deadline and not descendant_path.is_file():
-                time.sleep(0.05)
-            descendant_pid = int(descendant_path.read_text(encoding="utf-8"))
+            self.assertFalse(orphaned["services"]["server"]["running"])
             self.assertTrue(Path(f"/proc/{descendant_pid}").exists())
             for path, description in (
                 (layout_lock, "repository layout"),
@@ -6508,11 +6524,7 @@ class WorkspaceTests(unittest.TestCase):
                 time.sleep(0.05)
             self.assertFalse(Path(f"/proc/{descendant_pid}").exists())
         finally:
-            remaining = self.workspace.topology_status("server-lease")
-            if remaining["supervisor"]["running"] or any(
-                service["running"] for service in remaining["services"].values()
-            ):
-                self.workspace.topology_down("server-lease", timeout=5)
+            self.workspace.topology_down("server-lease", timeout=5)
 
         with exclusive_lock(Path(f"{state}.lock"), "server state", nonblocking=True):
             pass

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -195,6 +195,26 @@ def synthetic_client_process(
         raise
 
 
+def timed_layout_lock_process(
+    lock_path: str,
+    mode: str,
+    ready: object,
+    start: object,
+    results: object,
+) -> None:
+    try:
+        ready.put(mode)
+        if not start.wait(5):
+            raise TimeoutError("timed lock test did not start")
+        lock = shared_lock if mode == "shared" else exclusive_lock
+        with lock(Path(lock_path), "timed repository layout"):
+            time.sleep(0.4)
+        results.put(None)
+    except BaseException as error:
+        results.put(f"{type(error).__name__}: {error}")
+        raise
+
+
 COMPONENTS = (
     ("client", "client"),
     ("server", "server"),
@@ -5141,6 +5161,41 @@ class WorkspaceTests(unittest.TestCase):
             [results.get(timeout=2), results.get(timeout=2)], [None, None]
         )
 
+    def test_shared_layout_lock_improves_independent_elapsed_time(self) -> None:
+        context = multiprocessing.get_context("spawn")
+        lock = self.workspace.paths.workspace / "timed-layout.lock"
+
+        def measure(mode: str) -> float:
+            ready = context.Queue()
+            start = context.Event()
+            results = context.Queue()
+            processes = [
+                context.Process(
+                    target=timed_layout_lock_process,
+                    args=(str(lock), mode, ready, start, results),
+                )
+                for _ in range(2)
+            ]
+            for process in processes:
+                process.start()
+            self.assertEqual(
+                [ready.get(timeout=5), ready.get(timeout=5)], [mode, mode]
+            )
+            began = time.monotonic()
+            start.set()
+            for process in processes:
+                process.join(timeout=5)
+            elapsed = time.monotonic() - began
+            self.assertEqual([process.exitcode for process in processes], [0, 0])
+            self.assertEqual(
+                [results.get(timeout=2), results.get(timeout=2)], [None, None]
+            )
+            return elapsed
+
+        exclusive_elapsed = measure("exclusive")
+        shared_elapsed = measure("shared")
+        self.assertLess(shared_elapsed, exclusive_elapsed * 0.8)
+
     def test_same_build_root_serializes_across_processes(self) -> None:
         context = multiprocessing.get_context("spawn")
         entered = context.Queue()
@@ -5405,6 +5460,20 @@ class WorkspaceTests(unittest.TestCase):
         }
         atomic_json(topology_root / "status.json", status)
         barrier = threading.Barrier(4)
+        build_lock = self.workspace.paths.builds / "locks" / "stress-a.lock"
+        topology_lock = topology_root / "operation.lock"
+
+        def refresh_build(*_arguments: object, **_keywords: object) -> Path:
+            with exclusive_lock(build_lock, "stress build root"):
+                atomic_json(build_root / MANAGED_MARKER, marker)
+            return build_root
+
+        def refresh_topology(
+            *_arguments: object, **_keywords: object
+        ) -> dict[str, object]:
+            with exclusive_lock(topology_lock, "stress topology"):
+                atomic_json(topology_root / "status.json", status)
+            return copy.deepcopy(status)
 
         def repeat(operation: Callable[[], object]) -> list[object]:
             barrier.wait(timeout=5)
@@ -5419,9 +5488,9 @@ class WorkspaceTests(unittest.TestCase):
             lambda: self.workspace.cleanup(["builds"], 7, [], False),
         )
         with (
-            mock.patch.object(self.workspace, "_build", return_value=build_root),
+            mock.patch.object(self.workspace, "_build", side_effect=refresh_build),
             mock.patch.object(
-                self.workspace, "_topology_up", return_value=copy.deepcopy(status)
+                self.workspace, "_topology_up", side_effect=refresh_topology
             ),
             mock.patch(
                 "atrinik_workspace.workspace.process_matches", return_value=False
@@ -5857,6 +5926,7 @@ class WorkspaceTests(unittest.TestCase):
         )
         state = self.workspace._state_location("default")
         second_state = self.workspace.state_add("second", None)
+        layout_lock = self.workspace.paths.workspace / "repository-layout.lock"
         try:
             with (
                 mock.patch.object(
@@ -5909,6 +5979,11 @@ class WorkspaceTests(unittest.TestCase):
                     Path(f"{state}.lock"), "server state", nonblocking=True
                 ):
                     self.fail("supervised state lock unexpectedly became available")
+            with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                with exclusive_lock(
+                    layout_lock, "repository layout", nonblocking=True
+                ):
+                    self.fail("supervised client released its layout lock")
 
             supervisor = status["supervisor"]
             pidfd = os.pidfd_open(supervisor["pid"])
@@ -5937,6 +6012,11 @@ class WorkspaceTests(unittest.TestCase):
                     Path(f"{state}.lock"), "server state", nonblocking=True
                 ):
                     self.fail("orphaned server released its state lock")
+            with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                with exclusive_lock(
+                    layout_lock, "repository layout", nonblocking=True
+                ):
+                    self.fail("orphaned client released its layout lock")
             recovered = self.workspace.topology_down("server-review", timeout=5)
             self.assertFalse(
                 any(service["running"] for service in recovered["services"].values())
@@ -5959,6 +6039,8 @@ class WorkspaceTests(unittest.TestCase):
         with exclusive_lock(
             Path(f"{second_state}.lock"), "server state", nonblocking=True
         ):
+            pass
+        with exclusive_lock(layout_lock, "repository layout", nonblocking=True):
             pass
 
     def test_topology_port_selection_rejects_unavailable_port(self) -> None:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -293,6 +293,23 @@ def mixed_layout_operation_process(
         raise
 
 
+def join_or_stop_processes(
+    processes: list[multiprocessing.Process], timeout: float
+) -> None:
+    deadline = time.monotonic() + timeout
+    for process in processes:
+        process.join(timeout=max(0.0, deadline - time.monotonic()))
+    for process in processes:
+        if process.is_alive():
+            process.terminate()
+    for process in processes:
+        process.join(timeout=2)
+    for process in processes:
+        if process.is_alive():
+            process.kill()
+            process.join(timeout=2)
+
+
 COMPONENTS = (
     ("client", "client"),
     ("server", "server"),
@@ -5567,8 +5584,7 @@ class WorkspaceTests(unittest.TestCase):
             )
             start.set()
         finally:
-            for process in processes:
-                process.join(timeout=20)
+            join_or_stop_processes(processes, 20)
         self.assertEqual([process.exitcode for process in processes], [0] * 4)
         outcomes = dict(results.get(timeout=2) for _ in processes)
         self.assertEqual(outcomes, {operation: None for operation in operations})
@@ -6535,15 +6551,22 @@ class WorkspaceTests(unittest.TestCase):
         expected = "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81"
 
         def execute_client(*_arguments: object, **_keywords: object) -> None:
-            with self.assertRaisesRegex(WorkspaceError, "already in use"):
-                with exclusive_lock(
+            self.assertEqual(len(_keywords["pass_fds"]), 2)
+            for path, description in (
+                (
+                    self.workspace.paths.workspace / "repository-layout.lock",
+                    "repository layout",
+                ),
+                (
                     self.workspace.paths.builds
                     / "locks"
                     / "client-build.lock",
                     "profile build default",
-                    nonblocking=True,
-                ):
-                    self.fail("foreground client released its build-root lock")
+                ),
+            ):
+                with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                    with exclusive_lock(path, description, nonblocking=True):
+                        self.fail(f"foreground client released {description}")
 
         with (
             mock.patch.object(self.workspace, "_build", return_value=build_root),
@@ -6601,6 +6624,29 @@ class WorkspaceTests(unittest.TestCase):
         executable = runtime / "atrinik-server"
         executable.write_text("server\n", encoding="utf-8")
         selected = {"server": server}
+
+        def execute_server(*_arguments: object, **_keywords: object) -> None:
+            self.assertEqual(len(_keywords["pass_fds"]), 3)
+            for path, description in (
+                (
+                    self.workspace.paths.workspace / "repository-layout.lock",
+                    "repository layout",
+                ),
+                (
+                    self.workspace.paths.builds
+                    / "locks"
+                    / "server-build.lock",
+                    "profile build default",
+                ),
+                (
+                    Path(f"{self.workspace._state_location('default')}.lock"),
+                    "server state",
+                ),
+            ):
+                with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                    with exclusive_lock(path, description, nonblocking=True):
+                        self.fail(f"foreground server released {description}")
+
         with (
             mock.patch.object(
                 self.workspace, "_resolve_build_profile", return_value=selected
@@ -6611,6 +6657,9 @@ class WorkspaceTests(unittest.TestCase):
             mock.patch.object(
                 self.workspace, "_prepare_server_runtime", return_value=runtime
             ),
+            mock.patch(
+                "atrinik_workspace.workspace.run", side_effect=execute_server
+            ),
             mock.patch("builtins.print") as output,
         ):
             result = self.workspace.run_server(
@@ -6618,7 +6667,7 @@ class WorkspaceTests(unittest.TestCase):
                 "default",
                 1731,
                 ["--no_console", "--assetspath=/tmp/untrusted"],
-                True,
+                False,
             )
 
         self.assertEqual(result, executable)
@@ -6651,6 +6700,38 @@ class WorkspaceTests(unittest.TestCase):
             workspace_run(["tool"])
 
         self.assertIs(invoke.call_args.kwargs["stdout"], os.sys.stderr)
+
+    def test_operational_subprocess_inherits_active_lock_descriptors(self) -> None:
+        layout = self.workspace.paths.workspace / "repository-layout.lock"
+        build = self.workspace.paths.builds / "locks" / "inherited-build.lock"
+        state = self.workspace.paths.state / "inherited-state.lock"
+        completed = mock.MagicMock(stdout="")
+        with (
+            shared_lock(layout, "repository layout") as layout_lease,
+            exclusive_lock(build, "profile build inherited") as build_lease,
+            exclusive_lock(state, "server state inherited") as state_lease,
+            mock.patch(
+                "atrinik_workspace.workspace.subprocess.run",
+                return_value=completed,
+            ) as invoke,
+        ):
+            workspace_run(["tool"])
+            self.assertEqual(
+                set(invoke.call_args.kwargs["pass_fds"]),
+                {
+                    layout_lease.fileno(),
+                    build_lease.fileno(),
+                    state_lease.fileno(),
+                },
+            )
+            for path, description in (
+                (layout, "repository layout"),
+                (build, "profile build inherited"),
+                (state, "server state inherited"),
+            ):
+                with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                    with exclusive_lock(path, description, nonblocking=True):
+                        self.fail(f"subprocess lease did not protect {description}")
 
 
 if __name__ == "__main__":

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -612,6 +612,40 @@ class WorkspaceTests(unittest.TestCase):
 
         self.assertTrue((self.workspace.paths.repositories / "client" / ".git").exists())
 
+    def test_initialize_workers_inherit_repository_layout_lease(self) -> None:
+        observed: list[tuple[int, ...]] = []
+        observed_lock = threading.Lock()
+        layout = self.workspace.paths.workspace / "repository-layout.lock"
+
+        def run_in_worker(*_arguments: object, **keywords: object) -> object:
+            descriptors = keywords["pass_fds"]
+            with observed_lock:
+                observed.append(descriptors)
+            with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                with exclusive_lock(
+                    layout, "repository layout", nonblocking=True
+                ):
+                    self.fail("initialize worker released its layout lease")
+            return mock.MagicMock(stdout="")
+
+        def ensure(_checkout: object) -> None:
+            workspace_run(["tool"])
+
+        with (
+            mock.patch.object(self.workspace, "_validate_primary_checkout"),
+            mock.patch.object(
+                self.workspace, "_ensure_repository", side_effect=ensure
+            ),
+            mock.patch(
+                "atrinik_workspace.workspace.subprocess.run",
+                side_effect=run_in_worker,
+            ),
+        ):
+            self.workspace.initialize(["client", "server"], jobs=2)
+
+        self.assertEqual(len(observed), 2)
+        self.assertTrue(all(len(descriptors) == 1 for descriptors in observed))
+
     def test_failed_clone_does_not_strand_destination(self) -> None:
         destination = self.workspace.paths.repositories / "client"
         shutil.rmtree(destination)
@@ -6330,39 +6364,46 @@ class WorkspaceTests(unittest.TestCase):
             server_only = self.workspace.topology_up(
                 "server-lease", "default", "default", ["server"], 17302
             )
-        self.assertTrue(server_only["ready"])
-        for path, description in (
-            (layout_lock, "repository layout"),
-            (profile_lock, "profile build default"),
-        ):
-            with self.assertRaisesRegex(WorkspaceError, "already in use"):
-                with exclusive_lock(path, description, nonblocking=True):
-                    self.fail(f"server-only topology released {description}")
-        supervisor = server_only["supervisor"]
-        pidfd = os.pidfd_open(supervisor["pid"])
         try:
-            signal.pidfd_send_signal(pidfd, signal.SIGKILL)
+            self.assertTrue(server_only["ready"])
+            for path, description in (
+                (layout_lock, "repository layout"),
+                (profile_lock, "profile build default"),
+            ):
+                with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                    with exclusive_lock(path, description, nonblocking=True):
+                        self.fail(f"server-only topology released {description}")
+            supervisor = server_only["supervisor"]
+            pidfd = os.pidfd_open(supervisor["pid"])
+            try:
+                signal.pidfd_send_signal(pidfd, signal.SIGKILL)
+            finally:
+                os.close(pidfd)
+            deadline = time.monotonic() + 5
+            while (
+                time.monotonic() < deadline
+                and self.workspace.topology_status("server-lease")["supervisor"][
+                    "running"
+                ]
+            ):
+                time.sleep(0.05)
+            orphaned = self.workspace.topology_status("server-lease")
+            self.assertFalse(orphaned["supervisor"]["running"])
+            self.assertTrue(orphaned["services"]["server"]["running"])
+            for path, description in (
+                (layout_lock, "repository layout"),
+                (profile_lock, "profile build default"),
+            ):
+                with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                    with exclusive_lock(path, description, nonblocking=True):
+                        self.fail(f"orphaned server released {description}")
+            self.workspace.topology_down("server-lease", timeout=5)
         finally:
-            os.close(pidfd)
-        deadline = time.monotonic() + 5
-        while (
-            time.monotonic() < deadline
-            and self.workspace.topology_status("server-lease")["supervisor"][
-                "running"
-            ]
-        ):
-            time.sleep(0.05)
-        orphaned = self.workspace.topology_status("server-lease")
-        self.assertFalse(orphaned["supervisor"]["running"])
-        self.assertTrue(orphaned["services"]["server"]["running"])
-        for path, description in (
-            (layout_lock, "repository layout"),
-            (profile_lock, "profile build default"),
-        ):
-            with self.assertRaisesRegex(WorkspaceError, "already in use"):
-                with exclusive_lock(path, description, nonblocking=True):
-                    self.fail(f"orphaned server released {description}")
-        self.workspace.topology_down("server-lease", timeout=5)
+            remaining = self.workspace.topology_status("server-lease")
+            if remaining["supervisor"]["running"] or any(
+                service["running"] for service in remaining["services"].values()
+            ):
+                self.workspace.topology_down("server-lease", timeout=5)
 
         with exclusive_lock(Path(f"{state}.lock"), "server state", nonblocking=True):
             pass

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -196,20 +196,53 @@ def synthetic_client_process(
         raise
 
 
-def timed_layout_lock_process(
-    lock_path: str,
+def timed_public_build_process(
+    wrapper: str,
+    workspace_directory: str,
+    profile: str,
     mode: str,
     ready: object,
     start: object,
     results: object,
 ) -> None:
     try:
-        ready.put(mode)
-        if not start.wait(5):
-            raise TimeoutError("timed lock test did not start")
-        lock = shared_lock if mode == "shared" else exclusive_lock
-        with lock(Path(lock_path), "timed repository layout"):
-            time.sleep(0.4)
+        with mock.patch.dict(
+            os.environ, {"ATRINIK_WORKSPACE_DIR": workspace_directory}
+        ):
+            workspace = Workspace(Path(wrapper))
+            ready.put(profile)
+            if not start.wait(5):
+                raise TimeoutError("timed build test did not start")
+            with (
+                mock.patch.object(
+                    workspace, "_expand_build_target", return_value=["client"]
+                ),
+                mock.patch.object(
+                    workspace,
+                    "_resolve_build_profile",
+                    return_value={"client": Path(wrapper)},
+                ),
+                mock.patch.object(
+                    workspace, "_profile_build_key", return_value="a" * 12
+                ),
+                mock.patch.object(
+                    workspace,
+                    "_refresh_build_metadata",
+                    side_effect=lambda *_: time.sleep(0.4),
+                ),
+                mock.patch.object(
+                    workspace, "_uses_integrated_classic_build", return_value=False
+                ),
+                mock.patch.object(workspace, "_build_client"),
+            ):
+                if mode == "shared":
+                    workspace.build("client", profile, False)
+                else:
+                    with exclusive_lock(
+                        workspace.paths.workspace / "repository-layout.lock",
+                        "legacy repository layout",
+                    ):
+                        workspace._build("client", profile, False)
         results.put(None)
     except BaseException as error:
         results.put(f"{type(error).__name__}: {error}")
@@ -232,6 +265,25 @@ def inherited_leases_wrapper_process(
             [sys.executable, child_script, child_pid_path],
             diagnostics_to_stderr=False,
         )
+
+
+def cleanup_writer_wrapper_process(
+    layout_path: str,
+    repository: str,
+    executable_directory: str,
+    child_pid_path: str,
+) -> None:
+    from atrinik_workspace.cleanup import _command as cleanup_command
+
+    with mock.patch.dict(
+        os.environ,
+        {
+            "PATH": executable_directory + os.pathsep + os.environ["PATH"],
+            "ATRINIK_TEST_CHILD_PID": child_pid_path,
+        },
+    ):
+        with exclusive_lock(Path(layout_path), "repository layout"):
+            cleanup_command(Path(repository), "worktree", "prune")
 
 
 def compiler_cache_first_use_process(
@@ -5476,7 +5528,6 @@ class WorkspaceTests(unittest.TestCase):
 
     def test_shared_layout_lock_improves_independent_elapsed_time(self) -> None:
         context = multiprocessing.get_context("spawn")
-        lock = self.workspace.paths.workspace / "timed-layout.lock"
 
         def measure(mode: str) -> float:
             ready = context.Queue()
@@ -5484,20 +5535,30 @@ class WorkspaceTests(unittest.TestCase):
             results = context.Queue()
             processes = [
                 context.Process(
-                    target=timed_layout_lock_process,
-                    args=(str(lock), mode, ready, start, results),
+                    target=timed_public_build_process,
+                    args=(
+                        str(self.wrapper),
+                        str(self.workspace_directory),
+                        f"timed-{mode}-{index}",
+                        mode,
+                        ready,
+                        start,
+                        results,
+                    ),
                 )
-                for _ in range(2)
+                for index in range(2)
             ]
-            for process in processes:
-                process.start()
-            self.assertEqual(
-                [ready.get(timeout=5), ready.get(timeout=5)], [mode, mode]
-            )
-            began = time.monotonic()
-            start.set()
-            for process in processes:
-                process.join(timeout=5)
+            try:
+                for process in processes:
+                    process.start()
+                self.assertEqual(
+                    {ready.get(timeout=5), ready.get(timeout=5)},
+                    {f"timed-{mode}-0", f"timed-{mode}-1"},
+                )
+                began = time.monotonic()
+                start.set()
+            finally:
+                join_or_stop_processes(processes, 5)
             elapsed = time.monotonic() - began
             self.assertEqual([process.exitcode for process in processes], [0, 0])
             self.assertEqual(
@@ -6968,6 +7029,33 @@ class WorkspaceTests(unittest.TestCase):
                     with exclusive_lock(path, description, nonblocking=True):
                         self.fail(f"subprocess lease did not protect {description}")
 
+    def test_resource_listing_inherits_active_lock_descriptors(self) -> None:
+        source = self.root / "resource-listing"
+        source.mkdir()
+        (source / workspace_module.RESOURCE_PATHS_MANIFEST).write_text(
+            "paintings\n", encoding="utf-8"
+        )
+        layout = self.workspace.paths.workspace / "repository-layout.lock"
+        build = self.workspace.paths.builds / "locks" / "resource-build.lock"
+        completed = mock.MagicMock(stdout=b"paintings/scene.jpg\0", stderr=b"")
+        with (
+            shared_lock(layout, "repository layout") as layout_lease,
+            exclusive_lock(build, "profile build resources") as build_lease,
+            mock.patch(
+                "atrinik_workspace.workspace.subprocess.run",
+                return_value=completed,
+            ) as invoke,
+        ):
+            expected_fds = {layout_lease.fileno(), build_lease.fileno()}
+            runtime_paths, tracked = self.workspace._resource_runtime_files(source)
+
+        self.assertEqual(runtime_paths, ["paintings"])
+        self.assertEqual(tracked, ["paintings/scene.jpg"])
+        self.assertEqual(
+            set(invoke.call_args.kwargs["pass_fds"]),
+            expected_fds,
+        )
+
     def test_orphaned_operational_subprocess_retains_active_leases(self) -> None:
         child_script = self.root / "lease-child.py"
         child_pid_path = self.root / "lease-child.pid"
@@ -7036,6 +7124,73 @@ class WorkspaceTests(unittest.TestCase):
             except WorkspaceError:
                 if time.monotonic() >= deadline:
                     self.fail("orphaned child did not release inherited leases")
+                time.sleep(0.05)
+
+    def test_orphaned_cleanup_child_retains_layout_lease(self) -> None:
+        executable_directory = self.root / "fake-bin"
+        executable_directory.mkdir()
+        fake_git = executable_directory / "git"
+        fake_git.write_text(
+            f"#!{sys.executable}\n"
+            "import os, pathlib, time\n"
+            "pathlib.Path(os.environ['ATRINIK_TEST_CHILD_PID']).write_text("
+            "str(os.getpid()), encoding='ascii')\n"
+            "while True:\n"
+            "    time.sleep(0.1)\n",
+            encoding="utf-8",
+        )
+        fake_git.chmod(0o755)
+        child_pid_path = self.root / "cleanup-child.pid"
+        layout = self.workspace.paths.workspace / "repository-layout.lock"
+        context = multiprocessing.get_context("spawn")
+        wrapper = context.Process(
+            target=cleanup_writer_wrapper_process,
+            args=(
+                str(layout),
+                str(self.wrapper),
+                str(executable_directory),
+                str(child_pid_path),
+            ),
+        )
+        child_pidfd: int | None = None
+        try:
+            wrapper.start()
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline and not child_pid_path.is_file():
+                time.sleep(0.05)
+            self.assertTrue(child_pid_path.is_file())
+            child_pidfd = os.pidfd_open(
+                int(child_pid_path.read_text(encoding="ascii"))
+            )
+            wrapper.kill()
+            wrapper.join(timeout=5)
+            self.assertFalse(wrapper.is_alive())
+            with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                with exclusive_lock(
+                    layout, "repository layout", nonblocking=True
+                ):
+                    self.fail("orphaned cleanup child released the layout lock")
+        finally:
+            if wrapper.is_alive():
+                wrapper.kill()
+                wrapper.join(timeout=5)
+            if child_pidfd is not None:
+                try:
+                    signal.pidfd_send_signal(child_pidfd, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                os.close(child_pidfd)
+
+        deadline = time.monotonic() + 5
+        while True:
+            try:
+                with exclusive_lock(
+                    layout, "repository layout", nonblocking=True
+                ):
+                    break
+            except WorkspaceError:
+                if time.monotonic() >= deadline:
+                    self.fail("cleanup child did not release the layout lease")
                 time.sleep(0.05)
 
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -6142,6 +6142,11 @@ class WorkspaceTests(unittest.TestCase):
             with mock.patch("builtins.print") as output:
                 self.workspace.topology_logs("review", "client", 10, False)
             self.assertIn("client ready", "".join(call.args[0] for call in output.call_args_list))
+            (
+                self.workspace.paths.topologies
+                / "review"
+                / workspace_module.TOPOLOGY_PROCESS_TREE_LEASE
+            ).unlink()
         finally:
             try:
                 if self.workspace.topology_status("review-two")["supervisor"][
@@ -6412,6 +6417,11 @@ class WorkspaceTests(unittest.TestCase):
                     profile_lock, "profile build default", nonblocking=True
                 ):
                     self.fail("orphaned services released their build-root lock")
+            (
+                self.workspace.paths.topologies
+                / "server-review"
+                / workspace_module.TOPOLOGY_PROCESS_TREE_LEASE
+            ).unlink()
             recovered = self.workspace.topology_down("server-review", timeout=5)
             self.assertFalse(
                 any(service["running"] for service in recovered["services"].values())

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -18,7 +18,6 @@ import sys
 import tempfile
 import threading
 import time
-from typing import Callable
 import unittest
 from unittest import mock
 
@@ -174,7 +173,9 @@ def synthetic_client_process(
                     attempting.set()
                 real_flock(lock, operation)
 
-            def pause_client(*_arguments: object) -> Path:
+            def pause_client(
+                *_arguments: object, **_keywords: object
+            ) -> Path:
                 entered.set()
                 if not release.wait(10):
                     raise TimeoutError("test client was not released")
@@ -212,6 +213,83 @@ def timed_layout_lock_process(
         results.put(None)
     except BaseException as error:
         results.put(f"{type(error).__name__}: {error}")
+        raise
+
+
+def mixed_layout_operation_process(
+    wrapper: str,
+    workspace_directory: str,
+    operation: str,
+    build_root_value: str,
+    marker: dict[str, object],
+    status: dict[str, object],
+    ready: object,
+    start: object,
+    results: object,
+) -> None:
+    try:
+        with mock.patch.dict(
+            os.environ, {"ATRINIK_WORKSPACE_DIR": workspace_directory}
+        ):
+            workspace = Workspace(Path(wrapper))
+            build_root = Path(build_root_value)
+            topology_root = workspace.paths.topologies / "stress"
+
+            def refresh_build(*_arguments: object, **_keywords: object) -> Path:
+                with exclusive_lock(
+                    workspace.paths.builds / "locks" / "stress-a.lock",
+                    "stress build root",
+                ):
+                    atomic_json(build_root / MANAGED_MARKER, marker)
+                return build_root
+
+            def refresh_topology(
+                *_arguments: object, **_keywords: object
+            ) -> dict[str, object]:
+                with exclusive_lock(
+                    topology_root / "operation.lock", "stress topology"
+                ):
+                    atomic_json(topology_root / "status.json", status)
+                return copy.deepcopy(status)
+
+            ready.put(operation)
+            if not start.wait(5):
+                raise TimeoutError("mixed operation test did not start")
+            if operation == "build":
+                with mock.patch.object(
+                    workspace, "_build", side_effect=refresh_build
+                ):
+                    for _ in range(20):
+                        workspace.build("client", "stress", False)
+            elif operation == "topology":
+                with mock.patch.object(
+                    workspace, "_topology_up", side_effect=refresh_topology
+                ):
+                    for _ in range(20):
+                        workspace.topology_up(
+                            "stress", "default", "default", ["server"], None
+                        )
+            elif operation == "status":
+                with mock.patch(
+                    "atrinik_workspace.workspace.process_matches",
+                    return_value=False,
+                ):
+                    for _ in range(20):
+                        current = workspace.topology_status("stress")
+                        if current["resolved"] != status["resolved"]:
+                            raise AssertionError("topology coordinates changed")
+            else:
+                with mock.patch(
+                    "atrinik_workspace.cleanup.Cleanup._registered_worktree_paths",
+                    return_value=(set(), None),
+                ):
+                    for _ in range(20):
+                        report = workspace.cleanup(["builds"], 7, [], False)
+                        if report["inventory_errors"]:
+                            raise AssertionError(report["inventory_errors"])
+        results.put((operation, None))
+    except BaseException as error:
+        results.put((operation, f"{type(error).__name__}: {error}"))
         raise
 
 
@@ -5459,68 +5537,41 @@ class WorkspaceTests(unittest.TestCase):
             "error": "stress fixture",
         }
         atomic_json(topology_root / "status.json", status)
-        barrier = threading.Barrier(4)
-        build_lock = self.workspace.paths.builds / "locks" / "stress-a.lock"
-        topology_lock = topology_root / "operation.lock"
-
-        def refresh_build(*_arguments: object, **_keywords: object) -> Path:
-            with exclusive_lock(build_lock, "stress build root"):
-                atomic_json(build_root / MANAGED_MARKER, marker)
-            return build_root
-
-        def refresh_topology(
-            *_arguments: object, **_keywords: object
-        ) -> dict[str, object]:
-            with exclusive_lock(topology_lock, "stress topology"):
-                atomic_json(topology_root / "status.json", status)
-            return copy.deepcopy(status)
-
-        def repeat(operation: Callable[[], object]) -> list[object]:
-            barrier.wait(timeout=5)
-            return [operation() for _ in range(20)]
-
-        operations = (
-            lambda: self.workspace.build("client", "stress", False),
-            lambda: self.workspace.topology_up(
-                "stress", "default", "default", ["server"], None
-            ),
-            lambda: self.workspace.topology_status("stress"),
-            lambda: self.workspace.cleanup(["builds"], 7, [], False),
-        )
-        with (
-            mock.patch.object(self.workspace, "_build", side_effect=refresh_build),
-            mock.patch.object(
-                self.workspace, "_topology_up", side_effect=refresh_topology
-            ),
-            mock.patch(
-                "atrinik_workspace.workspace.process_matches", return_value=False
-            ),
-            mock.patch(
-                "atrinik_workspace.cleanup.Cleanup._registered_worktree_paths",
-                return_value=(set(), None),
-            ),
-            ThreadPoolExecutor(max_workers=4) as executor,
-        ):
-            results = [
-                future.result(timeout=15)
-                for future in [
-                    executor.submit(repeat, operation) for operation in operations
-                ]
-            ]
-
-        self.assertTrue(all(result == build_root for result in results[0]))
-        self.assertTrue(all(result == status for result in results[1]))
-        self.assertTrue(
-            all(
-                result["resolved"] == status["resolved"]
-                and "inert_historical_record" not in result
-                for result in results[2]
+        context = multiprocessing.get_context("spawn")
+        ready = context.Queue()
+        start = context.Event()
+        results = context.Queue()
+        operations = ("build", "topology", "status", "cleanup")
+        processes = [
+            context.Process(
+                target=mixed_layout_operation_process,
+                args=(
+                    str(self.wrapper),
+                    str(self.workspace_directory),
+                    operation,
+                    str(build_root),
+                    marker,
+                    status,
+                    ready,
+                    start,
+                    results,
+                ),
             )
-        )
-        self.assertEqual(
-            [result["inventory_errors"] for result in results[3]],
-            [[] for _ in results[3]],
-        )
+            for operation in operations
+        ]
+        try:
+            for process in processes:
+                process.start()
+            self.assertEqual(
+                {ready.get(timeout=5) for _ in processes}, set(operations)
+            )
+            start.set()
+        finally:
+            for process in processes:
+                process.join(timeout=20)
+        self.assertEqual([process.exitcode for process in processes], [0] * 4)
+        outcomes = dict(results.get(timeout=2) for _ in processes)
+        self.assertEqual(outcomes, {operation: None for operation in operations})
         self.assertEqual(load_json(build_root / MANAGED_MARKER), marker)
         self.assertEqual(load_json(topology_root / "status.json"), status)
 
@@ -5693,6 +5744,8 @@ class WorkspaceTests(unittest.TestCase):
             encoding="utf-8",
         )
         executable.chmod(0o755)
+        second_build_root = self.workspace.paths.builds / "fake-topology-second"
+        shutil.copytree(build_root, second_build_root, symlinks=True)
 
         with (
             mock.patch.object(
@@ -5713,7 +5766,9 @@ class WorkspaceTests(unittest.TestCase):
             )
             with (
                 mock.patch.object(
-                    self.workspace, "_build_resolved", return_value=build_root
+                    self.workspace,
+                    "_build_resolved",
+                    return_value=second_build_root,
                 ),
                 mock.patch.object(self.workspace, "_require_client_display"),
             ):
@@ -5839,6 +5894,11 @@ class WorkspaceTests(unittest.TestCase):
             encoding="utf-8",
         )
         client.chmod(0o755)
+        second_build_root = (
+            self.workspace.paths.builds / "profiles" / "fake-server-topology-second"
+        )
+        second_build_root.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(build_root, second_build_root, symlinks=True)
 
         with (
             mock.patch.object(
@@ -5927,10 +5987,15 @@ class WorkspaceTests(unittest.TestCase):
         state = self.workspace._state_location("default")
         second_state = self.workspace.state_add("second", None)
         layout_lock = self.workspace.paths.workspace / "repository-layout.lock"
+        profile_lock = (
+            self.workspace.paths.builds / "locks" / f"{build_root.name}.lock"
+        )
         try:
             with (
                 mock.patch.object(
-                    self.workspace, "_build_resolved", return_value=build_root
+                    self.workspace,
+                    "_build_resolved",
+                    return_value=second_build_root,
                 ),
                 mock.patch.object(
                     self.workspace, "_select_topology_port", return_value=17301
@@ -5984,6 +6049,11 @@ class WorkspaceTests(unittest.TestCase):
                     layout_lock, "repository layout", nonblocking=True
                 ):
                     self.fail("supervised client released its layout lock")
+            with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                with exclusive_lock(
+                    profile_lock, "profile build default", nonblocking=True
+                ):
+                    self.fail("supervised services released their build-root lock")
 
             supervisor = status["supervisor"]
             pidfd = os.pidfd_open(supervisor["pid"])
@@ -6017,6 +6087,11 @@ class WorkspaceTests(unittest.TestCase):
                     layout_lock, "repository layout", nonblocking=True
                 ):
                     self.fail("orphaned client released its layout lock")
+            with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                with exclusive_lock(
+                    profile_lock, "profile build default", nonblocking=True
+                ):
+                    self.fail("orphaned services released their build-root lock")
             recovered = self.workspace.topology_down("server-review", timeout=5)
             self.assertFalse(
                 any(service["running"] for service in recovered["services"].values())
@@ -6034,6 +6109,51 @@ class WorkspaceTests(unittest.TestCase):
             ):
                 self.workspace.topology_down("server-review", timeout=5)
 
+        with (
+            mock.patch.object(
+                self.workspace, "_build_resolved", return_value=build_root
+            ),
+            mock.patch.object(
+                self.workspace, "_select_topology_port", return_value=17302
+            ),
+        ):
+            server_only = self.workspace.topology_up(
+                "server-lease", "default", "default", ["server"], 17302
+            )
+        self.assertTrue(server_only["ready"])
+        for path, description in (
+            (layout_lock, "repository layout"),
+            (profile_lock, "profile build default"),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                with exclusive_lock(path, description, nonblocking=True):
+                    self.fail(f"server-only topology released {description}")
+        supervisor = server_only["supervisor"]
+        pidfd = os.pidfd_open(supervisor["pid"])
+        try:
+            signal.pidfd_send_signal(pidfd, signal.SIGKILL)
+        finally:
+            os.close(pidfd)
+        deadline = time.monotonic() + 5
+        while (
+            time.monotonic() < deadline
+            and self.workspace.topology_status("server-lease")["supervisor"][
+                "running"
+            ]
+        ):
+            time.sleep(0.05)
+        orphaned = self.workspace.topology_status("server-lease")
+        self.assertFalse(orphaned["supervisor"]["running"])
+        self.assertTrue(orphaned["services"]["server"]["running"])
+        for path, description in (
+            (layout_lock, "repository layout"),
+            (profile_lock, "profile build default"),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                with exclusive_lock(path, description, nonblocking=True):
+                    self.fail(f"orphaned server released {description}")
+        self.workspace.topology_down("server-lease", timeout=5)
+
         with exclusive_lock(Path(f"{state}.lock"), "server state", nonblocking=True):
             pass
         with exclusive_lock(
@@ -6041,6 +6161,10 @@ class WorkspaceTests(unittest.TestCase):
         ):
             pass
         with exclusive_lock(layout_lock, "repository layout", nonblocking=True):
+            pass
+        with exclusive_lock(
+            profile_lock, "profile build default", nonblocking=True
+        ):
             pass
 
     def test_topology_port_selection_rejects_unavailable_port(self) -> None:
@@ -6409,10 +6533,24 @@ class WorkspaceTests(unittest.TestCase):
         executable.write_text("client\n", encoding="utf-8")
         (build_root / "sources" / "client").mkdir(parents=True)
         expected = "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81"
+
+        def execute_client(*_arguments: object, **_keywords: object) -> None:
+            with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                with exclusive_lock(
+                    self.workspace.paths.builds
+                    / "locks"
+                    / "client-build.lock",
+                    "profile build default",
+                    nonblocking=True,
+                ):
+                    self.fail("foreground client released its build-root lock")
+
         with (
             mock.patch.object(self.workspace, "_build", return_value=build_root),
             mock.patch("builtins.print") as output,
-            mock.patch("atrinik_workspace.workspace.run") as execute,
+            mock.patch(
+                "atrinik_workspace.workspace.run", side_effect=execute_client
+            ) as execute,
             mock.patch.object(self.workspace, "_require_client_display"),
         ):
             result = self.workspace.run_client(


### PR DESCRIPTION
## Summary

- replace the repository-layout build/runtime lock with a fail-closed shared advisory lock
- preserve exclusive layout writers and per-build-root serialization with an explicit outer-to-inner lock order
- keep foreground client/server readers protected throughout their source-dependent lifecycle
- transfer layout and exact-build-root leases through foreground and supervised service processes until shutdown, including orphan recovery
- add deterministic spawned-process and mixed-operation stress coverage for overlap, serialization, writer waiting, and metadata coherence
- synchronize operator, architecture, and agent guidance with the new contract

## Validation

- `python3 -m coverage run -m unittest discover -v` — 456 tests passed
- `python3 -m coverage report --show-missing` — 81% total coverage
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `./atrinik cleanup --scope all --older-than 7 --dry-run --json` — 0 candidates, 0 errors
- `git diff --check`
- synchronized two-process public-build elapsed regression verifies independent shared-layout builds complete in less than 80% of the legacy-exclusive baseline

## Delivery

- Base: `main` at `38d8132c2b90f1e75b806ecae0ef0a87cd2b27d2`
- Head: `18e02dd4fd9a6a0434816b0d05955370869a7806`
- Runtime provisioning is not applicable: this changes wrapper lock coordination and is covered by deterministic process-level tests without starting game services.

Closes #328
