### PR TITLE
refactor(content)!: route Classic through content main

### DIFF
--- a/.agents/skills/atrinik-content-change/SKILL.md
+++ b/.agents/skills/atrinik-content-change/SKILL.md
@@ -1,17 +1,15 @@
 ---
 name: atrinik-content-change
-description: Change authored content on `main` or `1.x`, including maps, archetypes, media, and scripts.
+description: Change authored content on `main`, including maps, archetypes, media, and scripts.
 ---
 
 # Atrinik content change
 
-For issue fixes, assess both `content@main` and `content-1x@1.x`. Shared
-authored changes normally need separate worktrees, validation, commits, and
-linked PRs on both lines; record an evidence-backed format, consumer, runtime,
-or provenance reason for any single-line exception. Never merge lines wholesale
-or share generated output. Use `main` for replacement forward authoring and
-`1.x` for Classic maintenance; add `atrinik-multi-repo-workspace` for cross-line
-work.
+`content@main` is the sole authored source for replacement and Classic targets.
+Use a `content` worktree and select the target-specific publisher during
+validation; never edit or create a PR against the retired `1.x` line. Retained
+`content-1x` checkouts, artifacts, and records are immutable migration or
+release evidence. Add `atrinik-multi-repo-workspace` for cross-repository work.
 
 ## Establish the contract
 

--- a/.agents/skills/atrinik-issue-delivery/SKILL.md
+++ b/.agents/skills/atrinik-issue-delivery/SKILL.md
@@ -38,12 +38,10 @@ scenario procedures.
    when needed and set its existing Status to **In progress** per
    `github-settings/config/planning.json`; never invent an `in-progress` label.
    Use a status label only where an authorized repository makes it canonical.
-4. For content, assess `main` and `1.x`. Give shared fixes separate bases,
-   worktrees, validation, commits, linked PRs, reviews, and final-head checks;
-   record an evidence-backed exception. Paired: only the default-branch PR
-   closes; companions link. A sole `main` PR closes. A sole `1.x` PR links
-   without a closing keyword; close its issue manually after merge. Leave
-   issues open.
+4. For content, author only on `main` and validate every affected target and
+   consumer. The retired `1.x` line, artifacts, and local paths are immutable
+   migration/release evidence; never publish a new `1.x` PR. A content `main`
+   PR may close its issue when merged, but leave the issue open for maintainers.
 
 ## Resolve ownership and isolate work
 

--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -21,9 +21,9 @@ Run from the `atrinik/atrinik` wrapper root.
    keep only orchestration, composition, manifest, and wrapper docs here.
 
 Checkouts are independent ignored repositories. A `classic` worktree contains
-all five `classic-*` components; `content@main` and `content-1x@1.x` stay
-separate. Keep wrapper composition in `.devcontainer/` and reusable images in
-the `devcontainer` checkout.
+all five `classic-*` components. Both stacks share `content@main`; Classic
+selects its publisher adapter, and retained `content-1x` paths are historical.
+Keep wrapper composition in `.devcontainer/` and reusable images in its owner.
 
 ## Prepare safe worktrees
 

--- a/.agents/skills/atrinik-multi-repo-workspace/references/repository-migration.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/references/repository-migration.md
@@ -31,10 +31,10 @@ imports that exact local commit; never recreate or depend on a retired
 `history/*` namespace.
 
 Classic profile rewrites are atomic and select one complete monorepo root for
-all five logical components. The internal `migrated-worktree` selector is
-provenance for an exact historical `content-1x` worktree only; `profile set`
-must never create it. New classic content work uses a normal `content-1x`
-worktree.
+all five logical components. Content selector retirement is a distinct checked
+workflow: run `./atrinik migrate content --dry-run --json`, then explicit
+apply and audit. New Classic content work uses the shared `content@main`
+checkout and its target-specific publisher.
 
 Migration does not initialize other repositories or move/reinterpret content,
 states, builds, runtimes, scenarios, topologies, or logs. After a successful

--- a/.agents/skills/atrinik-protocol-change/SKILL.md
+++ b/.agents/skills/atrinik-protocol-change/SKILL.md
@@ -18,9 +18,10 @@ implementation skill for coordinated consumers.
   `classic/protocol/schema/game-commands.json`; packet payloads may be owned by
   classic client/server producers and consumers. Use a classic-derived profile
   and the monorepo's `classic-protocol-change` skill.
-- ADS/authored schemas live with their exact `content@main` or
-  `content-1x@1.x` format; `metaserver-worker` owns discovery implementation
-  and state rather than the shared contracts.
+- ADS/authored schemas live in `content@main`; select the replacement or
+  Classic publisher target and validate every affected consumer.
+  `metaserver-worker` owns discovery implementation and state rather than the
+  shared contracts. Retained `1.x` artifacts are immutable evidence.
 
 Resolve paths rather than assuming the wrapper CWD:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,10 +25,9 @@
   so root `git status` omits them.
 - Resolve ownership through `components.json` and the checkout's nearest
   `AGENTS.md`; keep implementation, tests, packages, and releases there.
-- `classic/` provides five `classic-*` components. `content/` is
-  `atrinik/content@main`; `content-1x/` its `1.x` checkout. `playtester/` is
-  classic-only `atrinik/playtester` with wrapper `build: none` and
-  repository-owned validation.
+- `classic/` provides five `classic-*` components. Both stacks share
+  `content@main`; Classic selects its publisher adapter. Retained `content-1x/`
+  is historical only. `playtester/` is classic-only with wrapper `build: none`.
   `.devcontainer/` owns wrapper composition and `devcontainer/` reusable images.
 
 ## Core behaviors and patterns

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,8 +70,10 @@ The canonical `server`, `client`, `editor`, `protocol`, `renderer`,
 `content-toolkit`, and `website` repositories form the MIT replacement stack.
 Plain `./atrinik init` is replacement/default-only. Exact
 `./atrinik init --with classic` adds the complete currently playable classic
-cohort: the `atrinik/classic` monorepo checkout, `content-1x@1.x`, the
-independent MIT `atrinik/playtester` checkout, and retained GPL tools. The
+cohort: the `atrinik/classic` monorepo checkout, the independent MIT
+`atrinik/playtester` checkout, and retained GPL tools. Both stacks reuse the
+one `content@main` checkout initialized by the default cohort; Classic selects
+its target-specific publisher adapter. The
 monorepo supplies the logical classic client, server, editor, protocol, and
 libatrinik components from source subdirectories. The playtester remains
 classic-only, has a wrapper `build: none` contract, and owns its installation

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Open this wrapper repository in VS Code and choose **Dev Containers: Reopen in
 Container** to use the pinned Linux build environment. On first creation, the
 container runs `./atrinik init`; it clones only missing replacement/default
 repositories and validates existing checkouts without updating or replacing
-them. It never adds classic repositories, `content@1.x`, the MIT playtester,
-or GPL tools implicitly. The Windows cross-build configuration is available at
+them. It never adds classic repositories, the MIT playtester, or GPL tools
+implicitly, and never touches a retained historical `content@1.x` path. The Windows cross-build configuration is available at
 `.devcontainer/windows-cross/devcontainer.json` after the required component
 checkouts have been initialized.
 
@@ -179,10 +179,10 @@ be preceded in the same workflow by an immutable `setup-node` action.
 When auditing review code, initialize the complete profile beside that wrapper
 checkout and use repeated absolute `--repository NAME=PATH` overrides only for
 the components under review. The command verifies each override's GitHub
-repository and branch identity before reading it. For duplicate coordinates, a
-review branch is accepted only when its linked worktree shares the expected
-checkout primary's common Git directory, so `content` and `content-1x` cannot
-be exchanged.
+repository and branch identity before reading it. A review branch is accepted
+only when its linked worktree shares the expected checkout primary's common Git
+directory, so an unrelated or historical checkout cannot impersonate
+`content@main`.
 
 ### Historical MIT provenance grants
 
@@ -220,8 +220,8 @@ initialization cohort. That includes the replacement MIT `server`, `client`,
 `editor`, `protocol`, `renderer`, `content-toolkit`, and `website` repositories;
 `content` from `atrinik/content@main`; compatible shared resources, sound, and
 metaserver code; and required development infrastructure. It does not clone
-`atrinik/classic`, `atrinik/content@1.x`, `atrinik/playtester`, or the GPL
-`tools` repository.
+`atrinik/classic`, `atrinik/playtester`, or the GPL `tools` repository, and
+does not touch a retained historical `atrinik/content@1.x` checkout.
 The replacement repositories have independently validated M1 build, package,
 provenance, and dependency contracts. Their wrapper manifest build/runtime
 adapters and complete service integration have not landed, so `default` is
@@ -272,7 +272,7 @@ command is reported with the same opt-out guidance.
 
 Building the Classic server also runs its offline worldmaker and stages the
 generated region-map `.png`/`.def` pairs in the profile build. Generation uses
-the selected Classic, `content-1x`, and resource views, so it requires the same
+the selected Classic, shared `content@main`, and resource views, so it requires the same
 native build dependencies as the server. A marker-owned cache is reused only
 while every selected checkout is clean and its recorded commit still matches;
 dirty inputs regenerate on every build. Missing `incuna_-1` output, incomplete
@@ -319,9 +319,9 @@ preparation/reuse time.
 
 `--with classic` has one exact meaning: add the complete classic initialization
 cohort to the replacement/default cohort. It is not a classic-only mode. The
-cohort consists of one `atrinik/classic` checkout, a distinct `content-1x`
-checkout of `atrinik/content@1.x`, the MIT `atrinik/playtester` checkout, and
-the retained GPL `tools` repository.
+cohort consists of one `atrinik/classic` checkout, the MIT
+`atrinik/playtester` checkout, and the retained GPL `tools` repository. The
+union initializes the shared `atrinik/content@main` checkout exactly once.
 The classic monorepo supplies logical `classic-server`, `classic-client`,
 `classic-editor`, `classic-libatrinik`, and `classic-protocol` components from
 its `server/`, `client/`, `editor/`, `libatrinik/`, and `protocol/` source
@@ -336,11 +336,11 @@ identity are coordinated here, while installation and tests remain owned by
 `atrinik/playtester`.
 
 Checkout entries have explicit local destinations; normally these are direct
-children of the wrapper root such as `./client`, `./classic`, `./content`, and
-`./content-1x`. Logical components name their owning checkout and a safe source
-root within it. `content` and `content-1x` deliberately name the same GitHub
-repository but use different branches, destinations, cohort memberships, and
-logical roles.
+children of the wrapper root such as `./client`, `./classic`, and `./content`.
+Logical components name their owning checkout and a safe source root within
+it. Both stacks map role `content` to that one shared checkout. A local
+`./content-1x` directory may remain as preserved migration history, but it is
+not initialized or selected as an active component.
 
 Initialization follows the GitHub transport of the wrapper's `origin` (then
 `upstream`): an SSH wrapper clone produces SSH component clones, while an HTTPS
@@ -415,6 +415,35 @@ Pre-split scenario records that lack immutable stack and provider identities
 remain on disk but are deliberately inert; recreate one before using it rather
 than allowing its old `default` profile name to acquire replacement providers.
 
+## Migrating persisted content selectors
+
+Workspaces created before the content consolidation can retain profiles that
+name `content-1x`, historical build/scenario/topology records, or worktrees in
+the former namespace. Keep all of that state in place and run the dedicated
+checked migration:
+
+~~~sh
+./atrinik migrate content --dry-run --json
+./atrinik migrate content --apply
+./atrinik migrate content --audit --json
+~~~
+
+The dry run proves the canonical `content@main` consolidation commit and
+inventories every legacy selector and affected resource. Apply refuses dirty,
+detached, locked, live, colliding, in-progress, or unproven inputs. A simple
+certified primary selector becomes `content@main`; a managed worktree moves to
+the shared namespace only when its repository, common Git directory,
+commit/tree ancestry, destination, and cleanliness all match. An old `1.x`
+worktree or arbitrary external path is never silently repointed.
+
+Original profile bytes are journaled and updated atomically. Audit is
+read-only. Before any later remote branch retirement, the exact bytes and
+proven worktree paths can be restored with
+`./atrinik migrate content --restore --json`. The old `./content-1x` checkout,
+stopped records, states, logs, and historical coordinates remain preserved and
+inert; this migration never deletes them. Cleanup continues to inventory those
+references and remains a separate preview-first operation.
+
 The current classic client command opens a graphical application. Verify that
 the devcontainer display forwarding socket is live before launching it. Use
 `--dry-run` to build and print either launch command without starting the
@@ -484,10 +513,9 @@ feature worktree from a newly synchronized primary branch only when intended:
 `sync --with classic` considers initialized default and classic checkouts; it
 does not turn an optional missing checkout into a clone. The command stops
 instead of changing a dirty checkout. Worktree merge or rebase conflicts are
-left in that worktree for normal Git resolution. A migration-retained classic
-content worktree is explicitly excluded from `content@main` worktree sync,
-even when dirty, and is reported as skipped. Create an ordinary `content-1x`
-worktree for ongoing classic content changes.
+left in that worktree for normal Git resolution. Historical `content-1x`
+paths and records are inert and are never treated as `content@main`. Create new
+content review worktrees from the shared `content` checkout.
 
 ## Checkout worktrees
 
@@ -505,7 +533,7 @@ Choose another start point or attach an existing local branch:
 ~~~sh
 ./atrinik worktree create classic release-fix \
   --branch fix/release --from origin/main
-./atrinik worktree create content-1x maps-pr \
+./atrinik worktree create content maps-pr \
   --branch review/maps-pr --existing
 ~~~
 
@@ -514,7 +542,7 @@ List or remove managed worktrees:
 ~~~sh
 ./atrinik worktree list
 ./atrinik worktree list --json
-./atrinik worktree remove content-1x maps-pr
+./atrinik worktree remove content maps-pr
 ~~~
 
 Removal refuses dirty worktrees. Each worktree is a full Git worktree of its
@@ -657,7 +685,7 @@ component, or one of its roles updates all five classic selectors together.
 
 ~~~sh
 ./atrinik profile create maps-review --from classic
-./atrinik profile set maps-review content-1x --worktree maps-pr
+./atrinik profile set maps-review content --worktree maps-pr
 ./atrinik profile set maps-review classic-server --worktree socket-review
 ./atrinik profile show maps-review
 ./atrinik build all --profile maps-review --test
@@ -695,14 +723,10 @@ different combinations of distinct physical checkouts—cannot overwrite one
 another. Scenario and topology records retain those same coordinates; older
 records without them are inert.
 
-Migration may retain a proven classic content worktree using an internal
-`migrated-worktree` selector. `profile set` cannot create that selector (while
-cloning an already migrated profile preserves it): resolution accepts it only
-for `content-1x`, only at its original managed
-`workspace/worktrees/content/<label>` path, and only while it remains attached
-to the canonical content Git directory. New worktrees use ordinary
-`content-1x` selectors. Normal `content@main` worktree synchronization always
-skips these migration-only paths.
+The content migration reader accepts the old internal `migrated-worktree`
+selector only as recovery input. Current profiles use normal `content`
+primary, worktree, or proven absolute-path selectors. Historical `1.x`
+selectors remain truthful and inert instead of being relabeled as `main`.
 
 Print an exact selected logical source path for use with `cd`, editors, or
 other tools. Read-only profile, worktree, and state listings also support
@@ -933,16 +957,16 @@ pull-request numbers:
 ~~~sh
 git -C classic fetch origin pull/CLIENT_PR/head:review/client-ui
 git -C classic fetch origin pull/SERVER_PR/head:review/server-combat
-git -C content-1x fetch origin pull/CONTENT_PR/head:review/content-maps
+git -C content fetch origin pull/CONTENT_PR/head:review/content-maps
 
 ./atrinik worktree create classic combined-classic \
   --branch review/combined-classic --from review/server-combat
-./atrinik worktree create content-1x maps-review \
+./atrinik worktree create content maps-review \
   --branch review/content-maps --existing
 
 ./atrinik profile create combined-review --from classic
 ./atrinik profile set combined-review classic --worktree combined-classic
-./atrinik profile set combined-review content-1x --worktree maps-review
+./atrinik profile set combined-review content --worktree maps-review
 
 CLASSIC_SOURCE="$(./atrinik path classic-server --profile combined-review)"
 git -C "$CLASSIC_SOURCE" merge --no-edit review/client-ui
@@ -965,11 +989,11 @@ checkout/source bill of materials for review notes or agent automation.
 ### Use case: review new maps with unchanged binaries
 
 Keep the classic client and server on their synchronized primary checkouts and
-select only the `content-1x` worktree:
+select only the shared `content@main` worktree:
 
 ~~~sh
 ./atrinik profile create map-check --from classic
-./atrinik profile set map-check content-1x --worktree maps-review
+./atrinik profile set map-check content --worktree maps-review
 ./atrinik topology show map-check
 ./atrinik state add map-check
 ./atrinik up --name map-check --profile map-check --state map-check
@@ -1084,11 +1108,11 @@ worktrees, so commit, stash, or otherwise preserve intentional edits first:
 ~~~sh
 ./atrinik down combined-review
 ./atrinik profile set combined-review classic --primary
-./atrinik profile set combined-review content-1x --primary
+./atrinik profile set combined-review content --primary
 ./atrinik cleanup --scope worktrees --scope builds \
-  classic content-1x --older-than 7 --dry-run
+  classic content --older-than 7 --dry-run
 ./atrinik cleanup --scope worktrees --scope builds \
-  classic content-1x --older-than 7 --apply
+  classic content --older-than 7 --apply
 ~~~
 
 The saved `combined-review` profile protects both selected worktrees until the

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -14,6 +14,7 @@ import subprocess
 from typing import Any, Iterable, Iterator
 
 from .locking import active_lock_fds
