### PR TITLE
build(devcontainer): adopt gh-stack image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Atrinik 2026 Linux Build",
-  "image": "ghcr.io/atrinik/linux-build:1.2.0@sha256:1231b39d40161c1199fd3e45e99e3d826dde02dade79729c030cc0ce3710898f",
+  "image": "ghcr.io/atrinik/linux-build:1.3.0@sha256:260658d2709e993b41148a9d8f724c2d2f7f1fd93543a139b00d139b10e7f31a",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:4": {
       "moby": false

--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -1497,25 +1497,25 @@
         "atrinik"
       ],
       "required": true,
-      "version": "1.2.0",
+      "version": "1.3.0",
       "version_source": "Immutable semantic-release image tag",
       "license": "LicenseRef-Atrinik-Image-Contents",
       "source_url": "https://github.com/atrinik/devcontainer/pkgs/container/linux-build",
       "locator": "ghcr.io/atrinik/linux-build",
-      "commit": "66b8508434044ca50822558172c5cef47a888762",
-      "checksum": "sha256:1231b39d40161c1199fd3e45e99e3d826dde02dade79729c030cc0ce3710898f",
+      "commit": "b4df04bf5b47a8f5d24e0783efd2c16c5e809f38",
+      "checksum": "sha256:260658d2709e993b41148a9d8f724c2d2f7f1fd93543a139b00d139b10e7f31a",
       "acquisition": "Dev Containers pulls the release tag and immutable manifest digest",
       "update_cadence_days": 30,
       "update_mechanism": "Weekly audit plus reviewed devcontainer release update",
       "eol_response": "Publish a supported replacement image and update the wrapper atomically",
-      "validation": "Devcontainer configuration tests and complete native build",
+      "validation": "Anonymous manifest and provenance inspection, whole-image SBOM, exact non-root gh-stack smoke, devcontainer configuration tests, and complete native build",
       "disposition": "retain",
       "packages": [],
       "evidence": [
         {
           "repository": "atrinik",
           "path": ".devcontainer/devcontainer.json",
-          "contains": "ghcr.io/atrinik/linux-build:1.2.0@sha256:1231b39d40161c1199fd3e45e99e3d826dde02dade79729c030cc0ce3710898f"
+          "contains": "ghcr.io/atrinik/linux-build:1.3.0@sha256:260658d2709e993b41148a9d8f724c2d2f7f1fd93543a139b00d139b10e7f31a"
         }
       ]
     },
@@ -4157,6 +4157,70 @@
           "repository": "devcontainer",
           "path": "linux/Dockerfile",
           "contains": "DEVCONTAINER_CLI_VERSION=0.88.0"
