### PR TITLE
feat(agents): add program delivery workflow

### DIFF
--- a/.agents/skills/atrinik-issue-delivery/SKILL.md
+++ b/.agents/skills/atrinik-issue-delivery/SKILL.md
@@ -12,6 +12,13 @@ force-pushes, issue closure, merges, policy bypass, destructive resets, cleanup
 application, self-approval, or unrelated external changes. Track a persistent
 goal only when explicitly asked.
 
+For an ordered master issue with merge-dependent leaves, use the explicitly
+invoked `$atrinik-program-delivery` orchestrator instead of stretching this
+single-issue contract across the whole program.
+An explicit program-delivery invocation delegates this contract to each
+dependency-ready child identified from that master's live graph and counts as
+explicit leaf authorization; do not create a separate goal for the leaf.
+
 Load `atrinik-multi-repo-workspace`, `atrinik-github-governance`, and only the
 applicable implementation skill. Add `atrinik-server-runtime` and
 `atrinik-test-scenario` only when verification needs them. Follow those skills

--- a/.agents/skills/atrinik-program-delivery/SKILL.md
+++ b/.agents/skills/atrinik-program-delivery/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: atrinik-program-delivery
+description: Deliver ordered Atrinik master issues through child work, merge gates, integration review, and final handoff. Explicit `$atrinik-program-delivery` invocation only.
+---
+
+# Deliver an Atrinik program
+
+Use this skill for a master issue whose acceptance depends on an ordered set of
+child issues, release-line pairs, or follow-up audits. Treat the program as one
+durable objective across multiple leaf deliveries and external merge gates.
+
+Explicit invocation authorizes assignment and Project updates for the master,
+ordinary branch pushes, child issue and draft PR creation when genuinely
+missing, updates to linked issues and PRs, ready transitions after exit
+conditions, and concise tracking comments. It does not authorize force-pushes,
+merges, issue closure, policy bypass, destructive resets, cleanup application,
+self-approval, or unrelated external changes. Do not infer merge authority from
+requests to finish, complete, or fully deliver a program.
+
+## Load the delivery contracts
+
+1. Read and follow the complete
+   [issue-delivery contract](../atrinik-issue-delivery/SKILL.md) for every leaf.
+   Its validation, review, publication, and ready-state exit conditions remain
+   mandatory; this skill adds orchestration rather than replacing them.
+2. Load `atrinik-multi-repo-workspace`, `atrinik-github-governance`, and the
+   narrow implementation, runtime, or scenario skills selected by each leaf.
+3. Read the full
+   [program review checklist](references/program-review-checklist.md) before
+   planning and again before the final audit.
+4. Copy [the program report template](assets/program-delivery-report.md) to an
+   ignored path such as
+   `<workspace>/build/program-delivery/<owner>-<repo>-<number>.md`. Prove the
+   destination is ignored before writing. Preserve and update that report
+   across resumptions; never delete it implicitly.
+
+## Establish the live program
+
+If and only if the user explicitly requested `/goal` or another persistent
+goal, create or resume one goal for the whole master before live preflight.
+Never create a nested or per-leaf goal. A preflight finding remains part of that
+objective rather than requiring a fresh goal on resumption.
+
+1. Normalize the master as `owner/repository#number`. Inspect the live issue,
+   body, comments, native parent/subissue graph, linked PRs, assignees, Project
+   item, releases, repository policy, and current branch tips before mutation.
+   Use the requested GitHub access path and never expose credentials.
+2. Treat hierarchy as ownership, not sequencing. Derive order only from the
+   master's explicit execution plan, dependency statements, and technical
+   constraints. Reject cycles, contradictory owners, repository mismatches,
+   ambiguous acceptance, or a closed master until reconciled.
+3. Verify every claimed completion from merged coordinates, current content,
+   checks, or an explicit maintainer attestation. Record attestations as such;
+   do not invent evidence.
+4. Build a stage matrix containing owner issue, target repository and release
+   line, dependencies, existing branch/PR/head, acceptance, validation, and the
+   next human gate. Reuse existing issues, worktrees, branches, and PRs. Create
+   and link a child only when required work has no current owner after a live
+   duplicate search.
+5. Apply the issue-delivery claim contract to the master: assign `zoeyrose`, add
+   it to **Atrinik work** when needed, and set the existing Status to
+   **In progress** from `github-settings/config/planning.json`. Never invent an
+   `in-progress` label. Let issue delivery claim each ready leaf.
+
+A merge-ready leaf is progress, not goal completion.
+
+## Deliver ready stages
+
+1. Select only a dependency-ready stage. Follow the master's stated order even
+   when later PRs are already green. Parallelize only independent work with no
+   shared base, schema, ledger, generated baseline, authored path, or closing
+   path.
+2. Apply the issue-delivery workflow completely to the leaf. Resume existing
+   work rather than creating replacement PRs. For paired release lines, keep
+   separate bases, commits, validation, and PRs; preserve the declared merge
+   order and canonical issue-closing path. Do not mark a draft ready until both
+   its leaf review and the cumulative program review below converge.
+3. Reconcile every head onto its current required base before relying on
+   validation. A prior green check proves only the old head/base combination.
+   Never bulk-merge or bulk-refresh a queue whose earlier merges change later
+   baselines.
+4. Run leaf whole-diff reviews to convergence, then review the cumulative
+   program state against already merged work, other in-flight heads, the master
+   invariants, and the program checklist. Give findings stable program IDs,
+   fix every actionable item, rerun affected validation, and record the exact
+   reviewed heads in the persistent report.
+5. Update the master matrix and relevant issue/PR bodies when durable state
+   changes. Keep comments concise, preserve history, verify remote rendering,
+   and avoid progress noise.
+
+## Stop at every merge or human gate
+
+Before yielding, confirm that each proposed PR is at the reviewed head, is
+mergeable, has current required checks, has no unresolved actionable feedback,
+and uses the intended closing reference. Report:
+
+- exact PR numbers, head SHAs, bases, and merge order;
+- checks and local validation at those heads;
+- any required manual scenario, policy decision, or post-merge action; and
+- which next stages will become stale or unblocked after the gate.
+
+Do not merge or close anything, and do not mark the program goal complete at a
+gate. Wait without busy-polling and follow the environment's active/blocked
+goal lifecycle; an unchanged external gate becomes blocked only under its
+required recurrence threshold. When work resumes, query GitHub rather than
+trusting the reported action: verify merged commits, issue state, new branch
+tips, checks, graph, and comments. Replan from that state. A merge on one
+release line invalidates only the dependent evidence, but every affected
+descendant must be reconciled and revalidated before its gate.
+
+## Finish the program
+
+After all implementation stages have been externally merged or explicitly
+excepted by the master or maintainer, run the master's terminal audit on the
+exact final tips. Review the complete resulting state rather than summing old
+PR reviews. Confirm that:
+
+- every acceptance item has a verified owner and outcome;
+- child and closing states match the declared release-line policy;
+- required ledgers, baselines, generated consumers, and branch invariants are
+  current, with no orphaned or duplicate work;
+- final validation and latest-head required checks pass; and
+- no known actionable leaf or program finding remains.
+
+When a terminal ledger or audit must account for commits it creates, record an
+immutable pre-ledger horizon for each line before the first terminal merge.
+Predeclare the exact ordered count of remaining squash commits and an exact
+changed-path allowlist for each ordinal. At the final tip, require the suffix
+length, order, and paths to match that declaration; any missing, extra,
+reordered, or out-of-allowlist commit invalidates it and requires a new horizon.
+Record the resulting suffix SHAs durably in the master and report after merge.
+Never require a commit to contain its own immutable hash.
+
+If the audit finds actionable work, return it to its existing owner or create a
+child only when the duplicate search proves none exists. Deliver that leaf
+through its review and merge gate, refresh the live graph and tips, then repeat
+the terminal audit. Never waive a stage or finding yourself.
+
+Update the master with exact final coordinates and a concise close-ready
+summary, but do not close it. The final handoff names any remaining human
+closure or release action and the preserved report path. Mark the durable goal
+complete only when the master is genuinely ready to close, not merely because
+the current stage is ready or waiting at a merge gate.

