### PR TITLE
docs(provenance): clarify approved Classic reuse

### DIFF
--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -137,9 +137,9 @@ operations.
   changes require `supply-chain/inventory.json` and a
   complete-profile audit; overrides stay mandatory and only aggregate roots own
   workflows/Dependabot.
-- Apply historical MIT grants only under
-  [`docs/PROVENANCE.md`](../../../docs/PROVENANCE.md); fail closed and record
-  complete evidence in the destination.
+- Follow [`docs/PROVENANCE.md`](../../../docs/PROVENANCE.md) for grant-proven
+  Classic source reference, copy, migration/port, translation/adaptation, or
+  MIT relicensing. Fail temporal, authorship, or separability uncertainty closed.
 
 ## Maintain guidance
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,8 @@
 - Unbound persisted records are historical and inert.
 - On touch, refresh existing Atrinik-owned copyright terminal years and blanket
   holders per `CONTRIBUTING.md`; preserve precise attribution.
-- MIT reuse follows `docs/PROVENANCE.md`; incomplete evidence fails
-  closed. Cite its registry revision.
+- MIT reuse follows `docs/PROVENANCE.md`; temporal, sole-authorship, and
+  separability uncertainty fails closed. Cite its registry revision.
 - Update `supply-chain/inventory.json` when dependency ownership or validation
   changes. Keep Actions/images immutable, add no submodules, and audit a
   complete profile. Only aggregate-root workflows and Dependabot are active.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,17 @@ foundations; their wrapper build/runtime adapters and integrated service
 closure have not landed, so current game integration uses a profile created
 from `classic`.
 
+Runtime cohort and Classic maintenance boundaries do not impose a blanket
+clean-room rule. Under [`docs/PROVENANCE.md`](docs/PROVENANCE.md), exact,
+independently separable Classic material proven to fall within an applicable
+approved historical grant—including that row's temporal and
+sole-original-authorship scope—may be inspected as source reference, copied,
+migrated or ported, translated or adapted, and MIT-relicensed after the required
+audit and
+destination record. Later material needs contemporaneous compatible permission.
+The Classic source and notices stay GPL; this does not approve a GPL dependency
+or bundle, and any contribution needing permission but lacking it is excluded.
+
 For a pre-split workspace, initialize only the destination with
 `./atrinik init classic`, run `./atrinik migrate repositories --dry-run`
 before apply, and finish with `--audit`. The checked migration combines proven

--- a/README.md
+++ b/README.md
@@ -196,10 +196,17 @@ machine record maps every fresh repository to its local CI, provenance,
 dependency, notices, packaging, SBOM, and mixed-license gates without making
 this coordinator a second copy of their implementation policy.
 
-Historical reuse fails closed unless the canonical contract proves complete
-history, sole original authorship, identity, separability, and third-party
-review. Destination evidence cites the exact wrapper revision containing the
-registry used.
+The Classic repository remains GPL-2.0-or-later, but that is not a blanket
+source-reuse ban. Exact, independently separable material proven to fall within
+an applicable approved historical grant—including that row's temporal and
+sole-original-authorship scope—may be inspected as implementation reference,
+copied, migrated or ported, translated or adapted, and MIT-relicensed after the
+canonical complete-history, identity, separability, embedded-material, and
+destination-record review. Source-informed work from qualifying material is
+provenance-approved reuse, not clean-room work. Later material needs
+contemporaneous compatible permission. The source license and unrelated
+dependencies, assets, and surrounding work do not change; destination evidence
+cites the exact wrapper revision containing the registry used.
 
 The GPL classic utilities and their user-facing replacement/retirement paths
 are inventoried in

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,10 +67,16 @@ input.
 
 Source provenance is also a cross-repository contract.
 [`PROVENANCE.md`](PROVENANCE.md) is the single exhaustive historical MIT
