### PR TITLE
feat(provenance): establish privacy-preserving identity registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,8 @@
 - Unbound persisted records are historical and inert.
 - On touch, refresh existing Atrinik-owned copyright terminal years and blanket
   holders per `CONTRIBUTING.md`; preserve precise attribution.
-- MIT reuse follows `docs/PROVENANCE.md`; temporal, sole-authorship, and
-  separability uncertainty fails closed. Cite its registry revision.
+- MIT reuse follows `docs/PROVENANCE.md` and its canonical identity registry;
+  any rights, identity, temporal, authorship, or scope uncertainty fails closed.
 - Update `supply-chain/inventory.json` when dependency ownership or validation
   changes. Keep Actions/images immutable, add no submodules, and audit a
   complete profile. Only aggregate-root workflows and Dependabot are active.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,7 @@ python3 -m coverage report --show-missing
 python3 -m compileall -q atrinik atrinik_workspace tests
 python3 -m atrinik_workspace.guidance_inventory --check
 ./atrinik manifest validate
+./atrinik provenance validate
 ./atrinik supply-chain validate
 git diff --check
 ~~~

--- a/README.md
+++ b/README.md
@@ -187,8 +187,12 @@ directory, so an unrelated or historical checkout cannot impersonate
 ### Historical MIT provenance grants
 
 [`docs/PROVENANCE.md`](docs/PROVENANCE.md) is the single exhaustive approved
-grantor registry and evidence contract. Do not duplicate its table in component
-guides or skills.
+grantor registry. The canonical privacy-preserving identity schema, public
+registry and operating policy are in
+[`governance/provenance-identities/`](governance/provenance-identities/) and
+[`docs/PROVENANCE_IDENTITIES.md`](docs/PROVENANCE_IDENTITIES.md). Component
+repositories keep exact material scope and an immutable pinned reference; they
+never duplicate aliases or canonical identity records.
 
 The cross-repository M1 evidence and exact reuse procedure are indexed in
 [`docs/REPLACEMENT_FOUNDATIONS.md`](docs/REPLACEMENT_FOUNDATIONS.md). The
@@ -207,6 +211,14 @@ provenance-approved reuse, not clean-room work. Later material needs
 contemporaneous compatible permission. The source license and unrelated
 dependencies, assets, and surrounding work do not change; destination evidence
 cites the exact wrapper revision containing the registry used.
+
+Validate the canonical registry and one or more component references through a
+bounded local checkout. This reads only the pinned registry/schema Git blobs and
+does not use the network:
+
+~~~sh
+./atrinik provenance validate --reference PATH
+~~~
 
 The GPL classic utilities and their user-facing replacement/retirement paths
 are inventoried in

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import argparse
-from datetime import date
+from datetime import datetime, timezone
 import json
 from pathlib import Path
 import sys
@@ -362,17 +362,23 @@ def parser() -> argparse.ArgumentParser:
     )
     mark(
         provenance_validate.add_argument(
+            "--reviewers",
+            type=Path,
+            default=ROOT / "governance/provenance-identities/reviewers.json",
+        ),
+        "path",
+    )
+    mark(
+        provenance_validate.add_argument(
             "--reference", type=Path, action="append", default=[]
         ),
         "path",
     )
     mark(
         provenance_validate.add_argument(
-            "--as-of",
-            type=date.fromisoformat,
-            default=date.today(),
-            metavar="YYYY-MM-DD",
-            help="freshness evaluation date (default: today)",
+            "--non-authorizing-audit-ref",
+            metavar="REF",
+            help="audit a pre-merge ref; output is not approval for production reuse",
         ),
         "none",
     )
@@ -445,11 +451,18 @@ def main(arguments: list[str] | None = None) -> int:
                 ROOT,
                 registry_path=options.registry,
                 schema_path=options.schema,
+                reviewers_path=options.reviewers,
                 reference_paths=options.reference,
-                as_of=options.as_of,
+                as_of=datetime.now(timezone.utc).date(),
+                trusted_ref=options.non_authorizing_audit_ref or "origin/main",
+            )
+            prefix = (
+                "NON-AUTHORIZING AUDIT: "
+                if options.non_authorizing_audit_ref
+                else ""
             )
             print(
-                "governance/provenance-identities/registry.json: valid "
+                prefix + "governance/provenance-identities/registry.json: valid "
                 f"({count} records, {len(options.reference)} references)"
             )
             return 0

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from datetime import date
 import json
 from pathlib import Path
 import sys
@@ -43,6 +44,12 @@ def version_report(*arguments: object, **keywords: object) -> object:
 
 def write_generated(*arguments: object, **keywords: object) -> object:
     from .supply_chain import write_generated as implementation
+
+    return implementation(*arguments, **keywords)
+
+
+def validate_provenance_identity(*arguments: object, **keywords: object) -> object:
+    from .provenance_identity import validate_paths as implementation
 
     return implementation(*arguments, **keywords)
 
@@ -330,6 +337,46 @@ def parser() -> argparse.ArgumentParser:
     supply_chain_versions = supply_chain_commands.add_parser("versions")
     mark(supply_chain_versions.add_argument("--output", type=Path), "path")
 
+    provenance = commands.add_parser(
+        "provenance", help="validate the canonical public identity registry"
+    )
+    provenance_commands = provenance.add_subparsers(
+        dest="provenance_command", required=True
+    )
+    provenance_validate = provenance_commands.add_parser("validate")
+    mark(
+        provenance_validate.add_argument(
+            "--registry",
+            type=Path,
+            default=ROOT / "governance/provenance-identities/registry.json",
+        ),
+        "path",
+    )
+    mark(
+        provenance_validate.add_argument(
+            "--schema",
+            type=Path,
+            default=ROOT / "governance/provenance-identities/schema-v1.json",
+        ),
+        "path",
+    )
+    mark(
+        provenance_validate.add_argument(
+            "--reference", type=Path, action="append", default=[]
+        ),
+        "path",
+    )
+    mark(
+        provenance_validate.add_argument(
+            "--as-of",
+            type=date.fromisoformat,
+            default=date.today(),
+            metavar="YYYY-MM-DD",
+            help="freshness evaluation date (default: today)",
+        ),
+        "none",
+    )
+
     launch = commands.add_parser("run", help="build and run client or server")
     launch_commands = launch.add_subparsers(dest="target", required=True)
     for target in ("client", "server"):
@@ -392,6 +439,19 @@ def main(arguments: list[str] | None = None) -> int:
         if options.command == "manifest":
             manifest = Manifest.load(ROOT / "components.json")
             print(f"components.json: valid ({len(manifest.components)} components)")
+            return 0
+        if options.command == "provenance":
+            count = validate_provenance_identity(
+                ROOT,
+                registry_path=options.registry,
+                schema_path=options.schema,
+                reference_paths=options.reference,
+                as_of=options.as_of,
+            )
+            print(
+                "governance/provenance-identities/registry.json: valid "
+                f"({count} records, {len(options.reference)} references)"
+            )
             return 0
 
         workspace_type = Workspace

--- a/atrinik_workspace/provenance_identity.py
+++ b/atrinik_workspace/provenance_identity.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from datetime import date
 import hashlib
 import json
+import os
 from pathlib import Path, PurePosixPath
 import re
 import subprocess
+import tempfile
 from typing import Any
 
 from .model import WorkspaceError
@@ -14,15 +16,21 @@ from .model import WorkspaceError
 SCHEMA_VERSION = 1
 POLICY_VERSION = 1
 MAX_DOCUMENT_BYTES = 1024 * 1024
+MAX_REVIEW_DAYS = 366
 CANONICALIZATION = "atrinik-json-v1"
 REGISTRY_PATH = Path("governance/provenance-identities/registry.json")
 SCHEMA_PATH = Path("governance/provenance-identities/schema-v1.json")
-RECORD_ID_PATTERN = re.compile(r"^pir-[a-z0-9][a-z0-9-]{15,63}$")
+REVIEWERS_PATH = Path("governance/provenance-identities/reviewers.json")
+TRUSTED_SCHEMA_CANONICAL_SHA256 = "2f52bcf87957ffc909cc99cb57ad8f0f1809dc02dfa4111d32e5ad24a4a3cb05"
+CONFIDENTIAL_RECORD_ID_PATTERN = re.compile(r"^pir-c-[0-9a-f]{32}$")
+PUBLIC_RECORD_ID_PATTERN = re.compile(r"^pir-p-[0-9a-f]{32}$")
+RECORD_ID_PATTERN = re.compile(r"^pir-[cp]-[0-9a-f]{32}$")
 SCOPE_BINDING_PATTERN = re.compile(r"^psb-[0-9a-f]{32}$")
 RESTRICTED_ID_PATTERN = re.compile(r"^restricted-[0-9a-f]{32}$")
 SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 REVISION_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 REVIEWER_PATTERN = re.compile(r"^github:[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$")
