### PR TITLE
chore(agents): raise global skill byte budget

### DIFF
--- a/atrinik_workspace/guidance_inventory.py
+++ b/atrinik_workspace/guidance_inventory.py
@@ -16,10 +16,7 @@ MAX_ROOT_GUIDE_BYTES = 6_000
 MAX_CATALOG_BYTES = 2_000
 MAX_STARTUP_BYTES = 8_000
 MAX_MULTI_SELECTED_BYTES = 14_500
-# The tenth skill adds explicit program delivery while large review contracts
-# stay progressively disclosed. The measured PR stack total is 37,378 bytes;
-# 37,500 is the smallest 250-byte ceiling retaining a strict guard.
-MAX_ALL_SKILL_BYTES = 37_500
+MAX_ALL_SKILL_BYTES = 50_000
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary

- raise the aggregate skill byte ceiling from 37,500 to 50,000
- remove the stale leading explanation tied to the previous measured ceiling

## Validation

- `python3 -m unittest discover -v` (546 tests)
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `git diff --check`