### PR TITLE
feat(classic): stage local playtest audio

### DIFF
--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -55,26 +55,23 @@ Reclaim review data only through preview-first cleanup:
 
 ```sh
 ./atrinik cleanup --dry-run --json
-./atrinik cleanup --scope worktrees --scope builds CHECKOUT... --older-than 7
-./atrinik cleanup --scope all --older-than 7 --apply
+./atrinik cleanup --scope sound-cache sound --older-than 7 --dry-run --json
+./atrinik cleanup --scope sound-cache sound --older-than 7 --apply
+./atrinik cleanup --scope worktrees sound --older-than 7 --dry-run --json
+./atrinik cleanup --scope worktrees sound --older-than 7 --apply
 ```
 
-Default scope covers worktrees, profile builds, Worker installs, and stale
-transactions; npm/compiler caches are opt-in. Text uses IEC; JSON uses bytes.
-References,
-ambiguous Git,
-and unsafe paths/markers protect targets. Only an `atrinik/atrinik@main`
-worktree directly below `build/worktrees/` has the historical-base exception:
-its PR targets `master` and supplies head, base, and merge SHAs; the merge's
-first parent equals the base, and the merge is ancestral to frozen boundary
-`ee5ba2096c94bce0161629423d4962a966bc61d8`. Proof ignores replace refs and
-rejects `info/grafts`. Under the layout lock, `--apply` reinventories and reruns
-proof plus exact-target safety; uncertainty fails closed. Status uses
-`--ignore-submodules=none`; populated submodule Git data protects. Cleanup
-removes builds first via non-force Git, preserving branch refs, profiles,
-scenarios, states, topology records/logs, migrations, retention records, Git
-objects, review reports, and unmarked paths. Hand off exact fixtures, JSON
-commands, reasons, and preserved records.
+Default cleanup covers worktrees/builds; npm, compiler, and sound caches are
+opt-in. Apply sound-cache before a fresh worktree preview/apply because every
+remaining cache protects its worktree. Sound build/verify shares the exact
+versioned Git-admin lease; removal locks its same inode exclusively. Missing,
+replaced, invalid, or busy leases fail closed. References, ambiguous Git,
+unsafe paths/markers, populated submodules, replace refs, and grafts protect
+targets. The sole historical-base exception is the frozen
+`atrinik/atrinik@main` `build/worktrees/` contract at
+`ee5ba2096c94bce0161629423d4962a966bc61d8`. Apply re-inventories under the
+layout lock and removes only exact proven targets through non-force Git while
+preserving refs, state, records, Git objects, reports, and unmarked paths.
 
 ## Compose coherent sources
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Atrinik 2026 Linux Build",
-  "image": "ghcr.io/atrinik/linux-build:1.0.5@sha256:be3427cfc7dabcf837450c7306d55883c32e20ba1ab7cc96b4da4b966b8066de",
+  "image": "ghcr.io/atrinik/linux-build:1.2.0@sha256:1231b39d40161c1199fd3e45e99e3d826dde02dade79729c030cc0ce3710898f",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:4": {
       "moby": false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,3 +77,10 @@ For CMake/cache changes, also repeat an unchanged build, exercise
 `--force-reconfigure` and `--no-ccache`, inspect `ccache --show-stats` when the
 command is installed, and preview shared-cache retention with
 `./atrinik cleanup --scope compiler-cache --dry-run --json`.
+
+For local-playtest sound staging changes, use a clean sound checkout that owns
+the public playtest-tree builder. Run the focused wrapper sound fixtures, build
+`classic-client` twice from the same Classic-derived local-playtest profile,
+inspect matching build/topology sound records, and run the complete Classic
+supply-chain audit. The generated tree remains ignored, nonpublishable local
+state; never attach, package, upload, or commit it.

--- a/README.md
+++ b/README.md
@@ -534,13 +534,15 @@ without changing the filesystem:
 ./atrinik cleanup --dry-run --json
 ./atrinik cleanup --scope worktrees classic-server --older-than 14
 ./atrinik cleanup --scope builds --scope npm-cache --scope compiler-cache --older-than 0
+./atrinik cleanup --scope sound-cache --older-than 7 --dry-run --json
 ./atrinik cleanup --scope all --older-than 7 --apply
 ~~~
 
 `--dry-run` is the explicit spelling of the default mode; only `--apply`
 mutates. Repeated `--scope` options combine `worktrees`, `builds`, and the
-opt-in `npm-cache` and `compiler-cache`; `all` selects all four. Positional checkout or logical
-component names narrow only the worktree inventory and still deduplicate
+opt-in `npm-cache`, `compiler-cache`, and `sound-cache`; `all` selects all five.
+Positional checkout or logical component names narrow worktree and sound-cache
+inventory and still deduplicate
 aliases to one physical checkout. The special `atrinik` filter selects wrapper
 worktrees. JSON output is stable schema-versioned data and keeps Git/GitHub
 diagnostics off stdout; its byte fields remain exact integers. Text output uses
@@ -617,12 +619,27 @@ top-level `build/` entries are report-only `unmanaged-build` items. Deep-review 
 builds, packages, archives, and unregistered siblings are never recursively
 deleted.
 
+The explicit `sound-cache` scope inventories only 20-hex exact-input trees
+below `build/atrinik-workspace/` in registered `atrinik/sound` primary and
+linked worktrees. It requires the exact nonpublishing playtest marker, safe
+Git-proven containment, conservative tree age, and an idle producer build
+lock. Apply repeats those proofs under that lock before removing one tree;
+invalid, active, young, unregistered, or uncertain entries remain protected.
+Every remaining producer cache, plus any busy or invalid per-output lock,
+protects its containing sound worktree from ordinary worktree cleanup,
+including `--scope all`. Run the sound-cache apply first and preview worktrees
+again afterward. Producer build/verify commands hold a shared Git-admin lease;
+worktree removal holds its exclusive side from final proof through Git removal,
+so a producer cannot start in the removal window. A sound worktree without the
+versioned producer lease marker is not reclaimable by wrapper cleanup.
+
 Apply holds the repository-layout lock and performs one complete inventory and
 size recomputation. Immediately before each removal it freshly revalidates the
 target's safety dependencies without rescanning unrelated report-only payloads.
-Any new uncertainty fails closed. It removes eligible builds first, exact Git
-worktrees second, and the explicitly selected cache or safely shared prunable
-Git metadata last. A pre-mutation race aborts without deletion; after the first
+Any new uncertainty fails closed. It removes eligible profile builds and
+explicit sound-cache entries first, exact Git worktrees second, other explicit
+caches next, and safely shared prunable Git metadata last. A pre-mutation race
+aborts without deletion; after the first
 successful mutation, the deterministic policy stops on the first error and
 reports exactly what was reclaimed without claiming rollback.
 
@@ -649,9 +666,10 @@ component, or one of its roles updates all five classic selectors together.
 The `classic-server` alias above has the same checkout-wide effect as naming
 `classic`: every classic logical component comes from `socket-review`.
 Resolution then returns the appropriate `server/`, `client/`, `editor/`,
-`libatrinik/`, or `protocol/` source root for each component. Profile schema 3
+`libatrinik/`, or `protocol/` source root for each component. Profile schema 4
 rejects different selectors for logical components that share one physical
-checkout.
+checkout and records the selected sound mode. Existing schema-3 profiles load
+as `source` mode and are upgraded when next changed.
 
 Clone an existing profile when starting a related combination instead of
 repeating every selector:
@@ -708,10 +726,41 @@ valid. Dirty inputs rebuild every time and do not receive reusable metadata;
 inputs are checked again after generation so a concurrent checkout change
 cannot replace the previous valid cache. Only tracked files below the resource
 repository's `runtime-paths.txt` allowlist are staged; development metadata and
-untracked files cannot become server assets. Client builds similarly expose the
-selected sound checkout. These operations never write generated files into a
-component checkout. The caches remain under the marker-owned profile build, so
-ordinary build retention and preview-first cleanup cover them.
+untracked files cannot become server assets. Client builds expose the selected
+sound checkout by default. A saved profile derived from `classic` may instead
+opt into the complete local-only compatibility tree supplied by the selected
+sound checkout:
+
+~~~sh
+./atrinik profile create classic-audio --from classic
+./atrinik profile set classic-audio sound --worktree issue-27-playtest-tree
+./atrinik profile sound-mode classic-audio local-playtest
+./atrinik profile show classic-audio --json
+./atrinik build classic-client --profile classic-audio --test
+./atrinik topology show classic-audio --service client --json
+~~~
+
+The built-in `classic` profile and every replacement profile remain in `source`
+mode. Local-playtest mode requires a clean selected sound checkout with the
+public `tools/sound_release.py build-playtest-tree` command. That repository
+owns conversion and full decoder verification; it writes only to its ignored
+`build/atrinik-workspace/` state. The wrapper independently requires the
+version-1 nonpublishing marker and schema, exact 339-key closure, every
+source-manifest-derived byte-preserved Vorbis or rendered Opus mapping
+(including payloads stored at legacy extensions), every payload/hash/count,
+immutable input hashes, and the complete tree digest. It never falls back to
+the raw mixed-format checkout.
+
+Exact clean inputs reuse the same verified local output without network access.
+The profile build and supervised client runtime link that one root, and their
+JSON records include its mode, source commit/tree, clean-state result,
+manifest/toolchain/schema/marker/blocker hashes, counts, and output digest.
+The tree is not an archive or released-runtime input and cannot enter the
+wrapper's `PACKAGE_TYPE=none` Classic build path as a package. A changed input
+gets a distinct cache key; failed or racing generation leaves existing output
+untouched. Wrapper-owned profile builds remain covered by ordinary retention.
+Sound-owned ignored outputs are preserved by default and are reclaimed only
+through the explicit preview-first `sound-cache` cleanup scope described above.
 
 ## Deterministic test scenarios
 

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import contextmanager
 from contextvars import copy_context
 from datetime import datetime, timezone
 import fcntl
@@ -10,7 +11,7 @@ from pathlib import Path, PurePosixPath
 import re
 import stat
 import subprocess
-from typing import Any, Iterable
+from typing import Any, Iterable, Iterator
 
 from .locking import active_lock_fds
 from .migration import MIGRATION_PENDING, MIGRATION_RECORD, OPERATION_PATHS
@@ -23,6 +24,7 @@ from .model import (
     managed_remove,
 )
 from .supervisor import process_matches
