### PR TITLE
chore(supply-chain): record Classic dependency bundle

### DIFF
--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -1294,13 +1294,13 @@
         "classic-server"
       ],
       "required": true,
-      "version": "materials-228d176282049daa32c82a568d2fa60eb80d03e560cd920a1c6ef37ff61db816",
+      "version": "materials-38c0eebad746c7af0f3fdc8a11c1e6a829b44eafd23e4e48faf797cbba4de85a",
       "version_source": "Classic dependencies.bundle.json material digest",
       "license": "LicenseRef-Atrinik-Image-Contents",
       "source_url": "https://github.com/atrinik/classic/pkgs/container/classic-dependencies",
-      "locator": "ghcr.io/atrinik/classic-dependencies@sha256:c6524604f0613cd9d0612befae18bea9a6155612e650fbf3d2cccb67051d031e",
+      "locator": "ghcr.io/atrinik/classic-dependencies@sha256:56d80341bfdec0fe1c2d9b297a3099b67af9b99d17c7c4fc120d1b63d440dae7",
       "commit": null,
-      "checksum": "sha256:c6524604f0613cd9d0612befae18bea9a6155612e650fbf3d2cccb67051d031e",
+      "checksum": "sha256:56d80341bfdec0fe1c2d9b297a3099b67af9b99d17c7c4fc120d1b63d440dae7",
       "acquisition": "A trusted current-main workflow builds the deterministic OCI layout through the authoritative Classic fetcher and publishes its exact manifest digest",
       "update_cadence_days": 30,
       "update_mechanism": "Reviewed Classic lock or acquisition-contract update with a regenerated material and OCI descriptor",
