### PR TITLE
chore(supply-chain): reconcile Playtester main inputs

### DIFF
--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -925,7 +925,8 @@
       "scope": [
         "atrinik",
         "classic",
-        "content"
+        "content",
+        "playtester"
       ],
       "required": true,
       "version": "v7.0.0",
@@ -951,6 +952,11 @@
         {
           "repository": "classic",
           "path": ".github/workflows/check.yml",
+          "contains": "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0"
+        },
+        {
+          "repository": "playtester",
+          "path": ".github/workflows/validate.yml",
           "contains": "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0"
         }
       ]
@@ -2479,25 +2485,25 @@
         "playtester"
       ],
       "required": true,
-      "version": "v1.8.0",
-      "version_source": "dependencies.lock.json content input",
+      "version": "v2.14.0",
+      "version_source": "dependencies.lock.json content source input",
       "license": "LicenseRef-Atrinik-Content",
-      "source_url": "https://github.com/atrinik/content/releases/tag/v1.8.0",
-      "locator": "pkg:github/atrinik/content@v1.8.0",
-      "commit": "96073eeff1854fc29347fdafd32e622394f24c07",
-      "checksum": null,
-      "acquisition": "The playtester verifies the exact content release commit before compiling world and runtime inputs",
+      "source_url": "https://github.com/atrinik/content/releases/tag/v2.14.0",
+      "locator": "pkg:github/atrinik/content@v2.14.0",
+      "commit": "7dde0c0afe8840fc95dd26f404310e77d9c82621",
+      "checksum": "sha256:bd5aa9acb8dd17c07e16913cb36c58644f7910f28f47e3b0739d00d91936a9e6",
+      "acquisition": "The playtester downloads the bounded source archive, verifies its exact digest and layout, and publishes it in a read-only atomic cache generation",
       "update_cadence_days": 30,
       "update_mechanism": "Reviewed content compatibility update with complete playtester regression validation",
       "eol_response": "Advance to a supported content release before removing the pinned compatibility baseline",
-      "validation": "Content identity verification, world-graph compilation, runtime asset loading, and playtester regression tests",
+      "validation": "Lock validation, checksum, safe extraction, atomic/offline cache tests, world-graph compilation, and complete playtester regressions",
       "disposition": "isolate",
       "packages": [],
       "evidence": [
         {
           "repository": "playtester",
           "path": "dependencies.lock.json",
-          "contains": "96073eeff1854fc29347fdafd32e622394f24c07"
+          "contains": "bd5aa9acb8dd17c07e16913cb36c58644f7910f28f47e3b0739d00d91936a9e6"
         }
       ]
     },
@@ -2507,21 +2513,22 @@
       "kind": "source-archive",
       "owner": "content",
       "scope": [
-        "classic-server"
+        "classic-server",
+        "playtester"
       ],
       "required": true,
       "version": "v2.14.0",
-      "version_source": "classic/server/dependencies.lock.json",
+      "version_source": "Classic server and playtester dependencies.lock.json files",
       "license": "LicenseRef-Atrinik-Asset-Per-File",
       "source_url": "https://github.com/atrinik/content/releases/tag/v2.14.0",
       "locator": "pkg:github/atrinik/content@v2.14.0",
       "commit": "7dde0c0afe8840fc95dd26f404310e77d9c82621",
       "checksum": "sha256:f4ad326e20e221869897c72f7e33b533c408ce6654038dbfc4352da1c3391261",
-      "acquisition": "Classic server dependency tool downloads and safely extracts the release archive",
+      "acquisition": "Classic server and playtester dependency tools download, checksum, safely extract, and atomically publish the release archive",
       "update_cadence_days": 30,
-      "update_mechanism": "Daily fail-closed GitHub App proposal and reviewed Classic lock pull request",
+      "update_mechanism": "Daily fail-closed GitHub App proposal plus reviewed Classic and playtester compatibility updates",
       "eol_response": "Update the lock to a supported content release or stop packaging the classic server",