--- a/.agents/skills/atrinik-program-delivery/agents/openai.yaml
+++ b/.agents/skills/atrinik-program-delivery/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Atrinik Program Delivery"
+  short_description: "Deliver ordered Atrinik programs through merge gates"
+  default_prompt: "Use $atrinik-program-delivery to deliver this Atrinik master issue as one durable objective across ordered child work, iterative leaf and program-wide review/fix cycles, current-base validation, and explicit maintainer merge gates. You may assign and update tracking, push ordinary branches, create missing child issues and draft PRs, mark drafts ready after exit conditions, and post concise comments; do not force-push, merge, close issues, bypass policy, destructively reset, or apply cleanup."
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/atrinik-program-delivery/assets/program-delivery-report.md
+++ b/.agents/skills/atrinik-program-delivery/assets/program-delivery-report.md
@@ -1,0 +1,41 @@
+# Program delivery report
+
+## Coordinates
+
+- Master issue:
+- Persistent goal:
+- Started/resumed:
+- Current repository tips:
+- Master body/graph last refreshed:
+
+## Program invariants
+
+-
+
+## Ordered stage matrix
+
+| Stage | Owner issue | Target / release line | Dependencies | Branch / PR / head | Acceptance and validation | State / next gate |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | | | | | | |
+
+## Program findings
+
+| ID | Severity | Stage or location | Finding | Disposition | Evidence / reviewed heads |
+| --- | --- | --- | --- | --- | --- |
+
+## Merge and human gate log
+
+| Time | Gate | Requested action and order | Verified outcome | Invalidated or unblocked work |
+| --- | --- | --- | --- | --- |
+
+## Final exact-tip audit
+
+- Final tips:
+- Pre-ledger horizons:
+- Declared terminal suffix count/order by line:
+- Per-ordinal changed-path allowlists:
+- Actual terminal squash SHAs:
+- Child/closing state:
+- Validation and checks:
+- Ledger/baseline/generated state:
+- Remaining human action:

--- a/.agents/skills/atrinik-program-delivery/references/program-review-checklist.md
+++ b/.agents/skills/atrinik-program-delivery/references/program-review-checklist.md
@@ -1,0 +1,76 @@
+# Program integration review checklist
+
+Use this after each leaf reaches its delivery exit conditions and again on the
+exact final repository tips. Leaf review remains governed by
+`atrinik-issue-delivery`; this checklist covers interactions that a leaf diff
+cannot prove alone.
+
+## Graph and ownership
+
+- Does every acceptance item have one clear existing owner issue or an
+  evidence-backed exception?
+- Do native parent/subissue relationships preserve existing ownership?
+- Are newly discovered issues genuinely absent rather than duplicates under a
+  different title, PR, branch, or parent?
+- Are closed, transferred, superseded, and maintainer-attested items described
+  accurately?
+
+## Order and gates
+
+- Is the next stage dependency-ready according to the explicit plan rather than
+  merely green?
+- Are there cycles, hidden prerequisites, shared files, schemas, ledgers,
+  baselines, or closing paths that require serialization?
+- Will the proposed merge order leave every issue open until all of its required
+  release lines land?
+- After each external merge, which heads, digests, baselines, reviews, and checks
+  are stale?
+
+## Cross-change integration
+
+- Compare cumulative resulting trees and semantic behavior, not only commit
+  counts or independently green PRs.
+- Check overlapping authored paths, generated consumers, descriptor versions,
+  validation schemas, benchmark inputs, inventory counts, and release metadata.
+- Confirm that conflict resolution preserves both the newly merged behavior and
+  the leaf's intended change; never restore a deliberately deleted surface.
+- Verify that temporary diagnostics and generated evidence remain in their
+  governed ignored or deployment locations.
+- Look for duplicate implementations, mutually obsolete work, repeated
+  rationales, order-only churn, and unnecessary cross-line divergence.
+
+## Release lines and publication
+
+- Does every shared change have separate current-base validation for each
+  required line, or a documented format, consumer, runtime, or provenance
+  reason for a single-line exception?
+- Do companion PRs link without closing while the canonical/default-line PR
+  alone closes the owner issue?
+- Are PR titles, bodies, checklists, head coordinates, issue links, validation
+  claims, and remote rendering current?
+- Are draft/ready states intentional, with no unresolved reviews, conversations,
+  or actionable comments?
+
+## Validation currency
+
+- Record exact base and head SHAs for every local validation and remote check.
+- Treat skipped or neutral checks according to repository policy; never call
+  stale, cancelled, pending, or old-head checks current.
+- Rerun all affected focused, aggregate, generated-output, archive, syntax,
+  runtime, scenario, and diff checks after reconciliation.
+- Review the raw cumulative diff and current final trees after the last merge;
+  prior leaf reports are supporting evidence, not a substitute.
+
+## Close readiness
+
+- Are all non-master stages externally merged, closed, or explicitly excepted
+  with exact evidence?
+- Does the terminal audit cover the final tips and include its own resulting
+  changes in any ledger it creates?
+- Does a self-maintaining ledger predeclare each line's immutable horizon,
+  exact suffix count/order, and per-ordinal changed-path allowlist, fail on any
+  other suffix, and record the resulting SHAs durably in the master?
+- Is the master body/checklist synchronized with reality and free of stale
+  counts, coordinates, dependencies, and artifact requirements?
+- Is there zero known actionable work, and is the only remaining action an
+  explicitly named human closure or release step?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,9 @@
   `atrinik-guidance-maintenance` for periodic guidance audits or drift updates.
 - Use `atrinik-issue-delivery` only when explicitly invoked for
   issue-to-ready-PR delivery; it stops before merge.