+from .sound import PLAYTEST_MARKER
 from .workspace import (
     BUILD_METADATA,
     BUILD_METADATA_SCHEMA_VERSION,
@@ -42,9 +44,10 @@ WORKER_DEPENDENCY_CLEANUP_SCHEMA_VERSIONS = frozenset(
     {1, 2, 3, WORKER_DEPENDENCY_SCHEMA_VERSION}
 )
 DEFAULT_SCOPES = ("worktrees", "builds")
-ALL_SCOPES = (*DEFAULT_SCOPES, "npm-cache", "compiler-cache")
+ALL_SCOPES = (*DEFAULT_SCOPES, "npm-cache", "compiler-cache", "sound-cache")
 BUILD_RETENTION_RECORD = "retention.json"
-BUILD_METADATA_KEYS = {
+LEGACY_BUILD_METADATA_SCHEMA_VERSION = 1
+LEGACY_BUILD_METADATA_KEYS = {
     "schema_version",
     "profile",
     "key",
@@ -52,6 +55,7 @@ BUILD_METADATA_KEYS = {
     "coordinates",
     "last_used_at",
 }
+BUILD_METADATA_KEYS = {*LEGACY_BUILD_METADATA_KEYS, "sound"}
 BUILD_COORDINATE_KEYS = {
     "component",
     "checkout",
@@ -66,6 +70,8 @@ PROFILE_PURPOSE = re.compile(
     r"^profile:(?P<profile>[a-z0-9][a-z0-9._-]*):(?P<key>[0-9a-f]{12})$"
 )
 HEAD_PATTERN = re.compile(r"^[0-9a-f]{40,64}$")
+SOUND_PRODUCER_LOCK = "atrinik-playtest-builds.lock"
+SOUND_PRODUCER_LOCK_MARKER = "atrinik-sound-playtest-builds-v1\n"
 HISTORICAL_PULL_BASE_BOUNDARIES = {
     (
         "atrinik/atrinik",
@@ -131,6 +137,147 @@ def _git_directories(path: Path) -> tuple[Path, Path]:
     if len(values) != 2 or not all(values):
         raise WorkspaceError(f"git returned invalid directory metadata at {path}")
     return Path(values[0]).resolve(), Path(values[1]).resolve()
+
+
+def _regular_text_identity(path: Path) -> tuple[str, tuple[int, int, int, int]]:
+    flags = os.O_RDONLY | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags)
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+            raise WorkspaceError(f"Git worktree pointer is not a safe regular file: {path}")
+        with os.fdopen(os.dup(descriptor), "r", encoding="utf-8") as stream:
+            value = stream.read(4097)
+        if len(value) > 4096:
+            raise WorkspaceError(f"Git worktree pointer is oversized: {path}")
+        return value, (
+            metadata.st_dev,
+            metadata.st_ino,
+            metadata.st_ctime_ns,
+            metadata.st_size,
+        )
+    finally:
+        os.close(descriptor)
+
+
+def _sound_worktree_identity(worktree: Path, common: Path) -> tuple[Any, ...]:
+    """Bind a sound path to its exact primary or linked Git admin record."""
+    common = common.resolve()
+    reported_common, git_directory = _git_directories(worktree)
+    if reported_common != common:
+        raise WorkspaceError("sound worktree has an unexpected Git common directory")
+    worktree_metadata = worktree.lstat()
+    if not stat.S_ISDIR(worktree_metadata.st_mode) or stat.S_ISLNK(worktree_metadata.st_mode):
+        raise WorkspaceError("sound worktree path is not a safe directory")
+    pointer = worktree / ".git"
+    if git_directory == common:
+        pointer_metadata = pointer.lstat()
+        if (
+            stat.S_ISLNK(pointer_metadata.st_mode)
+            or not stat.S_ISDIR(pointer_metadata.st_mode)
+            or pointer.resolve() != common
+        ):
+            raise WorkspaceError("sound primary Git directory is invalid")
+        return (
+            "primary",
+            worktree_metadata.st_dev,
+            worktree_metadata.st_ino,
+            pointer_metadata.st_dev,
+            pointer_metadata.st_ino,
+            str(common),
+        )
+    pointer_value, pointer_identity = _regular_text_identity(pointer)
+    prefix = "gitdir: "
+    if not pointer_value.endswith("\n") or not pointer_value.startswith(prefix):
+        raise WorkspaceError("sound linked-worktree pointer is invalid")
+    raw_git_directory = pointer_value.removeprefix(prefix).strip()
+    pointer_git_directory = Path(raw_git_directory)
+    if not pointer_git_directory.is_absolute():
+        pointer_git_directory = pointer.parent / pointer_git_directory
+    if pointer_git_directory.resolve() != git_directory:
+        raise WorkspaceError("sound linked-worktree pointer changed identity")
+    admin_metadata = git_directory.lstat()
+    if (
+        stat.S_ISLNK(admin_metadata.st_mode)
+        or not stat.S_ISDIR(admin_metadata.st_mode)
+        or git_directory.parent.resolve() != (common / "worktrees").resolve()
+    ):
+        raise WorkspaceError("sound linked-worktree Git directory is invalid")
+    backlink_value, backlink_identity = _regular_text_identity(git_directory / "gitdir")
+    backlink = Path(backlink_value.strip())
+    if not backlink.is_absolute():
+        backlink = git_directory / backlink
+    if backlink.resolve() != pointer.resolve():
+        raise WorkspaceError("sound linked-worktree Git backlink does not match its path")
+    return (
+        "linked",
+        worktree_metadata.st_dev,
+        worktree_metadata.st_ino,
+        *pointer_identity,
+        admin_metadata.st_dev,
+        admin_metadata.st_ino,
+        *backlink_identity,
+        str(common),
+        str(git_directory),
+    )
+
+
+def _sound_producer_lock_snapshot(
+    worktree: Path,
+) -> tuple[Path, tuple[int, int, int, int]]:
+    path = _git_directory(worktree) / SOUND_PRODUCER_LOCK
+    marker, identity = _regular_text_identity(path)
+    if marker != SOUND_PRODUCER_LOCK_MARKER or path.lstat().st_uid != os.geteuid():
+        raise WorkspaceError("sound producer cleanup lease marker is invalid")
+    return path, identity
+
+
+@contextmanager
+def _exclusive_sound_producer_lease(
+    worktree: Path,
+    expected_identity: tuple[int, int, int, int],
+) -> Iterator[None]:
+    path = _git_directory(worktree) / SOUND_PRODUCER_LOCK
+    flags = os.O_RDWR | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags)
+    try:
+        metadata = os.fstat(descriptor)
+        identity = (
+            metadata.st_dev,
+            metadata.st_ino,
+            metadata.st_ctime_ns,
+            metadata.st_size,
+        )
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+            or metadata.st_uid != os.geteuid()
+            or identity != expected_identity
+        ):
+            raise WorkspaceError("sound producer cleanup lease changed identity")
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as error:
+            raise WorkspaceError("sound playtest producer is already in use") from error
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        marker = os.read(descriptor, len(SOUND_PRODUCER_LOCK_MARKER.encode()) + 1)
+        try:
+            path_metadata = path.lstat()
+        except OSError as error:
+            raise WorkspaceError("sound producer cleanup lease path changed") from error
+        if (
+            marker != SOUND_PRODUCER_LOCK_MARKER.encode()
+            or (path_metadata.st_dev, path_metadata.st_ino)
+            != (metadata.st_dev, metadata.st_ino)
+        ):
+            raise WorkspaceError("sound producer cleanup lease changed while locking")
+        yield
+    finally:
+        os.close(descriptor)
 
 
 def _parse_time(value: Any, context: str) -> datetime:
@@ -462,6 +609,10 @@ class Cleanup:
             )
             if cache is not None:
                 items.append(cache)
+        if "sound-cache" in scopes and (names is None or "sound" in names):
+            items.extend(
+                self._sound_caches(older_than_days, reference_errors)
+            )
         items.sort(key=lambda item: (item["kind"], item["owner"], item["path"]))
         self._credit_sizes(items)
         for item in items:
@@ -492,6 +643,10 @@ class Cleanup:
         item.pop("_purpose", None)
         item.pop("_older_than_days", None)
         item.pop("_identity", None)
+        item.pop("_worktree_identity", None)
+        item.pop("_git_common", None)
+        item.pop("_sound_worktree_identity", None)
+        item.pop("_sound_producer_identity", None)
 
     def _revalidate_target(
         self,
@@ -560,13 +715,35 @@ class Cleanup:
             )
             if item is not None and item["path"] != target["path"]:
                 item = None
+        elif kind == "sound-cache":
+            item = next(
+                (
+                    candidate
+                    for candidate in self._sound_caches(
+                        older_than_days, reference_errors
+                    )
+                    if candidate["path"] == target["path"]
+                ),
+                None,
+            )
         else:
             raise WorkspaceError(f"unsupported cleanup target: {kind}")
         if item is not None:
             filesystem_identity = item.get("_identity")
+            worktree_identity = item.get("_worktree_identity")
+            git_common = item.get("_git_common")
+            sound_worktree_identity = item.get("_sound_worktree_identity")
+            sound_producer_identity = item.get("_sound_producer_identity")
             self._strip_internal(item)
-            if kind == "worker-dependency-transaction":
+            if kind in {"worker-dependency-transaction", "sound-cache"}:
                 item["_identity"] = filesystem_identity
+            if kind == "sound-cache":
+                item["_worktree_identity"] = worktree_identity
+                item["_git_common"] = git_common
+                item["_sound_producer_identity"] = sound_producer_identity
+            if kind == "worktree" and target["owner"] == "sound":
+                item["_sound_worktree_identity"] = sound_worktree_identity
+                item["_sound_producer_identity"] = sound_producer_identity
         return item
 
     def _revalidate_build_sources(
@@ -1236,6 +1413,25 @@ class Cleanup:
         if not path.is_dir():
             item["reasons"].append("missing_worktree")
             return item
+        if owner == "sound":
+            try:
+                item["_sound_worktree_identity"] = _sound_worktree_identity(
+                    path, common
+                )
+            except (OSError, RuntimeError, WorkspaceError) as error:
+                item["reasons"].append("unexpected_git_worktree_identity")
+                item["error"] = str(error)
+                item["_sound_worktree_identity"] = None
+            try:
+                _producer_path, producer_identity = (
+                    _sound_producer_lock_snapshot(path)
+                )
+                item["_sound_producer_identity"] = producer_identity
+            except FileNotFoundError:
+                item["_sound_producer_identity"] = None
+            except (OSError, RuntimeError, WorkspaceError):
+                item["_sound_producer_identity"] = None
+            item["reasons"].extend(self._sound_worktree_lock_reasons(path))
         try:
             worktree_common, worktree_git = _git_directories(path)
             if worktree_common != common:
@@ -1274,6 +1470,48 @@ class Cleanup:
             item["disposition"] = "skipped"
             item["reasons"] = ["github_pending"]
         return item
+
+    def _sound_worktree_lock_reasons(self, worktree: Path) -> list[str]:
+        reasons: list[str] = []
+        try:
+            producer_lock, _producer_identity = _sound_producer_lock_snapshot(
+                worktree
+            )
+            producer_busy, producer_error = self._lock_busy(producer_lock)
+        except FileNotFoundError:
+            reasons.append("sound_cleanup_lease_unavailable")
+            producer_busy, producer_error = False, None
+        except (OSError, RuntimeError, WorkspaceError):
+            reasons.append("sound_cache_lock_uncertain")
+            producer_busy, producer_error = False, None
+        if producer_error:
+            reasons.append("sound_cache_lock_uncertain")
+        elif producer_busy:
+            reasons.append("active_sound_build")
+        build_root = worktree / "build"
+        cache_root = build_root / "atrinik-workspace"
+        if not cache_root.exists() and not cache_root.is_symlink():
+            return reasons
+        if (
+            build_root.is_symlink()
+            or cache_root.is_symlink()
+            or not cache_root.is_dir()
+        ):
+            return sorted(set([*reasons, "sound_cache_lock_uncertain"]))
+        try:
+            children = sorted(cache_root.iterdir())
+        except OSError:
+            return sorted(set([*reasons, "sound_cache_lock_uncertain"]))
+        for child in children:
+            if not re.fullmatch(r"\.[0-9a-f]{20}\.build\.lock", child.name):
+                reasons.append("sound_cache_present")
+                continue
+            busy, error = self._lock_busy(child)
+            if error:
+                reasons.append("sound_cache_lock_uncertain")
+            elif busy:
+                reasons.append("active_sound_build")
+        return sorted(set(reasons))
 
     @staticmethod
     def _operation_in_progress(path: Path) -> bool:
@@ -2161,10 +2399,22 @@ class Cleanup:
         if path.is_symlink() or not path.is_file():
             raise WorkspaceError("build metadata is not a regular file")
         value = load_json(path)
-        if not isinstance(value, dict) or set(value) != BUILD_METADATA_KEYS:
+        if not isinstance(value, dict):
+            raise WorkspaceError("build metadata fields are invalid")
+        schema_version = value.get("schema_version")
+        expected_keys = (
+            LEGACY_BUILD_METADATA_KEYS
+            if schema_version == LEGACY_BUILD_METADATA_SCHEMA_VERSION
+            else BUILD_METADATA_KEYS
+        )
+        if set(value) != expected_keys:
             raise WorkspaceError("build metadata fields are invalid")
         if (
-            value.get("schema_version") != BUILD_METADATA_SCHEMA_VERSION
+            schema_version
+            not in {
+                LEGACY_BUILD_METADATA_SCHEMA_VERSION,
+                BUILD_METADATA_SCHEMA_VERSION,
+            }
             or value.get("profile") != item["profile"]
             or value.get("key") != item["key"]
             or value.get("purpose") != item["_purpose"]
@@ -2205,6 +2455,11 @@ class Cleanup:
                     raise WorkspaceError("build coordinate source path is invalid")
             except RuntimeError as error:
                 raise WorkspaceError("build coordinate path cannot be resolved") from error
+        if schema_version == BUILD_METADATA_SCHEMA_VERSION:
+            sound = value.get("sound")
+            if sound is not None:
+                from .sound import validate_sound_record
+                validate_sound_record(sound)
         return value
 
     def _build_lock_busy(self, profile: str, key: str) -> tuple[bool, str | None]:
@@ -2316,6 +2571,156 @@ class Cleanup:
             legacy_allowed=False,
         )
 
+    def _sound_caches(
+        self, older_than_days: int, reference_errors: set[str]
+    ) -> list[dict[str, Any]]:
+        checkout = self.manifest.by_checkout.get("sound")
+        if checkout is None:
+            return []
+        invocation = self.paths.repositories / checkout.path
+        if not invocation.exists() and not invocation.is_symlink():
+            return []
+        try:
+            common, records, _primary = self._repository_inventory(
+                checkout.repository, invocation
+            )
+        except (OSError, RuntimeError, WorkspaceError):
+            reference_errors.add("sound_cache_inventory_error")
+            return []
+        items: list[dict[str, Any]] = []
+        seen: set[Path] = set()
+        for row in records:
+            raw = row.get("worktree")
+            if raw is None:
+                continue
+            worktree = Path(raw)
+            build_root = worktree / "build"
+            cache_root = build_root / "atrinik-workspace"
+            try:
+                worktree_identity = _sound_worktree_identity(worktree, common)
+                if (
+                    worktree.is_symlink()
+                    or not worktree.is_dir()
+                    or build_root.is_symlink()
+                    or not build_root.is_dir()
+                    or cache_root.is_symlink()
+                    or not cache_root.is_dir()
+                ):
+                    continue
+                children = sorted(cache_root.iterdir())
+            except (OSError, RuntimeError, WorkspaceError):
+                reference_errors.add("sound_cache_inventory_error")
+                continue
+            try:
+                _producer_path, producer_identity = (
+                    _sound_producer_lock_snapshot(worktree)
+                )
+            except (OSError, RuntimeError, WorkspaceError):
+                producer_identity = None
+            for path in children:
+                if path.name.startswith("."):
+                    continue
+                try:
+                    if path.is_symlink():
+                        raise WorkspaceError("sound cache child is a symlink")
+                    normalized = path.resolve(strict=False)
+                except (OSError, RuntimeError, WorkspaceError):
+                    reference_errors.add("sound_cache_inventory_error")
+                    continue
+                if normalized in seen:
+                    continue
+                seen.add(normalized)
+                item = self._sound_cache_item(path, worktree, older_than_days)
+                item["_worktree_identity"] = worktree_identity
+                item["_git_common"] = str(common)
+                item["_sound_producer_identity"] = producer_identity
+                if producer_identity is None:
+                    item["disposition"] = "skipped"
+                    if item["reasons"] == ["stale_sound_cache"]:
+                        item["reasons"] = []
+                    item["reasons"].append("sound_cleanup_lease_unavailable")
+                items.append(item)
+        return items
+
+    def _sound_cache_item(
+        self,
+        path: Path,
+        worktree: Path,
+        older_than_days: int,
+        *,
+        check_lock: bool = True,
+    ) -> dict[str, Any]:
+        item = _base_item("sound-cache", "sound", "atrinik/sound", path)
+        item["checkout_path"] = str(worktree.resolve(strict=False))
+        inodes, observed, error = _tree_usage(path, [])
+        item["_inodes"] = inodes
+        try:
+            metadata = path.lstat()
+            item["_identity"] = (
+                metadata.st_dev,
+                metadata.st_ino,
+                metadata.st_ctime_ns,
+                stat.S_IFMT(metadata.st_mode),
+                stat.S_IMODE(metadata.st_mode),
+            )
+        except OSError:
+            item["_identity"] = None
+        item["age_basis"] = "tree-mtime" if observed else None
+        item["age_seconds"] = (
+            max(0, int((self.now - observed).total_seconds()))
+            if observed
+            else None
+        )
+        reasons: list[str] = []
+        expected_marker = {
+            "format": "atrinik-sound-playtest-tree",
+            "playtest_only": True,
+            "publishable": False,
+            "schema_version": 1,
+        }
+        try:
+            build_root = worktree / "build"
+            cache_root = build_root / "atrinik-workspace"
+            expected_parent = (
+                cache_root.resolve(strict=False)
+            )
+            marker = path / PLAYTEST_MARKER
+            if (
+                not re.fullmatch(r"[0-9a-f]{20}", path.name)
+                or worktree.is_symlink()
+                or build_root.is_symlink()
+                or cache_root.is_symlink()
+                or path.parent.resolve(strict=False) != expected_parent
+                or path.is_symlink()
+                or not path.is_dir()
+                or marker.is_symlink()
+                or not marker.is_file()
+                or load_json(marker) != expected_marker
+            ):
+                reasons.append("invalid_sound_cache_ownership")
+        except (OSError, RuntimeError, WorkspaceError):
+            reasons.append("invalid_sound_cache_ownership")
+        if check_lock:
+            lock = path.parent / f".{path.name}.build.lock"
+            busy, lock_error = self._lock_busy(lock)
+            if busy:
+                reasons.append("active_build_lock")
+            if lock_error:
+                reasons.append("invalid_build_lock")
+                item["error"] = lock_error
+        if error:
+            reasons.append("filesystem_traversal_error")
+            item["error"] = error
+        if observed is None:
+            reasons.append("age_unknown")
+        elif observed > self.now:
+            reasons.append("future_timestamp")
+        elif (self.now - observed).total_seconds() < older_than_days * 86400:
+            reasons.append("retained_by_age")
+        item["reasons"] = reasons or ["stale_sound_cache"]
+        item["disposition"] = "eligible" if not reasons else "skipped"
+        return item
+
     def _shared_cache(
         self,
         kind: str,
@@ -2386,7 +2791,11 @@ class Cleanup:
                 if (
                     not isinstance(metadata, dict)
                     or set(metadata) != expected_fields
-                    or metadata.get("schema_version") != BUILD_METADATA_SCHEMA_VERSION
+                    or metadata.get("schema_version")
+                    not in {
+                        LEGACY_BUILD_METADATA_SCHEMA_VERSION,
+                        BUILD_METADATA_SCHEMA_VERSION,
+                    }
                     or metadata.get("purpose") != purpose
                     or (
                         kind == "compiler-cache"
@@ -2479,6 +2888,7 @@ class Cleanup:
             "worktree": 1,
             "npm-cache": 2,
             "compiler-cache": 2,
+            "sound-cache": 0,
             "prunable-metadata": 3,
         }
         return order.get(item["kind"], 99), item["path"]
@@ -2596,7 +3006,59 @@ class Cleanup:
                 remove_owned_tree(path)
         elif item["kind"] == "worktree":
             primary = self._repositories[item["owner"]]
-            _command(primary, "worktree", "remove", "--", str(path))
+            if item["owner"] != "sound":
+                _command(primary, "worktree", "remove", "--", str(path))
+            else:
+                common = _git_common_directory(primary)
+                expected_worktree_identity = item.get(
+                    "_sound_worktree_identity"
+                )
+                expected_producer_identity = item.get(
+                    "_sound_producer_identity"
+                )
+                if (
+                    expected_worktree_identity is None
+                    or expected_producer_identity is None
+                    or _sound_worktree_identity(path, common)
+                    != expected_worktree_identity
+                ):
+                    raise WorkspaceError(
+                        "sound worktree identity changed before removal"
+                    )
+                with _exclusive_sound_producer_lease(
+                    path, expected_producer_identity
+                ):
+                    if (
+                        _sound_worktree_identity(path, common)
+                        != expected_worktree_identity
+                    ):
+                        raise WorkspaceError(
+                            "sound worktree identity changed while locking"
+                        )
+                    build_root = path / "build"
+                    cache_root = build_root / "atrinik-workspace"
+                    if cache_root.exists() or cache_root.is_symlink():
+                        if (
+                            build_root.is_symlink()
+                            or cache_root.is_symlink()
+                            or not cache_root.is_dir()
+                        ):
+                            raise WorkspaceError(
+                                "sound cache root changed before worktree removal"
+                            )
+                        for child in sorted(cache_root.iterdir()):
+                            if not re.fullmatch(
+                                r"\.[0-9a-f]{20}\.build\.lock", child.name
+                            ):
+                                raise WorkspaceError(
+                                    "sound cache remains before worktree removal"
+                                )
+                            busy, error = self._lock_busy(child)
+                            if busy or error:
+                                raise WorkspaceError(
+                                    "sound cache lock changed before worktree removal"
+                                )
+                    _command(primary, "worktree", "remove", "--", str(path))
         elif item["kind"] in {"npm-cache", "compiler-cache"}:
             purpose = item["kind"]
             if item.get("legacy_known_cache"):
@@ -2608,6 +3070,36 @@ class Cleanup:
                     {"schema_version": SCHEMA_VERSION, "purpose": purpose},
                 )
             managed_remove(path, self.paths.builds, purpose)
+        elif item["kind"] == "sound-cache":
+            checkout_path = Path(item["checkout_path"])
+            git_common = item.get("_git_common")
+            producer_identity = item.get("_sound_producer_identity")
+            if not isinstance(git_common, str) or (
+                _sound_worktree_identity(checkout_path, Path(git_common))
+                != item.get("_worktree_identity")
+            ) or producer_identity is None:
+                raise WorkspaceError("sound worktree identity changed before removal")
+            expected_parent = (
+                checkout_path / "build" / "atrinik-workspace"
+            ).resolve(strict=False)
+            if path.parent.resolve(strict=False) != expected_parent:
+                raise WorkspaceError("sound cache path changed before removal")
+            lock = path.parent / f".{path.name}.build.lock"
+            with _exclusive_sound_producer_lease(
+                checkout_path, producer_identity
+            ):
+                with exclusive_lock(
+                    lock, f"sound cache {path.name}", nonblocking=True
+                ):
+                    current = self._sound_cache_item(
+                        path, checkout_path, older_than_days, check_lock=False
+                    )
+                    if (
+                        current["disposition"] != "eligible"
+                        or current.get("_identity") != item.get("_identity")
+                    ):
+                        raise WorkspaceError("sound cache changed before removal")
+                    remove_owned_tree(path)
         elif item["kind"] == "prunable-metadata":
             primary = self._repositories[item["owner"]]
             _command(primary, "worktree", "prune", "--expire", "now")

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -166,7 +166,10 @@ def parser() -> argparse.ArgumentParser:
     cleanup.add_argument(
         "--scope",
         action="append",
-        choices=["worktrees", "builds", "npm-cache", "compiler-cache", "all"],
+        choices=[
+            "worktrees", "builds", "npm-cache", "compiler-cache",
+            "sound-cache", "all",
+        ],
         default=[],
     )
     mark(cleanup.add_argument("--older-than", type=int, default=7, metavar="DAYS"), "none")
@@ -190,6 +193,13 @@ def parser() -> argparse.ArgumentParser:
     profile_show = profile_commands.add_parser("show")
     mark(profile_show.add_argument("name", nargs="?", default="default"), "profile")
     profile_show.add_argument("--json", action="store_true")
+    profile_sound = profile_commands.add_parser(
+        "sound-mode", help="select raw source or local Classic playtest sound"
+    )
+    mark(profile_sound.add_argument("name"), "saved_profile")
+    profile_sound.add_argument(
+        "mode", choices=["source", "local-playtest"]
+    )
 
     path = commands.add_parser(
         "path", help="print a resolved logical-component source path"
@@ -586,6 +596,8 @@ def main(arguments: list[str] | None = None) -> int:
                     workspace.set_profile(
                         options.name, options.component, "path", str(options.path)
                     )
+            elif options.profile_command == "sound-mode":
+                workspace.set_profile_sound_mode(options.name, options.mode)
             else:
                 summary = workspace.profile_summary(options.name)
                 if options.json:
@@ -593,6 +605,7 @@ def main(arguments: list[str] | None = None) -> int:
                 else:
                     print(f"profile\t{summary['name']}")
                     print(f"stack\t{summary['stack']}")
+                    print(f"sound-mode\t{summary['sound_mode']}")
                     for row in summary["components"]:
                         if not row["initialized"]:
                             print(
@@ -625,6 +638,8 @@ def main(arguments: list[str] | None = None) -> int:
             else:
                 print(f"profile\t{summary['profile']}")
                 print(f"stack\t{summary['stack']}")
+                sound = summary.get("sound", {"mode": "source"})
+                print(f"sound-mode\t{sound['mode']}")
                 print(f"services\t{','.join(summary['services'])}")
                 print(f"dependencies\t{','.join(summary['dependencies'])}")
                 for role, provider in sorted(summary["providers"].items()):

--- a/atrinik_workspace/migration.py
+++ b/atrinik_workspace/migration.py
@@ -23,7 +23,8 @@ from .supervisor import process_matches
 
 
 PLAN_SCHEMA_VERSION = 2
-PROFILE_SCHEMA_VERSION = 3
+PROFILE_SCHEMA_VERSION = 4
+LEGACY_PROFILE_SCHEMA_VERSION = 3
 MIGRATION_NAME = "repositories"
 MIGRATION_RECORD = "migrations/repositories.json"
 MIGRATION_PENDING = "migrations/repositories.pending.json"
@@ -1162,9 +1163,25 @@ class RepositoryMigration:
             raise WorkspaceError("profile root must be an object")
         schema = profile.get("schema_version")
         if schema == PROFILE_SCHEMA_VERSION:
+            if (
+                profile.get("sound_mode") == "local-playtest"
+                and profile.get("stack") != "classic"
+            ):
+                raise WorkspaceError(
+                    "local-playtest sound mode requires a Classic-derived profile"
+                )
             if profile.get("stack") == "classic":
                 self._validate_profile_shape(path, profile)
             return None, None
+        if schema == LEGACY_PROFILE_SCHEMA_VERSION:
+            self._validate_legacy_profile_shape(path, profile)
+            if profile["stack"] != "classic":
+                return None, None
+            return {
+                **profile,
+                "schema_version": PROFILE_SCHEMA_VERSION,
+                "sound_mode": "source",
+            }, None
         if schema != 1:
             raise WorkspaceError("unsupported profile schema")
         name = profile.get("name")
@@ -1271,6 +1288,7 @@ class RepositoryMigration:
             "schema_version": PROFILE_SCHEMA_VERSION,
             "name": name,
             "stack": "classic",
+            "sound_mode": "source",
             "components": output,
         }
         self._validate_profile_shape(path, rewritten)
@@ -1341,18 +1359,26 @@ class RepositoryMigration:
         }
 
     def _validate_profile_shape(self, path: Path, profile: dict[str, Any]) -> None:
-        if set(profile) != {"schema_version", "name", "stack", "components"}:
-            raise WorkspaceError("schema-v3 profile has unexpected fields")
+        if set(profile) != {
+            "schema_version",
+            "name",
+            "stack",
+            "sound_mode",
+            "components",
+        }:
+            raise WorkspaceError("schema-v4 profile has unexpected fields")
         if profile["schema_version"] != PROFILE_SCHEMA_VERSION:
-            raise WorkspaceError("profile is not schema v3")
+            raise WorkspaceError("profile is not schema v4")
+        if profile["sound_mode"] not in {"source", "local-playtest"}:
+            raise WorkspaceError("schema-v4 profile sound mode is invalid")
         if profile["name"] != path.stem or profile["stack"] != "classic":
-            raise WorkspaceError("schema-v3 classic profile identity is invalid")
+            raise WorkspaceError("schema-v4 classic profile identity is invalid")
         components = profile["components"]
         if not isinstance(components, dict):
-            raise WorkspaceError("schema-v3 components must be an object")
+            raise WorkspaceError("schema-v4 components must be an object")
         expected = self._classic_profile_component_names()
         if set(components) != expected:
-            raise WorkspaceError("schema-v3 classic profile component closure is invalid")
+            raise WorkspaceError("schema-v4 classic profile component closure is invalid")
         for component_name, selector in components.items():
             self._validate_selector(component_name, selector)
         classic_selectors = {
@@ -1362,8 +1388,34 @@ class RepositoryMigration:
         }
         if len(classic_selectors) != 1:
             raise WorkspaceError(
-                "schema-v3 classic components must select one physical checkout root"
+                "schema-v4 classic components must select one physical checkout root"
             )
+
+    def _validate_legacy_profile_shape(
+        self, path: Path, profile: dict[str, Any]
+    ) -> None:
+        if set(profile) != {"schema_version", "name", "stack", "components"}:
+            raise WorkspaceError("schema-v3 profile has unexpected fields")
+        if (
+            profile["schema_version"] != LEGACY_PROFILE_SCHEMA_VERSION
+            or profile["name"] != path.stem
+            or not isinstance(profile["stack"], str)
+            or not profile["stack"]
+            or not isinstance(profile["components"], dict)
+        ):
+            raise WorkspaceError("schema-v3 profile identity is invalid")
+        for component_name, selector in profile["components"].items():
+            if not isinstance(component_name, str) or not component_name:
+                raise WorkspaceError("schema-v3 profile component is invalid")
+            self._validate_selector(component_name, selector)
+        if profile["stack"] != "classic":
+            return
+        upgraded = {
+            **profile,
+            "schema_version": PROFILE_SCHEMA_VERSION,
+            "sound_mode": "source",
+        }
+        self._validate_profile_shape(path, upgraded)
 
     @staticmethod
     def _validate_selector(component: str, selector: Any) -> dict[str, str]:

--- a/atrinik_workspace/process_tree.py
+++ b/atrinik_workspace/process_tree.py
@@ -15,7 +15,22 @@ def _holds_identity(pid: int, identity: tuple[int, int]) -> bool:
     for descriptor in descriptors:
         try:
             metadata = descriptor.stat()
+            flags_line = next(
+                line
+                for line in (
+                    directory.parent / "fdinfo" / descriptor.name
+                ).read_text().splitlines()
+                if line.startswith("flags:")
+            )
+            flags = int(flags_line.split()[1], 8)
         except OSError:
+            continue
+        except (StopIteration, ValueError):
+            continue
+        # O_PATH descriptors are observers, not inherited process-tree leases.
+        # This lets the controlling `down` process inspect and signal holders
+        # without becoming a target of the supervisor's own descendant cleanup.
+        if flags & getattr(os, "O_PATH", 0):
             continue
         if (metadata.st_dev, metadata.st_ino) == identity:
             return True

--- a/atrinik_workspace/sound.py
+++ b/atrinik_workspace/sound.py
@@ -9,7 +9,7 @@ import stat
 import subprocess
 from typing import Any
 
-from .model import WorkspaceError, load_json
+from .model import WorkspaceError
 
 
 PLAYTEST_MODE = "local-playtest"
@@ -259,7 +259,16 @@ def verify_playtest_tree(
     ):
         if manifest.get(key) != expected_inputs.get(key):
             raise WorkspaceError(f"local-playtest manifest has stale or tampered {key}")
-    toolchain = load_json(source / "manifests" / "playtest-audio-toolchain.json")
+    toolchain_payload = _read_regular(
+        source / "manifests" / "playtest-audio-toolchain.json",
+        "selected sound playtest toolchain",
+    )
+    if _hash_bytes(toolchain_payload) != expected_inputs.get("toolchain_sha256"):
+        raise WorkspaceError("selected sound playtest toolchain is stale or tampered")
+    try:
+        toolchain = json.loads(toolchain_payload)
+    except json.JSONDecodeError as error:
+        raise WorkspaceError("selected sound playtest toolchain is invalid JSON") from error
     if (
         not isinstance(toolchain, dict)
         or toolchain.get("$schema")
@@ -317,7 +326,18 @@ def verify_playtest_tree(
     ):
         raise WorkspaceError("local-playtest blocker report contract is invalid")
 
-    source_manifest = load_json(source / "manifests" / "source-assets.json")
+    source_manifest_payload = _read_regular(
+        source / "manifests" / "source-assets.json",
+        "selected sound source manifest",
+    )
+    if _hash_bytes(source_manifest_payload) != expected_inputs.get(
+        "source_manifest_sha256"
+    ):
+        raise WorkspaceError("selected sound source manifest is stale or tampered")
+    try:
+        source_manifest = json.loads(source_manifest_payload)
+    except json.JSONDecodeError as error:
+        raise WorkspaceError("selected sound source manifest is invalid JSON") from error
     if not isinstance(source_manifest, dict) or not isinstance(
         source_manifest.get("assets"), list
     ):

--- a/atrinik_workspace/sound.py
+++ b/atrinik_workspace/sound.py
@@ -1,0 +1,536 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import stat
+import subprocess
+from typing import Any
+
+from .model import WorkspaceError, load_json
+
+
+PLAYTEST_MODE = "local-playtest"
+SOURCE_MODE = "source"
+SOUND_MODES = {PLAYTEST_MODE, SOURCE_MODE}
+PLAYTEST_MANIFEST = "playtest-manifest.json"
+PLAYTEST_BLOCKERS = "playtest-blockers.json"
+PLAYTEST_MARKER = ".atrinik-playtest-tree.json"
+PLAYTEST_SCHEMA = "schemas/playtest-manifest-v1.schema.json"
+EXPECTED_PATHS = 339
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+OBJECT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+LOGICAL_PATH_PATTERN = re.compile(
+    r"^(background|effects)/(?:[a-z0-9][a-z0-9_.-]*/)*"
+    r"[a-z0-9][a-z0-9_.-]*\.(mid|mod|s3m|xm|ogg)$"
+)
+TOOL_NAMES = {
+    "ffmpeg",
+    "openmpt123",
+    "opusenc",
+    "opusinfo",
+    "sdl3_mixer_probe",
+    "wildmidi",
+}
+
+
+def _canonical_json(value: object) -> bytes:
+    return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def _hash_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _read_regular(path: Path, description: str) -> bytes:
+    try:
+        descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+    except OSError as error:
+        raise WorkspaceError(f"{description} is not a readable regular file: {path}") from error
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise WorkspaceError(f"{description} is not a regular file: {path}")
+        chunks: list[bytes] = []
+        while chunk := os.read(descriptor, 1024 * 1024):
+            chunks.append(chunk)
+        return b"".join(chunks)
+    finally:
+        os.close(descriptor)
+
+
+def _hash_regular(path: Path, description: str) -> tuple[str, int, bytes]:
+    try:
+        descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+    except OSError as error:
+        raise WorkspaceError(
+            f"{description} is not a readable regular file: {path}"
+        ) from error
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise WorkspaceError(f"{description} is not a regular file: {path}")
+        digest = hashlib.sha256()
+        prefix = bytearray()
+        size = 0
+        while chunk := os.read(descriptor, 1024 * 1024):
+            digest.update(chunk)
+            size += len(chunk)
+            if len(prefix) < 65536:
+                prefix.extend(chunk[: 65536 - len(prefix)])
+        return digest.hexdigest(), size, bytes(prefix)
+    finally:
+        os.close(descriptor)
+
+
+def _git(source: Path, *arguments: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(source), *arguments],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError) as error:
+        raise WorkspaceError(
+            f"cannot inspect local-playtest sound source identity: {source}"
+        ) from error
+    return result.stdout.strip()
+
+
+def clean_source_inputs(source: Path) -> dict[str, str]:
+    """Return exact immutable builder inputs from one clean sound checkout."""
+
+    before = _git(source, "status", "--porcelain", "--untracked-files=all")
+    commit = _git(source, "rev-parse", "HEAD")
+    tree = _git(source, "rev-parse", f"{commit}^{{tree}}")
+    files = {
+        "builder_sha256": source / "tools" / "sound_release.py",
+        "source_manifest_sha256": source / "manifests" / "source-assets.json",
+        "toolchain_sha256": source / "manifests" / "playtest-audio-toolchain.json",
+        "schema_sha256": source / "schemas" / "playtest-manifest-v1.schema.json",
+    }
+    hashes = {
+        name: _hash_regular(path, name.replace("_", " "))[0]
+        for name, path in files.items()
+    }
+    after = _git(source, "status", "--porcelain", "--untracked-files=all")
+    final_commit = _git(source, "rev-parse", "HEAD")
+    if before or after:
+        raise WorkspaceError(
+            f"local-playtest sound mode requires a clean selected checkout: {source}"
+        )
+    if commit != final_commit:
+        raise WorkspaceError(
+            f"local-playtest sound source changed while reading its identity: {source}"
+        )
+    if not OBJECT_PATTERN.fullmatch(commit) or not OBJECT_PATTERN.fullmatch(tree):
+        raise WorkspaceError(
+            f"local-playtest sound source has invalid Git coordinates: {source}"
+        )
+    return {"source_commit": commit, "source_tree": tree, **hashes}
+
+
+def cache_key(inputs: dict[str, str]) -> str:
+    payload = json.dumps(inputs, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:20]
+
+
+def source_record(source: Path) -> dict[str, Any]:
+    commit = _git(source, "rev-parse", "HEAD")
+    tree = _git(source, "rev-parse", f"{commit}^{{tree}}")
+    return {
+        "mode": SOURCE_MODE,
+        "root": str(source.resolve()),
+        "source_commit": commit,
+        "source_tree": tree,
+        "source_clean": not bool(
+            _git(source, "status", "--porcelain", "--untracked-files=all")
+        ),
+    }
+
+
+def _require_dict(value: object, keys: set[str], description: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != keys:
+        raise WorkspaceError(f"local-playtest {description} fields are invalid")
+    return value
+
+
+def _tree_files(root: Path) -> set[str]:
+    result: set[str] = set()
+    for directory, directories, files in os.walk(root, followlinks=False):
+        parent = Path(directory)
+        for name in directories:
+            path = parent / name
+            try:
+                mode = path.lstat().st_mode
+            except OSError as error:
+                raise WorkspaceError(f"cannot inspect local-playtest tree: {path}") from error
+            if not stat.S_ISDIR(mode):
+                raise WorkspaceError(
+                    f"local-playtest tree contains a non-directory or symlink: {path}"
+                )
+        for name in files:
+            path = parent / name
+            relative = path.relative_to(root).as_posix()
+            try:
+                descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+            except OSError as error:
+                raise WorkspaceError(
+                    f"local-playtest tree entry is not a readable regular file: {path}"
+                ) from error
+            try:
+                if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+                    raise WorkspaceError(
+                        f"local-playtest tree entry is not a regular file: {path}"
+                    )
+            finally:
+                os.close(descriptor)
+            result.add(relative)
+    return result
+
+
+def _validate_payload_codec(path: str, codec: str, prefix: bytes) -> None:
+    if not prefix.startswith(b"OggS"):
+        raise WorkspaceError(f"local-playtest payload is not an Ogg stream: {path}")
+    signature = b"OpusHead" if codec == "opus" else b"\x01vorbis"
+    if signature not in prefix:
+        raise WorkspaceError(
+            f"local-playtest payload codec does not match its manifest: {path}"
+        )
+
+
+def verify_playtest_tree(
+    source: Path, root: Path, expected_inputs: dict[str, str]
+) -> dict[str, Any]:
+    """Independently verify the public sound playtest-tree version 1 contract."""
+
+    if root.is_symlink() or not root.is_dir():
+        raise WorkspaceError(f"local-playtest sound root is not a regular directory: {root}")
+    manifest_payload = _read_regular(root / PLAYTEST_MANIFEST, "playtest manifest")
+    try:
+        manifest_value = json.loads(manifest_payload)
+    except json.JSONDecodeError as error:
+        raise WorkspaceError("local-playtest manifest is invalid JSON") from error
+    if manifest_payload != _canonical_json(manifest_value):
+        raise WorkspaceError("local-playtest manifest is not canonical JSON")
+    manifest = _require_dict(
+        manifest_value,
+        {
+            "$schema",
+            "assets",
+            "blocker_count",
+            "blocker_report_sha256",
+            "converted_opus_count",
+            "copied_vorbis_count",
+            "logical_path_count",
+            "marker_sha256",
+            "output_tree_sha256",
+            "playtest_only",
+            "publishable",
+            "schema_sha256",
+            "schema_version",
+            "source_commit",
+            "source_manifest_sha256",
+            "source_tree",
+            "tool_versions",
+            "toolchain_sha256",
+        },
+        "manifest",
+    )
+    if (
+        manifest["$schema"] != PLAYTEST_SCHEMA
+        or manifest["schema_version"] != 1
+        or manifest["playtest_only"] is not True
+        or manifest["publishable"] is not False
+    ):
+        raise WorkspaceError(
+            "local-playtest manifest must use schema 1 with "
+            "playtest_only=true and publishable=false"
+        )
+    for key in (
+        "source_commit",
+        "source_tree",
+        "source_manifest_sha256",
+        "toolchain_sha256",
+        "schema_sha256",
+    ):
+        if manifest.get(key) != expected_inputs.get(key):
+            raise WorkspaceError(f"local-playtest manifest has stale or tampered {key}")
+    toolchain = load_json(source / "manifests" / "playtest-audio-toolchain.json")
+    if (
+        not isinstance(toolchain, dict)
+        or toolchain.get("$schema")
+        != "../schemas/playtest-audio-toolchain-v1.schema.json"
+        or toolchain.get("schema_version") != 1
+    ):
+        raise WorkspaceError("selected sound toolchain schema is invalid")
+    tool_versions = manifest.get("tool_versions")
+    if (
+        not isinstance(tool_versions, dict)
+        or set(tool_versions) != TOOL_NAMES
+        or not all(isinstance(value, str) and value for value in tool_versions.values())
+    ):
+        raise WorkspaceError("local-playtest toolchain versions are invalid")
+
+    marker_payload = _read_regular(root / PLAYTEST_MARKER, "playtest marker")
+    expected_marker = _canonical_json(
+        {
+            "format": "atrinik-sound-playtest-tree",
+            "playtest_only": True,
+            "publishable": False,
+            "schema_version": 1,
+        }
+    )
+    if marker_payload != expected_marker or manifest["marker_sha256"] != _hash_bytes(
+        marker_payload
+    ):
+        raise WorkspaceError("local-playtest ownership marker is missing or tampered")
+    schema_hash, _schema_size, _schema_prefix = _hash_regular(
+        root / PLAYTEST_SCHEMA, "packaged playtest schema"
+    )
+    if schema_hash != manifest["schema_sha256"]:
+        raise WorkspaceError("local-playtest packaged schema is missing or tampered")
+    blocker_payload = _read_regular(root / PLAYTEST_BLOCKERS, "playtest blocker report")
+    if _hash_bytes(blocker_payload) != manifest["blocker_report_sha256"]:
+        raise WorkspaceError("local-playtest blocker report is missing or tampered")
+    try:
+        blockers = json.loads(blocker_payload)
+    except json.JSONDecodeError as error:
+        raise WorkspaceError("local-playtest blocker report is invalid JSON") from error
+    blocker_report = _require_dict(
+        blockers,
+        {"schema_version", "source_manifest_sha256", "source_count", "count", "findings"},
+        "blocker report",
+    )
+    if (
+        blocker_payload != _canonical_json(blocker_report)
+        or blocker_report["schema_version"] != 1
+        or blocker_report["source_manifest_sha256"]
+        != manifest["source_manifest_sha256"]
+        or blocker_report["source_count"] != EXPECTED_PATHS
+        or blocker_report["count"] != manifest["blocker_count"]
+        or not isinstance(blocker_report["findings"], list)
+        or len(blocker_report["findings"]) != blocker_report["count"]
+    ):
+        raise WorkspaceError("local-playtest blocker report contract is invalid")
+
+    source_manifest = load_json(source / "manifests" / "source-assets.json")
+    if not isinstance(source_manifest, dict) or not isinstance(
+        source_manifest.get("assets"), list
+    ):
+        raise WorkspaceError("selected sound source manifest is invalid")
+    source_assets = source_manifest["assets"]
+    expected_by_path: dict[str, dict[str, Any]] = {}
+    for value in source_assets:
+        if not isinstance(value, dict) or not isinstance(value.get("logical_path"), str):
+            raise WorkspaceError("selected sound source manifest assets are invalid")
+        logical_path = value["logical_path"]
+        if logical_path in expected_by_path:
+            raise WorkspaceError("selected sound source manifest has duplicate logical paths")
+        expected_by_path[logical_path] = value
+    expected_copied = sum(
+        isinstance(value.get("source"), dict)
+        and value["source"].get("codec") == "vorbis"
+        for value in expected_by_path.values()
+    )
+    expected_converted = len(expected_by_path) - expected_copied
+
+    assets = manifest.get("assets")
+    if not isinstance(assets, list):
+        raise WorkspaceError("local-playtest manifest assets must be an array")
+    actual_by_path: dict[str, dict[str, Any]] = {}
+    tree_digest = hashlib.sha256()
+    copied = 0
+    converted = 0
+    for value in assets:
+        asset = _require_dict(
+            value,
+            {"logical_path", "mapping", "output", "source", "source_path"},
+            "asset",
+        )
+        logical_path = asset.get("logical_path")
+        if (
+            not isinstance(logical_path, str)
+            or not LOGICAL_PATH_PATTERN.fullmatch(logical_path)
+            or PurePosixPath(logical_path).is_absolute()
+            or ".." in PurePosixPath(logical_path).parts
+            or logical_path in actual_by_path
+        ):
+            raise WorkspaceError("local-playtest manifest has an unsafe or duplicate path")
+        actual_by_path[logical_path] = asset
+        expected = expected_by_path.get(logical_path)
+        if expected is None:
+            raise WorkspaceError(f"local-playtest tree has an extra logical path: {logical_path}")
+        expected_source = expected.get("source")
+        if not isinstance(expected_source, dict):
+            raise WorkspaceError("selected sound source manifest asset is invalid")
+        source_value = _require_dict(
+            asset.get("source"), {"sha256", "codec", "container"}, "asset source"
+        )
+        output = _require_dict(
+            asset.get("output"),
+            {
+                "channels",
+                "codec",
+                "container",
+                "duration_seconds",
+                "sample_rate",
+                "sha256",
+                "size_bytes",
+            },
+            "asset output",
+        )
+        source_codec = expected_source.get("codec")
+        expected_mapping = "copy" if source_codec == "vorbis" else "render-opus"
+        expected_codec = "vorbis" if source_codec == "vorbis" else "opus"
+        if (
+            asset.get("source_path") != expected.get("source_path")
+            or asset.get("mapping") != expected_mapping
+            or source_value
+            != {
+                "sha256": expected_source.get("sha256"),
+                "codec": source_codec,
+                "container": expected_source.get("container"),
+            }
+            or output.get("codec") != expected_codec
+            or output.get("container") != "ogg"
+            or not isinstance(output.get("size_bytes"), int)
+            or isinstance(output.get("size_bytes"), bool)
+            or output["size_bytes"] < 1
+            or not isinstance(output.get("sample_rate"), int)
+            or isinstance(output.get("sample_rate"), bool)
+            or output["sample_rate"] < 1
+            or output.get("channels") not in {1, 2}
+            or not isinstance(output.get("duration_seconds"), (int, float))
+            or isinstance(output.get("duration_seconds"), bool)
+            or output["duration_seconds"] <= 0
+            or not isinstance(output.get("sha256"), str)
+            or not SHA256_PATTERN.fullmatch(output["sha256"])
+        ):
+            raise WorkspaceError(f"local-playtest mapping is invalid: {logical_path}")
+        payload_hash, payload_size, payload_prefix = _hash_regular(
+            root / logical_path, f"local-playtest payload {logical_path}"
+        )
+        if payload_hash != output["sha256"] or payload_size != output["size_bytes"]:
+            raise WorkspaceError(f"local-playtest payload hash or size mismatch: {logical_path}")
+        if expected_mapping == "copy" and output["sha256"] != source_value["sha256"]:
+            raise WorkspaceError(f"local-playtest Vorbis copy differs from source: {logical_path}")
+        _validate_payload_codec(logical_path, expected_codec, payload_prefix)
+        copied += expected_mapping == "copy"
+        converted += expected_mapping == "render-opus"
+        tree_digest.update(f"{payload_hash}  {logical_path}\n".encode("ascii"))
+
+    if set(actual_by_path) != set(expected_by_path):
+        missing = sorted(set(expected_by_path) - set(actual_by_path))
+        raise WorkspaceError(f"local-playtest tree is missing logical path: {missing[0]}")
+    if (
+        len(assets) != EXPECTED_PATHS
+        or manifest["logical_path_count"] != EXPECTED_PATHS
+        or copied != expected_copied
+        or manifest["copied_vorbis_count"] != expected_copied
+        or converted != expected_converted
+        or manifest["converted_opus_count"] != expected_converted
+    ):
+        raise WorkspaceError(
+            "local-playtest tree counts do not match the exact 339-path source corpus"
+        )
+    allowed = set(actual_by_path) | {
+        PLAYTEST_MANIFEST,
+        PLAYTEST_BLOCKERS,
+        PLAYTEST_MARKER,
+        PLAYTEST_SCHEMA,
+    }
+    if _tree_files(root) != allowed:
+        raise WorkspaceError("local-playtest tree has missing or unexpected files")
+    digest = tree_digest.hexdigest()
+    if manifest.get("output_tree_sha256") != digest:
+        raise WorkspaceError("local-playtest output-tree digest mismatch")
+    return {
+        "mode": PLAYTEST_MODE,
+        "root": str(root.resolve()),
+        "playtest_manifest_sha256": _hash_bytes(manifest_payload),
+        "playtest_schema_version": manifest["schema_version"],
+        "source_commit": manifest["source_commit"],
+        "source_tree": manifest["source_tree"],
+        "source_clean": True,
+        "source_manifest_sha256": manifest["source_manifest_sha256"],
+        "toolchain_sha256": manifest["toolchain_sha256"],
+        "toolchain_schema": toolchain["$schema"],
+        "toolchain_schema_version": toolchain["schema_version"],
+        "schema_sha256": manifest["schema_sha256"],
+        "marker_sha256": manifest["marker_sha256"],
+        "blocker_report_sha256": manifest["blocker_report_sha256"],
+        "output_tree_sha256": digest,
+        "logical_path_count": EXPECTED_PATHS,
+        "copied_vorbis_count": expected_copied,
+        "converted_opus_count": expected_converted,
+    }
+
+
+SOURCE_RECORD_KEYS = {
+    "mode", "root", "source_commit", "source_tree", "source_clean",
+}
+PLAYTEST_RECORD_KEYS = {
+    "mode", "root", "playtest_manifest_sha256", "playtest_schema_version",
+    "source_commit", "source_tree", "source_clean", "source_manifest_sha256",
+    "toolchain_sha256", "toolchain_schema", "toolchain_schema_version",
+    "schema_sha256", "marker_sha256", "blocker_report_sha256",
+    "output_tree_sha256", "logical_path_count", "copied_vorbis_count",
+    "converted_opus_count",
+}
+
+
+def validate_sound_record(value: object) -> dict[str, Any]:
+    """Validate the exact persisted provenance record for either sound mode."""
+
+    if not isinstance(value, dict):
+        raise WorkspaceError("sound provenance record is not an object")
+    mode = value.get("mode")
+    expected = SOURCE_RECORD_KEYS if mode == SOURCE_MODE else PLAYTEST_RECORD_KEYS
+    if mode not in SOUND_MODES or set(value) != expected:
+        raise WorkspaceError("sound provenance record fields are invalid")
+    root = value.get("root")
+    if not isinstance(root, str) or not root or not Path(root).is_absolute():
+        raise WorkspaceError("sound provenance root is invalid")
+    if (
+        not isinstance(value.get("source_commit"), str)
+        or not OBJECT_PATTERN.fullmatch(value["source_commit"])
+        or not isinstance(value.get("source_tree"), str)
+        or not OBJECT_PATTERN.fullmatch(value["source_tree"])
+        or not isinstance(value.get("source_clean"), bool)
+    ):
+        raise WorkspaceError("sound provenance source identity is invalid")
+    if mode == SOURCE_MODE:
+        return value
+    hashes = PLAYTEST_RECORD_KEYS - {
+        "mode", "root", "playtest_schema_version", "source_commit",
+        "source_tree", "source_clean", "toolchain_schema_version",
+        "logical_path_count", "copied_vorbis_count", "converted_opus_count",
+        "toolchain_schema",
+    }
+    if (
+        value["source_clean"] is not True
+        or any(
+            not isinstance(value.get(name), str)
+            or not SHA256_PATTERN.fullmatch(value[name])
+            for name in hashes
+        )
+        or value.get("playtest_schema_version") != 1
+        or value.get("toolchain_schema_version") != 1
+        or value.get("toolchain_schema")
+        != "../schemas/playtest-audio-toolchain-v1.schema.json"
+        or value.get("logical_path_count") != EXPECTED_PATHS
+        or not isinstance(value.get("copied_vorbis_count"), int)
+        or isinstance(value.get("copied_vorbis_count"), bool)
+        or value["copied_vorbis_count"] < 0
+        or not isinstance(value.get("converted_opus_count"), int)
+        or isinstance(value.get("converted_opus_count"), bool)
+        or value["converted_opus_count"] < 0
+        or value["copied_vorbis_count"] + value["converted_opus_count"]
+        != EXPECTED_PATHS
+    ):
+        raise WorkspaceError("local-playtest sound provenance is invalid")
+    return value

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -264,6 +264,8 @@ def _initial_status(spec: dict[str, Any], supervisor_start_time: str) -> dict[st
             raise RuntimeError("topology spec stack/provider identity is incomplete")
         status["stack"] = spec["stack"]
         status["providers"] = spec["providers"]
+    if "sound" in spec:
+        status["sound"] = spec["sound"]
     return status
 
 

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -57,10 +57,22 @@ from .migration import (
     rename_no_replace,
 )
 from .supervisor import process_matches
+from .sound import (
+    PLAYTEST_MODE,
+    SOUND_MODES,
+    SOURCE_MODE,
+    cache_key as sound_cache_key,
+    clean_source_inputs,
+    source_record as sound_source_record,
+    validate_sound_record,
+    verify_playtest_tree,
+)
 
 
-PROFILE_SCHEMA_VERSION = 3
-PROFILE_KEYS = {"schema_version", "name", "stack", "components"}
+PROFILE_SCHEMA_VERSION = 4
+LEGACY_PROFILE_SCHEMA_VERSION = 3
+PROFILE_KEYS = {"schema_version", "name", "stack", "components", "sound_mode"}
+LEGACY_PROFILE_KEYS = {"schema_version", "name", "stack", "components"}
 SELECTOR_KEYS = {"kind", "value"}
 EXPECTED_SERVER_DATA = {
     "files": ("bans", "motd"),
@@ -111,7 +123,7 @@ SCENARIO_SCHEMA_VERSION = 4
 SCENARIO_PRESETS = {"basic-player": {"archetype": "human_male"}}
 SCENARIO_PASSWORD_MAX_SIZE = 128
 BUILD_METADATA = ".atrinik-build.json"
-BUILD_METADATA_SCHEMA_VERSION = 1
+BUILD_METADATA_SCHEMA_VERSION = 2
 CACHE_METADATA = ".atrinik-cache.json"
 WORKER_DEPENDENCY_METADATA = ".atrinik-worker-dependencies.json"
 WORKER_VIEW_METADATA = ".atrinik-worker-view.json"
@@ -1841,6 +1853,7 @@ class Workspace:
             "schema_version": PROFILE_SCHEMA_VERSION,
             "name": name,
             "stack": source_profile["stack"],
+            "sound_mode": source_profile["sound_mode"],
             "components": {
                 component_name: dict(selector)
                 for component_name, selector in source_profile["components"].items()
@@ -1889,6 +1902,27 @@ class Workspace:
         for component in components:
             profile["components"][component.name] = {"kind": kind, "value": value}
         atomic_json(self.paths.profiles / f"{name}.json", profile)
+
+    def set_profile_sound_mode(self, name: str, mode: str) -> None:
+        self.paths.ensure()
+        with exclusive_lock(
+            self.paths.workspace / "repository-layout.lock",
+            "repository layout",
+        ):
+            if name in self.manifest.stacks:
+                raise WorkspaceError(
+                    "sound mode can be changed only on a saved derived profile"
+                )
+            profile = self._load_profile(name, require_file=True)
+            if profile["stack"] != "classic":
+                raise WorkspaceError(
+                    "local-playtest sound mode is available only to Classic-derived profiles"
+                )
+            if mode not in SOUND_MODES:
+                raise WorkspaceError(f"invalid profile sound mode: {mode}")
+            profile["schema_version"] = PROFILE_SCHEMA_VERSION
+            profile["sound_mode"] = mode
+            atomic_json(self.paths.profiles / f"{name}.json", profile)
 
     def _profile_components(
         self, profile: dict[str, Any], component_checkout_or_role: str
@@ -2097,6 +2131,7 @@ class Workspace:
                 "schema_version": PROFILE_SCHEMA_VERSION,
                 "name": name,
                 "stack": name,
+                "sound_mode": SOURCE_MODE,
                 "components": {
                     component.name: {"kind": "primary", "value": ""}
                     for component in stack.components
@@ -2108,15 +2143,23 @@ class Workspace:
         profile = load_json(path)
         if not isinstance(profile, dict):
             raise WorkspaceError(f"profile must be an object: {name}")
-        require_keys(profile, PROFILE_KEYS, f"profile {name}")
-        if (
-            profile["schema_version"] != PROFILE_SCHEMA_VERSION
-            or profile["name"] != name
-        ):
+        schema_version = profile.get("schema_version")
+        if schema_version == LEGACY_PROFILE_SCHEMA_VERSION:
+            require_keys(profile, LEGACY_PROFILE_KEYS, f"profile {name}")
+            profile = {**profile, "schema_version": PROFILE_SCHEMA_VERSION, "sound_mode": SOURCE_MODE}
+        else:
+            require_keys(profile, PROFILE_KEYS, f"profile {name}")
+        if profile["schema_version"] != PROFILE_SCHEMA_VERSION or profile["name"] != name:
             raise WorkspaceError(f"profile identity/schema mismatch: {name}")
+        if profile["sound_mode"] not in SOUND_MODES:
+            raise WorkspaceError(f"profile sound mode is invalid: {name}")
         stack_name = profile["stack"]
         if not isinstance(stack_name, str) or stack_name not in self.manifest.stacks:
             raise WorkspaceError(f"profile stack is invalid: {name}")
+        if profile["sound_mode"] == PLAYTEST_MODE and stack_name != "classic":
+            raise WorkspaceError(
+                f"local-playtest sound mode requires a Classic-derived profile: {name}"
+            )
         stack = self.manifest.stack(stack_name)
         selectors = profile["components"]
         expected = {component.name for component in stack.components}
@@ -2210,7 +2253,12 @@ class Workspace:
                     }
                 )
             rows.append(row)
-        return {"name": name, "stack": stack.name, "components": rows}
+        return {
+            "name": name,
+            "stack": stack.name,
+            "sound_mode": profile["sound_mode"],
+            "components": rows,
+        }
 
     def component_path(self, component_name: str, profile_name: str) -> Path:
         profile = self._load_profile(profile_name, require_file=False)
@@ -2385,7 +2433,20 @@ class Workspace:
             self._use_ccache = use_ccache
             self._source_view_unchanged = {}
             managed_directory(root, self.paths.builds, f"profile:{profile_name}:{key}")
-            self._refresh_build_metadata(root, profile_name, key, selected)
+            sound_root = selected.get("sound")
+            sound_record: dict[str, Any] | None = None
+            if "client" in targets:
+                if sound_root is not None:
+                    sound_root, sound_record = self._prepare_sound(
+                        root, selected, profile_name
+                    )
+            elif sound_root is not None:
+                profile = self._load_profile(profile_name, require_file=False)
+                if profile["sound_mode"] == SOURCE_MODE:
+                    sound_record = sound_source_record(sound_root)
+            self._refresh_build_metadata(
+                root, profile_name, key, selected, sound_record
+            )
             if "content" in targets or "server" in targets:
                 self._collect_content(root, selected, profile_name)
             if "server" in targets:
@@ -2394,14 +2455,20 @@ class Workspace:
                 targets, selected
             )
             if integrated_classic:
-                self._build_integrated_classic(root, selected, tests)
+                if sound_root is None:
+                    raise WorkspaceError(
+                        f"integrated Classic profile {profile_name} has no sound provider"
+                    )
+                self._build_integrated_classic(
+                    root, selected, tests, sound_root=sound_root
+                )
             else:
                 if "protocol" in targets:
                     self._build_protocol(root, selected, tests)
                 if "libatrinik" in targets:
                     self._build_library(root, selected, tests)
                 if "client" in targets:
-                    self._build_client(root, selected, tests)
+                    self._build_client(root, selected, tests, sound_root=sound_root)
                 if "server" in targets:
                     self._build_server(root, selected, tests)
             if "server" in targets:
@@ -2426,6 +2493,7 @@ class Workspace:
         profile_name: str,
         key: str,
         selected: dict[str, Path],
+        sound: dict[str, Any] | None = None,
     ) -> None:
         profile = self._load_profile(profile_name, require_file=False)
         stack = self.manifest.stack(profile["stack"])
@@ -2455,9 +2523,126 @@ class Workspace:
                 "key": key,
                 "purpose": f"profile:{profile_name}:{key}",
                 "coordinates": coordinates,
+                "sound": sound,
                 "last_used_at": datetime.now(timezone.utc).isoformat(),
             },
         )
+
+    def _prepare_sound(
+        self,
+        root: Path,
+        selected: dict[str, Path],
+        profile_name: str,
+    ) -> tuple[Path, dict[str, Any]]:
+        source = selected["sound"]
+        profile = self._load_profile(profile_name, require_file=False)
+        mode = profile["sound_mode"]
+        if mode == SOURCE_MODE:
+            return source, sound_source_record(source)
+        if mode != PLAYTEST_MODE or profile["stack"] != "classic":
+            raise WorkspaceError(
+                f"profile {profile_name} has unsupported sound mode {mode}"
+            )
+        source_identity = "unavailable"
+        try:
+            inputs = clean_source_inputs(source)
+            source_identity = (
+                f"commit {inputs['source_commit']} tree {inputs['source_tree']}"
+            )
+            output = source / "build" / "atrinik-workspace" / sound_cache_key(inputs)
+            builder = source / "tools" / "sound_release.py"
+            if not builder.is_file() or builder.is_symlink():
+                raise WorkspaceError(
+                    "selected sound checkout lacks the public "
+                    "tools/sound_release.py builder"
+                )
+            run(
+                [
+                    sys.executable,
+                    str(builder),
+                    "build-playtest-tree",
+                    str(output),
+                ],
+                cwd=source,
+            )
+            run(
+                [
+                    sys.executable,
+                    str(builder),
+                    "verify-playtest-tree",
+                    str(output),
+                ],
+                cwd=source,
+            )
+            record = verify_playtest_tree(source, output, inputs)
+            if clean_source_inputs(source) != inputs:
+                raise WorkspaceError(
+                    "selected sound inputs changed after playtest-tree generation"
+                )
+            staged = root / "runtime" / "sound-local-playtest"
+            runtime = staged.parent
+            if runtime.exists() or runtime.is_symlink():
+                if runtime.is_symlink() or not runtime.is_dir():
+                    raise WorkspaceError(
+                        "local-playtest handoff parent is not a safe directory"
+                    )
+            else:
+                runtime.mkdir()
+            try:
+                if runtime.resolve() != root.resolve() / "runtime":
+                    raise WorkspaceError(
+                        "local-playtest handoff parent escapes the profile build"
+                    )
+            except RuntimeError as error:
+                raise WorkspaceError(
+                    "local-playtest handoff parent cannot be resolved"
+                ) from error
+
+            def same_tree(left: dict[str, Any], right: dict[str, Any]) -> bool:
+                return {**left, "root": "<verified-root>"} == {
+                    **right,
+                    "root": "<verified-root>",
+                }
+
+            if staged.exists() or staged.is_symlink():
+                staged_record = verify_playtest_tree(source, staged, inputs)
+                if not same_tree(record, staged_record):
+                    raise WorkspaceError(
+                        "cached local-playtest handoff differs from producer verification"
+                    )
+            else:
+                with tempfile.TemporaryDirectory(
+                    prefix=".sound-local-playtest-", dir=staged.parent
+                ) as temporary:
+                    candidate = Path(temporary) / "tree"
+                    shutil.copytree(output, candidate, symlinks=True)
+                    staged_record = verify_playtest_tree(source, candidate, inputs)
+                    if not same_tree(record, staged_record):
+                        raise WorkspaceError(
+                            "local-playtest sound changed while creating the verified handoff"
+                        )
+                    if clean_source_inputs(source) != inputs:
+                        raise WorkspaceError(
+                            "selected sound inputs changed while staging the verified handoff"
+                        )
+                    rename_no_replace(candidate, staged)
+                staged_record = verify_playtest_tree(source, staged, inputs)
+                if not same_tree(record, staged_record):
+                    raise WorkspaceError(
+                        "installed local-playtest handoff differs from producer verification"
+                    )
+            record = staged_record
+            output = staged
+        except (OSError, WorkspaceError) as error:
+            raise WorkspaceError(
+                f"profile {profile_name} mode {mode} sound source {source} "
+                f"({source_identity}) failed contract: {error}"
+            ) from error
+        print(
+            "sound: staged local-playtest tree "
+            f"{record['output_tree_sha256']} at {output}"
+        )
+        return output, record
 
     def _selected_checkout_states(
         self,
@@ -2503,7 +2688,8 @@ class Workspace:
         )
         namespace = (
             f"profile-schema:{PROFILE_SCHEMA_VERSION};stack:{stack.name};"
-            f"generation:{stack.generation};providers:{providers}"
+            f"generation:{stack.generation};sound-mode:{profile['sound_mode']};"
+            f"providers:{providers}"
         )
         return profile_key(selected, namespace=namespace)
 
@@ -4189,7 +4375,12 @@ class Workspace:
         return root / "build" / role
 
     def _build_integrated_classic(
-        self, root: Path, selected: dict[str, Path], tests: bool
+        self,
+        root: Path,
+        selected: dict[str, Path],
+        tests: bool,
+        *,
+        sound_root: Path | None = None,
     ) -> None:
         checkout = selected["client"].parent.resolve()
         view = self._profile_source_view(
@@ -4207,7 +4398,10 @@ class Workspace:
             preserved_entries={"sound"},
         )
         self._source_view_link(
-            client, "sound", selected["sound"], target_is_directory=True
+            client,
+            "sound",
+            sound_root or selected["sound"],
+            target_is_directory=True,
         )
         server = self._profile_source_view(
             root,
@@ -4263,7 +4457,14 @@ class Workspace:
             tests,
         )
 
-    def _build_client(self, root: Path, selected: dict[str, Path], tests: bool) -> None:
+    def _build_client(
+        self,
+        root: Path,
+        selected: dict[str, Path],
+        tests: bool,
+        *,
+        sound_root: Path | None = None,
+    ) -> None:
         view = self._profile_source_view(
             root,
             "client",
@@ -4272,7 +4473,10 @@ class Workspace:
             preserved_entries={"sound"},
         )
         self._source_view_link(
-            view, "sound", selected["sound"], target_is_directory=True
+            view,
+            "sound",
+            sound_root or selected["sound"],
+            target_is_directory=True,
         )
         self._cmake(
             view,
@@ -6056,6 +6260,12 @@ class Workspace:
         return {
             "profile": profile_name,
             "stack": stack.name,
+            "sound": {
+                "mode": profile["sound_mode"],
+                "source_path": str(resolved["sound"])
+                if "sound" in resolved
+                else None,
+            },
             "services": selected_services,
             "dependencies": sorted(required),
             "providers": {
@@ -6629,7 +6839,10 @@ class Workspace:
         return {name: container / name for name in expected}
 
     def _prepare_topology_client_runtime(
-        self, topology_root: Path, selected: dict[str, Path]
+        self,
+        topology_root: Path,
+        selected: dict[str, Path],
+        sound_root: Path | None = None,
     ) -> Path:
         runtime = self._reset_topology_subdirectory(
             topology_root, "client-runtime", "topology-client-runtime"
@@ -6642,7 +6855,7 @@ class Workspace:
                 entry, target_is_directory=entry.is_dir()
             )
         (runtime / "sound").symlink_to(
-            selected["sound"], target_is_directory=True
+            sound_root or selected["sound"], target_is_directory=True
         )
         return runtime
 
@@ -6680,7 +6893,7 @@ class Workspace:
             "supervisor",
             "services",
         }
-        optional = {"stack", "providers"}
+        optional = {"stack", "providers", "sound"}
         historical_record = isinstance(status, dict) and not (
             {"stack", "providers"} & set(status)
         )
@@ -6733,6 +6946,13 @@ class Workspace:
             or "error" in status
             and not isinstance(status.get("error"), str)
         ):
+            raise WorkspaceError(f"topology status is invalid: {name}")
+        if "sound" in status:
+            try:
+                validate_sound_record(status["sound"])
+            except WorkspaceError as error:
+                raise WorkspaceError(f"topology status is invalid: {name}") from error
+        if not historical_record and "client" in status["dependencies"] and "sound" not in status:
             raise WorkspaceError(f"topology status is invalid: {name}")
         if historical_record:
             status["stack"] = "classic"
@@ -7118,6 +7338,12 @@ class Workspace:
                 build_lock = stack.enter_context(
                     self._profile_build_lock(root, profile_name)
                 )
+                build_metadata = load_json(root / BUILD_METADATA)
+                sound_status = (
+                    build_metadata.get("sound")
+                    if isinstance(build_metadata, dict)
+                    else None
+                )
                 endpoint: dict[str, Any] | None = None
                 if "server" in selected_services:
                     stack.enter_context(
@@ -7187,8 +7413,34 @@ class Workspace:
                     executable = (
                         self._classic_binary_directory(root, "client") / "atrinik"
                     )
+                    try:
+                        validated_sound = validate_sound_record(sound_status)
+                    except WorkspaceError as error:
+                        raise WorkspaceError(
+                            f"build sound metadata is invalid for profile {profile_name}"
+                        ) from error
+                    profile = self._load_profile(profile_name, require_file=False)
+                    if validated_sound["mode"] != profile["sound_mode"]:
+                        raise WorkspaceError(
+                            f"profile {profile_name} sound mode does not match build metadata"
+                        )
+                    sound_root = Path(validated_sound["root"])
+                    if validated_sound["mode"] == PLAYTEST_MODE:
+                        inputs = clean_source_inputs(selected["sound"])
+                        verified = verify_playtest_tree(
+                            selected["sound"], sound_root, inputs
+                        )
+                        if verified != validated_sound:
+                            raise WorkspaceError(
+                                f"profile {profile_name} local-playtest sound "
+                                "record changed before topology preparation"
+                            )
+                    elif sound_root.resolve() != selected["sound"].resolve():
+                        raise WorkspaceError(
+                            f"profile {profile_name} source sound root changed before topology preparation"
+                        )
                     working = self._prepare_topology_client_runtime(
-                        topology_root, selected
+                        topology_root, selected, sound_root
                     )
                     if not executable.is_file():
                         raise WorkspaceError(f"client executable is missing: {executable}")
@@ -7214,7 +7466,7 @@ class Workspace:
                 resolved_status = self._topology_resolved_status(
                     profile_name, selected
                 )
-                spec = {
+                spec: dict[str, Any] = {
                     "schema_version": SCHEMA_VERSION,
                     "name": name,
                     "profile": profile_name,
@@ -7230,6 +7482,8 @@ class Workspace:
                     "endpoint": endpoint,
                     "services": service_specs,
                 }
+                if sound_status is not None:
+                    spec["sound"] = sound_status
                 spec_path = topology_root / "spec.json"
                 atomic_json(spec_path, spec)
                 status_path.unlink(missing_ok=True)
@@ -7343,9 +7597,13 @@ class Workspace:
                 )
             if not process_tree_path.is_file():
                 return self._legacy_topology_down(name, status, timeout)
+            if not hasattr(os, "O_PATH"):
+                raise WorkspaceError(
+                    "topology process-tree observation is unavailable on this platform"
+                )
             process_tree_fd = open_regular_file(
                 process_tree_path,
-                os.O_RDWR,
+                os.O_PATH,
                 "topology process-tree lease",
             )
             try:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -129,6 +129,18 @@ workspace/
   states.json                        named external-state registry
 ~~~
 
+Selected sound repositories may also contain producer-owned
+`build/atrinik-workspace/<20-hex-key>/` playtest trees. They remain outside the
+wrapper build root but are inventoried only by the explicit preview-first
+`cleanup --scope sound-cache` path, which proves the Git worktree, exact
+nonpublishing marker, age, containment, and idle producer lock again on apply.
+Their public build and verify operations share a lease in the exact Git
+worktree admin directory with wrapper cleanup. Any remaining cache protects
+the containing worktree; final worktree removal holds the exclusive lease so
+new generation cannot enter after revalidation. The exact versioned lease
+marker proves that the producer participates; older or malformed producers
+keep the worktree protected.
+
 `ATRINIK_WORKSPACE_DIR` relocates the `workspace/` layout but never the primary
 physical repositories beside the wrapper. Manifest checkout destinations and
 clone-staging directories are ignored by the wrapper repository. Existing
@@ -435,6 +447,9 @@ full Classic closure -> integrated source view -> one protocol/libatrinik graph
                                              +-> server targets -> CMake/Ninja
 component-only client/server request -> standalone source view -> CMake/Ninja
 selected Classic + content + resources ---> offline worldmaker -> region-map cache
+clean selected sound + local-playtest mode -> sound-owned builder/verifier
+                                             -> nonpublishing compatibility tree
+                                             -> client source view + topology
 selected Worker -> keyed npm ci cache -> isolated reconciled view -> npm run check
 ~~~
 
@@ -474,6 +489,28 @@ The resources repository's `runtime-paths.txt` is the distribution boundary:
 only tracked regular files below those paths enter the runtime view. This keeps
 repository metadata, local untracked files, and symlinks out of the asset
 protocol.
+
+Sound composition has two explicit profile states. `source` preserves the
+historical raw-checkout link. `local-playtest` is accepted only on a saved
+Classic-derived profile and never changes the built-in profile or a replacement
+stack. It invokes the public builder and full-decoder verifier in the clean,
+profile-selected sound checkout. The builder alone owns media transformation
+policy and atomically installs the generated tree below ignored sound `build/`
+state. Its cache key binds the clean commit/tree plus builder, source-manifest,
+toolchain, and schema hashes; a changed or racing input cannot replace an
+existing key.
+
+Before exposure, the wrapper independently checks canonical schema-1 JSON,
+`playtest_only: true`, `publishable: false`, source/toolchain/schema/marker and
+blocker-report hashes, exact safe/unique logical paths, regular-file closure,
+all per-payload hashes and codec signatures, the fixed 339-path and
+source-manifest-derived mapping counts, and the producer's complete
+logical-tree digest. Raw MIDI or tracker
+bytes cannot pass even at legacy `.mid`, `.mod`, `.s3m`, or `.xm` paths. Build
+and topology metadata carry this evidence, and the same verified directory is
+linked into both the client source view and supervised client working tree.
+There is no archive, upload, installer, container-layer, release, or raw-source
+fallback path for this mode.
 
 Each CMake binary tree stores an atomic configure fingerprint covering the
 source-view identity, Ninja generator, CMake and compiler identities, toolchain
@@ -636,7 +673,8 @@ possible.
 ## Trust and command execution
 
 Selected checkout worktrees and component source roots are executable source:
-CMake, Python collection, npm, and runtime commands execute code from the
+CMake, Python collection, sound-tree generation, npm, and runtime commands
+execute code from the
 selected profile. Review a pull request before selecting its worktree.
 Profiles do not provide a security sandbox.
 

--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -1466,13 +1466,13 @@
         "atrinik"
       ],
       "required": true,
-      "version": "1.0.5",
+      "version": "1.2.0",
       "version_source": "Immutable semantic-release image tag",
       "license": "LicenseRef-Atrinik-Image-Contents",
       "source_url": "https://github.com/atrinik/devcontainer/pkgs/container/linux-build",
       "locator": "ghcr.io/atrinik/linux-build",
-      "commit": null,
-      "checksum": "sha256:be3427cfc7dabcf837450c7306d55883c32e20ba1ab7cc96b4da4b966b8066de",
+      "commit": "66b8508434044ca50822558172c5cef47a888762",
+      "checksum": "sha256:1231b39d40161c1199fd3e45e99e3d826dde02dade79729c030cc0ce3710898f",
       "acquisition": "Dev Containers pulls the release tag and immutable manifest digest",
       "update_cadence_days": 30,
       "update_mechanism": "Weekly audit plus reviewed devcontainer release update",
@@ -1484,7 +1484,7 @@
         {
           "repository": "atrinik",
           "path": ".devcontainer/devcontainer.json",
-          "contains": "ghcr.io/atrinik/linux-build:1.0.5@sha256:be3427cfc7dabcf837450c7306d55883c32e20ba1ab7cc96b4da4b966b8066de"
+          "contains": "ghcr.io/atrinik/linux-build:1.2.0@sha256:1231b39d40161c1199fd3e45e99e3d826dde02dade79729c030cc0ce3710898f"
         }
       ]
     },

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 import json
+import fcntl
 import os
 from pathlib import Path
 import shutil
@@ -14,10 +15,12 @@ from atrinik_workspace.cleanup import (
     Cleanup,
     _base_item,
     _command,
+    _exclusive_sound_producer_lease,
     _listed_usage,
     _parse_time,
     _path_relation,
     _tree_usage,
+    _sound_producer_lock_snapshot,
     _worktree_records,
     _workspace_owned,
 )
@@ -117,6 +120,383 @@ class CleanupTests(unittest.TestCase):
         (path / "ignored").mkdir()
         (path / "ignored" / "output.o").write_bytes(b"x" * 4096)
         return path
+
+    def make_sound_cache(self) -> tuple[Path, Path]:
+        sound = self.wrapper / "sound"
+        sound.mkdir()
+        command("git", "init", "-b", "main", cwd=sound)
+        command("git", "config", "user.name", "Tests", cwd=sound)
+        command("git", "config", "user.email", "tests@example.invalid", cwd=sound)
+        (sound / ".gitignore").write_text("/build/\n", encoding="utf-8")
+        command("git", "add", ".gitignore", cwd=sound)
+        command("git", "commit", "-m", "feat: seed", cwd=sound)
+        command(
+            "git", "remote", "add", "origin",
+            "https://github.com/atrinik/sound.git", cwd=sound,
+        )
+        self.write_sound_producer_lease(sound)
+        cache = sound / "build" / "atrinik-workspace" / ("a" * 20)
+        cache.mkdir(parents=True)
+        atomic_json(
+            cache / ".atrinik-playtest-tree.json",
+            {
+                "format": "atrinik-sound-playtest-tree",
+                "playtest_only": True,
+                "publishable": False,
+                "schema_version": 1,
+            },
+        )
+        (cache / "playtest-manifest.json").write_text("{}\n", encoding="utf-8")
+        return sound, cache
+
+    @staticmethod
+    def write_sound_producer_lease(worktree: Path) -> Path:
+        git_directory = Path(
+            command(
+                "git", "rev-parse", "--path-format=absolute", "--git-dir",
+                cwd=worktree,
+            )
+        )
+        lease = git_directory / "atrinik-playtest-builds.lock"
+        lease.write_text("atrinik-sound-playtest-builds-v1\n", encoding="utf-8")
+        return lease
+
+    def test_sound_cache_is_explicit_preview_first_and_lock_protected(self) -> None:
+        _sound, cache = self.make_sound_cache()
+
+        preview = self.workspace.cleanup(["sound-cache"], 0, [], False)
+        item = next(row for row in preview["items"] if row["path"] == str(cache))
+        self.assertEqual(item["disposition"], "eligible")
+        self.assertEqual(item["reasons"], ["stale_sound_cache"])
+        self.assertTrue(cache.is_dir())
+
+        lock_path = cache.parent / f".{cache.name}.build.lock"
+        descriptor = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            locked = self.workspace.cleanup(["sound-cache"], 0, [], False)
+            locked_item = next(
+                row for row in locked["items"] if row["path"] == str(cache)
+            )
+            self.assertEqual(locked_item["disposition"], "skipped")
+            self.assertIn("active_build_lock", locked_item["reasons"])
+        finally:
+            os.close(descriptor)
+
+        applied = self.workspace.cleanup(["sound-cache"], 0, [], True)
+        removed = next(row for row in applied["items"] if row["path"] == str(cache))
+        self.assertEqual(removed["disposition"], "removed", applied)
+        self.assertFalse(cache.exists())
+
+    def test_sound_cache_apply_preserves_per_output_verifier_reader(self) -> None:
+        _sound, cache = self.make_sound_cache()
+        lock_path = cache.parent / f".{cache.name}.build.lock"
+        descriptor = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_SH | fcntl.LOCK_NB)
+            applied = self.workspace.cleanup(["sound-cache"], 0, [], True)
+        finally:
+            os.close(descriptor)
+
+        item = next(row for row in applied["items"] if row["path"] == str(cache))
+        self.assertEqual(item["disposition"], "skipped")
+        self.assertIn("active_build_lock", item["reasons"])
+        self.assertTrue(cache.is_dir())
+
+    def test_sound_cache_apply_preserves_git_admin_verifier_reader(self) -> None:
+        sound, cache = self.make_sound_cache()
+        producer_lock = self.write_sound_producer_lease(sound)
+        descriptor = os.open(producer_lock, os.O_RDWR | os.O_NOFOLLOW)
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_SH | fcntl.LOCK_NB)
+            applied = self.workspace.cleanup(["sound-cache"], 0, [], True)
+        finally:
+            os.close(descriptor)
+
+        item = next(row for row in applied["items"] if row["path"] == str(cache))
+        self.assertNotEqual(item["disposition"], "removed")
+        self.assertTrue(cache.is_dir())
+
+    def test_sound_cache_rejects_stale_worktree_record_replaced_by_directory(self) -> None:
+        sound, _primary_cache = self.make_sound_cache()
+        stale = self.workspace.paths.worktrees / "sound" / "stale"
+        stale.parent.mkdir(parents=True)
+        command(
+            "git", "worktree", "add", "-b", "feat/stale", str(stale),
+            cwd=sound,
+        )
+        shutil.rmtree(stale)
+        cache = stale / "build" / "atrinik-workspace" / ("b" * 20)
+        cache.mkdir(parents=True)
+        atomic_json(
+            cache / ".atrinik-playtest-tree.json",
+            {
+                "format": "atrinik-sound-playtest-tree",
+                "playtest_only": True,
+                "publishable": False,
+                "schema_version": 1,
+            },
+        )
+
+        preview = self.workspace.cleanup(["sound-cache"], 0, [], False)
+
+        self.assertNotIn(str(cache), {row["path"] for row in preview["items"]})
+        self.assertTrue(cache.is_dir())
+
+    def test_sound_cache_symlink_loop_fails_closed_without_mutation(self) -> None:
+        _sound, cache = self.make_sound_cache()
+        loop = cache.parent / "loop"
+        loop.symlink_to(loop)
+
+        preview = self.workspace.cleanup(["sound-cache"], 0, [], False)
+        self.assertIn("sound_cache_inventory_error", preview["inventory_errors"])
+        self.assertTrue(cache.is_dir())
+        self.assertTrue(loop.is_symlink())
+
+        applied = self.workspace.cleanup(["sound-cache"], 0, [], True)
+        self.assertIn("sound_cache_inventory_error", applied["inventory_errors"])
+        self.assertEqual(applied["summary"]["removed_count"], 0)
+        self.assertTrue(cache.is_dir())
+        self.assertTrue(loop.is_symlink())
+
+    def test_sound_cache_rejects_copied_same_repository_worktree_pointer(self) -> None:
+        sound, _primary_cache = self.make_sound_cache()
+        parent = self.workspace.paths.worktrees / "sound"
+        stale = parent / "stale-pointer"
+        donor = parent / "donor"
+        parent.mkdir(parents=True)
+        command(
+            "git", "worktree", "add", "-b", "feat/stale-pointer", str(stale),
+            cwd=sound,
+        )
+        command(
+            "git", "worktree", "add", "-b", "feat/donor", str(donor),
+            cwd=sound,
+        )
+        self.write_sound_producer_lease(donor)
+        shutil.rmtree(stale)
+        stale.mkdir()
+        shutil.copyfile(donor / ".git", stale / ".git")
+        cache = stale / "build" / "atrinik-workspace" / ("e" * 20)
+        cache.mkdir(parents=True)
+        atomic_json(
+            cache / ".atrinik-playtest-tree.json",
+            {
+                "format": "atrinik-sound-playtest-tree",
+                "playtest_only": True,
+                "publishable": False,
+                "schema_version": 1,
+            },
+        )
+
+        preview = self.workspace.cleanup(["sound-cache"], 0, [], False)
+
+        self.assertNotIn(str(cache), {row["path"] for row in preview["items"]})
+        self.assertTrue(cache.is_dir())
+
+        with mock.patch.object(Cleanup, "_github_pulls", return_value=[]):
+            worktrees = self.workspace.cleanup(
+                ["worktrees"], 0, ["sound"], False
+            )
+        stale_item = next(
+            row for row in worktrees["items"] if row["path"] == str(stale)
+        )
+        self.assertEqual(stale_item["disposition"], "protected")
+        self.assertIn(
+            "unexpected_git_worktree_identity", stale_item["reasons"]
+        )
+        with mock.patch.object(Cleanup, "_github_pulls", return_value=[]):
+            applied = self.workspace.cleanup(["all"], 0, ["sound"], True)
+        stale_item = next(
+            row for row in applied["items"] if row["path"] == str(stale)
+        )
+        self.assertNotEqual(stale_item["disposition"], "removed")
+        self.assertTrue(stale.is_dir())
+        self.assertTrue(cache.is_dir())
+
+    def test_sound_cache_accepts_registered_linked_worktree(self) -> None:
+        sound, _primary_cache = self.make_sound_cache()
+        linked = self.workspace.paths.worktrees / "sound" / "linked"
+        linked.parent.mkdir(parents=True)
+        command(
+            "git", "worktree", "add", "-b", "feat/linked", str(linked),
+            cwd=sound,
+        )
+        self.write_sound_producer_lease(linked)
+        cache = linked / "build" / "atrinik-workspace" / ("c" * 20)
+        cache.mkdir(parents=True)
+        atomic_json(
+            cache / ".atrinik-playtest-tree.json",
+            {
+                "format": "atrinik-sound-playtest-tree",
+                "playtest_only": True,
+                "publishable": False,
+                "schema_version": 1,
+            },
+        )
+
+        preview = self.workspace.cleanup(["sound-cache"], 0, [], False)
+        item = next(row for row in preview["items"] if row["path"] == str(cache))
+
+        self.assertEqual(item["disposition"], "eligible")
+
+    def test_sound_cache_apply_order_precedes_its_worktree(self) -> None:
+        cleanup = Cleanup(self.workspace)
+        self.assertLess(
+            cleanup._apply_order({"kind": "sound-cache", "path": "/cache"}),
+            cleanup._apply_order({"kind": "worktree", "path": "/worktree"}),
+        )
+
+    def test_active_sound_producer_lock_protects_its_worktree(self) -> None:
+        sound, _primary_cache = self.make_sound_cache()
+        linked = self.workspace.paths.worktrees / "sound" / "active"
+        linked.parent.mkdir(parents=True)
+        command(
+            "git", "worktree", "add", "-b", "feat/active", str(linked),
+            cwd=sound,
+        )
+        self.write_sound_producer_lease(linked)
+        head = command("git", "rev-parse", "HEAD", cwd=linked)
+        cache = linked / "build" / "atrinik-workspace" / ("d" * 20)
+        cache.mkdir(parents=True)
+        atomic_json(
+            cache / ".atrinik-playtest-tree.json",
+            {
+                "format": "atrinik-sound-playtest-tree",
+                "playtest_only": True,
+                "publishable": False,
+                "schema_version": 1,
+            },
+        )
+        lock = cache.parent / f".{cache.name}.build.lock"
+        descriptor = os.open(lock, os.O_CREAT | os.O_RDWR, 0o600)
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        pull = self.merged_pull(head)
+        try:
+            with mock.patch.object(Cleanup, "_github_pulls", return_value=[pull]):
+                preview = self.workspace.cleanup(
+                    ["worktrees"], 0, ["sound"], False
+                )
+                worktree = next(
+                    row for row in preview["items"] if row["path"] == str(linked)
+                )
+                self.assertEqual(worktree["disposition"], "protected")
+                self.assertIn("active_sound_build", worktree["reasons"])
+
+                applied = self.workspace.cleanup(["all"], 0, ["sound"], True)
+        finally:
+            os.close(descriptor)
+
+        worktree = next(
+            row for row in applied["items"] if row["path"] == str(linked)
+        )
+        self.assertNotEqual(worktree["disposition"], "removed")
+        self.assertTrue(linked.is_dir())
+        self.assertTrue(cache.is_dir())
+
+    def test_nonremovable_sound_caches_protect_owning_worktrees(self) -> None:
+        sound, _primary_cache = self.make_sound_cache()
+        parent = self.workspace.paths.worktrees / "sound"
+        parent.mkdir(parents=True)
+        caches: list[tuple[Path, Path]] = []
+        for label, key in (("young", "f" * 20), ("invalid", "1" * 20)):
+            linked = parent / label
+            command(
+                "git", "worktree", "add", "-b", f"feat/{label}", str(linked),
+                cwd=sound,
+            )
+            self.write_sound_producer_lease(linked)
+            cache = linked / "build" / "atrinik-workspace" / key
+            cache.mkdir(parents=True)
+            atomic_json(
+                cache / ".atrinik-playtest-tree.json",
+                {
+                    "format": "atrinik-sound-playtest-tree",
+                    "playtest_only": True,
+                    "publishable": label != "invalid",
+                    "schema_version": 1,
+                },
+            )
+            caches.append((linked, cache))
+        pulls = [
+            self.merged_pull(command("git", "rev-parse", "HEAD", cwd=linked))
+            for linked, _cache in caches
+        ]
+
+        with mock.patch.object(Cleanup, "_github_pulls", return_value=pulls):
+            applied = self.workspace.cleanup(["all"], 7, ["sound"], True)
+
+        for linked, cache in caches:
+            worktree = next(
+                row for row in applied["items"] if row["path"] == str(linked)
+            )
+            self.assertNotEqual(worktree["disposition"], "removed")
+            self.assertIn("sound_cache_present", worktree["reasons"])
+            self.assertTrue(linked.is_dir())
+            self.assertTrue(cache.is_dir())
+
+    def test_sound_worktree_removal_holds_exclusive_producer_lease(self) -> None:
+        sound, _primary_cache = self.make_sound_cache()
+        linked = self.workspace.paths.worktrees / "sound" / "race"
+        linked.parent.mkdir(parents=True)
+        command(
+            "git", "worktree", "add", "-b", "feat/race", str(linked),
+            cwd=sound,
+        )
+        head = command("git", "rev-parse", "HEAD", cwd=linked)
+        git_directory = Path(
+            command("git", "rev-parse", "--path-format=absolute", "--git-dir", cwd=linked)
+        )
+        producer_lock = git_directory / "atrinik-playtest-builds.lock"
+        with mock.patch.object(
+            Cleanup, "_github_pulls", return_value=self.merged_pull(head)
+        ):
+            uncoordinated = self.workspace.cleanup(
+                ["worktrees"], 0, ["sound"], False
+            )
+        item = next(
+            row for row in uncoordinated["items"] if row["path"] == str(linked)
+        )
+        self.assertEqual(item["disposition"], "protected")
+        self.assertIn("sound_cleanup_lease_unavailable", item["reasons"])
+        producer_lock.write_text(
+            "atrinik-sound-playtest-builds-v1\n", encoding="utf-8"
+        )
+        observed = False
+
+        def checked_command(path: Path, *arguments: str) -> str:
+            nonlocal observed
+            if arguments[:2] == ("worktree", "remove"):
+                descriptor = os.open(
+                    producer_lock, os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW, 0o600
+                )
+                try:
+                    with self.assertRaises(BlockingIOError):
+                        fcntl.flock(descriptor, fcntl.LOCK_SH | fcntl.LOCK_NB)
+                    observed = True
+                finally:
+                    os.close(descriptor)
+            return _command(path, *arguments)
+
+        with mock.patch.object(
+            Cleanup, "_github_pulls", return_value=self.merged_pull(head)
+        ), mock.patch("atrinik_workspace.cleanup._command", side_effect=checked_command):
+            applied = self.workspace.cleanup(["worktrees"], 0, ["sound"], True)
+
+        item = next(row for row in applied["items"] if row["path"] == str(linked))
+        self.assertTrue(observed)
+        self.assertEqual(item["disposition"], "removed", applied)
+        self.assertFalse(linked.exists())
+
+    def test_sound_producer_lease_inode_replacement_is_rejected(self) -> None:
+        sound, _cache = self.make_sound_cache()
+        lease, identity = _sound_producer_lock_snapshot(sound)
+        lease.unlink()
+        lease.write_text("atrinik-sound-playtest-builds-v1\n", encoding="utf-8")
+
+        with self.assertRaisesRegex(WorkspaceError, "changed identity"):
+            with _exclusive_sound_producer_lease(sound, identity):
+                self.fail("replacement producer lease was accepted")
 
     def add_local_submodule_to_wrapper(self) -> Path:
         source = self.root / "local-submodule"
@@ -2359,7 +2739,10 @@ class CleanupTests(unittest.TestCase):
         cleanup = Cleanup(actual_workspace)
         self.assertEqual(
             cleanup._normalize_scopes(["all"]),
-            ["worktrees", "builds", "npm-cache", "compiler-cache"],
+            [
+                "worktrees", "builds", "npm-cache", "compiler-cache",
+                "sound-cache",
+            ],
         )
         self.assertEqual(cleanup._normalize_names(["atrinik"]), {"atrinik"})
         with self.assertRaisesRegex(WorkspaceError, "unknown components"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -525,6 +525,17 @@ class ParserTests(unittest.TestCase):
             "copy", "review"
         )
 
+    def test_profile_sound_mode_dispatches_explicit_opt_in(self) -> None:
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            result = main(
+                ["profile", "sound-mode", "audio-review", "local-playtest"]
+            )
+
+        self.assertEqual(result, 0)
+        workspace_type.return_value.set_profile_sound_mode.assert_called_once_with(
+            "audio-review", "local-playtest"
+        )
+
     def test_path_prints_resolved_component_checkout(self) -> None:
         with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
             workspace_type.return_value.component_path.return_value = Path(

--- a/tests/test_cohorts.py
+++ b/tests/test_cohorts.py
@@ -10,6 +10,7 @@ import unittest
 from unittest import mock
 
 from atrinik_workspace.model import WorkspaceError, atomic_json, load_json
+from atrinik_workspace.sound import cache_key as sound_cache_key
 from atrinik_workspace.workspace import Workspace
 
 
@@ -907,6 +908,165 @@ class CohortWorkspaceTests(unittest.TestCase):
             self.workspace.set_profile(
                 "classic-review", "renderer", "primary"
             )
+
+    def test_local_playtest_sound_requires_saved_classic_profile(self) -> None:
+        self.workspace.create_profile("classic-audio", "classic")
+        self.assertEqual(
+            self.workspace.profile_summary("classic-audio")["sound_mode"],
+            "source",
+        )
+
+        self.workspace.set_profile_sound_mode("classic-audio", "local-playtest")
+        self.assertEqual(
+            self.workspace.profile_summary("classic-audio")["sound_mode"],
+            "local-playtest",
+        )
+        with self.assertRaisesRegex(WorkspaceError, "saved derived profile"):
+            self.workspace.set_profile_sound_mode("classic", "local-playtest")
+        self.workspace.create_profile("replacement-audio", "default")
+        with self.assertRaisesRegex(WorkspaceError, "Classic-derived"):
+            self.workspace.set_profile_sound_mode(
+                "replacement-audio", "local-playtest"
+            )
+
+        replacement = self.workspace.paths.profiles / "replacement-audio.json"
+        malformed = load_json(replacement)
+        malformed["sound_mode"] = "local-playtest"
+        atomic_json(replacement, malformed)
+        with self.assertRaisesRegex(WorkspaceError, "Classic-derived"):
+            self.workspace.profile_summary("replacement-audio")
+
+    def test_local_playtest_staging_invokes_builder_and_rechecks_inputs(self) -> None:
+        self.workspace.create_profile("classic-audio", "classic")
+        self.workspace.set_profile_sound_mode("classic-audio", "local-playtest")
+        source = self.wrapper / "sound-fixture"
+        builder = source / "tools" / "sound_release.py"
+        builder.parent.mkdir(parents=True)
+        builder.write_text("# fixture\n", encoding="utf-8")
+        inputs = {
+            "source_commit": "a" * 40,
+            "source_tree": "b" * 40,
+            "source_manifest_sha256": "c" * 64,
+            "toolchain_sha256": "d" * 64,
+            "schema_sha256": "e" * 64,
+            "builder_sha256": "f" * 64,
+        }
+        record = {
+            "mode": "local-playtest",
+            "root": "unused",
+            "output_tree_sha256": "1" * 64,
+        }
+        (
+            source
+            / "build"
+            / "atrinik-workspace"
+            / sound_cache_key(inputs)
+        ).mkdir(parents=True)
+        (self.root / "build").mkdir()
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.clean_source_inputs",
+                side_effect=[inputs, inputs, inputs],
+            ) as inspect,
+            mock.patch("atrinik_workspace.workspace.run") as invoke,
+            mock.patch(
+                "atrinik_workspace.workspace.verify_playtest_tree",
+                return_value=record,
+            ) as verify,
+        ):
+            output, actual = self.workspace._prepare_sound(
+                self.root / "build", {"sound": source}, "classic-audio"
+            )
+
+        self.assertEqual(actual, record)
+        self.assertEqual(output, self.root / "build" / "runtime" / "sound-local-playtest")
+        self.assertEqual(inspect.call_count, 3)
+        self.assertEqual(invoke.call_count, 2)
+        self.assertEqual(
+            [call.args[0][2] for call in invoke.call_args_list],
+            ["build-playtest-tree", "verify-playtest-tree"],
+        )
+        self.assertEqual(verify.call_count, 3)
+
+        changed = {**inputs, "source_commit": "2" * 40}
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.clean_source_inputs",
+                side_effect=[inputs, changed],
+            ),
+            mock.patch("atrinik_workspace.workspace.run"),
+            mock.patch(
+                "atrinik_workspace.workspace.verify_playtest_tree",
+                return_value=record,
+            ),
+            self.assertRaisesRegex(WorkspaceError, "changed after"),
+        ):
+            self.workspace._prepare_sound(
+                self.root / "build", {"sound": source}, "classic-audio"
+            )
+
+    def test_local_playtest_handoff_binds_complete_producer_record(self) -> None:
+        self.workspace.create_profile("classic-audio", "classic")
+        self.workspace.set_profile_sound_mode("classic-audio", "local-playtest")
+        source = self.wrapper / "sound-fixture"
+        builder = source / "tools" / "sound_release.py"
+        builder.parent.mkdir(parents=True)
+        builder.write_text("# fixture\n", encoding="utf-8")
+        inputs = {
+            "source_commit": "a" * 40,
+            "source_tree": "b" * 40,
+            "source_manifest_sha256": "c" * 64,
+            "toolchain_sha256": "d" * 64,
+            "schema_sha256": "e" * 64,
+            "builder_sha256": "f" * 64,
+        }
+        producer = {
+            "root": "/producer",
+            "output_tree_sha256": "1" * 64,
+            "playtest_manifest_sha256": "2" * 64,
+        }
+        tampered = {
+            **producer,
+            "root": "/handoff",
+            "playtest_manifest_sha256": "3" * 64,
+        }
+        output = (
+            source / "build" / "atrinik-workspace" / sound_cache_key(inputs)
+        )
+        output.mkdir(parents=True)
+        root = self.root / "build"
+        (root / "runtime" / "sound-local-playtest").mkdir(parents=True)
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.clean_source_inputs",
+                side_effect=[inputs, inputs],
+            ),
+            mock.patch("atrinik_workspace.workspace.run"),
+            mock.patch(
+                "atrinik_workspace.workspace.verify_playtest_tree",
+                side_effect=[producer, tampered],
+            ),
+            self.assertRaisesRegex(WorkspaceError, "differs from producer"),
+        ):
+            self.workspace._prepare_sound(root, {"sound": source}, "classic-audio")
+
+        shutil.rmtree(root / "runtime")
+        outside = self.root / "outside"
+        outside.mkdir()
+        (root / "runtime").symlink_to(outside, target_is_directory=True)
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.clean_source_inputs",
+                side_effect=[inputs, inputs],
+            ),
+            mock.patch("atrinik_workspace.workspace.run"),
+            mock.patch(
+                "atrinik_workspace.workspace.verify_playtest_tree",
+                return_value=producer,
+            ),
+            self.assertRaisesRegex(WorkspaceError, "not a safe directory"),
+        ):
+            self.workspace._prepare_sound(root, {"sound": source}, "classic-audio")
 
     def test_fresh_seed_runtime_fails_before_resolving_checkouts(self) -> None:
         with mock.patch.object(self.workspace, "resolve_profile") as resolve:

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -674,7 +674,9 @@ class CompletionTests(unittest.TestCase):
             env=environment,
         )
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout.splitlines(), ["create", "set", "show"])
+        self.assertEqual(
+            result.stdout.splitlines(), ["create", "set", "show", "sound-mode"]
+        )
 
     def test_bash_adapter_completes_equals_form_paths(self) -> None:
         bash = shutil.which("bash")
