### PR TITLE
fix(build): remove immutable managed cache trees

### DIFF
--- a/atrinik_workspace/model.py
+++ b/atrinik_workspace/model.py
@@ -7,7 +7,6 @@ import json
 import os
 from pathlib import Path, PurePosixPath
 import re
-import shutil
 import stat
 import tempfile
 import time
@@ -1215,7 +1214,13 @@ def managed_reset(path: Path, workspace_builds: Path, purpose: str) -> None:
         metadata = load_json(marker)
         if metadata != {"schema_version": SCHEMA_VERSION, "purpose": purpose}:
             raise WorkspaceError(f"managed build marker does not match {purpose}: {path}")
-        shutil.rmtree(path)
+        # Import lazily to preserve the model/CLI boundary: workspace imports
+        # this module, while completion must not import the heavyweight
+        # workspace implementation. The owned-tree remover safely makes
+        # immutable generated directories writable before deleting them.
+        from .workspace import remove_owned_tree
+
+        remove_owned_tree(path)
     path.mkdir(parents=True)
     atomic_json(marker, {"schema_version": SCHEMA_VERSION, "purpose": purpose})
 
@@ -1248,7 +1253,9 @@ def managed_remove(path: Path, workspace_builds: Path, purpose: str) -> None:
     metadata = load_json(marker)
     if metadata != {"schema_version": SCHEMA_VERSION, "purpose": purpose}:
         raise WorkspaceError(f"managed build marker does not match {purpose}: {path}")
-    shutil.rmtree(path)
+    from .workspace import remove_owned_tree
+
+    remove_owned_tree(path)
 
 
 def profile_key(paths: dict[str, Path], *, namespace: str = "") -> str:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -693,6 +693,29 @@ class PathSafetyTests(unittest.TestCase):
 
             self.assertTrue(real.is_dir())
 
+    def test_managed_reset_replaces_read_only_generated_subtree(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            builds = Path(temporary) / "build"
+            target = builds / "profile"
+            managed_directory(target, builds, "test")
+            cache = target / "dependency-cache" / "source"
+            cache.mkdir(parents=True)
+            archive = cache / "archive.tar.gz"
+            archive.write_text("immutable\n", encoding="utf-8")
+            archive.chmod(0o444)
+            cache.chmod(0o555)
+
+            managed_reset(target, builds, "test")
+
+            self.assertTrue(target.is_dir())
+            self.assertFalse((target / "dependency-cache").exists())
+            self.assertEqual(
+                json.loads(
+                    (target / ".atrinik-workspace-managed.json").read_text()
+                ),
+                {"purpose": "test", "schema_version": 1},
+            )
+
     def test_managed_remove_revalidates_marker_purpose_and_containment(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -713,6 +736,22 @@ class PathSafetyTests(unittest.TestCase):
             with self.assertRaisesRegex(WorkspaceError, "outside workspace builds"):
                 managed_remove(outside, builds, "outside")
             self.assertTrue(outside.is_dir())
+
+    def test_managed_remove_deletes_read_only_generated_subtree(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            builds = Path(temporary) / "build"
+            target = builds / "profiles" / "review"
+            managed_directory(target, builds, "profile:review:key")
+            cache = target / "dependency-cache" / "source"
+            cache.mkdir(parents=True)
+            archive = cache / "archive.tar.gz"
+            archive.write_text("immutable\n", encoding="utf-8")
+            archive.chmod(0o444)
+            cache.chmod(0o555)
+
+            managed_remove(target, builds, "profile:review:key")
+
+            self.assertFalse(target.exists())
 
     def test_managed_remove_rejects_a_symlinked_build_container(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Summary

- remove owned build trees through the permission-aware workspace cleanup helper
- preserve marker, purpose, and containment validation before deletion
- cover reset and removal of read-only generated cache subtrees

## Context

This was discovered while validating classic client builds: immutable dependency-cache files could make managed reset or removal fail with a permission error.

## Validation

- `python3 -m unittest discover -v` (548 tests)
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `git diff --check`