+- Use `atrinik-program-delivery` only when explicitly invoked for an ordered
+  master issue; it composes leaf delivery across human merge gates and stops
+  before merge or issue closure.
 - Never replace or move a dirty primary checkout, remove a dirty worktree, or
   overwrite mutable server data. Preserve recoverable migration inputs.
 - Cleanup is explicit and preview-first: run

--- a/atrinik_workspace/guidance_inventory.py
+++ b/atrinik_workspace/guidance_inventory.py
@@ -15,11 +15,11 @@ SKILLS_ROOT = ROOT / ".agents" / "skills"
 MAX_ROOT_GUIDE_BYTES = 6_000
 MAX_CATALOG_BYTES = 2_000
 MAX_STARTUP_BYTES = 8_000
-MAX_MULTI_SELECTED_BYTES = 14_000
-# The ninth skill adds explicit issue delivery while its large checklist stays
-# progressively disclosed. The measured pre-addition total was 20,844 bytes;
-# 28,750 is the smallest 250-byte ceiling retaining a strict regression guard.
-MAX_ALL_SKILL_BYTES = 28_750
+MAX_MULTI_SELECTED_BYTES = 14_500
+# The tenth skill adds explicit program delivery while its integration checklist
+# stays progressively disclosed. The measured post-addition total is 37,275
+# bytes; 37,500 is the smallest 250-byte ceiling retaining a strict guard.
+MAX_ALL_SKILL_BYTES = 37_500
 
 
 @dataclass(frozen=True)

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -78,7 +78,7 @@ class AgentGuidanceTests(unittest.TestCase):
 
     def test_inventory_is_complete_and_within_budget(self) -> None:
         inventory = collect_inventory()