+from .content_migration import CONTENT_MIGRATION_PENDING, CONTENT_MIGRATION_RECORD
 from .migration import MIGRATION_PENDING, MIGRATION_RECORD, OPERATION_PATHS
 from .model import (
     MANAGED_MARKER,
@@ -969,17 +970,39 @@ class Cleanup:
             try:
                 if path.is_symlink():
                     raise WorkspaceError("profile is a symlink")
-                profile = self.workspace._load_profile(path.stem, require_file=True)
-                for component_name, selector in profile["components"].items():
-                    if component_name not in self.manifest.by_name or not isinstance(
-                        selector, dict
+                try:
+                    profile = self.workspace._load_profile(
+                        path.stem, require_file=True
+                    )
+                except WorkspaceError:
+                    profile = load_json(path)
+                    if (
+                        not isinstance(profile, dict)
+                        or profile.get("name") != path.stem
+                        or profile.get("stack") != "classic"
+                        or not isinstance(profile.get("components"), dict)
+                        or "content-1x" not in profile["components"]
+                        or "content" in profile["components"]
+                        or set(profile["components"])
+                        - set(self.manifest.by_name)
+                        != {"content-1x"}
                     ):
+                        raise
+                for component_name, selector in profile["components"].items():
+                    if (
+                        component_name not in self.manifest.by_name
+                        and component_name != "content-1x"
+                    ) or not isinstance(selector, dict):
                         raise WorkspaceError("profile selector is invalid")
                     if set(selector) != {"kind", "value"} or not isinstance(
                         selector.get("value"), str
                     ):
                         raise WorkspaceError("profile selector is invalid")
-                    checkout = self.manifest.by_name[component_name].checkout_name
+                    checkout = (
+                        "content-1x"
+                        if component_name == "content-1x"
+                        else self.manifest.by_name[component_name].checkout_name
+                    )
                     kind = selector.get("kind")
                     if kind == "worktree":
                         selected = self.paths.worktrees / checkout / selector["value"]
@@ -1175,7 +1198,12 @@ class Cleanup:
                 errors.add("topology_inventory_error")
 
     def _migration_references(self, references: dict[str, Any], errors: set[str]) -> None:
-        for relative in (MIGRATION_RECORD, MIGRATION_PENDING):
+        for relative in (
+            MIGRATION_RECORD,
+            MIGRATION_PENDING,
+            CONTENT_MIGRATION_RECORD,
+            CONTENT_MIGRATION_PENDING,
+        ):
             path = self.paths.workspace / relative
             if not path.exists() and not path.is_symlink():
                 continue
@@ -1199,8 +1227,10 @@ class Cleanup:
         sections = (
             ("sources", ("source", "archive", "path")),
             ("worktree_migrations", ("path", "destination")),
+            ("worktree_moves", ("source", "destination")),
             ("composite_worktrees", ("destination",)),
             ("worktrees", ("destination",)),
+            ("profiles", ("path",)),
         )
         for section, keys in sections:
             rows = value.get(section, [])
@@ -1230,6 +1260,36 @@ class Cleanup:
                 raise WorkspaceError("migration classic.path is invalid")
         elif classic is not None:
             raise WorkspaceError("migration classic path is invalid")
+        for section in ("canonical", "legacy"):
+            row = value.get(section)
+            if row is None:
+                continue
+            if not isinstance(row, dict):
+                raise WorkspaceError(f"migration {section} is invalid")
+            raw = row.get("path")
+            if not isinstance(raw, str) or not Path(raw).is_absolute():
+                raise WorkspaceError(f"migration {section}.path is invalid")
+            yield f"{section}.path", Path(raw)
+        resources = value.get("resources")
+        if resources is not None:
+            if not isinstance(resources, dict):
+                raise WorkspaceError("migration resources are invalid")
+            for category, rows in resources.items():
+                if not isinstance(category, str) or not isinstance(rows, list):
+                    raise WorkspaceError("migration resource category is invalid")
+                for index, row in enumerate(rows):
+                    if not isinstance(row, dict):
+                        raise WorkspaceError(
+                            f"migration resources.{category}[{index}] is invalid"
+                        )
+                    raw = row.get("path")
+                    if raw is None:
+                        continue
+                    if not isinstance(raw, str) or not Path(raw).is_absolute():
+                        raise WorkspaceError(
+                            f"migration resources.{category}[{index}].path is invalid"
+                        )
+                    yield f"resources.{category}[{index}].path", Path(raw)
 
     def _retention_references(self, references: dict[str, Any], errors: set[str]) -> None:
         path = self.paths.builds / BUILD_RETENTION_RECORD

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -137,6 +137,15 @@ def parser() -> argparse.ArgumentParser:
     migrate_mode.add_argument("--apply", action="store_true")
     migrate_mode.add_argument("--audit", action="store_true")
     migrate_repositories.add_argument("--json", action="store_true")
+    migrate_content = migrate_commands.add_parser(
+        "content", help="cut persisted Classic profiles over to content@main"
+    )
+    migrate_content_mode = migrate_content.add_mutually_exclusive_group(required=True)
+    migrate_content_mode.add_argument("--dry-run", action="store_true")
+    migrate_content_mode.add_argument("--apply", action="store_true")
+    migrate_content_mode.add_argument("--audit", action="store_true")
+    migrate_content_mode.add_argument("--restore", action="store_true")
+    migrate_content.add_argument("--json", action="store_true")
 
     worktree = commands.add_parser(
         "worktree", help="manage physical-checkout worktrees"
@@ -455,8 +464,20 @@ def main(arguments: list[str] | None = None) -> int:
                         f"cohorts={','.join(row['cohorts'])}\t{row['path']}"
                     )
         elif options.command == "migrate":
-            mode = "apply" if options.apply else "audit" if options.audit else "dry-run"
-            result = workspace.migrate_repositories(mode)
+            mode = (
+                "apply"
+                if options.apply
+                else "audit"
+                if options.audit
+                else "restore"
+                if getattr(options, "restore", False)
+                else "dry-run"
+            )
+            result = (
+                workspace.migrate_content(mode)
+                if options.migrate_command == "content"
+                else workspace.migrate_repositories(mode)
+            )
             if options.json:
                 print(json.dumps(result, indent=2, sort_keys=True))
             else:
@@ -489,6 +510,16 @@ def main(arguments: list[str] | None = None) -> int:
                     print(
                         f"profile\t{profile['status']}\t{profile['name']}\t"
                         f"{profile['path']}"
+                    )
+                for profile in result.get("profiles", []):
+                    print(
+                        f"profile\t{profile['status']}\t{profile['name']}\t"
+                        f"{profile['path']}"
+                    )
+                for worktree in result.get("worktree_moves", []):
+                    print(
+                        f"worktree\tmove\t{worktree['profile']}\t"
+                        f"{worktree['source']}\t{worktree['destination']}"
                     )
                 for topology in result.get("topologies", []):
                     print(

--- a/atrinik_workspace/completion.py
+++ b/atrinik_workspace/completion.py
@@ -297,19 +297,21 @@ def _dynamic_candidates(
             *(
                 ["all"]
                 if all(
-                    stack.providers[role].build != "none" for role in all_roles
+                    manifest.effective_build(stack_name, stack.providers[role])
+                    != "none"
+                    for role in all_roles
                 )
                 else []
             ),
             *(
                 role
                 for role, component in stack.providers.items()
-                if component.build != "none"
+                if manifest.effective_build(stack_name, component) != "none"
             ),
             *(
                 component.name
                 for component in stack.components
-                if component.build != "none"
+                if manifest.effective_build(stack_name, component) != "none"
             ),
         ]
     if kind == "profile":

--- a/atrinik_workspace/content_migration.py
+++ b/atrinik_workspace/content_migration.py
@@ -191,7 +191,30 @@ class ContentMigration:
                 result = self._audit()
                 if result["status"] == "complete":
                     result["status"] = "already-applied"
+                elif result["status"] == "restored":
+                    result["status"] = "refused"
+                    result["refusals"] = [
+                        _refusal(
+                            "migration_already_restored",
+                            "the recorded content migration was explicitly restored",
+                            "preserve the record; a new apply requires a separately "
+                            "reviewed migration transaction",
+                        )
+                    ]
                 return result
+            if self.record_path.exists() or self.record_path.is_symlink():
+                return {
+                    "migration": CONTENT_MIGRATION_NAME,
+                    "schema_version": CONTENT_MIGRATION_SCHEMA_VERSION,
+                    "status": "refused",
+                    "refusals": [
+                        _refusal(
+                            "invalid_migration_record",
+                            f"content migration record is unsafe: {self.record_path}",
+                            "preserve the path and restore the exact regular migration record",
+                        )
+                    ],
+                }
             if self.pending_path.exists() or self.pending_path.is_symlink():
                 return {
                     "migration": CONTENT_MIGRATION_NAME,
@@ -511,14 +534,17 @@ class ContentMigration:
         if kind == "primary":
             if value:
                 raise WorkspaceError("primary selector has a value")
-            if not legacy.get("proven") or not legacy.get("clean"):
+            if (
+                not legacy.get("proven")
+                or not legacy.get("clean")
+                or legacy.get("head") != CERTIFIED_1X_COMMIT
+            ):
                 raise WorkspaceError("legacy primary is not clean and certified")
             return {"kind": "primary", "value": ""}, None
         if kind == "worktree":
             if not NAME_PATTERN.fullmatch(value):
                 raise WorkspaceError("managed worktree label is invalid")
-            source = Path(self.paths.worktrees) / "content-1x" / value
-            destination = Path(self.paths.worktrees) / "content" / value
+            source, destination = self._managed_worktree_paths(value)
             proof = self._prove_main_worktree(source, canonical)
             if destination.exists() or destination.is_symlink():
                 raise WorkspaceError(
@@ -538,6 +564,23 @@ class ContentMigration:
             self._prove_main_worktree(selected, canonical)
             return {"kind": "path", "value": str(selected.resolve())}, None
         raise WorkspaceError(f"unsupported selector kind {kind}")
+
+    def _managed_worktree_paths(self, label: str) -> tuple[Path, Path]:
+        if not NAME_PATTERN.fullmatch(label):
+            raise WorkspaceError("managed worktree label is invalid")
+        root = Path(self.paths.worktrees)
+        if root.is_symlink() or not root.is_dir():
+            raise WorkspaceError(
+                f"managed worktree root is not a normal directory: {root}"
+            )
+        source_parent = root / "content-1x"
+        destination_parent = root / "content"
+        for parent in (source_parent, destination_parent):
+            if parent.is_symlink() or parent.exists() and not parent.is_dir():
+                raise WorkspaceError(
+                    f"managed content worktree namespace is unsafe: {parent}"
+                )
+        return source_parent / label, destination_parent / label
 
     def _prove_main_worktree(
         self, path: Path, canonical: dict[str, Any]
@@ -767,8 +810,11 @@ class ContentMigration:
         published = False
         try:
             for move in inspection["worktree_moves"]:
-                source = Path(move["source"])
-                destination = Path(move["destination"])
+                source, destination = self._managed_worktree_paths(
+                    Path(move["source"]).name
+                )
+                if str(source) != move["source"] or str(destination) != move["destination"]:
+                    raise WorkspaceError("worktree migration paths changed after preflight")
                 destination.parent.mkdir(parents=True, exist_ok=True)
                 self._prove_main_worktree(source, inspection["canonical"])
                 if destination.exists() or destination.is_symlink():
@@ -841,11 +887,13 @@ class ContentMigration:
             except BaseException as error:
                 errors.append(str(error))
         for move in reversed(moves):
-            source = Path(move["source"])
-            destination = Path(move["destination"])
             try:
+                source, destination = self._managed_worktree_paths(
+                    Path(move["source"]).name
+                )
                 if source.exists() or source.is_symlink():
                     raise WorkspaceError(f"original worktree path is occupied: {source}")
+                source.parent.mkdir(parents=True, exist_ok=True)
                 _git(self.canonical, "worktree", "move", str(destination), str(source))
             except BaseException as error:
                 errors.append(str(error))
@@ -951,6 +999,35 @@ class ContentMigration:
 
     def _audit(self) -> dict[str, Any]:
         refusals: list[dict[str, str]] = []
+        if not self.record_path.exists() and not self.record_path.is_symlink():
+            if self.pending_path.exists() or self.pending_path.is_symlink():
+                return {
+                    "migration": CONTENT_MIGRATION_NAME,
+                    "schema_version": CONTENT_MIGRATION_SCHEMA_VERSION,
+                    "status": "incomplete",
+                    "refusals": [
+                        _refusal(
+                            "pending_migration",
+                            f"an interrupted migration journal exists: {self.pending_path}",
+                            "preserve it and recover only its exact recorded bytes and paths",
+                        )
+                    ],
+                }
+            inspection = self._inspect()
+            if inspection["status"] == "not-needed":
+                return inspection
+            return {
+                **inspection,
+                "status": "incomplete",
+                "refusals": [
+                    *inspection["refusals"],
+                    _refusal(
+                        "migration_record_missing",
+                        f"content migration record is missing: {self.record_path}",
+                        "run the dry run and apply before auditing",
+                    ),
+                ],
+            }
         if self.record_path.is_symlink() or not self.record_path.is_file():
             return {
                 "migration": CONTENT_MIGRATION_NAME,
@@ -958,9 +1035,9 @@ class ContentMigration:
                 "status": "incomplete",
                 "refusals": [
                     _refusal(
-                        "migration_record_missing",
-                        f"content migration record is missing: {self.record_path}",
-                        "run the dry run and apply before auditing",
+                        "invalid_migration_record",
+                        f"content migration record is unsafe: {self.record_path}",
+                        "preserve the path and restore the exact regular migration record",
                     )
                 ],
             }
@@ -1021,8 +1098,14 @@ class ContentMigration:
         if record["status"] == "complete":
             for move in record["worktree_moves"]:
                 try:
-                    source = Path(move["source"])
-                    destination = Path(move["destination"])
+                    source, destination = self._managed_worktree_paths(
+                        Path(move["source"]).name
+                    )
+                    if (
+                        str(source) != move["source"]
+                        or str(destination) != move["destination"]
+                    ):
+                        raise WorkspaceError("journaled worktree paths changed")
                     if source.exists() or source.is_symlink():
                         raise WorkspaceError("original worktree path was recreated")
                     proof = self._prove_main_worktree(destination, record["canonical"])
@@ -1039,8 +1122,14 @@ class ContentMigration:
         else:
             for move in record["worktree_moves"]:
                 try:
-                    source = Path(move["source"])
-                    destination = Path(move["destination"])
+                    source, destination = self._managed_worktree_paths(
+                        Path(move["source"]).name
+                    )
+                    if (
+                        str(source) != move["source"]
+                        or str(destination) != move["destination"]
+                    ):
+                        raise WorkspaceError("journaled worktree paths changed")
                     if destination.exists() or destination.is_symlink():
                         raise WorkspaceError("migration destination was recreated")
                     proof = self._prove_main_worktree(source, record["canonical"])
@@ -1084,10 +1173,14 @@ class ContentMigration:
                 )
                 restored_profiles.append(row)
             for move in reversed(audit["worktree_moves"]):
-                source = Path(move["source"])
-                destination = Path(move["destination"])
+                source, destination = self._managed_worktree_paths(
+                    Path(move["source"]).name
+                )
+                if str(source) != move["source"] or str(destination) != move["destination"]:
+                    raise WorkspaceError("worktree restore paths changed after audit")
                 if source.exists() or source.is_symlink():
                     raise WorkspaceError(f"original worktree path is occupied: {source}")
+                source.parent.mkdir(parents=True, exist_ok=True)
                 _git(self.canonical, "worktree", "move", str(destination), str(source))
                 restored_moves.append(move)
             restored = {
@@ -1118,9 +1211,10 @@ class ContentMigration:
     ) -> list[str]:
         errors: list[str] = []
         for move in reversed(moves):
-            source = Path(move["source"])
-            destination = Path(move["destination"])
             try:
+                source, destination = self._managed_worktree_paths(
+                    Path(move["source"]).name
+                )
                 self._prove_main_worktree(source, canonical)
                 if destination.exists() or destination.is_symlink():
                     raise WorkspaceError(

--- a/atrinik_workspace/content_migration.py
+++ b/atrinik_workspace/content_migration.py
@@ -1,0 +1,1143 @@
+from __future__ import annotations
+
+import base64
+import binascii
+from datetime import datetime, timezone
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import subprocess
+import tempfile
+from typing import Any, TextIO
+
+from .locking import inherit_lock_fds
+from .model import WorkspaceError, atomic_json, load_json
+from .process_tree import holders_exist
+from .supervisor import process_matches
+
+
+CONTENT_MIGRATION_NAME = "content"
+CONTENT_MIGRATION_RECORD = "migrations/content.json"
+CONTENT_MIGRATION_PENDING = "migrations/content.pending.json"
+CONTENT_MIGRATION_SCHEMA_VERSION = 1
+CERTIFIED_MAIN_COMMIT = "7dde0c0afe8840fc95dd26f404310e77d9c82621"
+CERTIFIED_1X_COMMIT = "566bd25f78b80b08d5f75f4b02017ab2429204db"
+PROFILE_MAX_BYTES = 1024 * 1024
+PROFILE_KEYS = {"schema_version", "name", "stack", "components", "sound_mode"}
+LEGACY_PROFILE_KEYS = {"schema_version", "name", "stack", "components"}
+NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+OPERATION_PATHS = (
+    "BISECT_LOG",
+    "CHERRY_PICK_HEAD",
+    "MERGE_HEAD",
+    "REVERT_HEAD",
+    "rebase-apply",
+    "rebase-merge",
+    "sequencer",
+)
+
+
+def _refusal(code: str, message: str, recovery: str) -> dict[str, str]:
+    return {"code": code, "message": message, "recovery": recovery}
+
+
+def _certified_parity() -> dict[str, str]:
+    return {
+        "issue": "https://github.com/atrinik/content/issues/166",
+        "main_commit": CERTIFIED_MAIN_COMMIT,
+        "main_release": "v2.14.0",
+        "final_1x_commit": CERTIFIED_1X_COMMIT,
+        "final_1x_release": "v1.8.19",
+        "status": "certified",
+    }
+
+
+def _git(path: Path, *arguments: str, check: bool = True) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(path), *arguments],
+            check=check,
+            capture_output=True,
+            text=True,
+            pass_fds=(),
+        )
+    except FileNotFoundError as error:
+        raise WorkspaceError("required command not found: git") from error
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr.strip() or error.stdout.strip()
+        suffix = f": {detail}" if detail else ""
+        raise WorkspaceError(
+            f"git {' '.join(arguments)} failed in {path}{suffix}"
+        ) from error
+    return result.stdout.strip()
+
+
+def _git_succeeds(path: Path, *arguments: str) -> bool:
+    try:
+        return subprocess.run(
+            ["git", "-C", str(path), *arguments],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            pass_fds=(),
+        ).returncode == 0
+    except FileNotFoundError as error:
+        raise WorkspaceError("required command not found: git") from error
+
+
+def _remote_matches(url: str) -> bool:
+    normalized = url.strip().removesuffix(".git")
+    if normalized.startswith("git@github.com:"):
+        normalized = "github.com/" + normalized.removeprefix("git@github.com:")
+    elif normalized.startswith("ssh://git@github.com/"):
+        normalized = "github.com/" + normalized.removeprefix(
+            "ssh://git@github.com/"
+        )
+    elif normalized.startswith("https://"):
+        normalized = normalized.removeprefix("https://")
+    return normalized == "github.com/atrinik/content"
+
+
+def _digest(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _atomic_bytes(path: Path, value: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.content-migration-", dir=path.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(value)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        directory = os.open(
+            path.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+        )
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def _open_layout_lock(path: Path) -> TextIO:
+    flags = os.O_RDWR | os.O_CREAT | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags, 0o600)
+    except OSError as error:
+        raise WorkspaceError(f"cannot open repository layout lock {path}: {error}") from error
+    if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+        os.close(descriptor)
+        raise WorkspaceError(f"repository layout lock is not a regular file: {path}")
+    return os.fdopen(descriptor, "a+")
+
+
+class ContentMigration:
+    """Retire active ``content-1x`` selectors without rewriting history."""
+
+    def __init__(self, repository_root: Path, workspace_paths: Any, manifest: Any):
+        self.repository_root = Path(repository_root).resolve()
+        self.paths = workspace_paths
+        self.manifest = manifest
+        self.workspace = Path(workspace_paths.workspace).resolve()
+        self.record_path = self.workspace / CONTENT_MIGRATION_RECORD
+        self.pending_path = self.workspace / CONTENT_MIGRATION_PENDING
+        self.canonical = self.repository_root / "content"
+        self.legacy = self.repository_root / "content-1x"
+
+    def execute(self, mode: str) -> dict[str, Any]:
+        if mode not in {"dry-run", "apply", "audit", "restore"}:
+            raise WorkspaceError(f"unsupported content migration mode: {mode}")
+        if mode == "audit":
+            return self._audit()
+        if mode == "restore":
+            return self._locked_restore()
+        inspection = self._inspect()
+        if mode == "dry-run" or inspection["refusals"]:
+            return inspection
+        if inspection["status"] == "not-needed":
+            return inspection
+        return self._locked_apply()
+
+    def _locked_apply(self) -> dict[str, Any]:
+        lock_path = self.workspace / "repository-layout.lock"
+        with _open_layout_lock(lock_path) as lock, inherit_lock_fds(lock):
+            try:
+                fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                plan = self._inspect()
+                plan["refusals"].append(
+                    _refusal(
+                        "repository_layout_busy",
+                        "the repository layout is in use by another wrapper operation",
+                        "wait for that operation to finish and rerun the migration",
+                    )
+                )
+                plan["status"] = "refused"
+                return plan
+            if self.record_path.is_file() and not self.record_path.is_symlink():
+                result = self._audit()
+                if result["status"] == "complete":
+                    result["status"] = "already-applied"
+                return result
+            if self.pending_path.exists() or self.pending_path.is_symlink():
+                return {
+                    "migration": CONTENT_MIGRATION_NAME,
+                    "schema_version": CONTENT_MIGRATION_SCHEMA_VERSION,
+                    "status": "refused",
+                    "refusals": [
+                        _refusal(
+                            "pending_migration",
+                            f"an interrupted migration journal exists: {self.pending_path}",
+                            "preserve it and restore only its exact recorded "
+                            "profile bytes and worktree paths",
+                        )
+                    ],
+                }
+            inspection = self._inspect()
+            if inspection["refusals"] or inspection["status"] == "not-needed":
+                return inspection
+            return self._apply(inspection)
+
+    def _locked_restore(self) -> dict[str, Any]:
+        lock_path = self.workspace / "repository-layout.lock"
+        with _open_layout_lock(lock_path) as lock, inherit_lock_fds(lock):
+            try:
+                fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                return {
+                    "migration": CONTENT_MIGRATION_NAME,
+                    "schema_version": CONTENT_MIGRATION_SCHEMA_VERSION,
+                    "status": "refused",
+                    "refusals": [
+                        _refusal(
+                            "repository_layout_busy",
+                            "the repository layout is in use by another wrapper operation",
+                            "wait for that operation to finish and rerun the restore",
+                        )
+                    ],
+                }
+            return self._restore()
+
+    def _inspect(self) -> dict[str, Any]:
+        refusals: list[dict[str, str]] = []
+        canonical = self._inspect_checkout(
+            self.canonical,
+            "main",
+            CERTIFIED_MAIN_COMMIT,
+            required=True,
+            require_clean=True,
+            refusals=refusals,
+        )
+        legacy = self._inspect_checkout(
+            self.legacy,
+            "1.x",
+            CERTIFIED_1X_COMMIT,
+            required=False,
+            require_clean=False,
+            refusals=refusals,
+        )
+        profiles, moves, profile_refusals = self._inspect_profiles(
+            canonical, legacy
+        )
+        refusals.extend(profile_refusals)
+        changed = [row for row in profiles if row["status"] == "rewrite"]
+        resources, resource_refusals = self._resource_inventory(
+            {row["name"] for row in changed}
+        )
+        refusals.extend(resource_refusals)
+        refusals.sort(key=lambda row: (row["code"], row["message"]))
+        return {
+            "migration": CONTENT_MIGRATION_NAME,
+            "schema_version": CONTENT_MIGRATION_SCHEMA_VERSION,
+            "status": "refused" if refusals else ("ready" if changed else "not-needed"),
+            "certified": {
+                "main": CERTIFIED_MAIN_COMMIT,
+                "1.x": CERTIFIED_1X_COMMIT,
+            },
+            "parity_proof": _certified_parity(),
+            "canonical": canonical,
+            "legacy": legacy,
+            "profiles": profiles,
+            "worktree_moves": moves,
+            "resources": resources,
+            "refusals": refusals,
+        }
+
+    def _inspect_checkout(
+        self,
+        path: Path,
+        branch: str,
+        anchor: str,
+        *,
+        required: bool,
+        require_clean: bool,
+        refusals: list[dict[str, str]],
+    ) -> dict[str, Any]:
+        row: dict[str, Any] = {
+            "path": str(path),
+            "repository": "atrinik/content",
+            "expected_branch": branch,
+            "anchor": anchor,
+            "present": path.exists() or path.is_symlink(),
+            "head": None,
+            "tree": None,
+            "branch": None,
+            "clean": None,
+            "common_directory": None,
+            "proven": False,
+        }
+        if not row["present"]:
+            if required:
+                refusals.append(
+                    _refusal(
+                        "canonical_content_missing",
+                        f"canonical content checkout is missing: {path}",
+                        "initialize content@main and rerun the dry run",
+                    )
+                )
+            return row
+        try:
+            if path.is_symlink() or not path.is_dir():
+                raise WorkspaceError("path is not a normal directory")
+            if _git(path, "rev-parse", "--is-inside-work-tree") != "true":
+                raise WorkspaceError("path is not a Git worktree")
+            if Path(_git(path, "rev-parse", "--show-toplevel")).resolve() != path.resolve():
+                raise WorkspaceError("path is not the Git worktree root")
+            remote_found = False
+            for remote in ("origin", "upstream"):
+                output = _git(path, "remote", "get-url", "--all", remote, check=False)
+                urls = output.splitlines()
+                if urls and _remote_matches(urls[0]):
+                    remote_found = True
+                    break
+            if not remote_found:
+                raise WorkspaceError("no canonical atrinik/content origin or upstream")
+            actual_branch = _git(path, "branch", "--show-current")
+            head = _git(path, "rev-parse", "HEAD")
+            tree = _git(path, "rev-parse", "HEAD^{tree}")
+            common = Path(_git(path, "rev-parse", "--git-common-dir"))
+            if not common.is_absolute():
+                common = path / common
+            clean = not _git(
+                path, "status", "--porcelain", "--untracked-files=normal"
+            )
+            if actual_branch != branch:
+                raise WorkspaceError(
+                    f"expected branch {branch}, found {actual_branch or 'detached HEAD'}"
+                )
+            if not _git_succeeds(path, "merge-base", "--is-ancestor", anchor, head):
+                raise WorkspaceError(f"HEAD does not descend from certified commit {anchor}")
+            if require_clean and not clean:
+                raise WorkspaceError("checkout is dirty")
+            row.update(
+                {
+                    "head": head,
+                    "tree": tree,
+                    "branch": actual_branch,
+                    "clean": clean,
+                    "common_directory": str(common.resolve()),
+                    "proven": True,
+                }
+            )
+        except (OSError, WorkspaceError) as error:
+            code = "canonical_content_unproven" if required else "legacy_content_unproven"
+            row["error"] = str(error)
+            if required:
+                refusals.append(
+                    _refusal(
+                        code,
+                        f"cannot prove {path}: {error}",
+                        "preserve the checkout and repair its exact repository, "
+                        "branch, ancestry, and cleanliness",
+                    )
+                )
+        return row
+
+    def _inspect_profiles(
+        self, canonical: dict[str, Any], legacy: dict[str, Any]
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, str]]]:
+        rows: list[dict[str, Any]] = []
+        moves: list[dict[str, Any]] = []
+        refusals: list[dict[str, str]] = []
+        profiles_root = Path(self.paths.profiles)
+        if not profiles_root.exists():
+            return rows, moves, refusals
+        if profiles_root.is_symlink() or not profiles_root.is_dir():
+            return rows, moves, [
+                _refusal(
+                    "invalid_profiles_directory",
+                    f"profiles path is not a normal directory: {profiles_root}",
+                    "restore the wrapper-owned profiles directory",
+                )
+            ]
+        new_components = {
+            component.name for component in self.manifest.stack("classic").components
+        }
+        old_components = (new_components - {"content"}) | {"content-1x"}
+        for path in sorted(profiles_root.glob("*.json")):
+            try:
+                if path.is_symlink() or not path.is_file():
+                    raise WorkspaceError("profile is not a regular file")
+                original = path.read_bytes()
+                if len(original) > PROFILE_MAX_BYTES:
+                    raise WorkspaceError("profile exceeds the bounded migration size")
+                value = json.loads(original)
+                if not isinstance(value, dict) or value.get("name") != path.stem:
+                    raise WorkspaceError("profile identity is invalid")
+                schema_version = value.get("schema_version")
+                expected_keys = (
+                    LEGACY_PROFILE_KEYS if schema_version == 3 else PROFILE_KEYS
+                )
+                if schema_version not in {3, 4} or set(value) != expected_keys:
+                    raise WorkspaceError("profile schema is unsupported")
+                if schema_version == 4 and value.get("sound_mode") not in {
+                    "source",
+                    "local-playtest",
+                }:
+                    raise WorkspaceError("profile sound mode is invalid")
+                components = value.get("components")
+                if value.get("stack") != "classic":
+                    rows.append(
+                        {
+                            "name": path.stem,
+                            "path": str(path),
+                            "status": "inert",
+                            "reason": "non-classic profile",
+                        }
+                    )
+                    continue
+                if not isinstance(components, dict):
+                    raise WorkspaceError("profile components are invalid")
+                if set(components) == new_components:
+                    rows.append(
+                        {
+                            "name": path.stem,
+                            "path": str(path),
+                            "status": "current",
+                            "reason": "already uses content@main",
+                        }
+                    )
+                    continue
+                if set(components) != old_components:
+                    raise WorkspaceError(
+                        "classic profile component set is neither legacy nor current"
+                    )
+                selector = components["content-1x"]
+                replacement, move = self._migrate_selector(
+                    path.stem, selector, canonical, legacy
+                )
+                rewritten = dict(value)
+                rewritten_components = dict(components)
+                rewritten_components.pop("content-1x")
+                rewritten_components["content"] = replacement
+                rewritten["components"] = rewritten_components
+                replacement_bytes = (
+                    json.dumps(rewritten, indent=2, sort_keys=True).encode("utf-8")
+                    + b"\n"
+                )
+                row = {
+                    "name": path.stem,
+                    "path": str(path),
+                    "status": "rewrite",
+                    "selector": replacement,
+                    "original_sha256": _digest(original),
+                    "original_base64": base64.b64encode(original).decode("ascii"),
+                    "replacement_sha256": _digest(replacement_bytes),
+                    "replacement_base64": base64.b64encode(replacement_bytes).decode(
+                        "ascii"
+                    ),
+                }
+                rows.append(row)
+                if move is not None:
+                    move["profile"] = path.stem
+                    moves.append(move)
+            except (OSError, UnicodeError, json.JSONDecodeError, WorkspaceError) as error:
+                rows.append(
+                    {
+                        "name": path.stem,
+                        "path": str(path),
+                        "status": "blocked",
+                        "reason": str(error),
+                    }
+                )
+                refusals.append(
+                    _refusal(
+                        "profile_unproven",
+                        f"cannot migrate profile {path.stem}: {error}",
+                        "preserve the profile and repair only its exact selector evidence",
+                    )
+                )
+        destinations: dict[str, str] = {}
+        for move in moves:
+            previous = destinations.setdefault(move["destination"], move["profile"])
+            if previous != move["profile"]:
+                refusals.append(
+                    _refusal(
+                        "worktree_destination_collision",
+                        f"profiles {previous} and {move['profile']} select the "
+                        f"same migration destination {move['destination']}",
+                        "give each proven worktree a distinct managed label",
+                    )
+                )
+        return rows, moves, refusals
+
+    def _migrate_selector(
+        self,
+        profile: str,
+        selector: Any,
+        canonical: dict[str, Any],
+        legacy: dict[str, Any],
+    ) -> tuple[dict[str, str], dict[str, Any] | None]:
+        if not isinstance(selector, dict) or set(selector) != {"kind", "value"}:
+            raise WorkspaceError("content-1x selector is invalid")
+        kind, value = selector["kind"], selector["value"]
+        if not isinstance(kind, str) or not isinstance(value, str):
+            raise WorkspaceError("content-1x selector is invalid")
+        if not canonical.get("proven"):
+            raise WorkspaceError("canonical content@main is not proven")
+        if kind == "primary":
+            if value:
+                raise WorkspaceError("primary selector has a value")
+            if not legacy.get("proven") or not legacy.get("clean"):
+                raise WorkspaceError("legacy primary is not clean and certified")
+            return {"kind": "primary", "value": ""}, None
+        if kind == "worktree":
+            if not NAME_PATTERN.fullmatch(value):
+                raise WorkspaceError("managed worktree label is invalid")
+            source = Path(self.paths.worktrees) / "content-1x" / value
+            destination = Path(self.paths.worktrees) / "content" / value
+            proof = self._prove_main_worktree(source, canonical)
+            if destination.exists() or destination.is_symlink():
+                raise WorkspaceError(
+                    f"managed worktree destination already exists: {destination}"
+                )
+            return {"kind": "worktree", "value": value}, {
+                "source": str(source),
+                "destination": str(destination),
+                **proof,
+            }
+        if kind in {"path", "migrated-worktree"}:
+            selected = Path(value)
+            if not selected.is_absolute():
+                raise WorkspaceError(f"{kind} selector is not absolute")
+            if selected.resolve(strict=False) == self.canonical.resolve(strict=False):
+                return {"kind": "primary", "value": ""}, None
+            self._prove_main_worktree(selected, canonical)
+            return {"kind": "path", "value": str(selected.resolve())}, None
+        raise WorkspaceError(f"unsupported selector kind {kind}")
+
+    def _prove_main_worktree(
+        self, path: Path, canonical: dict[str, Any]
+    ) -> dict[str, str]:
+        if path.is_symlink() or not path.is_dir():
+            raise WorkspaceError(f"selected worktree is not a normal directory: {path}")
+        if Path(_git(path, "rev-parse", "--show-toplevel")).resolve() != path.resolve():
+            raise WorkspaceError(f"selected path is not a Git worktree root: {path}")
+        branch = _git(path, "branch", "--show-current")
+        if not branch:
+            raise WorkspaceError(f"selected worktree is detached: {path}")
+        head = _git(path, "rev-parse", "HEAD")
+        tree = _git(path, "rev-parse", "HEAD^{tree}")
+        common = Path(_git(path, "rev-parse", "--git-common-dir"))
+        if not common.is_absolute():
+            common = path / common
+        if str(common.resolve()) != canonical["common_directory"]:
+            raise WorkspaceError(
+                f"selected worktree is not attached to canonical content: {path}"
+            )
+        if _git(
+            path,
+            "status",
+            "--porcelain",
+            "--untracked-files=normal",
+        ):
+            raise WorkspaceError(f"selected worktree is dirty: {path}")
+        if not _git_succeeds(
+            path,
+            "merge-base",
+            "--is-ancestor",
+            CERTIFIED_MAIN_COMMIT,
+            head,
+        ):
+            raise WorkspaceError(
+                f"selected worktree does not descend from certified content@main: {path}"
+            )
+        for operation in OPERATION_PATHS:
+            git_path = Path(_git(path, "rev-parse", "--git-path", operation))
+            if not git_path.is_absolute():
+                git_path = path / git_path
+            if git_path.exists() or git_path.is_symlink():
+                raise WorkspaceError(
+                    f"selected worktree has in-progress Git operation {operation}: {path}"
+                )
+        records = _git(self.canonical, "worktree", "list", "--porcelain").splitlines()
+        current: str | None = None
+        for line in records:
+            if line.startswith("worktree "):
+                current = str(Path(line.removeprefix("worktree ")).resolve())
+            elif line.startswith("locked") and current == str(path.resolve()):
+                raise WorkspaceError(f"selected worktree is locked: {path}")
+        return {"head": head, "tree": tree, "branch": branch}
+
+    def _resource_inventory(
+        self, changed_profiles: set[str]
+    ) -> tuple[dict[str, list[dict[str, Any]]], list[dict[str, str]]]:
+        resources: dict[str, list[dict[str, Any]]] = {
+            "builds": [],
+            "topologies": [],
+            "scenarios": [],
+            "locks": [],
+            "historical_paths": [],
+        }
+        refusals: list[dict[str, str]] = []
+        resources["historical_paths"].append(
+            {
+                "path": str(self.legacy),
+                "coordinate": "atrinik/content@1.x",
+                "present": self.legacy.exists() or self.legacy.is_symlink(),
+                "disposition": "preserve",
+            }
+        )
+        for root_name, root, pattern in (
+            ("builds", Path(self.paths.builds), ".atrinik-build.json"),
+            ("scenarios", Path(self.paths.scenarios), "scenario.json"),
+        ):
+            if not root.exists():
+                continue
+            if root.is_symlink() or not root.is_dir():
+                refusals.append(
+                    _refusal(
+                        f"invalid_{root_name}_directory",
+                        f"{root_name} path is not a normal directory: {root}",
+                        f"restore the wrapper-owned {root_name} directory",
+                    )
+                )
+                continue
+            candidates = root.rglob(pattern)
+            for path in sorted(candidates):
+                if path.is_symlink() or not path.is_file():
+                    refusals.append(
+                        _refusal(
+                            f"unobservable_{root_name}_record",
+                            f"cannot safely inspect {root_name} record: {path}",
+                            "preserve the path and restore a regular wrapper-owned record",
+                        )
+                    )
+                    continue
+                try:
+                    raw = path.read_bytes()
+                except OSError as error:
+                    refusals.append(
+                        _refusal(
+                            f"unobservable_{root_name}_record",
+                            f"cannot inspect {root_name} record {path}: {error}",
+                            "preserve the path and restore readable wrapper-owned metadata",
+                        )
+                    )
+                    continue
+                if b"content-1x" in raw or b'"branch": "1.x"' in raw:
+                    resources[root_name].append(
+                        {
+                            "path": str(path),
+                            "status": "historical-inert",
+                            "sha256": _digest(raw),
+                        }
+                    )
+        topologies = Path(self.paths.topologies)
+        if topologies.exists() and (topologies.is_symlink() or not topologies.is_dir()):
+            refusals.append(
+                _refusal(
+                    "invalid_topologies_directory",
+                    f"topologies path is not a normal directory: {topologies}",
+                    "restore or stop the topology before migration",
+                )
+            )
+        elif topologies.is_dir():
+            for directory in sorted(topologies.iterdir()):
+                status_path = directory / "status.json"
+                if directory.is_symlink():
+                    refusals.append(
+                        _refusal(
+                            "unobservable_topology",
+                            f"topology path is a link: {directory}",
+                            "preserve the path and restore a normal wrapper-owned "
+                            "topology directory",
+                        )
+                    )
+                    continue
+                if not directory.is_dir() or not status_path.exists():
+                    continue
+                try:
+                    if status_path.is_symlink() or not status_path.is_file():
+                        raise WorkspaceError("status is not a regular file")
+                    value = load_json(status_path)
+                    if not isinstance(value, dict) or not isinstance(value.get("services"), dict):
+                        raise WorkspaceError("unsupported topology status")
+                    records = [value.get("supervisor"), *value["services"].values()]
+                    running = []
+                    for record in records:
+                        if not isinstance(record, dict):
+                            raise WorkspaceError("invalid topology process record")
+                        pid, start = record.get("pid"), record.get("start_time")
+                        if (
+                            not isinstance(pid, int)
+                            or isinstance(pid, bool)
+                            or pid <= 0
+                            or not isinstance(start, str)
+                            or not start.isdigit()
+                        ):
+                            raise WorkspaceError("invalid topology process identity")
+                        if process_matches(pid, start):
+                            running.append(pid)
+                    affected = (
+                        value.get("profile") in changed_profiles
+                        or "content-1x" in json.dumps(value, sort_keys=True)
+                    )
+                    resources["topologies"].append(
+                        {
+                            "name": directory.name,
+                            "path": str(directory),
+                            "profile": value.get("profile"),
+                            "affected": affected,
+                            "running_pids": running,
+                            "status": "blocked" if affected and running else "historical-inert",
+                        }
+                    )
+                    if affected and running:
+                        refusals.append(
+                            _refusal(
+                                "live_topology",
+                                f"affected topology is active: {directory.name}",
+                                f"run ./atrinik down {directory.name} before migration",
+                            )
+                        )
+                except (OSError, WorkspaceError) as error:
+                    refusals.append(
+                        _refusal(
+                            "unobservable_topology",
+                            f"cannot inspect topology {directory.name}: {error}",
+                            "stop or repair the topology before migration",
+                        )
+                    )
+        lock_roots = [
+            self.workspace / "repository-layout.lock",
+            Path(self.paths.builds) / "locks",
+        ]
+        for root in lock_roots:
+            paths = [root] if root.is_file() else sorted(root.glob("*")) if root.is_dir() else []
+            for path in paths:
+                if path.is_symlink() or not path.is_file():
+                    continue
+                descriptor: int | None = None
+                try:
+                    descriptor = os.open(path, os.O_RDONLY | os.O_CLOEXEC)
+                    active = holders_exist(descriptor, exclude={os.getpid()})
+                except (OSError, WorkspaceError):
+                    active = True
+                finally:
+                    if descriptor is not None:
+                        os.close(descriptor)
+                resources["locks"].append(
+                    {"path": str(path), "active": active, "status": "observed"}
+                )
+        return resources, refusals
+
+    def _apply(self, inspection: dict[str, Any]) -> dict[str, Any]:
+        journal = {
+            **inspection,
+            "status": "pending",
+            "started_at": datetime.now(timezone.utc).isoformat(),
+        }
+        atomic_json(self.pending_path, journal)
+        applied_profiles: list[dict[str, Any]] = []
+        applied_moves: list[dict[str, Any]] = []
+        published = False
+        try:
+            for move in inspection["worktree_moves"]:
+                source = Path(move["source"])
+                destination = Path(move["destination"])
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                self._prove_main_worktree(source, inspection["canonical"])
+                if destination.exists() or destination.is_symlink():
+                    raise WorkspaceError(
+                        f"worktree destination appeared during migration: {destination}"
+                    )
+                _git(self.canonical, "worktree", "move", str(source), str(destination))
+                applied_moves.append(move)
+            for row in inspection["profiles"]:
+                if row["status"] != "rewrite":
+                    continue
+                path = Path(row["path"])
+                current = path.read_bytes()
+                if _digest(current) != row["original_sha256"]:
+                    raise WorkspaceError(f"profile changed during migration: {path}")
+                replacement = base64.b64decode(row["replacement_base64"], validate=True)
+                _atomic_bytes(path, replacement)
+                applied_profiles.append(row)
+            record = {
+                **inspection,
+                "status": "complete",
+                "applied_at": datetime.now(timezone.utc).isoformat(),
+                "restore": {
+                    "available": True,
+                    "command": "./atrinik migrate content --restore --json",
+                    "precondition": (
+                        "all replacement profile bytes and worktree destinations "
+                        "remain exact"
+                    ),
+                },
+            }
+            atomic_json(self.record_path, record)
+            published = True
+            try:
+                self.pending_path.unlink()
+            except OSError:
+                return {
+                    **record,
+                    "pending_journal_retained": str(self.pending_path),
+                }
+            return record
+        except BaseException as error:
+            if published:
+                raise WorkspaceError(
+                    "content migration completed and its durable record was published, "
+                    f"but final journal cleanup failed: {error}; preserve {self.record_path} "
+                    f"and {self.pending_path} and run --audit"
+                ) from error
+            rollback_errors = self._rollback(applied_profiles, applied_moves)
+            if not rollback_errors:
+                self.pending_path.unlink(missing_ok=True)
+            detail = f"content migration failed: {error}"
+            if rollback_errors:
+                detail += "; rollback failed: " + "; ".join(rollback_errors)
+            raise WorkspaceError(detail) from error
+
+    def _rollback(
+        self,
+        profiles: list[dict[str, Any]],
+        moves: list[dict[str, Any]],
+    ) -> list[str]:
+        errors: list[str] = []
+        for row in reversed(profiles):
+            path = Path(row["path"])
+            try:
+                if _digest(path.read_bytes()) != row["replacement_sha256"]:
+                    raise WorkspaceError(f"replacement profile changed: {path}")
+                original = base64.b64decode(row["original_base64"], validate=True)
+                _atomic_bytes(path, original)
+            except BaseException as error:
+                errors.append(str(error))
+        for move in reversed(moves):
+            source = Path(move["source"])
+            destination = Path(move["destination"])
+            try:
+                if source.exists() or source.is_symlink():
+                    raise WorkspaceError(f"original worktree path is occupied: {source}")
+                _git(self.canonical, "worktree", "move", str(destination), str(source))
+            except BaseException as error:
+                errors.append(str(error))
+        return errors
+
+    def _load_record(self) -> dict[str, Any]:
+        record = load_json(self.record_path)
+        if (
+            not isinstance(record, dict)
+            or record.get("migration") != CONTENT_MIGRATION_NAME
+            or record.get("schema_version") != CONTENT_MIGRATION_SCHEMA_VERSION
+            or record.get("status") not in {"complete", "restored"}
+            or record.get("certified")
+            != {"main": CERTIFIED_MAIN_COMMIT, "1.x": CERTIFIED_1X_COMMIT}
+            or record.get("parity_proof") != _certified_parity()
+            or not isinstance(record.get("canonical"), dict)
+            or record["canonical"].get("path") != str(self.canonical)
+            or record["canonical"].get("repository") != "atrinik/content"
+            or record["canonical"].get("expected_branch") != "main"
+            or record["canonical"].get("anchor") != CERTIFIED_MAIN_COMMIT
+            or not isinstance(record["canonical"].get("common_directory"), str)
+            or not Path(record["canonical"]["common_directory"]).is_absolute()
+            or not isinstance(record.get("legacy"), dict)
+            or record["legacy"].get("path") != str(self.legacy)
+            or not isinstance(record.get("profiles"), list)
+            or not isinstance(record.get("worktree_moves"), list)
+        ):
+            raise WorkspaceError("record has an unsupported shape")
+        rewrite_names: set[str] = set()
+        for row in record["profiles"]:
+            if not isinstance(row, dict) or not isinstance(row.get("status"), str):
+                raise WorkspaceError("record profile row is invalid")
+            if row["status"] != "rewrite":
+                continue
+            name = row.get("name")
+            if not isinstance(name, str) or not NAME_PATTERN.fullmatch(name):
+                raise WorkspaceError("record profile name is invalid")
+            expected_path = (Path(self.paths.profiles) / f"{name}.json").resolve(
+                strict=False
+            )
+            raw_path = row.get("path")
+            if (
+                name in rewrite_names
+                or not isinstance(raw_path, str)
+                or Path(raw_path).resolve(strict=False) != expected_path
+            ):
+                raise WorkspaceError("record profile path is invalid")
+            rewrite_names.add(name)
+            for prefix in ("original", "replacement"):
+                encoded = row.get(f"{prefix}_base64")
+                digest = row.get(f"{prefix}_sha256")
+                if (
+                    not isinstance(encoded, str)
+                    or not isinstance(digest, str)
+                    or re.fullmatch(r"[0-9a-f]{64}", digest) is None
+                ):
+                    raise WorkspaceError("record profile bytes are invalid")
+                try:
+                    decoded = base64.b64decode(encoded, validate=True)
+                except (ValueError, binascii.Error) as error:
+                    raise WorkspaceError("record profile bytes are invalid") from error
+                if _digest(decoded) != digest:
+                    raise WorkspaceError("record profile digest is invalid")
+        move_profiles: set[str] = set()
+        for move in record["worktree_moves"]:
+            if not isinstance(move, dict):
+                raise WorkspaceError("record worktree move is invalid")
+            profile = move.get("profile")
+            source = move.get("source")
+            destination = move.get("destination")
+            if (
+                not isinstance(profile, str)
+                or profile not in rewrite_names
+                or profile in move_profiles
+                or not isinstance(source, str)
+                or not isinstance(destination, str)
+            ):
+                raise WorkspaceError("record worktree move identity is invalid")
+            source_path = Path(source).resolve(strict=False)
+            destination_path = Path(destination).resolve(strict=False)
+            source_parent = (Path(self.paths.worktrees) / "content-1x").resolve(
+                strict=False
+            )
+            destination_parent = (Path(self.paths.worktrees) / "content").resolve(
+                strict=False
+            )
+            if (
+                source_path.parent != source_parent
+                or destination_path.parent != destination_parent
+                or source_path.name != destination_path.name
+                or not NAME_PATTERN.fullmatch(source_path.name)
+                or any(
+                    not isinstance(move.get(key), str)
+                    or re.fullmatch(r"[0-9a-f]{40,64}", move[key]) is None
+                    for key in ("head", "tree")
+                )
+                or not isinstance(move.get("branch"), str)
+                or not move["branch"]
+            ):
+                raise WorkspaceError("record worktree move path is invalid")
+            move_profiles.add(profile)
+        return record
+
+    def _audit(self) -> dict[str, Any]:
+        refusals: list[dict[str, str]] = []
+        if self.record_path.is_symlink() or not self.record_path.is_file():
+            return {
+                "migration": CONTENT_MIGRATION_NAME,
+                "schema_version": CONTENT_MIGRATION_SCHEMA_VERSION,
+                "status": "incomplete",
+                "refusals": [
+                    _refusal(
+                        "migration_record_missing",
+                        f"content migration record is missing: {self.record_path}",
+                        "run the dry run and apply before auditing",
+                    )
+                ],
+            }
+        try:
+            record = self._load_record()
+        except WorkspaceError as error:
+            return {
+                "migration": CONTENT_MIGRATION_NAME,
+                "schema_version": CONTENT_MIGRATION_SCHEMA_VERSION,
+                "status": "incomplete",
+                "refusals": [
+                    _refusal(
+                        "invalid_migration_record",
+                        f"cannot validate {self.record_path}: {error}",
+                        "restore the exact migration record",
+                    )
+                ],
+            }
+        expected_profile_field = (
+            "original_sha256" if record["status"] == "restored" else "replacement_sha256"
+        )
+        for row in record["profiles"]:
+            if not isinstance(row, dict) or row.get("status") != "rewrite":
+                continue
+            try:
+                path = Path(row["path"])
+                if _digest(path.read_bytes()) != row[expected_profile_field]:
+                    raise WorkspaceError("profile bytes differ from the journal")
+            except (OSError, KeyError, WorkspaceError) as error:
+                refusals.append(
+                    _refusal(
+                        "profile_audit_failed",
+                        f"profile audit failed for {row.get('path')}: {error}",
+                        "restore the exact journaled bytes or record a new reviewed migration",
+                    )
+                )
+        canonical_refusals: list[dict[str, str]] = []
+        canonical = self._inspect_checkout(
+            self.canonical,
+            "main",
+            CERTIFIED_MAIN_COMMIT,
+            required=True,
+            require_clean=False,
+            refusals=canonical_refusals,
+        )
+        refusals.extend(canonical_refusals)
+        if canonical.get("proven") and any(
+            canonical.get(key) != record["canonical"].get(key)
+            for key in ("common_directory", "repository")
+        ):
+            refusals.append(
+                _refusal(
+                    "canonical_audit_failed",
+                    "canonical content identity differs from the migration journal",
+                    "preserve all paths and restore the exact certified checkout",
+                )
+            )
+        if record["status"] == "complete":
+            for move in record["worktree_moves"]:
+                try:
+                    source = Path(move["source"])
+                    destination = Path(move["destination"])
+                    if source.exists() or source.is_symlink():
+                        raise WorkspaceError("original worktree path was recreated")
+                    proof = self._prove_main_worktree(destination, record["canonical"])
+                    if any(proof[key] != move[key] for key in ("head", "tree", "branch")):
+                        raise WorkspaceError("worktree identity changed")
+                except (OSError, KeyError, WorkspaceError) as error:
+                    refusals.append(
+                        _refusal(
+                            "worktree_audit_failed",
+                            f"worktree audit failed for {move.get('destination')}: {error}",
+                            "preserve both paths and restore only the exact journaled worktree",
+                        )
+                    )
+        else:
+            for move in record["worktree_moves"]:
+                try:
+                    source = Path(move["source"])
+                    destination = Path(move["destination"])
+                    if destination.exists() or destination.is_symlink():
+                        raise WorkspaceError("migration destination was recreated")
+                    proof = self._prove_main_worktree(source, record["canonical"])
+                    if any(proof[key] != move[key] for key in ("head", "tree", "branch")):
+                        raise WorkspaceError("restored worktree identity changed")
+                except (OSError, KeyError, WorkspaceError) as error:
+                    refusals.append(
+                        _refusal(
+                            "worktree_audit_failed",
+                            f"restored worktree audit failed for {move.get('source')}: {error}",
+                            "preserve both paths and repair only the exact journaled worktree",
+                        )
+                    )
+        return {
+            **record,
+            "status": "incomplete" if refusals else record["status"],
+            "refusals": refusals,
+        }
+
+    def _restore(self) -> dict[str, Any]:
+        audit = self._audit()
+        if audit.get("status") != "complete":
+            return audit
+        resources, refusals = self._resource_inventory(
+            {row["name"] for row in audit["profiles"] if row.get("status") == "rewrite"}
+        )
+        if refusals:
+            return {**audit, "status": "refused", "resources": resources, "refusals": refusals}
+        restored_profiles: list[dict[str, Any]] = []
+        restored_moves: list[dict[str, Any]] = []
+        try:
+            for row in audit["profiles"]:
+                if row.get("status") != "rewrite":
+                    continue
+                path = Path(row["path"])
+                if _digest(path.read_bytes()) != row["replacement_sha256"]:
+                    raise WorkspaceError(f"replacement profile changed: {path}")
+                _atomic_bytes(
+                    path,
+                    base64.b64decode(row["original_base64"], validate=True),
+                )
+                restored_profiles.append(row)
+            for move in reversed(audit["worktree_moves"]):
+                source = Path(move["source"])
+                destination = Path(move["destination"])
+                if source.exists() or source.is_symlink():
+                    raise WorkspaceError(f"original worktree path is occupied: {source}")
+                _git(self.canonical, "worktree", "move", str(destination), str(source))
+                restored_moves.append(move)
+            restored = {
+                **audit,
+                "status": "restored",
+                "restored_at": datetime.now(timezone.utc).isoformat(),
+                "refusals": [],
+            }
+            atomic_json(self.record_path, restored)
+            return restored
+        except BaseException as error:
+            rollback_errors = self._rollback_restore(
+                restored_profiles, restored_moves, audit["canonical"]
+            )
+            detail = (
+                "content migration restore stopped after a changed precondition: "
+                f"{error}; preserve the journal and all paths"
+            )
+            if rollback_errors:
+                detail += "; restore rollback failed: " + "; ".join(rollback_errors)
+            raise WorkspaceError(detail) from error
+
+    def _rollback_restore(
+        self,
+        profiles: list[dict[str, Any]],
+        moves: list[dict[str, Any]],
+        canonical: dict[str, Any],
+    ) -> list[str]:
+        errors: list[str] = []
+        for move in reversed(moves):
+            source = Path(move["source"])
+            destination = Path(move["destination"])
+            try:
+                self._prove_main_worktree(source, canonical)
+                if destination.exists() or destination.is_symlink():
+                    raise WorkspaceError(
+                        f"migration destination is occupied: {destination}"
+                    )
+                _git(self.canonical, "worktree", "move", str(source), str(destination))
+            except BaseException as error:
+                errors.append(str(error))
+        for row in reversed(profiles):
+            path = Path(row["path"])
+            try:
+                if _digest(path.read_bytes()) != row["original_sha256"]:
+                    raise WorkspaceError(f"original profile changed: {path}")
+                replacement = base64.b64decode(
+                    row["replacement_base64"], validate=True
+                )
+                _atomic_bytes(path, replacement)
+            except BaseException as error:
+                errors.append(str(error))
+        return errors

--- a/atrinik_workspace/content_migration.py
+++ b/atrinik_workspace/content_migration.py
@@ -27,6 +27,8 @@ CONTENT_MIGRATION_SCHEMA_VERSION = 1
 CERTIFIED_MAIN_COMMIT = "7dde0c0afe8840fc95dd26f404310e77d9c82621"
 CERTIFIED_1X_COMMIT = "566bd25f78b80b08d5f75f4b02017ab2429204db"
 PROFILE_MAX_BYTES = 1024 * 1024
+RESOURCE_RECORD_MAX_BYTES = 4 * 1024 * 1024
+MIGRATION_RECORD_MAX_BYTES = 64 * 1024 * 1024
 PROFILE_KEYS = {"schema_version", "name", "stack", "components", "sound_mode"}
 LEGACY_PROFILE_KEYS = {"schema_version", "name", "stack", "components"}
 NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
@@ -104,6 +106,15 @@ def _remote_matches(url: str) -> bool:
 
 def _digest(value: bytes) -> str:
     return hashlib.sha256(value).hexdigest()
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise WorkspaceError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
 
 
 def _atomic_bytes(path: Path, value: bytes) -> None:
@@ -414,10 +425,12 @@ class ContentMigration:
             try:
                 if path.is_symlink() or not path.is_file():
                     raise WorkspaceError("profile is not a regular file")
+                if path.stat().st_size > PROFILE_MAX_BYTES:
+                    raise WorkspaceError("profile exceeds the bounded migration size")
                 original = path.read_bytes()
                 if len(original) > PROFILE_MAX_BYTES:
                     raise WorkspaceError("profile exceeds the bounded migration size")
-                value = json.loads(original)
+                value = json.loads(original, object_pairs_hook=_reject_duplicate_keys)
                 if not isinstance(value, dict) or value.get("name") != path.stem:
                     raise WorkspaceError("profile identity is invalid")
                 schema_version = value.get("schema_version")
@@ -445,6 +458,7 @@ class ContentMigration:
                 if not isinstance(components, dict):
                     raise WorkspaceError("profile components are invalid")
                 if set(components) == new_components:
+                    self._validate_current_profile_components(components)
                     rows.append(
                         {
                             "name": path.stem,
@@ -466,6 +480,7 @@ class ContentMigration:
                 rewritten_components = dict(components)
                 rewritten_components.pop("content-1x")
                 rewritten_components["content"] = replacement
+                self._validate_current_profile_components(rewritten_components)
                 rewritten["components"] = rewritten_components
                 replacement_bytes = (
                     json.dumps(rewritten, indent=2, sort_keys=True).encode("utf-8")
@@ -487,7 +502,13 @@ class ContentMigration:
                 if move is not None:
                     move["profile"] = path.stem
                     moves.append(move)
-            except (OSError, UnicodeError, json.JSONDecodeError, WorkspaceError) as error:
+            except (
+                OSError,
+                UnicodeError,
+                json.JSONDecodeError,
+                RecursionError,
+                WorkspaceError,
+            ) as error:
                 rows.append(
                     {
                         "name": path.stem,
@@ -516,6 +537,41 @@ class ContentMigration:
                     )
                 )
         return rows, moves, refusals
+
+    def _validate_current_profile_components(
+        self, components: dict[str, Any]
+    ) -> None:
+        checkout_selectors: dict[str, dict[str, str]] = {}
+        for component_name, selector in components.items():
+            if (
+                component_name not in self.manifest.by_name
+                or not isinstance(selector, dict)
+                or set(selector) != {"kind", "value"}
+                or not isinstance(selector.get("kind"), str)
+                or not isinstance(selector.get("value"), str)
+            ):
+                raise WorkspaceError("profile selector is invalid")
+            kind = selector["kind"]
+            value = selector["value"]
+            if kind == "primary":
+                if value:
+                    raise WorkspaceError("primary selector has a value")
+            elif kind == "worktree":
+                if not NAME_PATTERN.fullmatch(value):
+                    raise WorkspaceError("managed worktree selector is invalid")
+            elif kind == "path":
+                if not Path(value).is_absolute():
+                    raise WorkspaceError("external path selector is not absolute")
+            else:
+                raise WorkspaceError(
+                    f"selector kind is not valid after content migration: {kind}"
+                )
+            checkout = self.manifest.by_name[component_name].checkout_name
+            previous = checkout_selectors.setdefault(checkout, selector)
+            if previous != selector:
+                raise WorkspaceError(
+                    f"profile selectors disagree for shared checkout {checkout}"
+                )
 
     def _migrate_selector(
         self,
@@ -681,8 +737,10 @@ class ContentMigration:
                     )
                     continue
                 try:
+                    if path.stat().st_size > RESOURCE_RECORD_MAX_BYTES:
+                        raise WorkspaceError("record exceeds the bounded inventory size")
                     raw = path.read_bytes()
-                except OSError as error:
+                except (OSError, RecursionError, WorkspaceError) as error:
                     refusals.append(
                         _refusal(
                             f"unobservable_{root_name}_record",
@@ -726,6 +784,8 @@ class ContentMigration:
                 try:
                     if status_path.is_symlink() or not status_path.is_file():
                         raise WorkspaceError("status is not a regular file")
+                    if status_path.stat().st_size > RESOURCE_RECORD_MAX_BYTES:
+                        raise WorkspaceError("status exceeds the bounded inventory size")
                     value = load_json(status_path)
                     if not isinstance(value, dict) or not isinstance(value.get("services"), dict):
                         raise WorkspaceError("unsupported topology status")
@@ -767,7 +827,7 @@ class ContentMigration:
                                 f"run ./atrinik down {directory.name} before migration",
                             )
                         )
-                except (OSError, WorkspaceError) as error:
+                except (OSError, RecursionError, WorkspaceError) as error:
                     refusals.append(
                         _refusal(
                             "unobservable_topology",
@@ -780,9 +840,39 @@ class ContentMigration:
             Path(self.paths.builds) / "locks",
         ]
         for root in lock_roots:
-            paths = [root] if root.is_file() else sorted(root.glob("*")) if root.is_dir() else []
+            if root.is_symlink() or root.exists() and not (
+                root.is_file() or root.is_dir()
+            ):
+                resources["locks"].append(
+                    {"path": str(root), "active": True, "status": "unsafe"}
+                )
+                refusals.append(
+                    _refusal(
+                        "invalid_lock_path",
+                        f"lock inventory path is unsafe: {root}",
+                        "preserve the path and restore a regular lock file or directory",
+                    )
+                )
+                continue
+            paths = (
+                [root]
+                if root.is_file()
+                else sorted(root.glob("*"))
+                if root.is_dir()
+                else []
+            )
             for path in paths:
                 if path.is_symlink() or not path.is_file():
+                    resources["locks"].append(
+                        {"path": str(path), "active": True, "status": "unsafe"}
+                    )
+                    refusals.append(
+                        _refusal(
+                            "invalid_lock_path",
+                            f"lock inventory entry is unsafe: {path}",
+                            "preserve the path and restore a regular lock file",
+                        )
+                    )
                     continue
                 descriptor: int | None = None
                 try:
@@ -900,7 +990,17 @@ class ContentMigration:
         return errors
 
     def _load_record(self) -> dict[str, Any]:
-        record = load_json(self.record_path)
+        try:
+            if self.record_path.stat().st_size > MIGRATION_RECORD_MAX_BYTES:
+                raise WorkspaceError("record exceeds the bounded migration size")
+            raw = self.record_path.read_bytes()
+            if len(raw) > MIGRATION_RECORD_MAX_BYTES:
+                raise WorkspaceError("record exceeds the bounded migration size")
+            record = json.loads(raw, object_pairs_hook=_reject_duplicate_keys)
+        except (UnicodeError, json.JSONDecodeError, RecursionError) as error:
+            raise WorkspaceError(f"cannot parse migration record: {error}") from error
+        except OSError as error:
+            raise WorkspaceError(f"cannot inspect migration record: {error}") from error
         if (
             not isinstance(record, dict)
             or record.get("migration") != CONTENT_MIGRATION_NAME
@@ -938,7 +1038,7 @@ class ContentMigration:
             if (
                 name in rewrite_names
                 or not isinstance(raw_path, str)
-                or Path(raw_path).resolve(strict=False) != expected_path
+                or raw_path != str(expected_path)
             ):
                 raise WorkspaceError("record profile path is invalid")
             rewrite_names.add(name)
@@ -972,14 +1072,10 @@ class ContentMigration:
                 or not isinstance(destination, str)
             ):
                 raise WorkspaceError("record worktree move identity is invalid")
-            source_path = Path(source).resolve(strict=False)
-            destination_path = Path(destination).resolve(strict=False)
-            source_parent = (Path(self.paths.worktrees) / "content-1x").resolve(
-                strict=False
-            )
-            destination_parent = (Path(self.paths.worktrees) / "content").resolve(
-                strict=False
-            )
+            source_path = Path(source)
+            destination_path = Path(destination)
+            source_parent = Path(self.paths.worktrees) / "content-1x"
+            destination_parent = Path(self.paths.worktrees) / "content"
             if (
                 source_path.parent != source_parent
                 or destination_path.parent != destination_parent
@@ -1043,7 +1139,7 @@ class ContentMigration:
             }
         try:
             record = self._load_record()
-        except WorkspaceError as error:
+        except (WorkspaceError, RecursionError) as error:
             return {
                 "migration": CONTENT_MIGRATION_NAME,
                 "schema_version": CONTENT_MIGRATION_SCHEMA_VERSION,

--- a/atrinik_workspace/content_migration.py
+++ b/atrinik_workspace/content_migration.py
@@ -175,11 +175,8 @@ class ContentMigration:
             return self._audit()
         if mode == "restore":
             return self._locked_restore()
-        inspection = self._inspect()
-        if mode == "dry-run" or inspection["refusals"]:
-            return inspection
-        if inspection["status"] == "not-needed":
-            return inspection
+        if mode == "dry-run":
+            return self._inspect()
         return self._locked_apply()
 
     def _locked_apply(self) -> dict[str, Any]:

--- a/atrinik_workspace/model.py
+++ b/atrinik_workspace/model.py
@@ -61,7 +61,6 @@ REQUIRED_COHORT_CHECKOUTS = {
     },
     "classic": {
         "classic",
-        "content-1x",
         "playtester",
         "tools",
     },
@@ -88,7 +87,7 @@ REQUIRED_STACK_PROVIDERS = {
         "protocol": "classic-protocol",
         "libatrinik": "classic-libatrinik",
         "editor": "classic-editor",
-        "content": "content-1x",
+        "content": "content",
         "playtester": "playtester",
         "tools": "tools",
         "sound": "sound",
@@ -226,6 +225,7 @@ class Component:
     branch: str
     checkout: str
     build: str
+    build_by_stack: tuple[tuple[str, str], ...]
     generation: str
     provides: tuple[str, ...]
     requires: tuple[str, ...]
@@ -356,6 +356,7 @@ class Manifest:
                     branch=branch,
                     checkout=name,
                     build=V1_BUILD_KINDS[build],
+                    build_by_stack=(),
                     generation="shared",
                     provides=(name,),
                     requires=(),
@@ -516,7 +517,7 @@ class Manifest:
         components: list[Component] = []
         names: set[str] = set()
         sources: dict[str, list[tuple[str, PurePosixPath]]] = {}
-        expected = {
+        required = {
             "name",
             "checkout",
             "source",
@@ -526,11 +527,21 @@ class Manifest:
             "requires",
             "license",
         }
+        allowed = required | {"build_by_stack"}
         for index, raw in enumerate(raw_components):
             context = f"component {index}"
             if not isinstance(raw, dict):
                 raise WorkspaceError(f"{context} must be an object")
-            require_keys(raw, expected, context)
+            actual_keys = set(raw)
+            if not required <= actual_keys or not actual_keys <= allowed:
+                missing = sorted(required - actual_keys)
+                extra = sorted(actual_keys - allowed)
+                detail: list[str] = []
+                if missing:
+                    detail.append(f"missing {', '.join(missing)}")
+                if extra:
+                    detail.append(f"unexpected {', '.join(extra)}")
+                raise WorkspaceError(f"{context}: {'; '.join(detail)}")
             name = validate_name(raw["name"], f"{context}.name")
             checkout_name = validate_name(raw["checkout"], f"{context}.checkout")
             if checkout_name not in by_checkout:
@@ -538,10 +549,31 @@ class Manifest:
             checkout = by_checkout[checkout_name]
             source = _validate_source(raw["source"], f"{context}.source")
             build = raw["build"]
+            raw_build_by_stack = raw.get("build_by_stack", {})
             generation = raw["generation"]
             license_name = _validate_license(raw["license"], f"{context}.license")
             if not isinstance(build, str) or build not in BUILD_KINDS:
                 raise WorkspaceError(f"{context}.build is invalid")
+            if not isinstance(raw_build_by_stack, dict):
+                raise WorkspaceError(f"{context}.build_by_stack must be an object")
+            build_by_stack: dict[str, str] = {}
+            for raw_stack, raw_adapter in raw_build_by_stack.items():
+                stack_name = validate_name(
+                    raw_stack, f"{context}.build_by_stack stack"
+                )
+                if stack_name not in STACK_NAMES:
+                    raise WorkspaceError(
+                        f"{context}.build_by_stack names unknown stack {stack_name}"
+                    )
+                if not isinstance(raw_adapter, str) or raw_adapter not in BUILD_KINDS:
+                    raise WorkspaceError(
+                        f"{context}.build_by_stack.{stack_name} is invalid"
+                    )
+                if raw_adapter == build:
+                    raise WorkspaceError(
+                        f"{context}.build_by_stack.{stack_name} redundantly repeats build"
+                    )
+                build_by_stack[stack_name] = raw_adapter
             if not isinstance(generation, str) or generation not in GENERATIONS:
                 raise WorkspaceError(f"{context}.generation is invalid")
             if generation != checkout.generation:
@@ -566,7 +598,13 @@ class Manifest:
                     f"{context} claims incompatible implementation roles: "
                     f"{', '.join(sorted(claimed_implementations))}"
                 )
-            if generation == "shared" and claimed_implementations:
+            shared_content = (
+                generation == "shared"
+                and name == "content"
+                and checkout_name == "content"
+                and claimed_implementations == {"content"}
+            )
+            if generation == "shared" and claimed_implementations and not shared_content:
                 raise WorkspaceError(
                     f"{context} shared component claims implementation role: "
                     f"{', '.join(sorted(claimed_implementations))}"
@@ -600,6 +638,7 @@ class Manifest:
                     branch=checkout.branch,
                     checkout=checkout.path,
                     build=build,
+                    build_by_stack=tuple(sorted(build_by_stack.items())),
                     generation=generation,
                     provides=provides,
                     requires=requires,
@@ -706,6 +745,36 @@ class Manifest:
             actual_providers: dict[str, str] = {}
             for component_name in stack.components:
                 component = by_name[component_name]
+                build_by_stack = dict(component.build_by_stack)
+                effective_build = build_by_stack.get(stack_name, component.build)
+                unused_overrides = sorted(set(build_by_stack) - {
+                    candidate
+                    for candidate, candidate_stack in stacks.items()
+                    if component_name in candidate_stack.components
+                })
+                if unused_overrides:
+                    raise WorkspaceError(
+                        f"component {component_name}.build_by_stack targets stacks where "
+                        f"the component is absent: {', '.join(unused_overrides)}"
+                    )
+                effective_generation = (
+                    "replacement" if stack_name == "default" else "classic"
+                )
+                if (
+                    stack_name in build_by_stack
+                    and effective_build
+                    not in GENERATION_BUILD_KINDS[effective_generation]
+                ):
+                    raise WorkspaceError(
+                        f"component {component_name} effective build {effective_build} "
+                        f"is incompatible with {stack_name} stack"
+                    )
+                adapter_role = CLASSIC_BUILD_ROLES.get(effective_build)
+                if adapter_role is not None and adapter_role not in component.provides:
+                    raise WorkspaceError(
+                        f"component {component_name} effective build {effective_build} "
+                        f"requires provided role {adapter_role}"
+                    )
                 if component.generation not in {stack.generation, "shared"}:
                     raise WorkspaceError(
                         f"{context} mixes {component.generation} component {component_name} "
@@ -774,6 +843,17 @@ class Manifest:
         if role not in selected.providers:
             raise WorkspaceError(f"stack {stack} has no provider for role {role}")
         return selected.providers[role]
+
+    def effective_build(self, stack: str, component: Component | str) -> str:
+        """Return the one validated build adapter for a component in a stack."""
+
+        selected = self.stack(stack)
+        value = self.by_name[component] if isinstance(component, str) else component
+        if value.name not in {candidate.name for candidate in selected.components}:
+            raise WorkspaceError(
+                f"component {value.name} is not part of {selected.name} stack"
+            )
+        return dict(value.build_by_stack).get(selected.name, value.build)
 
     def component_cohorts(self, name: str) -> tuple[str, ...]:
         if name not in self.by_name:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -3322,8 +3322,6 @@ class Workspace:
         if actual != expected:
             raise WorkspaceError("collected content does not match its manifest")
         entries = {entry["path"]: entry for entry in manifest["files"]}
-        if len(entries) != len(manifest["files"]):
-            raise WorkspaceError("collected content manifest contains duplicate paths")
         if adapter == "classic-content":
             licenses = manifest["license_files"]
             license_entries: dict[str, dict[str, Any]] = {}

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -30,6 +30,7 @@ import time
 from typing import Any, Callable, Iterator, TextIO
 
 from .launch_identity import CLIENT_LAUNCH_LABEL_ENV, client_launch_label
+from .content_migration import ContentMigration
 from .locking import active_lock_fds, inherit_lock_fds
 from .process_tree import holders_exist, signal_holders
 
@@ -1248,6 +1249,13 @@ class Workspace:
             self.paths.repository, self.paths, self.manifest
         ).execute(mode)
 
+    def migrate_content(self, mode: str) -> dict[str, Any]:
+        if mode in {"apply", "restore"}:
+            self.paths.ensure()
+        return ContentMigration(
+            self.paths.repository, self.paths, self.manifest
+        ).execute(mode)
+
     def cleanup(
         self,
         scopes: list[str],
@@ -1673,22 +1681,42 @@ class Workspace:
 
         if not self.paths.profiles.is_dir():
             return set()
-        component = self.manifest.by_name.get("content-1x")
+        component = self.manifest.by_name.get("content")
         if component is None:
             return set()
         protected: set[Path] = set()
         for path in sorted(self.paths.profiles.glob("*.json")):
-            profile = self._load_profile(path.stem, require_file=True)
+            try:
+                profile = load_json(path)
+            except WorkspaceError:
+                continue
+            if not isinstance(profile, dict) or not isinstance(
+                profile.get("components"), dict
+            ):
+                continue
             selector = profile["components"].get("content-1x")
-            if selector is None or selector["kind"] != MIGRATED_CONTENT_WORKTREE_KIND:
+            if (
+                not isinstance(selector, dict)
+                or set(selector) != {"kind", "value"}
+                or selector.get("kind") != MIGRATED_CONTENT_WORKTREE_KIND
+                or not isinstance(selector.get("value"), str)
+            ):
                 continue
             selected = Path(selector["value"]).resolve()
-            self._validate_selected_checkout(
-                component,
-                selected,
-                MIGRATED_CONTENT_WORKTREE_KIND,
-                trace=False,
-            )
+            expected_parent = (self.paths.worktrees / "content").resolve()
+            if selected.parent != expected_parent:
+                raise WorkspaceError(
+                    f"invalid migration-only content worktree path: {selected}"
+                )
+            self._validate_checkout(component, selected, trace=False)
+            primary = self._primary_path(component)
+            self._validate_primary_checkout(component, primary, trace=False)
+            if self._git_common_directory(selected, trace=False) != self._git_common_directory(
+                primary, trace=False
+            ):
+                raise WorkspaceError(
+                    f"migration-only content worktree lost canonical lineage: {selected}"
+                )
             protected.add(selected)
         return protected
 
@@ -2224,6 +2252,7 @@ class Workspace:
                 "repository": component.repository,
                 "branch": component.branch,
                 "source": component.source,
+                "build": self.manifest.effective_build(stack.name, component),
                 "roles": sorted(component.provides),
                 "path": str(path),
                 "checkout_path": str(checkout_root),
@@ -2267,15 +2296,16 @@ class Workspace:
             profile_name, {component.name}, trace=False
         )[component.name]
 
-    @staticmethod
-    def _classic_requires(component: Component) -> tuple[str, ...]:
+    def _classic_requires(
+        self, component: Component, stack_name: str
+    ) -> tuple[str, ...]:
         if component.requires:
             return component.requires
         return {
             "classic-client": ("sound", "libatrinik", "protocol"),
             "classic-server": ("content", "resources", "libatrinik", "protocol"),
             "classic-library": ("protocol",),
-        }.get(component.build, ())
+        }.get(self.manifest.effective_build(stack_name, component), ())
 
     def _dependency_roles(
         self, profile: dict[str, Any], requested: set[str]
@@ -2294,7 +2324,7 @@ class Workspace:
                 continue
             resolved.add(role)
             component = stack.providers[role]
-            for requirement in self._classic_requires(component):
+            for requirement in self._classic_requires(component, stack.name):
                 if requirement not in stack.providers:
                     raise WorkspaceError(
                         f"{component.name} requires role {requirement}, which has no "
@@ -2320,7 +2350,10 @@ class Workspace:
                 raise WorkspaceError(
                     f"{stack.name} stack has no provider for runtime role {role}"
                 )
-            if adapter is not None and component.build != adapter:
+            if (
+                adapter is not None
+                and self.manifest.effective_build(stack.name, component) != adapter
+            ):
                 raise WorkspaceError(
                     f"{component.name} has no wrapper build/runtime contract yet "
                     f"for the {stack.name} stack"
@@ -2335,7 +2368,7 @@ class Workspace:
         build_targets = {
             role
             for role, component in stack.providers.items()
-            if component.build != "none"
+            if self.manifest.effective_build(stack.name, component) != "none"
         }
         common_roles = self._dependency_roles(profile, build_targets)
         common_components = {
@@ -2709,7 +2742,7 @@ class Workspace:
             ]
         for role in targets:
             component = stack.providers[role]
-            if component.build == "none":
+            if self.manifest.effective_build(stack.name, component) == "none":
                 raise WorkspaceError(
                     f"{component.name} has no wrapper build/runtime contract yet "
                     f"for the {stack.name} stack"
@@ -3146,6 +3179,7 @@ class Workspace:
     def _validate_collected_content(
         path: Path,
         coordinate: dict[str, str],
+        adapter: str,
         *,
         require_metadata: bool = True,
     ) -> None:
@@ -3157,25 +3191,91 @@ class Workspace:
                 raise WorkspaceError(
                     f"collected content lacks required directory: {required}"
                 )
-        for name in ("compatibility.json", "manifest.json"):
+        required_files = ["manifest.json"]
+        if adapter == "classic-content":
+            required_files.append("compatibility.json")
+        for name in required_files:
             required = path / name
             if not required.is_file() or required.is_symlink():
                 raise WorkspaceError(
                     f"collected content lacks required file: {required}"
                 )
         manifest = load_json(path / "manifest.json")
-        if (
-            not isinstance(manifest, dict)
-            or manifest.get("schema_version") != 2
-            or manifest.get("source")
-            != {
-                "repository": coordinate["repository"],
-                "branch": coordinate["branch"],
-                "commit": coordinate["head"],
-            }
-            or not isinstance(manifest.get("files"), list)
-        ):
+        if not isinstance(manifest, dict):
             raise WorkspaceError("collected content manifest is invalid")
+        if adapter == "classic-content":
+            expected_contract = {
+                "schema_version": 1,
+                "target": "classic",
+                "component": "content",
+                "repository": "atrinik/content",
+                "branch": "main",
+                "content_format": "classic-ads-v1",
+                "artifact_format": "atrinik-classic-runtime-content-v1",
+                "compatible_classic_releases": ">=5.10.1 <6.0.0",
+                "consumers": [
+                    "classic/client",
+                    "classic/editor",
+                    "classic/server",
+                ],
+                "replacement_ready": False,
+                "replacement_toolkit_package": False,
+            }
+            compatibility = load_json(path / "compatibility.json")
+            if compatibility != expected_contract:
+                raise WorkspaceError(
+                    "collected Classic content compatibility contract is invalid"
+                )
+            if (
+                set(manifest)
+                != {
+                    "schema_version",
+                    "target",
+                    "source",
+                    "release_version",
+                    "content_format",
+                    "artifact_format",
+                    "compatible_classic_releases",
+                    "consumers",
+                    "replacement_ready",
+                    "replacement_toolkit_package",
+                    "license_files",
+                    "files",
+                }
+                or manifest.get("schema_version") != 2
+                or manifest.get("target") != "classic"
+                or manifest.get("source")
+                != {
+                    "repository": coordinate["repository"],
+                    "branch": coordinate["branch"],
+                    "commit": coordinate["head"],
+                }
+                or manifest.get("release_version") != "unreleased"
+                or any(
+                    manifest.get(key) != expected_contract[key]
+                    for key in (
+                        "content_format",
+                        "artifact_format",
+                        "compatible_classic_releases",
+                        "consumers",
+                        "replacement_ready",
+                        "replacement_toolkit_package",
+                    )
+                )
+                or not isinstance(manifest.get("license_files"), list)
+                or not isinstance(manifest.get("files"), list)
+            ):
+                raise WorkspaceError("collected Classic content manifest is invalid")
+        elif adapter in {"none", "content"}:
+            if (
+                set(manifest) != {"schema_version", "source_commit", "files"}
+                or manifest.get("schema_version") != 1
+                or manifest.get("source_commit") != coordinate["head"]
+                or not isinstance(manifest.get("files"), list)
+            ):
+                raise WorkspaceError("collected default content manifest is invalid")
+        else:
+            raise WorkspaceError(f"unsupported content build adapter: {adapter}")
         expected = {MANAGED_MARKER, "manifest.json"}
         if require_metadata:
             expected.add(RUNTIME_INPUT_METADATA)
@@ -3222,6 +3322,28 @@ class Workspace:
         if actual != expected:
             raise WorkspaceError("collected content does not match its manifest")
         entries = {entry["path"]: entry for entry in manifest["files"]}
+        if len(entries) != len(manifest["files"]):
+            raise WorkspaceError("collected content manifest contains duplicate paths")
+        if adapter == "classic-content":
+            licenses = manifest["license_files"]
+            license_entries: dict[str, dict[str, Any]] = {}
+            for entry in licenses:
+                if (
+                    not isinstance(entry, dict)
+                    or set(entry) != {"path", "sha256", "size"}
+                    or not isinstance(entry.get("path"), str)
+                    or not entry["path"].startswith("attribution/")
+                    or PurePosixPath(entry["path"]).name not in {"COPYING", "LICENSE"}
+                    or entries.get(entry["path"]) != entry
+                ):
+                    raise WorkspaceError(
+                        "collected Classic content license entry is invalid"
+                    )
+                license_entries[entry["path"]] = entry
+            if len(license_entries) != len(licenses) or not license_entries:
+                raise WorkspaceError(
+                    "collected Classic content license inventory is invalid"
+                )
         for relative, entry in entries.items():
             candidate = path.joinpath(*PurePosixPath(relative).parts)
             digest = hashlib.sha256()
@@ -3419,13 +3541,16 @@ class Workspace:
         inputs, cacheable = self._runtime_input_coordinates(
             profile_name, selected, "content"
         )
+        profile = self._load_profile(profile_name, require_file=False)
+        component = self.manifest.provider(profile["stack"], "content")
+        adapter = self.manifest.effective_build(profile["stack"], component)
         matched = self._runtime_input_cache_matches(
             output,
             "collected-content",
             inputs,
             cacheable,
             lambda path: self._validate_collected_content(
-                path, inputs["coordinate"]
+                path, inputs["coordinate"], adapter
             ),
         )
         validated_inputs, validated_cacheable = self._runtime_input_coordinates(
@@ -3446,24 +3571,28 @@ class Workspace:
         source = selected["content"]
         commit = inputs["coordinate"]["head"]
         try:
-            run(
-                [
-                    sys.executable,
-                    str(source / "tools" / "build_runtime.py"),
-                    "--source",
-                    str(source),
-                    "--output",
-                    str(staging),
-                    "--source-commit",
-                    commit,
-                ]
-            )
+            command = [
+                sys.executable,
+                str(source / "tools" / "build_runtime.py"),
+                "--source",
+                str(source),
+                "--output",
+                str(staging),
+                "--source-commit",
+                commit,
+            ]
+            if adapter == "classic-content":
+                command.extend(("--target", "classic"))
+            run(command)
             atomic_json(
                 staging / MANAGED_MARKER,
                 {"schema_version": SCHEMA_VERSION, "purpose": "collected-content"},
             )
             self._validate_collected_content(
-                staging, inputs["coordinate"], require_metadata=False
+                staging,
+                inputs["coordinate"],
+                adapter,
+                require_metadata=False,
             )
             final_inputs, final_cacheable = self._runtime_input_coordinates(
                 profile_name, selected, "content"
@@ -6916,6 +7045,18 @@ class Workspace:
                 for record in status["resolved"].values()
             )
         )
+        retired_content_record = (
+            isinstance(status, dict)
+            and not historical_record
+            and isinstance(status.get("providers"), dict)
+            and status["providers"].get("content") == "content-1x"
+            and isinstance(status.get("resolved"), dict)
+            and isinstance(status["resolved"].get("content-1x"), dict)
+            and status["resolved"]["content-1x"].get("repository")
+            == "atrinik/content"
+            and status["resolved"]["content-1x"].get("branch") == "1.x"
+            and status["resolved"]["content-1x"].get("checkout") == "content-1x"
+        )
         if (
             not isinstance(status, dict)
             or status.get("schema_version") != SCHEMA_VERSION
@@ -6967,7 +7108,7 @@ class Workspace:
                 for role in status["dependencies"]
             }
             status["inert_historical_record"] = True
-        elif coordinate_historical_record:
+        elif coordinate_historical_record or retired_content_record:
             stack_name = status.get("stack")
             providers = status.get("providers")
             if (
@@ -7050,7 +7191,11 @@ class Workspace:
                 or not isinstance(resolved.get("dirty"), bool)
             ):
                 raise WorkspaceError(f"topology resolution status is invalid: {name}")
-            if not historical_record and not coordinate_historical_record:
+            if (
+                not historical_record
+                and not coordinate_historical_record
+                and not (retired_content_record and component == "content-1x")
+            ):
                 provider = self.manifest.by_name[component]
                 checkout_path = Path(resolved["checkout_path"]).resolve(
                     strict=False

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -3266,7 +3266,7 @@ class Workspace:
                 or not isinstance(manifest.get("files"), list)
             ):
                 raise WorkspaceError("collected Classic content manifest is invalid")
-        elif adapter in {"none", "content"}:
+        elif adapter == "none":
             if (
                 set(manifest) != {"schema_version", "source_commit", "files"}
                 or manifest.get("schema_version") != 1
@@ -3338,11 +3338,30 @@ class Workspace:
                 ):
                     raise WorkspaceError(
                         "collected Classic content license entry is invalid"
-                    )
+                )
                 license_entries[entry["path"]] = entry
-            if len(license_entries) != len(licenses) or not license_entries:
+            expected_license_paths = {
+                relative
+                for relative in entries
+                if relative.startswith("attribution/")
+                and PurePosixPath(relative).name in {"COPYING", "LICENSE"}
+            }
+            if (
+                len(license_entries) != len(licenses)
+                or set(license_entries) != expected_license_paths
+                or not license_entries
+            ):
                 raise WorkspaceError(
                     "collected Classic content license inventory is invalid"
+                )
+            payload_roots = {
+                PurePosixPath(relative).parts[0]
+                for relative in entries
+                if PurePosixPath(relative).parts
+            }
+            if not {"lib", "maps"} <= payload_roots:
+                raise WorkspaceError(
+                    "collected Classic content payload is incomplete"
                 )
         for relative, entry in entries.items():
             candidate = path.joinpath(*PurePosixPath(relative).parts)
@@ -7048,6 +7067,7 @@ class Workspace:
         retired_content_record = (
             isinstance(status, dict)
             and not historical_record
+            and status.get("stack") == "classic"
             and isinstance(status.get("providers"), dict)
             and status["providers"].get("content") == "content-1x"
             and isinstance(status.get("resolved"), dict)
@@ -7056,6 +7076,19 @@ class Workspace:
             == "atrinik/content"
             and status["resolved"]["content-1x"].get("branch") == "1.x"
             and status["resolved"]["content-1x"].get("checkout") == "content-1x"
+            and status["resolved"]["content-1x"].get("source") == "."
+            and isinstance(
+                status["resolved"]["content-1x"].get("path"), str
+            )
+            and isinstance(
+                status["resolved"]["content-1x"].get("checkout_path"), str
+            )
+            and Path(
+                status["resolved"]["content-1x"]["path"]
+            ).resolve(strict=False)
+            == Path(
+                status["resolved"]["content-1x"]["checkout_path"]
+            ).resolve(strict=False)
         )
         if (
             not isinstance(status, dict)

--- a/components.json
+++ b/components.json
@@ -18,7 +18,6 @@
     ],
     "classic": [
       "classic",
-      "content-1x",
       "playtester",
       "tools"
     ]
@@ -65,7 +64,7 @@
         "classic-protocol",
         "classic-libatrinik",
         "classic-editor",
-        "content-1x",
+        "content",
         "playtester",
         "tools",
         "sound",
@@ -80,7 +79,7 @@
         "protocol": "classic-protocol",
         "libatrinik": "classic-libatrinik",
         "editor": "classic-editor",
-        "content": "content-1x",
+        "content": "content",
         "playtester": "playtester",
         "tools": "tools",
         "sound": "sound",
@@ -153,7 +152,7 @@
       "repository": "atrinik/content",
       "branch": "main",
       "path": "content",
-      "generation": "replacement",
+      "generation": "shared",
       "license": "LicenseRef-Atrinik-Content"
     },
     {
@@ -203,14 +202,6 @@
       "path": "classic",
       "generation": "classic",
       "license": "GPL-2.0-or-later"
-    },
-    {
-      "name": "content-1x",
-      "repository": "atrinik/content",
-      "branch": "1.x",
-      "path": "content-1x",
-      "generation": "classic",
-      "license": "LicenseRef-Atrinik-Content"
     },
     {
       "name": "playtester",
@@ -305,7 +296,10 @@
       "checkout": "content",
       "source": ".",
       "build": "none",
-      "generation": "replacement",
+      "build_by_stack": {
+        "classic": "classic-content"
+      },
+      "generation": "shared",
       "provides": ["content"],
       "requires": [],
       "license": "LicenseRef-Atrinik-Content"
@@ -409,16 +403,6 @@
       "provides": ["editor"],
       "requires": ["content", "resources"],
       "license": "GPL-2.0-or-later"
-    },
-    {
-      "name": "content-1x",
-      "checkout": "content-1x",
-      "source": ".",
-      "build": "classic-content",
-      "generation": "classic",
-      "provides": ["content"],
-      "requires": [],
-      "license": "LicenseRef-Atrinik-Content"
     },
     {
       "name": "playtester",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,9 +30,10 @@ rather than aliases for every manifest entry.
 The `atrinik/classic@main` checkout at `./classic` provides five logical
 components: `classic-client` from `client/`, `classic-server` from `server/`,
 `classic-editor` from `editor/`, `classic-libatrinik` from `libatrinik/`, and
-`classic-protocol` from `protocol/`. `content` remains
-`atrinik/content@main` at `./content` for the replacement stack, while
-`content-1x` is `atrinik/content@1.x` at `./content-1x` for the classic stack.
+`classic-protocol` from `protocol/`. One shared `content` component remains
+`atrinik/content@main` at `./content` for both stacks. Its global build is
+`none`; the narrowly validated `build_by_stack.classic` override selects the
+`classic-content` publisher only for Classic.
 The classic-only `playtester` component occupies `atrinik/playtester@main` at
 `./playtester`, provides the `playtester` role, and requires the classic stack's
 `content`, `libatrinik`, and `protocol` providers. Its `build: none` contract
@@ -90,18 +91,16 @@ source audits exclude imported nested copies while continuing to audit their
 dependency inputs. A named profile audit refuses to run unless every
 audit-ready component in the stack is initialized or explicitly overridden;
 absence cannot degrade a complete audit into a partial report. Explicit
-worktree overrides are
-absolute and must match the expected repository and branch identity. A review
-branch for a repeated coordinate must share the expected checkout primary's
-common Git directory, preventing `content` and `content-1x` from being
-interchanged. Deterministic
+worktree overrides are absolute and must match the expected repository and
+branch identity. A review branch must share the expected checkout primary's
+common Git directory, preventing historical or unrelated content from
+impersonating `content@main`. Deterministic
 license, CycloneDX, SPDX, and local version reports are generated only below
 the ignored build directory; report generation resolves full commit IDs through
 `--profile PROFILE`. The scheduled audit delegates checkout composition to
-`./atrinik init --with classic`, audits both complete stacks including both
-content release lines, and publishes stack-separated reports; regression tests
-bind that initialization ordering, the fail-closed profile contract, and the
-`content@1.x` workflow-runner policy.
+`./atrinik init --with classic`, audits both complete stacks against the one
+active content source, and publishes stack-separated reports; regression tests
+bind that initialization ordering and fail-closed profile contract.
 
 Read-only inspection commands keep structured data on stdout and suppress Git
 traces so callers can safely consume `status --json`, `worktree list --json`,
@@ -158,8 +157,8 @@ public HTTPS is the fallback when the wrapper has no recognized GitHub remote.
 With no explicit arguments, initialization resolves only the
 replacement/default cohort. `init --with classic` resolves the union of the
 default and classic cohorts; the option is additive and has no classic-only
-alias. The `classic` monorepo, GPL `tools`, MIT `playtester`, and
-`content-1x@1.x` are absent from ordinary initialization. Explicit checkout or
+alias. The `classic` monorepo, GPL `tools`, and MIT `playtester` are absent from
+ordinary initialization. The shared content checkout is cloned once. Explicit checkout or
 logical-component initialization remains available for partial workspaces.
 Aliases that own one physical checkout are deduplicated. Initialization is
 idempotent, stages clones away from their destination, and does not update or
@@ -374,13 +373,24 @@ Scenario metadata records its stack and exact checkout/component/source
 providers. An old scenario without that immutable identity is kept as an inert
 record and cannot inherit the current meaning of a reused profile name.
 
+Content selector retirement has its own preview/apply/audit transaction. Its
+certified anchors bind the merged consolidation commits on `main` and the final
+immutable `1.x` release. Preflight inventories legacy profile selectors,
+managed and external worktrees, builds, scenarios, topology records, locks,
+and live processes. Apply holds the repository-layout lock, journals exact
+original profile bytes, uses atomic replacements, and rolls back exact changes
+on failure. Restore holds the same lock and is available only while journaled
+replacement bytes and worktree identities remain unchanged. Historical
+coordinates are preserved as inert facts, and neither migration nor cleanup
+deletes the old checkout or records.
+
 ## Profile resolution and build flow
 
 A profile records a stack and maps each logical component in that stack to its
 primary checkout root, a managed physical-checkout worktree label, or an
 absolute external checkout root. The built-in `default` profile chooses
 replacement providers; the built-in `classic` profile chooses the five
-`classic-*` providers from `atrinik/classic` plus `content-1x`. Cloning a
+`classic-*` providers from `atrinik/classic` plus shared `content@main`. Cloning a
 built-in or saved profile with `profile create --from` retains that stack
 identity. Resolution verifies that every selected root is a Git worktree whose
 `origin` or `upstream` and checkout identity match the manifest. Primary
@@ -399,13 +409,12 @@ Separate module branches must first be combined into one monorepo branch and
 worktree. Resolution then appends each logical component's own source without
 treating a subdirectory as an independent Git worktree.
 
-An exact historical schema-1 or schema-2 classic profile may be migrated with
-an internal `migrated-worktree` selector for an existing content worktree. This exception
-is restricted to `content-1x`, the old managed content-worktree namespace, and
-the `content@main` Git common directory; normal selectors retain the exact
-branch/common-directory rules. Profile-aware sync treats every such path as a
-classic migration artifact and excludes it before checking or updating
-`content@main` worktrees.
+Legacy profile schemas are read by the dedicated content migration before the
+current manifest component set is required. An internal
+`migrated-worktree` selector is accepted only as recovery input. The migration
+normalizes a worktree into the shared namespace only after proving repository
+identity, common Git directory, commit/tree ancestry, destination, and
+cleanliness; old `1.x` or arbitrary external paths remain inert.
 
 The role graph is resolved before component source paths or commands. Each required role
 has exactly one provider in the selected stack, and the transitive service
@@ -440,7 +449,7 @@ CMake inputs cannot remain hidden behind a warm graph.
 The currently playable classic build flow is:
 
 ~~~text
-selected content-1x -> build_runtime.py -> isolated content/lib + content/maps
+selected content@main -> build_runtime.py --target classic -> isolated content/lib + content/maps
 selected tracked resource allowlist -> isolated resource view
 full Classic closure -> integrated source view -> one protocol/libatrinik graph
                                              +-> client targets -> CMake/Ninja
@@ -558,7 +567,7 @@ match; dirty inputs deliberately regenerate.
 
 For the currently runnable classic profile, server launch preparation assembles
 a disposable working directory with links to the selected build, plugins,
-collected `content-1x`, resources, configuration, GPL tools, and named
+collected Classic-target `content@main`, resources, configuration, GPL tools, and named
 persistent state. GPL tools are not part of the replacement/default role graph.
 First use initializes a state atomically from the selected server's
 `install_data`; an existing directory is validated and never overlaid. State

--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -191,32 +191,11 @@
         "content"
       ],
       "stacks": [
+        "classic",
         "default"
       ],
       "supported": true,
       "checkout": "content",
-      "source": "."
-    },
-    {
-      "audit_ready": true,
-      "audit_mode": "full",
-      "branch": "1.x",
-      "cohorts": [
-        "classic"
-      ],
-      "license": "LicenseRef-Atrinik-Content",
-      "commit": null,
-      "name": "content-1x",
-      "repository": "atrinik/content",
-      "role": "Classic authored world content release line",
-      "roles": [
-        "content"
-      ],
-      "stacks": [
-        "classic"
-      ],
-      "supported": true,
-      "checkout": "content-1x",
       "source": "."
     },
     {
@@ -602,7 +581,6 @@
         "classic",
         "client",
         "content",
-        "content-1x",
         "content-toolkit",
         "devcontainer",
         "editor",
@@ -827,7 +805,6 @@
         "classic",
         "client",
         "content",
-        "content-1x",
         "content-toolkit",
         "devcontainer",
         "editor",
@@ -875,11 +852,6 @@
         },
         {
           "repository": "content",
-          "path": ".github/workflows/release.yml",
-          "contains": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0"
-        },
-        {
-          "repository": "content-1x",
           "path": ".github/workflows/release.yml",
           "contains": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0"
         },
@@ -953,8 +925,7 @@
       "scope": [
         "atrinik",
         "classic",
-        "content",
-        "content-1x"
+        "content"
       ],
       "required": true,
       "version": "v7.0.0",
@@ -1671,8 +1642,7 @@
       "kind": "external-tool",
       "owner": "content",
       "scope": [
-        "content",
-        "content-1x"
+        "content"
       ],
       "required": true,
       "version": "per-file",
@@ -1692,11 +1662,6 @@
       "evidence": [
         {
           "repository": "content",
-          "path": "arch/license_check.py",
-          "contains": "LICENSE"
-        },
-        {
-          "repository": "content-1x",
           "path": "arch/license_check.py",
           "contains": "LICENSE"
         }
@@ -2509,7 +2474,7 @@
       "id": "source/atrinik-content-playtester",
       "name": "Atrinik content source for playtester world planning",
       "kind": "source-archive",
-      "owner": "content-1x",
+      "owner": "content",
       "scope": [
         "playtester"
       ],
@@ -4170,7 +4135,6 @@
         "classic",
         "client",
         "content",
-        "content-1x",
         "content-toolkit",
         "devcontainer",
         "editor",
@@ -4218,11 +4182,6 @@
         },
         {
           "repository": "content",
-          "path": ".github/workflows/check.yml",
-          "contains": "runs-on: ubuntu-24.04"
-        },
-        {
-          "repository": "content-1x",
           "path": ".github/workflows/check.yml",
           "contains": "runs-on: ubuntu-24.04"
         },
@@ -4334,7 +4293,7 @@
       "name": "GitHub-hosted Windows 2025 runner",
       "kind": "toolchain",
       "owner": "github-settings",
-      "scope": ["classic", "client", "content", "content-1x", "devcontainer", "editor", "server", "website"],
+      "scope": ["classic", "client", "content", "devcontainer", "editor", "server", "website"],
       "required": true,
       "version": "windows-2025",
       "version_source": "Explicit GitHub Actions runner label and generated version report",
@@ -4354,7 +4313,6 @@
         {"repository":"classic","path":".github/workflows/check.yml","contains":"runs-on: windows-2025"},
         {"repository":"client","path":".github/workflows/validate.yml","contains":"runs-on: windows-2025"},
         {"repository":"content","path":".github/workflows/check.yml","contains":"- windows-2025"},
-        {"repository":"content-1x","path":".github/workflows/check.yml","contains":"- windows-2025"},
         {"repository":"devcontainer","path":".github/workflows/validate.yml","contains":"runs-on: windows-2025"},
         {"repository":"editor","path":".github/workflows/validate.yml","contains":"runs-on: windows-2025"},
         {"repository":"server","path":".github/workflows/validate.yml","contains":"runs-on: windows-2025"},
@@ -4397,7 +4355,6 @@
         "classic",
         "client",
         "content",
-        "content-1x",
         "content-toolkit",
         "devcontainer",
         "editor",
@@ -4448,11 +4405,6 @@
         },
         {
           "repository": "content",
-          "path": ".github/workflows/release.yml",
-          "contains": "node-version: 24.18.1"
-        },
-        {
-          "repository": "content-1x",
           "path": ".github/workflows/release.yml",
           "contains": "node-version: 24.18.1"
         },
@@ -4539,7 +4491,6 @@
         "classic-protocol",
         "classic-server",
         "content",
-        "content-1x",
         "devcontainer",
         "playtester",
         "tools"

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -244,7 +244,7 @@ class AgentGuidanceTests(unittest.TestCase):
         self.assertIn("## Scale and performance", checklist)
         self.assertIn("## Safety, security, and supply chain", checklist)
 
-    def test_content_issue_delivery_covers_both_release_lines(self) -> None:
+    def test_content_issue_delivery_uses_main_as_sole_authored_source(self) -> None:
         content = " ".join(
             (
                 ROOT / ".agents/skills/atrinik-content-change/SKILL.md"
@@ -264,28 +264,17 @@ class AgentGuidanceTests(unittest.TestCase):
         ).read_text(encoding="utf-8")
 
         for marker in {
-            "For issue fixes, assess both `content@main` and `content-1x@1.x`",
-            (
-                "Shared authored changes normally need separate worktrees, "
-                "validation, commits, and linked PRs on both lines"
-            ),
-            (
-                "record an evidence-backed format, consumer, runtime, or "
-                "provenance reason for any single-line exception"
-            ),
+            "`content@main` is the sole authored source",
+            "select the target-specific publisher",
+            "never edit or create a PR against the retired `1.x` line",
         }:
             with self.subTest(surface="content", marker=marker):
                 self.assertIn(marker, content)
         for marker in {
-            "assess `main` and `1.x`",
-            "separate bases",
-            "final-head checks",
-            "Paired: only the default-branch PR closes; companions link",
-            "companions link",
-            (
-                "A sole `main` PR closes. A sole `1.x` PR links without a "
-                "closing keyword; close its issue manually after merge"
-            ),
+            "author only on `main`",
+            "validate every affected target and consumer",
+            "never publish a new `1.x` PR",
+            "A content `main` PR may close its issue",
             "per-target bases",
         }:
             with self.subTest(surface="delivery", marker=marker):

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1292,10 +1292,24 @@ class CleanupTests(unittest.TestCase):
                 "composite_worktrees": [{"destination": str(worktree)}],
             },
         )
+        atomic_json(
+            migrations / "content.json",
+            {
+                "canonical": {"path": str(self.wrapper / "content")},
+                "legacy": {"path": str(self.wrapper / "content-1x")},
+                "worktree_moves": [
+                    {"source": str(worktree), "destination": str(worktree)}
+                ],
+                "profiles": [{"path": str(self.workspace.paths.profiles / "old.json")}],
+                "resources": {
+                    "historical_paths": [{"path": str(worktree)}]
+                },
+            },
+        )
         report = self.workspace.cleanup(["worktrees"], 0, ["client"], False)
         item = next(row for row in report["items"] if row["path"] == str(worktree))
         self.assertIn("migration_reference", item["reasons"])
-        self.assertGreaterEqual(len(item["references"]["migration"]), 3)
+        self.assertGreaterEqual(len(item["references"]["migration"]), 6)
 
     def test_migration_path_inventory_covers_every_current_record_shape(self) -> None:
         paths = list(
@@ -1318,10 +1332,22 @@ class CleanupTests(unittest.TestCase):
                     ],
                     "worktrees": [{"destination": str(self.root / "worktree")}],
                     "classic": {"path": str(self.root / "classic")},
+                    "canonical": {"path": str(self.root / "content")},
+                    "legacy": {"path": str(self.root / "content-1x")},
+                    "worktree_moves": [
+                        {
+                            "source": str(self.root / "content-old-worktree"),
+                            "destination": str(self.root / "content-worktree"),
+                        }
+                    ],
+                    "profiles": [{"path": str(self.root / "profile.json")}],
+                    "resources": {
+                        "scenarios": [{"path": str(self.root / "scenario.json")}]
+                    },
                 }
             )
         )
-        self.assertEqual(len(paths), 7)
+        self.assertEqual(len(paths), 13)
         self.assertIn(("classic.path", self.root / "classic"), paths)
 
         with self.assertRaisesRegex(WorkspaceError, "is not a list"):
@@ -2753,10 +2779,9 @@ class CleanupTests(unittest.TestCase):
             ),
             {"classic"},
         )
-        self.assertEqual(
-            cleanup._normalize_names(["content", "content-1x"]),
-            {"content", "content-1x"},
-        )
+        self.assertEqual(cleanup._normalize_names(["content"]), {"content"})
+        with self.assertRaisesRegex(WorkspaceError, "unknown components"):
+            cleanup._normalize_names(["content-1x"])
 
         head = "a" * 40
         pulls = self.merged_pull(head, base="main")
@@ -2772,6 +2797,7 @@ class CleanupTests(unittest.TestCase):
             "kind": "migrated-worktree",
             "value": str(migrated),
         }
+        profile["components"].pop("content")
         atomic_json(actual_workspace.paths.profiles / "migrated.json", profile)
         references: dict[str, object] = {"profiles": {}}
         errors: set[str] = set()

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1357,6 +1357,28 @@ class CleanupTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "classic path"):
             list(Cleanup._migration_paths({"classic": 7}))
 