@@ -717,7 +719,8 @@ class CompletionTests(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(
-            result.stdout.splitlines(), ["--", "create", "set", "show"]
+            result.stdout.splitlines(),
+            ["--", "create", "set", "show", "sound-mode"],
         )
 
     def test_zsh_adapter_loads_from_fpath_with_real_compinit(self) -> None:
@@ -743,7 +746,10 @@ class CompletionTests(unittest.TestCase):
             [zsh, "-c", program], text=True, capture_output=True, cwd=ROOT
         )
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout.splitlines(), ["--", "create", "set", "show"])
+        self.assertEqual(
+            result.stdout.splitlines(),
+            ["--", "create", "set", "show", "sound-mode"],
+        )
 
     def test_fish_adapter_smoke(self) -> None:
         fish = shutil.which("fish")
@@ -773,7 +779,9 @@ class CompletionTests(unittest.TestCase):
             env=environment,
         )
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout.splitlines(), ["create", "set", "show"])
+        self.assertEqual(
+            result.stdout.splitlines(), ["create", "set", "show", "sound-mode"]
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_devcontainer.py
+++ b/tests/test_devcontainer.py
@@ -20,8 +20,8 @@ class DevcontainerTests(unittest.TestCase):
         self.assertEqual(config["postCreateCommand"], "./atrinik init")
         self.assertEqual(
             config["image"],
-            "ghcr.io/atrinik/linux-build:1.0.5@sha256:"
-            "be3427cfc7dabcf837450c7306d55883c32e20ba1ab7cc96b4da4b966b8066de",
+            "ghcr.io/atrinik/linux-build:1.2.0@sha256:"
+            "1231b39d40161c1199fd3e45e99e3d826dde02dade79729c030cc0ce3710898f",
         )
 
     def test_windows_configuration_validates_component_manifest(self) -> None:

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -386,6 +386,101 @@ class RepositoryMigrationTests(unittest.TestCase):
         self.assertIsNone(composite)
         self.assertEqual(json.loads(profile.read_text(encoding="utf-8")), value)
 
+    def test_schema_v3_classic_profile_upgrades_to_source_sound(self) -> None:
+        migration = self.migration()
+        profile = self.paths.profiles / "classic.json"
+        selector = {"kind": "primary", "value": ""}
+        value = {
+            "schema_version": 3,
+            "name": "classic",
+            "stack": "classic",
+            "components": {
+                name: dict(selector)
+                for name in migration._classic_profile_component_names()
+            },
+        }
+
+        rewritten, composite = migration._rewrite_profile(profile, value, {}, None)
+
+        self.assertIsNone(composite)
+        self.assertEqual(
+            rewritten,
+            {
+                **value,
+                "schema_version": 4,
+                "sound_mode": "source",
+            },
+        )
+
+    def test_current_and_legacy_profile_shapes_fail_closed(self) -> None:
+        migration = self.migration()
+        profile = self.paths.profiles / "classic.json"
+        components = {
+            name: {"kind": "primary", "value": ""}
+            for name in migration._classic_profile_component_names()
+        }
+        current = {
+            "schema_version": 4,
+            "name": "classic",
+            "stack": "classic",
+            "sound_mode": "source",
+            "components": components,
+        }
+        current_mutations = {
+            "unexpected field": {**current, "unexpected": True},
+            "wrong schema": {**current, "schema_version": 3},
+            "invalid sound mode": {**current, "sound_mode": "released"},
+            "wrong identity": {**current, "name": "other"},
+            "non-object components": {**current, "components": []},
+            "incomplete closure": {
+                **current,
+                "components": dict(list(components.items())[1:]),
+            },
+            "split classic checkout": {
+                **current,
+                "components": {
+                    **components,
+                    "classic-client": {"kind": "worktree", "value": "split"},
+                },
+            },
+        }
+        for label, malformed in current_mutations.items():
+            with self.subTest(schema="current", case=label):
+                with self.assertRaises(WorkspaceError):
+                    migration._validate_profile_shape(profile, malformed)
+
+        legacy = {
+            "schema_version": 3,
+            "name": "classic",
+            "stack": "classic",
+            "components": components,
+        }
+        legacy_mutations = {
+            "unexpected field": {**legacy, "unexpected": True},
+            "invalid identity": {**legacy, "stack": ""},
+            "invalid component": {
+                **legacy,
+                "components": {"": {"kind": "primary", "value": ""}},
+            },
+        }
+        for label, malformed in legacy_mutations.items():
+            with self.subTest(schema="legacy", case=label):
+                with self.assertRaises(WorkspaceError):
+                    migration._validate_legacy_profile_shape(profile, malformed)
+
+    def test_replacement_profile_cannot_enable_local_playtest_sound(self) -> None:
+        profile = self.paths.profiles / "replacement.json"
+        value = {
+            "schema_version": 4,
+            "name": "replacement",
+            "stack": "default",
+            "sound_mode": "local-playtest",
+            "components": {},
+        }
+
+        with self.assertRaisesRegex(WorkspaceError, "Classic-derived"):
+            self.migration()._rewrite_profile(profile, value, {}, None)
+
     def test_audit_accepts_manifest_owned_replacement_at_reused_source_path(
         self,
     ) -> None:

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -313,7 +313,7 @@ class RepositoryMigrationTests(unittest.TestCase):
         self.assertTrue(source.is_dir())
         self.assertEqual(profile.read_bytes(), before)
 
-    def test_apply_archives_clean_source_and_rewrites_profile_to_schema_v3(self) -> None:
+    def test_apply_archives_clean_source_and_rewrites_profile_to_schema_v4(self) -> None:
         source = self.make_repository("client", "client")
         classic = self.make_classic({"client": source})
         head = command("git", "rev-parse", "HEAD", cwd=source).decode().strip()
@@ -342,7 +342,8 @@ class RepositoryMigrationTests(unittest.TestCase):
         self.assertEqual(self.status_bytes(archive), b"")
         self.assertEqual(self.status_bytes(classic), b"")
         value = json.loads(profile.read_text(encoding="utf-8"))
-        self.assertEqual(value["schema_version"], 3)
+        self.assertEqual(value["schema_version"], 4)
+        self.assertEqual(value["sound_mode"], "source")
         self.assertEqual(value["stack"], "classic")
         self.assertEqual(stat.S_IMODE(profile.stat().st_mode), 0o600)
         self.assertEqual(
@@ -361,6 +362,29 @@ class RepositoryMigrationTests(unittest.TestCase):
         audit = self.migration().execute("audit")
         self.assertEqual(audit["status"], "complete", audit)
         self.assertEqual(self.migration().execute("apply")["status"], "already-applied")
+
+    def test_schema_v3_replacement_profile_is_valid_and_left_unchanged(self) -> None:
+        profile = self.paths.profiles / "replacement.json"
+        value = {
+            "schema_version": 3,
+            "name": "replacement",
+            "stack": "default",
+            "components": {
+                "client": {"kind": "primary", "value": ""},
+                "sound": {"kind": "primary", "value": ""},
+            },
+        }
+        profile.write_text(
+            json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+
+        rewritten, composite = self.migration()._rewrite_profile(
+            profile, value, {}, None
+        )
+
+        self.assertIsNone(rewritten)
+        self.assertIsNone(composite)
+        self.assertEqual(json.loads(profile.read_text(encoding="utf-8")), value)
 
     def test_audit_accepts_manifest_owned_replacement_at_reused_source_path(
         self,

--- a/tests/test_process_tree.py
+++ b/tests/test_process_tree.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+from atrinik_workspace import process_tree
+
+
+class ProcessTreeIdentityTests(unittest.TestCase):
+    def test_malformed_fdinfo_is_ignored(self) -> None:
+        descriptor = mock.Mock()
+        descriptor.name = "7"
+        descriptor.stat.return_value = SimpleNamespace(st_dev=11, st_ino=22)
+
+        for fdinfo in ("position:\t0\n", "flags:\tinvalid\n"):
+            with self.subTest(fdinfo=fdinfo):
+                with (
+                    mock.patch.object(Path, "iterdir", return_value=[descriptor]),
+                    mock.patch.object(Path, "read_text", return_value=fdinfo),
+                ):
+                    self.assertFalse(process_tree._holds_identity(123, (11, 22)))
+
+    def test_observer_descriptor_is_not_a_process_tree_holder(self) -> None:
+        descriptor = mock.Mock()
+        descriptor.name = "7"
+        descriptor.stat.return_value = SimpleNamespace(st_dev=11, st_ino=22)
+
+        with (
+            mock.patch.object(Path, "iterdir", return_value=[descriptor]),
+            mock.patch.object(
+                Path,
+                "read_text",
+                return_value=f"flags:\t{getattr(os, 'O_PATH', 0):o}\n",
+            ),
+        ):
+            self.assertFalse(process_tree._holds_identity(123, (11, 22)))
+
+        with (
+            mock.patch.object(Path, "iterdir", return_value=[descriptor]),
+            mock.patch.object(Path, "read_text", return_value="flags:\t0\n"),
+        ):
+            self.assertTrue(process_tree._holds_identity(123, (11, 22)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -371,12 +371,47 @@ class PlaytestSoundTests(unittest.TestCase):
             with self.subTest(description=description):
                 try:
                     assert callable(mutate)
-                    mutate()
+                    candidate_inputs = mutate()
+                    inputs = (
+                        candidate_inputs
+                        if isinstance(candidate_inputs, dict)
+                        else self.inputs
+                    )
                     with self.assertRaisesRegex(WorkspaceError, error):
-                        verify_playtest_tree(self.source, self.output, self.inputs)
+                        verify_playtest_tree(
+                            self.source,
+                            self.output,
+                            inputs,
+                        )
                 finally:
                     for path, payload in originals.items():
                         path.write_bytes(payload)
+
+        def install_toolchain_payload(payload: bytes) -> dict[str, str]:
+            toolchain_path.write_bytes(payload)
+            toolchain_hash = digest(toolchain_path)
+            manifest = copy.deepcopy(self.manifest)
+            manifest["toolchain_sha256"] = toolchain_hash
+            self.rewrite_manifest(manifest)
+            return {**self.inputs, "toolchain_sha256": toolchain_hash}
+
+        def install_toolchain(value: object) -> dict[str, str]:
+            return install_toolchain_payload(canonical(value))
+
+        def install_source_manifest_payload(payload: bytes) -> dict[str, str]:
+            source_manifest_path.write_bytes(payload)
+            source_manifest_hash = digest(source_manifest_path)
+            blocker = json.loads(originals[blocker_path])
+            blocker["source_manifest_sha256"] = source_manifest_hash
+            blocker_path.write_bytes(canonical(blocker))
+            manifest = copy.deepcopy(self.manifest)
+            manifest["source_manifest_sha256"] = source_manifest_hash
+            manifest["blocker_report_sha256"] = digest(blocker_path)
+            self.rewrite_manifest(manifest)
+            return {**self.inputs, "source_manifest_sha256": source_manifest_hash}
+
+        def install_source_manifest(value: object) -> dict[str, str]:
+            return install_source_manifest_payload(canonical(value))
 
         reject(
             "manifest-json",
@@ -391,7 +426,19 @@ class PlaytestSoundTests(unittest.TestCase):
         reject(
             "toolchain-schema",
             "toolchain schema is invalid",
-            lambda: toolchain_path.write_bytes(canonical({"schema_version": 2})),
+            lambda: install_toolchain({"schema_version": 2}),
+        )
+        reject(
+            "toolchain-json",
+            "toolchain is invalid JSON",
+            lambda: install_toolchain_payload(b"{"),
+        )
+        reject(
+            "toolchain-hash",
+            "toolchain is stale or tampered",
+            lambda: toolchain_path.write_bytes(
+                canonical({**json.loads(originals[toolchain_path]), "unused": True})
+            ),
         )
         reject(
             "packaged-schema",
@@ -428,13 +475,27 @@ class PlaytestSoundTests(unittest.TestCase):
         reject(
             "source-manifest",
             "source manifest is invalid",
-            lambda: source_manifest_path.write_bytes(canonical({"assets": {}})),
+            lambda: install_source_manifest({"assets": {}}),
+        )
+        reject(
+            "source-manifest-json",
+            "source manifest is invalid JSON",
+            lambda: install_source_manifest_payload(b"{"),
+        )
+        reject(
+            "source-manifest-hash",
+            "source manifest is stale or tampered",
+            lambda: source_manifest_path.write_bytes(
+                canonical(
+                    {**json.loads(originals[source_manifest_path]), "unused": True}
+                )
+            ),
         )
 
-        def invalid_source_asset() -> None:
+        def invalid_source_asset() -> dict[str, str]:
             source_manifest = json.loads(originals[source_manifest_path])
             source_manifest["assets"][0] = []
-            source_manifest_path.write_bytes(canonical(source_manifest))
+            return install_source_manifest(source_manifest)
 
         reject(
             "source-asset",
@@ -442,10 +503,10 @@ class PlaytestSoundTests(unittest.TestCase):
             invalid_source_asset,
         )
 
-        def invalid_expected_source() -> None:
+        def invalid_expected_source() -> dict[str, str]:
             source_manifest = json.loads(originals[source_manifest_path])
             source_manifest["assets"][0]["source"] = []
-            source_manifest_path.write_bytes(canonical(source_manifest))
+            return install_source_manifest(source_manifest)
 
         reject(
             "source-asset-identity",
@@ -453,12 +514,12 @@ class PlaytestSoundTests(unittest.TestCase):
             invalid_expected_source,
         )
 
-        def duplicate_source_asset() -> None:
+        def duplicate_source_asset() -> dict[str, str]:
             source_manifest = json.loads(originals[source_manifest_path])
             source_manifest["assets"][1]["logical_path"] = source_manifest["assets"][0][
                 "logical_path"
             ]
-            source_manifest_path.write_bytes(canonical(source_manifest))
+            return install_source_manifest(source_manifest)
 
         reject(
             "duplicate-source-asset",

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -1,0 +1,405 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+from atrinik_workspace.model import WorkspaceError
+from atrinik_workspace.sound import (
+    PLAYTEST_BLOCKERS,
+    PLAYTEST_MANIFEST,
+    PLAYTEST_MARKER,
+    PLAYTEST_SCHEMA,
+    cache_key,
+    clean_source_inputs,
+    validate_sound_record,
+    verify_playtest_tree,
+)
+from atrinik_workspace.workspace import BUILD_METADATA, Workspace
+
+
+def canonical(value: object) -> bytes:
+    return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode()
+
+
+def digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class PlaytestSoundTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.source = self.root / "sound"
+        self.output = self.source / "build" / "tree"
+        (self.source / "manifests").mkdir(parents=True)
+        (self.source / "schemas").mkdir()
+        self.output.mkdir(parents=True)
+
+        source_assets: list[dict[str, object]] = []
+        playtest_assets: list[dict[str, object]] = []
+        for index in range(339):
+            copied = index < 196
+            logical = (
+                f"effects/copy-{index:03}.ogg"
+                if copied
+                else f"background/convert-{index:03}.mid"
+            )
+            source_codec = "vorbis" if copied else "midi"
+            source_payload = f"source-{index}".encode()
+            source_hash = hashlib.sha256(source_payload).hexdigest()
+            payload = (
+                b"OggS\x00fixture\x01vorbis" + source_payload
+                if copied
+                else b"OggS\x00fixtureOpusHead" + source_payload
+            )
+            if copied:
+                source_hash = hashlib.sha256(payload).hexdigest()
+            destination = self.output / logical
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(payload)
+            source = {
+                "sha256": source_hash,
+                "codec": source_codec,
+                "container": "ogg" if copied else "midi",
+            }
+            source_assets.append(
+                {
+                    "logical_path": logical,
+                    "source_path": logical,
+                    "source": source,
+                    "render": {},
+                }
+            )
+            playtest_assets.append(
+                {
+                    "logical_path": logical,
+                    "source_path": logical,
+                    "mapping": "copy" if copied else "render-opus",
+                    "source": source,
+                    "output": {
+                        "sha256": hashlib.sha256(payload).hexdigest(),
+                        "size_bytes": len(payload),
+                        "codec": "vorbis" if copied else "opus",
+                        "container": "ogg",
+                        "sample_rate": 48000,
+                        "channels": 2,
+                        "duration_seconds": 1.0,
+                    },
+                }
+            )
+
+        source_manifest = {"audio_source_count": 339, "assets": source_assets}
+        source_manifest_path = self.source / "manifests" / "source-assets.json"
+        source_manifest_path.write_bytes(canonical(source_manifest))
+        toolchain = self.source / "manifests" / "playtest-audio-toolchain.json"
+        toolchain.write_bytes(
+            canonical(
+                {
+                    "$schema": "../schemas/playtest-audio-toolchain-v1.schema.json",
+                    "schema_version": 1,
+                }
+            )
+        )
+        schema = self.source / "schemas" / "playtest-manifest-v1.schema.json"
+        schema.write_bytes(b"{}\n")
+        packaged_schema = self.output / PLAYTEST_SCHEMA
+        packaged_schema.parent.mkdir()
+        packaged_schema.write_bytes(schema.read_bytes())
+        marker = {
+            "format": "atrinik-sound-playtest-tree",
+            "playtest_only": True,
+            "publishable": False,
+            "schema_version": 1,
+        }
+        (self.output / PLAYTEST_MARKER).write_bytes(canonical(marker))
+        blockers = {
+            "schema_version": 1,
+            "source_manifest_sha256": digest(source_manifest_path),
+            "source_count": 339,
+            "count": 0,
+            "findings": [],
+        }
+        (self.output / PLAYTEST_BLOCKERS).write_bytes(canonical(blockers))
+        tree_hash = hashlib.sha256()
+        for asset in playtest_assets:
+            logical = str(asset["logical_path"])
+            tree_hash.update(f"{digest(self.output / logical)}  {logical}\n".encode())
+        self.inputs = {
+            "source_commit": "a" * 40,
+            "source_tree": "b" * 40,
+            "source_manifest_sha256": digest(source_manifest_path),
+            "toolchain_sha256": digest(toolchain),
+            "schema_sha256": digest(schema),
+            "builder_sha256": "c" * 64,
+        }
+        self.manifest = {
+            "$schema": PLAYTEST_SCHEMA,
+            "schema_version": 1,
+            "playtest_only": True,
+            "publishable": False,
+            "source_commit": self.inputs["source_commit"],
+            "source_tree": self.inputs["source_tree"],
+            "source_manifest_sha256": self.inputs["source_manifest_sha256"],
+            "toolchain_sha256": self.inputs["toolchain_sha256"],
+            "tool_versions": {
+                name: "fixture"
+                for name in (
+                    "ffmpeg",
+                    "openmpt123",
+                    "opusenc",
+                    "opusinfo",
+                    "sdl3_mixer_probe",
+                    "wildmidi",
+                )
+            },
+            "schema_sha256": self.inputs["schema_sha256"],
+            "marker_sha256": digest(self.output / PLAYTEST_MARKER),
+            "blocker_report_sha256": digest(self.output / PLAYTEST_BLOCKERS),
+            "blocker_count": 0,
+            "logical_path_count": 339,
+            "copied_vorbis_count": 196,
+            "converted_opus_count": 143,
+            "output_tree_sha256": tree_hash.hexdigest(),
+            "assets": playtest_assets,
+        }
+        (self.output / PLAYTEST_MANIFEST).write_bytes(canonical(self.manifest))
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def rewrite_manifest(self, value: dict[str, object]) -> None:
+        (self.output / PLAYTEST_MANIFEST).write_bytes(canonical(value))
+
+    def test_complete_current_tree_is_accepted(self) -> None:
+        record = verify_playtest_tree(self.source, self.output, self.inputs)
+
+        self.assertEqual(record["mode"], "local-playtest")
+        self.assertEqual(record["logical_path_count"], 339)
+        self.assertEqual(record["output_tree_sha256"], self.manifest["output_tree_sha256"])
+        self.assertEqual(record["toolchain_schema_version"], 1)
+        self.assertEqual(record["playtest_manifest_sha256"], digest(self.output / PLAYTEST_MANIFEST))
+        self.assertEqual(validate_sound_record(record), record)
+
+        replacement_record = dict(record)
+        replacement_record["copied_vorbis_count"] = 189
+        replacement_record["converted_opus_count"] = 150
+        self.assertEqual(
+            validate_sound_record(replacement_record), replacement_record
+        )
+        replacement_record["converted_opus_count"] = 149
+        with self.assertRaisesRegex(WorkspaceError, "provenance is invalid"):
+            validate_sound_record(replacement_record)
+
+        incomplete = dict(record)
+        incomplete.pop("blocker_report_sha256")
+        with self.assertRaisesRegex(WorkspaceError, "fields are invalid"):
+            validate_sound_record(incomplete)
+
+    def test_payload_corruption_and_legacy_raw_bytes_are_rejected(self) -> None:
+        payload = self.output / "background" / "convert-196.mid"
+        payload.write_bytes(b"MThd" + b"\0" * 20)
+        with self.assertRaisesRegex(WorkspaceError, "hash or size mismatch"):
+            verify_playtest_tree(self.source, self.output, self.inputs)
+
+        asset = self.manifest["assets"][196]
+        assert isinstance(asset, dict) and isinstance(asset["output"], dict)
+        asset["output"]["sha256"] = digest(payload)
+        asset["output"]["size_bytes"] = payload.stat().st_size
+        self.rewrite_manifest(self.manifest)
+        with self.assertRaisesRegex(WorkspaceError, "not an Ogg stream"):
+            verify_playtest_tree(self.source, self.output, self.inputs)
+
+    def test_marker_schema_and_exact_closure_fail_closed(self) -> None:
+        marker = json.loads((self.output / PLAYTEST_MARKER).read_text())
+        marker["publishable"] = True
+        (self.output / PLAYTEST_MARKER).write_bytes(canonical(marker))
+        with self.assertRaisesRegex(WorkspaceError, "marker"):
+            verify_playtest_tree(self.source, self.output, self.inputs)
+
+        (self.output / PLAYTEST_MARKER).write_bytes(
+            canonical(
+                {
+                    "format": "atrinik-sound-playtest-tree",
+                    "playtest_only": True,
+                    "publishable": False,
+                    "schema_version": 1,
+                }
+            )
+        )
+        extra = self.output / "unexpected.bin"
+        extra.write_bytes(b"no")
+        with self.assertRaisesRegex(WorkspaceError, "missing or unexpected"):
+            verify_playtest_tree(self.source, self.output, self.inputs)
+
+    def test_cache_key_binds_every_exact_input(self) -> None:
+        baseline = cache_key(self.inputs)
+        for key in self.inputs:
+            changed = copy.deepcopy(self.inputs)
+            changed[key] = "f" * len(changed[key])
+            self.assertNotEqual(cache_key(changed), baseline, key)
+
+    def test_clean_source_identity_rejects_dirty_checkout(self) -> None:
+        tools = self.source / "tools"
+        tools.mkdir()
+        (tools / "sound_release.py").write_text("# builder\n", encoding="utf-8")
+        (self.source / ".gitignore").write_text("/build/\n", encoding="utf-8")
+        subprocess.run(["git", "init", "-b", "main"], cwd=self.source, check=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Tests"], cwd=self.source, check=True
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "tests@example.invalid"],
+            cwd=self.source,
+            check=True,
+        )
+        subprocess.run(["git", "add", "."], cwd=self.source, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "feat: fixture"],
+            cwd=self.source,
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+
+        inputs = clean_source_inputs(self.source)
+        self.assertEqual(inputs["source_commit"], subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=self.source,
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip())
+        (tools / "sound_release.py").write_text("# dirty\n", encoding="utf-8")
+        with self.assertRaisesRegex(WorkspaceError, "requires a clean"):
+            clean_source_inputs(self.source)
+
+    def test_wrapper_reuses_offline_tree_and_topology_prepares_same_root(self) -> None:
+        tools = self.source / "tools"
+        tools.mkdir()
+        builder = tools / "sound_release.py"
+        builder.write_text(
+            "#!/usr/bin/env python3\n"
+            "from pathlib import Path\n"
+            "import shutil, sys\n"
+            "root = Path(__file__).resolve().parents[1]\n"
+            "command, output = sys.argv[1], Path(sys.argv[2])\n"
+            "with (root / 'build' / 'calls').open('a') as stream:\n"
+            "    stream.write(command + '\\n')\n"
+            "if command == 'build-playtest-tree' and not output.exists():\n"
+            "    shutil.copytree(root / 'build' / 'tree', output)\n"
+            "elif command == 'verify-playtest-tree':\n"
+            "    assert (output / '.atrinik-playtest-tree.json').is_file()\n",
+            encoding="utf-8",
+        )
+        (self.source / ".gitignore").write_text("/build/\n", encoding="utf-8")
+        subprocess.run(["git", "init", "-b", "main"], cwd=self.source, check=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Tests"], cwd=self.source, check=True
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "tests@example.invalid"],
+            cwd=self.source,
+            check=True,
+        )
+        subprocess.run(["git", "add", "."], cwd=self.source, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "feat: fixture producer"],
+            cwd=self.source,
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+        subprocess.run(
+            [
+                "git", "remote", "add", "origin",
+                "https://github.com/atrinik/sound.git",
+            ],
+            cwd=self.source,
+            check=True,
+        )
+        self.manifest["source_commit"] = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=self.source,
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+        self.manifest["source_tree"] = subprocess.run(
+            ["git", "rev-parse", "HEAD^{tree}"],
+            cwd=self.source,
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+        self.rewrite_manifest(self.manifest)
+
+        wrapper = self.root / "wrapper"
+        wrapper.mkdir()
+        shutil.copy2(Path(__file__).resolve().parents[1] / "components.json", wrapper)
+        subprocess.run(["git", "init", "-b", "main"], cwd=wrapper, check=True)
+        workspace_root = self.root / "workspace"
+        previous = os.environ.get("ATRINIK_WORKSPACE_DIR")
+        os.environ["ATRINIK_WORKSPACE_DIR"] = str(workspace_root)
+        try:
+            workspace = Workspace(wrapper)
+            workspace.paths.ensure()
+            workspace.create_profile("classic-audio", "classic")
+            workspace.set_profile(
+                "classic-audio", "sound", "path", str(self.source)
+            )
+            workspace.set_profile_sound_mode("classic-audio", "local-playtest")
+            profile_build = workspace.paths.builds / "profiles" / "fixture"
+            profile_build.mkdir(parents=True)
+            first_root, first_record = workspace._prepare_sound(
+                profile_build, {"sound": self.source}, "classic-audio"
+            )
+            second_root, second_record = workspace._prepare_sound(
+                profile_build, {"sound": self.source}, "classic-audio"
+            )
+            workspace._refresh_build_metadata(
+                profile_build,
+                "classic-audio",
+                "fixture",
+                {"sound": self.source},
+                second_record,
+            )
+            client = self.root / "client"
+            client.mkdir()
+            (client / "tracked").write_text("fixture\n", encoding="utf-8")
+            topology = workspace.paths.topologies / "fixture"
+            topology.mkdir(parents=True)
+            runtime = workspace._prepare_topology_client_runtime(
+                topology, {"client": client, "sound": self.source}, second_root
+            )
+        finally:
+            if previous is None:
+                os.environ.pop("ATRINIK_WORKSPACE_DIR", None)
+            else:
+                os.environ["ATRINIK_WORKSPACE_DIR"] = previous
+
+        self.assertEqual(first_root, second_root)
+        self.assertEqual(first_record, second_record)
+        self.assertEqual(
+            (runtime / "sound").resolve(),
+            first_root.resolve(),
+        )
+        metadata = json.loads((profile_build / BUILD_METADATA).read_text())
+        self.assertEqual(metadata["sound"], first_record)
+        self.assertEqual(
+            (self.source / "build" / "calls").read_text().splitlines(),
+            [
+                "build-playtest-tree",
+                "verify-playtest-tree",
+                "build-playtest-tree",
+                "verify-playtest-tree",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -9,7 +9,9 @@ import shutil
 import subprocess
 import tempfile
 import unittest
+from unittest import mock
 
+from atrinik_workspace import sound as sound_module
 from atrinik_workspace.model import WorkspaceError
 from atrinik_workspace.sound import (
     PLAYTEST_BLOCKERS,
@@ -202,6 +204,289 @@ class PlaytestSoundTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "fields are invalid"):
             validate_sound_record(incomplete)
 
+    def test_sound_record_validation_rejects_each_invalid_identity(self) -> None:
+        record = verify_playtest_tree(self.source, self.output, self.inputs)
+        cases: list[tuple[str, object, str]] = [
+            ("not-object", [], "not an object"),
+            ("unknown-mode", {**record, "mode": "released"}, "fields are invalid"),
+            ("relative-root", {**record, "root": "relative"}, "root is invalid"),
+            ("bad-commit", {**record, "source_commit": "bad"}, "identity is invalid"),
+            ("bad-tree", {**record, "source_tree": "bad"}, "identity is invalid"),
+            ("unclean", {**record, "source_clean": False}, "provenance is invalid"),
+            (
+                "bad-manifest-hash",
+                {**record, "playtest_manifest_sha256": "bad"},
+                "provenance is invalid",
+            ),
+            (
+                "bad-playtest-schema",
+                {**record, "playtest_schema_version": 2},
+                "provenance is invalid",
+            ),
+            (
+                "bad-toolchain-schema-version",
+                {**record, "toolchain_schema_version": 2},
+                "provenance is invalid",
+            ),
+            (
+                "bad-toolchain-schema",
+                {**record, "toolchain_schema": "schema.json"},
+                "provenance is invalid",
+            ),
+            (
+                "bad-path-count",
+                {**record, "logical_path_count": 338},
+                "provenance is invalid",
+            ),
+            (
+                "boolean-copy-count",
+                {**record, "copied_vorbis_count": True},
+                "provenance is invalid",
+            ),
+            (
+                "negative-copy-count",
+                {**record, "copied_vorbis_count": -1},
+                "provenance is invalid",
+            ),
+            (
+                "boolean-converted-count",
+                {**record, "converted_opus_count": True},
+                "provenance is invalid",
+            ),
+            (
+                "negative-converted-count",
+                {**record, "converted_opus_count": -1},
+                "provenance is invalid",
+            ),
+            (
+                "incomplete-count",
+                {**record, "converted_opus_count": 142},
+                "provenance is invalid",
+            ),
+        ]
+        for description, value, error in cases:
+            with self.subTest(description=description):
+                with self.assertRaisesRegex(WorkspaceError, error):
+                    validate_sound_record(value)
+
+    def test_manifest_identity_and_mapping_mutations_fail_closed(self) -> None:
+        def set_asset(value: dict[str, object], key: str, replacement: object) -> None:
+            assets = value["assets"]
+            assert isinstance(assets, list) and isinstance(assets[0], dict)
+            assets[0][key] = replacement
+
+        def set_output(value: dict[str, object], key: str, replacement: object) -> None:
+            assets = value["assets"]
+            assert isinstance(assets, list) and isinstance(assets[0], dict)
+            output = assets[0]["output"]
+            assert isinstance(output, dict)
+            output[key] = replacement
+
+        cases = [
+            (
+                "schema",
+                lambda value: value.__setitem__("schema_version", 2),
+                "must use schema 1",
+            ),
+            (
+                "stale-source",
+                lambda value: value.__setitem__("source_commit", "d" * 40),
+                "stale or tampered source_commit",
+            ),
+            (
+                "tool-versions",
+                lambda value: value.__setitem__("tool_versions", {}),
+                "toolchain versions are invalid",
+            ),
+            (
+                "assets-type",
+                lambda value: value.__setitem__("assets", {}),
+                "assets must be an array",
+            ),
+            (
+                "unsafe-path",
+                lambda value: set_asset(value, "logical_path", "../unsafe.ogg"),
+                "unsafe or duplicate path",
+            ),
+            (
+                "extra-path",
+                lambda value: set_asset(value, "logical_path", "effects/extra.ogg"),
+                "extra logical path",
+            ),
+            (
+                "source-path",
+                lambda value: set_asset(value, "source_path", "effects/other.ogg"),
+                "mapping is invalid",
+            ),
+            (
+                "channels",
+                lambda value: set_output(value, "channels", 3),
+                "mapping is invalid",
+            ),
+            (
+                "missing-path",
+                lambda value: value["assets"].pop(),
+                "missing logical path",
+            ),
+            (
+                "counts",
+                lambda value: value.__setitem__("copied_vorbis_count", 195),
+                "counts do not match",
+            ),
+            (
+                "tree-digest",
+                lambda value: value.__setitem__("output_tree_sha256", "f" * 64),
+                "output-tree digest mismatch",
+            ),
+        ]
+        for description, mutate, error in cases:
+            with self.subTest(description=description):
+                value = copy.deepcopy(self.manifest)
+                mutate(value)
+                self.rewrite_manifest(value)
+                try:
+                    with self.assertRaisesRegex(WorkspaceError, error):
+                        verify_playtest_tree(self.source, self.output, self.inputs)
+                finally:
+                    self.rewrite_manifest(self.manifest)
+
+    def test_auxiliary_contract_mutations_fail_closed(self) -> None:
+        manifest_path = self.output / PLAYTEST_MANIFEST
+        blocker_path = self.output / PLAYTEST_BLOCKERS
+        schema_path = self.output / PLAYTEST_SCHEMA
+        toolchain_path = self.source / "manifests" / "playtest-audio-toolchain.json"
+        source_manifest_path = self.source / "manifests" / "source-assets.json"
+        originals = {
+            path: path.read_bytes()
+            for path in (
+                manifest_path,
+                blocker_path,
+                schema_path,
+                toolchain_path,
+                source_manifest_path,
+            )
+        }
+
+        def reject(description: str, error: str, mutate: object) -> None:
+            with self.subTest(description=description):
+                try:
+                    assert callable(mutate)
+                    mutate()
+                    with self.assertRaisesRegex(WorkspaceError, error):
+                        verify_playtest_tree(self.source, self.output, self.inputs)
+                finally:
+                    for path, payload in originals.items():
+                        path.write_bytes(payload)
+
+        reject(
+            "manifest-json",
+            "manifest is invalid JSON",
+            lambda: manifest_path.write_bytes(b"{"),
+        )
+        reject(
+            "manifest-canonical",
+            "manifest is not canonical JSON",
+            lambda: manifest_path.write_text(json.dumps(self.manifest), encoding="utf-8"),
+        )
+        reject(
+            "toolchain-schema",
+            "toolchain schema is invalid",
+            lambda: toolchain_path.write_bytes(canonical({"schema_version": 2})),
+        )
+        reject(
+            "packaged-schema",
+            "packaged schema is missing or tampered",
+            lambda: schema_path.write_bytes(b"changed\n"),
+        )
+        reject(
+            "blocker-hash",
+            "blocker report is missing or tampered",
+            lambda: blocker_path.write_bytes(b"changed\n"),
+        )
+
+        def invalid_blocker_json() -> None:
+            blocker_path.write_bytes(b"{")
+            value = copy.deepcopy(self.manifest)
+            value["blocker_report_sha256"] = digest(blocker_path)
+            self.rewrite_manifest(value)
+
+        reject("blocker-json", "blocker report is invalid JSON", invalid_blocker_json)
+
+        def invalid_blocker_contract() -> None:
+            blocker = json.loads(originals[blocker_path])
+            blocker["source_count"] = 338
+            blocker_path.write_bytes(canonical(blocker))
+            value = copy.deepcopy(self.manifest)
+            value["blocker_report_sha256"] = digest(blocker_path)
+            self.rewrite_manifest(value)
+
+        reject(
+            "blocker-contract",
+            "blocker report contract is invalid",
+            invalid_blocker_contract,
+        )
+        reject(
+            "source-manifest",
+            "source manifest is invalid",
+            lambda: source_manifest_path.write_bytes(canonical({"assets": {}})),
+        )
+
+        def invalid_source_asset() -> None:
+            source_manifest = json.loads(originals[source_manifest_path])
+            source_manifest["assets"][0] = []
+            source_manifest_path.write_bytes(canonical(source_manifest))
+
+        reject(
+            "source-asset",
+            "source manifest assets are invalid",
+            invalid_source_asset,
+        )
+
+        def invalid_expected_source() -> None:
+            source_manifest = json.loads(originals[source_manifest_path])
+            source_manifest["assets"][0]["source"] = []
+            source_manifest_path.write_bytes(canonical(source_manifest))
+
+        reject(
+            "source-asset-identity",
+            "source manifest asset is invalid",
+            invalid_expected_source,
+        )
+
+        def duplicate_source_asset() -> None:
+            source_manifest = json.loads(originals[source_manifest_path])
+            source_manifest["assets"][1]["logical_path"] = source_manifest["assets"][0][
+                "logical_path"
+            ]
+            source_manifest_path.write_bytes(canonical(source_manifest))
+
+        reject(
+            "duplicate-source-asset",
+            "duplicate logical paths",
+            duplicate_source_asset,
+        )
+
+    def test_vorbis_copy_must_match_the_source_hash(self) -> None:
+        logical_path = "effects/copy-000.ogg"
+        payload_path = self.output / logical_path
+        original_payload = payload_path.read_bytes()
+        replacement = b"OggS\x00fixture\x01vorbisreplacement"
+        payload_path.write_bytes(replacement)
+        value = copy.deepcopy(self.manifest)
+        asset = value["assets"][0]
+        assert isinstance(asset, dict)
+        output = asset["output"]
+        assert isinstance(output, dict)
+        output["sha256"] = digest(payload_path)
+        output["size_bytes"] = len(replacement)
+        self.rewrite_manifest(value)
+        try:
+            with self.assertRaisesRegex(WorkspaceError, "copy differs from source"):
+                verify_playtest_tree(self.source, self.output, self.inputs)
+        finally:
+            payload_path.write_bytes(original_payload)
+            self.rewrite_manifest(self.manifest)
+
     def test_payload_corruption_and_legacy_raw_bytes_are_rejected(self) -> None:
         payload = self.output / "background" / "convert-196.mid"
         payload.write_bytes(b"MThd" + b"\0" * 20)
@@ -278,6 +563,112 @@ class PlaytestSoundTests(unittest.TestCase):
         (tools / "sound_release.py").write_text("# dirty\n", encoding="utf-8")
         with self.assertRaisesRegex(WorkspaceError, "requires a clean"):
             clean_source_inputs(self.source)
+
+    def test_low_level_sound_inputs_fail_closed(self) -> None:
+        missing = self.root / "missing"
+        directory = self.root / "directory"
+        directory.mkdir()
+        for description, invoke in (
+            (
+                "missing read",
+                lambda: sound_module._read_regular(missing, "fixture"),
+            ),
+            (
+                "directory read",
+                lambda: sound_module._read_regular(directory, "fixture"),
+            ),
+            (
+                "missing hash",
+                lambda: sound_module._hash_regular(missing, "fixture"),
+            ),
+            (
+                "directory hash",
+                lambda: sound_module._hash_regular(directory, "fixture"),
+            ),
+            (
+                "git failure",
+                lambda: sound_module._git(missing, "rev-parse", "HEAD"),
+            ),
+            (
+                "non-object contract",
+                lambda: sound_module._require_dict([], set(), "fixture"),
+            ),
+            (
+                "wrong codec",
+                lambda: sound_module._validate_payload_codec(
+                    "fixture.ogg", "opus", b"OggS\x00\x01vorbis"
+                ),
+            ),
+            (
+                "missing playtest root",
+                lambda: verify_playtest_tree(self.source, missing, self.inputs),
+            ),
+        ):
+            with self.subTest(description=description):
+                with self.assertRaises(WorkspaceError):
+                    invoke()
+
+    def test_tree_closure_rejects_symlinks_and_nonregular_entries(self) -> None:
+        closure = self.root / "closure"
+        closure.mkdir()
+        real_directory = closure / "real"
+        real_directory.mkdir()
+        (closure / "linked-directory").symlink_to(real_directory, target_is_directory=True)
+        with self.assertRaisesRegex(WorkspaceError, "non-directory or symlink"):
+            sound_module._tree_files(closure)
+
+        (closure / "linked-directory").unlink()
+        payload = closure / "payload"
+        payload.write_bytes(b"payload")
+        (closure / "linked-file").symlink_to(payload)
+        with self.assertRaisesRegex(WorkspaceError, "not a readable regular file"):
+            sound_module._tree_files(closure)
+
+        (closure / "linked-file").unlink()
+        with (
+            mock.patch.object(sound_module.os, "open", return_value=17),
+            mock.patch.object(
+                sound_module.os,
+                "fstat",
+                return_value=mock.Mock(st_mode=0),
+            ),
+            mock.patch.object(sound_module.os, "close"),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "not a regular file"):
+                sound_module._tree_files(closure)
+
+    def test_clean_source_identity_rejects_races_and_invalid_coordinates(self) -> None:
+        coordinates = "a" * 40
+        tree = "b" * 40
+        with (
+            mock.patch.object(
+                sound_module,
+                "_hash_regular",
+                return_value=("c" * 64, 1, b"x"),
+            ),
+            mock.patch.object(
+                sound_module,
+                "_git",
+                side_effect=["", coordinates, tree, "", "d" * 40],
+            ),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "changed while reading"):
+                clean_source_inputs(self.source)
+
+        with (
+            mock.patch.object(
+                sound_module,
+                "_hash_regular",
+                return_value=("c" * 64, 1, b"x"),
+            ),
+            mock.patch.object(
+                sound_module,
+                "_git",
+                side_effect=["", "invalid", tree, "", "invalid"],
+            ),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "invalid Git coordinates"):
+                clean_source_inputs(self.source)
 
     def test_wrapper_reuses_offline_tree_and_topology_prepares_same_root(self) -> None:
         tools = self.source / "tools"

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -267,11 +267,16 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                 **spec,
                 "stack": "classic",
                 "providers": {"server": "classic-server"},
+                "sound": {"mode": "local-playtest", "root": "/tmp/sound"},
             },
             "123",
         )
         self.assertEqual(current["stack"], "classic")
         self.assertEqual(current["providers"], {"server": "classic-server"})
+        self.assertEqual(
+            current["sound"],
+            {"mode": "local-playtest", "root": "/tmp/sound"},
+        )
 
         with self.assertRaisesRegex(RuntimeError, "identity is incomplete"):
             _initial_status({**spec, "stack": "classic"}, "123")

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -353,7 +353,7 @@ def mixed_layout_operation_process(
                     return
                 first_entry = False
                 entered.put(operation)
-                if not release.wait(5):
+                if not release.wait(20):
                     raise TimeoutError("mixed operation was not released")
 
             def compile_client(*_arguments: object, **_keywords: object) -> None:
@@ -5837,6 +5837,7 @@ class WorkspaceTests(unittest.TestCase):
             "supervisor": {"pid": 999, "start_time": "1"},
             "services": {},
             "error": "stress fixture",
+            "sound": workspace_module.sound_source_record(self.wrapper / "sound"),
         }
         atomic_json(topology_root / "status.json", status)
         context = multiprocessing.get_context("spawn")
@@ -5871,7 +5872,7 @@ class WorkspaceTests(unittest.TestCase):
             )
             start.set()
             self.assertEqual(
-                {entered.get(timeout=5) for _ in processes}, set(operations)
+                {entered.get(timeout=20) for _ in processes}, set(operations)
             )
         finally:
             release.set()
@@ -6047,6 +6048,10 @@ class WorkspaceTests(unittest.TestCase):
             },
         )
         self.assertIn("default-", summary["build_root"])
+        self.assertEqual(
+            summary["sound"],
+            {"mode": "source", "source_path": str(self.wrapper / "sound")},
+        )
 
     def test_supervised_topology_lifecycle_and_logs(self) -> None:
         build_root = self.workspace.paths.builds / "fake-topology"
@@ -6065,6 +6070,10 @@ class WorkspaceTests(unittest.TestCase):
             encoding="utf-8",
         )
         executable.chmod(0o755)
+        atomic_json(
+            build_root / workspace_module.BUILD_METADATA,
+            {"sound": workspace_module.sound_source_record(self.wrapper / "sound")},
+        )
         second_build_root = self.workspace.paths.builds / "fake-topology-second"
         shutil.copytree(build_root, second_build_root, symlinks=True)
 
@@ -6081,6 +6090,10 @@ class WorkspaceTests(unittest.TestCase):
         try:
             self.assertTrue(status["supervisor"]["running"])
             self.assertTrue(status["services"]["client"]["running"])
+            self.assertEqual(
+                status["sound"],
+                workspace_module.sound_source_record(self.wrapper / "sound"),
+            )
             self.assertEqual(
                 Path(status["services"]["client"]["cwd"]),
                 self.workspace.paths.topologies / "review" / "client-runtime",
@@ -6164,6 +6177,136 @@ class WorkspaceTests(unittest.TestCase):
         self.assertFalse(stopped["supervisor"]["running"])
         self.assertFalse(stopped["services"]["client"]["running"])
 
+    def test_supervised_local_playtest_client_uses_recorded_verified_root(self) -> None:
+        self.workspace.create_profile("classic-audio", "classic")
+        self.workspace.set_profile_sound_mode("classic-audio", "local-playtest")
+        build_root = self.workspace.paths.builds / "fake-playtest-topology"
+        executable = build_root / "build" / "client" / "atrinik"
+        executable.parent.mkdir(parents=True)
+        executable.write_text(
+            "#!/usr/bin/env python3\n"
+            "import time\n"
+            "print('local playtest client ready', flush=True)\n"
+            "time.sleep(5)\n",
+            encoding="utf-8",
+        )
+        executable.chmod(0o755)
+        sound_root = build_root / "runtime" / "sound-local-playtest"
+        sound_root.mkdir(parents=True)
+        sound_record = {
+            "mode": "local-playtest",
+            "root": str(sound_root),
+            "playtest_manifest_sha256": "1" * 64,
+            "playtest_schema_version": 1,
+            "source_commit": "2" * 40,
+            "source_tree": "3" * 40,
+            "source_clean": True,
+            "source_manifest_sha256": "4" * 64,
+            "toolchain_sha256": "5" * 64,
+            "toolchain_schema": "../schemas/playtest-audio-toolchain-v1.schema.json",
+            "toolchain_schema_version": 1,
+            "schema_sha256": "6" * 64,
+            "marker_sha256": "7" * 64,
+            "blocker_report_sha256": "8" * 64,
+            "output_tree_sha256": "9" * 64,
+            "logical_path_count": 339,
+            "copied_vorbis_count": 196,
+            "converted_opus_count": 143,
+        }
+        atomic_json(build_root / workspace_module.BUILD_METADATA, {"sound": sound_record})
+        selected = {
+            "client": self.wrapper / "client",
+            "sound": self.wrapper / "sound",
+        }
+        resolved = {
+            "client": {
+                "path": str(self.wrapper / "client"),
+                "checkout_path": str(self.wrapper / "client"),
+                "checkout": "client",
+                "repository": "atrinik/client",
+                "branch": "main",
+                "source": ".",
+                "head": "a" * 40,
+                "dirty": False,
+            },
+            "sound": {
+                "path": str(self.wrapper / "sound"),
+                "checkout_path": str(self.wrapper / "sound"),
+                "checkout": "sound",
+                "repository": "atrinik/sound",
+                "branch": "main",
+                "source": ".",
+                "head": "b" * 40,
+                "dirty": False,
+            },
+        }
+        inputs = {
+            "source_commit": sound_record["source_commit"],
+            "source_tree": sound_record["source_tree"],
+        }
+        classic_stack = mock.Mock()
+        classic_stack.name = "classic"
+        classic_stack.components = ()
+        classic_stack.providers = {
+            "client": self.workspace.manifest.by_name["client"],
+            "sound": self.workspace.manifest.by_name["sound"],
+        }
+        with (
+            mock.patch.object(
+                self.workspace.manifest, "stack", return_value=classic_stack
+            ),
+            mock.patch.object(self.workspace, "_require_classic_contracts"),
+            mock.patch.object(self.workspace, "_require_client_display"),
+            mock.patch.object(
+                self.workspace, "_resolve_build_profile", return_value=selected
+            ),
+            mock.patch.object(
+                self.workspace, "_build_resolved", return_value=build_root
+            ),
+            mock.patch.object(
+                self.workspace, "_topology_resolved_status", return_value=resolved
+            ),
+            mock.patch(
+                "atrinik_workspace.workspace.clean_source_inputs",
+                return_value=inputs,
+            ),
+            mock.patch(
+                "atrinik_workspace.workspace.verify_playtest_tree",
+                return_value=sound_record,
+            ),
+        ):
+            status = self.workspace.topology_up(
+                "playtest-client", "classic-audio", "default", ["client"]
+            )
+        try:
+            self.assertTrue(status["services"]["client"]["running"])
+            self.assertEqual(status["sound"], sound_record)
+            runtime = Path(status["services"]["client"]["cwd"])
+            self.assertEqual((runtime / "sound").resolve(), sound_root.resolve())
+            log = self.workspace.paths.topologies / "playtest-client" / "client.log"
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline and (
+                not log.is_file()
+                or "local playtest client ready" not in log.read_text()
+            ):
+                time.sleep(0.05)
+            with mock.patch("builtins.print") as output:
+                self.workspace.topology_logs(
+                    "playtest-client", "client", tail=20, follow=False
+                )
+            self.assertIn(
+                "local playtest client ready",
+                "".join(call.args[0] for call in output.call_args_list),
+            )
+        finally:
+            with mock.patch.object(
+                self.workspace.manifest, "stack", return_value=classic_stack
+            ):
+                stopped = self.workspace.topology_down(
+                    "playtest-client", timeout=5
+                )
+        self.assertFalse(stopped["services"]["client"]["running"])
+
     def test_supervised_pair_pins_client_and_holds_state_lock_until_down(self) -> None:
         source = self.workspace.paths.repositories / "server"
         (source / "tools").mkdir()
@@ -6221,6 +6364,10 @@ class WorkspaceTests(unittest.TestCase):
             encoding="utf-8",
         )
         client.chmod(0o755)
+        atomic_json(
+            build_root / workspace_module.BUILD_METADATA,
+            {"sound": workspace_module.sound_source_record(self.wrapper / "sound")},
+        )
         second_build_root = (
             self.workspace.paths.builds / "profiles" / "fake-server-topology-second"
         )


### PR DESCRIPTION
Fixes #332

## Summary

- add a saved Classic-only `local-playtest` sound mode while preserving `source` as the default and migration behavior
- invoke the sound repository's public deterministic builder/verifier, independently verify its exact 339-path nonpublishing tree, and atomically hand one verified root to both build and supervised client runtime
- persist strict source/toolchain/schema/marker/blocker/tree provenance through build, topology, status, and support diagnostics with no raw-source fallback
- add explicit preview-first sound-cache cleanup, exact linked-worktree/backlink proof, active/retained cache protection, and producer/cache leases that close generation, verification, and removal races
- update CLI completion, devcontainer toolchain pinning, migration, cleanup, architecture, README, and agent cleanup guidance

## Dependency

- atrinik/sound#28 is merged at `e0ceed5af78df62f4172ef4d826987a1ed8ce0fe`, providing the public playtest-tree producer and shared cleanup lease contract.

## Validation

- complete 494-test wrapper suite passes, including repeated mixed-layout multiprocessing stress coverage
- focused sound, cleanup, cohort, CLI, completion, migration, supervisor, and supervised local-playtest lifecycle suites pass
- dependent sound `tools/validate.sh` passes 70 tests against the current 339-path corpus (189 Vorbis copies, 150 rendered Opus outputs)
- dependent sound latest-head checks pass, including the 1h4m9s offline full-corpus double-build and independent verifier
- coverage report: 82%; Codecov-equivalent patch coverage: 78.76%
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `./atrinik cleanup --scope all --older-than 7 --dry-run --json` (zero inventory errors; no mutation)
- `git diff --check`

## Notes

- A live host producer build was attempted but the host lacks the pinned ffmpeg/toolchain; the matched devcontainer remains the required real conversion environment.
- No archive, package, upload, release, or container layer consumes the local-playtest tree.