-      "validation": "Lock validation, checksum, safe extraction, collection, and classic server runtime tests",
+      "validation": "Lock validation, checksum, safe extraction, collection, Classic runtime tests, and playtester atomic/offline cache regressions",
       "disposition": "isolate",
       "packages": [],
       "evidence": [
@@ -2529,6 +2536,11 @@
           "repository": "classic-server",
           "path": "dependencies.lock.json",
           "contains": "atrinik-content-2.14.0-classic-runtime.tar.gz"
+        },
+        {
+          "repository": "playtester",
+          "path": "dependencies.lock.json",
+          "contains": "f4ad326e20e221869897c72f7e33b533c408ce6654038dbfc4352da1c3391261"
         }
       ]
     },
@@ -2573,7 +2585,7 @@
       ],
       "required": true,
       "version": "v1.1.5",
-      "version_source": "CMakeLists.txt FetchContent declaration",
+      "version_source": "dependencies.lock.json pathfinding input consumed by CMake",
       "license": "GPL-2.0-or-later",
       "source_url": "https://github.com/atrinik/legacy-libatrinik/releases/tag/v1.1.5",
       "locator": "pkg:github/atrinik/legacy-libatrinik@v1.1.5",
@@ -2589,13 +2601,13 @@
       "evidence": [
         {
           "repository": "playtester",
-          "path": "CMakeLists.txt",
-          "contains": "libatrinik-1.1.5.tar.gz"
+          "path": "dependencies.lock.json",
+          "contains": "3c07b178cc236881f52272df6e38bc2d4186943b782e4cee34b2e733da9c8f9a"
         },
         {
           "repository": "playtester",
           "path": "dependencies.lock.json",
-          "contains": "3c07b178cc236881f52272df6e38bc2d4186943b782e4cee34b2e733da9c8f9a"
+          "contains": "libatrinik-1.1.5.tar.gz"
         }
       ]
     },

--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -940,7 +940,7 @@
       "update_cadence_days": 7,
       "update_mechanism": "Dependabot GitHub Actions update group",
       "eol_response": "Upgrade the action and supported Python matrix together",
-      "validation": "Actionlint plus Python generation, content, and workspace tests",
+      "validation": "Actionlint plus Python generation, content, Playtester, and workspace tests",
       "disposition": "retain",
       "packages": [],
       "evidence": [
@@ -2527,7 +2527,7 @@
       "acquisition": "Classic server and playtester dependency tools download, checksum, safely extract, and atomically publish the release archive",
       "update_cadence_days": 30,
       "update_mechanism": "Daily fail-closed GitHub App proposal plus reviewed Classic and playtester compatibility updates",
-      "eol_response": "Update the lock to a supported content release or stop packaging the classic server",
+      "eol_response": "Update both locks to a supported content release or stop Classic packaging and Playtester operation",
       "validation": "Lock validation, checksum, safe extraction, collection, Classic runtime tests, and playtester atomic/offline cache regressions",
       "disposition": "isolate",
       "packages": [],

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -236,10 +236,23 @@ class InventoryTests(unittest.TestCase):
         ]
         self.assertEqual(playtester_content.owner, "content")
         self.assertEqual(playtester_content.scope, ("playtester",))