+    def test_migration_path_inventory_rejects_every_malformed_extension(self) -> None:
+        cases = (
+            ({"canonical": []}, "migration canonical is invalid"),
+            ({"legacy": {"path": "relative"}}, "migration legacy.path is invalid"),
+            ({"resources": []}, "migration resources are invalid"),
+            ({"resources": {7: []}}, "migration resource category is invalid"),
+            ({"resources": {"states": [7]}}, r"resources.states\[0\] is invalid"),
+            (
+                {"resources": {"states": [{"path": "relative"}]}},
+                r"resources.states\[0\].path is invalid",
+            ),
+        )
+        for value, message in cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(WorkspaceError, message):
+                    list(Cleanup._migration_paths(value))
+
+        self.assertEqual(
+            list(Cleanup._migration_paths({"resources": {"states": [{}]}})),
+            [],
+        )
+
     def test_apply_revalidates_then_removes_without_deleting_branch(self) -> None:
         worktree = self.make_wrapper_worktree()
         branch = command("git", "branch", "--show-current", cwd=worktree)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -344,6 +344,89 @@ class ParserTests(unittest.TestCase):
 
         self.assertEqual(result, 1)
 
+    def test_content_migration_json_dispatches_each_selected_mode(self) -> None:
+        for flag, mode in (
+            ("--dry-run", "dry-run"),
+            ("--apply", "apply"),
+            ("--audit", "audit"),
+            ("--restore", "restore"),
+        ):
+            with self.subTest(flag=flag):
+                plan = {
+                    "migration": "content",
+                    "status": "complete" if mode == "audit" else "ready",
+                    "refusals": [],
+                }
+                with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+                    workspace_type.return_value.migrate_content.return_value = plan
+                    with mock.patch("builtins.print") as output:
+                        result = main(["migrate", "content", flag, "--json"])
+
+                self.assertEqual(result, 0)
+                workspace_type.return_value.migrate_content.assert_called_once_with(mode)
+                self.assertEqual(json.loads(output.call_args.args[0]), plan)
+
+    def test_content_migration_refusal_returns_failure(self) -> None:
+        plan = {
+            "migration": "content",
+            "status": "refused",
+            "refusals": [
+                {
+                    "code": "legacy_content_unproven",
+                    "message": "legacy content is dirty",
+                    "recovery": "preserve the checkout",
+                }
+            ],
+        }
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.migrate_content.return_value = plan
+            with mock.patch("builtins.print"):
+                result = main(["migrate", "content", "--apply"])
+
+        self.assertEqual(result, 1)
+
+    def test_content_migration_text_reports_profiles_and_worktree_moves(self) -> None:
+        plan = {
+            "migration": "content",
+            "status": "ready",
+            "profiles": [
+                {
+                    "status": "rewrite",
+                    "name": "classic-review",
+                    "path": "/workspace/profiles/classic-review.json",
+                }
+            ],
+            "worktree_moves": [
+                {
+                    "profile": "classic-review",
+                    "source": "/workspace/worktrees/content-1x/maps",
+                    "destination": "/workspace/worktrees/content/maps",
+                }
+            ],
+            "refusals": [],
+        }
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.migrate_content.return_value = plan
+            with mock.patch("builtins.print") as output:
+                result = main(["migrate", "content", "--dry-run"])
+
+        self.assertEqual(result, 0)
+        self.assertIn(
+            mock.call(
+                "profile\trewrite\tclassic-review\t"
+                "/workspace/profiles/classic-review.json"
+            ),
+            output.call_args_list,
+        )
+        self.assertIn(
+            mock.call(
+                "worktree\tmove\tclassic-review\t"
+                "/workspace/worktrees/content-1x/maps\t"
+                "/workspace/worktrees/content/maps"
+            ),
+            output.call_args_list,
+        )
+
     def test_repository_migration_text_reports_action_statuses(self) -> None:
         plan = {
             "migration": "repositories",

--- a/tests/test_cohorts.py
+++ b/tests/test_cohorts.py
@@ -88,7 +88,10 @@ class CohortWorkspaceTests(unittest.TestCase):
             for component in self.workspace.manifest.cohort(cohort)
         }
         self.assertEqual(selected, expected)