@@ -1317,7 +1317,7 @@
         {
           "repository": "classic",
           "path": "dependencies.bundle.json",
-          "contains": "sha256:c6524604f0613cd9d0612befae18bea9a6155612e650fbf3d2cccb67051d031e"
+          "contains": "sha256:56d80341bfdec0fe1c2d9b297a3099b67af9b99d17c7c4fc120d1b63d440dae7"
         },
         {
           "repository": "classic",

--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -1284,6 +1284,49 @@
       ]
     },
     {
+      "id": "container/classic-dependencies",
+      "name": "Atrinik Classic durable dependency bundle",
+      "kind": "container-image",
+      "owner": "classic-server",
+      "scope": [
+        "classic",
+        "classic-client",
+        "classic-server"
+      ],
+      "required": true,
+      "version": "materials-228d176282049daa32c82a568d2fa60eb80d03e560cd920a1c6ef37ff61db816",
+      "version_source": "Classic dependencies.bundle.json material digest",
+      "license": "LicenseRef-Atrinik-Image-Contents",
+      "source_url": "https://github.com/atrinik/classic/pkgs/container/classic-dependencies",
+      "locator": "ghcr.io/atrinik/classic-dependencies@sha256:c6524604f0613cd9d0612befae18bea9a6155612e650fbf3d2cccb67051d031e",
+      "commit": null,
+      "checksum": "sha256:c6524604f0613cd9d0612befae18bea9a6155612e650fbf3d2cccb67051d031e",
+      "acquisition": "A trusted current-main workflow builds the deterministic OCI layout through the authoritative Classic fetcher and publishes its exact manifest digest",
+      "update_cadence_days": 30,
+      "update_mechanism": "Reviewed Classic lock or acquisition-contract update with a regenerated material and OCI descriptor",
+      "eol_response": "Retain every digest referenced by a supported release; publish and pin a verified replacement before retiring a bundle",
+      "validation": "Outer OCI digest, closed manifest, provenance, source-lock/material digests, exact archive set, sizes, inner SHA-256 values, offline release rehearsal, and negative corruption tests",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic",
+          "path": ".github/workflows/publish-dependency-bundle.yml",
+          "contains": "Publish exact verified OCI layout"
+        },
+        {
+          "repository": "classic",
+          "path": "dependencies.bundle.json",
+          "contains": "sha256:c6524604f0613cd9d0612befae18bea9a6155612e650fbf3d2cccb67051d031e"
+        },
+        {
+          "repository": "classic",
+          "path": "tools/release/dependency_bundle.py",
+          "contains": "ghcr.io/atrinik/classic-dependencies"
+        }
+      ]
+    },
+    {
       "id": "container/classic-server",
       "name": "Atrinik Classic server image",
       "kind": "container-image",
@@ -1299,11 +1342,11 @@
       "locator": "ghcr.io/atrinik/classic-server",
       "commit": null,
       "checksum": null,
-      "acquisition": "The root release workflow builds server/Dockerfile from the monorepo context and publishes the version tag with provenance and an SBOM",
+      "acquisition": "The root release workflow verifies the durable dependency-bundle digest, builds server/Dockerfile offline from its inner archives, and publishes the version tag with provenance and an SBOM",
       "update_cadence_days": 30,
       "update_mechanism": "Classic Dockerfile and release-workflow review with every dependency update",
       "eol_response": "Publish a rebuilt supported image before retiring the current server image line",
-      "validation": "Read-only release-candidate image build plus production digest, provenance, and SBOM checks",
+      "validation": "Read-only offline release-candidate image build plus dependency-bundle, production digest, provenance, and SBOM checks",
       "disposition": "retain",
       "packages": [],
       "evidence": [
@@ -2524,11 +2567,11 @@
       "locator": "pkg:github/atrinik/content@v2.14.0",
       "commit": "7dde0c0afe8840fc95dd26f404310e77d9c82621",
       "checksum": "sha256:f4ad326e20e221869897c72f7e33b533c408ce6654038dbfc4352da1c3391261",
-      "acquisition": "Classic server and playtester dependency tools download, checksum, safely extract, and atomically publish the release archive",
+      "acquisition": "Classic release packaging obtains the archive from the exact durable dependency-bundle digest and rechecks it before safe extraction; Playtester retains its own verified atomic cache boundary",
       "update_cadence_days": 30,
       "update_mechanism": "Daily fail-closed GitHub App proposal plus reviewed Classic and playtester compatibility updates",
       "eol_response": "Update both locks to a supported content release or stop Classic packaging and Playtester operation",
-      "validation": "Lock validation, checksum, safe extraction, collection, Classic runtime tests, and playtester atomic/offline cache regressions",
+      "validation": "Lock and dependency-bundle validation, checksum, safe extraction, offline Classic rehearsal/runtime tests, and playtester atomic/offline cache regressions",
       "disposition": "isolate",
       "packages": [],
       "evidence": [
@@ -2715,11 +2758,11 @@
       "locator": "pkg:github/atrinik/resources@v1.0.1",
       "commit": "a3bd8c8a2b746d15b397a67d9f641af7d97a6078",
       "checksum": "sha256:4db9ecdd74aa570bc7e20eccac980844f3aba8d668230502728b22146d3b2c54",
-      "acquisition": "Classic server dependency tool downloads and safely extracts the release archive",
+      "acquisition": "Classic release packaging obtains the archive from the exact durable dependency-bundle digest, rechecks it, and safely extracts it offline",
       "update_cadence_days": 30,
       "update_mechanism": "Weekly lock drift audit and reviewed release consumption",
       "eol_response": "Update the lock to a supported resource release or stop packaging the classic server",
-      "validation": "Lock validation, checksum, safe extraction, and runtime allowlist",
+      "validation": "Lock and dependency-bundle validation, checksum, safe extraction, offline rehearsal, and runtime allowlist",
       "disposition": "isolate",
       "packages": [],
       "evidence": [
@@ -2746,11 +2789,11 @@
       "locator": "pkg:github/atrinik/sound@v1.0.3",
       "commit": "18234cce19bf641f24d81333d8abcc0f1e34cd08",
       "checksum": "sha256:5427d2d2b5b73bad30c279ea5b7f012c380fd402249d45d9363b85ea7674e4bb",
-      "acquisition": "Classic client dependency tool downloads and safely extracts the release archive",
+      "acquisition": "Classic release packaging obtains the archive from the exact durable dependency-bundle digest, rechecks it, and safely extracts it offline",
       "update_cadence_days": 30,
       "update_mechanism": "Weekly lock drift audit and reviewed release consumption",
       "eol_response": "Update the lock to a supported sound release or disable packaging",
-      "validation": "Lock validation, checksum, safe extraction, and classic client package test",
+      "validation": "Lock and dependency-bundle validation, checksum, safe extraction, offline rehearsal, and classic client package test",
       "disposition": "isolate",
       "packages": [],
       "evidence": [
@@ -3030,11 +3073,11 @@
       "locator": "pkg:github/libpcpnatpmp/libpcpnatpmp@866d283da99f5e98eecff702a8df63e2ae57ffca",
       "commit": "866d283da99f5e98eecff702a8df63e2ae57ffca",
       "checksum": "sha256:65ab99547ecc8277434527607d24f8a1b02a2344ed4cea475bed751606e60202",
-      "acquisition": "CMake FetchContent downloads the commit archive and applies a reviewed MinGW patch",
+      "acquisition": "Classic release packaging obtains the commit archive from the exact durable dependency-bundle digest; CMake rechecks and extracts it offline before applying the reviewed MinGW patch",
       "update_cadence_days": 90,
       "update_mechanism": "Scheduled source-pin audit and sanitizer/network smoke review",
       "eol_response": "Update the isolated source or replace NAT-PMP support without a fallback copy",
-      "validation": "Checksum, idempotent patch, native tests, and Linux/MinGW builds",
+      "validation": "Dependency-bundle and checksum verification, idempotent patch, native tests, offline rehearsal, and Linux/MinGW builds",
       "disposition": "isolate",
       "packages": [],
       "evidence": [
@@ -4563,6 +4606,37 @@
           "repository": "website",
           "path": "package.json",
           "contains": "\"node\": \">=24.18.1 <25\""
+        }
+      ]
+    },
+    {
+      "id": "toolchain/oras",
+      "name": "ORAS CLI",
+      "kind": "toolchain",
+      "owner": "classic-server",
+      "scope": [
+        "classic"
+      ],
+      "required": true,
+      "version": "v1.3.3",
+      "version_source": "Classic dependency-bundle publisher workflow",
+      "license": "Apache-2.0",
+      "source_url": "https://github.com/oras-project/oras/releases/tag/v1.3.3",
+      "locator": "pkg:github/oras-project/oras@v1.3.3",
+      "commit": null,
+      "checksum": "sha256:9ce999f8d2de03fc03968b29d743077a58783e545e5eaa53917ca177352d0e59",
+      "acquisition": "The trusted Classic publisher downloads the exact official linux-amd64 release asset through GitHub CLI and verifies its GitHub-published SHA-256 before extraction",
+      "update_cadence_days": 90,
+      "update_mechanism": "Reviewed ORAS release and asset-digest update with deterministic OCI layout copy validation",
+      "eol_response": "Pin and validate a supported ORAS release before the current client loses required OCI distribution behavior",
+      "validation": "Exact archive SHA-256 and version plus digest-preserving OCI layout copy and registry postcondition",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic",
+          "path": ".github/workflows/publish-dependency-bundle.yml",
+          "contains": "9ce999f8d2de03fc03968b29d743077a58783e545e5eaa53917ca177352d0e59"
         }
       ]
     },

--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -572,6 +572,68 @@
       ]
     },
     {
+      "id": "action/actions-cache-restore",
+      "name": "actions/cache/restore",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "classic"
+      ],
+      "required": true,
+      "version": "v6",
+      "version_source": "Reviewed upstream major release",
+      "license": "MIT",
+      "source_url": "https://github.com/actions/cache",
+      "locator": "actions/cache/restore",
+      "commit": "55cc8345863c7cc4c66a329aec7e433d2d1c52a9",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade all cache consumers together or remove the explicit restore step",
+      "validation": "Actionlint plus complete-key verified dependency cache restore coverage",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic",
+          "path": ".github/workflows/check.yml",
+          "contains": "actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6"
+        }
+      ]
+    },
+    {
+      "id": "action/actions-cache-save",
+      "name": "actions/cache/save",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "classic"
+      ],
+      "required": true,
+      "version": "v6",
+      "version_source": "Reviewed upstream major release",
+      "license": "MIT",
+      "source_url": "https://github.com/actions/cache",
+      "locator": "actions/cache/save",
+      "commit": "55cc8345863c7cc4c66a329aec7e433d2d1c52a9",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade all cache consumers together or remove the explicit save step",
+      "validation": "Actionlint plus repaired-generation-only verified dependency cache save coverage",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic",
+          "path": ".github/workflows/check.yml",
+          "contains": "actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6"
+        }
+      ]
+    },
+    {
       "id": "action/actions-checkout",
       "name": "actions/checkout",
       "kind": "github-action",
@@ -1294,18 +1356,18 @@
         "classic-server"
       ],
       "required": true,