+KEY_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{7,63}$")
 KNOWN_CLAIMS = {
     "authorship",
     "identity",
@@ -149,6 +157,8 @@ def _repository_path(value: object, context: str) -> str:
 
 
 def _validate_schema(schema: dict[str, Any]) -> None:
+    if sha256(canonical_bytes(schema)) != TRUSTED_SCHEMA_CANONICAL_SHA256:
+        raise WorkspaceError("provenance identity schema differs from the trusted version")
     if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
         raise WorkspaceError("provenance identity schema must use draft 2020-12")
     if schema.get("$id") != "https://atrinik.org/schema/provenance-identities-v1.json":
@@ -156,8 +166,122 @@ def _validate_schema(schema: dict[str, Any]) -> None:
     if schema.get("type") != "object" or schema.get("additionalProperties") is not False:
         raise WorkspaceError("provenance identity schema must reject non-object or extra fields")
     version = schema.get("properties", {}).get("schema_version", {}).get("const")
-    if version != SCHEMA_VERSION:
+    if type(version) is not int or version != SCHEMA_VERSION:
         raise WorkspaceError("provenance identity schema has an unsupported version")
+
+
+def validate_reviewers(value: dict[str, Any], *, as_of: date) -> dict[str, dict[str, Any]]:
+    _exact_keys(value, {"reviewers", "schema_version"}, "provenance reviewer registry")
+    if type(value["schema_version"]) is not int or value["schema_version"] != 1:
+        raise WorkspaceError("provenance reviewer registry has an unsupported version")
+    raw = value["reviewers"]
+    if not isinstance(raw, list) or not raw:
+        raise WorkspaceError("provenance reviewer registry must contain reviewers")
+    result: dict[str, dict[str, Any]] = {}
+    for index, reviewer in enumerate(raw):
+        context = f"provenance reviewer {index}"
+        if not isinstance(reviewer, dict):
+            raise WorkspaceError(f"{context}: must be an object")
+        _exact_keys(
+            reviewer,
+            {"effective_on", "expires_on", "identity", "key_id", "public_key", "status", "synthetic"},
+            context,
+        )
+        identity = reviewer["identity"]
+        if not isinstance(identity, str) or not REVIEWER_PATTERN.fullmatch(identity):
+            raise WorkspaceError(f"{context}.identity: invalid GitHub identity")
+        key_id = reviewer["key_id"]
+        if not isinstance(key_id, str) or not KEY_ID_PATTERN.fullmatch(key_id):
+            raise WorkspaceError(f"{context}.key_id: invalid key identifier")
+        if key_id in result:
+            raise WorkspaceError(f"{context}: duplicate key identifier")
+        if reviewer["status"] not in {"active", "revoked"}:
+            raise WorkspaceError(f"{context}.status: invalid status")
+        if not isinstance(reviewer["synthetic"], bool):
+            raise WorkspaceError(f"{context}.synthetic: must be a boolean")
+        effective = _iso_date(reviewer["effective_on"], f"{context}.effective_on")
+        expires = _iso_date(reviewer["expires_on"], f"{context}.expires_on")
+        if effective > expires:
+            raise WorkspaceError(f"{context}: invalid effective interval")
+        public_key = _text(reviewer["public_key"], f"{context}.public_key")
+        if not re.fullmatch(r"ssh-ed25519 [A-Za-z0-9+/]+={0,2}", public_key):
+            raise WorkspaceError(f"{context}.public_key: must be an Ed25519 SSH key")
+        result[key_id] = reviewer
+    if list(result) != sorted(result):
+        raise WorkspaceError("provenance reviewers must be sorted by key_id")
+    return result
+
+
+def _approval_payload(record: dict[str, Any]) -> bytes:
+    return canonical_bytes(
+        {key: value for key, value in record.items() if key not in {"approval", "integrity"}}
+    )
+
+
+def _verify_approval(
+    approval: object,
+    payload: bytes,
+    *,
+    reviewer_identity: str,
+    reviewed_on: date,
+    reviewers: dict[str, dict[str, Any]],
+    synthetic: bool,
+    context: str,
+) -> None:
+    if not isinstance(approval, dict):
+        raise WorkspaceError(f"{context}: must be an object")
+    _exact_keys(approval, {"key_id", "signature"}, context)
+    key_id = approval["key_id"]
+    if key_id not in reviewers:
+        raise WorkspaceError(f"{context}.key_id: reviewer key is not authorized")
+    reviewer = reviewers[key_id]
+    if reviewer["identity"] != reviewer_identity:
+        raise WorkspaceError(f"{context}: key does not belong to the named reviewer")
+    if reviewer["status"] != "active":
+        raise WorkspaceError(f"{context}: reviewer key is revoked")
+    if reviewer["synthetic"] != synthetic:
+        raise WorkspaceError(f"{context}: synthetic reviewer boundary mismatch")
+    if not (
+        _iso_date(reviewer["effective_on"], f"{context}.effective_on")
+        <= reviewed_on
+        <= _iso_date(reviewer["expires_on"], f"{context}.expires_on")
+    ):
+        raise WorkspaceError(f"{context}: reviewer key was not effective at review")
+    signature = _text(approval["signature"], f"{context}.signature")
+    if not signature.startswith("-----BEGIN SSH SIGNATURE-----\n") or not signature.endswith(
+        "\n-----END SSH SIGNATURE-----"
+    ):
+        raise WorkspaceError(f"{context}.signature: invalid SSH signature envelope")
+    try:
+        with tempfile.TemporaryDirectory(prefix="atrinik-provenance-signature-") as temporary:
+            allowed = Path(temporary) / "allowed_signers"
+            signature_path = Path(temporary) / "signature"
+            allowed.write_text(
+                f"{reviewer_identity} {reviewer['public_key']}\n", encoding="utf-8"
+            )
+            signature_path.write_text(signature + "\n", encoding="utf-8")
+            result = subprocess.run(
+                [
+                    "ssh-keygen",
+                    "-Y",
+                    "verify",
+                    "-f",
+                    str(allowed),
+                    "-I",
+                    reviewer_identity,
+                    "-n",
+                    "atrinik-provenance-v1",
+                    "-s",
+                    str(signature_path),
+                ],
+                input=payload,
+                capture_output=True,
+                timeout=10,
+            )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise WorkspaceError(f"{context}: cannot verify reviewer signature") from exc
+    if result.returncode != 0:
+        raise WorkspaceError(f"{context}: reviewer signature is invalid")
 
 
 def _walk_confidential_keys(value: object, context: str) -> None:
@@ -191,11 +315,16 @@ def _validate_integrity(record: dict[str, Any], context: str) -> None:
         raise WorkspaceError(f"{context}.integrity.digest: does not match canonical record")
 
 
-def _validate_common_record(record: dict[str, Any], context: str, as_of: date) -> None:
+def _validate_common_record(
+    record: dict[str, Any],
+    context: str,
+    as_of: date,
+    reviewers: dict[str, dict[str, Any]],
+) -> None:
     identifier = record.get("record_id")
     if not isinstance(identifier, str) or not RECORD_ID_PATTERN.fullmatch(identifier):
         raise WorkspaceError(f"{context}.record_id: must be an opaque pir identifier")
-    if record.get("policy_version") != POLICY_VERSION:
+    if type(record.get("policy_version")) is not int or record["policy_version"] != POLICY_VERSION:
         raise WorkspaceError(f"{context}.policy_version: unsupported policy version")
     if record.get("status") not in {"active", "revoked", "superseded"}:
         raise WorkspaceError(f"{context}.status: unsupported status")
@@ -204,7 +333,9 @@ def _validate_common_record(record: dict[str, Any], context: str, as_of: date) -
         raise WorkspaceError(f"{context}.reviewer: must be a public GitHub reviewer identity")
     reviewed = _iso_date(record.get("reviewed_on"), f"{context}.reviewed_on")
     expires = _iso_date(record.get("expires_on"), f"{context}.expires_on")
-    if expires <= reviewed:
+    if reviewed > as_of:
+        raise WorkspaceError(f"{context}: review date is in the future")
+    if expires <= reviewed or (expires - reviewed).days > MAX_REVIEW_DAYS:
         raise WorkspaceError(f"{context}: expires_on must be after reviewed_on")
     if record.get("status") == "active" and expires < as_of:
         raise WorkspaceError(f"{context}: active attestation is stale")
@@ -212,14 +343,26 @@ def _validate_common_record(record: dict[str, Any], context: str, as_of: date) -
     if not set(claims) <= KNOWN_CLAIMS:
         raise WorkspaceError(f"{context}.claims: contains an unknown claim")
     _validate_integrity(record, context)
+    _verify_approval(
+        record.get("approval"),
+        _approval_payload(record),
+        reviewer_identity=reviewer,
+        reviewed_on=reviewed,
+        reviewers=reviewers,
+        synthetic=record["synthetic"],
+        context=f"{context}.approval",
+    )
 
 
-def _validate_confidential_record(record: dict[str, Any], context: str, as_of: date) -> None:
+def _validate_confidential_record(
+    record: dict[str, Any], context: str, as_of: date, reviewers: dict[str, dict[str, Any]]
+) -> None:
     _walk_confidential_keys(record, context)
     _exact_keys(
         record,
         {
             "claims",
+            "approval",
             "expires_on",
             "integrity",
             "policy_version",
@@ -231,6 +374,7 @@ def _validate_confidential_record(record: dict[str, Any], context: str, as_of: d
             "reviewer",
             "scope_binding",
             "status",
+            "status_detail",
             "synthetic",
         },
         context,
@@ -257,16 +401,21 @@ def _validate_confidential_record(record: dict[str, Any], context: str, as_of: d
     fields = _string_array(review["fields_reviewed"], f"{context}.publication_review.fields_reviewed")
     if fields != sorted(record):
         raise WorkspaceError(f"{context}.publication_review: must cover every public field")
-    _validate_common_record(record, context, as_of)
+    if not CONFIDENTIAL_RECORD_ID_PATTERN.fullmatch(record["record_id"]):
+        raise WorkspaceError(f"{context}.record_id: confidential identifiers must be random hex")
+    _validate_common_record(record, context, as_of, reviewers)
     if set(record["claims"]) != KNOWN_CLAIMS:
         raise WorkspaceError(f"{context}.claims: confidential review must prove all claims")
 
 
-def _validate_public_alias_record(record: dict[str, Any], context: str, as_of: date) -> None:
+def _validate_public_alias_record(
+    record: dict[str, Any], context: str, as_of: date, reviewers: dict[str, dict[str, Any]]
+) -> None:
     _exact_keys(
         record,
         {
             "aliases",
+            "approval",
             "claims",
             "display_name",
             "expires_on",
@@ -278,6 +427,7 @@ def _validate_public_alias_record(record: dict[str, Any], context: str, as_of: d
             "reviewed_on",
             "reviewer",
             "status",
+            "status_detail",
             "synthetic",
         },
         context,
@@ -307,24 +457,33 @@ def _validate_public_alias_record(record: dict[str, Any], context: str, as_of: d
         raise WorkspaceError(f"{context}.publication_authorization: must explicitly cover all identity fields")
     if not RESTRICTED_ID_PATTERN.fullmatch(str(authorization["restricted_record_id"])):
         raise WorkspaceError(f"{context}.publication_authorization.restricted_record_id: invalid identifier")
-    _validate_common_record(record, context, as_of)
+    if not PUBLIC_RECORD_ID_PATTERN.fullmatch(record["record_id"]):
+        raise WorkspaceError(f"{context}.record_id: public identifiers must be random hex")
+    _validate_common_record(record, context, as_of, reviewers)
 
 
 def validate_registry(
-    registry: dict[str, Any], schema: dict[str, Any], *, as_of: date
+    registry: dict[str, Any],
+    schema: dict[str, Any],
+    reviewers_value: dict[str, Any],
+    *,
+    as_of: date,
 ) -> dict[str, dict[str, Any]]:
     _validate_schema(schema)
+    reviewers = validate_reviewers(reviewers_value, as_of=as_of)
     _exact_keys(
         registry,
-        {"policy_version", "records", "schema", "schema_version"},
+        {"policy_version", "records", "reviewers", "schema", "schema_version"},
         "provenance identity registry",
     )
-    if registry["schema_version"] != SCHEMA_VERSION:
+    if type(registry["schema_version"]) is not int or registry["schema_version"] != SCHEMA_VERSION:
         raise WorkspaceError("provenance identity registry has an unsupported schema version")
-    if registry["policy_version"] != POLICY_VERSION:
+    if type(registry["policy_version"]) is not int or registry["policy_version"] != POLICY_VERSION:
         raise WorkspaceError("provenance identity registry has an unsupported policy version")
     if registry["schema"] != SCHEMA_PATH.as_posix():
         raise WorkspaceError("provenance identity registry names an unexpected schema")
+    if registry["reviewers"] != REVIEWERS_PATH.as_posix():
+        raise WorkspaceError("provenance identity registry names unexpected reviewers")
     records = registry["records"]
     if not isinstance(records, list):
         raise WorkspaceError("provenance identity registry records must be an array")
@@ -340,7 +499,7 @@ def validate_registry(
             raise WorkspaceError(f"{context}: duplicate record identifier {identifier}")
         record_type = record.get("record_type")
         if record_type == "confidential-attestation":
-            _validate_confidential_record(record, context, as_of)
+            _validate_confidential_record(record, context, as_of, reviewers)
             binding = record["scope_binding"]
             restricted_id = record["restricted_evidence"]["record_id"]
             if binding in bindings:
@@ -350,30 +509,109 @@ def validate_registry(
             bindings.add(binding)
             restricted_ids.add(restricted_id)
         elif record_type == "public-alias":
-            _validate_public_alias_record(record, context, as_of)
+            _validate_public_alias_record(record, context, as_of, reviewers)
         else:
             raise WorkspaceError(f"{context}.record_type: unsupported record type")
         identifier = record["record_id"]
         result[identifier] = record
     if list(result) != sorted(result):
         raise WorkspaceError("provenance identity registry records must be sorted by record_id")
+    for identifier, record in result.items():
+        detail = record["status_detail"]
+        if not isinstance(detail, dict):
+            raise WorkspaceError(f"record {identifier}.status_detail: must be an object")
+        effective = _iso_date(detail.get("effective_on"), f"record {identifier}.status_detail.effective_on")
+        if effective < _iso_date(record["reviewed_on"], f"record {identifier}.reviewed_on"):
+            raise WorkspaceError(f"record {identifier}: status predates review")
+        if record["status"] == "active":
+            _exact_keys(detail, {"effective_on"}, f"record {identifier}.status_detail")
+        elif record["status"] == "revoked":
+            _exact_keys(detail, {"effective_on", "reason"}, f"record {identifier}.status_detail")
+            if detail["reason"] not in {"compromise", "correction", "dispute", "withdrawal"}:
+                raise WorkspaceError(f"record {identifier}: invalid revocation reason")
+        else:
+            _exact_keys(detail, {"effective_on", "superseded_by"}, f"record {identifier}.status_detail")
+            target = detail["superseded_by"]
+            if target == identifier or target not in result:
+                raise WorkspaceError(f"record {identifier}: invalid supersession target")
+            if result[target]["status"] != "active":
+                raise WorkspaceError(f"record {identifier}: supersession target is not active")
     return result
 
 
-def _git_blob(repository_root: Path, revision: str, path: str) -> bytes:
+def _git_environment() -> dict[str, str]:
+    return {**os.environ, "GIT_NO_REPLACE_OBJECTS": "1"}
+
+
+def _git_output(repository_root: Path, arguments: list[str], context: str) -> bytes:
     try:
         result = subprocess.run(
-            ["git", "show", f"{revision}:{path}"],
+            ["git", *arguments],
             cwd=repository_root,
             check=True,
             capture_output=True,
             timeout=10,
+            env=_git_environment(),
         )
     except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
-        raise WorkspaceError(f"immutable reference cannot resolve {revision}:{path}") from exc
-    if len(result.stdout) > MAX_DOCUMENT_BYTES:
-        raise WorkspaceError("immutable reference document exceeds the size limit")
+        raise WorkspaceError(context) from exc
     return result.stdout
+
+
+def _validate_repository_trust(
+    repository_root: Path, revision: str, trusted_ref: str
+) -> None:
+    if _git_output(
+        repository_root,
+        ["rev-parse", "--is-shallow-repository"],
+        "cannot inspect coordinator checkout depth",
+    ).strip() != b"false":
+        raise WorkspaceError("coordinator checkout must be non-shallow")
+    common = _git_output(
+        repository_root,
+        ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+        "cannot resolve coordinator Git directory",
+    ).decode().strip()
+    if (Path(common) / "info" / "grafts").exists():
+        raise WorkspaceError("coordinator checkout has legacy grafts")
+    origin = _git_output(
+        repository_root,
+        ["remote", "get-url", "origin"],
+        "coordinator checkout requires origin",
+    ).decode().strip()
+    if origin not in {
+        "https://github.com/atrinik/atrinik.git",
+        "git@github.com:atrinik/atrinik.git",
+    }:
+        raise WorkspaceError("coordinator origin is not atrinik/atrinik")
+    _git_output(
+        repository_root,
+        ["merge-base", "--is-ancestor", revision, trusted_ref],
+        f"coordinator revision is not reachable from trusted ref {trusted_ref}",
+    )
+
+
+def _git_blob(repository_root: Path, revision: str, path: str) -> bytes:
+    object_name = f"{revision}:{path}"
+    raw_size = _git_output(
+        repository_root,
+        ["cat-file", "-s", object_name],
+        f"immutable reference cannot size {object_name}",
+    )
+    try:
+        size = int(raw_size)
+    except ValueError as exc:
+        raise WorkspaceError(f"immutable reference returned invalid size for {object_name}") from exc
+    if size > MAX_DOCUMENT_BYTES:
+        raise WorkspaceError("immutable reference document exceeds the size limit")
+    result = _git_output(
+        repository_root,
+        ["cat-file", "blob", object_name],
+        f"immutable reference cannot resolve {object_name}",
+    )
+    if len(result) != size:
+        raise WorkspaceError("immutable reference blob size changed during read")
+    return result
 
 
 def _load_bytes(value: bytes, context: str) -> dict[str, Any]:
@@ -387,7 +625,13 @@ def _load_bytes(value: bytes, context: str) -> dict[str, Any]:
 
 
 def validate_component_reference(
-    reference: dict[str, Any], *, repository_root: Path, as_of: date
+    reference: dict[str, Any],
+    *,
+    repository_root: Path,
+    as_of: date,
+    trusted_ref: str,
+    current_records: dict[str, dict[str, Any]],
+    current_reviewers: dict[str, dict[str, Any]],
 ) -> None:
     _exact_keys(
         reference,
@@ -395,13 +639,14 @@ def validate_component_reference(
             "destination",
             "evidence_reference",
             "schema_version",
+            "scope_approval",
             "scope_binding",
             "source",
             "transformation",
         },
         "component provenance record",
     )
-    if reference["schema_version"] != SCHEMA_VERSION:
+    if type(reference["schema_version"]) is not int or reference["schema_version"] != SCHEMA_VERSION:
         raise WorkspaceError("component provenance record has an unsupported schema version")
     for key in ("source", "destination"):
         coordinate = reference[key]
@@ -446,6 +691,7 @@ def validate_component_reference(
     )
     if evidence["url"] != expected_url:
         raise WorkspaceError("component provenance reference URL is not the canonical immutable permalink")
+    _validate_repository_trust(repository_root, revision, trusted_ref)
     for key in ("registry_sha256", "schema_sha256"):
         if not isinstance(evidence[key], str) or not SHA256_PATTERN.fullmatch(evidence[key]):
             raise WorkspaceError(f"component provenance reference {key} is invalid")
@@ -458,6 +704,10 @@ def validate_component_reference(
     records = validate_registry(
         _load_bytes(registry_blob, "referenced registry"),
         _load_bytes(schema_blob, "referenced schema"),
+        _load_bytes(
+            _git_blob(repository_root, revision, REVIEWERS_PATH.as_posix()),
+            "referenced reviewers",
+        ),
         as_of=as_of,
     )
     if record_id not in records:
@@ -469,6 +719,23 @@ def validate_component_reference(
         raise WorkspaceError("component provenance reference must select a confidential attestation")
     if record["scope_binding"] != reference["scope_binding"]:
         raise WorkspaceError("component provenance scope binding does not match the attestation")
+    current = current_records.get(record_id)
+    if current is None or current["status"] != "active":
+        raise WorkspaceError("component provenance record is not active in the current registry")
+    if current["scope_binding"] != reference["scope_binding"]:
+        raise WorkspaceError("current provenance scope binding differs from the pinned record")
+    scope_payload = canonical_bytes(
+        {key: value for key, value in reference.items() if key != "scope_approval"}
+    )
+    _verify_approval(
+        reference["scope_approval"],
+        scope_payload,
+        reviewer_identity=record["reviewer"],
+        reviewed_on=_iso_date(record["reviewed_on"], "referenced record reviewed_on"),
+        reviewers=current_reviewers,
+        synthetic=record["synthetic"],
+        context="component provenance scope_approval",
+    )
     if record["synthetic"] and not str(reference["destination"]["repository"]).startswith("atrinik/synthetic-"):
         raise WorkspaceError("synthetic attestations may only be used by synthetic component fixtures")
 
@@ -478,10 +745,26 @@ def validate_paths(
     *,
     registry_path: Path,
     schema_path: Path,
+    reviewers_path: Path,
     reference_paths: list[Path],
     as_of: date,
+    trusted_ref: str,
 ) -> int:
-    records = validate_registry(load_document(registry_path), load_document(schema_path), as_of=as_of)
+    reviewers_value = load_document(reviewers_path)
+    reviewers = validate_reviewers(reviewers_value, as_of=as_of)
+    records = validate_registry(
+        load_document(registry_path),
+        load_document(schema_path),
+        reviewers_value,
+        as_of=as_of,
+    )
     for path in reference_paths:
-        validate_component_reference(load_document(path), repository_root=root, as_of=as_of)
+        validate_component_reference(
+            load_document(path),
+            repository_root=root,
+            as_of=as_of,
+            trusted_ref=trusted_ref,
+            current_records=records,
+            current_reviewers=reviewers,
+        )
     return len(records)

--- a/atrinik_workspace/provenance_identity.py
+++ b/atrinik_workspace/provenance_identity.py
@@ -1,0 +1,458 @@
+from __future__ import annotations
+
+from datetime import date
+import hashlib
+import json
+from pathlib import Path
+import re
+import subprocess
+from typing import Any
+
+from .model import WorkspaceError
+
+
+SCHEMA_VERSION = 1
+POLICY_VERSION = 1
+MAX_DOCUMENT_BYTES = 1024 * 1024
+CANONICALIZATION = "atrinik-json-v1"
+REGISTRY_PATH = Path("governance/provenance-identities/registry.json")
+SCHEMA_PATH = Path("governance/provenance-identities/schema-v1.json")
+RECORD_ID_PATTERN = re.compile(r"^pir-[a-z0-9][a-z0-9-]{15,63}$")
+SCOPE_BINDING_PATTERN = re.compile(r"^psb-[0-9a-f]{32}$")
+RESTRICTED_ID_PATTERN = re.compile(r"^restricted-[0-9a-f]{32}$")
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+REVISION_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+REVIEWER_PATTERN = re.compile(r"^github:[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$")
+KNOWN_CLAIMS = {
+    "authorship",
+    "identity",
+    "rights-grant",
+    "temporal-scope",
+}
+CONFIDENTIAL_FORBIDDEN_KEYS = {
+    "alias",
+    "aliases",
+    "commit",
+    "contact",
+    "destination",
+    "display_name",
+    "email",
+    "grantor",
+    "handle",
+    "legal_name",
+    "login",
+    "name",
+    "path",
+    "repository",
+    "revision",
+    "source",
+    "subject",
+    "username",
+}
+
+
+def _object_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise WorkspaceError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_document(path: Path) -> dict[str, Any]:
+    try:
+        if path.stat().st_size > MAX_DOCUMENT_BYTES:
+            raise WorkspaceError(f"{path}: document exceeds {MAX_DOCUMENT_BYTES} bytes")
+        value = json.loads(
+            path.read_text(encoding="utf-8"), object_pairs_hook=_object_pairs
+        )
+    except WorkspaceError:
+        raise
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise WorkspaceError(f"{path}: cannot load JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise WorkspaceError(f"{path}: root must be an object")
+    return value
+
+
+def canonical_bytes(value: object) -> bytes:
+    """Serialize the deliberately integer-free public contract deterministically."""
+
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def record_digest(record: dict[str, Any]) -> str:
+    payload = {key: value for key, value in record.items() if key != "integrity"}
+    return sha256(canonical_bytes(payload))
+
+
+def _exact_keys(value: dict[str, Any], expected: set[str], context: str) -> None:
+    missing = expected - set(value)
+    extra = set(value) - expected
+    if missing or extra:
+        details = []
+        if missing:
+            details.append(f"missing {', '.join(sorted(missing))}")
+        if extra:
+            details.append(f"unexpected {', '.join(sorted(extra))}")
+        raise WorkspaceError(f"{context}: {'; '.join(details)}")
+
+
+def _text(value: object, context: str) -> str:
+    if not isinstance(value, str) or not value or value.strip() != value:
+        raise WorkspaceError(f"{context}: must be non-empty trimmed text")
+    return value
+
+
+def _iso_date(value: object, context: str) -> date:
+    text = _text(value, context)
+    try:
+        parsed = date.fromisoformat(text)
+    except ValueError as exc:
+        raise WorkspaceError(f"{context}: must be an ISO date") from exc
+    if parsed.isoformat() != text:
+        raise WorkspaceError(f"{context}: must use canonical YYYY-MM-DD form")
+    return parsed
+
+
+def _string_array(value: object, context: str) -> list[str]:
+    if not isinstance(value, list) or not value:
+        raise WorkspaceError(f"{context}: must be a non-empty array")
+    result = [_text(item, f"{context}[{index}]") for index, item in enumerate(value)]
+    if result != sorted(set(result)):
+        raise WorkspaceError(f"{context}: must be sorted and unique")
+    return result
+
+
+def _validate_schema(schema: dict[str, Any]) -> None:
+    if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        raise WorkspaceError("provenance identity schema must use draft 2020-12")
+    if schema.get("$id") != "https://atrinik.org/schema/provenance-identities-v1.json":
+        raise WorkspaceError("provenance identity schema has an unexpected $id")
+    if schema.get("type") != "object" or schema.get("additionalProperties") is not False:
+        raise WorkspaceError("provenance identity schema must reject non-object or extra fields")
+    version = schema.get("properties", {}).get("schema_version", {}).get("const")
+    if version != SCHEMA_VERSION:
+        raise WorkspaceError("provenance identity schema has an unsupported version")
+
+
+def _walk_confidential_keys(value: object, context: str) -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key.lower() in CONFIDENTIAL_FORBIDDEN_KEYS:
+                raise WorkspaceError(
+                    f"{context}: confidential record contains unsafe public field {key!r}"
+                )
+            _walk_confidential_keys(child, context)
+    elif isinstance(value, list):
+        for child in value:
+            _walk_confidential_keys(child, context)
+
+
+def _validate_integrity(record: dict[str, Any], context: str) -> None:
+    integrity = record.get("integrity")
+    if not isinstance(integrity, dict):
+        raise WorkspaceError(f"{context}.integrity: must be an object")
+    _exact_keys(integrity, {"algorithm", "canonicalization", "digest"}, f"{context}.integrity")
+    if integrity["algorithm"] != "sha256":
+        raise WorkspaceError(f"{context}.integrity.algorithm: must be sha256")
+    if integrity["canonicalization"] != CANONICALIZATION:
+        raise WorkspaceError(
+            f"{context}.integrity.canonicalization: must be {CANONICALIZATION}"
+        )
+    digest = integrity["digest"]
+    if not isinstance(digest, str) or not SHA256_PATTERN.fullmatch(digest):
+        raise WorkspaceError(f"{context}.integrity.digest: must be lowercase SHA-256")
+    if digest != record_digest(record):
+        raise WorkspaceError(f"{context}.integrity.digest: does not match canonical record")
+
+
+def _validate_common_record(record: dict[str, Any], context: str, as_of: date) -> None:
+    identifier = record.get("record_id")
+    if not isinstance(identifier, str) or not RECORD_ID_PATTERN.fullmatch(identifier):
+        raise WorkspaceError(f"{context}.record_id: must be an opaque pir identifier")
+    if record.get("policy_version") != POLICY_VERSION:
+        raise WorkspaceError(f"{context}.policy_version: unsupported policy version")
+    if record.get("status") not in {"active", "revoked", "superseded"}:
+        raise WorkspaceError(f"{context}.status: unsupported status")
+    reviewer = record.get("reviewer")
+    if not isinstance(reviewer, str) or not REVIEWER_PATTERN.fullmatch(reviewer):
+        raise WorkspaceError(f"{context}.reviewer: must be a public GitHub reviewer identity")
+    reviewed = _iso_date(record.get("reviewed_on"), f"{context}.reviewed_on")
+    expires = _iso_date(record.get("expires_on"), f"{context}.expires_on")
+    if expires <= reviewed:
+        raise WorkspaceError(f"{context}: expires_on must be after reviewed_on")
+    if record.get("status") == "active" and expires < as_of:
+        raise WorkspaceError(f"{context}: active attestation is stale")
+    claims = _string_array(record.get("claims"), f"{context}.claims")
+    if not set(claims) <= KNOWN_CLAIMS:
+        raise WorkspaceError(f"{context}.claims: contains an unknown claim")
+    _validate_integrity(record, context)
+
+
+def _validate_confidential_record(record: dict[str, Any], context: str, as_of: date) -> None:
+    _walk_confidential_keys(record, context)
+    _exact_keys(
+        record,
+        {
+            "claims",
+            "expires_on",
+            "integrity",
+            "policy_version",
+            "publication_review",
+            "record_id",
+            "record_type",
+            "restricted_evidence",
+            "reviewed_on",
+            "reviewer",
+            "scope_binding",
+            "status",
+            "synthetic",
+        },
+        context,
+    )
+    if not isinstance(record["synthetic"], bool):
+        raise WorkspaceError(f"{context}.synthetic: must be a boolean")
+    binding = record["scope_binding"]
+    if not isinstance(binding, str) or not SCOPE_BINDING_PATTERN.fullmatch(binding):
+        raise WorkspaceError(f"{context}.scope_binding: must be an opaque binding")
+    evidence = record["restricted_evidence"]
+    if not isinstance(evidence, dict):
+        raise WorkspaceError(f"{context}.restricted_evidence: must be an object")
+    _exact_keys(evidence, {"integrity", "record_id"}, f"{context}.restricted_evidence")
+    if not RESTRICTED_ID_PATTERN.fullmatch(str(evidence["record_id"])):
+        raise WorkspaceError(f"{context}.restricted_evidence.record_id: invalid identifier")
+    if not re.fullmatch(r"hmac-sha256:[0-9a-f]{64}", str(evidence["integrity"])):
+        raise WorkspaceError(f"{context}.restricted_evidence.integrity: invalid keyed digest")
+    review = record["publication_review"]
+    if not isinstance(review, dict):
+        raise WorkspaceError(f"{context}.publication_review: must be an object")
+    _exact_keys(review, {"correlation_risk", "fields_reviewed"}, f"{context}.publication_review")
+    if review["correlation_risk"] != "approved":
+        raise WorkspaceError(f"{context}.publication_review: correlation risk is not approved")
+    fields = _string_array(review["fields_reviewed"], f"{context}.publication_review.fields_reviewed")
+    if fields != sorted(record):
+        raise WorkspaceError(f"{context}.publication_review: must cover every public field")
+    _validate_common_record(record, context, as_of)
+
+
+def _validate_public_alias_record(record: dict[str, Any], context: str, as_of: date) -> None:
+    _exact_keys(
+        record,
+        {
+            "aliases",
+            "claims",
+            "display_name",
+            "expires_on",
+            "integrity",
+            "policy_version",
+            "publication_authorization",
+            "record_id",
+            "record_type",
+            "reviewed_on",
+            "reviewer",
+            "status",
+            "synthetic",
+        },
+        context,
+    )
+    if not isinstance(record["synthetic"], bool):
+        raise WorkspaceError(f"{context}.synthetic: must be a boolean")
+    _text(record["display_name"], f"{context}.display_name")
+    _string_array(record["aliases"], f"{context}.aliases")
+    authorization = record["publication_authorization"]
+    if not isinstance(authorization, dict):
+        raise WorkspaceError(f"{context}.publication_authorization: must be an object")
+    _exact_keys(
+        authorization,
+        {"authorized_on", "fields", "restricted_record_id"},
+        f"{context}.publication_authorization",
+    )
+    _iso_date(authorization["authorized_on"], f"{context}.publication_authorization.authorized_on")
+    if _string_array(authorization["fields"], f"{context}.publication_authorization.fields") != [
+        "aliases",
+        "display_name",
+    ]:
+        raise WorkspaceError(f"{context}.publication_authorization: must explicitly cover all identity fields")
+    if not RESTRICTED_ID_PATTERN.fullmatch(str(authorization["restricted_record_id"])):
+        raise WorkspaceError(f"{context}.publication_authorization.restricted_record_id: invalid identifier")
+    _validate_common_record(record, context, as_of)
+
+
+def validate_registry(
+    registry: dict[str, Any], schema: dict[str, Any], *, as_of: date
+) -> dict[str, dict[str, Any]]:
+    _validate_schema(schema)
+    _exact_keys(
+        registry,
+        {"policy_version", "records", "schema", "schema_version"},
+        "provenance identity registry",
+    )
+    if registry["schema_version"] != SCHEMA_VERSION:
+        raise WorkspaceError("provenance identity registry has an unsupported schema version")
+    if registry["policy_version"] != POLICY_VERSION:
+        raise WorkspaceError("provenance identity registry has an unsupported policy version")
+    if registry["schema"] != SCHEMA_PATH.as_posix():
+        raise WorkspaceError("provenance identity registry names an unexpected schema")
+    records = registry["records"]
+    if not isinstance(records, list):
+        raise WorkspaceError("provenance identity registry records must be an array")
+    result: dict[str, dict[str, Any]] = {}
+    bindings: set[str] = set()
+    restricted_ids: set[str] = set()
+    for index, record in enumerate(records):
+        context = f"provenance identity record {index}"
+        if not isinstance(record, dict):
+            raise WorkspaceError(f"{context}: must be an object")
+        identifier = record.get("record_id")
+        if identifier in result:
+            raise WorkspaceError(f"{context}: duplicate record identifier {identifier}")
+        record_type = record.get("record_type")
+        if record_type == "confidential-attestation":
+            _validate_confidential_record(record, context, as_of)
+            binding = record["scope_binding"]
+            restricted_id = record["restricted_evidence"]["record_id"]
+            if binding in bindings:
+                raise WorkspaceError(f"{context}: duplicate scope binding")
+            if restricted_id in restricted_ids:
+                raise WorkspaceError(f"{context}: duplicate restricted evidence identifier")
+            bindings.add(binding)
+            restricted_ids.add(restricted_id)
+        elif record_type == "public-alias":
+            _validate_public_alias_record(record, context, as_of)
+        else:
+            raise WorkspaceError(f"{context}.record_type: unsupported record type")
+        identifier = record["record_id"]
+        result[identifier] = record
+    if list(result) != sorted(result):
+        raise WorkspaceError("provenance identity registry records must be sorted by record_id")
+    return result
+
+
+def _git_blob(repository_root: Path, revision: str, path: str) -> bytes:
+    try:
+        result = subprocess.run(
+            ["git", "show", f"{revision}:{path}"],
+            cwd=repository_root,
+            check=True,
+            capture_output=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        raise WorkspaceError(f"immutable reference cannot resolve {revision}:{path}") from exc
+    if len(result.stdout) > MAX_DOCUMENT_BYTES:
+        raise WorkspaceError("immutable reference document exceeds the size limit")
+    return result.stdout
+
+
+def _load_bytes(value: bytes, context: str) -> dict[str, Any]:
+    try:
+        result = json.loads(value.decode("utf-8"), object_pairs_hook=_object_pairs)
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise WorkspaceError(f"{context}: invalid JSON") from exc
+    if not isinstance(result, dict):
+        raise WorkspaceError(f"{context}: root must be an object")
+    return result
+
+
+def validate_component_reference(
+    reference: dict[str, Any], *, repository_root: Path, as_of: date
+) -> None:
+    _exact_keys(
+        reference,
+        {
+            "destination",
+            "evidence_reference",
+            "schema_version",
+            "scope_binding",
+            "source",
+            "transformation",
+        },
+        "component provenance record",
+    )
+    if reference["schema_version"] != SCHEMA_VERSION:
+        raise WorkspaceError("component provenance record has an unsupported schema version")
+    for key in ("source", "destination"):
+        coordinate = reference[key]
+        if not isinstance(coordinate, dict):
+            raise WorkspaceError(f"component provenance record {key} must be an object")
+        required = {"path", "repository", "revision"} if key == "source" else {"path", "repository"}
+        _exact_keys(coordinate, required, f"component provenance record {key}")
+        if not re.fullmatch(r"atrinik/[a-z0-9][a-z0-9._-]*", str(coordinate["repository"])):
+            raise WorkspaceError(f"component provenance record {key}.repository is invalid")
+        _text(coordinate["path"], f"component provenance record {key}.path")
+        if key == "source" and not _text(coordinate["revision"], "source.revision"):
+            raise AssertionError("unreachable")
+    _text(reference["transformation"], "component provenance record transformation")
+    evidence = reference["evidence_reference"]
+    if not isinstance(evidence, dict):
+        raise WorkspaceError("component provenance evidence_reference must be an object")
+    _exact_keys(
+        evidence,
+        {"record_id", "registry_sha256", "repository", "revision", "schema_sha256", "url"},
+        "component provenance evidence_reference",
+    )
+    if evidence["repository"] != "atrinik/atrinik":
+        raise WorkspaceError("component provenance reference must use atrinik/atrinik")
+    revision = evidence["revision"]
+    if not isinstance(revision, str) or not REVISION_PATTERN.fullmatch(revision):
+        raise WorkspaceError("component provenance reference revision must be a full Git SHA")
+    record_id = evidence["record_id"]
+    if not isinstance(record_id, str) or not RECORD_ID_PATTERN.fullmatch(record_id):
+        raise WorkspaceError("component provenance reference record_id is invalid")
+    expected_url = (
+        f"https://github.com/atrinik/atrinik/blob/{revision}/"
+        f"{REGISTRY_PATH.as_posix()}#{record_id}"
+    )
+    if evidence["url"] != expected_url:
+        raise WorkspaceError("component provenance reference URL is not the canonical immutable permalink")
+    for key in ("registry_sha256", "schema_sha256"):
+        if not isinstance(evidence[key], str) or not SHA256_PATTERN.fullmatch(evidence[key]):
+            raise WorkspaceError(f"component provenance reference {key} is invalid")
+    registry_blob = _git_blob(repository_root, revision, REGISTRY_PATH.as_posix())
+    schema_blob = _git_blob(repository_root, revision, SCHEMA_PATH.as_posix())
+    if sha256(registry_blob) != evidence["registry_sha256"]:
+        raise WorkspaceError("component provenance reference registry digest does not match")
+    if sha256(schema_blob) != evidence["schema_sha256"]:
+        raise WorkspaceError("component provenance reference schema digest does not match")
+    records = validate_registry(
+        _load_bytes(registry_blob, "referenced registry"),
+        _load_bytes(schema_blob, "referenced schema"),
+        as_of=as_of,
+    )
+    if record_id not in records:
+        raise WorkspaceError("component provenance reference record is absent")
+    record = records[record_id]
+    if record["status"] != "active":
+        raise WorkspaceError("component provenance reference record is not active")
+    if record["record_type"] != "confidential-attestation":
+        raise WorkspaceError("component provenance reference must select a confidential attestation")
+    if record["scope_binding"] != reference["scope_binding"]:
+        raise WorkspaceError("component provenance scope binding does not match the attestation")
+    if record["synthetic"] and not str(reference["destination"]["repository"]).startswith("atrinik/synthetic-"):
+        raise WorkspaceError("synthetic attestations may only be used by synthetic component fixtures")
+
+
+def validate_paths(
+    root: Path,
+    *,
+    registry_path: Path,
+    schema_path: Path,
+    reference_paths: list[Path],
+    as_of: date,
+) -> int:
+    records = validate_registry(load_document(registry_path), load_document(schema_path), as_of=as_of)
+    for path in reference_paths:
+        validate_component_reference(load_document(path), repository_root=root, as_of=as_of)
+    return len(records)

--- a/atrinik_workspace/provenance_identity.py
+++ b/atrinik_workspace/provenance_identity.py
@@ -21,7 +21,7 @@ CANONICALIZATION = "atrinik-json-v1"
 REGISTRY_PATH = Path("governance/provenance-identities/registry.json")
 SCHEMA_PATH = Path("governance/provenance-identities/schema-v1.json")
 REVIEWERS_PATH = Path("governance/provenance-identities/reviewers.json")
-TRUSTED_SCHEMA_CANONICAL_SHA256 = "e04b15c8c79690c4f04752676a54febd95d1473fab7d968ad1cf4b6cedc35704"
+TRUSTED_SCHEMA_CANONICAL_SHA256 = "d80f49a1b17d00ad203a70229f2649d005bf69b738fc197c5ad6da8f944e57bd"
 CONFIDENTIAL_RECORD_ID_PATTERN = re.compile(r"^pir-c-[0-9a-f]{32}$")
 PUBLIC_RECORD_ID_PATTERN = re.compile(r"^pir-p-[0-9a-f]{32}$")
 RECORD_ID_PATTERN = re.compile(r"^pir-[cp]-[0-9a-f]{32}$")
@@ -547,7 +547,21 @@ def validate_registry(
 
 
 def _git_environment() -> dict[str, str]:
-    return {**os.environ, "GIT_NO_REPLACE_OBJECTS": "1"}
+    environment = os.environ.copy()
+    for name in (
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_CEILING_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        "GIT_DIR",
+        "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_REPLACE_REF_BASE",
+        "GIT_WORK_TREE",
+    ):
+        environment.pop(name, None)
+    environment["GIT_NO_REPLACE_OBJECTS"] = "1"
+    return environment
 
 
 def _git_output(repository_root: Path, arguments: list[str], context: str) -> bytes:

--- a/atrinik_workspace/provenance_identity.py
+++ b/atrinik_workspace/provenance_identity.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import date
 import hashlib
 import json
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 import re
 import subprocess
 from typing import Any
@@ -77,7 +77,7 @@ def load_document(path: Path) -> dict[str, Any]:
 
 
 def canonical_bytes(value: object) -> bytes:
-    """Serialize the deliberately integer-free public contract deterministically."""
+    """Serialize the deliberately floating-point-free contract deterministically."""
 
     return json.dumps(
         value,
@@ -133,6 +133,19 @@ def _string_array(value: object, context: str) -> list[str]:
     if result != sorted(set(result)):
         raise WorkspaceError(f"{context}: must be sorted and unique")
     return result
+
+
+def _repository_path(value: object, context: str) -> str:
+    text = _text(value, context)
+    path = PurePosixPath(text)
+    if (
+        text.startswith("/")
+        or "\\" in text
+        or path.as_posix() != text
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
+        raise WorkspaceError(f"{context}: must be a safe repository-relative path")
+    return text
 
 
 def _validate_schema(schema: dict[str, Any]) -> None:
@@ -245,6 +258,8 @@ def _validate_confidential_record(record: dict[str, Any], context: str, as_of: d
     if fields != sorted(record):
         raise WorkspaceError(f"{context}.publication_review: must cover every public field")
     _validate_common_record(record, context, as_of)
+    if set(record["claims"]) != KNOWN_CLAIMS:
+        raise WorkspaceError(f"{context}.claims: confidential review must prove all claims")
 
 
 def _validate_public_alias_record(record: dict[str, Any], context: str, as_of: date) -> None:
@@ -279,7 +294,12 @@ def _validate_public_alias_record(record: dict[str, Any], context: str, as_of: d
         {"authorized_on", "fields", "restricted_record_id"},
         f"{context}.publication_authorization",
     )
-    _iso_date(authorization["authorized_on"], f"{context}.publication_authorization.authorized_on")
+    authorized = _iso_date(
+        authorization["authorized_on"],
+        f"{context}.publication_authorization.authorized_on",
+    )
+    if authorized > _iso_date(record["reviewed_on"], f"{context}.reviewed_on"):
+        raise WorkspaceError(f"{context}.publication_authorization: cannot postdate review")
     if _string_array(authorization["fields"], f"{context}.publication_authorization.fields") != [
         "aliases",
         "display_name",
@@ -391,10 +411,19 @@ def validate_component_reference(
         _exact_keys(coordinate, required, f"component provenance record {key}")
         if not re.fullmatch(r"atrinik/[a-z0-9][a-z0-9._-]*", str(coordinate["repository"])):
             raise WorkspaceError(f"component provenance record {key}.repository is invalid")
-        _text(coordinate["path"], f"component provenance record {key}.path")
-        if key == "source" and not _text(coordinate["revision"], "source.revision"):
-            raise AssertionError("unreachable")
+        _repository_path(coordinate["path"], f"component provenance record {key}.path")
+        if key == "source":
+            source_revision = _text(coordinate["revision"], "source.revision")
+            if not re.fullmatch(
+                r"[0-9a-f]{40}(?:\.\.[0-9a-f]{40})?", source_revision
+            ):
+                raise WorkspaceError(
+                    "component provenance source.revision must be a full Git SHA or exact SHA range"
+                )
     _text(reference["transformation"], "component provenance record transformation")
+    binding = reference["scope_binding"]
+    if not isinstance(binding, str) or not SCOPE_BINDING_PATTERN.fullmatch(binding):
+        raise WorkspaceError("component provenance scope_binding is invalid")
     evidence = reference["evidence_reference"]
     if not isinstance(evidence, dict):
         raise WorkspaceError("component provenance evidence_reference must be an object")

--- a/atrinik_workspace/provenance_identity.py
+++ b/atrinik_workspace/provenance_identity.py
@@ -21,7 +21,7 @@ CANONICALIZATION = "atrinik-json-v1"
 REGISTRY_PATH = Path("governance/provenance-identities/registry.json")
 SCHEMA_PATH = Path("governance/provenance-identities/schema-v1.json")
 REVIEWERS_PATH = Path("governance/provenance-identities/reviewers.json")
-TRUSTED_SCHEMA_CANONICAL_SHA256 = "2f52bcf87957ffc909cc99cb57ad8f0f1809dc02dfa4111d32e5ad24a4a3cb05"
+TRUSTED_SCHEMA_CANONICAL_SHA256 = "e04b15c8c79690c4f04752676a54febd95d1473fab7d968ad1cf4b6cedc35704"
 CONFIDENTIAL_RECORD_ID_PATTERN = re.compile(r"^pir-c-[0-9a-f]{32}$")
 PUBLIC_RECORD_ID_PATTERN = re.compile(r"^pir-p-[0-9a-f]{32}$")
 RECORD_ID_PATTERN = re.compile(r"^pir-[cp]-[0-9a-f]{32}$")
@@ -490,6 +490,7 @@ def validate_registry(
     result: dict[str, dict[str, Any]] = {}
     bindings: set[str] = set()
     restricted_ids: set[str] = set()
+    restricted_integrities: set[str] = set()
     for index, record in enumerate(records):
         context = f"provenance identity record {index}"
         if not isinstance(record, dict):
@@ -502,12 +503,16 @@ def validate_registry(
             _validate_confidential_record(record, context, as_of, reviewers)
             binding = record["scope_binding"]
             restricted_id = record["restricted_evidence"]["record_id"]
+            restricted_integrity = record["restricted_evidence"]["integrity"]
             if binding in bindings:
                 raise WorkspaceError(f"{context}: duplicate scope binding")
             if restricted_id in restricted_ids:
                 raise WorkspaceError(f"{context}: duplicate restricted evidence identifier")
+            if restricted_integrity in restricted_integrities:
+                raise WorkspaceError(f"{context}: duplicate restricted evidence integrity")
             bindings.add(binding)
             restricted_ids.add(restricted_id)
+            restricted_integrities.add(restricted_integrity)
         elif record_type == "public-alias":
             _validate_public_alias_record(record, context, as_of, reviewers)
         else:
@@ -523,6 +528,8 @@ def validate_registry(
         effective = _iso_date(detail.get("effective_on"), f"record {identifier}.status_detail.effective_on")
         if effective < _iso_date(record["reviewed_on"], f"record {identifier}.reviewed_on"):
             raise WorkspaceError(f"record {identifier}: status predates review")
+        if effective > as_of:
+            raise WorkspaceError(f"record {identifier}: status effective date is in the future")
         if record["status"] == "active":
             _exact_keys(detail, {"effective_on"}, f"record {identifier}.status_detail")
         elif record["status"] == "revoked":
@@ -787,6 +794,27 @@ def validate_paths(
         reviewers_value,
         as_of=as_of,
     )
+    if reference_paths:
+        _validate_repository_trust(root, trusted_ref, trusted_ref)
+        trusted_registry = _load_bytes(
+            _git_blob(root, trusted_ref, REGISTRY_PATH.as_posix()),
+            "trusted current registry",
+        )
+        trusted_schema = _load_bytes(
+            _git_blob(root, trusted_ref, SCHEMA_PATH.as_posix()),
+            "trusted current schema",
+        )
+        trusted_reviewers_value = _load_bytes(
+            _git_blob(root, trusted_ref, REVIEWERS_PATH.as_posix()),
+            "trusted current reviewers",
+        )
+        records = validate_registry(
+            trusted_registry,
+            trusted_schema,
+            trusted_reviewers_value,
+            as_of=as_of,
+        )
+        reviewers = validate_reviewers(trusted_reviewers_value, as_of=as_of)
     for path in reference_paths:
         validate_component_reference(
             load_document(path),

--- a/atrinik_workspace/provenance_identity.py
+++ b/atrinik_workspace/provenance_identity.py
@@ -642,19 +642,27 @@ def validate_component_reference(
             "scope_approval",
             "scope_binding",
             "source",
+            "synthetic",
             "transformation",
         },
         "component provenance record",
     )
-    if type(reference["schema_version"]) is not int or reference["schema_version"] != SCHEMA_VERSION:
+    if (
+        type(reference["schema_version"]) is not int
+        or reference["schema_version"] != SCHEMA_VERSION
+    ):
         raise WorkspaceError("component provenance record has an unsupported schema version")
+    if not isinstance(reference["synthetic"], bool):
+        raise WorkspaceError("component provenance record synthetic must be a boolean")
     for key in ("source", "destination"):
         coordinate = reference[key]
         if not isinstance(coordinate, dict):
             raise WorkspaceError(f"component provenance record {key} must be an object")
         required = {"path", "repository", "revision"} if key == "source" else {"path", "repository"}
         _exact_keys(coordinate, required, f"component provenance record {key}")
-        if not re.fullmatch(r"atrinik/[a-z0-9][a-z0-9._-]*", str(coordinate["repository"])):
+        if not re.fullmatch(
+            r"atrinik/[a-z0-9][a-z0-9._-]*", str(coordinate["repository"])
+        ):
             raise WorkspaceError(f"component provenance record {key}.repository is invalid")
         _repository_path(coordinate["path"], f"component provenance record {key}.path")
         if key == "source":
@@ -674,7 +682,15 @@ def validate_component_reference(
         raise WorkspaceError("component provenance evidence_reference must be an object")
     _exact_keys(
         evidence,
-        {"record_id", "registry_sha256", "repository", "reviewers_sha256", "revision", "schema_sha256", "url"},
+        {
+            "record_id",
+            "registry_sha256",
+            "repository",
+            "reviewers_sha256",
+            "revision",
+            "schema_sha256",
+            "url",
+        },
         "component provenance evidence_reference",
     )
     if evidence["repository"] != "atrinik/atrinik":
@@ -690,10 +706,14 @@ def validate_component_reference(
         f"{REGISTRY_PATH.as_posix()}#{record_id}"
     )
     if evidence["url"] != expected_url:
-        raise WorkspaceError("component provenance reference URL is not the canonical immutable permalink")
+        raise WorkspaceError(
+            "component provenance reference URL is not the canonical immutable permalink"
+        )
     _validate_repository_trust(repository_root, revision, trusted_ref)
     for key in ("registry_sha256", "reviewers_sha256", "schema_sha256"):
-        if not isinstance(evidence[key], str) or not SHA256_PATTERN.fullmatch(evidence[key]):
+        if not isinstance(evidence[key], str) or not SHA256_PATTERN.fullmatch(
+            evidence[key]
+        ):
             raise WorkspaceError(f"component provenance reference {key} is invalid")
     registry_blob = _git_blob(repository_root, revision, REGISTRY_PATH.as_posix())
     schema_blob = _git_blob(repository_root, revision, SCHEMA_PATH.as_posix())
@@ -716,12 +736,16 @@ def validate_component_reference(
     if record["status"] != "active":
         raise WorkspaceError("component provenance reference record is not active")
     if record["record_type"] != "confidential-attestation":
-        raise WorkspaceError("component provenance reference must select a confidential attestation")
+        raise WorkspaceError(
+            "component provenance reference must select a confidential attestation"
+        )
     if record["scope_binding"] != reference["scope_binding"]:
         raise WorkspaceError("component provenance scope binding does not match the attestation")
     current = current_records.get(record_id)
     if current is None or current["status"] != "active":
-        raise WorkspaceError("component provenance record is not active in the current registry")
+        raise WorkspaceError(
+            "component provenance record is not active in the current registry"
+        )
     if current["scope_binding"] != reference["scope_binding"]:
         raise WorkspaceError("current provenance scope binding differs from the pinned record")
     scope_payload = canonical_bytes(
@@ -736,8 +760,10 @@ def validate_component_reference(
         synthetic=record["synthetic"],
         context="component provenance scope_approval",
     )
-    if record["synthetic"] and not str(reference["destination"]["repository"]).startswith("atrinik/synthetic-"):
-        raise WorkspaceError("synthetic attestations may only be used by synthetic component fixtures")
+    if record["synthetic"] != reference["synthetic"]:
+        raise WorkspaceError(
+            "component provenance synthetic boundary does not match the attestation"
+        )
 
 
 def validate_paths(

--- a/atrinik_workspace/provenance_identity.py
+++ b/atrinik_workspace/provenance_identity.py
@@ -748,6 +748,8 @@ def validate_component_reference(
         )
     if current["scope_binding"] != reference["scope_binding"]:
         raise WorkspaceError("current provenance scope binding differs from the pinned record")
+    if current["integrity"]["digest"] != record["integrity"]["digest"]:
+        raise WorkspaceError("current provenance record differs from the pinned attestation")
     scope_payload = canonical_bytes(
         {key: value for key, value in reference.items() if key != "scope_approval"}
     )

--- a/atrinik_workspace/provenance_identity.py
+++ b/atrinik_workspace/provenance_identity.py
@@ -580,6 +580,7 @@ def _validate_repository_trust(
         "coordinator checkout requires origin",
     ).decode().strip()
     if origin not in {
+        "https://github.com/atrinik/atrinik",
         "https://github.com/atrinik/atrinik.git",
         "git@github.com:atrinik/atrinik.git",
     }:

--- a/atrinik_workspace/provenance_identity.py
+++ b/atrinik_workspace/provenance_identity.py
@@ -256,10 +256,15 @@ def _verify_approval(
         with tempfile.TemporaryDirectory(prefix="atrinik-provenance-signature-") as temporary:
             allowed = Path(temporary) / "allowed_signers"
             signature_path = Path(temporary) / "signature"
-            allowed.write_text(
-                f"{reviewer_identity} {reviewer['public_key']}\n", encoding="utf-8"
-            )
-            signature_path.write_text(signature + "\n", encoding="utf-8")
+            with open(
+                allowed, "x", encoding="utf-8", opener=_private_file_opener
+            ) as stream:
+                stream.write(f"{reviewer_identity} {reviewer['public_key']}\n")
+            with open(
+                signature_path,
+                "x", encoding="utf-8", opener=_private_file_opener
+            ) as stream:
+                stream.write(signature + "\n")
             result = subprocess.run(
                 [
                     "ssh-keygen",
@@ -282,6 +287,10 @@ def _verify_approval(
         raise WorkspaceError(f"{context}: cannot verify reviewer signature") from exc
     if result.returncode != 0:
         raise WorkspaceError(f"{context}: reviewer signature is invalid")
+
+
+def _private_file_opener(path: str, flags: int) -> int:
+    return os.open(path, flags, 0o600)
 
 
 def _walk_confidential_keys(value: object, context: str) -> None:

--- a/atrinik_workspace/provenance_identity.py
+++ b/atrinik_workspace/provenance_identity.py
@@ -259,12 +259,14 @@ def _verify_approval(
             with open(
                 allowed, "x", encoding="utf-8", opener=_private_file_opener
             ) as stream:
-                stream.write(f"{reviewer_identity} {reviewer['public_key']}\n")
+                # Public verifier material, not a secret; ssh-keygen requires a file.
+                stream.write(f"{reviewer_identity} {reviewer['public_key']}\n")  # lgtm[py/clear-text-storage-sensitive-data]
             with open(
                 signature_path,
                 "x", encoding="utf-8", opener=_private_file_opener
             ) as stream:
-                stream.write(signature + "\n")
+                # The checked-in public signature contains no private key material.
+                stream.write(signature + "\n")  # lgtm[py/clear-text-storage-sensitive-data]
             result = subprocess.run(
                 [
                     "ssh-keygen",

--- a/atrinik_workspace/provenance_identity.py
+++ b/atrinik_workspace/provenance_identity.py
@@ -674,7 +674,7 @@ def validate_component_reference(
         raise WorkspaceError("component provenance evidence_reference must be an object")
     _exact_keys(
         evidence,
-        {"record_id", "registry_sha256", "repository", "revision", "schema_sha256", "url"},
+        {"record_id", "registry_sha256", "repository", "reviewers_sha256", "revision", "schema_sha256", "url"},
         "component provenance evidence_reference",
     )
     if evidence["repository"] != "atrinik/atrinik":
@@ -692,22 +692,22 @@ def validate_component_reference(
     if evidence["url"] != expected_url:
         raise WorkspaceError("component provenance reference URL is not the canonical immutable permalink")
     _validate_repository_trust(repository_root, revision, trusted_ref)
-    for key in ("registry_sha256", "schema_sha256"):
+    for key in ("registry_sha256", "reviewers_sha256", "schema_sha256"):
         if not isinstance(evidence[key], str) or not SHA256_PATTERN.fullmatch(evidence[key]):
             raise WorkspaceError(f"component provenance reference {key} is invalid")
     registry_blob = _git_blob(repository_root, revision, REGISTRY_PATH.as_posix())
     schema_blob = _git_blob(repository_root, revision, SCHEMA_PATH.as_posix())
+    reviewers_blob = _git_blob(repository_root, revision, REVIEWERS_PATH.as_posix())
     if sha256(registry_blob) != evidence["registry_sha256"]:
         raise WorkspaceError("component provenance reference registry digest does not match")
     if sha256(schema_blob) != evidence["schema_sha256"]:
         raise WorkspaceError("component provenance reference schema digest does not match")
+    if sha256(reviewers_blob) != evidence["reviewers_sha256"]:
+        raise WorkspaceError("component provenance reference reviewers digest does not match")
     records = validate_registry(
         _load_bytes(registry_blob, "referenced registry"),
         _load_bytes(schema_blob, "referenced schema"),
-        _load_bytes(
-            _git_blob(repository_root, revision, REVIEWERS_PATH.as_posix()),
-            "referenced reviewers",
-        ),
+        _load_bytes(reviewers_blob, "referenced reviewers"),
         as_of=as_of,
     )
     if record_id not in records:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,15 @@ input.
 
 Source provenance is also a cross-repository contract.
 [`PROVENANCE.md`](PROVENANCE.md) is the single exhaustive historical MIT
-grantor registry and evidence procedure. Exact independently separable Classic
+grantor registry and rights procedure. The coordinator also owns the only
+versioned public identity registry and schema under
+`governance/provenance-identities/`; components hold exact material scope and a
+full-commit reference rather than copied identities. Restricted mappings stay
+outside public Git while opaque, digest-bound attestations join an approved
+identity review to a destination record. The bounded validator resolves only
+size-limited blobs from the pinned local Git revision and fails closed on
+unsafe fields, stale/revoked records, version drift, or broken integrity.
+Exact independently separable Classic
 material proven to fall within an applicable approved historical grant,
 including its temporal and sole-original-authorship scope, may be inspected as
 source reference, copied, migrated or ported, translated or adapted, and

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -21,6 +21,40 @@ material receives additional MIT permission in the recorded destination; no
 surrounding file, dependency, asset, subtree, binary, or repository is
 relicensed.
 
+## Identity evidence gates
+
+Historical identity reconciliation may use the privacy-preserving attestation
+path in [`PROVENANCE_IDENTITIES.md`](PROVENANCE_IDENTITIES.md), but an
+attestation does not replace the material and rights review below. Accept it
+only when all of these gates pass:
+
+1. The restricted store, custodian/reviewer separation, access ledger, key
+   custody, retention, correction, and incident controls are operational. If
+   they are not, confidential reconciliation fails closed.
+2. The public record is active, fresh, schema/policy-version compatible,
+   canonical-digest valid, and reviewed by an authorized reviewer for identity,
+   sole authorship, temporal scope, and rights grant. A public alias also has
+   explicit restricted authorization for every published identity field.
+3. A complete public-record and diff review finds no subject identifier and no
+   practical re-identification path through identifiers, dates, reviewers,
+   grant names, source scopes, hashes, ordering, or correlated metadata.
+4. The destination record contains the exact source, destination,
+   transformation, and matching opaque scope binding, plus a full-commit GitHub
+   permalink and exact registry/schema digests. The pinned coordinator commit
+   is on the default branch or belongs to an approved immutable release.
+5. `./atrinik provenance validate --reference PATH` succeeds at the review
+   date from a bounded non-shallow coordinator checkout. Revoked, superseded,
+   stale, unknown-version, malformed, movable, missing, or digest-mismatched
+   evidence fails closed.
+
+The canonical public registry and schema exist only in
+`governance/provenance-identities/` in `atrinik/atrinik`. Component repositories
+must not copy aliases or canonical identity records. Restricted mappings,
+contact data, raw statements, keys, and private review notes must not enter
+public Git, GitHub discussion, CI logs, artifacts, or review reports. The two
+current registry entries and component fixtures are synthetic demonstrations;
+they confer no rights over real material.
+
 “Past” is temporal: each row covers only contributions completed before that
 row was recorded. Zoey Rose's row was first recorded in
 `d2af1c9fba462e5c18782d3c8206dbc5cfd74bb0`; Daniel Liptrot's row was first
@@ -47,10 +81,12 @@ Before applying a grant:
    authored contribution, generated output, or inseparable mixed work. Do not
    copy a mixed-authorship file merely because some surviving lines qualify.
 5. Record the source repository/path/revision, destination repository/path,
-   complete history and identity evidence, transformation, third-party review,
-   applicable grantor and grant, and required notices in the destination pull
-   request or a committed provenance manifest. Cite the exact
-   `atrinik/atrinik` revision containing this registry as the grant evidence.
+   complete history and approved identity-evidence reference, transformation,
+   third-party review, applicable grant and required notices in the destination
+   pull request or a committed provenance manifest. For confidential identity
+   evidence, cite only the opaque record and scope binding described above; do
+   not publish the grantor mapping. Cite the exact `atrinik/atrinik` revision
+   containing both this grant registry and the identity registry used.
 
 Use of an agent or other tool neither proves nor defeats permission to reuse
 the exact material. A listed person's prompting, direction, selection, receipt

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -42,7 +42,7 @@ only when all of these gates pass:
    transformation, and matching opaque scope binding, plus a full-commit GitHub
    permalink and exact registry/schema digests. The pinned coordinator commit
    is on the default branch or belongs to an approved immutable release.
-5. `./atrinik provenance validate --reference PATH` succeeds at the review
+5. `./atrinik provenance validate --reference PATH` succeeds on the current UTC
    date from a bounded non-shallow coordinator checkout. Revoked, superseded,
    stale, unknown-version, malformed, movable, missing, or digest-mismatched
    evidence fails closed.

--- a/docs/PROVENANCE_IDENTITIES.md
+++ b/docs/PROVENANCE_IDENTITIES.md
@@ -125,7 +125,7 @@ binding. Its `evidence_reference` has exactly:
 - `repository: atrinik/atrinik`;
 - a full 40-character coordinator commit reachable from canonical `origin/main`;
 - the opaque record ID;
-- SHA-256 digests of the registry and schema bytes; and
+- SHA-256 digests of the registry, schema, and reviewer-roster bytes; and
 - the canonical GitHub `blob/<commit>/.../registry.json#<record-id>` permalink.
 
 Online review opens that permalink and verifies that the commit is on the
@@ -138,9 +138,10 @@ history, or consult a local alias copy. A signed-release mode is not implemented
 in schema v1 and therefore fails closed.
 
 The synthetic component-owned records for `atrinik/client` and
-`atrinik/server` exercise both paths. The copies in this repository are test
-fixtures; each component keeps its own identical reference record and validates
-it without copying the canonical registry, schema, or reviewer roster:
+`atrinik/server` exercise the bounded audit path before merge. The copies in
+this repository are test fixtures; each component keeps its own identical
+reference record and validates it without copying the canonical registry,
+schema, or reviewer roster:
 
 ```sh
 ./atrinik provenance validate \
@@ -148,12 +149,15 @@ it without copying the canonical registry, schema, or reviewer roster:
   --reference tests/fixtures/provenance-identities/positive/synthetic-beta.json
 ```
 
-Their pinned URLs become online after this branch is pushed. Before merge they
-may be exercised only with `--non-authorizing-audit-ref
+Their pinned URLs become online after this branch is pushed. They may be
+exercised only with `--non-authorizing-audit-ref
 origin/feat/privacy-preserving-provenance-registry`; that mode is visibly not an
 approval for reuse. They carry an authenticated `synthetic: true` boundary and
-are test evidence, not permission for real material. Production validation
-accepts only a revision that has landed on the default branch.
+are test evidence, not permission for real material. Because the branch is
+squash-merged, these exact intermediate commits do not become default-branch
+ancestors. Completing the production-path demonstration is therefore an
+explicit post-merge dependency: new records must be reviewed and signed only
+after their coordinator revision has landed on the default branch.
 
 ## Migration and review
 

--- a/docs/PROVENANCE_IDENTITIES.md
+++ b/docs/PROVENANCE_IDENTITIES.md
@@ -1,0 +1,169 @@
+# Privacy-preserving provenance identities
+
+This is the operating policy for the canonical public provenance identity
+registry in `governance/provenance-identities/registry.json`. The registry and
+its versioned schema belong only to `atrinik/atrinik`; component repositories
+store exact material provenance and an immutable reference, never a copied
+alias registry. All examples and current records are synthetic.
+
+## Threat model and classification
+
+The protected subject may have used a former name, pseudonym, email address,
+account, signing key, or other identifier. An observer can search Git history,
+issues, pull requests, Actions artifacts and logs, compare timestamps and
+commit ranges, brute-force unkeyed hashes, and correlate fields across
+repositories. Removing an `alias` field alone does not prevent
+re-identification.
+
+Information is classified as follows:
+
+- A **public alias** is a display name and alias set that the affected person
+  explicitly authorized for publication. The restricted authorization records
+  the exact fields and date. Prior public appearance is not authorization.
+- **Restricted identity evidence** includes mappings, contact data, raw
+  statements, account history, exact private review notes, salts and keys. It
+  never enters public Git, GitHub discussion, CI input/output, artifacts, or
+  local review reports.
+- A **public confidential attestation** is the minimum opaque record proving
+  that an authorized reviewer checked identity, sole authorship, temporal
+  scope, and the rights grant. It contains no subject identifier or exact
+  material coordinate.
+- The **exact material scope** remains in the destination repository's
+  provenance record. An opaque `scope_binding` joins it to the attestation
+  without identifying the subject.
+- **Integrity metadata** includes schema/policy versions, reviewer, dates,
+  status, keyed restricted-evidence integrity, canonical public-record digest,
+  and immutable registry/schema digests. It is public only after the complete
+  record passes correlation review.
+
+Public record review considers the whole diff and surrounding metadata,
+including identifier shape, reviewer and date combinations, source/destination
+coordinates, commit ranges, grant names, ordering, and changes near other
+work. If those facts make the subject readily inferable, the record must be
+coarsened, delayed, split, or rejected. Confidential reconciliation fails
+closed whenever safe publication cannot be demonstrated.
+
+## Restricted evidence decision
+
+Restricted evidence is stored as encrypted, versioned objects in a dedicated
+private Atrinik organization repository named `provenance-evidence`, separate
+from every public source repository. Each object is encrypted before upload to
+the current `provenance-custodians` age recipient set. The repository contains
+only ciphertext, an opaque record ID, a keyed HMAC over the canonical decrypted
+record, and encrypted correction/supersession history. Plaintext, encryption
+identities, HMAC keys, recovery material, and local exports are excluded from
+Git and GitHub.
+
+The repository must remain unprovisioned, or confidential decisions must fail
+closed, until all of these controls exist:
+
+1. The organization owners designate at least two custodians in the
+   `provenance-custodians` team and at least two rights reviewers in the
+   `provenance-reviewers` team. A person may submit evidence but may not be the
+   sole reviewer of their own identity or grant.
+2. Custodians keep decryption and HMAC material in distinct organization-owned
+   password-manager vault items with individual access, mandatory MFA, no
+   shared plaintext secret, and an offline recovery copy held by a second
+   custodian.
+3. Branch protection requires two custodian reviews for ciphertext changes.
+   GitHub organization audit-log entries and a restricted access ledger record
+   read/export purpose, requester, approver, object IDs, and disposition.
+4. A reviewer receives only the minimum decrypted evidence through an
+   ephemeral encrypted workspace, records claim results separately, and
+   destroys exports after review. CI and GitHub Actions never decrypt evidence.
+
+Evidence is retained while any active or archived Atrinik revision relies on
+it, plus seven years after the last reliance is withdrawn. A subject may ask a
+custodian to correct or withdraw evidence. Corrections create a new restricted
+object and superseding public record; history is not rewritten. Withdrawal or
+unresolvable dispute revokes the public record and blocks new reuse. Archived
+or deleted repositories retain exact repository/revision/path facts in their
+own surviving provenance record, not in the identity registry.
+
+Suspected disclosure freezes new attestations, revokes affected public records
+where reliance is unsafe, preserves restricted audit evidence, notifies
+organization owners and affected people privately, and triggers scope review.
+Key compromise rotates recipients and HMAC keys, re-encrypts every active
+object, emits new keyed integrity values and superseding public records, and
+revokes records that cannot be reverified. Public incident text must not reveal
+the mapping it is protecting.
+
+## Attestation and integrity contract
+
+An approved reviewer attests only after restricted evidence proves all four
+claims: historical identity, exact original/sole authorship, temporal inclusion
+in the applicable grant, and rights sufficient for the destination operation.
+The reviewer creates a random public `record_id`, restricted object ID, and
+`scope_binding`; none is derived from personal data or source coordinates.
+Unkeyed hashes of names, aliases, emails, commits, or ranges are forbidden.
+
+`atrinik-json-v1` serializes UTF-8 JSON with lexicographically sorted object
+keys, no insignificant whitespace, JSON string escaping, and no floating-point
+values. A record's public SHA-256 covers every field except `integrity`. The
+restricted HMAC uses a separately held key and covers the canonical decrypted
+evidence plus the exact scope binding. Public aliases additionally require a
+restricted authorization naming every public identity field.
+
+Records expire and must be re-reviewed before use. `revoked` records are
+invalid immediately; `superseded` records direct operators to a separately
+published replacement without mutating history. Schema or policy changes use a
+new version and require explicit migration review. The validator rejects
+unknown versions, duplicate IDs/bindings, stale active records, unsafe fields,
+digest drift, and references to non-active records.
+
+## Immutable component references
+
+A component provenance record owns exact source repository, path and full Git
+revision; destination repository and path; transformation; and the opaque scope
+binding. Its `evidence_reference` has exactly:
+
+- `repository: atrinik/atrinik`;
+- a full 40-character coordinator commit reachable from its default branch, or
+  the commit named by an immutable signed release artifact;
+- the opaque record ID;
+- SHA-256 digests of the registry and schema bytes; and
+- the canonical GitHub `blob/<commit>/.../registry.json#<record-id>` permalink.
+
+Online review opens that permalink and verifies that the commit is on the
+coordinator default branch or covered by the cited release. Bounded offline
+review uses an existing non-shallow coordinator checkout containing the pinned
+commit; `git show` reads only the two pinned blobs, each limited to 1 MiB. It
+does not fetch, search history, follow a branch, or consult a local alias copy.
+
+The synthetic two-component fixtures exercise both paths:
+
+```sh
+./atrinik provenance validate --as-of 2026-08-13 \
+  --reference tests/fixtures/provenance-identities/positive/synthetic-alpha.json \
+  --reference tests/fixtures/provenance-identities/positive/synthetic-beta.json
+```
+
+Their pinned URLs become online after this branch is pushed. They are synthetic
+test evidence, not permission for real material. Production consumers must pin
+a revision that has landed on the default branch or an approved release.
+
+## Migration and review
+
+For each existing or future component provenance manifest:
+
+1. Preserve its exact source/destination and transformation facts. Inventory
+   every identity field or alias copy and stop if removing it would obscure an
+   unresolved rights decision.
+2. Obtain explicit publication authorization for public aliases, or create
+   restricted evidence and an opaque confidential attestation through the
+   two-role review above. Never infer authorization from old public metadata.
+3. Run whole-record correlation review. Commit only the component reference and
+   exact material scope, then validate online and with the bounded offline
+   command. Do not copy canonical records or schema into the component.
+4. On correction, add a superseding record and update the component reference
+   in an ordinary reviewed change. On withdrawal, compromise, expiry, or
+   revocation, fail closed and stop reuse until a new active record is approved.
+5. For renamed, transferred, archived, or deleted repositories, retain the
+   immutable original coordinate and archived commit evidence. A repository's
+   disappearance never turns a movable URL, cached alias file, or unverifiable
+   record into acceptable proof.
+
+Current named grants in `docs/PROVENANCE.md` are not silently converted into
+alias records. They remain public grant statements, but any historical identity
+reconciliation must use this process and an active record. No real
+confidential mapping may be added through a public issue or pull request.

--- a/docs/PROVENANCE_IDENTITIES.md
+++ b/docs/PROVENANCE_IDENTITIES.md
@@ -102,11 +102,16 @@ keys, no insignificant whitespace, JSON string escaping, and no floating-point
 values. A record's public SHA-256 covers every field except `integrity`. The
 restricted HMAC uses a separately held key and covers the canonical decrypted
 evidence plus the exact scope binding. Public aliases additionally require a
-restricted authorization naming every public identity field.
+restricted authorization naming every public identity field. Every public
+record and exact component-scope statement carries an Ed25519 SSH signature
+from a key in the versioned `reviewers.json` roster. The validator checks the
+key's identity, role boundary, effective dates and current revocation status;
+plain SHA-256 integrity is never treated as authorization.
 
-Records expire and must be re-reviewed before use. `revoked` records are
-invalid immediately; `superseded` records direct operators to a separately
-published replacement without mutating history. Schema or policy changes use a
+Reviews expire within 366 days and must be re-reviewed before use. `revoked`
+records carry an effective date and privacy-safe reason and are invalid
+immediately; `superseded` records carry an effective date and active replacement
+pointer without mutating history. Schema or policy changes use a
 new version and require explicit migration review. The validator rejects
 unknown versions, duplicate IDs/bindings, stale active records, unsafe fields,
 digest drift, and references to non-active records.
@@ -118,29 +123,34 @@ revision; destination repository and path; transformation; and the opaque scope
 binding. Its `evidence_reference` has exactly:
 
 - `repository: atrinik/atrinik`;
-- a full 40-character coordinator commit reachable from its default branch, or
-  the commit named by an immutable signed release artifact;
+- a full 40-character coordinator commit reachable from canonical `origin/main`;
 - the opaque record ID;
 - SHA-256 digests of the registry and schema bytes; and
 - the canonical GitHub `blob/<commit>/.../registry.json#<record-id>` permalink.
 
 Online review opens that permalink and verifies that the commit is on the
 coordinator default branch or covered by the cited release. Bounded offline
-review uses an existing non-shallow coordinator checkout containing the pinned
-commit; `git show` reads only the two pinned blobs, each limited to 1 MiB. It
-does not fetch, search history, follow a branch, or consult a local alias copy.
+review uses an existing non-shallow canonical coordinator checkout containing
+the pinned commit. It disables replace objects, rejects grafts, proves ancestry
+from `origin/main`, sizes each object before reading at most 1 MiB, and reads
+only the pinned registry, schema and reviewer roster. It does not fetch, search
+history, or consult a local alias copy. A signed-release mode is not implemented
+in schema v1 and therefore fails closed.
 
 The synthetic two-component fixtures exercise both paths:
 
 ```sh
-./atrinik provenance validate --as-of 2026-08-13 \
+./atrinik provenance validate \
   --reference tests/fixtures/provenance-identities/positive/synthetic-alpha.json \
   --reference tests/fixtures/provenance-identities/positive/synthetic-beta.json
 ```
 
-Their pinned URLs become online after this branch is pushed. They are synthetic
-test evidence, not permission for real material. Production consumers must pin
-a revision that has landed on the default branch or an approved release.
+Their pinned URLs become online after this branch is pushed. Before merge they
+may be exercised only with `--non-authorizing-audit-ref
+origin/feat/privacy-preserving-provenance-registry`; that mode is visibly not an
+approval for reuse. They are synthetic test evidence, not permission for real
+material. Production validation accepts only a revision that has landed on the
+default branch.
 
 ## Migration and review
 

--- a/docs/PROVENANCE_IDENTITIES.md
+++ b/docs/PROVENANCE_IDENTITIES.md
@@ -137,7 +137,10 @@ only the pinned registry, schema and reviewer roster. It does not fetch, search
 history, or consult a local alias copy. A signed-release mode is not implemented
 in schema v1 and therefore fails closed.
 
-The synthetic two-component fixtures exercise both paths:
+The synthetic component-owned records for `atrinik/client` and
+`atrinik/server` exercise both paths. The copies in this repository are test
+fixtures; each component keeps its own identical reference record and validates
+it without copying the canonical registry, schema, or reviewer roster:
 
 ```sh
 ./atrinik provenance validate \
@@ -148,9 +151,9 @@ The synthetic two-component fixtures exercise both paths:
 Their pinned URLs become online after this branch is pushed. Before merge they
 may be exercised only with `--non-authorizing-audit-ref
 origin/feat/privacy-preserving-provenance-registry`; that mode is visibly not an
-approval for reuse. They are synthetic test evidence, not permission for real
-material. Production validation accepts only a revision that has landed on the
-default branch.
+approval for reuse. They carry an authenticated `synthetic: true` boundary and
+are test evidence, not permission for real material. Production validation
+accepts only a revision that has landed on the default branch.
 
 ## Migration and review
 

--- a/governance/provenance-identities/README.md
+++ b/governance/provenance-identities/README.md
@@ -1,0 +1,15 @@
+# Provenance identity registry
+
+`registry.json` is the only public Atrinik provenance identity registry and
+`schema-v1.json` is its canonical schema. The operating, privacy, custody,
+attestation, reference, and migration rules are in
+[`docs/PROVENANCE_IDENTITIES.md`](../../docs/PROVENANCE_IDENTITIES.md).
+
+Validate the registry and any component references without network access:
+
+```sh
+./atrinik provenance validate --reference PATH
+```
+
+Never place real restricted identity evidence, aliases lacking explicit
+publication authorization, encryption/HMAC keys, or private review notes here.

--- a/governance/provenance-identities/README.md
+++ b/governance/provenance-identities/README.md
@@ -1,7 +1,8 @@
 # Provenance identity registry
 
-`registry.json` is the only public Atrinik provenance identity registry and
-`schema-v1.json` is its canonical schema. The operating, privacy, custody,
+`registry.json` is the only public Atrinik provenance identity registry,
+`schema-v1.json` is its canonical schema, and `reviewers.json` is the versioned
+authorized signing-key roster. The operating, privacy, custody,
 attestation, reference, and migration rules are in
 [`docs/PROVENANCE_IDENTITIES.md`](../../docs/PROVENANCE_IDENTITIES.md).
 

--- a/governance/provenance-identities/registry.json
+++ b/governance/provenance-identities/registry.json
@@ -2,16 +2,18 @@
   "schema_version": 1,
   "policy_version": 1,
   "schema": "governance/provenance-identities/schema-v1.json",
+  "reviewers": "governance/provenance-identities/reviewers.json",
   "records": [
     {
-      "record_id": "pir-synthetic-alpha-0001",
+      "record_id": "pir-c-11111111111111111111111111111111",
       "record_type": "confidential-attestation",
       "status": "active",
+      "status_detail": {"effective_on": "2026-08-13"},
       "synthetic": true,
       "policy_version": 1,
       "reviewer": "github:synthetic-reviewer",
       "reviewed_on": "2026-08-13",
-      "expires_on": "2099-12-31",
+      "expires_on": "2027-08-13",
       "claims": ["authorship", "identity", "rights-grant", "temporal-scope"],
       "scope_binding": "psb-11111111111111111111111111111111",
       "restricted_evidence": {
@@ -20,23 +22,28 @@
       },
       "publication_review": {
         "correlation_risk": "approved",
-        "fields_reviewed": ["claims", "expires_on", "integrity", "policy_version", "publication_review", "record_id", "record_type", "restricted_evidence", "reviewed_on", "reviewer", "scope_binding", "status", "synthetic"]
+        "fields_reviewed": ["approval", "claims", "expires_on", "integrity", "policy_version", "publication_review", "record_id", "record_type", "restricted_evidence", "reviewed_on", "reviewer", "scope_binding", "status", "status_detail", "synthetic"]
+      },
+      "approval": {
+        "key_id": "synthetic-reviewer-2026",
+        "signature": "-----BEGIN SSH SIGNATURE-----\nU1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgBruVWBv4FEuaHvyX1z13qRO9BU\nTXED0DGAjTaWDx1NAAAAAVYXRyaW5pay1wcm92ZW5hbmNlLXYxAAAAAAAAAAZzaGE1MTIA\nAABTAAAAC3NzaC1lZDI1NTE5AAAAQFlpemJx/lO0N7nc3wISkYE6s0iYmq6G1NHeYAkUq6\nu1+1ESy5P0kgHlHE3CgniQGcHgQroTFryHERDinM9C8wE=\n-----END SSH SIGNATURE-----"
       },
       "integrity": {
         "algorithm": "sha256",
         "canonicalization": "atrinik-json-v1",
-        "digest": "9d4107ebde6e6a84228b9ea553441ec2a0f85294d4bab9305644da17fa6c4250"
+        "digest": "1d855bba5809b77c72600b0a88b0455b33b92537417fcc1527533ebe2a7ac623"
       }
     },
     {
-      "record_id": "pir-synthetic-beta-00001",
+      "record_id": "pir-c-22222222222222222222222222222222",
       "record_type": "confidential-attestation",
       "status": "active",
+      "status_detail": {"effective_on": "2026-08-13"},
       "synthetic": true,
       "policy_version": 1,
       "reviewer": "github:synthetic-reviewer",
       "reviewed_on": "2026-08-13",
-      "expires_on": "2099-12-31",
+      "expires_on": "2027-08-13",
       "claims": ["authorship", "identity", "rights-grant", "temporal-scope"],
       "scope_binding": "psb-22222222222222222222222222222222",
       "restricted_evidence": {
@@ -45,12 +52,16 @@
       },
       "publication_review": {
         "correlation_risk": "approved",
-        "fields_reviewed": ["claims", "expires_on", "integrity", "policy_version", "publication_review", "record_id", "record_type", "restricted_evidence", "reviewed_on", "reviewer", "scope_binding", "status", "synthetic"]
+        "fields_reviewed": ["approval", "claims", "expires_on", "integrity", "policy_version", "publication_review", "record_id", "record_type", "restricted_evidence", "reviewed_on", "reviewer", "scope_binding", "status", "status_detail", "synthetic"]
+      },
+      "approval": {
+        "key_id": "synthetic-reviewer-2026",
+        "signature": "-----BEGIN SSH SIGNATURE-----\nU1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgBruVWBv4FEuaHvyX1z13qRO9BU\nTXED0DGAjTaWDx1NAAAAAVYXRyaW5pay1wcm92ZW5hbmNlLXYxAAAAAAAAAAZzaGE1MTIA\nAABTAAAAC3NzaC1lZDI1NTE5AAAAQPIBMAsVhr/MbFu1hEon8X3pix+6HzkVYN5JXUF6Df\nHQygoLAOLKnspOHb1rFzt37B7m9XiJ9sExwTpXOaBgUAw=\n-----END SSH SIGNATURE-----"
       },
       "integrity": {
         "algorithm": "sha256",
         "canonicalization": "atrinik-json-v1",
-        "digest": "f085481974eb70bbc9e27c9666fcee7d1b75b054e3cc0802b69cef9493695219"
+        "digest": "3bd239072c59c4cb381c839e4fd7ddb5dc69d52d5f72189be5ee1f6c8ad76cec"
       }
     }
   ]

--- a/governance/provenance-identities/registry.json
+++ b/governance/provenance-identities/registry.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": 1,
+  "policy_version": 1,
+  "schema": "governance/provenance-identities/schema-v1.json",
+  "records": [
+    {
+      "record_id": "pir-synthetic-alpha-0001",
+      "record_type": "confidential-attestation",
+      "status": "active",
+      "synthetic": true,
+      "policy_version": 1,
+      "reviewer": "github:synthetic-reviewer",
+      "reviewed_on": "2026-08-13",
+      "expires_on": "2099-12-31",
+      "claims": ["authorship", "identity", "rights-grant", "temporal-scope"],
+      "scope_binding": "psb-11111111111111111111111111111111",
+      "restricted_evidence": {
+        "record_id": "restricted-11111111111111111111111111111111",
+        "integrity": "hmac-sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      },
+      "publication_review": {
+        "correlation_risk": "approved",
+        "fields_reviewed": ["claims", "expires_on", "integrity", "policy_version", "publication_review", "record_id", "record_type", "restricted_evidence", "reviewed_on", "reviewer", "scope_binding", "status", "synthetic"]
+      },
+      "integrity": {
+        "algorithm": "sha256",
+        "canonicalization": "atrinik-json-v1",
+        "digest": "9d4107ebde6e6a84228b9ea553441ec2a0f85294d4bab9305644da17fa6c4250"
+      }
+    },
+    {
+      "record_id": "pir-synthetic-beta-00001",
+      "record_type": "confidential-attestation",
+      "status": "active",
+      "synthetic": true,
+      "policy_version": 1,
+      "reviewer": "github:synthetic-reviewer",
+      "reviewed_on": "2026-08-13",
+      "expires_on": "2099-12-31",
+      "claims": ["authorship", "identity", "rights-grant", "temporal-scope"],
+      "scope_binding": "psb-22222222222222222222222222222222",
+      "restricted_evidence": {
+        "record_id": "restricted-22222222222222222222222222222222",
+        "integrity": "hmac-sha256:2222222222222222222222222222222222222222222222222222222222222222"
+      },
+      "publication_review": {
+        "correlation_risk": "approved",
+        "fields_reviewed": ["claims", "expires_on", "integrity", "policy_version", "publication_review", "record_id", "record_type", "restricted_evidence", "reviewed_on", "reviewer", "scope_binding", "status", "synthetic"]
+      },
+      "integrity": {
+        "algorithm": "sha256",
+        "canonicalization": "atrinik-json-v1",
+        "digest": "f085481974eb70bbc9e27c9666fcee7d1b75b054e3cc0802b69cef9493695219"
+      }
+    }
+  ]
+}

--- a/governance/provenance-identities/reviewers.json
+++ b/governance/provenance-identities/reviewers.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "reviewers": [
+    {
+      "key_id": "synthetic-reviewer-2026",
+      "identity": "github:synthetic-reviewer",
+      "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAa7lVgb+BRLmh78l9c9d6kTvQVE1xA9AxgI02lg8dTQ",
+      "effective_on": "2026-08-13",
+      "expires_on": "2027-08-13",
+      "status": "active",
+      "synthetic": true
+    }
+  ]
+}

--- a/governance/provenance-identities/schema-v1.json
+++ b/governance/provenance-identities/schema-v1.json
@@ -21,6 +21,8 @@
   },
   "$defs": {
     "recordId": {"type": "string", "pattern": "^pir-[cp]-[0-9a-f]{32}$"},
+    "publicRecordId": {"type": "string", "pattern": "^pir-p-[0-9a-f]{32}$"},
+    "confidentialRecordId": {"type": "string", "pattern": "^pir-c-[0-9a-f]{32}$"},
     "reviewer": {"type": "string", "pattern": "^github:[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$"},
     "date": {"type": "string", "format": "date"},
     "claims": {
@@ -50,6 +52,7 @@
     },
     "statusDetail": {
       "type": "object",
+      "additionalProperties": false,
       "required": ["effective_on"],
       "properties": {
         "effective_on": {"$ref": "#/$defs/date"},
@@ -62,7 +65,7 @@
       "additionalProperties": false,
       "required": ["record_id", "record_type", "status", "status_detail", "synthetic", "policy_version", "reviewer", "reviewed_on", "expires_on", "claims", "display_name", "aliases", "publication_authorization", "approval", "integrity"],
       "properties": {
-        "record_id": {"$ref": "#/$defs/recordId"},
+        "record_id": {"$ref": "#/$defs/publicRecordId"},
         "record_type": {"const": "public-alias"},
         "status": {"enum": ["active", "revoked", "superseded"]},
         "status_detail": {"$ref": "#/$defs/statusDetail"},
@@ -93,7 +96,7 @@
       "additionalProperties": false,
       "required": ["record_id", "record_type", "status", "status_detail", "synthetic", "policy_version", "reviewer", "reviewed_on", "expires_on", "claims", "scope_binding", "restricted_evidence", "publication_review", "approval", "integrity"],
       "properties": {
-        "record_id": {"$ref": "#/$defs/recordId"},
+        "record_id": {"$ref": "#/$defs/confidentialRecordId"},
         "record_type": {"const": "confidential-attestation"},
         "status": {"enum": ["active", "revoked", "superseded"]},
         "status_detail": {"$ref": "#/$defs/statusDetail"},

--- a/governance/provenance-identities/schema-v1.json
+++ b/governance/provenance-identities/schema-v1.json
@@ -60,10 +60,39 @@
         "superseded_by": {"$ref": "#/$defs/recordId"}
       }
     },
+    "activeStatusDetail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["effective_on"],
+      "properties": {"effective_on": {"$ref": "#/$defs/date"}}
+    },
+    "revokedStatusDetail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["effective_on", "reason"],
+      "properties": {
+        "effective_on": {"$ref": "#/$defs/date"},
+        "reason": {"enum": ["compromise", "correction", "dispute", "withdrawal"]}
+      }
+    },
+    "supersededStatusDetail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["effective_on", "superseded_by"],
+      "properties": {
+        "effective_on": {"$ref": "#/$defs/date"},
+        "superseded_by": {"$ref": "#/$defs/recordId"}
+      }
+    },
     "publicAlias": {
       "type": "object",
       "additionalProperties": false,
       "required": ["record_id", "record_type", "status", "status_detail", "synthetic", "policy_version", "reviewer", "reviewed_on", "expires_on", "claims", "display_name", "aliases", "publication_authorization", "approval", "integrity"],
+      "allOf": [
+        {"if": {"properties": {"status": {"const": "active"}}}, "then": {"properties": {"status_detail": {"$ref": "#/$defs/activeStatusDetail"}}}},
+        {"if": {"properties": {"status": {"const": "revoked"}}}, "then": {"properties": {"status_detail": {"$ref": "#/$defs/revokedStatusDetail"}}}},
+        {"if": {"properties": {"status": {"const": "superseded"}}}, "then": {"properties": {"status_detail": {"$ref": "#/$defs/supersededStatusDetail"}}}}
+      ],
       "properties": {
         "record_id": {"$ref": "#/$defs/publicRecordId"},
         "record_type": {"const": "public-alias"},
@@ -95,6 +124,11 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["record_id", "record_type", "status", "status_detail", "synthetic", "policy_version", "reviewer", "reviewed_on", "expires_on", "claims", "scope_binding", "restricted_evidence", "publication_review", "approval", "integrity"],
+      "allOf": [
+        {"if": {"properties": {"status": {"const": "active"}}}, "then": {"properties": {"status_detail": {"$ref": "#/$defs/activeStatusDetail"}}}},
+        {"if": {"properties": {"status": {"const": "revoked"}}}, "then": {"properties": {"status_detail": {"$ref": "#/$defs/revokedStatusDetail"}}}},
+        {"if": {"properties": {"status": {"const": "superseded"}}}, "then": {"properties": {"status_detail": {"$ref": "#/$defs/supersededStatusDetail"}}}}
+      ],
       "properties": {
         "record_id": {"$ref": "#/$defs/confidentialRecordId"},
         "record_type": {"const": "confidential-attestation"},

--- a/governance/provenance-identities/schema-v1.json
+++ b/governance/provenance-identities/schema-v1.json
@@ -5,11 +5,12 @@
   "description": "Public aliases with explicit authorization and privacy-preserving attestations backed by restricted evidence.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "policy_version", "schema", "records"],
+  "required": ["schema_version", "policy_version", "schema", "reviewers", "records"],
   "properties": {
     "schema_version": {"const": 1},
     "policy_version": {"const": 1},
     "schema": {"const": "governance/provenance-identities/schema-v1.json"},
+    "reviewers": {"const": "governance/provenance-identities/reviewers.json"},
     "records": {
       "type": "array",
       "items": {"oneOf": [
@@ -19,7 +20,7 @@
     }
   },
   "$defs": {
-    "recordId": {"type": "string", "pattern": "^pir-[a-z0-9][a-z0-9-]{15,63}$"},
+    "recordId": {"type": "string", "pattern": "^pir-[cp]-[0-9a-f]{32}$"},
     "reviewer": {"type": "string", "pattern": "^github:[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$"},
     "date": {"type": "string", "format": "date"},
     "claims": {
@@ -38,14 +39,33 @@
         "digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
       }
     },
+    "approval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key_id", "signature"],
+      "properties": {
+        "key_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]{7,63}$"},
+        "signature": {"type": "string", "pattern": "^-----BEGIN SSH SIGNATURE-----\\n[A-Za-z0-9+/=\\n]+\\n-----END SSH SIGNATURE-----$"}
+      }
+    },
+    "statusDetail": {
+      "type": "object",
+      "required": ["effective_on"],
+      "properties": {
+        "effective_on": {"$ref": "#/$defs/date"},
+        "reason": {"enum": ["compromise", "correction", "dispute", "withdrawal"]},
+        "superseded_by": {"$ref": "#/$defs/recordId"}
+      }
+    },
     "publicAlias": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["record_id", "record_type", "status", "synthetic", "policy_version", "reviewer", "reviewed_on", "expires_on", "claims", "display_name", "aliases", "publication_authorization", "integrity"],
+      "required": ["record_id", "record_type", "status", "status_detail", "synthetic", "policy_version", "reviewer", "reviewed_on", "expires_on", "claims", "display_name", "aliases", "publication_authorization", "approval", "integrity"],
       "properties": {
         "record_id": {"$ref": "#/$defs/recordId"},
         "record_type": {"const": "public-alias"},
         "status": {"enum": ["active", "revoked", "superseded"]},
+        "status_detail": {"$ref": "#/$defs/statusDetail"},
         "synthetic": {"type": "boolean"},
         "policy_version": {"const": 1},
         "reviewer": {"$ref": "#/$defs/reviewer"},
@@ -64,17 +84,19 @@
             "restricted_record_id": {"type": "string", "pattern": "^restricted-[0-9a-f]{32}$"}
           }
         },
+        "approval": {"$ref": "#/$defs/approval"},
         "integrity": {"$ref": "#/$defs/integrity"}
       }
     },
     "confidentialAttestation": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["record_id", "record_type", "status", "synthetic", "policy_version", "reviewer", "reviewed_on", "expires_on", "claims", "scope_binding", "restricted_evidence", "publication_review", "integrity"],
+      "required": ["record_id", "record_type", "status", "status_detail", "synthetic", "policy_version", "reviewer", "reviewed_on", "expires_on", "claims", "scope_binding", "restricted_evidence", "publication_review", "approval", "integrity"],
       "properties": {
         "record_id": {"$ref": "#/$defs/recordId"},
         "record_type": {"const": "confidential-attestation"},
         "status": {"enum": ["active", "revoked", "superseded"]},
+        "status_detail": {"$ref": "#/$defs/statusDetail"},
         "synthetic": {"type": "boolean"},
         "policy_version": {"const": 1},
         "reviewer": {"$ref": "#/$defs/reviewer"},
@@ -100,6 +122,7 @@
             "fields_reviewed": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string"}}
           }
         },
+        "approval": {"$ref": "#/$defs/approval"},
         "integrity": {"$ref": "#/$defs/integrity"}
       }
     }

--- a/governance/provenance-identities/schema-v1.json
+++ b/governance/provenance-identities/schema-v1.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://atrinik.org/schema/provenance-identities-v1.json",
+  "title": "Atrinik public provenance identity registry",
+  "description": "Public aliases with explicit authorization and privacy-preserving attestations backed by restricted evidence.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "policy_version", "schema", "records"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "policy_version": {"const": 1},
+    "schema": {"const": "governance/provenance-identities/schema-v1.json"},
+    "records": {
+      "type": "array",
+      "items": {"oneOf": [
+        {"$ref": "#/$defs/publicAlias"},
+        {"$ref": "#/$defs/confidentialAttestation"}
+      ]}
+    }
+  },
+  "$defs": {
+    "recordId": {"type": "string", "pattern": "^pir-[a-z0-9][a-z0-9-]{15,63}$"},
+    "reviewer": {"type": "string", "pattern": "^github:[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$"},
+    "date": {"type": "string", "format": "date"},
+    "claims": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"enum": ["authorship", "identity", "rights-grant", "temporal-scope"]}
+    },
+    "integrity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "canonicalization", "digest"],
+      "properties": {
+        "algorithm": {"const": "sha256"},
+        "canonicalization": {"const": "atrinik-json-v1"},
+        "digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    },
+    "publicAlias": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["record_id", "record_type", "status", "synthetic", "policy_version", "reviewer", "reviewed_on", "expires_on", "claims", "display_name", "aliases", "publication_authorization", "integrity"],
+      "properties": {
+        "record_id": {"$ref": "#/$defs/recordId"},
+        "record_type": {"const": "public-alias"},
+        "status": {"enum": ["active", "revoked", "superseded"]},
+        "synthetic": {"type": "boolean"},
+        "policy_version": {"const": 1},
+        "reviewer": {"$ref": "#/$defs/reviewer"},
+        "reviewed_on": {"$ref": "#/$defs/date"},
+        "expires_on": {"$ref": "#/$defs/date"},
+        "claims": {"$ref": "#/$defs/claims"},
+        "display_name": {"type": "string", "minLength": 1},
+        "aliases": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "publication_authorization": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["authorized_on", "fields", "restricted_record_id"],
+          "properties": {
+            "authorized_on": {"$ref": "#/$defs/date"},
+            "fields": {"const": ["aliases", "display_name"]},
+            "restricted_record_id": {"type": "string", "pattern": "^restricted-[0-9a-f]{32}$"}
+          }
+        },
+        "integrity": {"$ref": "#/$defs/integrity"}
+      }
+    },
+    "confidentialAttestation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["record_id", "record_type", "status", "synthetic", "policy_version", "reviewer", "reviewed_on", "expires_on", "claims", "scope_binding", "restricted_evidence", "publication_review", "integrity"],
+      "properties": {
+        "record_id": {"$ref": "#/$defs/recordId"},
+        "record_type": {"const": "confidential-attestation"},
+        "status": {"enum": ["active", "revoked", "superseded"]},
+        "synthetic": {"type": "boolean"},
+        "policy_version": {"const": 1},
+        "reviewer": {"$ref": "#/$defs/reviewer"},
+        "reviewed_on": {"$ref": "#/$defs/date"},
+        "expires_on": {"$ref": "#/$defs/date"},
+        "claims": {"$ref": "#/$defs/claims"},
+        "scope_binding": {"type": "string", "pattern": "^psb-[0-9a-f]{32}$"},
+        "restricted_evidence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["record_id", "integrity"],
+          "properties": {
+            "record_id": {"type": "string", "pattern": "^restricted-[0-9a-f]{32}$"},
+            "integrity": {"type": "string", "pattern": "^hmac-sha256:[0-9a-f]{64}$"}
+          }
+        },
+        "publication_review": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["correlation_risk", "fields_reviewed"],
+          "properties": {
+            "correlation_risk": {"const": "approved"},
+            "fields_reviewed": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string"}}
+          }
+        },
+        "integrity": {"$ref": "#/$defs/integrity"}
+      }
+    }
+  }
+}

--- a/tests/fixtures/provenance-identities/negative/broken-reference.json
+++ b/tests/fixtures/provenance-identities/negative/broken-reference.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "source": {
+    "repository": "atrinik/synthetic-history",
+    "path": "engine/alpha.c",
+    "revision": "1111111111111111111111111111111111111111"
+  },
+  "destination": {
+    "repository": "atrinik/synthetic-alpha",
+    "path": "src/alpha.rs"
+  },
+  "transformation": "Synthetic negative fixture.",
+  "scope_binding": "psb-11111111111111111111111111111111",
+  "evidence_reference": {
+    "repository": "atrinik/atrinik",
+    "revision": "a700f92274f98476bae84beda7017cf81c6311d8",
+    "record_id": "pir-synthetic-alpha-0001",
+    "registry_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+    "schema_sha256": "681f0cffad6f7e767b005902beef3c71f1747936b8d2b0f2a3b54da32e9d5774",
+    "url": "https://github.com/atrinik/atrinik/blob/a700f92274f98476bae84beda7017cf81c6311d8/governance/provenance-identities/registry.json#pir-synthetic-alpha-0001"
+  }
+}

--- a/tests/fixtures/provenance-identities/negative/broken-reference.json
+++ b/tests/fixtures/provenance-identities/negative/broken-reference.json
@@ -18,11 +18,11 @@
   },
   "evidence_reference": {
     "repository": "atrinik/atrinik",
-    "revision": "98ff80ef66a71d8b7c48e7d0c71029abd5c90227",
+    "revision": "89fc98b95f23c0f0f068c5254ffb72c62f173119",
     "record_id": "pir-c-11111111111111111111111111111111",
     "registry_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
-    "schema_sha256": "34ab398af4f166b8b65ac68500b547b9ade4955bd0b73770eeda1337bf5dcf47",
+    "schema_sha256": "e040c1575fbd2906d0fe1fcb27a874518a39b8bc5629ac2a987652ea801553f9",
     "reviewers_sha256": "b7a44ad27cec663a9092b924a0f6a9c95bf95a2ce74cf75ba8873e7938782240",
-    "url": "https://github.com/atrinik/atrinik/blob/98ff80ef66a71d8b7c48e7d0c71029abd5c90227/governance/provenance-identities/registry.json#pir-c-11111111111111111111111111111111"
+    "url": "https://github.com/atrinik/atrinik/blob/89fc98b95f23c0f0f068c5254ffb72c62f173119/governance/provenance-identities/registry.json#pir-c-11111111111111111111111111111111"
   }
 }

--- a/tests/fixtures/provenance-identities/negative/broken-reference.json
+++ b/tests/fixtures/provenance-identities/negative/broken-reference.json
@@ -1,5 +1,6 @@
 {
   "schema_version": 1,
+  "synthetic": true,
   "source": {
     "repository": "atrinik/synthetic-history",
     "path": "engine/alpha.c",

--- a/tests/fixtures/provenance-identities/negative/broken-reference.json
+++ b/tests/fixtures/provenance-identities/negative/broken-reference.json
@@ -11,12 +11,17 @@
   },
   "transformation": "Synthetic negative fixture.",
   "scope_binding": "psb-11111111111111111111111111111111",
+  "scope_approval": {
+    "key_id": "synthetic-reviewer-2026",
+    "signature": "INVALID"
+  },
   "evidence_reference": {
     "repository": "atrinik/atrinik",
-    "revision": "a700f92274f98476bae84beda7017cf81c6311d8",
-    "record_id": "pir-synthetic-alpha-0001",
+    "revision": "98ff80ef66a71d8b7c48e7d0c71029abd5c90227",
+    "record_id": "pir-c-11111111111111111111111111111111",
     "registry_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
-    "schema_sha256": "681f0cffad6f7e767b005902beef3c71f1747936b8d2b0f2a3b54da32e9d5774",
-    "url": "https://github.com/atrinik/atrinik/blob/a700f92274f98476bae84beda7017cf81c6311d8/governance/provenance-identities/registry.json#pir-synthetic-alpha-0001"
+    "schema_sha256": "34ab398af4f166b8b65ac68500b547b9ade4955bd0b73770eeda1337bf5dcf47",
+    "reviewers_sha256": "b7a44ad27cec663a9092b924a0f6a9c95bf95a2ce74cf75ba8873e7938782240",
+    "url": "https://github.com/atrinik/atrinik/blob/98ff80ef66a71d8b7c48e7d0c71029abd5c90227/governance/provenance-identities/registry.json#pir-c-11111111111111111111111111111111"
   }
 }

--- a/tests/fixtures/provenance-identities/negative/broken-reference.json
+++ b/tests/fixtures/provenance-identities/negative/broken-reference.json
@@ -18,11 +18,11 @@
   },
   "evidence_reference": {
     "repository": "atrinik/atrinik",
-    "revision": "89fc98b95f23c0f0f068c5254ffb72c62f173119",
+    "revision": "51aa7ac9d5ae9c0ff0b2a24a46b5d3e97739bbe0",
     "record_id": "pir-c-11111111111111111111111111111111",
     "registry_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
-    "schema_sha256": "e040c1575fbd2906d0fe1fcb27a874518a39b8bc5629ac2a987652ea801553f9",
+    "schema_sha256": "9c726627c8679b4b437db2b54b2480fe0c45eef788de7cd76de1dec5c3ce3409",
     "reviewers_sha256": "b7a44ad27cec663a9092b924a0f6a9c95bf95a2ce74cf75ba8873e7938782240",
-    "url": "https://github.com/atrinik/atrinik/blob/89fc98b95f23c0f0f068c5254ffb72c62f173119/governance/provenance-identities/registry.json#pir-c-11111111111111111111111111111111"
+    "url": "https://github.com/atrinik/atrinik/blob/51aa7ac9d5ae9c0ff0b2a24a46b5d3e97739bbe0/governance/provenance-identities/registry.json#pir-c-11111111111111111111111111111111"
   }
 }

--- a/tests/fixtures/provenance-identities/positive/synthetic-alpha.json
+++ b/tests/fixtures/provenance-identities/positive/synthetic-alpha.json
@@ -11,12 +11,17 @@
   },
   "transformation": "Synthetic translation used only to verify the reference contract.",
   "scope_binding": "psb-11111111111111111111111111111111",
+  "scope_approval": {
+    "key_id": "synthetic-reviewer-2026",
+    "signature": "-----BEGIN SSH SIGNATURE-----\nU1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgBruVWBv4FEuaHvyX1z13qRO9BU\nTXED0DGAjTaWDx1NAAAAAVYXRyaW5pay1wcm92ZW5hbmNlLXYxAAAAAAAAAAZzaGE1MTIA\nAABTAAAAC3NzaC1lZDI1NTE5AAAAQHod8VRbzn/Ofc1PggUFDDamZRYQ6PezFWocLrgXB8\ncZypJEWzFRxduGNAHPzpjcZzgWUiJ2ze0E9+WJOLAdLQk=\n-----END SSH SIGNATURE-----"
+  },
   "evidence_reference": {
     "repository": "atrinik/atrinik",
-    "revision": "a700f92274f98476bae84beda7017cf81c6311d8",
-    "record_id": "pir-synthetic-alpha-0001",
-    "registry_sha256": "a21d130eedc1dcb381098723f1d67ed87b10c72860756289116b2f30c4d44b92",
-    "schema_sha256": "681f0cffad6f7e767b005902beef3c71f1747936b8d2b0f2a3b54da32e9d5774",
-    "url": "https://github.com/atrinik/atrinik/blob/a700f92274f98476bae84beda7017cf81c6311d8/governance/provenance-identities/registry.json#pir-synthetic-alpha-0001"
+    "revision": "98ff80ef66a71d8b7c48e7d0c71029abd5c90227",
+    "record_id": "pir-c-11111111111111111111111111111111",
+    "registry_sha256": "0a04fcadccb37e64f6c1209bc0b7e8d5762639ce4c5521c3bba028d9eba037bd",
+    "schema_sha256": "34ab398af4f166b8b65ac68500b547b9ade4955bd0b73770eeda1337bf5dcf47",
+    "reviewers_sha256": "b7a44ad27cec663a9092b924a0f6a9c95bf95a2ce74cf75ba8873e7938782240",
+    "url": "https://github.com/atrinik/atrinik/blob/98ff80ef66a71d8b7c48e7d0c71029abd5c90227/governance/provenance-identities/registry.json#pir-c-11111111111111111111111111111111"
   }
 }

--- a/tests/fixtures/provenance-identities/positive/synthetic-alpha.json
+++ b/tests/fixtures/provenance-identities/positive/synthetic-alpha.json
@@ -14,15 +14,15 @@
   "scope_binding": "psb-11111111111111111111111111111111",
   "scope_approval": {
     "key_id": "synthetic-reviewer-2026",
-    "signature": "-----BEGIN SSH SIGNATURE-----\nU1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgBruVWBv4FEuaHvyX1z13qRO9BU\nTXED0DGAjTaWDx1NAAAAAVYXRyaW5pay1wcm92ZW5hbmNlLXYxAAAAAAAAAAZzaGE1MTIA\nAABTAAAAC3NzaC1lZDI1NTE5AAAAQF0i/DNh32dohqOtoylZX6XLbKggGzrVMYJDuV1at+\n88JzYGTP4BezChsqH/dCmOfEbxYPCmR8SOKokebaoSLwM=\n-----END SSH SIGNATURE-----"
+    "signature": "-----BEGIN SSH SIGNATURE-----\nU1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgBruVWBv4FEuaHvyX1z13qRO9BU\nTXED0DGAjTaWDx1NAAAAAVYXRyaW5pay1wcm92ZW5hbmNlLXYxAAAAAAAAAAZzaGE1MTIA\nAABTAAAAC3NzaC1lZDI1NTE5AAAAQItDk43Z/DT32bCWwTUrmCW5qtS9sCzETIeVGSoe9b\n9Rw2rjYAFWY+c2vV2Ix/U8ZkX7ljYhq1ejCjHSzIBlHww=\n-----END SSH SIGNATURE-----"
   },
   "evidence_reference": {
     "repository": "atrinik/atrinik",
-    "revision": "89fc98b95f23c0f0f068c5254ffb72c62f173119",
+    "revision": "51aa7ac9d5ae9c0ff0b2a24a46b5d3e97739bbe0",
     "record_id": "pir-c-11111111111111111111111111111111",
     "registry_sha256": "0a04fcadccb37e64f6c1209bc0b7e8d5762639ce4c5521c3bba028d9eba037bd",
-    "schema_sha256": "e040c1575fbd2906d0fe1fcb27a874518a39b8bc5629ac2a987652ea801553f9",
+    "schema_sha256": "9c726627c8679b4b437db2b54b2480fe0c45eef788de7cd76de1dec5c3ce3409",
     "reviewers_sha256": "b7a44ad27cec663a9092b924a0f6a9c95bf95a2ce74cf75ba8873e7938782240",
-    "url": "https://github.com/atrinik/atrinik/blob/89fc98b95f23c0f0f068c5254ffb72c62f173119/governance/provenance-identities/registry.json#pir-c-11111111111111111111111111111111"
+    "url": "https://github.com/atrinik/atrinik/blob/51aa7ac9d5ae9c0ff0b2a24a46b5d3e97739bbe0/governance/provenance-identities/registry.json#pir-c-11111111111111111111111111111111"
   }
 }

--- a/tests/fixtures/provenance-identities/positive/synthetic-alpha.json
+++ b/tests/fixtures/provenance-identities/positive/synthetic-alpha.json
@@ -1,19 +1,20 @@
 {
   "schema_version": 1,
+  "synthetic": true,
   "source": {
     "repository": "atrinik/synthetic-history",
     "path": "engine/alpha.c",
     "revision": "1111111111111111111111111111111111111111"
   },
   "destination": {
-    "repository": "atrinik/synthetic-alpha",
-    "path": "src/alpha.rs"
+    "repository": "atrinik/client",
+    "path": "crates/atrinik-client/src/main.rs"
   },
   "transformation": "Synthetic translation used only to verify the reference contract.",
   "scope_binding": "psb-11111111111111111111111111111111",
   "scope_approval": {
     "key_id": "synthetic-reviewer-2026",
-    "signature": "-----BEGIN SSH SIGNATURE-----\nU1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgBruVWBv4FEuaHvyX1z13qRO9BU\nTXED0DGAjTaWDx1NAAAAAVYXRyaW5pay1wcm92ZW5hbmNlLXYxAAAAAAAAAAZzaGE1MTIA\nAABTAAAAC3NzaC1lZDI1NTE5AAAAQHod8VRbzn/Ofc1PggUFDDamZRYQ6PezFWocLrgXB8\ncZypJEWzFRxduGNAHPzpjcZzgWUiJ2ze0E9+WJOLAdLQk=\n-----END SSH SIGNATURE-----"
+    "signature": "-----BEGIN SSH SIGNATURE-----\nU1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgBruVWBv4FEuaHvyX1z13qRO9BU\nTXED0DGAjTaWDx1NAAAAAVYXRyaW5pay1wcm92ZW5hbmNlLXYxAAAAAAAAAAZzaGE1MTIA\nAABTAAAAC3NzaC1lZDI1NTE5AAAAQMgjQuvAvo5r+ET7qrh0aTvzS+32y8m+YLeI3KGtSe\nt2AqlgKssz5XRgRMMSnIYwqQx9CxYG/afvB5Cbze2duQc=\n-----END SSH SIGNATURE-----"
   },
   "evidence_reference": {
     "repository": "atrinik/atrinik",

--- a/tests/fixtures/provenance-identities/positive/synthetic-alpha.json
+++ b/tests/fixtures/provenance-identities/positive/synthetic-alpha.json
@@ -14,15 +14,15 @@
   "scope_binding": "psb-11111111111111111111111111111111",
   "scope_approval": {
     "key_id": "synthetic-reviewer-2026",
-    "signature": "-----BEGIN SSH SIGNATURE-----\nU1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgBruVWBv4FEuaHvyX1z13qRO9BU\nTXED0DGAjTaWDx1NAAAAAVYXRyaW5pay1wcm92ZW5hbmNlLXYxAAAAAAAAAAZzaGE1MTIA\nAABTAAAAC3NzaC1lZDI1NTE5AAAAQMgjQuvAvo5r+ET7qrh0aTvzS+32y8m+YLeI3KGtSe\nt2AqlgKssz5XRgRMMSnIYwqQx9CxYG/afvB5Cbze2duQc=\n-----END SSH SIGNATURE-----"
+    "signature": "-----BEGIN SSH SIGNATURE-----\nU1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgBruVWBv4FEuaHvyX1z13qRO9BU\nTXED0DGAjTaWDx1NAAAAAVYXRyaW5pay1wcm92ZW5hbmNlLXYxAAAAAAAAAAZzaGE1MTIA\nAABTAAAAC3NzaC1lZDI1NTE5AAAAQF0i/DNh32dohqOtoylZX6XLbKggGzrVMYJDuV1at+\n88JzYGTP4BezChsqH/dCmOfEbxYPCmR8SOKokebaoSLwM=\n-----END SSH SIGNATURE-----"
   },
   "evidence_reference": {
     "repository": "atrinik/atrinik",
-    "revision": "98ff80ef66a71d8b7c48e7d0c71029abd5c90227",
+    "revision": "89fc98b95f23c0f0f068c5254ffb72c62f173119",
     "record_id": "pir-c-11111111111111111111111111111111",
     "registry_sha256": "0a04fcadccb37e64f6c1209bc0b7e8d5762639ce4c5521c3bba028d9eba037bd",
-    "schema_sha256": "34ab398af4f166b8b65ac68500b547b9ade4955bd0b73770eeda1337bf5dcf47",
+    "schema_sha256": "e040c1575fbd2906d0fe1fcb27a874518a39b8bc5629ac2a987652ea801553f9",
     "reviewers_sha256": "b7a44ad27cec663a9092b924a0f6a9c95bf95a2ce74cf75ba8873e7938782240",
-    "url": "https://github.com/atrinik/atrinik/blob/98ff80ef66a71d8b7c48e7d0c71029abd5c90227/governance/provenance-identities/registry.json#pir-c-11111111111111111111111111111111"
+    "url": "https://github.com/atrinik/atrinik/blob/89fc98b95f23c0f0f068c5254ffb72c62f173119/governance/provenance-identities/registry.json#pir-c-11111111111111111111111111111111"
   }
 }

--- a/tests/fixtures/provenance-identities/positive/synthetic-alpha.json
+++ b/tests/fixtures/provenance-identities/positive/synthetic-alpha.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "source": {
+    "repository": "atrinik/synthetic-history",
+    "path": "engine/alpha.c",
+    "revision": "1111111111111111111111111111111111111111"
+  },
+  "destination": {
+    "repository": "atrinik/synthetic-alpha",
+    "path": "src/alpha.rs"
+  },
+  "transformation": "Synthetic translation used only to verify the reference contract.",
+  "scope_binding": "psb-11111111111111111111111111111111",
+  "evidence_reference": {
+    "repository": "atrinik/atrinik",
+    "revision": "a700f92274f98476bae84beda7017cf81c6311d8",
+    "record_id": "pir-synthetic-alpha-0001",
+    "registry_sha256": "a21d130eedc1dcb381098723f1d67ed87b10c72860756289116b2f30c4d44b92",
+    "schema_sha256": "681f0cffad6f7e767b005902beef3c71f1747936b8d2b0f2a3b54da32e9d5774",
+    "url": "https://github.com/atrinik/atrinik/blob/a700f92274f98476bae84beda7017cf81c6311d8/governance/provenance-identities/registry.json#pir-synthetic-alpha-0001"
+  }
+}

--- a/tests/fixtures/provenance-identities/positive/synthetic-beta.json
+++ b/tests/fixtures/provenance-identities/positive/synthetic-beta.json
@@ -11,12 +11,17 @@
   },
   "transformation": "Synthetic port used only to verify the reference contract.",
   "scope_binding": "psb-22222222222222222222222222222222",
+  "scope_approval": {
+    "key_id": "synthetic-reviewer-2026",
+    "signature": "-----BEGIN SSH SIGNATURE-----\nU1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgBruVWBv4FEuaHvyX1z13qRO9BU\nTXED0DGAjTaWDx1NAAAAAVYXRyaW5pay1wcm92ZW5hbmNlLXYxAAAAAAAAAAZzaGE1MTIA\nAABTAAAAC3NzaC1lZDI1NTE5AAAAQNlkEKILZFIae4QwqXhqHyv6mBJz1jMZFdUbOZZskZ\nNqqP6ucgD/AotcFPdoRBICDaecUK0Qe3V8J+6VGmxfHgA=\n-----END SSH SIGNATURE-----"
+  },
   "evidence_reference": {
     "repository": "atrinik/atrinik",
-    "revision": "a700f92274f98476bae84beda7017cf81c6311d8",
-    "record_id": "pir-synthetic-beta-00001",
-    "registry_sha256": "a21d130eedc1dcb381098723f1d67ed87b10c72860756289116b2f30c4d44b92",
-    "schema_sha256": "681f0cffad6f7e767b005902beef3c71f1747936b8d2b0f2a3b54da32e9d5774",
-    "url": "https://github.com/atrinik/atrinik/blob/a700f92274f98476bae84beda7017cf81c6311d8/governance/provenance-identities/registry.json#pir-synthetic-beta-00001"
+    "revision": "98ff80ef66a71d8b7c48e7d0c71029abd5c90227",
+    "record_id": "pir-c-22222222222222222222222222222222",
+    "registry_sha256": "0a04fcadccb37e64f6c1209bc0b7e8d5762639ce4c5521c3bba028d9eba037bd",
+    "schema_sha256": "34ab398af4f166b8b65ac68500b547b9ade4955bd0b73770eeda1337bf5dcf47",
+    "reviewers_sha256": "b7a44ad27cec663a9092b924a0f6a9c95bf95a2ce74cf75ba8873e7938782240",
+    "url": "https://github.com/atrinik/atrinik/blob/98ff80ef66a71d8b7c48e7d0c71029abd5c90227/governance/provenance-identities/registry.json#pir-c-22222222222222222222222222222222"
   }
 }

--- a/tests/fixtures/provenance-identities/positive/synthetic-beta.json
+++ b/tests/fixtures/provenance-identities/positive/synthetic-beta.json
@@ -14,15 +14,15 @@
   "scope_binding": "psb-22222222222222222222222222222222",
   "scope_approval": {
     "key_id": "synthetic-reviewer-2026",
-    "signature": "-----BEGIN SSH SIGNATURE-----\nU1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgBruVWBv4FEuaHvyX1z13qRO9BU\nTXED0DGAjTaWDx1NAAAAAVYXRyaW5pay1wcm92ZW5hbmNlLXYxAAAAAAAAAAZzaGE1MTIA\nAABTAAAAC3NzaC1lZDI1NTE5AAAAQGcyoaKoDFIcb6bogMTJmFpDJZhY3ro3N+OoeHalXc\nb0OI8EcGvJehLZy1beFGd8P5TKdASQD0lP+uvR2rKkQgw=\n-----END SSH SIGNATURE-----"
+    "signature": "-----BEGIN SSH SIGNATURE-----\nU1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgBruVWBv4FEuaHvyX1z13qRO9BU\nTXED0DGAjTaWDx1NAAAAAVYXRyaW5pay1wcm92ZW5hbmNlLXYxAAAAAAAAAAZzaGE1MTIA\nAABTAAAAC3NzaC1lZDI1NTE5AAAAQEFugnjUUCSFgna/vEgGbOICU997Tt/8eQzkbpW9Q+\n2I3AWwe5/21Woy/HAYW3EQPMjTyLpyx/ZNOPUhE23D6AU=\n-----END SSH SIGNATURE-----"
   },
   "evidence_reference": {
     "repository": "atrinik/atrinik",
-    "revision": "98ff80ef66a71d8b7c48e7d0c71029abd5c90227",
+    "revision": "89fc98b95f23c0f0f068c5254ffb72c62f173119",
     "record_id": "pir-c-22222222222222222222222222222222",
     "registry_sha256": "0a04fcadccb37e64f6c1209bc0b7e8d5762639ce4c5521c3bba028d9eba037bd",
-    "schema_sha256": "34ab398af4f166b8b65ac68500b547b9ade4955bd0b73770eeda1337bf5dcf47",
+    "schema_sha256": "e040c1575fbd2906d0fe1fcb27a874518a39b8bc5629ac2a987652ea801553f9",
     "reviewers_sha256": "b7a44ad27cec663a9092b924a0f6a9c95bf95a2ce74cf75ba8873e7938782240",
-    "url": "https://github.com/atrinik/atrinik/blob/98ff80ef66a71d8b7c48e7d0c71029abd5c90227/governance/provenance-identities/registry.json#pir-c-22222222222222222222222222222222"
+    "url": "https://github.com/atrinik/atrinik/blob/89fc98b95f23c0f0f068c5254ffb72c62f173119/governance/provenance-identities/registry.json#pir-c-22222222222222222222222222222222"
   }
 }

--- a/tests/fixtures/provenance-identities/positive/synthetic-beta.json
+++ b/tests/fixtures/provenance-identities/positive/synthetic-beta.json
@@ -1,19 +1,20 @@
 {
   "schema_version": 1,
+  "synthetic": true,
   "source": {
     "repository": "atrinik/synthetic-history",
     "path": "engine/beta.c",
     "revision": "2222222222222222222222222222222222222222"
   },
   "destination": {
-    "repository": "atrinik/synthetic-beta",
-    "path": "src/beta.go"
+    "repository": "atrinik/server",
+    "path": "internal/kernel/kernel.go"
   },
   "transformation": "Synthetic port used only to verify the reference contract.",
   "scope_binding": "psb-22222222222222222222222222222222",
   "scope_approval": {
     "key_id": "synthetic-reviewer-2026",
-    "signature": "-----BEGIN SSH SIGNATURE-----\nU1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgBruVWBv4FEuaHvyX1z13qRO9BU\nTXED0DGAjTaWDx1NAAAAAVYXRyaW5pay1wcm92ZW5hbmNlLXYxAAAAAAAAAAZzaGE1MTIA\nAABTAAAAC3NzaC1lZDI1NTE5AAAAQNlkEKILZFIae4QwqXhqHyv6mBJz1jMZFdUbOZZskZ\nNqqP6ucgD/AotcFPdoRBICDaecUK0Qe3V8J+6VGmxfHgA=\n-----END SSH SIGNATURE-----"
+    "signature": "-----BEGIN SSH SIGNATURE-----\nU1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgBruVWBv4FEuaHvyX1z13qRO9BU\nTXED0DGAjTaWDx1NAAAAAVYXRyaW5pay1wcm92ZW5hbmNlLXYxAAAAAAAAAAZzaGE1MTIA\nAABTAAAAC3NzaC1lZDI1NTE5AAAAQGcyoaKoDFIcb6bogMTJmFpDJZhY3ro3N+OoeHalXc\nb0OI8EcGvJehLZy1beFGd8P5TKdASQD0lP+uvR2rKkQgw=\n-----END SSH SIGNATURE-----"
   },
   "evidence_reference": {
     "repository": "atrinik/atrinik",

--- a/tests/fixtures/provenance-identities/positive/synthetic-beta.json
+++ b/tests/fixtures/provenance-identities/positive/synthetic-beta.json
@@ -14,15 +14,15 @@
   "scope_binding": "psb-22222222222222222222222222222222",
   "scope_approval": {
     "key_id": "synthetic-reviewer-2026",
-    "signature": "-----BEGIN SSH SIGNATURE-----\nU1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgBruVWBv4FEuaHvyX1z13qRO9BU\nTXED0DGAjTaWDx1NAAAAAVYXRyaW5pay1wcm92ZW5hbmNlLXYxAAAAAAAAAAZzaGE1MTIA\nAABTAAAAC3NzaC1lZDI1NTE5AAAAQEFugnjUUCSFgna/vEgGbOICU997Tt/8eQzkbpW9Q+\n2I3AWwe5/21Woy/HAYW3EQPMjTyLpyx/ZNOPUhE23D6AU=\n-----END SSH SIGNATURE-----"
+    "signature": "-----BEGIN SSH SIGNATURE-----\nU1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgBruVWBv4FEuaHvyX1z13qRO9BU\nTXED0DGAjTaWDx1NAAAAAVYXRyaW5pay1wcm92ZW5hbmNlLXYxAAAAAAAAAAZzaGE1MTIA\nAABTAAAAC3NzaC1lZDI1NTE5AAAAQIIntFyZwxlBb8JrL5UGvsL55gDCSPrsD63OUhQdDz\n1u0Aiv3EtOOR5D79Ort0aOsVmoADkKb3IVmxYRM7vt3wI=\n-----END SSH SIGNATURE-----"
   },
   "evidence_reference": {
     "repository": "atrinik/atrinik",
-    "revision": "89fc98b95f23c0f0f068c5254ffb72c62f173119",
+    "revision": "51aa7ac9d5ae9c0ff0b2a24a46b5d3e97739bbe0",
     "record_id": "pir-c-22222222222222222222222222222222",
     "registry_sha256": "0a04fcadccb37e64f6c1209bc0b7e8d5762639ce4c5521c3bba028d9eba037bd",
-    "schema_sha256": "e040c1575fbd2906d0fe1fcb27a874518a39b8bc5629ac2a987652ea801553f9",
+    "schema_sha256": "9c726627c8679b4b437db2b54b2480fe0c45eef788de7cd76de1dec5c3ce3409",
     "reviewers_sha256": "b7a44ad27cec663a9092b924a0f6a9c95bf95a2ce74cf75ba8873e7938782240",
-    "url": "https://github.com/atrinik/atrinik/blob/89fc98b95f23c0f0f068c5254ffb72c62f173119/governance/provenance-identities/registry.json#pir-c-22222222222222222222222222222222"
+    "url": "https://github.com/atrinik/atrinik/blob/51aa7ac9d5ae9c0ff0b2a24a46b5d3e97739bbe0/governance/provenance-identities/registry.json#pir-c-22222222222222222222222222222222"
   }
 }

--- a/tests/fixtures/provenance-identities/positive/synthetic-beta.json
+++ b/tests/fixtures/provenance-identities/positive/synthetic-beta.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "source": {
+    "repository": "atrinik/synthetic-history",
+    "path": "engine/beta.c",
+    "revision": "2222222222222222222222222222222222222222"
+  },
+  "destination": {
+    "repository": "atrinik/synthetic-beta",
+    "path": "src/beta.go"
+  },
+  "transformation": "Synthetic port used only to verify the reference contract.",
+  "scope_binding": "psb-22222222222222222222222222222222",
+  "evidence_reference": {
+    "repository": "atrinik/atrinik",
+    "revision": "a700f92274f98476bae84beda7017cf81c6311d8",
+    "record_id": "pir-synthetic-beta-00001",
+    "registry_sha256": "a21d130eedc1dcb381098723f1d67ed87b10c72860756289116b2f30c4d44b92",
+    "schema_sha256": "681f0cffad6f7e767b005902beef3c71f1747936b8d2b0f2a3b54da32e9d5774",
+    "url": "https://github.com/atrinik/atrinik/blob/a700f92274f98476bae84beda7017cf81c6311d8/governance/provenance-identities/registry.json#pir-synthetic-beta-00001"
+  }
+}

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -45,6 +45,45 @@ class AgentGuidanceTests(unittest.TestCase):
             with self.subTest(marker=marker):
                 self.assertIn(marker, registry)
 
+        identity_policy = " ".join(
+            (ROOT / "docs/PROVENANCE_IDENTITIES.md")
+            .read_text(encoding="utf-8")
+            .split()
+        )
+        for marker in {
+            "Prior public appearance is not authorization",
+            "Removing an `alias` field alone does not prevent re-identification",
+            "provenance-custodians",
+            "provenance-reviewers",
+            "seven years after the last reliance is withdrawn",
+            "Suspected disclosure freezes new attestations",
+            "Key compromise rotates recipients and HMAC keys",
+            "Unkeyed hashes of names, aliases, emails, commits, or ranges are forbidden",
+            "full 40-character coordinator commit reachable from its default branch",
+            "Current named grants in `docs/PROVENANCE.md` are not silently converted",
+        }:
+            with self.subTest(marker=marker):
+                self.assertIn(marker, identity_policy)
+
+        schema = json.loads(
+            (ROOT / "governance/provenance-identities/schema-v1.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        public_registry = json.loads(
+            (ROOT / "governance/provenance-identities/registry.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(schema["properties"]["schema_version"]["const"], 1)
+        self.assertTrue(public_registry["records"])
+        self.assertTrue(
+            all(record["synthetic"] for record in public_registry["records"])
+        )
+        fixtures = ROOT / "tests/fixtures/provenance-identities"
+        self.assertEqual(len(list((fixtures / "positive").glob("*.json"))), 2)
+        self.assertTrue(list((fixtures / "negative").glob("*.json")))
+
     def test_copyright_header_contract_is_complete(self) -> None:
         guide = " ".join(
             (ROOT / "AGENTS.md").read_text(encoding="utf-8").split()

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -59,7 +59,7 @@ class AgentGuidanceTests(unittest.TestCase):
             "Suspected disclosure freezes new attestations",
             "Key compromise rotates recipients and HMAC keys",
             "Unkeyed hashes of names, aliases, emails, commits, or ranges are forbidden",
-            "full 40-character coordinator commit reachable from its default branch",
+            "full 40-character coordinator commit reachable from canonical `origin/main`",
             "Current named grants in `docs/PROVENANCE.md` are not silently converted",
         }:
             with self.subTest(marker=marker):

--- a/tests/test_provenance_identity.py
+++ b/tests/test_provenance_identity.py
@@ -155,6 +155,14 @@ class ProvenanceIdentityTests(unittest.TestCase):
             "HEAD",
         )
 
+    def test_repository_trust_accepts_github_actions_canonical_origin(self) -> None:
+        outputs = [b"false\n", b"/tmp/coordinator.git\n", b"https://github.com/atrinik/atrinik\n", b""]
+        with mock.patch(
+            "atrinik_workspace.provenance_identity._git_output",
+            side_effect=outputs,
+        ), mock.patch("pathlib.Path.exists", return_value=False):
+            _validate_repository_trust(ROOT, "1" * 40, "origin/main")
+
     def test_record_digest_detects_mutation(self) -> None:
         value = registry()
         value["records"][0]["claims"].remove("authorship")

--- a/tests/test_provenance_identity.py
+++ b/tests/test_provenance_identity.py
@@ -301,6 +301,22 @@ class ProvenanceIdentityTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "duplicate record identifier"):
             validate_registry(value, schema(), reviewers(), as_of=AS_OF)
 
+    def test_registry_container_contract_fails_closed(self) -> None:
+        mutations = (
+            lambda value: value.update(schema="unexpected.json"),
+            lambda value: value.update(reviewers="unexpected.json"),
+            lambda value: value.update(records=None),
+            lambda value: value.update(records=[None]),
+            lambda value: value["records"][0].update(record_type="unknown"),
+            lambda value: value.update(records=list(reversed(value["records"]))),
+        )
+        for index, mutate in enumerate(mutations):
+            with self.subTest(mutation=index):
+                value = registry()
+                mutate(value)
+                with self.assertRaises(WorkspaceError):
+                    validate_registry(value, schema(), reviewers(), as_of=AS_OF)
+
     def test_duplicate_restricted_integrity_fails_closed(self) -> None:
         value = registry()
         value["records"][1]["restricted_evidence"]["integrity"] = value["records"][0][

--- a/tests/test_provenance_identity.py
+++ b/tests/test_provenance_identity.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from datetime import date
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+from atrinik_workspace.cli import main, parser
+from atrinik_workspace.model import WorkspaceError
+from atrinik_workspace.provenance_identity import (
+    load_document,
+    record_digest,
+    validate_component_reference,
+    validate_registry,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = ROOT / "governance/provenance-identities/registry.json"
+SCHEMA = ROOT / "governance/provenance-identities/schema-v1.json"
+AS_OF = date(2026, 8, 13)
+
+
+def registry() -> dict[str, object]:
+    return json.loads(REGISTRY.read_text(encoding="utf-8"))
+
+
+def schema() -> dict[str, object]:
+    return json.loads(SCHEMA.read_text(encoding="utf-8"))
+
+
+def refresh_digest(record: dict[str, object]) -> None:
+    record["integrity"]["digest"] = record_digest(record)
+
+
+class ProvenanceIdentityTests(unittest.TestCase):
+    def test_canonical_registry_and_schema_are_valid(self) -> None:
+        records = validate_registry(registry(), schema(), as_of=AS_OF)
+        self.assertEqual(
+            list(records),
+            ["pir-synthetic-alpha-0001", "pir-synthetic-beta-00001"],
+        )
+        self.assertTrue(all(record["synthetic"] for record in records.values()))
+
+    def test_parser_exposes_bounded_local_validation(self) -> None:
+        options = parser().parse_args(
+            ["provenance", "validate", "--as-of", "2026-08-13"]
+        )
+        self.assertEqual(options.command, "provenance")
+        self.assertEqual(options.provenance_command, "validate")
+        self.assertEqual(options.as_of, AS_OF)
+
+        with mock.patch("builtins.print") as output:
+            self.assertEqual(
+                main(["provenance", "validate", "--as-of", "2026-08-13"]),
+                0,
+            )
+        self.assertIn("2 records, 0 references", output.call_args.args[0])
+
+    def test_duplicate_json_keys_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "duplicate.json"
+            path.write_text('{"schema_version": 1, "schema_version": 1}\n')
+            with self.assertRaisesRegex(WorkspaceError, "duplicate JSON key"):
+                load_document(path)
+
+    def test_duplicate_record_identifiers_fail_closed(self) -> None:
+        value = registry()
+        duplicate = json.loads(json.dumps(value["records"][0]))
+        value["records"].append(duplicate)
+        with self.assertRaisesRegex(WorkspaceError, "duplicate record identifier"):
+            validate_registry(value, schema(), as_of=AS_OF)
+
+    def test_confidential_subject_fields_fail_closed(self) -> None:
+        value = registry()
+        value["records"][0]["alias"] = "synthetic-private-alias"
+        refresh_digest(value["records"][0])
+        with self.assertRaisesRegex(WorkspaceError, "unsafe public field 'alias'"):
+            validate_registry(value, schema(), as_of=AS_OF)
+
+    def test_stale_active_attestation_fails_closed(self) -> None:
+        value = registry()
+        value["records"][0]["reviewed_on"] = "2020-01-01"
+        value["records"][0]["expires_on"] = "2026-08-12"
+        refresh_digest(value["records"][0])
+        with self.assertRaisesRegex(WorkspaceError, "active attestation is stale"):
+            validate_registry(value, schema(), as_of=AS_OF)
+
+    def test_unknown_policy_version_fails_closed(self) -> None:
+        value = registry()
+        value["policy_version"] = 2
+        with self.assertRaisesRegex(WorkspaceError, "unsupported policy version"):
+            validate_registry(value, schema(), as_of=AS_OF)
+
+    def test_record_digest_detects_mutation(self) -> None:
+        value = registry()
+        value["records"][0]["claims"].remove("authorship")
+        with self.assertRaisesRegex(WorkspaceError, "does not match canonical record"):
+            validate_registry(value, schema(), as_of=AS_OF)
+
+    def test_reference_rejects_noncanonical_url_without_git_access(self) -> None:
+        value = {
+            "schema_version": 1,
+            "source": {
+                "repository": "atrinik/synthetic-source",
+                "path": "src/example.c",
+                "revision": "1" * 40,
+            },
+            "destination": {
+                "repository": "atrinik/synthetic-alpha",
+                "path": "src/example.rs",
+            },
+            "transformation": "synthetic translation",
+            "scope_binding": "psb-11111111111111111111111111111111",
+            "evidence_reference": {
+                "repository": "atrinik/atrinik",
+                "revision": "1" * 40,
+                "record_id": "pir-synthetic-alpha-0001",
+                "registry_sha256": "1" * 64,
+                "schema_sha256": "2" * 64,
+                "url": "https://example.invalid/movable",
+            },
+        }
+        with self.assertRaisesRegex(WorkspaceError, "canonical immutable permalink"):
+            validate_component_reference(value, repository_root=ROOT, as_of=AS_OF)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_provenance_identity.py
+++ b/tests/test_provenance_identity.py
@@ -362,11 +362,11 @@ class ProvenanceIdentityTests(unittest.TestCase):
     def test_unmerged_anchor_requires_explicit_non_authorizing_ref(self) -> None:
         with self.assertRaisesRegex(WorkspaceError, "not reachable from trusted ref"):
             _validate_repository_trust(
-                ROOT, "89fc98b95f23c0f0f068c5254ffb72c62f173119", "main"
+                ROOT, "51aa7ac9d5ae9c0ff0b2a24a46b5d3e97739bbe0", "main"
             )
         _validate_repository_trust(
             ROOT,
-            "89fc98b95f23c0f0f068c5254ffb72c62f173119",
+            "51aa7ac9d5ae9c0ff0b2a24a46b5d3e97739bbe0",
             "HEAD",
         )
 

--- a/tests/test_provenance_identity.py
+++ b/tests/test_provenance_identity.py
@@ -11,10 +11,15 @@ from unittest import mock
 from atrinik_workspace.cli import main, parser
 from atrinik_workspace.model import WorkspaceError
 from atrinik_workspace.provenance_identity import (
+    MAX_DOCUMENT_BYTES,
+    _git_blob,
+    _git_output,
+    _load_bytes,
     _validate_repository_trust,
     load_document,
     record_digest,
     validate_component_reference,
+    validate_paths,
     validate_registry,
     validate_reviewers,
 )
@@ -52,6 +57,176 @@ def refresh_digest(record: dict[str, object]) -> None:
 
 
 class ProvenanceIdentityTests(unittest.TestCase):
+    def test_bounded_document_and_json_helpers_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            oversized = root / "oversized.json"
+            oversized.write_bytes(b" " * (MAX_DOCUMENT_BYTES + 1))
+            with self.assertRaisesRegex(WorkspaceError, "exceeds"):
+                load_document(oversized)
+            with self.assertRaisesRegex(WorkspaceError, "cannot load JSON"):
+                load_document(root / "missing.json")
+            array = root / "array.json"
+            array.write_text("[]")
+            with self.assertRaisesRegex(WorkspaceError, "root must be an object"):
+                load_document(array)
+        with self.assertRaisesRegex(WorkspaceError, "invalid JSON"):
+            _load_bytes(b"not-json", "fixture")
+        with self.assertRaisesRegex(WorkspaceError, "root must be an object"):
+            _load_bytes(b"[]", "fixture")
+
+    def test_reviewer_registry_rejects_malformed_authorities(self) -> None:
+        mutations = (
+            (lambda value: value.update(schema_version=True), "unsupported version"),
+            (lambda value: value.update(reviewers=[]), "contain reviewers"),
+            (lambda value: value["reviewers"].__setitem__(0, "bad"), "must be an object"),
+            (lambda value: value["reviewers"][0].update(identity="invalid"), "invalid GitHub"),
+            (lambda value: value["reviewers"][0].update(key_id="short"), "invalid key"),
+            (lambda value: value["reviewers"][0].update(status="unknown"), "invalid status"),
+            (lambda value: value["reviewers"][0].update(synthetic="yes"), "must be a boolean"),
+            (lambda value: value["reviewers"][0].update(effective_on="2028-01-01"), "invalid effective"),
+            (lambda value: value["reviewers"][0].update(public_key="ssh-rsa bad"), "Ed25519"),
+        )
+        for mutate, message in mutations:
+            with self.subTest(message=message):
+                value = reviewers()
+                mutate(value)
+                with self.assertRaisesRegex(WorkspaceError, message):
+                    validate_reviewers(value, as_of=AS_OF)
+        value = reviewers()
+        duplicate = json.loads(json.dumps(value["reviewers"][0]))
+        value["reviewers"].append(duplicate)
+        with self.assertRaisesRegex(WorkspaceError, "duplicate key"):
+            validate_reviewers(value, as_of=AS_OF)
+
+    def test_public_alias_and_status_transitions_validate(self) -> None:
+        alias = {
+            "record_id": "pir-p-33333333333333333333333333333333",
+            "record_type": "public-alias",
+            "status": "active",
+            "status_detail": {"effective_on": "2026-08-13"},
+            "synthetic": True,
+            "policy_version": 1,
+            "reviewer": "github:synthetic-reviewer",
+            "reviewed_on": "2026-08-13",
+            "expires_on": "2027-08-13",
+            "claims": ["identity"],
+            "display_name": "Synthetic Contributor",
+            "aliases": ["synthetic-contributor"],
+            "publication_authorization": {
+                "authorized_on": "2026-08-13",
+                "fields": ["aliases", "display_name"],
+                "restricted_record_id": "restricted-33333333333333333333333333333333",
+            },
+            "approval": {"key_id": "synthetic-reviewer-2026", "signature": "synthetic"},
+            "integrity": {
+                "algorithm": "sha256",
+                "canonicalization": "atrinik-json-v1",
+                "digest": "",
+            },
+        }
+        refresh_digest(alias)
+        value = registry()
+        value["records"] = [alias]
+        with mock.patch("atrinik_workspace.provenance_identity._verify_approval"):
+            self.assertIn(alias["record_id"], validate_registry(value, schema(), reviewers(), as_of=AS_OF))
+
+            value = registry()
+            value["records"][0]["status"] = "revoked"
+            value["records"][0]["status_detail"] = {
+                "effective_on": "2026-08-13",
+                "reason": "withdrawal",
+            }
+            refresh_digest(value["records"][0])
+            validate_registry(value, schema(), reviewers(), as_of=AS_OF)
+
+            value = registry()
+            value["records"][0]["status"] = "superseded"
+            value["records"][0]["status_detail"] = {
+                "effective_on": "2026-08-13",
+                "superseded_by": value["records"][1]["record_id"],
+            }
+            refresh_digest(value["records"][0])
+            validate_registry(value, schema(), reviewers(), as_of=AS_OF)
+
+    def test_future_status_effective_date_fails_closed(self) -> None:
+        value = registry()
+        value["records"][0]["status_detail"]["effective_on"] = "2026-08-14"
+        refresh_digest(value["records"][0])
+        with mock.patch(
+            "atrinik_workspace.provenance_identity._verify_approval"
+        ), self.assertRaisesRegex(WorkspaceError, "effective date is in the future"):
+            validate_registry(value, schema(), reviewers(), as_of=AS_OF)
+
+    def test_git_trust_and_blob_bounds_fail_closed(self) -> None:
+        with mock.patch(
+            "atrinik_workspace.provenance_identity._git_output", return_value=b"true\n"
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "non-shallow"):
+                _validate_repository_trust(ROOT, "1" * 40, "origin/main")
+        outputs = [b"false\n", b"/tmp/coordinator.git\n", b"https://example.invalid/repo\n"]
+        with mock.patch(
+            "atrinik_workspace.provenance_identity._git_output", side_effect=outputs
+        ), mock.patch("pathlib.Path.exists", return_value=False):
+            with self.assertRaisesRegex(WorkspaceError, "origin is not"):
+                _validate_repository_trust(ROOT, "1" * 40, "origin/main")
+        with mock.patch("subprocess.run", side_effect=OSError("missing git")):
+            with self.assertRaisesRegex(WorkspaceError, "cannot run git"):
+                _git_output(ROOT, ["status"], "cannot run git")
+        with mock.patch(
+            "atrinik_workspace.provenance_identity._git_output", return_value=b"invalid"
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "invalid size"):
+                _git_blob(ROOT, "1" * 40, "registry.json")
+
+    def test_reference_validation_uses_current_state_from_trusted_ref(self) -> None:
+        reference = FIXTURES / "positive" / "synthetic-alpha.json"
+        pinned_registry = REGISTRY.read_bytes()
+        revoked = registry()
+        revoked["records"][0]["status"] = "revoked"
+        revoked["records"][0]["status_detail"] = {
+            "effective_on": "2026-08-13",
+            "reason": "withdrawal",
+        }
+        refresh_digest(revoked["records"][0])
+        trusted_registry = (json.dumps(revoked) + "\n").encode()
+
+        def blob(_root: Path, revision: str, path: str) -> bytes:
+            if path == "governance/provenance-identities/registry.json":
+                return trusted_registry if revision == "trusted" else pinned_registry
+            if path.endswith("schema-v1.json"):
+                return SCHEMA.read_bytes()
+            return REVIEWERS.read_bytes()
+
+        with mock.patch(
+            "atrinik_workspace.provenance_identity._validate_repository_trust"
+        ), mock.patch(
+            "atrinik_workspace.provenance_identity._git_blob", side_effect=blob
+        ), mock.patch(
+            "atrinik_workspace.provenance_identity._verify_approval"
+        ), self.assertRaisesRegex(WorkspaceError, "current registry"):
+            validate_paths(
+                ROOT,
+                registry_path=REGISTRY,
+                schema_path=SCHEMA,
+                reviewers_path=REVIEWERS,
+                reference_paths=[reference],
+                as_of=AS_OF,
+                trusted_ref="trusted",
+            )
+        with mock.patch(
+            "atrinik_workspace.provenance_identity._git_output",
+            return_value=str(MAX_DOCUMENT_BYTES + 1).encode(),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "exceeds"):
+                _git_blob(ROOT, "1" * 40, "registry.json")
+        with mock.patch(
+            "atrinik_workspace.provenance_identity._git_output",
+            side_effect=[b"2", b"x"],
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "size changed"):
+                _git_blob(ROOT, "1" * 40, "registry.json")
+
     def test_canonical_registry_and_schema_are_valid(self) -> None:
         records = validate_registry(registry(), schema(), reviewers(), as_of=AS_OF)
         self.assertEqual(
@@ -83,6 +258,17 @@ class ProvenanceIdentityTests(unittest.TestCase):
         duplicate = json.loads(json.dumps(value["records"][0]))
         value["records"].append(duplicate)
         with self.assertRaisesRegex(WorkspaceError, "duplicate record identifier"):
+            validate_registry(value, schema(), reviewers(), as_of=AS_OF)
+
+    def test_duplicate_restricted_integrity_fails_closed(self) -> None:
+        value = registry()
+        value["records"][1]["restricted_evidence"]["integrity"] = value["records"][0][
+            "restricted_evidence"
+        ]["integrity"]
+        refresh_digest(value["records"][1])
+        with mock.patch(
+            "atrinik_workspace.provenance_identity._verify_approval"
+        ), self.assertRaisesRegex(WorkspaceError, "duplicate restricted evidence integrity"):
             validate_registry(value, schema(), reviewers(), as_of=AS_OF)
 
     def test_confidential_subject_fields_fail_closed(self) -> None:

--- a/tests/test_provenance_identity.py
+++ b/tests/test_provenance_identity.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import date
+import hashlib
 import json
 from pathlib import Path
 import tempfile
@@ -20,6 +21,7 @@ from atrinik_workspace.provenance_identity import (
 ROOT = Path(__file__).resolve().parents[1]
 REGISTRY = ROOT / "governance/provenance-identities/registry.json"
 SCHEMA = ROOT / "governance/provenance-identities/schema-v1.json"
+FIXTURES = ROOT / "tests/fixtures/provenance-identities"
 AS_OF = date(2026, 8, 13)
 
 
@@ -125,6 +127,46 @@ class ProvenanceIdentityTests(unittest.TestCase):
         }
         with self.assertRaisesRegex(WorkspaceError, "canonical immutable permalink"):
             validate_component_reference(value, repository_root=ROOT, as_of=AS_OF)
+
+    def test_two_synthetic_component_references_validate_offline(self) -> None:
+        for name in ("synthetic-alpha.json", "synthetic-beta.json"):
+            with self.subTest(name=name):
+                validate_component_reference(
+                    load_document(FIXTURES / "positive" / name),
+                    repository_root=ROOT,
+                    as_of=AS_OF,
+                )
+
+    def test_broken_immutable_reference_fixture_fails_closed(self) -> None:
+        with self.assertRaisesRegex(WorkspaceError, "registry digest does not match"):
+            validate_component_reference(
+                load_document(FIXTURES / "negative" / "broken-reference.json"),
+                repository_root=ROOT,
+                as_of=AS_OF,
+            )
+
+    def test_reference_to_revoked_attestation_fails_closed(self) -> None:
+        reference = load_document(FIXTURES / "positive" / "synthetic-alpha.json")
+        registry_blob = json.loads(
+            REGISTRY.read_text(encoding="utf-8")
+        )
+        registry_blob["records"][0]["status"] = "revoked"
+        refresh_digest(registry_blob["records"][0])
+        encoded_registry = (json.dumps(registry_blob) + "\n").encode()
+        reference["evidence_reference"]["registry_sha256"] = hashlib.sha256(
+            encoded_registry
+        ).hexdigest()
+
+        def blob(_root: Path, _revision: str, path: str) -> bytes:
+            if path.endswith("registry.json"):
+                return encoded_registry
+            return SCHEMA.read_bytes()
+
+        with mock.patch(
+            "atrinik_workspace.provenance_identity._git_blob", side_effect=blob
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "record is not active"):
+                validate_component_reference(reference, repository_root=ROOT, as_of=AS_OF)
 
 
 if __name__ == "__main__":

--- a/tests/test_provenance_identity.py
+++ b/tests/test_provenance_identity.py
@@ -11,10 +11,12 @@ from unittest import mock
 from atrinik_workspace.cli import main, parser
 from atrinik_workspace.model import WorkspaceError
 from atrinik_workspace.provenance_identity import (
+    _validate_repository_trust,
     load_document,
     record_digest,
     validate_component_reference,
     validate_registry,
+    validate_reviewers,
 )
 
 
@@ -22,6 +24,7 @@ ROOT = Path(__file__).resolve().parents[1]
 REGISTRY = ROOT / "governance/provenance-identities/registry.json"
 SCHEMA = ROOT / "governance/provenance-identities/schema-v1.json"
 FIXTURES = ROOT / "tests/fixtures/provenance-identities"
+REVIEWERS = ROOT / "governance/provenance-identities/reviewers.json"
 AS_OF = date(2026, 8, 13)
 
 
@@ -33,32 +36,39 @@ def schema() -> dict[str, object]:
     return json.loads(SCHEMA.read_text(encoding="utf-8"))
 
 
+def reviewers() -> dict[str, object]:
+    return json.loads(REVIEWERS.read_text(encoding="utf-8"))
+
+
+def current() -> tuple[dict[str, dict[str, object]], dict[str, dict[str, object]]]:
+    return (
+        validate_registry(registry(), schema(), reviewers(), as_of=AS_OF),
+        validate_reviewers(reviewers(), as_of=AS_OF),
+    )
+
+
 def refresh_digest(record: dict[str, object]) -> None:
     record["integrity"]["digest"] = record_digest(record)
 
 
 class ProvenanceIdentityTests(unittest.TestCase):
     def test_canonical_registry_and_schema_are_valid(self) -> None:
-        records = validate_registry(registry(), schema(), as_of=AS_OF)
+        records = validate_registry(registry(), schema(), reviewers(), as_of=AS_OF)
         self.assertEqual(
             list(records),
-            ["pir-synthetic-alpha-0001", "pir-synthetic-beta-00001"],
+            [
+                "pir-c-11111111111111111111111111111111",
+                "pir-c-22222222222222222222222222222222",
+            ],
         )
         self.assertTrue(all(record["synthetic"] for record in records.values()))
 
     def test_parser_exposes_bounded_local_validation(self) -> None:
-        options = parser().parse_args(
-            ["provenance", "validate", "--as-of", "2026-08-13"]
-        )
+        options = parser().parse_args(["provenance", "validate"])
         self.assertEqual(options.command, "provenance")
         self.assertEqual(options.provenance_command, "validate")
-        self.assertEqual(options.as_of, AS_OF)
-
         with mock.patch("builtins.print") as output:
-            self.assertEqual(
-                main(["provenance", "validate", "--as-of", "2026-08-13"]),
-                0,
-            )
+            self.assertEqual(main(["provenance", "validate"]), 0)
         self.assertIn("2 records, 0 references", output.call_args.args[0])
 
     def test_duplicate_json_keys_fail_closed(self) -> None:
@@ -73,34 +83,83 @@ class ProvenanceIdentityTests(unittest.TestCase):
         duplicate = json.loads(json.dumps(value["records"][0]))
         value["records"].append(duplicate)
         with self.assertRaisesRegex(WorkspaceError, "duplicate record identifier"):
-            validate_registry(value, schema(), as_of=AS_OF)
+            validate_registry(value, schema(), reviewers(), as_of=AS_OF)
 
     def test_confidential_subject_fields_fail_closed(self) -> None:
         value = registry()
         value["records"][0]["alias"] = "synthetic-private-alias"
         refresh_digest(value["records"][0])
         with self.assertRaisesRegex(WorkspaceError, "unsafe public field 'alias'"):
-            validate_registry(value, schema(), as_of=AS_OF)
+            validate_registry(value, schema(), reviewers(), as_of=AS_OF)
 
     def test_stale_active_attestation_fails_closed(self) -> None:
         value = registry()
-        value["records"][0]["reviewed_on"] = "2020-01-01"
         value["records"][0]["expires_on"] = "2026-08-12"
         refresh_digest(value["records"][0])
-        with self.assertRaisesRegex(WorkspaceError, "active attestation is stale"):
-            validate_registry(value, schema(), as_of=AS_OF)
+        with self.assertRaisesRegex(WorkspaceError, "expires_on must be after reviewed_on"):
+            validate_registry(value, schema(), reviewers(), as_of=AS_OF)
 
     def test_unknown_policy_version_fails_closed(self) -> None:
         value = registry()
         value["policy_version"] = 2
         with self.assertRaisesRegex(WorkspaceError, "unsupported policy version"):
-            validate_registry(value, schema(), as_of=AS_OF)
+            validate_registry(value, schema(), reviewers(), as_of=AS_OF)
+
+    def test_boolean_versions_and_schema_drift_fail_closed(self) -> None:
+        value = registry()
+        value["schema_version"] = True
+        with self.assertRaisesRegex(WorkspaceError, "unsupported schema version"):
+            validate_registry(value, schema(), reviewers(), as_of=AS_OF)
+
+        drifted = schema()
+        drifted["title"] = "untrusted drift"
+        with self.assertRaisesRegex(WorkspaceError, "trusted version"):
+            validate_registry(registry(), drifted, reviewers(), as_of=AS_OF)
+
+    def test_future_review_and_readable_confidential_id_fail_closed(self) -> None:
+        value = registry()
+        value["records"][0]["reviewed_on"] = "2026-08-14"
+        value["records"][0]["expires_on"] = "2027-08-14"
+        refresh_digest(value["records"][0])
+        with mock.patch("atrinik_workspace.provenance_identity._verify_approval"):
+            with self.assertRaisesRegex(WorkspaceError, "review date is in the future"):
+                validate_registry(value, schema(), reviewers(), as_of=AS_OF)
+
+        value = registry()
+        value["records"][0]["record_id"] = "pir-c-john-smith-readable-identity"
+        refresh_digest(value["records"][0])
+        with self.assertRaisesRegex(WorkspaceError, "random hex"):
+            validate_registry(value, schema(), reviewers(), as_of=AS_OF)
+
+    def test_untrusted_reviewer_and_signature_mutation_fail_closed(self) -> None:
+        value = registry()
+        value["records"][0]["approval"]["key_id"] = "unknown-reviewer-key"
+        refresh_digest(value["records"][0])
+        with self.assertRaisesRegex(WorkspaceError, "reviewer key is not authorized"):
+            validate_registry(value, schema(), reviewers(), as_of=AS_OF)
+
+        value = registry()
+        value["records"][0]["claims"].remove("authorship")
+        refresh_digest(value["records"][0])
+        with self.assertRaisesRegex(WorkspaceError, "reviewer signature is invalid"):
+            validate_registry(value, schema(), reviewers(), as_of=AS_OF)
+
+    def test_unmerged_anchor_requires_explicit_non_authorizing_ref(self) -> None:
+        with self.assertRaisesRegex(WorkspaceError, "not reachable from trusted ref"):
+            _validate_repository_trust(
+                ROOT, "98ff80ef66a71d8b7c48e7d0c71029abd5c90227", "main"
+            )
+        _validate_repository_trust(
+            ROOT,
+            "98ff80ef66a71d8b7c48e7d0c71029abd5c90227",
+            "HEAD",
+        )
 
     def test_record_digest_detects_mutation(self) -> None:
         value = registry()
         value["records"][0]["claims"].remove("authorship")
         with self.assertRaisesRegex(WorkspaceError, "does not match canonical record"):
-            validate_registry(value, schema(), as_of=AS_OF)
+            validate_registry(value, schema(), reviewers(), as_of=AS_OF)
 
     def test_reference_rejects_noncanonical_url_without_git_access(self) -> None:
         value = {
@@ -116,33 +175,51 @@ class ProvenanceIdentityTests(unittest.TestCase):
             },
             "transformation": "synthetic translation",
             "scope_binding": "psb-11111111111111111111111111111111",
+            "scope_approval": {"key_id": "synthetic-reviewer-2026", "signature": "invalid"},
             "evidence_reference": {
                 "repository": "atrinik/atrinik",
                 "revision": "1" * 40,
-                "record_id": "pir-synthetic-alpha-0001",
+                "record_id": "pir-c-11111111111111111111111111111111",
                 "registry_sha256": "1" * 64,
+                "reviewers_sha256": "3" * 64,
                 "schema_sha256": "2" * 64,
                 "url": "https://example.invalid/movable",
             },
         }
+        records, reviewer_keys = current()
         with self.assertRaisesRegex(WorkspaceError, "canonical immutable permalink"):
-            validate_component_reference(value, repository_root=ROOT, as_of=AS_OF)
+            validate_component_reference(
+                value,
+                repository_root=ROOT,
+                as_of=AS_OF,
+                trusted_ref="HEAD",
+                current_records=records,
+                current_reviewers=reviewer_keys,
+            )
 
     def test_two_synthetic_component_references_validate_offline(self) -> None:
+        records, reviewer_keys = current()
         for name in ("synthetic-alpha.json", "synthetic-beta.json"):
             with self.subTest(name=name):
                 validate_component_reference(
                     load_document(FIXTURES / "positive" / name),
                     repository_root=ROOT,
                     as_of=AS_OF,
+                    trusted_ref="HEAD",
+                    current_records=records,
+                    current_reviewers=reviewer_keys,
                 )
 
     def test_broken_immutable_reference_fixture_fails_closed(self) -> None:
+        records, reviewer_keys = current()
         with self.assertRaisesRegex(WorkspaceError, "registry digest does not match"):
             validate_component_reference(
                 load_document(FIXTURES / "negative" / "broken-reference.json"),
                 repository_root=ROOT,
                 as_of=AS_OF,
+                trusted_ref="HEAD",
+                current_records=records,
+                current_reviewers=reviewer_keys,
             )
 
     def test_reference_to_revoked_attestation_fails_closed(self) -> None:
@@ -151,6 +228,10 @@ class ProvenanceIdentityTests(unittest.TestCase):
             REGISTRY.read_text(encoding="utf-8")
         )
         registry_blob["records"][0]["status"] = "revoked"
+        registry_blob["records"][0]["status_detail"] = {
+            "effective_on": "2026-08-13",
+            "reason": "withdrawal",
+        }
         refresh_digest(registry_blob["records"][0])
         encoded_registry = (json.dumps(registry_blob) + "\n").encode()
         reference["evidence_reference"]["registry_sha256"] = hashlib.sha256(
@@ -160,13 +241,55 @@ class ProvenanceIdentityTests(unittest.TestCase):
         def blob(_root: Path, _revision: str, path: str) -> bytes:
             if path.endswith("registry.json"):
                 return encoded_registry
-            return SCHEMA.read_bytes()
+            if path.endswith("schema-v1.json"):
+                return SCHEMA.read_bytes()
+            return REVIEWERS.read_bytes()
 
+        records, reviewer_keys = current()
         with mock.patch(
             "atrinik_workspace.provenance_identity._git_blob", side_effect=blob
+        ), mock.patch(
+            "atrinik_workspace.provenance_identity._validate_repository_trust"
+        ), mock.patch(
+            "atrinik_workspace.provenance_identity._verify_approval"
         ):
             with self.assertRaisesRegex(WorkspaceError, "record is not active"):
-                validate_component_reference(reference, repository_root=ROOT, as_of=AS_OF)
+                validate_component_reference(
+                    reference,
+                    repository_root=ROOT,
+                    as_of=AS_OF,
+                    trusted_ref="HEAD",
+                    current_records=records,
+                    current_reviewers=reviewer_keys,
+                )
+
+    def test_current_revocation_overrides_active_pinned_record(self) -> None:
+        reference = load_document(FIXTURES / "positive" / "synthetic-alpha.json")
+        records, reviewer_keys = current()
+        records[reference["evidence_reference"]["record_id"]]["status"] = "revoked"
+        with self.assertRaisesRegex(WorkspaceError, "current registry"):
+            validate_component_reference(
+                reference,
+                repository_root=ROOT,
+                as_of=AS_OF,
+                trusted_ref="HEAD",
+                current_records=records,
+                current_reviewers=reviewer_keys,
+            )
+
+    def test_scope_replay_invalidates_reviewer_signature(self) -> None:
+        reference = load_document(FIXTURES / "positive" / "synthetic-alpha.json")
+        reference["source"]["path"] = "engine/unapproved.c"
+        records, reviewer_keys = current()
+        with self.assertRaisesRegex(WorkspaceError, "reviewer signature is invalid"):
+            validate_component_reference(
+                reference,
+                repository_root=ROOT,
+                as_of=AS_OF,
+                trusted_ref="HEAD",
+                current_records=records,
+                current_reviewers=reviewer_keys,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_provenance_identity.py
+++ b/tests/test_provenance_identity.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import date
 import hashlib
 import json
+import os
 from pathlib import Path
 import tempfile
 import unittest
@@ -13,6 +14,7 @@ from atrinik_workspace.model import WorkspaceError
 from atrinik_workspace.provenance_identity import (
     MAX_DOCUMENT_BYTES,
     _git_blob,
+    _git_environment,
     _git_output,
     _load_bytes,
     _validate_repository_trust,
@@ -302,6 +304,33 @@ class ProvenanceIdentityTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "trusted version"):
             validate_registry(registry(), drifted, reviewers(), as_of=AS_OF)
 
+    def test_schema_status_shapes_match_the_validator_contract(self) -> None:
+        definitions = schema()["$defs"]
+        expected = {
+            "active": "activeStatusDetail",
+            "revoked": "revokedStatusDetail",
+            "superseded": "supersededStatusDetail",
+        }
+        for record_name in ("publicAlias", "confidentialAttestation"):
+            conditions = definitions[record_name]["allOf"]
+            actual = {
+                condition["if"]["properties"]["status"]["const"]:
+                condition["then"]["properties"]["status_detail"]["$ref"].rsplit("/", 1)[-1]
+                for condition in conditions
+            }
+            self.assertEqual(actual, expected)
+        self.assertEqual(
+            set(definitions["activeStatusDetail"]["properties"]), {"effective_on"}
+        )
+        self.assertEqual(
+            set(definitions["revokedStatusDetail"]["required"]),
+            {"effective_on", "reason"},
+        )
+        self.assertEqual(
+            set(definitions["supersededStatusDetail"]["required"]),
+            {"effective_on", "superseded_by"},
+        )
+
     def test_future_review_and_readable_confidential_id_fail_closed(self) -> None:
         value = registry()
         value["records"][0]["reviewed_on"] = "2026-08-14"
@@ -348,6 +377,23 @@ class ProvenanceIdentityTests(unittest.TestCase):
             side_effect=outputs,
         ), mock.patch("pathlib.Path.exists", return_value=False):
             _validate_repository_trust(ROOT, "1" * 40, "origin/main")
+
+    def test_git_environment_cannot_redirect_the_coordinator_repository(self) -> None:
+        selecting = {
+            "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+            "GIT_CEILING_DIRECTORIES",
+            "GIT_COMMON_DIR",
+            "GIT_DIR",
+            "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+            "GIT_INDEX_FILE",
+            "GIT_OBJECT_DIRECTORY",
+            "GIT_REPLACE_REF_BASE",
+            "GIT_WORK_TREE",
+        }
+        with mock.patch.dict(os.environ, {name: "/tmp/untrusted" for name in selecting}):
+            environment = _git_environment()
+        self.assertTrue(selecting.isdisjoint(environment))
+        self.assertEqual(environment["GIT_NO_REPLACE_OBJECTS"], "1")
 
     def test_record_digest_detects_mutation(self) -> None:
         value = registry()

--- a/tests/test_provenance_identity.py
+++ b/tests/test_provenance_identity.py
@@ -278,6 +278,22 @@ class ProvenanceIdentityTests(unittest.TestCase):
                 current_reviewers=reviewer_keys,
             )
 
+    def test_current_registry_cannot_replace_an_active_pinned_record(self) -> None:
+        reference = load_document(FIXTURES / "positive" / "synthetic-alpha.json")
+        records, reviewer_keys = current()
+        records[reference["evidence_reference"]["record_id"]]["integrity"]["digest"] = (
+            "f" * 64
+        )
+        with self.assertRaisesRegex(WorkspaceError, "differs from the pinned"):
+            validate_component_reference(
+                reference,
+                repository_root=ROOT,
+                as_of=AS_OF,
+                trusted_ref="HEAD",
+                current_records=records,
+                current_reviewers=reviewer_keys,
+            )
+
     def test_scope_replay_invalidates_reviewer_signature(self) -> None:
         reference = load_document(FIXTURES / "positive" / "synthetic-alpha.json")
         reference["source"]["path"] = "engine/unapproved.c"

--- a/tests/test_provenance_identity.py
+++ b/tests/test_provenance_identity.py
@@ -506,6 +506,9 @@ class ProvenanceIdentityTests(unittest.TestCase):
                 mutate(value)
                 with mock.patch(
                     "atrinik_workspace.provenance_identity._validate_repository_trust"
+                ), mock.patch(
+                    "atrinik_workspace.provenance_identity._git_blob",
+                    side_effect=AssertionError("unexpected blob read"),
                 ), self.assertRaises(WorkspaceError):
                     validate_component_reference(
                         value,

--- a/tests/test_provenance_identity.py
+++ b/tests/test_provenance_identity.py
@@ -477,6 +477,45 @@ class ProvenanceIdentityTests(unittest.TestCase):
                 current_reviewers=reviewer_keys,
             )
 
+    def test_component_reference_shape_fails_closed_before_blob_reads(self) -> None:
+        baseline = load_document(FIXTURES / "positive" / "synthetic-alpha.json")
+        records, reviewer_keys = current()
+        mutations = (
+            lambda value: value.update(schema_version=True),
+            lambda value: value.update(synthetic="yes"),
+            lambda value: value.update(source=None),
+            lambda value: value["destination"].update(extra=True),
+            lambda value: value["source"].update(repository="outside/project"),
+            lambda value: value["destination"].update(path="/absolute"),
+            lambda value: value["source"].update(revision="short"),
+            lambda value: value.update(transformation=""),
+            lambda value: value.update(scope_binding="readable"),
+            lambda value: value.update(evidence_reference=None),
+            lambda value: value["evidence_reference"].update(extra=True),
+            lambda value: value["evidence_reference"].update(repository="outside/project"),
+            lambda value: value["evidence_reference"].update(revision="short"),
+            lambda value: value["evidence_reference"].update(record_id="readable"),
+            lambda value: value["evidence_reference"].update(url="https://example.invalid"),
+            lambda value: value["evidence_reference"].update(registry_sha256="invalid"),
+            lambda value: value["evidence_reference"].update(reviewers_sha256=True),
+            lambda value: value["evidence_reference"].update(schema_sha256="A" * 64),
+        )
+        for index, mutate in enumerate(mutations):
+            with self.subTest(mutation=index):
+                value = json.loads(json.dumps(baseline))
+                mutate(value)
+                with mock.patch(
+                    "atrinik_workspace.provenance_identity._validate_repository_trust"
+                ), self.assertRaises(WorkspaceError):
+                    validate_component_reference(
+                        value,
+                        repository_root=ROOT,
+                        as_of=AS_OF,
+                        trusted_ref="HEAD",
+                        current_records=records,
+                        current_reviewers=reviewer_keys,
+                    )
+
     def test_two_synthetic_component_references_validate_offline(self) -> None:
         records, reviewer_keys = current()
         for name in ("synthetic-alpha.json", "synthetic-beta.json"):

--- a/tests/test_provenance_identity.py
+++ b/tests/test_provenance_identity.py
@@ -333,11 +333,11 @@ class ProvenanceIdentityTests(unittest.TestCase):
     def test_unmerged_anchor_requires_explicit_non_authorizing_ref(self) -> None:
         with self.assertRaisesRegex(WorkspaceError, "not reachable from trusted ref"):
             _validate_repository_trust(
-                ROOT, "98ff80ef66a71d8b7c48e7d0c71029abd5c90227", "main"
+                ROOT, "89fc98b95f23c0f0f068c5254ffb72c62f173119", "main"
             )
         _validate_repository_trust(
             ROOT,
-            "98ff80ef66a71d8b7c48e7d0c71029abd5c90227",
+            "89fc98b95f23c0f0f068c5254ffb72c62f173119",
             "HEAD",
         )
 

--- a/tests/test_provenance_identity.py
+++ b/tests/test_provenance_identity.py
@@ -16,7 +16,12 @@ from atrinik_workspace.provenance_identity import (
     _git_blob,
     _git_environment,
     _git_output,
+    _exact_keys,
+    _iso_date,
     _load_bytes,
+    _private_file_opener,
+    _repository_path,
+    _string_array,
     _validate_repository_trust,
     load_document,
     record_digest,
@@ -254,6 +259,40 @@ class ProvenanceIdentityTests(unittest.TestCase):
             path.write_text('{"schema_version": 1, "schema_version": 1}\n')
             with self.assertRaisesRegex(WorkspaceError, "duplicate JSON key"):
                 load_document(path)
+
+    def test_primitive_contract_helpers_reject_ambiguous_inputs(self) -> None:
+        with self.assertRaisesRegex(WorkspaceError, "missing wanted; unexpected extra"):
+            _exact_keys({"extra": True}, {"wanted"}, "fixture")
+        for value in (None, "", " untrimmed"):
+            with self.subTest(text=value), self.assertRaisesRegex(
+                WorkspaceError, "non-empty trimmed text"
+            ):
+                _iso_date(value, "fixture date")
+        for value in ("not-a-date", "2026-8-3"):
+            with self.subTest(date=value), self.assertRaisesRegex(
+                WorkspaceError, "ISO date|canonical YYYY-MM-DD"
+            ):
+                _iso_date(value, "fixture date")
+        for value in (None, [], ["beta", "alpha"], ["same", "same"]):
+            with self.subTest(array=value), self.assertRaises(WorkspaceError):
+                _string_array(value, "fixture array")
+        for value in ("/absolute", "parent/../escape", "windows\\path"):
+            with self.subTest(path=value), self.assertRaisesRegex(
+                WorkspaceError, "safe repository-relative path"
+            ):
+                _repository_path(value, "fixture path")
+        for value in (b"not-json", b"[]"):
+            with self.subTest(document=value), self.assertRaisesRegex(
+                WorkspaceError, "invalid JSON|root must be an object"
+            ):
+                _load_bytes(value, "fixture document")
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "private"
+            descriptor = _private_file_opener(
+                str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL
+            )
+            os.close(descriptor)
+            self.assertEqual(path.stat().st_mode & 0o777, 0o600)
 
     def test_duplicate_record_identifiers_fail_closed(self) -> None:
         value = registry()

--- a/tests/test_provenance_identity.py
+++ b/tests/test_provenance_identity.py
@@ -164,6 +164,7 @@ class ProvenanceIdentityTests(unittest.TestCase):
     def test_reference_rejects_noncanonical_url_without_git_access(self) -> None:
         value = {
             "schema_version": 1,
+            "synthetic": True,
             "source": {
                 "repository": "atrinik/synthetic-source",
                 "path": "src/example.c",
@@ -280,6 +281,20 @@ class ProvenanceIdentityTests(unittest.TestCase):
     def test_scope_replay_invalidates_reviewer_signature(self) -> None:
         reference = load_document(FIXTURES / "positive" / "synthetic-alpha.json")
         reference["source"]["path"] = "engine/unapproved.c"
+        records, reviewer_keys = current()
+        with self.assertRaisesRegex(WorkspaceError, "reviewer signature is invalid"):
+            validate_component_reference(
+                reference,
+                repository_root=ROOT,
+                as_of=AS_OF,
+                trusted_ref="HEAD",
+                current_records=records,
+                current_reviewers=reviewer_keys,
+            )
+
+    def test_component_reference_cannot_cross_the_synthetic_boundary(self) -> None:
+        reference = load_document(FIXTURES / "positive" / "synthetic-alpha.json")
+        reference["synthetic"] = False
         records, reviewer_keys = current()
         with self.assertRaisesRegex(WorkspaceError, "reviewer signature is invalid"):
             validate_component_reference(


### PR DESCRIPTION
## Summary

- define the coordinator-owned versioned public provenance identity schema, reviewer-key roster, and canonical synthetic-only registry
- verify reviewer signatures over attestations and exact component scope, including an authenticated synthetic/production boundary
- add bounded offline validation for canonical digests, trusted-ref current revocation, freshness, status transitions, immutable ancestry, shallow/graft/replace defenses, and component references
- govern restricted evidence custody, publication authorization, correlation review, retention, correction, withdrawal, compromise, and migration
- demonstrate component-owned references in atrinik/client#58 and atrinik/server#85 without copying the canonical registry or aliases

Closes #378.

## Delivery coordinates

- Base: `main` at `f0d1225791da7484e9456b39104cc30b0c77fe52`
- Head: `feat/privacy-preserving-provenance-registry` at `13cc2fce5`
- Client demonstration: atrinik/client#58 (closes atrinik/client#57)
- Server demonstration: atrinik/server#85 (closes atrinik/server#84)

## Privacy and trust boundaries

- Checked-in identities and demonstrations are synthetic and confer no rights over real material.
- Confidential mappings, contact data, raw evidence, salts, private keys, and private review notes are forbidden from the public registry and CI output.
- Production confidential reconciliation fails closed until the documented restricted store, teams, key custody, and audit controls are operational.
- Component records authenticate exact source, destination, transformation, evidence pin, and synthetic boundary; current canonical revocation or mutation is loaded from the trusted ref and overrides a historical active pin.
- Production references require a canonical non-shallow coordinator checkout and a pinned revision already reachable from `origin/main`. The explicit feature-ref mode is labeled non-authorizing and exists only for audit.

## Validation

- complete wrapper suite — 580 passed
- focused provenance suite — 33 passed
- aggregate coverage — 81%; Codecov patch gate passed
- client and server strict local positive/negative reference suites — passed
- client and server foundation checks — passed
- coordinator audit against both published component records — 2 records and 2 references valid, visibly non-authorizing
- `shellcheck` for changed native shell validators — passed
- `git diff --check` in all three repositories — passed
- `python3 -m compileall -q atrinik atrinik_workspace tests` — passed
- guidance inventory — passed
- manifest and supply-chain validation — 20 components and 105 dependencies valid
- latest-head CodeQL, integration, Python/actions analysis, title, and Codecov patch checks — passed

## Verification

Audit the exact synthetic demonstrations from the issue worktree:

```sh
./atrinik provenance validate \
  --reference /path/to/client/provenance/identity-reference.synthetic.json \
  --reference /path/to/server/provenance/identity-reference.synthetic.json \
  --non-authorizing-audit-ref origin/feat/privacy-preserving-provenance-registry
```

Because Atrinik uses squash merges, these exact synthetic records intentionally remain non-authorizing: their intermediate pinned commit will not become an `origin/main` ancestor. Any production record must be reviewed and signed only after its coordinator revision is already reachable from the trusted main ref. Post-merge production-path verification is tracked in #386.

Runtime verification is not applicable: this changes a local policy/schema validator and creates no profile, topology, service, state, scenario, or mutable server data.

## Review status

Multiple independent review/fix cycles identified trust-boundary, authorization, freshness, transition, schema-parity, native-shape, correlation, bounded-Git, and test-quality issues. All are fixed and validated. Final coordinator, client, and server whole-diff reviews report zero actionable findings, and all latest-head checks pass.