-        self.assertIn("content-1x", selected)
+        self.assertEqual(
+            [call.args[0].name for call in ensure.call_args_list].count("content"),
+            1,
+        )
         self.assertIn("playtester", selected)
         self.assertIn("tools", selected)
 
@@ -259,7 +262,7 @@ class CohortWorkspaceTests(unittest.TestCase):
                 "client": "classic-client",
                 "protocol": "classic-protocol",
                 "libatrinik": "classic-libatrinik",
-                "content": "content-1x",
+                "content": "content",
             },
         )
         self.assertEqual(
@@ -267,10 +270,10 @@ class CohortWorkspaceTests(unittest.TestCase):
         )
         self.assertEqual(default["components"]["content"]["branch"], "main")
         self.assertEqual(
-            classic["components"]["content-1x"]["repository"],
+            classic["components"]["content"]["repository"],
             "atrinik/content",
         )
-        self.assertEqual(classic["components"]["content-1x"]["branch"], "1.x")
+        self.assertEqual(classic["components"]["content"]["branch"], "main")
 
     def test_concurrent_first_initialization_claims_workspace_once(self) -> None:
         workspaces = [Workspace(self.wrapper) for _ in range(8)]
@@ -488,7 +491,7 @@ class CohortWorkspaceTests(unittest.TestCase):
         self.assertEqual(validate.call_count, 30)
         expected_checkouts = {
             "classic",
-            "content-1x",
+            "content",
             "sound",
             "resources",
             "metaserver-worker",
@@ -514,7 +517,10 @@ class CohortWorkspaceTests(unittest.TestCase):
             {
                 role
                 for role, component in stack.providers.items()
-                if component.build != "none"
+                if self.workspace.manifest.effective_build(
+                    stack.name, component
+                )
+                != "none"
             },
         )
         requested = self.workspace._dependency_roles(profile, {"client"})