-      "version": "materials-38c0eebad746c7af0f3fdc8a11c1e6a829b44eafd23e4e48faf797cbba4de85a",
+      "version": "materials-428265fcc11e9e3f7fc534659b55008cd26e9da6c74da054074279b7bc4af2e9",
       "version_source": "Classic dependencies.bundle.json material digest",
       "license": "LicenseRef-Atrinik-Image-Contents",
       "source_url": "https://github.com/atrinik/classic/pkgs/container/classic-dependencies",
-      "locator": "ghcr.io/atrinik/classic-dependencies@sha256:56d80341bfdec0fe1c2d9b297a3099b67af9b99d17c7c4fc120d1b63d440dae7",
+      "locator": "ghcr.io/atrinik/classic-dependencies@sha256:ffe1fa8d28a323d502d01400e2260b7b5eec37842e762c439b88bd9ee823923e",
       "commit": null,
-      "checksum": "sha256:56d80341bfdec0fe1c2d9b297a3099b67af9b99d17c7c4fc120d1b63d440dae7",
+      "checksum": "sha256:ffe1fa8d28a323d502d01400e2260b7b5eec37842e762c439b88bd9ee823923e",
       "acquisition": "A trusted current-main workflow builds the deterministic OCI layout through the authoritative Classic fetcher and publishes its exact manifest digest",
       "update_cadence_days": 30,
       "update_mechanism": "Reviewed Classic lock or acquisition-contract update with a regenerated material and OCI descriptor",
       "eol_response": "Retain every digest referenced by a supported release; publish and pin a verified replacement before retiring a bundle",