+        }
+      ]
+    },
+    {
+      "id": "toolchain/gh-stack",
+      "name": "GitHub PR stack extension",
+      "kind": "toolchain",
+      "owner": "devcontainer",
+      "scope": [
+        "atrinik",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "0.1.0",
+      "version_source": "linux/Dockerfile checksum and pinned extension manifest",
+      "license": "MIT",
+      "source_url": "https://github.com/github/gh-stack/releases/tag/v0.1.0",
+      "locator": "pkg:github/github/gh-stack@v0.1.0",
+      "commit": "a1b4a3d4d0bcde9ec3a78ab99b2d63af121857a9",
+      "checksum": "sha256:358552dd7dce0a46ce153fe196270cec482b84f080947890aad4061a8d44bc0b",
+      "acquisition": "The Linux image installs the v0.1.0 extension for ubuntu and verifies its attested binary digest",
+      "update_cadence_days": 30,
+      "update_mechanism": "Reviewed version, source, checksum, license, and release-attestation update in the devcontainer image",
+      "eol_response": "Replace the extension before its command contract becomes unsupported",
+      "validation": "Pinned manifest, non-root discovery and dispatch, exact version and checksum, and attestation constrained to github/gh-stack, .github/workflows/release.yml, refs/tags/v0.1.0, and the source commit",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "linux/Dockerfile",
+          "contains": "GH_STACK_SHA256_AMD64=358552dd7dce0a46ce153fe196270cec482b84f080947890aad4061a8d44bc0b"
+        }
+      ]
+    },
+    {
+      "id": "toolchain/github-cli",
+      "name": "GitHub CLI",
+      "kind": "toolchain",
+      "owner": "devcontainer",
+      "scope": [
+        "atrinik",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "2.97.0",
+      "version_source": "linux/Dockerfile",
+      "license": "MIT",
+      "source_url": "https://github.com/cli/cli/releases/tag/v2.97.0",
+      "locator": "pkg:github/cli/cli@v2.97.0",
+      "commit": "55dbb4dc6b7edb10b48e3d7fc5bccd32318d1b55",
+      "checksum": "sha256:a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112",
+      "acquisition": "The Linux image downloads the checksum-pinned official linux-amd64 release archive",
+      "update_cadence_days": 30,
+      "update_mechanism": "Scheduled upstream release review with a reviewed version and checksum update",
+      "eol_response": "Upgrade before the supported GitHub CLI line loses required PR stack behavior",
+      "validation": "Sole executable path, exact non-root version, archive checksum, license, and whole-image SBOM",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "linux/Dockerfile",
+          "contains": "GH_SHA256=a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112"
         }
       ]
     },

--- a/tests/test_devcontainer.py
+++ b/tests/test_devcontainer.py
@@ -20,8 +20,8 @@ class DevcontainerTests(unittest.TestCase):
         self.assertEqual(config["postCreateCommand"], "./atrinik init")
         self.assertEqual(
             config["image"],
-            "ghcr.io/atrinik/linux-build:1.2.0@sha256:"
-            "1231b39d40161c1199fd3e45e99e3d826dde02dade79729c030cc0ce3710898f",
+            "ghcr.io/atrinik/linux-build:1.3.0@sha256:"
+            "260658d2709e993b41148a9d8f724c2d2f7f1fd93543a139b00d139b10e7f31a",
         )
 
     def test_windows_configuration_validates_component_manifest(self) -> None:

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -303,6 +303,36 @@ class InventoryTests(unittest.TestCase):
         cmake = inventory.dependencies_by_id["toolchain/cmake"]
         self.assertIn("playtester", cmake.scope)
         self.assertNotIn("tools", cmake.scope)