@@ -661,8 +667,8 @@ class CohortWorkspaceTests(unittest.TestCase):
                 self.workspace.manifest.by_name["classic-server"], checkout
             )
 
-    def test_content_1x_clone_is_branch_qualified(self) -> None:
-        component = self.workspace.manifest.by_name["content-1x"]
+    def test_shared_content_clone_is_main_branch_qualified(self) -> None:
+        component = self.workspace.manifest.by_name["content"]
         with (
             mock.patch("atrinik_workspace.workspace.run") as run,
             mock.patch.object(
@@ -671,9 +677,9 @@ class CohortWorkspaceTests(unittest.TestCase):
         ):
             destination = self.workspace._ensure_repository(component)
 
-        self.assertEqual(destination, self.wrapper / "content-1x")
+        self.assertEqual(destination, self.wrapper / "content")
         clone = run.call_args.args[0]
-        self.assertEqual(clone[:5], ["git", "clone", "--branch", "1.x", "--single-branch"])
+        self.assertEqual(clone[:5], ["git", "clone", "--branch", "main", "--single-branch"])
 
     def test_default_sync_skips_uninitialized_components_without_cloning(self) -> None:
         with mock.patch.object(self.workspace, "_ensure_repository") as ensure:
@@ -698,15 +704,17 @@ class CohortWorkspaceTests(unittest.TestCase):
 
         self.assertEqual(git.call_count, 2)
 
-    def test_duplicate_repository_profile_paths_require_correct_primary(self) -> None:
+    def test_external_content_profile_requires_canonical_repository(self) -> None:
         selected = self.wrapper / "external-content-review"
         selected.mkdir()
-        content_1x = self.workspace.manifest.by_name["content-1x"]
-        primary = self.wrapper / "content-1x"
+        content_1x = self.workspace.manifest.by_name["content"]
+        primary = self.wrapper / "content"
         primary.mkdir()
         with (
             mock.patch.object(
-                self.workspace, "_validate_checkout", return_value="origin"
+                self.workspace,
+                "_validate_checkout",
+                side_effect=WorkspaceError("checkout cannot be proven"),
             ),
             mock.patch.object(
                 self.workspace, "_validate_primary_checkout", return_value="origin"
@@ -720,9 +728,7 @@ class CohortWorkspaceTests(unittest.TestCase):
                 side_effect=[self.wrapper / ".git-main", self.wrapper / ".git-1x"],
             ),
         ):
-            with self.assertRaisesRegex(
-                WorkspaceError, "cannot be proven to belong to content-1x@1.x"
-            ):
+            with self.assertRaisesRegex(WorkspaceError, "checkout cannot be proven"):
                 self.workspace._validate_selected_checkout(
                     content_1x, selected, "path"
                 )
@@ -750,10 +756,10 @@ class CohortWorkspaceTests(unittest.TestCase):
                 "origin",
             )
 
-    def test_migrated_content_worktree_requires_old_managed_lineage(self) -> None:
+    def test_retired_migrated_selector_is_rejected_by_current_profiles(self) -> None:
         selected = self.workspace.paths.worktrees / "content" / "maps-review"
         selected.mkdir(parents=True)
-        content_1x = self.workspace.manifest.by_name["content-1x"]
+        content_1x = self.workspace.manifest.by_name["content"]
         content = self.workspace.manifest.by_name["content"]
         primary = self.wrapper / "content"
         primary.mkdir()
@@ -769,15 +775,12 @@ class CohortWorkspaceTests(unittest.TestCase):
                 self.workspace, "_git_common_directory", return_value=common
             ),
         ):
-            self.assertEqual(
+            with self.assertRaisesRegex(
+                WorkspaceError, "valid only for content-1x"
+            ):
                 self.workspace._validate_selected_checkout(
                     content_1x, selected, "migrated-worktree"
-                ),
-                "origin",
-            )
-        validate_primary.assert_called_once_with(
-            self.workspace.manifest.by_checkout["content"], primary, trace=True
-        )
+                )
 
         outside = self.wrapper / "external-content-review"
         outside.mkdir()
@@ -785,13 +788,13 @@ class CohortWorkspaceTests(unittest.TestCase):
             self.workspace, "_validate_checkout", return_value="origin"
         ):
             with self.assertRaisesRegex(
-                WorkspaceError, "must remain directly below"
+                WorkspaceError, "valid only for content-1x"
             ):
                 self.workspace._validate_selected_checkout(
                     content_1x, outside, "migrated-worktree"
                 )
 
-    def test_migration_only_selector_is_restricted_when_loading_profiles(self) -> None:
+    def test_legacy_migration_selector_requires_dedicated_migration(self) -> None:
         self.workspace.paths.ensure()
         profile = self.workspace._load_profile("classic", require_file=False)
         profile["name"] = "migrated-content"
@@ -803,24 +806,7 @@ class CohortWorkspaceTests(unittest.TestCase):
         }
         path = self.workspace.paths.profiles / "migrated-content.json"
         atomic_json(path, profile)
-        loaded = self.workspace._load_profile(
-            "migrated-content", require_file=True
-        )
-        self.assertEqual(
-            loaded["components"]["content-1x"]["kind"],
-            "migrated-worktree",
-        )
-
-        loaded["components"]["classic-server"] = {
-            "kind": "migrated-worktree",
-            "value": str(
-                (self.workspace.paths.worktrees / "content" / "maps").resolve()
-            ),
-        }
-        atomic_json(path, loaded)
-        with self.assertRaisesRegex(
-            WorkspaceError, "invalid migrated content worktree selector"
-        ):
+        with self.assertRaisesRegex(WorkspaceError, "component set does not match"):
             self.workspace._load_profile("migrated-content", require_file=True)
 
     def test_content_sync_protects_profile_owned_migrated_worktree(self) -> None:
@@ -843,6 +829,9 @@ class CohortWorkspaceTests(unittest.TestCase):
                 self.workspace, "_validate_selected_checkout", return_value="origin"
             ),
             mock.patch.object(
+                self.workspace, "_validate_checkout", return_value="origin"
+            ),
+            mock.patch.object(
                 self.workspace, "_validate_primary_checkout", return_value="origin"
             ),
             mock.patch.object(
@@ -855,6 +844,11 @@ class CohortWorkspaceTests(unittest.TestCase):
                 return_value=([], [selected.resolve()]),
             ) as worktrees,
             mock.patch("atrinik_workspace.workspace.git"),
+            mock.patch.object(
+                self.workspace,
+                "_git_common_directory",
+                return_value=self.wrapper / ".git-content",
+            ),
         ):
             self.workspace.sync(["content"], "merge")
 
@@ -884,7 +878,7 @@ class CohortWorkspaceTests(unittest.TestCase):
                 "classic-editor",
             ],
         )
-        self.assertEqual(by_name["content-1x"]["default_branch"], "1.x")
+        self.assertEqual(by_name["content"]["default_branch"], "main")
 
     def test_builtin_profiles_retain_coherent_stack_identity(self) -> None:
         default = self.workspace._load_profile("default", require_file=False)
@@ -898,7 +892,7 @@ class CohortWorkspaceTests(unittest.TestCase):
         self.assertNotIn("server", classic["components"])
         self.assertEqual(
             self.workspace.manifest.provider("classic", "content").name,
-            "content-1x",
+            "content",
         )
 
     def test_profile_override_cannot_cross_stacks(self) -> None:

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -160,7 +160,7 @@ class CompletionTests(unittest.TestCase):
         self.assertEqual(values.count("classic"), 1)
         self.assertIn("classic-client", values)
         self.assertIn("content", values)
-        self.assertIn("content-1x", values)
+        self.assertNotIn("content-1x", values)
 
         mode, values = self.candidates("build", "--profile", "classic", "")
         self.assertEqual(mode, "candidates")
@@ -221,21 +221,21 @@ class CompletionTests(unittest.TestCase):
 
     def test_worktree_labels_are_filtered_by_selected_physical_checkout(self) -> None:
         (self.workspace / "worktrees" / "content" / "main-maps").mkdir(parents=True)