-grantor registry and evidence procedure. Reuse fails closed unless complete,
-rename-aware history proves sole original authorship and identity, separates
-eligible material, excludes conflicting embedded work, and records the exact
-source, destination, transformation, review, and wrapper registry revision.
+grantor registry and evidence procedure. Exact independently separable Classic
+material proven to fall within an applicable approved historical grant,
+including its temporal and sole-original-authorship scope, may be inspected as
+source reference, copied, migrated or ported, translated or adapted, and
+MIT-relicensed; this provenance-approved reuse does not require clean-room
+isolation. Complete, rename-aware history must prove authorship and identity,
+separate eligible material, exclude conflicting embedded work, and record the
+exact source, destination, transformation, review, and registry revision. The
+Classic source remains GPL as distributed; later or uncovered contributions,
+dependencies, assets, and surrounding work receive no permission by association.
 
 The `supply-chain` command resolves component inputs through the same profile
 selectors as builds, then reads Git-indexed files without mutating a checkout.

--- a/docs/CLASSIC_TOOLS_MIGRATION.md
+++ b/docs/CLASSIC_TOOLS_MIGRATION.md
@@ -26,12 +26,16 @@ direct supervision and steering. Zoey directs its MIT distribution and grants
 under MIT any rights she holds in that code, so its destination owner is
 `atrinik/playtester`. That direction does not relicense the separately fetched
 GPL libatrinik source or any combined binary; those obligations remain explicit
-in the supply-chain inventory. Other replacement owners may use behavior and
-fixtures as public compatibility evidence, but may not translate mixed GPL
-implementation. A provenance grant is considered only after the full root
-process in
-[`REPLACEMENT_FOUNDATIONS.md`](REPLACEMENT_FOUNDATIONS.md) proves a separable
-candidate.
+in the supply-chain inventory. Replacement owners may use documented observable
+behavior as compatibility evidence. Existing fixtures may be copied only when
+their license is compatible with the intended destination or an exact grant
+record permits it; otherwise create synthetic or black-box fixtures without
+translating GPL implementation. Exact, independently separable implementation
+proven to fall within an applicable
+approved historical grant may be inspected as source reference, copied,
+migrated or ported, translated or adapted, or MIT-relicensed when the full root
+process in [`REPLACEMENT_FOUNDATIONS.md`](REPLACEMENT_FOUNDATIONS.md) passes.
+Later or uncovered implementation remains excluded.
 
 The final tools support gate is zero unowned entry points, passing replacement
 parity/safety fixtures, migrated user documentation, and preservation of the

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -9,17 +9,42 @@ repository, file, or current-blame region.
 | Zoey Rose | All original past Atrinik contributions solely authored by Zoey Rose | Copy, migrate, translate, or relicense | MIT |
 | Daniel Liptrot | All original past Atrinik contributions solely authored by Daniel Liptrot | Copy, migrate, translate, or relicense | MIT |
 
+These are affirmative permissions for the exact material they cover. The
+checked-in `atrinik/classic` distribution and notices remain
+GPL-2.0-or-later, but that repository license is not a blanket prohibition on
+MIT reuse. Qualifying, independently separable material may be inspected and
+used as implementation reference, copied, migrated or ported, translated or
+adapted, and relicensed for an MIT destination. A source-informed
+implementation derived only from qualifying material is provenance-approved
+reuse; clean-room isolation is not required. Only the exact proven selected
+material receives additional MIT permission in the recorded destination; no
+surrounding file, dependency, asset, subtree, binary, or repository is
+relicensed.
+
+“Past” is temporal: each row covers only contributions completed before that
+row was recorded. Zoey Rose's row was first recorded in
+`d2af1c9fba462e5c18782d3c8206dbc5cfd74bb0`; Daniel Liptrot's row was first
+recorded in `d64a8e958ca2adad783ad8912493d468a805f3fd`. A row is not a
+prospective grant for later human- or agent-assisted work. Later material needs
+its own contemporaneous compatible license or grant.
+
 Before applying a grant:
 
 1. Follow renames and moves through complete, non-shallow Git history for the
    exact source repository, path, and revision or revision range.
-2. Prove that the selected material is the named grantor's original work and
-   that the grantor solely authored it. Verify historical author identities;
-   current blame alone is not proof.
+2. Prove that each selected contribution is the applicable named grantor's
+   original work, that the grantor solely authored it, and that it falls within
+   the row's temporal scope. Verify historical author identities; current blame
+   alone is not proof.
 3. Review every relevant change and the material itself for copied, generated,
    vendored, embedded third-party, or conflicting-licensed work. Fail closed on