-        self.assertEqual(inventory["summary"]["skill_count"], 9)
+        self.assertEqual(inventory["summary"]["skill_count"], 10)
         self.assertIn(
             "atrinik-guidance-maintenance",
             [skill["name"] for skill in inventory["skills"]],
@@ -139,7 +139,7 @@ class AgentGuidanceTests(unittest.TestCase):
         with redirect_stdout(stdout):
             self.assertEqual(main(["--json"]), 0)
         inventory = json.loads(stdout.getvalue())
-        self.assertEqual(inventory["summary"]["skill_count"], 9)
+        self.assertEqual(inventory["summary"]["skill_count"], 10)
 
         stderr = io.StringIO()
         with mock.patch.object(
@@ -294,6 +294,83 @@ class AgentGuidanceTests(unittest.TestCase):
         self.assertIn("cross-repository or cross-line", checklist)
         self.assertIn("Issue-closing path", report)
         self.assertIn("manual post-merge close", checklist)
+
+    def test_program_delivery_is_explicit_and_merge_gated(self) -> None:
+        skill = ROOT / ".agents/skills/atrinik-program-delivery"
+        package = {
+            path.relative_to(skill).as_posix()
+            for path in skill.rglob("*")
+            if path.is_file()
+        }
+        self.assertEqual(
+            package,
+            {
+                "SKILL.md",
+                "agents/openai.yaml",
+                "assets/program-delivery-report.md",
+                "references/program-review-checklist.md",
+            },
+        )
+
+        body = (skill / "SKILL.md").read_text(encoding="utf-8")
+        interface = (skill / "agents/openai.yaml").read_text(encoding="utf-8")
+        report = (skill / "assets/program-delivery-report.md").read_text(
+            encoding="utf-8"
+        )
+        checklist = (
+            skill / "references/program-review-checklist.md"
+        ).read_text(encoding="utf-8")
+        normalized_body = " ".join(body.split())
+
+        self.assertIn("$atrinik-program-delivery", body)
+        self.assertIn(
+            "../atrinik-issue-delivery/SKILL.md",
+            body,
+        )
+        self.assertIn("policy:\n  allow_implicit_invocation: false", interface)
+        self.assertIn("$atrinik-program-delivery", interface)
+        self.assertIn('display_name: "Atrinik Program Delivery"', interface)
+        self.assertIn(
+            'short_description: "Deliver ordered Atrinik programs through merge gates"',
+            interface,
+        )
+        for boundary in {
+            "Do not infer merge authority",
+            "Do not merge or close anything",
+            "If and only if the user explicitly requested `/goal`",
+            "Never create a nested or per-leaf goal",
+            "A merge-ready leaf is progress, not goal completion",
+            "Do not mark a draft ready until both its leaf review",
+            "query GitHub rather than trusting the reported action",
+            "prior green check proves only the old head/base combination",
+            "follow the environment's active/blocked goal lifecycle",
+            "exact ordered count of remaining squash commits",
+            "any missing, extra, reordered, or out-of-allowlist commit",
+            "Never require a commit to contain its own immutable hash",
+            "then repeat the terminal audit",
+            "master is genuinely ready to close",
+        }:
+            with self.subTest(boundary=boundary):
+                self.assertIn(boundary, normalized_body)
+        self.assertIn("references/program-review-checklist.md", body)
+        self.assertIn("assets/program-delivery-report.md", body)
+        self.assertIn("## Ordered stage matrix", report)
+        self.assertIn("## Merge and human gate log", report)
+        self.assertIn("Declared terminal suffix count/order by line", report)
+        self.assertIn("Per-ordinal changed-path allowlists", report)
+        self.assertIn("## Cross-change integration", checklist)
+        self.assertIn("## Validation currency", checklist)
+        self.assertIn("assign `zoeyrose`", body)
+        self.assertIn("**Atrinik work**", body)
+        self.assertIn("destination is ignored before writing", normalized_body)
+
+        leaf_delivery = (
+            ROOT / ".agents/skills/atrinik-issue-delivery/SKILL.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            "program-delivery invocation delegates this contract",
+            " ".join(leaf_delivery.split()),
+        )
 
     def test_removed_stale_routes_do_not_return(self) -> None:
         paths = [ROOT / "AGENTS.md"]


### PR DESCRIPTION
## Summary

- add explicit `$atrinik-program-delivery` orchestration for ordered master issues
- delegate leaf work to `$atrinik-issue-delivery` while preserving human merge gates
- add cumulative review/report contracts, live-base invalidation, and finite terminal-ledger handling
- route and regression-test the tenth Atrinik skill

## Safety boundaries

- explicit invocation only
- no force-pushes, merges, issue closure, policy bypass, destructive reset, cleanup, or self-approval
- one master goal only when `/goal` is requested; no nested leaf goals
- finite terminal ledger suffix: per-line horizon, exact count/order, per-ordinal paths, and durable resulting SHAs

## Validation

- `python3 -m coverage run -m unittest discover -v` — 458 tests passed
- `python3 -m coverage report --show-missing` — 81%
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- skill package quick validation
- `git diff --check`
- read-only forward test against `atrinik/content#154`

No GitHub issue is closed by this guidance-only PR.
