### PR TITLE
fix(build): permit generated Worker type declarations

### DIFF
--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -144,7 +144,7 @@ WORKER_SOURCE_EXCLUSIONS = {
     "worker-runtime.d.ts",
     ".wrangler",
 }
-WORKER_VIEW_NODE_MODULES_EXCLUSIONS = {".vite", ".vite-temp"}
+WORKER_VIEW_NODE_MODULES_EXCLUSIONS = {".mf", ".vite", ".vite-temp"}
 WORKER_NPM_FILE_CONFIG_KEYS = {
     "cafile",
     "certfile",
@@ -5841,7 +5841,11 @@ class Workspace:
             ):
                 raise WorkspaceError("Worker view controls are invalid before checks")
             try:
-                run(["npm", "run", "check"], cwd=view, env=environment)
+                run(
+                    ["npm", "run", "check"],
+                    cwd=view,
+                    env={**environment, "PYTHONDONTWRITEBYTECODE": "1"},
+                )
             finally:
                 try:
                     current_status = view.lstat()

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -138,6 +138,10 @@ WORKER_SOURCE_EXCLUSIONS = {
     "build",
     "dist",
     "node_modules",
+    "publisher-worker-configuration.d.ts",
+    "rendezvous-worker-configuration.d.ts",
+    "worker-configuration.d.ts",
+    "worker-runtime.d.ts",
     ".wrangler",
 }
 WORKER_VIEW_NODE_MODULES_EXCLUSIONS = {".vite", ".vite-temp"}

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2131,6 +2131,10 @@ class WorkspaceTests(unittest.TestCase):
         (first[0] / "node_modules" / ".vite" / "cache").write_text(
             "profile generated\n", encoding="utf-8"
         )
+        (first[0] / "node_modules" / ".mf").mkdir()
+        (first[0] / "node_modules" / ".mf" / "cache").write_text(
+            "profile generated\n", encoding="utf-8"
+        )
         second = self.workspace._worker_view(
             root, source, dependencies, "a" * 64, metadata
         )
@@ -2231,11 +2235,15 @@ class WorkspaceTests(unittest.TestCase):
         view_metadata = reconciled_after_check[0] / ".atrinik-worker-view.json"
 
         def fail_after_corrupting_controls(*args: object, **kwargs: object) -> None:
+            check_environment = kwargs.get("env")
+            assert isinstance(check_environment, dict)
+            self.assertEqual(check_environment.get("PYTHONDONTWRITEBYTECODE"), "1")
             marker.unlink()
             view_metadata.unlink()
             view_metadata.symlink_to(external_metadata)
             raise subprocess.CalledProcessError(1, ["npm", "run", "check"])
 
+        worker_environment: dict[str, str] = {}
         with (
             mock.patch(
                 "atrinik_workspace.workspace.run",
@@ -2244,8 +2252,9 @@ class WorkspaceTests(unittest.TestCase):
             self.assertRaises(subprocess.CalledProcessError),
         ):
             self.workspace._run_worker_checks(
-                reconciled_after_check[0], {}, "a" * 64, metadata
+                reconciled_after_check[0], worker_environment, "a" * 64, metadata
             )
+        self.assertNotIn("PYTHONDONTWRITEBYTECODE", worker_environment)
         self.assertEqual(
             load_json(marker),
             {

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2137,9 +2137,26 @@ class WorkspaceTests(unittest.TestCase):
         self.assertFalse(first[1])
         self.assertTrue(second[1])
         self.assertTrue((second[0] / "src" / "build" / "nested.ts").is_file())
+        generated_type_declarations = (
+            "publisher-worker-configuration.d.ts",
+            "rendezvous-worker-configuration.d.ts",
+            "worker-configuration.d.ts",
+            "worker-runtime.d.ts",
+        )
+        for name in generated_type_declarations:
+            (second[0] / name).write_text("generated\n", encoding="utf-8")
         self.workspace._reconcile_worker_view_after_checks(
             source, second[0], "a" * 64, metadata
         )
+        for name in generated_type_declarations:
+            self.assertTrue((second[0] / name).is_file())
+        nested_generated_type = second[0] / "src" / "worker-runtime.d.ts"
+        nested_generated_type.write_text("unexpected\n", encoding="utf-8")
+        with self.assertRaisesRegex(WorkspaceError, "source changed"):
+            self.workspace._reconcile_worker_view_after_checks(
+                source, second[0], "a" * 64, metadata
+            )
+        nested_generated_type.unlink()
         unexpected_dependency_output = second[0] / "node_modules" / "alpha" / "changed"
         unexpected_dependency_output.write_text("changed\n", encoding="utf-8")
         with self.assertRaisesRegex(WorkspaceError, "does not match cache metadata"):


### PR DESCRIPTION
## Summary

- exclude the four deterministic root type declarations generated by the metaserver-worker's normal check command from Worker source/view digests
- prevent Python admin checks from writing bytecode into the isolated source view and recognize Miniflare's root `.mf` cache alongside existing Vite dependency caches
- keep exclusions root-only so matching names nested in authored source still fail the integrity guard
- cover successful root reconciliation and nested-mutation rejection in the Worker view lifecycle regression

## Validation

- `python3 -m unittest -v tests.test_workspace.WorkspaceTests.test_worker_view_reuses_application_and_isolates_dependencies`
- `python3 -m unittest discover -v` — 546 tests passed
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `git diff --check`
- exact-tip `./atrinik build all --profile classic --test` — 107 CTest, 487 Worker, 61 admin, and 2 service-binding tests passed; all three Worker deploy dry-runs passed; post-check integrity reconciliation passed

## Program context

This is the first of the two predeclared terminal wrapper suffix commits for https://github.com/atrinik/atrinik/issues/357. The required exact-tip Classic aggregate build had already passed all 107 native CTest cases, 487 Worker tests, 61 Worker admin tests, two service-binding tests, and all deployment dry-runs before the wrapper rejected these expected generated declarations.

Closes #368