-      "validation": "Outer OCI digest, closed manifest, provenance, source-lock/material digests, exact archive set, sizes, inner SHA-256 values, offline release rehearsal, and negative corruption tests",
+      "validation": "GitHub-signed OCI attestation, outer OCI digest, closed manifest and materials statement, source-lock/material digests, exact archive set, sizes, inner SHA-256 values, offline consumer isolation contracts, and negative corruption tests",
       "disposition": "isolate",
       "packages": [],
       "evidence": [
@@ -1317,7 +1379,7 @@
         {
           "repository": "classic",
           "path": "dependencies.bundle.json",
-          "contains": "sha256:56d80341bfdec0fe1c2d9b297a3099b67af9b99d17c7c4fc120d1b63d440dae7"
+          "contains": "sha256:ffe1fa8d28a323d502d01400e2260b7b5eec37842e762c439b88bd9ee823923e"
         },
         {
           "repository": "classic",


### PR DESCRIPTION
## Summary

- record the digest-pinned, GitHub-attested Classic durable dependency bundle as a required supply-chain boundary
- update Classic dependency and server-image acquisition evidence for offline release consumption
- inventory the pinned ORAS 1.3.3 publication client and verified release-asset checksum
- complete the composed Classic action inventory with the distinct pinned `actions/cache/restore` and `actions/cache/save` locators

## Relationship

Companion inventory change for atrinik/classic#204 and atrinik/classic#246. The Classic implementation PR is the sole issue-closing path and should land before this evidence update.

## Validation

- `python3 -m unittest discover -q` (548 tests)
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- complete `classic` profile supply-chain audit with the Classic PR worktree override (wrapper: 86 inputs / 8 actions; Classic: 103 inputs / 94 actions)
- `git diff --check`