-        self.assertEqual(playtester_content.version, "v1.8.0")
+        self.assertEqual(playtester_content.version, "v2.14.0")
         self.assertEqual(
             playtester_content.commit,
-            "96073eeff1854fc29347fdafd32e622394f24c07",
+            "7dde0c0afe8840fc95dd26f404310e77d9c82621",
+        )
+        self.assertEqual(
+            playtester_content.checksum,
+            "sha256:bd5aa9acb8dd17c07e16913cb36c58644f7910f28f47e3b0739d00d91936a9e6",
+        )
+
+        content_runtime = inventory.dependencies_by_id[
+            "source/atrinik-content-runtime"
+        ]
+        self.assertEqual(content_runtime.scope, ("classic-server", "playtester"))
+        self.assertEqual(
+            content_runtime.checksum,
+            "sha256:f4ad326e20e221869897c72f7e33b533c408ce6654038dbfc4352da1c3391261",
         )
 
         playtester_protocol = inventory.dependencies_by_id[
@@ -258,6 +271,10 @@ class InventoryTests(unittest.TestCase):
         self.assertEqual(playtester_libatrinik.owner, "playtester")
         self.assertEqual(playtester_libatrinik.scope, ("playtester",))
         self.assertEqual(
+            {evidence.path for evidence in playtester_libatrinik.evidence},
+            {"dependencies.lock.json"},
+        )
+        self.assertEqual(
             inventory.dependencies_by_id[
                 "source/atrinik-libatrinik-server"
             ].scope,
@@ -270,6 +287,10 @@ class InventoryTests(unittest.TestCase):
         self.assertIn(
             "playtester",
             inventory.dependencies_by_id["action/actions-setup-node"].scope,
+        )
+        self.assertIn(
+            "playtester",
+            inventory.dependencies_by_id["action/actions-setup-python"].scope,
         )
         self.assertIn(
             "playtester",


### PR DESCRIPTION
Refs #357.

Follows merged atrinik/playtester#23 and records its final `content@main` compatibility inputs in the wrapper-owned supply-chain ledger.

## Summary

- replace Playtester’s retired `content@1.x` source coordinate with `content@main` `v2.14.0@7dde0c0afe8840fc95dd26f404310e77d9c82621` and source SHA-256 `bd5aa9acb8dd17c07e16913cb36c58644f7910f28f47e3b0739d00d91936a9e6`
- extend the existing Classic-runtime record to Playtester using the same immutable SHA-256 `f4ad326e20e221869897c72f7e33b533c408ce6654038dbfc4352da1c3391261`
- cover Playtester’s pinned `actions/setup-python@v7.0.0` use
- move pathfinding evidence from the retired CMake literal to the authoritative compatibility lock
- strengthen inventory tests for the shared main-line source/runtime coordinates and evidence ownership

## Coordinates and terminal ledger contract

- Base/horizon: `main@23eb14ce6d30a065fbf4b5fac384cb8c65e9188c` (tree `712da3b1961a6a05eba8e19a810de5fe25d9d599`)
- Branch: `chore/playtester-inventory`
- Head: `50b3f99ace644da71affe6b76335f6b2438ff939`
- Branch commits: `5df0a80053d54552f6b1dc43acef6eebe145be7a`, `50b3f99ace644da71affe6b76335f6b2438ff939`
- Worktree: `/workspaces/atrinik/workspace/worktrees/atrinik/issue-357-playtester-inventory`
- Declared suffix: exactly one squash merge commit after the horizon
- Exact changed-path allowlist: `supply-chain/inventory.json`, `tests/test_supply_chain.py`

Any intervening/extra commit or any other changed path invalidates the terminal declaration and requires a fresh horizon.

## Verified upstream outcome

- atrinik/playtester#23 merged as `4a5614ad6cefdd15eafc6cd26c5b7c8b8fafa00b`
- merged-tip Validate, CodeQL, and Semantic Release workflows succeeded
- immutable `v1.1.0` tag resolves to `4a5614ad6cefdd15eafc6cd26c5b7c8b8fafa00b`
- atrinik/playtester#2 closed through its intended merged PR reference

## Validation

- 546 complete wrapper unit tests
- 50 focused supply-chain tests
- complete Classic-profile supply-chain audit across 15 repository records: 17,892 version-controlled inputs and 156 action references
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `python3 -W error -m compileall -q atrinik atrinik_workspace tests`
- `git diff --check`; `git show --check HEAD`

## Review

The complete review found and fixed two ledger defects: stale pathfinding evidence still pointed at a removed CMake literal, and shared action/runtime lifecycle descriptions did not name the newly added Playtester consumer. A fresh whole-diff pass at `50b3f99ace644da71affe6b76335f6b2438ff939` found zero remaining actionable findings.

The complete audit uses the isolated profile `issue-357-playtester-ledger`, the reviewed Classic and Playtester worktrees, and `content@main`. It performs no merge, issue closure, release mutation, governance change, cleanup, or content-branch deletion.