-   any history gap, unresolved identity, mixed authorship, or uncertain origin.
-4. Reuse only independently separable material covered by the proof. Do not
+   any history gap, unresolved identity, uncovered authorship, or uncertain
+   origin.
+4. Reuse only independently separable material wholly covered by the proof.
+   Multiple rows may appear in one destination record only for distinct
+   contributions that each independently satisfy one row's temporal and
+   sole-original-authorship scope. Rows cannot be combined to cover a jointly
+   authored contribution, generated output, or inseparable mixed work. Do not
    copy a mixed-authorship file merely because some surviving lines qualify.
 5. Record the source repository/path/revision, destination repository/path,
    complete history and identity evidence, transformation, third-party review,
@@ -27,5 +52,26 @@ Before applying a grant:
    request or a committed provenance manifest. Cite the exact
    `atrinik/atrinik` revision containing this registry as the grant evidence.
 
-Independent implementation from documented behavior remains the default when
-reuse cannot be proven.
+Use of an agent or other tool neither proves nor defeats permission to reuse
+the exact material. A listed person's prompting, direction, selection, receipt
+of output, or Git identity does not by itself place agent-generated output
+within a row covering past contributions solely authored by that person. The
+record must establish independently documented rights sufficient for the
+intended destination for the exact output and every human or third-party input,
+plus any applicable contemporaneous license or grant.
+
+Third-party or separately licensed portions are not relicensed by these
+historical grants. They may be included only under their own compatible terms
+and required notices. If a destination must be solely MIT, exclude them unless
+separate permission expressly authorizes MIT relicensing. Likewise, admitting
+exact material for source reference, copying, porting, translation, adaptation,
+or relicensing does not approve linking to, depending on, or bundling the GPL
+Classic repository, library, or binary; dependency, package, and distribution
+obligations remain separately governed.
+
+Tests, fixtures, generated bindings, assets, and dependency code receive no
+presumption of coverage. Each requires the same exact rights review plus the
+destination repository's manifests, notices, and supply-chain treatment.
+
+Independent implementation from documented observable behavior remains an
+available path and is the default when qualifying reuse cannot be proven.

--- a/docs/REPLACEMENT_FOUNDATIONS.md
+++ b/docs/REPLACEMENT_FOUNDATIONS.md
@@ -6,16 +6,27 @@ It maps every fresh replacement repository to its M1 issues, merged proof pull
 requests, stable aggregate check, contribution/provenance guidance, dependency
 policy, notices, package/SBOM contract, and mixed-license boundary.
 
-The repositories do not inherit permission to reuse classic code. New MIT work
-is the default. [`PROVENANCE.md`](PROVENANCE.md) is the current exhaustive grant
-registry. Existing reproducible decisions retain the exact historical registry
-path and revision they used; new decisions cite the merged wrapper revision
-containing this file. A grant remains usable only after a complete,
-non-shallow, rename-aware history audit proves the named grantor's sole original
-authorship. The review must also verify identity, embedded third-party material,
-exact source/destination paths, transformation, copyright, grant, and reviewer.
-Mixed or uncertain candidates are excluded; current blame, committer identity,
-or a repository-level ownership inference is never enough.
+The repositories do not automatically inherit permission to reuse arbitrary
+Classic code. [`PROVENANCE.md`](PROVENANCE.md) is the current exhaustive grant
+registry and expressly permits qualifying material to be used as source
+reference, copied, migrated or ported, translated or adapted, and relicensed
+for an MIT destination. That provenance-approved path is not clean-room work.
+Independent implementation is the default only when exact grant coverage
+cannot be proven. Qualifying means that an independently separable contribution
+falls within one row's temporal and sole-original-authorship scope. Later work
+requires contemporaneous compatible permission; multiple rows cannot be
+combined to cover joint authorship, generated output, or an inseparable work.
+
+Existing reproducible decisions retain the exact historical registry path and
+revision they used; new decisions cite the merged wrapper revision containing
+this file. A grant remains usable only after a complete, non-shallow,
+rename-aware history audit proves the applicable grantor's sole original
+authorship and temporal scope. The review must also verify identity,
+separability, embedded third-party material, exact source/destination paths,
+transformation, copyright, grant, and reviewer. Current blame, committer
+identity, agent direction, or a repository-level ownership inference is never
+enough. The Classic source repository remains under its existing license;
+grant-qualified source reuse does not approve GPL dependencies or bundles.
 
 ## Reproducible decisions
 
