### PR TITLE
chore(supply-chain): govern Classic App token action

### DIFF
--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -691,6 +691,37 @@
       ]
     },
     {
+      "id": "action/actions-create-github-app-token",
+      "name": "actions/create-github-app-token",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "classic"
+      ],
+      "required": true,
+      "version": "v3.2.0",
+      "version_source": "Reviewed signed upstream release",
+      "license": "MIT",
+      "source_url": "https://github.com/actions/create-github-app-token",
+      "locator": "actions/create-github-app-token",
+      "commit": "bcd2ba49218906704ab6c1aa796996da409d3eb1",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade the Classic dependency updater after App-token workflow review or disable its mutation job",
+      "validation": "Actionlint, Classic workflow contract tests, and a manual disposable App-authored lock pull request",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic",
+          "path": ".github/workflows/update-content.yml",
+          "contains": "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0"
+        }
+      ]
+    },
+    {
       "id": "action/actions-download-artifact",
       "name": "actions/download-artifact",
       "kind": "github-action",


### PR DESCRIPTION
## Summary

- govern the signed immutable `actions/create-github-app-token` pin introduced by the Classic content-lock updater
- bind its ownership, Classic-only scope, update cadence, validation, and exact workflow evidence in the aggregate supply-chain inventory

## Coordinate

- upstream release: `v3.2.0`
- commit: `bcd2ba49218906704ab6c1aa796996da409d3eb1`
- upstream commit signature: verified GitHub signature
- license: MIT
- consumer: `atrinik/classic/.github/workflows/update-content.yml`
- implementation PR: https://github.com/atrinik/classic/pull/179

## Validation

- complete wrapper unittest suite — passed
- aggregate coverage report — 82%
- `./atrinik manifest validate` — 21 components valid
- `./atrinik supply-chain validate` — 104 dependencies valid
- `python3 -m atrinik_workspace.guidance_inventory --check` — passed
- `python3 -m compileall -q atrinik atrinik_workspace tests` — passed
- `git diff --check origin/main...HEAD` — passed

## Merge order

This is a companion to atrinik/atrinik#356. Merge it only after Classic PR #179 places the evidence path on `classic@main`, and before manually dispatching the updater. It does not close the master issue; the App-authored lock PR, rehearsal, normal release, artifact/runtime audit, and schedule activation remain downstream human gates.
