### PR TITLE
feat(scenario): expose lighting review presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,7 +834,14 @@ Reset refuses a running or otherwise locked state and validates the ownership
 marker, state registration, state shape, and credential permissions before it
 replaces anything. External and shared states are never scenario reset targets.
 Do not create static account or player fixtures; add a tested server-owned
-preset if a future reproduction needs more than `basic-player`.
+preset if a future reproduction needs more than `basic-player`. The Classic
+server also owns `lighting-radiance-day`, `lighting-radiance-dawn`, and
+`lighting-radiance-night`: each places an unapplied mithril lamp in a character
+at the Greyton lighting-review map and initializes the isolated world clock to
+the named period. `lighting-radiance-inside` places the character beside the
+same map's interior fireplace at night so ownership-gated roof and interior
+rendering can be reviewed. These presets are reserved for repeatable renderer
+reviews whose ordinary world progression would dominate the test.
 
 ## Supervised topologies and practical workflows
 

--- a/atrinik_workspace/completion.py
+++ b/atrinik_workspace/completion.py
@@ -34,6 +34,15 @@ _SCENARIO_KEYS = {
     "resolved",
     "provisioned_at",
 }
+_SCENARIO_PRESETS = frozenset(
+    {
+        "basic-player",
+        "lighting-radiance-day",
+        "lighting-radiance-dawn",
+        "lighting-radiance-night",
+        "lighting-radiance-inside",
+    }
+)
 
 
 def mark(action: argparse.Action, kind: str) -> argparse.Action:
@@ -589,7 +598,7 @@ def _valid_scenario(
         or value.get("name") != name
         or value.get("stack") != stack_name
         or value.get("state") != state_name
-        or value.get("preset") != "basic-player"
+        or value.get("preset") not in _SCENARIO_PRESETS
         or any(
             not isinstance(value.get(field), str) or not value[field]
             for field in ("account", "character", "archetype", "provisioned_at")

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -121,7 +121,13 @@ SCENARIO_KEYS = {
     "provisioned_at",
 }
 SCENARIO_SCHEMA_VERSION = 4
-SCENARIO_PRESETS = {"basic-player": {"archetype": "human_male"}}
+SCENARIO_PRESETS = {
+    "basic-player": {"archetype": "human_male"},
+    "lighting-radiance-day": {"archetype": "human_male"},
+    "lighting-radiance-dawn": {"archetype": "human_male"},
+    "lighting-radiance-night": {"archetype": "human_male"},
+    "lighting-radiance-inside": {"archetype": "human_male"},
+}
 SCENARIO_PASSWORD_MAX_SIZE = 128
 BUILD_METADATA = ".atrinik-build.json"
 BUILD_METADATA_SCHEMA_VERSION = 2
@@ -6133,18 +6139,19 @@ class Workspace:
                 root, selected, state, metadata["state"]
             )
             executable = runtime / "atrinik-server"
-            run(
-                [
-                    str(executable),
-                    "--provision_scenario",
-                    f"--provision_account={metadata['account']}",
-                    f"--provision_character={metadata['character']}",
-                    f"--provision_archetype={metadata['archetype']}",
-                    f"--provision_password_file={password_file}",
-                    f"--assetspath={runtime / 'assets'}",
-                ],
-                cwd=runtime,
-            )
+            arguments = [
+                str(executable),
+                "--provision_scenario",
+                f"--provision_account={metadata['account']}",
+                f"--provision_character={metadata['character']}",
+                f"--provision_archetype={metadata['archetype']}",
+                f"--provision_password_file={password_file}",
+                f"--assetspath={runtime / 'assets'}",
+            ]
+            preset = metadata.get("preset", "basic-player")
+            if preset != "basic-player":
+                arguments.append(f"--provision_preset={preset}")
+            run(arguments, cwd=runtime)
         profile = self._load_profile(metadata["profile"], require_file=False)
         stack = self.manifest.stack(profile["stack"])
         audited = {role: selected[role] for role in required}

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7221,6 +7221,7 @@ class WorkspaceTests(unittest.TestCase):
             if "--provision_scenario" not in arguments:
                 return workspace_run(arguments, cwd=cwd, **kwargs)
             assert cwd is not None
+            self.assertIn("--provision_preset=lighting-radiance-day", arguments)
             assetspath = Path(
                 next(
                     argument.split("=", 1)[1]
@@ -7252,7 +7253,7 @@ class WorkspaceTests(unittest.TestCase):
             mock.patch("atrinik_workspace.workspace.run", side_effect=provision),
         ):
             created = self.workspace.scenario_create(
-                "fresh-assets", "default", "basic-player"
+                "fresh-assets", "default", "lighting-radiance-day"
             )
             self.assertEqual(
                 self.workspace.scenario_show("fresh-assets")["state"],


### PR DESCRIPTION
## Summary

- expose the four Classic lighting review presets through workspace scenarios
- forward non-default presets to server-owned provisioning while retaining `basic-player` compatibility
- accept the presets in completion records and document their deterministic review states
- cover preset forwarding with fresh staged assets

## Context

This completes the workspace side of the deterministic lighting scenarios introduced by [atrinik/classic#181](https://github.com/atrinik/classic/pull/181).

## Validation

- `python3 -m unittest discover -v` (546 tests)
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `git diff --check`