@@ -28,6 +39,10 @@ attribution, and the pinned root grant. From a complete content checkout, run:
 ```sh
 tools/audit-provenance.sh --source /absolute/non-shallow/content/checkout
 ```
+
+This historical decision remains governed by its pinned registry revision and
+evidence contract. It is not a substitute for the current review requirements
+when recording a new reuse decision.
 
 The excluded example is
 `atrinik/content-toolkit:provenance/reuse.json#remaining-content-tools`. The
@@ -44,8 +59,10 @@ For future reuse:
 3. Follow every candidate path through renames and moves; record immutable
    revisions and blob IDs, every author/committer identity, and independent
    GitHub identity evidence.
-4. Separate only material whose sole original authorship and embedded licenses
-   are proven. Exclude everything else.
+4. Separate only material whose original authorship, temporal scope, and exact
+   reuse permission are proven. Separately licensed portions retain their own
+   terms and notices and cannot be described as MIT-relicensed unless their
+   permission expressly allows it. Exclude everything else.
 5. Record every field listed in `required_record_fields`, pin the exact root
    grant-registry revision, and add a reproducible checker before importing.
 6. Keep dependency allowlists, lockfiles, third-party notices, fixture/asset

--- a/governance/classic-tools.json
+++ b/governance/classic-tools.json
@@ -45,7 +45,7 @@
       "owner_milestone": "M4 — Shared editor and scalable presentation",
       "disposition": "replace",
       "replacement_command": "Future bounded import/conversion commands owned by atrinik/editor#11.",
-      "licensing_method": "Clean-room reimplementation from documented input/output fixtures; do not copy GPL converter source without a separately proven grant record.",
+      "licensing_method": "Independent reimplementation from synthetic or independently licensed input/output fixtures; any GPL source reuse requires the canonical exact-grant process.",
       "safety": "Parse untrusted authored data with bounded sizes and write only through editor safe-filesystem transactions.",
       "verification": "Compile gridarta-types-convert.c with strict warnings and compare synthetic conversion fixtures in atrinik/editor#11."
     },
@@ -62,7 +62,7 @@
       "owner_milestone": "M4 — Shared editor and scalable presentation",
       "disposition": "replace",
       "replacement_command": "atrinik-content check (planned by atrinik/content-toolkit#8); native UI integration belongs to atrinik/editor#11.",
-      "licensing_method": "Retain GPL checker for classic use; port only independently specified diagnostics and parity fixtures into clean-room MIT owners.",
+      "licensing_method": "Retain the GPL checker for classic use; the current replacement disposition is independent implementation from specified diagnostics and synthetic parity fixtures. Any source reuse requires the canonical exact-grant process.",
       "safety": "Retain checksum, traversal, link, size, atomic-install, and import-origin checks; keep CLI validation display-independent.",
       "verification": "python3 -m unittest discover -s map-checker-qt/tests -v && python3 map-checker-qt/dependencies.py verify"
     },
@@ -79,7 +79,7 @@
       "owner_milestone": "M4 — Shared editor and scalable presentation",
       "disposition": "retire",
       "replacement_command": "Use the maintained map-checker-qt command until atrinik-content check reaches parity.",
-      "licensing_method": "Preserve GPL history only; no source migration.",
+      "licensing_method": "Preserve GPL history only; no source migration is approved by this retirement disposition.",
       "safety": "Do not reinstall unsupported Python 2/PyGTK or process untrusted maps with this command.",
       "verification": "Confirm every retained diagnostic has a map-checker-qt or atrinik-content parity fixture before removal."
     },
@@ -113,7 +113,7 @@
       "owner_milestone": "M4 — Shared editor and scalable presentation",
       "disposition": "replace",
       "replacement_command": "Future atrinik-content batch/query subcommands from atrinik/content-toolkit#8.",
