### PR TITLE
chore(supply-chain): reconcile libpcpnatpmp evidence

### DIFF
--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -3024,7 +3024,7 @@
       ],
       "required": true,
       "version": "866d283da99f5e98eecff702a8df63e2ae57ffca",
-      "version_source": "classic/server/cmake/pcpnatpmp.cmake",
+      "version_source": "classic/server/cmake/immutable_sources.lock.json",
       "license": "BSD-3-Clause",
       "source_url": "https://github.com/libpcpnatpmp/libpcpnatpmp",
       "locator": "pkg:github/libpcpnatpmp/libpcpnatpmp@866d283da99f5e98eecff702a8df63e2ae57ffca",
@@ -3040,8 +3040,18 @@
       "evidence": [
         {
           "repository": "classic-server",
-          "path": "cmake/pcpnatpmp.cmake",
+          "path": "cmake/immutable_source_cache.cmake",
+          "contains": "atrinik_extract_immutable_source"
+        },
+        {
+          "repository": "classic-server",
+          "path": "cmake/immutable_sources.lock.json",
           "contains": "866d283da99f5e98eecff702a8df63e2ae57ffca"
+        },
+        {
+          "repository": "classic-server",
+          "path": "cmake/pcpnatpmp.cmake",
+          "contains": "immutable_sources.lock.json"
         }
       ]
     },


### PR DESCRIPTION
## Summary

- repoint the existing libpcpnatpmp ledger entry from the retired CMake literal to Classic's authoritative immutable source lock
- preserve the unchanged commit, archive checksum, PURL, license, scope, and disposition
- record evidence for the source lock, shared immutable extraction helper, and consuming CMake module

## Program context

This is the second and final commit in the terminal wrapper suffix predeclared for #357. Its exact parent is the verified squash merge of #369:

- declared horizon: `d7b5920ed2032146bb790a73aacee8408acc040a`
- first suffix merge: `d055cc837d04a28c9025a27233006ea458a32532`
- this reviewed head: `7c36f5389642104c84f88971bca6564dd5c634da`
- exact path allowlist: `supply-chain/inventory.json`

Classic #215 moved libpcpnatpmp's immutable URL, commit, and archive/tree digests into `server/cmake/immutable_sources.lock.json`. The wrapper's complete profile audit correctly failed closed while its ledger still cited the retired commit literal in `pcpnatpmp.cmake`.

## Validation

- `python3 -m unittest -v tests.test_supply_chain` — 50 tests passed
- `python3 -m unittest discover -v` — 546 tests passed at the committed head
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `./atrinik supply-chain audit --profile classic` — 15 repositories, 17,901 version-controlled inputs, and 156 action references audited
- `git diff --check`
- fresh complete whole-diff review — zero known actionable findings

## Delivery coordinates

- base: `main@d055cc837d04a28c9025a27233006ea458a32532`
- branch: `chore/357-classic-source-evidence`
- worktree: `/workspaces/atrinik/workspace/worktrees/atrinik/issue-357-classic-source-evidence`
- commit: `7c36f5389642104c84f88971bca6564dd5c634da`

Refs #357