-        (self.workspace / "worktrees" / "content-1x" / "classic-maps").mkdir(
+        (self.workspace / "worktrees" / "content" / "classic-maps").mkdir(
             parents=True
         )
         (self.workspace / "worktrees" / "content" / "main-maps" / ".git").write_text(
             "gitdir: /tmp/main-maps\n", encoding="utf-8"
         )
         (
-            self.workspace / "worktrees" / "content-1x" / "classic-maps" / ".git"
+            self.workspace / "worktrees" / "content" / "classic-maps" / ".git"
         ).write_text("gitdir: /tmp/classic-maps\n", encoding="utf-8")
         _, main_values = self.candidates("worktree", "remove", "content", "")
         _, classic_values = self.candidates(
-            "worktree", "remove", "content-1x", ""
+            "worktree", "remove", "content", ""
         )
-        self.assertEqual(main_values, ["main-maps"])
-        self.assertEqual(classic_values, ["classic-maps"])
+        self.assertEqual(main_values, ["classic-maps", "main-maps"])
+        self.assertEqual(classic_values, ["classic-maps", "main-maps"])
 
     def test_profile_role_selects_owning_checkout_for_worktrees(self) -> None:
         stack = parser()  # Ensure a fresh parser does not retain process state.

--- a/tests/test_content_migration.py
+++ b/tests/test_content_migration.py
@@ -1,0 +1,395 @@
+from __future__ import annotations
+
+import json
+import os
+import fcntl
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+from atrinik_workspace import content_migration as migration_module
+from atrinik_workspace.content_migration import ContentMigration
+from atrinik_workspace.workspace import Workspace
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ContentMigrationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.wrapper = self.root / "wrapper"
+        self.wrapper.mkdir()
+        shutil.copy2(ROOT / "components.json", self.wrapper / "components.json")
+        self.environment = mock.patch.dict(
+            os.environ,
+            {"ATRINIK_WORKSPACE_DIR": str(self.root / "workspace")},
+        )
+        self.environment.start()
+        self.workspace = Workspace(self.wrapper)
+        self.workspace.paths.ensure()
+        self.main = self._repository(self.wrapper / "content", "main", "main\n")
+        self.one_x = self._repository(
+            self.wrapper / "content-1x", "1.x", "frozen\n"
+        )
+        self.main_anchor = self._git(self.main, "rev-parse", "HEAD")
+        self.one_x_anchor = self._git(self.one_x, "rev-parse", "HEAD")
+        self.anchors = mock.patch.multiple(
+            migration_module,
+            CERTIFIED_MAIN_COMMIT=self.main_anchor,
+            CERTIFIED_1X_COMMIT=self.one_x_anchor,
+        )
+        self.anchors.start()
+
+    def tearDown(self) -> None:
+        self.anchors.stop()
+        self.environment.stop()
+        self.temporary.cleanup()
+
+    @staticmethod
+    def _git(path: Path, *arguments: str) -> str:
+        return subprocess.run(
+            ["git", "-C", str(path), *arguments],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    def _repository(self, path: Path, branch: str, payload: str) -> Path:
+        path.mkdir()
+        subprocess.run(["git", "init", "-q", "-b", branch], cwd=path, check=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Migration Fixture"],
+            cwd=path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "fixture@example.invalid"],
+            cwd=path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/atrinik/content.git"],
+            cwd=path,
+            check=True,
+        )
+        (path / "payload.txt").write_text(payload, encoding="utf-8")
+        subprocess.run(["git", "add", "payload.txt"], cwd=path, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "fixture"], cwd=path, check=True)
+        return path
+
+    def _legacy_profile(
+        self, name: str = "classic-review", selector: dict[str, str] | None = None
+    ) -> tuple[Path, bytes]:
+        current = self.workspace._load_profile("classic", require_file=False)
+        components = dict(current["components"])
+        components["content-1x"] = selector or {"kind": "primary", "value": ""}
+        components.pop("content")
+        value = {**current, "name": name, "components": components}
+        path = self.workspace.paths.profiles / f"{name}.json"
+        original = json.dumps(value, indent=2, sort_keys=True).encode() + b"\n"
+        path.write_bytes(original)
+        return path, original
+
+    def migration(self) -> ContentMigration:
+        return ContentMigration(
+            self.workspace.paths.repository,
+            self.workspace.paths,
+            self.workspace.manifest,
+        )
+
+    def test_primary_profile_apply_audit_and_restore_preserve_legacy_checkout(self) -> None:
+        profile, original = self._legacy_profile()
+
+        planned = self.migration().execute("dry-run")
+        self.assertEqual(planned["status"], "ready")
+        self.assertEqual(planned["profiles"][0]["selector"], {"kind": "primary", "value": ""})
+        self.assertEqual(planned["parity_proof"]["main_commit"], self.main_anchor)
+        self.assertEqual(planned["parity_proof"]["final_1x_commit"], self.one_x_anchor)
+
+        applied = self.migration().execute("apply")
+        self.assertEqual(applied["status"], "complete")
+        current = json.loads(profile.read_text(encoding="utf-8"))
+        self.assertIn("content", current["components"])
+        self.assertNotIn("content-1x", current["components"])
+        self.assertTrue(self.one_x.is_dir())
+        self.assertEqual(self.migration().execute("audit")["status"], "complete")
+
+        restored = self.migration().execute("restore")
+        self.assertEqual(restored["status"], "restored")
+        self.assertEqual(profile.read_bytes(), original)
+        self.assertEqual(self.migration().execute("audit")["status"], "restored")
+
+    def test_dirty_legacy_primary_refuses_without_rewriting_profile(self) -> None:
+        profile, original = self._legacy_profile()
+        (self.one_x / "untracked.txt").write_text("keep\n", encoding="utf-8")
+
+        result = self.migration().execute("apply")
+
+        self.assertEqual(result["status"], "refused")
+        self.assertIn("profile_unproven", {row["code"] for row in result["refusals"]})
+        self.assertEqual(profile.read_bytes(), original)
+        self.assertTrue((self.one_x / "untracked.txt").is_file())
+
+    def test_proven_managed_main_worktree_moves_to_shared_namespace(self) -> None:
+        source = self.workspace.paths.worktrees / "content-1x" / "maps"
+        source.parent.mkdir(parents=True)
+        subprocess.run(
+            ["git", "worktree", "add", "-q", "-b", "review/maps", str(source)],
+            cwd=self.main,
+            check=True,
+        )
+        profile, _ = self._legacy_profile(
+            selector={"kind": "worktree", "value": "maps"}
+        )
+        destination = self.workspace.paths.worktrees / "content" / "maps"
+
+        result = self.migration().execute("apply")
+
+        self.assertEqual(result["status"], "complete")
+        self.assertFalse(source.exists())
+        self.assertTrue(destination.is_dir())
+        selector = json.loads(profile.read_text(encoding="utf-8"))["components"]["content"]
+        self.assertEqual(selector, {"kind": "worktree", "value": "maps"})
+        self.assertEqual(self.migration().execute("audit")["status"], "complete")
+
+    def test_detached_external_worktree_refuses_without_repointing(self) -> None:
+        selected = self.root / "detached-content"
+        subprocess.run(
+            ["git", "worktree", "add", "-q", "--detach", str(selected)],
+            cwd=self.main,
+            check=True,
+        )
+        profile, original = self._legacy_profile(
+            selector={"kind": "path", "value": str(selected)}
+        )
+
+        result = self.migration().execute("apply")
+
+        self.assertEqual(result["status"], "refused")
+        self.assertEqual(profile.read_bytes(), original)
+        self.assertTrue(selected.is_dir())
+
+    def test_proven_external_and_migration_only_main_worktrees_are_preserved(self) -> None:
+        for kind in ("path", "migrated-worktree"):
+            with self.subTest(kind=kind):
+                selected = self.root / f"external-{kind}"
+                subprocess.run(
+                    ["git", "worktree", "add", "-q", "-b", f"review/{kind}", str(selected)],
+                    cwd=self.main,
+                    check=True,
+                )
+                profile, _ = self._legacy_profile(
+                    name=f"classic-{kind}",
+                    selector={"kind": kind, "value": str(selected)},
+                )
+
+                result = self.migration().execute("apply")
+
+                self.assertEqual(result["status"], "complete")
+                selector = json.loads(profile.read_text(encoding="utf-8"))["components"]["content"]
+                self.assertEqual(selector, {"kind": "path", "value": str(selected.resolve())})
+                self.assertTrue(selected.is_dir())
+                self.assertEqual(self.migration().execute("audit")["status"], "complete")
+                self.assertEqual(self.migration().execute("restore")["status"], "restored")
+                self.migration().record_path.unlink()
+
+    def test_locked_in_progress_and_colliding_managed_worktrees_refuse(self) -> None:
+        for condition in ("locked", "in-progress", "collision"):
+            with self.subTest(condition=condition):
+                source = self.workspace.paths.worktrees / "content-1x" / condition
+                source.parent.mkdir(parents=True, exist_ok=True)
+                subprocess.run(
+                    ["git", "worktree", "add", "-q", "-b", f"review/{condition}", str(source)],
+                    cwd=self.main,
+                    check=True,
+                )
+                if condition == "locked":
+                    subprocess.run(
+                        ["git", "worktree", "lock", str(source)],
+                        cwd=self.main,
+                        check=True,
+                    )
+                elif condition == "in-progress":
+                    operation = Path(self._git(source, "rev-parse", "--git-path", "MERGE_HEAD"))
+                    operation.write_text(self.main_anchor + "\n", encoding="utf-8")
+                else:
+                    destination = self.workspace.paths.worktrees / "content" / condition
+                    destination.mkdir(parents=True)
+                profile, original = self._legacy_profile(
+                    name=f"classic-{condition}",
+                    selector={"kind": "worktree", "value": condition},
+                )
+
+                result = self.migration().execute("apply")
+
+                self.assertEqual(result["status"], "refused")
+                self.assertEqual(profile.read_bytes(), original)
+                self.assertTrue(source.is_dir())
+                if condition == "locked":
+                    subprocess.run(
+                        ["git", "worktree", "unlock", str(source)],
+                        cwd=self.main,
+                        check=True,
+                    )
+
+    def test_historical_build_scenario_and_stopped_topology_are_inventoried(self) -> None:
+        self._legacy_profile()
+        build = self.workspace.paths.builds / "profiles" / "legacy"
+        build.mkdir(parents=True)
+        (build / ".atrinik-build.json").write_text(
+            '{"coordinate":{"checkout":"content-1x","branch":"1.x"}}\n',
+            encoding="utf-8",
+        )
+        scenario = self.workspace.paths.scenarios / "legacy"
+        scenario.mkdir(parents=True)
+        (scenario / "scenario.json").write_text(
+            '{"providers":{"content":"content-1x"}}\n', encoding="utf-8"
+        )
+        topology = self.workspace.paths.topologies / "stopped"
+        topology.mkdir(parents=True)
+        (topology / "status.json").write_text(
+            json.dumps(
+                {
+                    "stack": "classic",
+                    "profile": "classic-review",
+                    "supervisor": {"pid": 100, "start_time": "1"},
+                    "services": {"server": {"pid": 101, "start_time": "2"}},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with mock.patch.object(migration_module, "process_matches", return_value=False):
+            result = self.migration().execute("dry-run")
+
+        self.assertEqual(result["status"], "ready")
+        self.assertEqual(len(result["resources"]["builds"]), 1)
+        self.assertEqual(len(result["resources"]["scenarios"]), 1)
+        self.assertEqual(result["resources"]["topologies"][0]["status"], "historical-inert")
+
+    def test_restore_refuses_while_repository_layout_lock_is_held(self) -> None:
+        self._legacy_profile()
+        self.assertEqual(self.migration().execute("apply")["status"], "complete")
+        lock_path = self.workspace.paths.workspace / "repository-layout.lock"
+        descriptor = os.open(lock_path, os.O_RDWR)
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            result = self.migration().execute("restore")
+        finally:
+            os.close(descriptor)
+
+        self.assertEqual(result["status"], "refused")
+        self.assertEqual(result["refusals"][0]["code"], "repository_layout_busy")
+
+    def test_tampered_journal_cannot_redirect_profile_restore(self) -> None:
+        self._legacy_profile()
+        self.assertEqual(self.migration().execute("apply")["status"], "complete")
+        external = self.root / "external.json"
+        external.write_text("preserve\n", encoding="utf-8")
+        record = json.loads(self.migration().record_path.read_text(encoding="utf-8"))
+        rewrite = next(row for row in record["profiles"] if row["status"] == "rewrite")
+        rewrite["path"] = str(external)
+        self.migration().record_path.write_text(
+            json.dumps(record), encoding="utf-8"
+        )
+
+        audit = self.migration().execute("audit")
+        restore = self.migration().execute("restore")
+
+        self.assertEqual(audit["status"], "incomplete")
+        self.assertEqual(restore["status"], "incomplete")
+        self.assertEqual(external.read_text(encoding="utf-8"), "preserve\n")
+
+    def test_failed_restore_rolls_profiles_forward_to_complete_state(self) -> None:
+        source = self.workspace.paths.worktrees / "content-1x" / "rollback"
+        source.parent.mkdir(parents=True)
+        subprocess.run(
+            ["git", "worktree", "add", "-q", "-b", "review/rollback", str(source)],
+            cwd=self.main,
+            check=True,
+        )
+        profile, _ = self._legacy_profile(
+            selector={"kind": "worktree", "value": "rollback"}
+        )
+        self.assertEqual(self.migration().execute("apply")["status"], "complete")
+        replacement = profile.read_bytes()
+        real_git = migration_module._git
+        failed = False
+
+        def fail_restore_move(path: Path, *arguments: str, check: bool = True) -> str:
+            nonlocal failed
+            if arguments[:2] == ("worktree", "move") and not failed:
+                failed = True
+                raise migration_module.WorkspaceError("simulated move failure")
+            return real_git(path, *arguments, check=check)
+
+        with mock.patch.object(migration_module, "_git", side_effect=fail_restore_move):
+            with self.assertRaisesRegex(
+                migration_module.WorkspaceError, "restore stopped"
+            ):
+                self.migration().execute("restore")
+
+        self.assertEqual(profile.read_bytes(), replacement)
+        self.assertEqual(self.migration().execute("audit")["status"], "complete")
+
+    def test_affected_live_topology_blocks_apply(self) -> None:
+        self._legacy_profile()
+        topology = self.workspace.paths.topologies / "live-classic"
+        topology.mkdir()
+        (topology / "status.json").write_text(
+            json.dumps(
+                {
+                    "stack": "classic",
+                    "profile": "classic-review",
+                    "supervisor": {"pid": 100, "start_time": "1"},
+                    "services": {
+                        "server": {"pid": 101, "start_time": "2"}
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with mock.patch.object(migration_module, "process_matches", return_value=True):
+            result = self.migration().execute("apply")
+
+        self.assertEqual(result["status"], "refused")
+        self.assertIn("live_topology", {row["code"] for row in result["refusals"]})
+
+    def test_current_live_classic_topology_is_not_mislabeled_as_affected(self) -> None:
+        topology = self.workspace.paths.topologies / "current-classic"
+        topology.mkdir(parents=True)
+        (topology / "status.json").write_text(
+            json.dumps(
+                {
+                    "stack": "classic",
+                    "profile": "classic",
+                    "supervisor": {"pid": 100, "start_time": "1"},
+                    "services": {"server": {"pid": 101, "start_time": "2"}},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with mock.patch.object(migration_module, "process_matches", return_value=True):
+            result = self.migration().execute("dry-run")
+
+        self.assertEqual(result["status"], "not-needed")
+        self.assertFalse(result["resources"]["topologies"][0]["affected"])
+
+    def test_missing_canonical_checkout_fails_closed(self) -> None:
+        shutil.rmtree(self.main)
+        result = self.migration().execute("dry-run")
+        self.assertEqual(result["status"], "refused")
+        self.assertIn(
+            "canonical_content_missing", {row["code"] for row in result["refusals"]}
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_content_migration.py
+++ b/tests/test_content_migration.py
@@ -216,6 +216,13 @@ class ContentMigrationTests(unittest.TestCase):
         self.assertEqual(selector, {"kind": "worktree", "value": "maps"})
         self.assertEqual(self.migration().execute("audit")["status"], "complete")
 
+        restored = self.migration().execute("restore")
+
+        self.assertEqual(restored["status"], "restored")
+        self.assertTrue(source.is_dir())
+        self.assertFalse(destination.exists())
+        self.assertEqual(self.migration().execute("audit")["status"], "restored")
+
     def test_detached_external_worktree_refuses_without_repointing(self) -> None:
         selected = self.root / "detached-content"
         subprocess.run(
@@ -689,6 +696,38 @@ class ContentMigrationTests(unittest.TestCase):
             if item["name"] == "replacement"
         )
         self.assertEqual(row["status"], "inert")
+
+    def test_profile_inventory_fails_closed_on_unsafe_storage_shapes(self) -> None:
+        profiles = self.workspace.paths.profiles
+        shutil.rmtree(profiles)
+        self.assertEqual(self.migration().execute("dry-run")["profiles"], [])
+
+        actual = self.root / "external-profiles"
+        actual.mkdir()
+        profiles.symlink_to(actual, target_is_directory=True)
+        result = self.migration().execute("dry-run")
+        self.assertIn(
+            "invalid_profiles_directory",
+            {row["code"] for row in result["refusals"]},
+        )
+        profiles.unlink()
+        profiles.mkdir()
+
+        linked_profile = profiles / "linked.json"
+        linked_profile.symlink_to(self.root / "missing-profile.json")
+        result = self.migration().execute("dry-run")
+        linked = next(row for row in result["profiles"] if row["name"] == "linked")
+        self.assertEqual(linked["status"], "blocked")
+        linked_profile.unlink()
+
+        profile, original = self._legacy_profile(name="oversized")
+        with mock.patch.object(migration_module, "PROFILE_MAX_BYTES", 1):
+            result = self.migration().execute("dry-run")
+        oversized = next(
+            row for row in result["profiles"] if row["name"] == "oversized"
+        )
+        self.assertEqual(oversized["status"], "blocked")
+        self.assertEqual(profile.read_bytes(), original)
 
     def test_current_profile_selector_validation_rejects_each_unsafe_kind(self) -> None:
         components = self.workspace._load_profile("classic", require_file=False)[

--- a/tests/test_content_migration.py
+++ b/tests/test_content_migration.py
@@ -156,6 +156,44 @@ class ContentMigrationTests(unittest.TestCase):
         self.assertEqual(profile.read_bytes(), original)
         self.assertTrue((self.one_x / "local-commit.txt").is_file())
 
+    def test_duplicate_legacy_profile_keys_refuse_without_normalization(self) -> None:
+        profile, original = self._legacy_profile()
+        duplicated = b'{"name":"ambiguous",' + original[1:]
+        profile.write_bytes(duplicated)
+
+        result = self.migration().execute("apply")
+
+        self.assertEqual(result["status"], "refused")
+        self.assertIn("profile_unproven", {row["code"] for row in result["refusals"]})
+        self.assertEqual(profile.read_bytes(), duplicated)
+
+    def test_incoherent_legacy_checkout_selectors_refuse_without_rewrite(self) -> None:
+        profile, _ = self._legacy_profile()
+        value = json.loads(profile.read_text(encoding="utf-8"))
+        value["components"]["classic-client"] = {
+            "kind": "worktree",
+            "value": "client-only",
+        }
+        original = json.dumps(value, indent=2, sort_keys=True).encode() + b"\n"
+        profile.write_bytes(original)
+
+        result = self.migration().execute("apply")
+
+        self.assertEqual(result["status"], "refused")
+        self.assertEqual(profile.read_bytes(), original)
+
+    def test_malformed_current_profile_prevents_not_needed_audit(self) -> None:
+        current = self.workspace._load_profile("classic", require_file=False)
+        current["name"] = "current-invalid"
+        current["components"]["content"] = {"kind": "primary", "value": "bad"}
+        path = self.workspace.paths.profiles / "current-invalid.json"
+        path.write_text(json.dumps(current), encoding="utf-8")
+
+        result = self.migration().execute("audit")
+
+        self.assertEqual(result["status"], "incomplete")
+        self.assertIn("profile_unproven", {row["code"] for row in result["refusals"]})
+
     def test_proven_managed_main_worktree_moves_to_shared_namespace(self) -> None:
         source = self.workspace.paths.worktrees / "content-1x" / "maps"
         source.parent.mkdir(parents=True)
@@ -349,6 +387,20 @@ class ContentMigrationTests(unittest.TestCase):
         self.assertEqual(audit["status"], "incomplete")
         self.assertEqual(restore["status"], "incomplete")
         self.assertEqual(external.read_text(encoding="utf-8"), "preserve\n")
+
+    def test_duplicate_migration_record_keys_refuse_audit(self) -> None:
+        self._legacy_profile()
+        self.assertEqual(self.migration().execute("apply")["status"], "complete")
+        record = self.migration().record_path
+        original = record.read_bytes()
+        record.write_bytes(b'{"migration":"ambiguous",' + original[1:])
+
+        result = self.migration().execute("audit")
+
+        self.assertEqual(result["status"], "incomplete")
+        self.assertIn(
+            "invalid_migration_record", {row["code"] for row in result["refusals"]}
+        )
 
     def test_pending_and_unsafe_record_paths_fail_closed(self) -> None:
         profile, original = self._legacy_profile()

--- a/tests/test_content_migration.py
+++ b/tests/test_content_migration.py
@@ -514,6 +514,426 @@ class ContentMigrationTests(unittest.TestCase):
         self.assertEqual(result["status"], "not-needed")
         self.assertEqual(result["refusals"], [])
 
+    def test_helper_failures_are_bounded_and_actionable(self) -> None:
+        with self.assertRaisesRegex(
+            migration_module.WorkspaceError, "unsupported content migration mode"
+        ):
+            self.migration().execute("erase")
+        for url in (
+            "git@github.com:atrinik/content.git",
+            "ssh://git@github.com/atrinik/content.git",
+            "https://github.com/atrinik/content.git",
+        ):
+            with self.subTest(url=url):
+                self.assertTrue(migration_module._remote_matches(url))
+        self.assertFalse(migration_module._remote_matches("file:///tmp/content"))
+
+        missing = mock.Mock(side_effect=FileNotFoundError())
+        with mock.patch.object(migration_module.subprocess, "run", missing):
+            with self.assertRaisesRegex(
+                migration_module.WorkspaceError, "required command not found"
+            ):
+                migration_module._git(self.main, "status")
+            with self.assertRaisesRegex(
+                migration_module.WorkspaceError, "required command not found"
+            ):
+                migration_module._git_succeeds(self.main, "status")
+
+        failed = subprocess.CalledProcessError(
+            1, ["git"], output="", stderr="fixture failure"
+        )
+        with mock.patch.object(migration_module.subprocess, "run", side_effect=failed):
+            with self.assertRaisesRegex(
+                migration_module.WorkspaceError, "fixture failure"
+            ):
+                migration_module._git(self.main, "status")
+
+        target = self.root / "atomic" / "profile.json"
+        with mock.patch.object(migration_module.os, "replace", side_effect=OSError("race")):
+            with self.assertRaisesRegex(OSError, "race"):
+                migration_module._atomic_bytes(target, b"preserve\n")
+        self.assertFalse(target.exists())
+        self.assertEqual(list(target.parent.iterdir()), [])
+
+    def test_layout_lock_rejects_unsafe_path_and_apply_contention(self) -> None:
+        unsafe = self.root / "unsafe-lock"
+        unsafe.mkdir()
+        with self.assertRaisesRegex(
+            migration_module.WorkspaceError, "cannot open repository layout lock"
+        ):
+            migration_module._open_layout_lock(unsafe)
+
+        self._legacy_profile()
+        lock_path = self.workspace.paths.workspace / "repository-layout.lock"
+        descriptor = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            result = self.migration().execute("apply")
+        finally:
+            os.close(descriptor)
+        self.assertEqual(result["status"], "refused")
+        self.assertEqual(result["refusals"][-1]["code"], "repository_layout_busy")
+
+    def test_apply_is_idempotent_only_before_explicit_restore(self) -> None:
+        self._legacy_profile()
+        self.assertEqual(self.migration().execute("apply")["status"], "complete")
+        self.assertEqual(self.migration().execute("apply")["status"], "already-applied")
+
+    def test_apply_reports_not_needed_without_legacy_profiles(self) -> None:
+        result = self.migration().execute("apply")
+
+        self.assertEqual(result["status"], "not-needed")
+        self.assertFalse(self.migration().record_path.exists())
+
+    def test_canonical_checkout_identity_failures_refuse_migration(self) -> None:
+        cases = ("symlink", "remote", "branch", "ancestry", "dirty")
+        for condition in cases:
+            with self.subTest(condition=condition):
+                with tempfile.TemporaryDirectory() as temporary:
+                    root = Path(temporary)
+                    wrapper = root / "wrapper"
+                    wrapper.mkdir()
+                    shutil.copy2(ROOT / "components.json", wrapper / "components.json")
+                    with mock.patch.dict(
+                        os.environ, {"ATRINIK_WORKSPACE_DIR": str(root / "workspace")}
+                    ):
+                        workspace = Workspace(wrapper)
+                        workspace.paths.ensure()
+                        main = self._repository(wrapper / "content", "main", "main\n")
+                        one_x = self._repository(
+                            wrapper / "content-1x", "1.x", "frozen\n"
+                        )
+                        main_anchor = self._git(main, "rev-parse", "HEAD")
+                        one_x_anchor = self._git(one_x, "rev-parse", "HEAD")
+                        current = workspace._load_profile("classic", require_file=False)
+                        components = dict(current["components"])
+                        components["content-1x"] = {"kind": "primary", "value": ""}
+                        components.pop("content")
+                        current.update(name="legacy", components=components)
+                        (workspace.paths.profiles / "legacy.json").write_text(
+                            json.dumps(current), encoding="utf-8"
+                        )
+                        if condition == "symlink":
+                            actual = wrapper / "actual-content"
+                            main.rename(actual)
+                            main.symlink_to(actual, target_is_directory=True)
+                        elif condition == "remote":
+                            subprocess.run(
+                                [
+                                    "git",
+                                    "remote",
+                                    "set-url",
+                                    "origin",
+                                    "https://example.invalid/content.git",
+                                ],
+                                cwd=main,
+                                check=True,
+                            )
+                        elif condition == "branch":
+                            subprocess.run(
+                                ["git", "branch", "-m", "other"],
+                                cwd=main,
+                                check=True,
+                            )
+                        elif condition == "dirty":
+                            (main / "dirty.txt").write_text(
+                                "preserve\n", encoding="utf-8"
+                            )
+                        anchor = "0" * 40 if condition == "ancestry" else main_anchor
+                        with mock.patch.multiple(
+                            migration_module,
+                            CERTIFIED_MAIN_COMMIT=anchor,
+                            CERTIFIED_1X_COMMIT=one_x_anchor,
+                        ):
+                            result = ContentMigration(
+                                workspace.paths.repository,
+                                workspace.paths,
+                                workspace.manifest,
+                            ).execute("dry-run")
+                        self.assertEqual(result["status"], "refused")
+                        self.assertIn(
+                            "canonical_content_unproven",
+                            {row["code"] for row in result["refusals"]},
+                        )
+
+    def test_profile_schema_and_selector_failures_preserve_exact_bytes(self) -> None:
+        current = self.workspace._load_profile("classic", require_file=False)
+        cases: dict[str, object] = {
+            "not-object": [],
+            "wrong-name": {**current, "name": "elsewhere"},
+            "schema": {**current, "schema_version": 99},
+            "sound": {**current, "sound_mode": "surround"},
+            "components": {**current, "components": []},
+            "component-set": {
+                **current,
+                "components": {"content": {"kind": "primary", "value": ""}},
+            },
+        }
+        for name, value in cases.items():
+            with self.subTest(name=name):
+                path = self.workspace.paths.profiles / f"{name}.json"
+                raw = json.dumps(value).encode()
+                path.write_bytes(raw)
+                result = self.migration().execute("dry-run")
+                row = next(item for item in result["profiles"] if item["name"] == name)
+                self.assertEqual(row["status"], "blocked")
+                self.assertEqual(path.read_bytes(), raw)
+                path.unlink()
+
+        inert = {**current, "name": "replacement", "stack": "default"}
+        path = self.workspace.paths.profiles / "replacement.json"
+        path.write_text(json.dumps(inert), encoding="utf-8")
+        row = next(
+            item
+            for item in self.migration().execute("dry-run")["profiles"]
+            if item["name"] == "replacement"
+        )
+        self.assertEqual(row["status"], "inert")
+
+    def test_current_profile_selector_validation_rejects_each_unsafe_kind(self) -> None:
+        components = self.workspace._load_profile("classic", require_file=False)[
+            "components"
+        ]
+        cases = (
+            ("unknown", {**components, "unknown": {"kind": "primary", "value": ""}}),
+            ("shape", {**components, "content": []}),
+            ("primary", {**components, "content": {"kind": "primary", "value": "bad"}}),
+            ("worktree", {**components, "content": {"kind": "worktree", "value": "../bad"}}),
+            ("path", {**components, "content": {"kind": "path", "value": "relative"}}),
+            ("kind", {**components, "content": {"kind": "migrated-worktree", "value": "/tmp/x"}}),
+        )
+        migration = self.migration()
+        for name, value in cases:
+            with self.subTest(name=name):
+                with self.assertRaises(migration_module.WorkspaceError):
+                    migration._validate_current_profile_components(value)
+
+    def test_legacy_selector_validation_covers_supported_boundaries(self) -> None:
+        migration = self.migration()
+        inspection = migration._inspect()
+        canonical = inspection["canonical"]
+        legacy = inspection["legacy"]
+        cases: tuple[object, ...] = (
+            [],
+            {"kind": 1, "value": ""},
+            {"kind": "primary", "value": "unexpected"},
+            {"kind": "worktree", "value": "../bad"},
+            {"kind": "path", "value": "relative"},
+            {"kind": "migrated-worktree", "value": "relative"},
+            {"kind": "unknown", "value": "value"},
+        )
+        for selector in cases:
+            with self.subTest(selector=selector):
+                with self.assertRaises(migration_module.WorkspaceError):
+                    migration._migrate_selector("profile", selector, canonical, legacy)
+        replacement, move = migration._migrate_selector(
+            "profile",
+            {"kind": "path", "value": str(self.main)},
+            canonical,
+            legacy,
+        )
+        self.assertEqual(replacement, {"kind": "primary", "value": ""})
+        self.assertIsNone(move)
+
+    def test_resource_inventory_rejects_unsafe_and_malformed_records(self) -> None:
+        builds = self.workspace.paths.builds
+        shutil.rmtree(builds)
+        external = self.root / "external-builds"
+        external.mkdir()
+        builds.symlink_to(external, target_is_directory=True)
+        topologies = self.workspace.paths.topologies
+        shutil.rmtree(topologies)
+        topologies.write_text("unsafe\n", encoding="utf-8")
+        locks = self.workspace.paths.workspace / "repository-layout.lock"
+        locks.symlink_to(self.root / "missing-lock")
+
+        resources, refusals = self.migration()._resource_inventory(set())
+
+        codes = {row["code"] for row in refusals}
+        self.assertIn("invalid_builds_directory", codes)
+        self.assertIn("invalid_topologies_directory", codes)
+        self.assertIn("invalid_lock_path", codes)
+        self.assertEqual(resources["locks"][0]["status"], "unsafe")
+
+    def test_resource_inventory_rejects_bad_entries_and_process_records(self) -> None:
+        build = self.workspace.paths.builds / "bad"
+        build.mkdir(parents=True)
+        (build / ".atrinik-build.json").symlink_to(self.root / "missing-build")
+        lock_directory = self.workspace.paths.builds / "locks"
+        lock_directory.mkdir()
+        (lock_directory / "bad").mkdir()
+        topology_link = self.workspace.paths.topologies / "linked"
+        topology_link.symlink_to(self.root, target_is_directory=True)
+        topology = self.workspace.paths.topologies / "malformed"
+        topology.mkdir()
+        (topology / "status.json").write_text(
+            json.dumps({"supervisor": None, "services": {"server": None}}),
+            encoding="utf-8",
+        )
+
+        resources, refusals = self.migration()._resource_inventory(set())
+
+        codes = [row["code"] for row in refusals]
+        self.assertIn("unobservable_builds_record", codes)
+        self.assertIn("unobservable_topology", codes)
+        self.assertIn("invalid_lock_path", codes)
+        self.assertTrue(any(row["status"] == "unsafe" for row in resources["locks"]))
+
+    def test_resource_inventory_bounds_records_and_observes_lock_failures(self) -> None:
+        build = self.workspace.paths.builds / "large"
+        build.mkdir(parents=True)
+        record = build / ".atrinik-build.json"
+        record.write_bytes(b"1234")
+        lock_directory = self.workspace.paths.builds / "locks"
+        lock_directory.mkdir()
+        lock = lock_directory / "busy.lock"
+        lock.write_text("lock\n", encoding="utf-8")
+        with (
+            mock.patch.object(migration_module, "RESOURCE_RECORD_MAX_BYTES", 1),
+            mock.patch.object(
+                migration_module,
+                "holders_exist",
+                side_effect=migration_module.WorkspaceError("unobservable"),
+            ),
+        ):
+            resources, refusals = self.migration()._resource_inventory(set())
+        self.assertIn(
+            "unobservable_builds_record", {row["code"] for row in refusals}
+        )
+        observed = next(row for row in resources["locks"] if row["path"] == str(lock))
+        self.assertTrue(observed["active"])
+
+    def test_apply_rolls_back_when_profile_changes_after_preflight(self) -> None:
+        profile, original = self._legacy_profile()
+        migration = self.migration()
+        plan = migration.execute("dry-run")
+        profile.write_bytes(original + b" ")
+
+        with self.assertRaisesRegex(
+            migration_module.WorkspaceError, "profile changed during migration"
+        ):
+            migration._apply(plan)
+
+        self.assertFalse(migration.pending_path.exists())
+        self.assertFalse(migration.record_path.exists())
+        self.assertEqual(profile.read_bytes(), original + b" ")
+
+    def test_apply_rolls_back_profiles_when_record_publication_fails(self) -> None:
+        profile, original = self._legacy_profile()
+        migration = self.migration()
+        plan = migration.execute("dry-run")
+        real_atomic_json = migration_module.atomic_json
+        calls = 0
+
+        def fail_record(path: Path, value: object) -> None:
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise OSError("record publication failed")
+            real_atomic_json(path, value)
+
+        with mock.patch.object(migration_module, "atomic_json", side_effect=fail_record):
+            with self.assertRaisesRegex(
+                migration_module.WorkspaceError, "record publication failed"
+            ):
+                migration._apply(plan)
+
+        self.assertEqual(profile.read_bytes(), original)
+        self.assertFalse(migration.pending_path.exists())
+        self.assertFalse(migration.record_path.exists())
+
+    def test_apply_reports_retained_pending_journal_after_commit(self) -> None:
+        self._legacy_profile()
+        migration = self.migration()
+        plan = migration.execute("dry-run")
+        real_unlink = Path.unlink
+
+        def fail_pending(path: Path, *args: object, **kwargs: object) -> None:
+            if path == migration.pending_path:
+                raise OSError("retain journal")
+            real_unlink(path, *args, **kwargs)
+
+        with mock.patch.object(Path, "unlink", fail_pending):
+            result = migration._apply(plan)
+
+        self.assertEqual(result["status"], "complete")
+        self.assertEqual(result["pending_journal_retained"], str(migration.pending_path))
+        self.assertTrue(migration.record_path.is_file())
+        self.assertTrue(migration.pending_path.is_file())
+
+    def test_journal_shape_and_digest_tampering_fail_closed(self) -> None:
+        self._legacy_profile()
+        migration = self.migration()
+        self.assertEqual(migration.execute("apply")["status"], "complete")
+        original = json.loads(migration.record_path.read_text(encoding="utf-8"))
+        rewrite_index = next(
+            index
+            for index, row in enumerate(original["profiles"])
+            if row["status"] == "rewrite"
+        )
+        cases = {
+            "shape": lambda value: value.update(migration="other"),
+            "profile-row": lambda value: value["profiles"].append([]),
+            "profile-name": lambda value: value["profiles"][rewrite_index].update(
+                name="../bad"
+            ),
+            "profile-path": lambda value: value["profiles"][rewrite_index].update(
+                path="/tmp/redirect"
+            ),
+            "profile-bytes": lambda value: value["profiles"][rewrite_index].update(
+                original_base64="!"
+            ),
+            "profile-digest": lambda value: value["profiles"][rewrite_index].update(
+                original_sha256="0" * 64
+            ),
+            "move-row": lambda value: value["worktree_moves"].append([]),
+        }
+        for name, mutate in cases.items():
+            with self.subTest(name=name):
+                value = json.loads(json.dumps(original))
+                mutate(value)
+                migration.record_path.write_text(json.dumps(value), encoding="utf-8")
+                result = migration.execute("audit")
+                self.assertEqual(result["status"], "incomplete")
+                self.assertEqual(
+                    result["refusals"][0]["code"], "invalid_migration_record"
+                )
+
+    def test_audit_detects_profile_and_worktree_drift(self) -> None:
+        source = self.workspace.paths.worktrees / "content-1x" / "audit-drift"
+        source.parent.mkdir(parents=True)
+        subprocess.run(
+            ["git", "worktree", "add", "-q", "-b", "review/audit-drift", str(source)],
+            cwd=self.main,
+            check=True,
+        )
+        profile, _ = self._legacy_profile(
+            selector={"kind": "worktree", "value": "audit-drift"}
+        )
+        migration = self.migration()
+        self.assertEqual(migration.execute("apply")["status"], "complete")
+        profile.write_text("changed\n", encoding="utf-8")
+        source.mkdir(parents=True)
+
+        audit = migration.execute("audit")
+
+        codes = {row["code"] for row in audit["refusals"]}
+        self.assertIn("profile_audit_failed", codes)
+        self.assertIn("worktree_audit_failed", codes)
+
+    def test_restore_refuses_new_unsafe_resources_after_a_clean_audit(self) -> None:
+        self._legacy_profile()
+        migration = self.migration()
+        self.assertEqual(migration.execute("apply")["status"], "complete")
+        lock_directory = self.workspace.paths.builds / "locks"
+        lock_directory.mkdir(parents=True)
+        (lock_directory / "unsafe").mkdir()
+
+        restored = migration.execute("restore")
+
+        self.assertEqual(restored["status"], "refused")
+        self.assertIn("invalid_lock_path", {row["code"] for row in restored["refusals"]})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_content_migration.py
+++ b/tests/test_content_migration.py
@@ -325,6 +325,66 @@ class ContentMigrationTests(unittest.TestCase):
         self.assertEqual(result["status"], "refused")
         self.assertEqual(profile.read_bytes(), original)
         self.assertTrue(source.is_dir())
+
+    def test_managed_worktree_paths_reject_every_unsafe_namespace_shape(self) -> None:
+        migration = self.migration()
+        canonical = migration._inspect()["canonical"]
+        root = self.workspace.paths.worktrees
+        with self.assertRaisesRegex(
+            migration_module.WorkspaceError, "worktree label is invalid"
+        ):
+            migration._managed_worktree_paths("../escape")
+
+        shutil.rmtree(root)
+        external = self.root / "external-worktrees"
+        external.mkdir()
+        root.symlink_to(external, target_is_directory=True)
+        with self.assertRaisesRegex(
+            migration_module.WorkspaceError, "root is not a normal directory"
+        ):
+            migration._managed_worktree_paths("maps")
+        root.unlink()
+        root.write_text("unsafe\n", encoding="utf-8")
+        with self.assertRaisesRegex(
+            migration_module.WorkspaceError, "root is not a normal directory"
+        ):
+            migration._managed_worktree_paths("maps")
+        root.unlink()
+        root.mkdir()
+
+        source_parent = root / "content-1x"
+        source_parent.write_text("unsafe\n", encoding="utf-8")
+        with self.assertRaisesRegex(
+            migration_module.WorkspaceError, "worktree namespace is unsafe"
+        ):
+            migration._managed_worktree_paths("maps")
+
+        selected_file = self.root / "selected-file"
+        selected_file.write_text("unsafe\n", encoding="utf-8")
+        with self.assertRaisesRegex(
+            migration_module.WorkspaceError, "not a normal directory"
+        ):
+            migration._prove_main_worktree(selected_file, canonical)
+        selected_link = self.root / "selected-link"
+        selected_link.symlink_to(self.main, target_is_directory=True)
+        with self.assertRaisesRegex(
+            migration_module.WorkspaceError, "not a normal directory"
+        ):
+            migration._prove_main_worktree(selected_link, canonical)
+
+        nested = self.main / "nested"
+        nested.mkdir()
+        with self.assertRaisesRegex(
+            migration_module.WorkspaceError, "not a Git worktree root"
+        ):
+            migration._prove_main_worktree(nested, canonical)
+        source_parent.unlink()
+        destination_parent = root / "content"
+        destination_parent.symlink_to(external, target_is_directory=True)
+        with self.assertRaisesRegex(
+            migration_module.WorkspaceError, "worktree namespace is unsafe"
+        ):
+            migration._managed_worktree_paths("maps")
         self.assertEqual(list(external.iterdir()), [])
 
     def test_historical_build_scenario_and_stopped_topology_are_inventoried(self) -> None:

--- a/tests/test_content_migration.py
+++ b/tests/test_content_migration.py
@@ -123,6 +123,11 @@ class ContentMigrationTests(unittest.TestCase):
         self.assertEqual(restored["status"], "restored")
         self.assertEqual(profile.read_bytes(), original)
         self.assertEqual(self.migration().execute("audit")["status"], "restored")
+        reapplied = self.migration().execute("apply")
+        self.assertEqual(reapplied["status"], "refused")
+        self.assertEqual(
+            reapplied["refusals"][0]["code"], "migration_already_restored"
+        )
 
     def test_dirty_legacy_primary_refuses_without_rewriting_profile(self) -> None:
         profile, original = self._legacy_profile()
@@ -134,6 +139,22 @@ class ContentMigrationTests(unittest.TestCase):
         self.assertIn("profile_unproven", {row["code"] for row in result["refusals"]})
         self.assertEqual(profile.read_bytes(), original)
         self.assertTrue((self.one_x / "untracked.txt").is_file())
+
+    def test_clean_legacy_primary_ahead_of_frozen_commit_refuses(self) -> None:
+        profile, original = self._legacy_profile()
+        (self.one_x / "local-commit.txt").write_text("preserve\n", encoding="utf-8")
+        subprocess.run(["git", "add", "local-commit.txt"], cwd=self.one_x, check=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "local preserved change"],
+            cwd=self.one_x,
+            check=True,
+        )
+
+        result = self.migration().execute("apply")
+
+        self.assertEqual(result["status"], "refused")
+        self.assertEqual(profile.read_bytes(), original)
+        self.assertTrue((self.one_x / "local-commit.txt").is_file())
 
     def test_proven_managed_main_worktree_moves_to_shared_namespace(self) -> None:
         source = self.workspace.paths.worktrees / "content-1x" / "maps"
@@ -237,6 +258,30 @@ class ContentMigrationTests(unittest.TestCase):
                         check=True,
                     )
 
+    def test_symlinked_managed_namespace_refuses_without_moving_worktree(self) -> None:
+        source = self.workspace.paths.worktrees / "content-1x" / "linked"
+        source.parent.mkdir(parents=True)
+        subprocess.run(
+            ["git", "worktree", "add", "-q", "-b", "review/linked", str(source)],
+            cwd=self.main,
+            check=True,
+        )
+        external = self.root / "external-worktrees"
+        external.mkdir()
+        (self.workspace.paths.worktrees / "content").symlink_to(
+            external, target_is_directory=True
+        )
+        profile, original = self._legacy_profile(
+            selector={"kind": "worktree", "value": "linked"}
+        )
+
+        result = self.migration().execute("apply")
+
+        self.assertEqual(result["status"], "refused")
+        self.assertEqual(profile.read_bytes(), original)
+        self.assertTrue(source.is_dir())
+        self.assertEqual(list(external.iterdir()), [])
+
     def test_historical_build_scenario_and_stopped_topology_are_inventoried(self) -> None:
         self._legacy_profile()
         build = self.workspace.paths.builds / "profiles" / "legacy"
@@ -303,6 +348,27 @@ class ContentMigrationTests(unittest.TestCase):
 
         self.assertEqual(audit["status"], "incomplete")
         self.assertEqual(restore["status"], "incomplete")
+        self.assertEqual(external.read_text(encoding="utf-8"), "preserve\n")
+
+    def test_pending_and_unsafe_record_paths_fail_closed(self) -> None:
+        profile, original = self._legacy_profile()
+        self.migration().pending_path.parent.mkdir(parents=True, exist_ok=True)
+        self.migration().pending_path.write_text("{}\n", encoding="utf-8")
+
+        audit = self.migration().execute("audit")
+
+        self.assertEqual(audit["status"], "incomplete")
+        self.assertEqual(audit["refusals"][0]["code"], "pending_migration")
+        self.migration().pending_path.unlink()
+        external = self.root / "external-record.json"
+        external.write_text("preserve\n", encoding="utf-8")
+        self.migration().record_path.symlink_to(external)
+
+        applied = self.migration().execute("apply")
+
+        self.assertEqual(applied["status"], "refused")
+        self.assertEqual(applied["refusals"][0]["code"], "invalid_migration_record")
+        self.assertEqual(profile.read_bytes(), original)
         self.assertEqual(external.read_text(encoding="utf-8"), "preserve\n")
 
     def test_failed_restore_rolls_profiles_forward_to_complete_state(self) -> None:
@@ -389,6 +455,12 @@ class ContentMigrationTests(unittest.TestCase):
         self.assertIn(
             "canonical_content_missing", {row["code"] for row in result["refusals"]}
         )
+
+    def test_fresh_workspace_audit_reports_no_migration_needed(self) -> None:
+        result = self.migration().execute("audit")
+
+        self.assertEqual(result["status"], "not-needed")
+        self.assertEqual(result["refusals"], [])
 
 
 if __name__ == "__main__":

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -48,11 +48,10 @@ class ManifestTests(unittest.TestCase):
         by_name = {component["name"]: component for component in value["components"]}
         value["components"] = [
             by_name["content"],
-            by_name["content-1x"],
             *(
                 component
                 for component in value["components"]
-                if component["name"] not in {"content", "content-1x"}
+                if component["name"] != "content"
             ),
         ]
         return value
@@ -68,21 +67,21 @@ class ManifestTests(unittest.TestCase):
             self.assertEqual(manifest.by_name["server"].checkout, "server")
             self.assertEqual(manifest.cohorts["default"][0], "client")
 
-    def test_loads_v3_manifest_with_two_branches_of_content(self) -> None:
+    def test_loads_v3_manifest_with_one_shared_content_checkout(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             path = self.write_manifest(Path(temporary), self.valid_v3_manifest())
             manifest = Manifest.load(path)
 
-            self.assertIn("content-1x", manifest.cohorts["classic"])
+            self.assertNotIn("content-1x", manifest.by_checkout)
             self.assertEqual(manifest.component_cohorts("content"), ("default",))
             self.assertEqual(
-                manifest.component_stacks("content-1x"), ("classic",)
+                manifest.component_stacks("content"), ("default", "classic")
             )
             self.assertEqual(
-                manifest.provider("classic", "content").checkout, "content-1x"
+                manifest.provider("classic", "content").checkout, "content"
             )
             self.assertIn(
-                "content-1x",
+                "content",
                 tuple(
                     component.name
                     for component in manifest.stack("classic").components
@@ -90,7 +89,7 @@ class ManifestTests(unittest.TestCase):
             )
             self.assertEqual(
                 manifest.stack("classic").providers["content"].name,
-                "content-1x",
+                "content",
             )
             self.assertEqual(
                 manifest.by_name["classic-server"].checkout_name, "classic"
@@ -103,7 +102,7 @@ class ManifestTests(unittest.TestCase):
             )
             self.assertEqual(
                 {checkout.name for checkout in manifest.cohort("classic")},
-                {"classic", "content-1x", "playtester", "tools"},
+                {"classic", "playtester", "tools"},
             )
             self.assertIn(
                 "content",
@@ -134,10 +133,11 @@ class ManifestTests(unittest.TestCase):
         manifest = self.valid_v3_manifest()
         checkouts = manifest["checkouts"]
         self.assertIsInstance(checkouts, list)
-        content_1x = next(
-            checkout for checkout in checkouts if checkout["name"] == "content-1x"
+        duplicate = copy.deepcopy(
+            next(checkout for checkout in checkouts if checkout["name"] == "content")
         )
-        content_1x["branch"] = "main"
+        duplicate.update({"name": "content-copy", "path": "content-copy"})
+        checkouts.append(duplicate)
         with tempfile.TemporaryDirectory() as temporary:
             path = self.write_manifest(Path(temporary), manifest)
             with self.assertRaisesRegex(
@@ -149,10 +149,16 @@ class ManifestTests(unittest.TestCase):
         manifest = self.valid_v3_manifest()
         checkouts = manifest["checkouts"]
         self.assertIsInstance(checkouts, list)
-        content_1x = next(
-            checkout for checkout in checkouts if checkout["name"] == "content-1x"
+        duplicate = copy.deepcopy(
+            next(checkout for checkout in checkouts if checkout["name"] == "content")
         )
-        content_1x["path"] = "content"
+        duplicate.update(
+            {
+                "name": "content-copy",
+                "repository": "atrinik/content-copy",
+            }
+        )
+        checkouts.append(duplicate)
         with tempfile.TemporaryDirectory() as temporary:
             path = self.write_manifest(Path(temporary), manifest)
             with self.assertRaisesRegex(WorkspaceError, "duplicate checkout path"):
@@ -168,49 +174,29 @@ class ManifestTests(unittest.TestCase):
         self.assertIsInstance(components, list)
         self.assertIsInstance(cohorts, dict)
         self.assertIsInstance(stacks, dict)
-        content_1x = next(
-            component for component in components if component["name"] == "content-1x"
-        )
-        content_1x_checkout = next(
-            checkout for checkout in checkouts if checkout["name"] == "content-1x"
-        )
-        content_1x_checkout["generation"] = "replacement"
-        content_1x["generation"] = "replacement"
-        content_1x["build"] = "none"
-        content_1x["provides"] = ["sound"]
-        content_1x["requires"] = []
-        cohorts["classic"].remove("content-1x")  # type: ignore[index, union-attr]
-        cohorts["default"].append("content-1x")  # type: ignore[union-attr]
-        stacks["classic"]["components"].remove("content-1x")  # type: ignore[index, union-attr]
         checkouts.append(  # type: ignore[union-attr]
             {
-                "name": "classic-content-provider",
-                "repository": "atrinik/classic-content-provider",
-                "branch": "main",
-                "path": "classic-content-provider",
-                "generation": "classic",
-                "license": "MIT",
+                "name": "content-1x",
+                "repository": "atrinik/content",
+                "branch": "1.x",
+                "path": "content-1x",
+                "generation": "shared",
+                "license": "LicenseRef-Atrinik-Content",
             }
         )
         components.append(  # type: ignore[union-attr]
             {
-                "name": "classic-content-provider",
-                "checkout": "classic-content-provider",
+                "name": "content-1x",
+                "checkout": "content-1x",
                 "source": ".",
-                "build": "classic-content",
-                "generation": "classic",
-                "provides": ["content"],
+                "build": "none",
+                "generation": "shared",
+                "provides": ["resources"],
                 "requires": [],
-                "license": "MIT",
+                "license": "LicenseRef-Atrinik-Content",
             }
         )
-        cohorts["classic"].append("classic-content-provider")  # type: ignore[union-attr]
-        stacks["classic"]["components"].append(  # type: ignore[index, union-attr]
-            "classic-content-provider"
-        )
-        stacks["classic"]["providers"]["content"] = (  # type: ignore[index]
-            "classic-content-provider"
-        )
+        cohorts["default"].append("content-1x")  # type: ignore[union-attr]
         with tempfile.TemporaryDirectory() as temporary:
             path = self.write_manifest(Path(temporary), manifest)
             with self.assertRaisesRegex(
@@ -266,6 +252,8 @@ class ManifestTests(unittest.TestCase):
                 "name": "other-content",
                 "checkout": "other-content",
                 "source": ".",
+                "generation": "replacement",
+                "build_by_stack": {},
             }
         )
         checkouts.append(  # type: ignore[union-attr]
@@ -383,12 +371,46 @@ class ManifestTests(unittest.TestCase):
         manifest = self.valid_v3_manifest()
         components = manifest["components"]
         self.assertIsInstance(components, list)
-        components[0]["build"] = "classic-server"  # type: ignore[index]
+        components[0]["build_by_stack"] = {"default": "classic-server"}  # type: ignore[index]
         with tempfile.TemporaryDirectory() as temporary:
             path = self.write_manifest(Path(temporary), manifest)
             with self.assertRaisesRegex(
                 WorkspaceError,
-                "classic-server is incompatible with replacement generation",
+                "effective build classic-server is incompatible with default stack",
+            ):
+                Manifest.load(path)
+
+    def test_v3_rejects_unknown_redundant_and_unused_stack_build_overrides(self) -> None:
+        for override, message, component_name in (
+            ({"future": "assets"}, "unknown stack future", "content"),
+            ({"default": "none"}, "redundantly repeats build", "content"),
+            ({"default": "assets"}, "targets stacks where the component is absent", "classic-client"),
+        ):
+            with self.subTest(override=override):
+                manifest = self.valid_v3_manifest()
+                component = next(
+                    row
+                    for row in manifest["components"]  # type: ignore[index]
+                    if row["name"] == component_name
+                )
+                component["build_by_stack"] = override
+                with tempfile.TemporaryDirectory() as temporary:
+                    path = self.write_manifest(Path(temporary), manifest)
+                    with self.assertRaisesRegex(WorkspaceError, message):
+                        Manifest.load(path)
+
+    def test_v3_rejects_stack_adapter_for_an_unprovided_role(self) -> None:
+        manifest = self.valid_v3_manifest()
+        content = next(
+            row
+            for row in manifest["components"]  # type: ignore[index]
+            if row["name"] == "content"
+        )
+        content["build_by_stack"] = {"classic": "classic-server"}
+        with tempfile.TemporaryDirectory() as temporary:
+            path = self.write_manifest(Path(temporary), manifest)
+            with self.assertRaisesRegex(
+                WorkspaceError, "requires provided role server"
             ):
                 Manifest.load(path)
 
@@ -396,10 +418,10 @@ class ManifestTests(unittest.TestCase):
         manifest = self.valid_v3_manifest()
         stacks = manifest["stacks"]
         self.assertIsInstance(stacks, dict)
-        stacks["default"]["components"].append("content-1x")  # type: ignore[index, union-attr]
+        stacks["default"]["components"].append("classic-client")  # type: ignore[index, union-attr]
         with tempfile.TemporaryDirectory() as temporary:
             path = self.write_manifest(Path(temporary), manifest)
-            with self.assertRaisesRegex(WorkspaceError, "mixes classic component content-1x"):
+            with self.assertRaisesRegex(WorkspaceError, "mixes classic component classic-client"):
                 Manifest.load(path)
 
     def test_v3_rejects_dependency_cycles(self) -> None:
@@ -537,13 +559,15 @@ class ReleaseConfigurationTests(unittest.TestCase):
             set(manifest.cohorts["classic"]),
             {
                 "classic",
-                "content-1x",
                 "playtester",
                 "tools",
             },
         )
         self.assertEqual(manifest.by_name["content"].branch, "main")
-        self.assertEqual(manifest.by_name["content-1x"].branch, "1.x")
+        self.assertEqual(manifest.effective_build("default", "content"), "none")
+        self.assertEqual(
+            manifest.effective_build("classic", "content"), "classic-content"
+        )
         self.assertEqual(
             manifest.stack("classic").providers["libatrinik"].name,
             "classic-libatrinik",
@@ -578,7 +602,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
                 "server": "classic-server",
                 "protocol": "classic-protocol",
                 "libatrinik": "classic-libatrinik",
-                "content": "content-1x",
+                "content": "content",
             },
         )
         self.assertFalse(

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -380,6 +380,33 @@ class ManifestTests(unittest.TestCase):
             ):
                 Manifest.load(path)
 
+    def test_v3_rejects_malformed_component_shape_and_stack_builds(self) -> None:
+        cases = (
+            ("shape", None, "missing source; unexpected extra"),
+            ("builds", [], "build_by_stack must be an object"),
+            ("adapter", {"classic": []}, "build_by_stack.classic is invalid"),
+        )
+        for name, value, message in cases:
+            with self.subTest(name=name):
+                manifest = self.valid_v3_manifest()
+                component = manifest["components"][0]  # type: ignore[index]
+                if name == "shape":
+                    component.pop("source")
+                    component["extra"] = True
+                else:
+                    component["build_by_stack"] = value
+                with tempfile.TemporaryDirectory() as temporary:
+                    path = self.write_manifest(Path(temporary), manifest)
+                    with self.assertRaisesRegex(WorkspaceError, message):
+                        Manifest.load(path)
+
+    def test_effective_build_rejects_component_outside_selected_stack(self) -> None:
+        manifest = Manifest.load(ROOT / "components.json")
+        with self.assertRaisesRegex(
+            WorkspaceError, "component classic-client is not part of default stack"
+        ):
+            manifest.effective_build("default", "classic-client")
+
     def test_v3_rejects_unknown_redundant_and_unused_stack_build_overrides(self) -> None:
         for override, message, component_name in (
             ({"future": "assets"}, "unknown stack future", "content"),

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -180,13 +180,10 @@ class InventoryTests(unittest.TestCase):
         self.assertGreaterEqual(len(inventory.dependencies), 60)
         self.assertIn("nawerhals", inventory.repositories_by_name)
         self.assertFalse(inventory.repositories_by_name["nawerhals"].supported)
+        self.assertNotIn("content-1x", inventory.repositories_by_name)
         self.assertEqual(
-            inventory.repositories_by_name["content"].repository,
-            inventory.repositories_by_name["content-1x"].repository,
-        )
-        self.assertNotEqual(
-            inventory.repositories_by_name["content"].branch,
-            inventory.repositories_by_name["content-1x"].branch,
+            inventory.repositories_by_name["content"].stacks,
+            ("classic", "default"),
         )
         classic = [
             inventory.repositories_by_name[name]
@@ -237,7 +234,7 @@ class InventoryTests(unittest.TestCase):
         playtester_content = inventory.dependencies_by_id[
             "source/atrinik-content-playtester"
         ]
-        self.assertEqual(playtester_content.owner, "content-1x")
+        self.assertEqual(playtester_content.owner, "content")
         self.assertEqual(playtester_content.scope, ("playtester",))
         self.assertEqual(playtester_content.version, "v1.8.0")
         self.assertEqual(
@@ -973,30 +970,30 @@ class InventoryTests(unittest.TestCase):
         content = next(
             component
             for component in cyclonedx["components"]
-            if component["bom-ref"] == "atrinik:component:content-1x"
+            if component["bom-ref"] == "atrinik:component:content"
         )
         properties = {
             property_["name"]: property_["value"]
             for property_ in content["properties"]
         }
-        self.assertEqual(properties["atrinik:branch"], "1.x")
+        self.assertEqual(properties["atrinik:branch"], "main")
         self.assertEqual(properties["atrinik:commit"], "unavailable")
         self.assertEqual(content["version"], "unavailable")
-        self.assertEqual(properties["atrinik:stacks"], "classic")
+        self.assertEqual(properties["atrinik:stacks"], "classic,default")
         self.assertEqual(properties["atrinik:roles"], "content")
         spdx_content = next(
             package
             for package in spdx["packages"]
-            if package["name"] == "content-1x"
+            if package["name"] == "content"
         )
         self.assertIn("repository: atrinik/content", spdx_content["packageComment"])
-        self.assertIn("branch: 1.x", spdx_content["packageComment"])
-        self.assertIn("stacks: classic", spdx_content["packageComment"])
+        self.assertIn("branch: main", spdx_content["packageComment"])
+        self.assertIn("stacks: classic,default", spdx_content["packageComment"])
         self.assertIn("commit: unavailable", spdx_content["packageComment"])
         self.assertIn("| Dependency | Version |", inventory.report("licenses"))
         self.assertIn("| Component | Repository | Branch |", inventory.report("licenses"))
 
-    def test_reports_resolve_profile_commits_without_conflating_content_branches(self) -> None:
+    def test_reports_resolve_one_content_commit_for_both_stacks(self) -> None:
         inventory = self.load_inventory()
         default_commit = "a" * 40
         classic_commit = "b" * 40
@@ -1011,7 +1008,7 @@ class InventoryTests(unittest.TestCase):
         classic = json.loads(
             inventory.report(
                 "cyclonedx",
-                {"atrinik": root_commit, "content-1x": classic_commit},
+                {"atrinik": root_commit, "content": classic_commit},
                 "classic",
             )
         )
@@ -1027,27 +1024,21 @@ class InventoryTests(unittest.TestCase):
             }
 
         default_content = properties(default, "content")
-        default_classic_content = properties(default, "content-1x")
-        classic_content = properties(classic, "content-1x")
-        classic_default_content = properties(classic, "content")
+        classic_content = properties(classic, "content")
         self.assertEqual(default_content["atrinik:commit"], default_commit)
         self.assertEqual(default_content["atrinik:selected"], "true")
-        self.assertEqual(default_classic_content["atrinik:commit"], "unavailable")
-        self.assertEqual(default_classic_content["atrinik:selected"], "false")
         self.assertEqual(classic_content["atrinik:commit"], classic_commit)
         self.assertEqual(classic_content["atrinik:selected"], "true")
-        self.assertEqual(classic_default_content["atrinik:commit"], "unavailable")
-        self.assertEqual(classic_default_content["atrinik:selected"], "false")
 
         spdx = json.loads(
             inventory.report(
                 "spdx",
-                {"atrinik": root_commit, "content-1x": classic_commit},
+                {"atrinik": root_commit, "content": classic_commit},
                 "classic",
             )
         )
         content_package = next(
-            package for package in spdx["packages"] if package["name"] == "content-1x"
+            package for package in spdx["packages"] if package["name"] == "content"
         )
         self.assertEqual(content_package["versionInfo"], classic_commit)
         self.assertEqual(
@@ -1057,9 +1048,9 @@ class InventoryTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "unknown first-party"):
             inventory.report("spdx", {"unknown": root_commit}, "classic")
         with self.assertRaisesRegex(WorkspaceError, "outside the selected stack"):
-            inventory.report("spdx", {"content": default_commit}, "classic")
+            inventory.report("spdx", {"client": default_commit}, "classic")
         with self.assertRaisesRegex(WorkspaceError, "full lowercase Git commit"):
-            inventory.report("spdx", {"content-1x": "short"}, "classic")
+            inventory.report("spdx", {"content": "short"}, "classic")
         with self.assertRaisesRegex(WorkspaceError, "unknown.*report stack"):
             inventory.report("spdx", {}, "mixed")
 
@@ -1651,7 +1642,7 @@ jobs:
                 ),
             ):
                 with self.assertRaisesRegex(
-                    WorkspaceError, "cannot prove content@main lineage"
+                    WorkspaceError, "is not based on atrinik/content@main"
                 ):
                     repository_roots(
                         ROOT,
@@ -1773,7 +1764,7 @@ jobs:
         ):
             repository_roots(ROOT, workspace, "classic-review")
 
-    def test_repository_roots_fail_closed_when_content_1x_is_missing(self) -> None:
+    def test_repository_roots_fail_closed_when_shared_content_is_missing(self) -> None:
         workspace = mock.Mock()
         document = json.loads(
             (ROOT / "components.json").read_text(encoding="utf-8")
@@ -1785,7 +1776,7 @@ jobs:
             "components": [
                 {
                     "component": name,
-                    "initialized": name != "content-1x",
+                    "initialized": name != "content",
                     "path": f"/workspace/classic/{name}",
                 }
                 for name in classic_components
@@ -1795,7 +1786,7 @@ jobs:
         with self.assertRaisesRegex(
             WorkspaceError,
             r"profile classic is incomplete.*./atrinik init --with classic.*"
-            r"content-1x \(content-1x\)",
+            r"content \(content\)",
         ):
             repository_roots(ROOT, workspace, "classic")
 
@@ -1971,15 +1962,15 @@ jobs:
         classic_components = json.loads(
             (ROOT / "components.json").read_text(encoding="utf-8")
         )["stacks"]["classic"]["components"]
-        content_path = "/workspace/classic-review/content-1x"
+        content_path = "/workspace/classic-review/content"
         workspace.profile_summary.return_value = {
             "name": "classic-review",
             "stack": "classic",
             "components": [
                 {
                     "component": name,
-                    "initialized": name == "content-1x",
-                    "path": content_path if name == "content-1x" else f"/missing/{name}",
+                    "initialized": name == "content",
+                    "path": content_path if name == "content" else f"/missing/{name}",
                 }
                 for name in classic_components
             ],
@@ -1996,10 +1987,9 @@ jobs:
 
         self.assertEqual(stack, "classic")
         self.assertEqual(commits["atrinik"], root_commit)
-        self.assertEqual(commits["content-1x"], content_commit)
+        self.assertEqual(commits["content"], content_commit)
         self.assertIsNone(commits["classic-server"])
         self.assertIsNone(commits["classic"])
-        self.assertNotIn("content", commits)
         self.assertEqual(git_head.call_count, 2)
         git_head.assert_any_call(Path(content_path))
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -592,25 +592,63 @@ class WorkspaceTests(unittest.TestCase):
         (output / "lib").mkdir(parents=True)
         (output / "maps").mkdir()
         compatibility = output / "compatibility.json"
-        compatibility.write_text(payload, encoding="utf-8")
+        atomic_json(
+            compatibility,
+            {
+                "schema_version": 1,
+                "target": "classic",
+                "component": "content",
+                "repository": "atrinik/content",
+                "branch": "main",
+                "content_format": "classic-ads-v1",
+                "artifact_format": "atrinik-classic-runtime-content-v1",
+                "compatible_classic_releases": ">=5.10.1 <6.0.0",
+                "consumers": [
+                    "classic/client",
+                    "classic/editor",
+                    "classic/server",
+                ],
+                "replacement_ready": False,
+                "replacement_toolkit_package": False,
+            },
+        )
+        payload_file = output / "maps" / "payload"
+        payload_file.write_text(payload, encoding="utf-8")
+        license_file = output / "attribution" / "maps" / "COPYING"
+        license_file.parent.mkdir(parents=True)
+        license_file.write_text("fixture license\n", encoding="utf-8")
+        files = []
+        for candidate in (compatibility, license_file, payload_file):
+            files.append(
+                {
+                    "path": candidate.relative_to(output).as_posix(),
+                    "sha256": hashlib.sha256(candidate.read_bytes()).hexdigest(),
+                    "size": candidate.stat().st_size,
+                }
+            )
         atomic_json(
             output / "manifest.json",
             {
                 "schema_version": 2,
+                "target": "classic",
                 "source": {
                     "repository": "atrinik/content",
                     "branch": "main",
                     "commit": commit,
                 },
-                "files": [
-                    {
-                        "path": "compatibility.json",
-                        "sha256": hashlib.sha256(
-                            compatibility.read_bytes()
-                        ).hexdigest(),
-                        "size": compatibility.stat().st_size,
-                    }
+                "release_version": "unreleased",
+                "content_format": "classic-ads-v1",
+                "artifact_format": "atrinik-classic-runtime-content-v1",
+                "compatible_classic_releases": ">=5.10.1 <6.0.0",
+                "consumers": [
+                    "classic/client",
+                    "classic/editor",
+                    "classic/server",
                 ],
+                "replacement_ready": False,
+                "replacement_toolkit_package": False,
+                "license_files": [files[1]],
+                "files": files,
             },
         )
 
@@ -3894,12 +3932,16 @@ class WorkspaceTests(unittest.TestCase):
             def mutate_after_validation(
                 path: Path,
                 coordinate: dict[str, str],
+                adapter: str,
                 *,
                 require_metadata: bool = True,
             ) -> None:
                 nonlocal mutated
                 real_validate(
-                    path, coordinate, require_metadata=require_metadata
+                    path,
+                    coordinate,
+                    adapter,
+                    require_metadata=require_metadata,
                 )
                 if not mutated:
                     mutated = True
@@ -4981,21 +5023,21 @@ class WorkspaceTests(unittest.TestCase):
         root_file.write_text("bad\n", encoding="utf-8")
         with self.assertRaisesRegex(WorkspaceError, "not a directory"):
             self.workspace._validate_collected_content(
-                root_file, coordinate, require_metadata=False
+                root_file, coordinate, "classic-content", require_metadata=False
             )
 
         missing_directory = content("content-missing-directory")
         shutil.rmtree(missing_directory / "lib")
         with self.assertRaisesRegex(WorkspaceError, "required directory"):
             self.workspace._validate_collected_content(
-                missing_directory, coordinate, require_metadata=False
+                missing_directory, coordinate, "classic-content", require_metadata=False
             )
 
         invalid_manifest = content("content-invalid-manifest")
         atomic_json(invalid_manifest / "manifest.json", [])
         with self.assertRaisesRegex(WorkspaceError, "manifest is invalid"):
             self.workspace._validate_collected_content(
-                invalid_manifest, coordinate, require_metadata=False
+                invalid_manifest, coordinate, "classic-content", require_metadata=False
             )
 
         invalid_entry = content("content-invalid-entry")
@@ -5004,21 +5046,21 @@ class WorkspaceTests(unittest.TestCase):
         atomic_json(invalid_entry / "manifest.json", manifest)
         with self.assertRaisesRegex(WorkspaceError, "file entry is invalid"):
             self.workspace._validate_collected_content(
-                invalid_entry, coordinate, require_metadata=False
+                invalid_entry, coordinate, "classic-content", require_metadata=False
             )
 
         linked = content("content-link")
         (linked / "linked").symlink_to(self.root, target_is_directory=True)
         with self.assertRaisesRegex(WorkspaceError, "contains a link"):
             self.workspace._validate_collected_content(
-                linked, coordinate, require_metadata=False
+                linked, coordinate, "classic-content", require_metadata=False
             )
 
         extra = content("content-extra")
         (extra / "extra").write_text("extra\n", encoding="utf-8")
         with self.assertRaisesRegex(WorkspaceError, "does not match"):
             self.workspace._validate_collected_content(
-                extra, coordinate, require_metadata=False
+                extra, coordinate, "classic-content", require_metadata=False
             )
 
         wrong_size = content("content-size")
@@ -5027,7 +5069,7 @@ class WorkspaceTests(unittest.TestCase):
         atomic_json(wrong_size / "manifest.json", manifest)
         with self.assertRaisesRegex(WorkspaceError, "size does not match"):
             self.workspace._validate_collected_content(
-                wrong_size, coordinate, require_metadata=False
+                wrong_size, coordinate, "classic-content", require_metadata=False
             )
 
         unreadable = content("content-unreadable")
@@ -5061,7 +5103,7 @@ class WorkspaceTests(unittest.TestCase):
         ):
             with self.assertRaisesRegex(WorkspaceError, "cannot inspect collected"):
                 self.workspace._validate_collected_content(
-                    unreadable, coordinate, require_metadata=False
+                    unreadable, coordinate, "classic-content", require_metadata=False
                 )
 
         special_content = content("content-special")
@@ -5074,7 +5116,7 @@ class WorkspaceTests(unittest.TestCase):
         atomic_json(special_content / "manifest.json", manifest)
         with self.assertRaisesRegex(WorkspaceError, "non-regular file"):
             self.workspace._validate_collected_content(
-                special_content, coordinate, require_metadata=False
+                special_content, coordinate, "classic-content", require_metadata=False
             )
 
         source = self.workspace.paths.repositories / "resources"
@@ -5166,6 +5208,109 @@ class WorkspaceTests(unittest.TestCase):
                 ["paintings/fifo"],
                 require_metadata=False,
             )
+
+    def test_default_content_validator_accepts_only_schema_one_source_commit(self) -> None:
+        coordinate = {
+            "repository": "atrinik/content",
+            "branch": "main",
+            "head": "a" * 40,
+        }
+        candidate = self.root / "default-content"
+        (candidate / "lib").mkdir(parents=True)
+        (candidate / "maps").mkdir()
+        atomic_json(
+            candidate / MANAGED_MARKER,
+            {"schema_version": 1, "purpose": "collected-content"},
+        )
+        atomic_json(
+            candidate / "manifest.json",
+            {
+                "schema_version": 1,
+                "source_commit": coordinate["head"],
+                "files": [],
+            },
+        )
+
+        self.workspace._validate_collected_content(
+            candidate, coordinate, "none", require_metadata=False
+        )
+        manifest = load_json(candidate / "manifest.json")
+        manifest["source_commit"] = "b" * 40
+        atomic_json(candidate / "manifest.json", manifest)
+        with self.assertRaisesRegex(WorkspaceError, "default content manifest"):
+            self.workspace._validate_collected_content(
+                candidate, coordinate, "none", require_metadata=False
+            )
+
+    def test_stack_selects_only_its_content_publisher_target(self) -> None:
+        wrapper = self.root / "actual-wrapper"
+        wrapper.mkdir()
+        shutil.copy2(
+            Path(__file__).resolve().parents[1] / "components.json",
+            wrapper / "components.json",
+        )
+        workspace = Workspace(wrapper)
+        workspace.paths.ensure()
+        source = self.workspace.paths.repositories / "content"
+        commit = command("git", "rev-parse", "HEAD", cwd=source)
+        inputs = {
+            "schema_version": 1,
+            "cacheable": False,
+            "coordinate": {
+                "component": "content",
+                "repository": "atrinik/content",
+                "branch": "main",
+                "checkout": "content",
+                "source": ".",
+                "checkout_path": str(source),
+                "source_path": str(source),
+                "head": commit,
+            },
+        }
+
+        for stack_name, expected_target in (("default", False), ("classic", True)):
+            with self.subTest(stack=stack_name):
+                root = workspace.paths.builds / "profiles" / f"target-{stack_name}"
+                managed_directory(root, workspace.paths.builds, "test-profile")
+
+                def collect(arguments: list[str], **kwargs: object) -> str:
+                    self.assertEqual("--target" in arguments, expected_target)
+                    if expected_target:
+                        self.assertEqual(arguments[-2:], ["--target", "classic"])
+                    output = Path(arguments[arguments.index("--output") + 1])
+                    if expected_target:
+                        self.make_content_candidate(output, commit, "classic\n")
+                    else:
+                        (output / "lib").mkdir(parents=True)
+                        (output / "maps").mkdir()
+                        atomic_json(
+                            output / "manifest.json",
+                            {
+                                "schema_version": 1,
+                                "source_commit": commit,
+                                "files": [],
+                            },
+                        )
+                    return ""
+
+                with (
+                    mock.patch.object(
+                        workspace,
+                        "_runtime_input_coordinates",
+                        return_value=(inputs, False),
+                    ),
+                    mock.patch.object(
+                        workspace,
+                        "_load_profile",
+                        return_value={"stack": stack_name},
+                    ),
+                    mock.patch("atrinik_workspace.workspace.run", side_effect=collect),
+                ):
+                    output = workspace._collect_content(
+                        root, {"content": source}, stack_name
+                    )
+
+                self.assertTrue((output / "manifest.json").is_file())
 
     def test_replace_directory_interrupted_journal_publish_is_retryable(
         self,

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -614,11 +614,13 @@ class WorkspaceTests(unittest.TestCase):
         )
         payload_file = output / "maps" / "payload"
         payload_file.write_text(payload, encoding="utf-8")
+        library_file = output / "lib" / "payload"
+        library_file.write_text(payload, encoding="utf-8")
         license_file = output / "attribution" / "maps" / "COPYING"
         license_file.parent.mkdir(parents=True)
         license_file.write_text("fixture license\n", encoding="utf-8")
         files = []
-        for candidate in (compatibility, license_file, payload_file):
+        for candidate in (compatibility, license_file, library_file, payload_file):
             files.append(
                 {
                     "path": candidate.relative_to(output).as_posix(),
@@ -5119,6 +5121,33 @@ class WorkspaceTests(unittest.TestCase):
                 special_content, coordinate, "classic-content", require_metadata=False
             )
 
+        missing_license = content("content-missing-license-binding")
+        manifest = load_json(missing_license / "manifest.json")
+        manifest["license_files"] = []
+        atomic_json(missing_license / "manifest.json", manifest)
+        with self.assertRaisesRegex(WorkspaceError, "license inventory"):
+            self.workspace._validate_collected_content(
+                missing_license,
+                coordinate,
+                "classic-content",
+                require_metadata=False,
+            )
+
+        incomplete_payload = content("content-incomplete-payload")
+        (incomplete_payload / "lib" / "payload").unlink()
+        manifest = load_json(incomplete_payload / "manifest.json")
+        manifest["files"] = [
+            entry for entry in manifest["files"] if entry["path"] != "lib/payload"
+        ]
+        atomic_json(incomplete_payload / "manifest.json", manifest)
+        with self.assertRaisesRegex(WorkspaceError, "payload is incomplete"):
+            self.workspace._validate_collected_content(
+                incomplete_payload,
+                coordinate,
+                "classic-content",
+                require_metadata=False,
+            )
+
         source = self.workspace.paths.repositories / "resources"
 
         def resource(name: str) -> Path:
@@ -6988,6 +7017,51 @@ class WorkspaceTests(unittest.TestCase):
         atomic_json(root / "status.json", current)
         with self.assertRaisesRegex(WorkspaceError, "component identity is invalid"):
             self.workspace.topology_status("historical-coordinate")
+
+    def test_topology_status_recognizes_only_exact_retired_content_coordinate(self) -> None:
+        root = self.workspace._topology_directory("retired-content", create=True)
+        checkout = self.root / "content-1x"
+        record = {
+            "schema_version": 1,
+            "name": "retired-content",
+            "profile": "classic-review",
+            "stack": "classic",
+            "providers": {"content": "content-1x"},
+            "dependencies": ["content"],
+            "state": "/tmp/state",
+            "build_root": "/tmp/build",
+            "resolved": {
+                "content-1x": {
+                    "path": str(checkout),
+                    "checkout_path": str(checkout),
+                    "checkout": "content-1x",
+                    "repository": "atrinik/content",
+                    "branch": "1.x",
+                    "source": ".",
+                    "head": "a" * 40,
+                    "dirty": False,
+                }
+            },
+            "endpoint": None,
+            "ready": False,
+            "started_at": "2026-08-08T00:00:00+00:00",
+            "stopped_at": "2026-08-08T01:00:00+00:00",
+            "supervisor": {"pid": 999, "start_time": "1"},
+            "services": {},
+            "error": "historical fixture",
+        }
+        atomic_json(root / "status.json", record)
+
+        with mock.patch(
+            "atrinik_workspace.workspace.process_matches", return_value=False
+        ):
+            historical = self.workspace.topology_status("retired-content")
+
+        self.assertTrue(historical["inert_historical_record"])
+        record["resolved"]["content-1x"]["source"] = "maps"
+        atomic_json(root / "status.json", record)
+        with self.assertRaisesRegex(WorkspaceError, "no provider"):
+            self.workspace.topology_status("retired-content")
 
     def test_client_only_topology_rejects_server_port(self) -> None:
         with self.assertRaisesRegex(WorkspaceError, "requires the server"):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -5042,6 +5042,38 @@ class WorkspaceTests(unittest.TestCase):
                 invalid_manifest, coordinate, "classic-content", require_metadata=False
             )
 
+        invalid_compatibility = content("content-invalid-compatibility")
+        compatibility = load_json(invalid_compatibility / "compatibility.json")
+        compatibility["branch"] = "1.x"
+        atomic_json(invalid_compatibility / "compatibility.json", compatibility)
+        with self.assertRaisesRegex(WorkspaceError, "compatibility contract is invalid"):
+            self.workspace._validate_collected_content(
+                invalid_compatibility,
+                coordinate,
+                "classic-content",
+                require_metadata=False,
+            )
+
+        invalid_classic_manifest = content("content-invalid-classic-manifest")
+        manifest = load_json(invalid_classic_manifest / "manifest.json")
+        manifest["source"]["branch"] = "1.x"
+        atomic_json(invalid_classic_manifest / "manifest.json", manifest)
+        with self.assertRaisesRegex(WorkspaceError, "Classic content manifest is invalid"):
+            self.workspace._validate_collected_content(
+                invalid_classic_manifest,
+                coordinate,
+                "classic-content",
+                require_metadata=False,
+            )
+
+        with self.assertRaisesRegex(WorkspaceError, "unsupported content build adapter"):
+            self.workspace._validate_collected_content(
+                content("content-unsupported-adapter"),
+                coordinate,
+                "future-content",
+                require_metadata=False,
+            )
+
         invalid_entry = content("content-invalid-entry")
         manifest = load_json(invalid_entry / "manifest.json")
         manifest["files"][0]["path"] = "../escape"
@@ -5128,6 +5160,18 @@ class WorkspaceTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "license inventory"):
             self.workspace._validate_collected_content(
                 missing_license,
+                coordinate,
+                "classic-content",
+                require_metadata=False,
+            )
+
+        invalid_license = content("content-invalid-license-binding")
+        manifest = load_json(invalid_license / "manifest.json")
+        manifest["license_files"][0]["path"] = "maps/COPYING"
+        atomic_json(invalid_license / "manifest.json", manifest)
+        with self.assertRaisesRegex(WorkspaceError, "license entry is invalid"):
+            self.workspace._validate_collected_content(
+                invalid_license,
                 coordinate,
                 "classic-content",
                 require_metadata=False,


### PR DESCRIPTION
Closes #358

## Outcome

Routes both replacement and Classic stacks through the single
`atrinik/content@main` checkout while retaining a narrowly scoped Classic
publisher adapter. Removes `content-1x` from the active manifest and active
supply-chain ownership without deleting or rewriting any historical checkout,
worktree, build, topology, scenario, state, log, or release evidence.

## Certified prerequisite

- `atrinik/content#166` is merged.
- Final immutable `1.x` coordinate: `566bd25f78b80b08d5f75f4b02017ab2429204db`, release `v1.8.19`.
- Consolidated `main` coordinate: `7dde0c0afe8840fc95dd26f404310e77d9c82621`, release `v2.14.0`.
- Both tags resolve to the exact reviewed heads and both release asset checksums were verified.
- The `v2.14.0` Classic runtime artifact was independently validated as schema 2 with 4,180 files, 157 license bindings, source branch `main`, and complete checksums.

## Changes

- Adds strict `build_by_stack` manifest support and one effective-build accessor used by validation, dependency expansion, execution, profile reporting, and completion.
- Makes `content` the sole active source for both stacks; default keeps `build: none`, while Classic resolves `classic-content`.
- Invokes the content publisher with `--target classic` and validates schema, compatibility, source coordinates, payload roots, complete attribution bindings, and checksums.
- Adds `./atrinik migrate content` dry-run, apply, audit, and restore modes with an exclusive layout lock, exact-byte journaling, bounded and duplicate-key-safe records, transactional rollback, and exact checkout/worktree proof.
- Keeps the retired coordinate readable as historical and inert, and teaches cleanup to inventory every preserved legacy reference without applying cleanup.
- Collapses active supply-chain ownership to `content@main` across both stacks and synchronizes wrapper/content/delivery/protocol guidance.

## Review

The complete base-to-head diff was reviewed again after delayed patch-coverage
feedback reopened delivery. Twelve findings were fixed across `cf69c13ee`,
`a04ebcc22`, `624af18e2`, `ec4493986`, and `f570dfe06`. Recovery tests exposed and fixed an
apply-retry ordering defect; exact-gate remediation added contract-focused
tests and removed one provably unreachable defensive branch. A fresh review of
committed head `f570dfe06` found no remaining
actionable findings.

## Validation

- 545 unit tests pass in 139.485 seconds.
- Aggregate branch coverage: 82%.
- Conservative changed executable-line/partial-branch coverage: 690/840 (82.14286%).
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate` — 20 components.
- `./atrinik supply-chain validate` — 105 dependencies.
- `git diff --check`
- `./atrinik profile show classic --json` reports `content@main` with effective build `classic-content`.
- The isolated issue worktree's real migration dry run refuses safely because its canonical content checkout is intentionally absent; 40 fixture-backed migration tests cover dry-run/apply/audit/restore, retries, dirty/detached/locked/live/collision inputs, identity, tampering, rollback, retained journals, malformed records, unsafe namespaces/resources, and restored-worktree auditing.

Integrated Classic build/runtime and consumer lock proof remains ordered behind
this wrapper leaf and belongs to the downstream consumer leaves in #357.

## Safety and rollback

No governance setting or workflow policy is changed. No cleanup apply, remote
branch deletion, issue closure, or merge is performed. `content-1x/` remains a
preserved migration input. The journal can restore exact original profile bytes
and proven worktree paths before any separately authorized retirement action.