-      "licensing_method": "Clean-room implementation from explicit operation fixtures; preserve GPL source only in tools.",
+      "licensing_method": "The current replacement disposition is independent implementation from synthetic operation fixtures; preserve GPL source only in tools.",
       "safety": "Require bounded traversal, source-root confinement, dry-run plans, atomic writes, and lossless round trips.",
       "verification": "Run new batch operations against synthetic maps and compare dry-run/edit plans without copying legacy source."
     },
@@ -147,7 +147,7 @@
       "owner_milestone": "M6 — Production hardening and cutover",
       "disposition": "retain-classic",
       "replacement_command": "Use platform-native Go/Rust crash and symbol packaging in each replacement owner; these commands remain classic-only until final classic retirement.",
-      "licensing_method": "Keep GPL scripts in tools; do not copy them into MIT repositories.",
+      "licensing_method": "Keep GPL scripts in tools; no source copy into an MIT repository is currently approved. Any future reuse proposal requires the canonical exact-grant process.",
       "safety": "Operate only on explicit build artifacts, preserve originals until verification, avoid shell-expanded broad paths, and redact sensitive paths from published traces.",
       "verification": "Run against disposable classic release artifacts and verify build IDs, debug links, symbol lookup, and unchanged runtime behavior."
     },
@@ -164,7 +164,7 @@
       "owner_milestone": "M6 — Production hardening and cutover",
       "disposition": "replace",
       "replacement_command": "Use deterministic renderer-owned world imagery and projection metadata from atrinik/renderer#13.",
-      "licensing_method": "Keep the GPL PHP implementation in tools and build a clean-room renderer and consumer; no parser/render source migration.",
+      "licensing_method": "Keep the GPL PHP implementation in tools; the current disposition is an independent renderer and consumer, with no parser/render source migration approved.",
       "safety": "Do not expose the legacy PHP server; bound map traversal and image dimensions; publish only reviewed content/resource licenses.",
       "verification": "Renderer projection fixtures must cover coordinates, labels, bounds, deterministic hashes, and chunk seams before retirement."
     }

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -27,9 +27,23 @@ LINK = re.compile(r"\[[^]]+\]\(([^)]+)\)")
 
 class AgentGuidanceTests(unittest.TestCase):
     def test_current_provenance_registry_is_complete(self) -> None:
-        registry = (ROOT / "docs/PROVENANCE.md").read_text(encoding="utf-8")
+        registry = " ".join(
+            (ROOT / "docs/PROVENANCE.md").read_text(encoding="utf-8").split()
+        )
         self.assertIn("Zoey Rose", registry)
         self.assertIn("Daniel Liptrot", registry)
+        for marker in {
+            "affirmative permissions",
+            "used as implementation reference",
+            "clean-room isolation is not required",
+            "original past Atrinik contributions",
+            "not a prospective grant",
+            "cannot be combined to cover a jointly authored contribution",
+            "not relicensed by these historical grants",
+            "does not by itself place agent-generated output",
+        }:
+            with self.subTest(marker=marker):
+                self.assertIn(marker, registry)
 
     def test_copyright_header_contract_is_complete(self) -> None:
         guide = " ".join(


### PR DESCRIPTION
## Summary

- document the Zoey Rose and Daniel Liptrot historical grants as affirmative permission for exact, independently separable Classic material
- preserve each grant row's past-contribution, sole-authorship, and per-contribution evidence boundaries
- distinguish recorded MIT destination reuse from the unchanged GPL Classic distribution and from GPL dependency or bundling approval
- synchronize workspace guidance, migration policy, machine inventory wording, and regression coverage

## Validation

- `/workspaces/atrinik/.venv/bin/python -m coverage run -m unittest discover -v` (546 tests passed)
- `/workspaces/atrinik/.venv/bin/python -m coverage report --show-missing` (82% total)
- `/workspaces/atrinik/.venv/bin/python -m compileall -q atrinik atrinik_workspace tests`
- `/workspaces/atrinik/.venv/bin/python -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `git diff --check`