+        linux_image = inventory.dependencies_by_id["container/linux-build"]
+        self.assertEqual(linux_image.version, "1.3.0")
+        self.assertEqual(
+            linux_image.commit,
+            "b4df04bf5b47a8f5d24e0783efd2c16c5e809f38",
+        )
+        self.assertEqual(
+            linux_image.checksum,
+            "sha256:260658d2709e993b41148a9d8f724c2d2f7f1fd93543a139b00d139b10e7f31a",
+        )
+        github_cli = inventory.dependencies_by_id["toolchain/github-cli"]
+        self.assertEqual(github_cli.owner, "devcontainer")
+        self.assertEqual(github_cli.scope, ("atrinik", "devcontainer"))
+        self.assertEqual(github_cli.version, "2.97.0")
+        self.assertEqual(
+            github_cli.checksum,
+            "sha256:a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112",
+        )
+        gh_stack = inventory.dependencies_by_id["toolchain/gh-stack"]
+        self.assertEqual(gh_stack.owner, "devcontainer")
+        self.assertEqual(gh_stack.scope, ("atrinik", "devcontainer"))
+        self.assertEqual(gh_stack.version, "0.1.0")
+        self.assertEqual(
+            gh_stack.commit,
+            "a1b4a3d4d0bcde9ec3a78ab99b2d63af121857a9",
+        )
+        self.assertEqual(
+            gh_stack.checksum,
+            "sha256:358552dd7dce0a46ce153fe196270cec482b84f080947890aad4061a8d44bc0b",
+        )
         self.assertTrue(
             all(
                 repository.commit is None


### PR DESCRIPTION
## Summary

- adopt `ghcr.io/atrinik/linux-build:1.3.0` by its immutable manifest digest
- record the released image, GitHub CLI 2.97.0, and pinned `github/gh-stack` 0.1.0 provenance in the aggregate supply-chain inventory
- bind the image and dependency coordinates with focused regression assertions

Closes #362.

## Coordinates

- Base: `main` at `b877b27a647d1f3af03113c283d97f54e163d935`
- Head: `build/adopt-gh-stack-image` at `e7ef18125048564e6657235668e504c1a1b2a087`
- Worktree: `/workspaces/atrinik/workspace/worktrees/atrinik/issue-362-gh-stack-image`
- Commit: `e7ef181 build(devcontainer): adopt gh-stack image`
- Image: `ghcr.io/atrinik/linux-build:1.3.0@sha256:260658d2709e993b41148a9d8f724c2d2f7f1fd93543a139b00d139b10e7f31a`
- Image source: `atrinik/devcontainer@b4df04bf5b47a8f5d24e0783efd2c16c5e809f38`

## Validation

- `python3 -m unittest -v tests.test_devcontainer tests.test_supply_chain`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- complete `default` and `classic` supply-chain audits with exact absolute review overrides, including `devcontainer@b4df04bf5b47a8f5d24e0783efd2c16c5e809f38`
- complete wrapper suite: 494 tests, 82% aggregate coverage, compileall, and guidance-inventory check
- anonymous OCI manifest and SLSA provenance inspection resolved the released tag to the recorded digest and source revision
- exact-digest non-root smoke verified GitHub CLI 2.97.0, `github/gh-stack` v0.1.0, `ispinned: true`, `gh stack version 0.1.0`, and SHA-256 `358552dd7dce0a46ce153fe196270cec482b84f080947890aad4061a8d44bc0b`
- whole-image SPDX 2.3 generation found `github.com/cli/cli/v2` v2.97.0 and `github.com/github/gh-stack` v0.1.0
- parent #361 now records the pinned command as the primary verified interface while retaining explicit merge authority, exact coordinates, and the asynchronous API fallback
- two independent whole-diff reviews plus a fresh post-fix pass found zero remaining actionable findings
- `git diff --check`

All required local validation and the iterative whole-diff review are complete at the recorded head.

## Manual verification

Game runtime topology is not applicable: this change adopts a development image and does not alter an Atrinik game service. Re-run the exact read-only image verification with:

```sh
image=ghcr.io/atrinik/linux-build@sha256:260658d2709e993b41148a9d8f724c2d2f7f1fd93543a139b00d139b10e7f31a
docker buildx imagetools inspect "$image"
docker run --rm --user ubuntu --env HOME=/home/ubuntu \
  --env GH_TOKEN=unused "$image" gh version
docker run --rm --user ubuntu --env HOME=/home/ubuntu \
  --env GH_TOKEN=unused "$image" gh extension list
docker run --rm --user ubuntu --env HOME=/home/ubuntu "$image" \
  grep -Fx 'ispinned: true' \
  /home/ubuntu/.local/share/gh/extensions/gh-stack/manifest.yml
docker run --rm --user ubuntu --env HOME=/home/ubuntu "$image" \
  gh stack --version
docker run --rm --user ubuntu --env HOME=/home/ubuntu "$image" \
  sha256sum /home/ubuntu/.local/share/gh/extensions/gh-stack/gh-stack
```

`GH_TOKEN=unused` is a non-secret placeholder needed only for local extension listing. These commands do not inspect or mutate a live PR stack. Repeating them is safe; each disposable container removes itself. A devcontainer rebuild is the user-visible activation step after merge. No wrapper profile, scenario, state, topology, server/client data, or cleanup operation is involved.
