### PR TITLE
feat(runtime): stage released sound artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,7 +829,9 @@ The verified archive and tree live below the coordinate-keyed profile build;
 unchanged inputs reuse them offline. Build and topology records retain all
 coordinates and verification results. A changed coordinate produces a distinct
 build key, while incomplete or mismatched caches fail closed and remain covered
-by normal preview-first build cleanup.
+by normal preview-first build cleanup. Supply-chain audit output identifies the
+selected archive, source commit/tree, and logical tree; license, CycloneDX, and
+SPDX reports for that profile also carry the complete immutable coordinate set.
 
 ## Deterministic test scenarios
 

--- a/README.md
+++ b/README.md
@@ -909,24 +909,24 @@ through the explicit preview-first `sound-cache` cleanup scope described above.
 A saved Classic-derived profile may instead consume the publishable Classic
 compatibility runtime from an immutable `atrinik/sound` release. Released mode
 does not invoke a source builder and never falls back to `source` or
-`local-playtest`. Supply every coordinate posted by the sound release (values
-below are placeholders until `atrinik/sound#30` publishes):
+`local-playtest`. Supply every coordinate posted by the sound release. For
+example, the published v1.4.1 Classic runtime is selected with:
 
 ~~~sh
 ./atrinik profile create classic-released-audio --from classic
 ./atrinik profile sound-mode classic-released-audio released \
   --release-repository atrinik/sound \
-  --release-tag vX.Y.Z \
-  --release-product-version X.Y.Z \
-  --release-source-commit COMMIT \
-  --release-source-tree TREE \
-  --release-asset-url https://github.com/atrinik/sound/releases/download/vX.Y.Z/atrinik-sound-classic-runtime-X.Y.Z.tar.gz \
-  --release-archive-sha256 ARCHIVE_SHA256 \
-  --release-manifest-sha256 MANIFEST_SHA256 \
-  --release-source-manifest-sha256 SOURCE_MANIFEST_SHA256 \
-  --release-schema-sha256 SCHEMA_SHA256 \
-  --release-toolchain-sha256 TOOLCHAIN_SHA256 \
-  --release-tree-sha256 LOGICAL_TREE_SHA256
+  --release-tag v1.4.1 \
+  --release-product-version 1.4.1 \
+  --release-source-commit 49a169bf41568e4e3b3ac70dfaf42b1a3eabe985 \
+  --release-source-tree 92b81774820dfd55944f4d7b005c1dc344b43561 \
+  --release-asset-url https://github.com/atrinik/sound/releases/download/v1.4.1/atrinik-sound-classic-runtime-1.4.1.tar.gz \
+  --release-archive-sha256 8373868ab4632eda58ae7959909f414a10a43ce519dd1ef9e7f911d4fa208a52 \
+  --release-manifest-sha256 7961ea27069c2cd54131466394571942d486e31e1007c9d957b97cb8b0d63b56 \
+  --release-source-manifest-sha256 3aacd122abe16da771ac1eb6ad80c50c1c6e7ab43d555dc8772f21be24248366 \
+  --release-schema-sha256 428e1312d9922ab4ec20c0ee89d93d842528db6d8cc75197c135f4d4f59066aa \
+  --release-toolchain-sha256 ee842444c37df3c6784665c2dacef4ab9220f3abfc5c2daf9214fe4b40aadbf7 \
+  --release-tree-sha256 2c3d42ea91ca088ac37e5215e3452dad31e5f1fb17018941ed5ad0a3c53060da
 ./atrinik profile show classic-released-audio --json
 ./atrinik build classic-client --profile classic-released-audio --test
 ./atrinik topology show classic-released-audio --service client --json
@@ -934,9 +934,10 @@ below are placeholders until `atrinik/sound#30` publishes):
 
 The wrapper downloads only that exact versioned GitHub release URL, verifies
 the outer checksum, safely extracts one bounded product prefix, and then checks
-canonical internal checksums, the publishable/non-playtest marker, packaged
-schema, notices, exact 339-path closure, every payload hash and codec signature,
-the 189 byte-preserved Vorbis / 150 Opus split, and the logical-tree digest.
+canonical internal checksums, the publishable/non-playtest manifest and
+packaged schema, the nonblocking remediation report, packaged notices and
+licenses, exact 339-path closure, every payload hash and codec signature, the
+189 byte-preserved Vorbis / 150 Opus split, and the logical-tree digest.
 The verified archive and tree live below the coordinate-keyed profile build;
 unchanged inputs reuse them offline. Build and topology records retain all
 coordinates and verification results. A changed coordinate produces a distinct

--- a/README.md
+++ b/README.md
@@ -701,10 +701,11 @@ component, or one of its roles updates all five classic selectors together.
 The `classic-server` alias above has the same checkout-wide effect as naming
 `classic`: every classic logical component comes from `socket-review`.
 Resolution then returns the appropriate `server/`, `client/`, `editor/`,
-`libatrinik/`, or `protocol/` source root for each component. Profile schema 4
+`libatrinik/`, or `protocol/` source root for each component. Profile schema 5
 rejects different selectors for logical components that share one physical
-checkout and records the selected sound mode. Existing schema-3 profiles load
-as `source` mode and are upgraded when next changed.
+checkout and records the selected sound mode plus immutable released-product
+coordinates when applicable. Existing schema-3 and schema-4 profiles load as
+`source` or their previously selected mode and are upgraded when next changed.
 
 Clone an existing profile when starting a related combination instead of
 repeating every selector:
@@ -792,6 +793,43 @@ gets a distinct cache key; failed or racing generation leaves existing output
 untouched. Wrapper-owned profile builds remain covered by ordinary retention.
 Sound-owned ignored outputs are preserved by default and are reclaimed only
 through the explicit preview-first `sound-cache` cleanup scope described above.
+
+A saved Classic-derived profile may instead consume the publishable Classic
+compatibility runtime from an immutable `atrinik/sound` release. Released mode
+does not invoke a source builder and never falls back to `source` or
+`local-playtest`. Supply every coordinate posted by the sound release (values
+below are placeholders until `atrinik/sound#30` publishes):
+
+~~~sh
+./atrinik profile create classic-released-audio --from classic
+./atrinik profile sound-mode classic-released-audio released \
+  --release-repository atrinik/sound \
+  --release-tag vX.Y.Z \
+  --release-product-version X.Y.Z \
+  --release-source-commit COMMIT \
+  --release-source-tree TREE \
+  --release-asset-url https://github.com/atrinik/sound/releases/download/vX.Y.Z/atrinik-sound-classic-runtime-X.Y.Z.tar.gz \
+  --release-archive-sha256 ARCHIVE_SHA256 \
+  --release-manifest-sha256 MANIFEST_SHA256 \
+  --release-source-manifest-sha256 SOURCE_MANIFEST_SHA256 \
+  --release-schema-sha256 SCHEMA_SHA256 \
+  --release-toolchain-sha256 TOOLCHAIN_SHA256 \
+  --release-tree-sha256 LOGICAL_TREE_SHA256
+./atrinik profile show classic-released-audio --json
+./atrinik build classic-client --profile classic-released-audio --test
+./atrinik topology show classic-released-audio --service client --json
+~~~
+
+The wrapper downloads only that exact versioned GitHub release URL, verifies
+the outer checksum, safely extracts one bounded product prefix, and then checks
+canonical internal checksums, the publishable/non-playtest marker, packaged
+schema, notices, exact 339-path closure, every payload hash and codec signature,
+the 189 byte-preserved Vorbis / 150 Opus split, and the logical-tree digest.
+The verified archive and tree live below the coordinate-keyed profile build;
+unchanged inputs reuse them offline. Build and topology records retain all
+coordinates and verification results. A changed coordinate produces a distinct
+build key, while incomplete or mismatched caches fail closed and remain covered
+by normal preview-first build cleanup.
 
 ## Deterministic test scenarios
 

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -203,12 +203,27 @@ def parser() -> argparse.ArgumentParser:
     mark(profile_show.add_argument("name", nargs="?", default="default"), "profile")
     profile_show.add_argument("--json", action="store_true")
     profile_sound = profile_commands.add_parser(
-        "sound-mode", help="select raw source or local Classic playtest sound"
+        "sound-mode", help="select source, local-playtest, or released Classic sound"
     )
     mark(profile_sound.add_argument("name"), "saved_profile")
     profile_sound.add_argument(
-        "mode", choices=["source", "local-playtest"]
+        "mode", choices=["source", "local-playtest", "released"]
     )
+    for flag, destination in (
+        ("--release-repository", "release_repository"),
+        ("--release-tag", "release_tag"),
+        ("--release-product-version", "release_product_version"),
+        ("--release-source-commit", "release_source_commit"),
+        ("--release-source-tree", "release_source_tree"),
+        ("--release-asset-url", "release_asset_url"),
+        ("--release-archive-sha256", "release_archive_sha256"),
+        ("--release-manifest-sha256", "release_manifest_sha256"),
+        ("--release-source-manifest-sha256", "release_source_manifest_sha256"),
+        ("--release-schema-sha256", "release_schema_sha256"),
+        ("--release-toolchain-sha256", "release_toolchain_sha256"),
+        ("--release-tree-sha256", "release_tree_sha256"),
+    ):
+        mark(profile_sound.add_argument(flag, dest=destination), "none")
 
     path = commands.add_parser(
         "path", help="print a resolved logical-component source path"
@@ -415,6 +430,19 @@ def main(arguments: list[str] | None = None) -> int:
                     )
                 ):
                     print(message)
+                summary = workspace.profile_summary(options.profile)
+                release = summary.get("sound_release")
+                if summary.get("sound_mode") == "released" and isinstance(
+                    release, dict
+                ):
+                    print(
+                        "sound-release: "
+                        f"{release['repository']}@{release['tag']} "
+                        f"commit={release['source_commit']} "
+                        f"tree={release['source_tree']} "
+                        f"archive=sha256:{release['archive_sha256']} "
+                        f"logical-tree=sha256:{release['output_tree_sha256']}"
+                    )
             elif options.supply_chain_command == "report":
                 stack, commits = report_component_commits(
                     ROOT, workspace, options.profile
@@ -628,7 +656,38 @@ def main(arguments: list[str] | None = None) -> int:
                         options.name, options.component, "path", str(options.path)
                     )
             elif options.profile_command == "sound-mode":
-                workspace.set_profile_sound_mode(options.name, options.mode)
+                release_values = {
+                    "repository": options.release_repository,
+                    "tag": options.release_tag,
+                    "product_version": options.release_product_version,
+                    "source_commit": options.release_source_commit,
+                    "source_tree": options.release_source_tree,
+                    "asset_url": options.release_asset_url,
+                    "archive_sha256": options.release_archive_sha256,
+                    "release_manifest_sha256": options.release_manifest_sha256,
+                    "source_manifest_sha256": options.release_source_manifest_sha256,
+                    "schema_sha256": options.release_schema_sha256,
+                    "toolchain_sha256": options.release_toolchain_sha256,
+                    "output_tree_sha256": options.release_tree_sha256,
+                    "product": "atrinik-sound-classic-runtime",
+                    "manifest_schema_version": 1,
+                }
+                coordinates = (
+                    release_values
+                    if options.mode == "released"
+                    or any(
+                        release_values[key] is not None
+                        for key in release_values
+                        if key not in {"product", "manifest_schema_version"}
+                    )
+                    else None
+                )
+                if coordinates is None:
+                    workspace.set_profile_sound_mode(options.name, options.mode)
+                else:
+                    workspace.set_profile_sound_mode(
+                        options.name, options.mode, coordinates
+                    )
             else:
                 summary = workspace.profile_summary(options.name)
                 if options.json:
@@ -637,6 +696,13 @@ def main(arguments: list[str] | None = None) -> int:
                     print(f"profile\t{summary['name']}")
                     print(f"stack\t{summary['stack']}")
                     print(f"sound-mode\t{summary['sound_mode']}")
+                    if summary["sound_release"] is not None:
+                        print(
+                            "sound-release\t"
+                            f"{summary['sound_release']['repository']}@"
+                            f"{summary['sound_release']['tag']}\t"
+                            f"{summary['sound_release']['archive_sha256']}"
+                        )
                     for row in summary["components"]:
                         if not row["initialized"]:
                             print(

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -447,10 +447,19 @@ def main(arguments: list[str] | None = None) -> int:
                 stack, commits = report_component_commits(
                     ROOT, workspace, options.profile
                 )
+                summary = workspace.profile_summary(options.profile)
+                release = (
+                    summary.get("sound_release")
+                    if summary.get("sound_mode") == "released"
+                    else None
+                )
+                report_arguments = [options.format, commits, stack]
+                if isinstance(release, dict):
+                    report_arguments.append(release)
                 write_generated(
                     ROOT,
                     options.output,
-                    inventory.report(options.format, commits, stack),
+                    inventory.report(*report_arguments),
                 )
             else:
                 write_generated(ROOT, options.output, version_report(inventory))

--- a/atrinik_workspace/completion.py
+++ b/atrinik_workspace/completion.py
@@ -20,6 +20,24 @@ _MAX_RECORD_ENTRIES = 64
 _MAX_RECORD_BYTES = 64 * 1024
 _MAX_MARKER_BYTES = 1024
 _PROFILE_KEYS = {"schema_version", "name", "stack", "components"}
+_PROFILE_SOUND_KEYS = {*_PROFILE_KEYS, "sound_mode"}
+_PROFILE_RELEASE_KEYS = {*_PROFILE_SOUND_KEYS, "sound_release"}
+_SOUND_RELEASE_KEYS = {
+    "archive_sha256",
+    "asset_url",
+    "manifest_schema_version",
+    "output_tree_sha256",
+    "product",
+    "product_version",
+    "release_manifest_sha256",
+    "repository",
+    "schema_sha256",
+    "source_commit",
+    "source_manifest_sha256",
+    "source_tree",
+    "tag",
+    "toolchain_sha256",
+}
 _SCENARIO_KEYS = {
     "schema_version",
     "name",
@@ -420,17 +438,43 @@ def _profile_value(
     if not _valid_name(name):
         return None
     value = _json_at(profiles, f"{name}.json", _MAX_RECORD_BYTES)
-    if not isinstance(value, dict) or set(value) != _PROFILE_KEYS:
+    if not isinstance(value, dict):
+        return None
+    schema_version = value.get("schema_version")
+    expected_keys = {
+        3: _PROFILE_KEYS,
+        4: _PROFILE_SOUND_KEYS,
+        5: _PROFILE_RELEASE_KEYS,
+    }.get(schema_version)
+    if expected_keys is None or set(value) != expected_keys:
         return None
     stack_name = value.get("stack")
     if (
-        value.get("schema_version") != 3
-        or value.get("name") != name
+        value.get("name") != name
         or not isinstance(stack_name, str)
         or stack_name not in manifest.stacks
         or not isinstance(value.get("components"), dict)
     ):
         return None
+    if schema_version >= 4:
+        sound_mode = value.get("sound_mode")
+        allowed_modes = (
+            {"source", "local-playtest"}
+            if schema_version == 4
+            else {"source", "local-playtest", "released"}
+        )
+        if sound_mode not in allowed_modes:
+            return None
+        if schema_version == 5:
+            sound_release = value.get("sound_release")
+            if sound_mode == "released":
+                if (
+                    not isinstance(sound_release, dict)
+                    or set(sound_release) != _SOUND_RELEASE_KEYS
+                ):
+                    return None
+            elif sound_release is not None:
+                return None
     expected = {component.name for component in manifest.stacks[stack_name].components}
     if set(value["components"]) != expected:
         return None

--- a/atrinik_workspace/completion.py
+++ b/atrinik_workspace/completion.py
@@ -10,6 +10,7 @@ from typing import Any, Iterable
 
 from .model import MANAGED_MARKER, Manifest, Paths, WorkspaceError, validate_name
 from .process_tree import control_socket_path
+from .sound import validate_release_coordinates
 
 
 _PROTOCOL_COMMAND = "__complete"
@@ -466,6 +467,8 @@ def _profile_value(
         )
         if sound_mode not in allowed_modes:
             return None
+        if sound_mode != "source" and stack_name != "classic":
+            return None
         if schema_version == 5:
             sound_release = value.get("sound_release")
             if sound_mode == "released":
@@ -473,6 +476,10 @@ def _profile_value(
                     not isinstance(sound_release, dict)
                     or set(sound_release) != _SOUND_RELEASE_KEYS
                 ):
+                    return None
+                try:
+                    validate_release_coordinates(sound_release)
+                except WorkspaceError:
                     return None
             elif sound_release is not None:
                 return None

--- a/atrinik_workspace/content_migration.py
+++ b/atrinik_workspace/content_migration.py
@@ -17,6 +17,7 @@ from typing import Any, TextIO
 from .locking import inherit_lock_fds
 from .model import WorkspaceError, atomic_json, load_json
 from .process_tree import holders_exist
+from .sound import validate_release_coordinates
 from .supervisor import process_matches
 
 
@@ -29,8 +30,12 @@ CERTIFIED_1X_COMMIT = "566bd25f78b80b08d5f75f4b02017ab2429204db"
 PROFILE_MAX_BYTES = 1024 * 1024
 RESOURCE_RECORD_MAX_BYTES = 4 * 1024 * 1024
 MIGRATION_RECORD_MAX_BYTES = 64 * 1024 * 1024
-PROFILE_KEYS = {"schema_version", "name", "stack", "components", "sound_mode"}
-LEGACY_PROFILE_KEYS = {"schema_version", "name", "stack", "components"}
+PROFILE_KEYS = {
+    "schema_version", "name", "stack", "components", "sound_mode",
+    "sound_release",
+}
+LEGACY_PROFILE_KEYS = {"schema_version", "name", "stack", "components", "sound_mode"}
+OLDEST_PROFILE_KEYS = {"schema_version", "name", "stack", "components"}
 NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
 OPERATION_PATHS = (
     "BISECT_LOG",
@@ -431,16 +436,25 @@ class ContentMigration:
                 if not isinstance(value, dict) or value.get("name") != path.stem:
                     raise WorkspaceError("profile identity is invalid")
                 schema_version = value.get("schema_version")
-                expected_keys = (
-                    LEGACY_PROFILE_KEYS if schema_version == 3 else PROFILE_KEYS
-                )
-                if schema_version not in {3, 4} or set(value) != expected_keys:
+                expected_keys = {
+                    3: OLDEST_PROFILE_KEYS,
+                    4: LEGACY_PROFILE_KEYS,
+                    5: PROFILE_KEYS,
+                }.get(schema_version)
+                if expected_keys is None or set(value) != expected_keys:
                     raise WorkspaceError("profile schema is unsupported")
-                if schema_version == 4 and value.get("sound_mode") not in {
+                if schema_version in {4, 5} and value.get("sound_mode") not in {
                     "source",
                     "local-playtest",
+                    "released",
                 }:
                     raise WorkspaceError("profile sound mode is invalid")
+                if schema_version == 5:
+                    release = value.get("sound_release")
+                    if (value.get("sound_mode") == "released") != isinstance(release, dict):
+                        raise WorkspaceError("profile sound release coordinates are invalid")
+                    if isinstance(release, dict):
+                        validate_release_coordinates(release)
                 components = value.get("components")
                 if value.get("stack") != "classic":
                     rows.append(

--- a/atrinik_workspace/content_migration.py
+++ b/atrinik_workspace/content_migration.py
@@ -443,11 +443,11 @@ class ContentMigration:
                 }.get(schema_version)
                 if expected_keys is None or set(value) != expected_keys:
                     raise WorkspaceError("profile schema is unsupported")
-                if schema_version in {4, 5} and value.get("sound_mode") not in {
-                    "source",
-                    "local-playtest",
-                    "released",
-                }:
+                allowed_sound_modes = {
+                    4: {"source", "local-playtest"},
+                    5: {"source", "local-playtest", "released"},
+                }.get(schema_version)
+                if allowed_sound_modes is not None and value.get("sound_mode") not in allowed_sound_modes:
                     raise WorkspaceError("profile sound mode is invalid")
                 if schema_version == 5:
                     release = value.get("sound_release")

--- a/atrinik_workspace/content_migration.py
+++ b/atrinik_workspace/content_migration.py
@@ -524,6 +524,14 @@ class ContentMigration:
                 }.get(schema_version)
                 if allowed_sound_modes is not None and value.get("sound_mode") not in allowed_sound_modes:
                     raise WorkspaceError("profile sound mode is invalid")
+                if (
+                    allowed_sound_modes is not None
+                    and value.get("sound_mode") != "source"
+                    and value.get("stack") != "classic"
+                ):
+                    raise WorkspaceError(
+                        "non-source sound modes require the classic stack"
+                    )
                 if schema_version == 5:
                     release = value.get("sound_release")
                     if (value.get("sound_mode") == "released") != isinstance(release, dict):

--- a/atrinik_workspace/migration.py
+++ b/atrinik_workspace/migration.py
@@ -1178,6 +1178,20 @@ class RepositoryMigration:
         if schema == LEGACY_PROFILE_SCHEMA_VERSION:
             if profile.get("stack") == "classic":
                 self._validate_schema_four_profile_shape(path, profile)
+            else:
+                if (
+                    set(profile) != {
+                        "schema_version", "name", "stack", "sound_mode", "components"
+                    }
+                    or profile.get("name") != path.stem
+                    or not isinstance(profile.get("stack"), str)
+                    or profile.get("sound_mode") != "source"
+                    or not isinstance(profile.get("components"), dict)
+                ):
+                    raise WorkspaceError("schema-v4 replacement profile is invalid")
+                for component_name, selector in profile["components"].items():
+                    self._validate_selector(component_name, selector)
+                return None, None
             return {
                 **profile,
                 "schema_version": PROFILE_SCHEMA_VERSION,

--- a/atrinik_workspace/migration.py
+++ b/atrinik_workspace/migration.py
@@ -19,12 +19,14 @@ from typing import Any, Iterable
 
 from .locking import active_lock_fds, inherit_lock_fds
 from .model import WorkspaceError, atomic_json, load_json
+from .sound import validate_release_coordinates
 from .supervisor import process_matches
 
 
 PLAN_SCHEMA_VERSION = 2
-PROFILE_SCHEMA_VERSION = 4
-LEGACY_PROFILE_SCHEMA_VERSION = 3
+PROFILE_SCHEMA_VERSION = 5
+LEGACY_PROFILE_SCHEMA_VERSION = 4
+OLDEST_PROFILE_SCHEMA_VERSION = 3
 MIGRATION_NAME = "repositories"
 MIGRATION_RECORD = "migrations/repositories.json"
 MIGRATION_PENDING = "migrations/repositories.pending.json"
@@ -1164,16 +1166,24 @@ class RepositoryMigration:
         schema = profile.get("schema_version")
         if schema == PROFILE_SCHEMA_VERSION:
             if (
-                profile.get("sound_mode") == "local-playtest"
+                profile.get("sound_mode") != "source"
                 and profile.get("stack") != "classic"
             ):
                 raise WorkspaceError(
-                    "local-playtest sound mode requires a Classic-derived profile"
+                    "non-source sound mode requires a Classic-derived profile"
                 )
             if profile.get("stack") == "classic":
                 self._validate_profile_shape(path, profile)
             return None, None
         if schema == LEGACY_PROFILE_SCHEMA_VERSION:
+            if profile.get("stack") == "classic":
+                self._validate_schema_four_profile_shape(path, profile)
+            return {
+                **profile,
+                "schema_version": PROFILE_SCHEMA_VERSION,
+                "sound_release": None,
+            }, None
+        if schema == OLDEST_PROFILE_SCHEMA_VERSION:
             self._validate_legacy_profile_shape(path, profile)
             if profile["stack"] != "classic":
                 return None, None
@@ -1181,6 +1191,7 @@ class RepositoryMigration:
                 **profile,
                 "schema_version": PROFILE_SCHEMA_VERSION,
                 "sound_mode": "source",
+                "sound_release": None,
             }, None
         if schema != 1:
             raise WorkspaceError("unsupported profile schema")
@@ -1289,6 +1300,7 @@ class RepositoryMigration:
             "name": name,
             "stack": "classic",
             "sound_mode": "source",
+            "sound_release": None,
             "components": output,
         }
         self._validate_profile_shape(path, rewritten)
@@ -1364,21 +1376,28 @@ class RepositoryMigration:
             "name",
             "stack",
             "sound_mode",
+            "sound_release",
             "components",
         }:
-            raise WorkspaceError("schema-v4 profile has unexpected fields")
+            raise WorkspaceError("schema-v5 profile has unexpected fields")
         if profile["schema_version"] != PROFILE_SCHEMA_VERSION:
-            raise WorkspaceError("profile is not schema v4")
-        if profile["sound_mode"] not in {"source", "local-playtest"}:
-            raise WorkspaceError("schema-v4 profile sound mode is invalid")
+            raise WorkspaceError("profile is not schema v5")
+        if profile["sound_mode"] not in {"source", "local-playtest", "released"}:
+            raise WorkspaceError("schema-v5 profile sound mode is invalid")
+        if (profile["sound_mode"] == "released") != isinstance(
+            profile["sound_release"], dict
+        ):
+            raise WorkspaceError("schema-v5 profile sound release coordinates are invalid")
+        if isinstance(profile["sound_release"], dict):
+            validate_release_coordinates(profile["sound_release"])
         if profile["name"] != path.stem or profile["stack"] != "classic":
-            raise WorkspaceError("schema-v4 classic profile identity is invalid")
+            raise WorkspaceError("schema-v5 classic profile identity is invalid")
         components = profile["components"]
         if not isinstance(components, dict):
-            raise WorkspaceError("schema-v4 components must be an object")
+            raise WorkspaceError("schema-v5 components must be an object")
         expected = self._classic_profile_component_names()
         if set(components) != expected:
-            raise WorkspaceError("schema-v4 classic profile component closure is invalid")
+            raise WorkspaceError("schema-v5 classic profile component closure is invalid")
         for component_name, selector in components.items():
             self._validate_selector(component_name, selector)
         classic_selectors = {
@@ -1388,8 +1407,22 @@ class RepositoryMigration:
         }
         if len(classic_selectors) != 1:
             raise WorkspaceError(
-                "schema-v4 classic components must select one physical checkout root"
+                "schema-v5 classic components must select one physical checkout root"
             )
+
+    def _validate_schema_four_profile_shape(
+        self, path: Path, profile: dict[str, Any]
+    ) -> None:
+        if set(profile) != {
+            "schema_version", "name", "stack", "sound_mode", "components"
+        }:
+            raise WorkspaceError("schema-v4 profile has unexpected fields")
+        upgraded = {
+            **profile,
+            "schema_version": PROFILE_SCHEMA_VERSION,
+            "sound_release": None,
+        }
+        self._validate_profile_shape(path, upgraded)
 
     def _validate_legacy_profile_shape(
         self, path: Path, profile: dict[str, Any]
@@ -1397,7 +1430,7 @@ class RepositoryMigration:
         if set(profile) != {"schema_version", "name", "stack", "components"}:
             raise WorkspaceError("schema-v3 profile has unexpected fields")
         if (
-            profile["schema_version"] != LEGACY_PROFILE_SCHEMA_VERSION
+            profile["schema_version"] != OLDEST_PROFILE_SCHEMA_VERSION
             or profile["name"] != path.stem
             or not isinstance(profile["stack"], str)
             or not profile["stack"]
@@ -1414,6 +1447,7 @@ class RepositoryMigration:
             **profile,
             "schema_version": PROFILE_SCHEMA_VERSION,
             "sound_mode": "source",
+            "sound_release": None,
         }
         self._validate_profile_shape(path, upgraded)
 

--- a/atrinik_workspace/sound.py
+++ b/atrinik_workspace/sound.py
@@ -34,9 +34,35 @@ EXPECTED_SOURCE_MIDI = 122
 EXPECTED_SOURCE_FLAC = 28
 RELEASE_PRODUCT = "atrinik-sound-classic-runtime"
 RELEASE_MANIFEST = "classic-runtime-manifest.json"
-RELEASE_MARKER = ".atrinik-classic-runtime.json"
+RELEASE_REMEDIATION = "classic-runtime-remediation.json"
 RELEASE_SCHEMA = "schemas/classic-runtime-manifest-v1.schema.json"
 RELEASE_CHECKSUMS = "SHA256SUMS"
+RELEASE_METADATA_FILES = {
+    "README.md",
+    "background/LICENSE",
+    "background/README.md",
+    "effects/LICENSE",
+    "effects/README.md",
+    RELEASE_REMEDIATION,
+    "licenses/CC-BY-3.0.txt",
+    "licenses/CC-BY-SA-3.0-DE.txt",
+    "licenses/CC-BY-SA-3.0.txt",
+    "licenses/CC0-1.0.txt",
+    "licenses/GPL-2.0.txt",
+    "licenses/GPL-3.0.txt",
+    "manifests/classic-audio-toolchain.json",
+    "manifests/license-reviews.json",
+    "manifests/source-assets.json",
+    "manifests/source-replacements.json",
+    "manifests/vorbis-quality-reviews.json",
+    "schemas/classic-audio-toolchain-v1.schema.json",
+    "schemas/classic-remediation-v1.schema.json",
+    RELEASE_SCHEMA,
+    "schemas/license-reviews-v2.schema.json",
+    "schemas/source-assets-v1.schema.json",
+    "schemas/source-replacements-v1.schema.json",
+    "schemas/vorbis-quality-reviews-v2.schema.json",
+}
 RELEASE_COORDINATE_KEYS = {
     "archive_sha256",
     "asset_url",
@@ -60,7 +86,7 @@ MAX_RELEASE_MEMBERS = 4096
 MAX_RELEASE_TAR_BYTES = MAX_RELEASE_EXTRACTED_BYTES + MAX_RELEASE_MEMBERS * 1024
 MAX_RELEASE_MANIFEST_BYTES = 8 * 1024 * 1024
 MAX_RELEASE_CHECKSUM_BYTES = 256 * 1024
-MAX_RELEASE_MARKER_BYTES = 4096
+MAX_RELEASE_REMEDIATION_BYTES = 16 * 1024 * 1024
 MAX_RELEASE_SCHEMA_BYTES = 1024 * 1024
 MAX_RELEASE_METADATA_BYTES = 64 * 1024
 SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
@@ -454,10 +480,8 @@ def _extract_release_archive(
             for _member, relative in files
             for index in range(1, len(relative.parts))
         }
-        if directories != required_directories:
-            raise WorkspaceError(
-                "released sound archive has missing or unexpected directories"
-            )
+        if not directories.issubset(required_directories):
+            raise WorkspaceError("released sound archive has unexpected directories")
         destination.mkdir(mode=0o700)
         try:
             for member, relative in files:
@@ -916,8 +940,9 @@ def _validate_release_schema_structure(
     supported = {
         "$defs", "$id", "$ref", "$schema", "additionalProperties", "allOf",
         "anyOf", "const", "default", "description", "enum", "examples", "format",
-        "items", "maxItems", "maxLength", "maxProperties", "maximum", "minItems",
-        "minLength", "minProperties", "minimum", "oneOf", "pattern", "properties",
+        "exclusiveMaximum", "exclusiveMinimum", "items", "maxItems", "maxLength",
+        "maxProperties", "maximum", "minItems", "minLength", "minProperties",
+        "minimum", "oneOf", "pattern", "properties",
         "required", "title", "type", "uniqueItems",
     }
     if set(schema) - supported:
@@ -950,7 +975,7 @@ def _validate_release_schema_structure(
             not isinstance(value, int) or isinstance(value, bool) or value < 0
         ):
             raise WorkspaceError(f"released sound packaged schema {keyword} is invalid")
-    for keyword in ("maximum", "minimum"):
+    for keyword in ("exclusiveMaximum", "exclusiveMinimum", "maximum", "minimum"):
         value = schema.get(keyword)
         if keyword in schema and (
             not isinstance(value, (int, float))
@@ -1049,8 +1074,9 @@ def _validate_release_schema_instance(
     supported = {
         "$defs", "$id", "$ref", "$schema", "additionalProperties", "allOf",
         "anyOf", "const", "default", "description", "enum", "examples", "format",
-        "items", "maxItems", "maxLength", "maxProperties", "maximum", "minItems",
-        "minLength", "minProperties", "minimum", "oneOf", "pattern", "properties",
+        "exclusiveMaximum", "exclusiveMinimum", "items", "maxItems", "maxLength",
+        "maxProperties", "maximum", "minItems", "minLength", "minProperties",
+        "minimum", "oneOf", "pattern", "properties",
         "required", "title", "type", "uniqueItems",
     }
     if set(schema) - supported:
@@ -1064,7 +1090,7 @@ def _validate_release_schema_instance(
             not isinstance(limit, int) or isinstance(limit, bool) or limit < 0
         ):
             raise WorkspaceError(f"released sound packaged schema {keyword} is invalid")
-    for keyword in ("maximum", "minimum"):
+    for keyword in ("exclusiveMaximum", "exclusiveMinimum", "maximum", "minimum"):
         limit = schema.get(keyword)
         if limit is not None and (
             not isinstance(limit, (int, float))
@@ -1242,7 +1268,12 @@ def _validate_release_schema_instance(
             if not matches:
                 raise _ReleaseSchemaMismatch(f"released sound manifest violates pattern at {location}")
     if isinstance(instance, (int, float)) and not isinstance(instance, bool):
-        for keyword, comparison in (("minimum", lambda a, b: a >= b), ("maximum", lambda a, b: a <= b)):
+        for keyword, comparison in (
+            ("exclusiveMinimum", lambda a, b: a > b),
+            ("exclusiveMaximum", lambda a, b: a < b),
+            ("minimum", lambda a, b: a >= b),
+            ("maximum", lambda a, b: a <= b),
+        ):
             limit = schema.get(keyword)
             if limit is not None and (not isinstance(limit, (int, float)) or isinstance(limit, bool) or not math.isfinite(limit)):
                 raise WorkspaceError(f"released sound packaged schema {keyword} is invalid")
@@ -1311,30 +1342,25 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
         "converted_opus_count",
         "copied_vorbis_count",
         "logical_path_count",
-        "marker_sha256",
-        "notices",
         "output_tree_sha256",
         "playtest_only",
-        "product",
-        "product_version",
         "publishable",
         "release_tag",
-        "repository",
+        "remediation_finding_count",
+        "remediation_report_sha256",
         "schema_sha256",
         "schema_version",
         "source_commit",
         "source_manifest_sha256",
         "source_tree",
+        "tool_versions",
         "toolchain_sha256",
     }
     if not isinstance(manifest_value, dict) or set(manifest_value) != manifest_keys:
         raise WorkspaceError("released sound manifest fields are invalid")
     manifest = manifest_value
     identity_fields = {
-        "product": "product",
-        "product_version": "product_version",
         "release_tag": "tag",
-        "repository": "repository",
         "schema_version": "manifest_schema_version",
         "source_commit": "source_commit",
         "source_manifest_sha256": "source_manifest_sha256",
@@ -1353,25 +1379,13 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
         )
     ):
         raise WorkspaceError("released sound manifest identity does not match the profile")
-    marker_payload = _read_regular(
-        root / RELEASE_MARKER,
-        "released sound marker",
-        maximum_bytes=MAX_RELEASE_MARKER_BYTES,
-    )
-    expected_marker = _canonical_json(
-        {
-            "format": RELEASE_PRODUCT,
-            "playtest_only": False,
-            "product_version": expected["product_version"],
-            "publishable": True,
-            "schema_version": 1,
-        }
-    )
+    tool_versions = manifest.get("tool_versions")
     if (
-        marker_payload != expected_marker
-        or manifest.get("marker_sha256") != _hash_bytes(marker_payload)
+        not isinstance(tool_versions, dict)
+        or set(tool_versions) != TOOL_NAMES
+        or not all(isinstance(value, str) and value for value in tool_versions.values())
     ):
-        raise WorkspaceError("released sound ownership marker is missing or tampered")
+        raise WorkspaceError("released sound toolchain versions are invalid")
     schema_hash, _schema_size, _schema_prefix = _hash_regular(
         root / RELEASE_SCHEMA, "released sound packaged schema"
     )
@@ -1398,7 +1412,8 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
     properties = schema.get("properties")
     if (
         schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema"
-        or schema.get("$id") != f"https://atrinik.org/{RELEASE_SCHEMA}"
+        or schema.get("$id")
+        != "https://atrinik.org/schemas/sound/classic-runtime-manifest-v1.schema.json"
         or schema.get("type") != "object"
         or schema.get("additionalProperties") is not False
         or not isinstance(required, list)
@@ -1410,33 +1425,58 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
         raise WorkspaceError("released sound packaged schema contract is invalid")
     _validate_release_schema_instance(manifest, schema, schema)
 
-    notices = manifest.get("notices")
-    if not isinstance(notices, list) or not notices:
-        raise WorkspaceError("released sound notices must be a nonempty array")
-    notice_paths: set[str] = set()
-    notice_folded: set[str] = set()
-    for raw_notice in notices:
-        if not isinstance(raw_notice, dict) or set(raw_notice) != {"path", "sha256"}:
-            raise WorkspaceError("released sound notice fields are invalid")
-        path = _safe_release_path(raw_notice.get("path"), "notice")
-        digest = raw_notice.get("sha256")
-        if (
-            not isinstance(digest, str)
-            or not SHA256_PATTERN.fullmatch(digest)
-            or path in notice_paths
-            or path.casefold() in notice_folded
-            or path.casefold().endswith("-blocked.json")
-        ):
-            raise WorkspaceError("released sound notice identity is invalid")
-        actual_hash, _size, _prefix = _hash_regular(
-            root / path, f"released sound notice {path}"
+    remediation_payload = _read_regular(
+        root / RELEASE_REMEDIATION,
+        "released sound remediation report",
+        maximum_bytes=MAX_RELEASE_REMEDIATION_BYTES,
+    )
+    if _hash_bytes(remediation_payload) != manifest.get("remediation_report_sha256"):
+        raise WorkspaceError("released sound remediation report is missing or tampered")
+    try:
+        remediation_value = json.loads(
+            remediation_payload,
+            parse_constant=lambda value: (_ for _ in ()).throw(ValueError(value)),
         )
-        if actual_hash != digest:
-            raise WorkspaceError(f"released sound notice hash mismatch: {path}")
-        notice_paths.add(path)
-        notice_folded.add(path.casefold())
-    if [notice["path"] for notice in notices] != sorted(notice_paths):
-        raise WorkspaceError("released sound notices are not canonically ordered")
+    except (json.JSONDecodeError, ValueError) as error:
+        raise WorkspaceError("released sound remediation report is invalid JSON") from error
+    remediation_keys = {
+        "$schema", "category_counts", "classification", "count", "findings",
+        "release_boundary", "schema_version", "source_commit",
+        "source_count", "source_manifest_sha256", "source_tree",
+    }
+    if (
+        remediation_payload != _canonical_json(remediation_value)
+        or not isinstance(remediation_value, dict)
+        or set(remediation_value) != remediation_keys
+        or remediation_value.get("$schema")
+        != "schemas/classic-remediation-v1.schema.json"
+        or remediation_value.get("schema_version") != 1
+        or remediation_value.get("classification") != "nonblocking-modernization"
+        or remediation_value.get("source_commit") != expected["source_commit"]
+        or remediation_value.get("source_tree") != expected["source_tree"]
+        or remediation_value.get("source_manifest_sha256")
+        != expected["source_manifest_sha256"]
+        or remediation_value.get("source_count") != EXPECTED_PATHS
+        or not isinstance(remediation_value.get("release_boundary"), str)
+        or not remediation_value["release_boundary"]
+    ):
+        raise WorkspaceError("released sound remediation report contract is invalid")
+    findings = remediation_value.get("findings")
+    category_counts = remediation_value.get("category_counts")
+    actual_categories: dict[str, int] = {}
+    if not isinstance(findings, list) or not isinstance(category_counts, dict):
+        raise WorkspaceError("released sound remediation report contract is invalid")
+    for finding in findings:
+        if not isinstance(finding, dict) or not isinstance(finding.get("category"), str):
+            raise WorkspaceError("released sound remediation finding is invalid")
+        category = finding["category"]
+        actual_categories[category] = actual_categories.get(category, 0) + 1
+    if (
+        remediation_value.get("count") != len(findings)
+        or manifest.get("remediation_finding_count") != len(findings)
+        or category_counts != actual_categories
+    ):
+        raise WorkspaceError("released sound remediation finding counts are invalid")
 
     assets = manifest.get("assets")
     if not isinstance(assets, list):
@@ -1484,7 +1524,9 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
         elif source_codec in {"flac", "midi"}:
             expected_mapping = "render-opus"
             expected_codec = "opus"
-            expected_source_container = source_codec
+            expected_source_container = (
+                "standard-midi-file" if source_codec == "midi" else "flac"
+            )
         else:
             raise WorkspaceError(f"released sound source codec is invalid: {logical_path}")
         if (
@@ -1529,8 +1571,6 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
         tree_entries.append((logical_path, payload_hash))
         if not source_path:
             raise WorkspaceError(f"released sound source path is invalid: {logical_path}")
-    if [asset["logical_path"] for asset in assets] != sorted(logical_paths):
-        raise WorkspaceError("released sound assets are not canonically ordered")
     if (
         len(assets) != EXPECTED_PATHS
         or manifest.get("logical_path_count") != EXPECTED_PATHS
@@ -1550,11 +1590,9 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
 
     checksums = _release_checksums(root)
     files = _tree_files(root, contract="released sound")
-    expected_files = logical_paths | notice_paths | {
+    expected_files = logical_paths | RELEASE_METADATA_FILES | {
         RELEASE_CHECKSUMS,
         RELEASE_MANIFEST,
-        RELEASE_MARKER,
-        RELEASE_SCHEMA,
     }
     if files != expected_files or set(checksums) != files - {RELEASE_CHECKSUMS}:
         raise WorkspaceError("released sound archive has missing or unexpected files")
@@ -1580,7 +1618,8 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
         "source_manifest_sha256": expected["source_manifest_sha256"],
         "toolchain_sha256": expected["toolchain_sha256"],
         "schema_sha256": expected["schema_sha256"],
-        "marker_sha256": manifest["marker_sha256"],
+        "remediation_report_sha256": manifest["remediation_report_sha256"],
+        "remediation_finding_count": manifest["remediation_finding_count"],
         "output_tree_sha256": expected["output_tree_sha256"],
         "logical_path_count": EXPECTED_PATHS,
         "copied_vorbis_count": EXPECTED_COPIED_VORBIS,
@@ -1604,8 +1643,9 @@ RELEASE_RECORD_KEYS = {
     "asset_url", "archive_sha256", "release_manifest_sha256",
     "manifest_schema_version", "source_commit", "source_tree",
     "source_manifest_sha256", "toolchain_sha256", "schema_sha256",
-    "marker_sha256", "output_tree_sha256", "logical_path_count",
-    "copied_vorbis_count", "converted_opus_count",
+    "remediation_report_sha256", "remediation_finding_count",
+    "output_tree_sha256", "logical_path_count", "copied_vorbis_count",
+    "converted_opus_count",
 }
 
 
@@ -1643,8 +1683,8 @@ def validate_sound_record(value: object) -> dict[str, Any]:
         hashes = RELEASE_RECORD_KEYS - {
             "asset_url", "copied_vorbis_count", "converted_opus_count",
             "logical_path_count", "manifest_schema_version", "mode", "product",
-            "product_version", "repository", "root", "source_commit",
-            "source_tree", "tag",
+            "product_version", "remediation_finding_count", "repository", "root",
+            "source_commit", "source_tree", "tag",
         }
         if (
             any(
@@ -1655,6 +1695,9 @@ def validate_sound_record(value: object) -> dict[str, Any]:
             or value.get("logical_path_count") != EXPECTED_PATHS
             or value.get("copied_vorbis_count") != EXPECTED_COPIED_VORBIS
             or value.get("converted_opus_count") != EXPECTED_CONVERTED_OPUS
+            or not isinstance(value.get("remediation_finding_count"), int)
+            or isinstance(value.get("remediation_finding_count"), bool)
+            or value["remediation_finding_count"] < 0
         ):
             raise WorkspaceError("released sound provenance is invalid")
         return value

--- a/atrinik_workspace/sound.py
+++ b/atrinik_workspace/sound.py
@@ -885,6 +885,10 @@ def _safe_release_path(value: object, description: str) -> str:
     return path.as_posix()
 
 
+class _ReleaseSchemaMismatch(WorkspaceError):
+    """The instance does not match an otherwise structurally valid schema."""
+
+
 def _validate_release_schema_instance(
     instance: object,
     schema: object,
@@ -904,8 +908,12 @@ def _validate_release_schema_instance(
         raise WorkspaceError("released sound packaged schema exceeds evaluation limits")
     if schema is True:
         return
-    if schema is False or not isinstance(schema, dict):
-        raise WorkspaceError(f"released sound manifest violates its schema at {location}")
+    if schema is False:
+        raise _ReleaseSchemaMismatch(
+            f"released sound manifest violates its schema at {location}"
+        )
+    if not isinstance(schema, dict):
+        raise WorkspaceError("released sound packaged schema node is invalid")
     supported = {
         "$defs", "$id", "$ref", "$schema", "additionalProperties", "allOf",
         "anyOf", "const", "default", "description", "enum", "examples", "format",
@@ -915,6 +923,39 @@ def _validate_release_schema_instance(
     }
     if set(schema) - supported:
         raise WorkspaceError("released sound packaged schema uses unsupported keywords")
+    for keyword in (
+        "maxItems", "maxLength", "maxProperties", "minItems", "minLength",
+        "minProperties",
+    ):
+        limit = schema.get(keyword)
+        if limit is not None and (
+            not isinstance(limit, int) or isinstance(limit, bool) or limit < 0
+        ):
+            raise WorkspaceError(f"released sound packaged schema {keyword} is invalid")
+    for keyword in ("maximum", "minimum"):
+        limit = schema.get(keyword)
+        if limit is not None and (
+            not isinstance(limit, (int, float))
+            or isinstance(limit, bool)
+            or not math.isfinite(limit)
+        ):
+            raise WorkspaceError(f"released sound packaged schema {keyword} is invalid")
+    if "enum" in schema and (
+        not isinstance(schema["enum"], list) or not schema["enum"]
+    ):
+        raise WorkspaceError("released sound packaged schema enum is invalid")
+    required_value = schema.get("required")
+    if required_value is not None and (
+        not isinstance(required_value, list)
+        or any(not isinstance(name, str) for name in required_value)
+    ):
+        raise WorkspaceError("released sound packaged schema required is invalid")
+    if "properties" in schema and not isinstance(schema["properties"], dict):
+        raise WorkspaceError("released sound packaged schema properties is invalid")
+    if "pattern" in schema and not isinstance(schema["pattern"], str):
+        raise WorkspaceError("released sound packaged schema pattern is invalid")
+    if "uniqueItems" in schema and not isinstance(schema["uniqueItems"], bool):
+        raise WorkspaceError("released sound packaged schema uniqueItems is invalid")
     reference = schema.get("$ref")
     if reference is not None:
         if not isinstance(reference, str) or not reference.startswith("#/$defs/"):
@@ -954,9 +995,7 @@ def _validate_release_schema_instance(
                     budget=budget,
                     depth=depth + 1,
                 )
-            except WorkspaceError as error:
-                if not str(error).startswith("released sound manifest"):
-                    raise
+            except _ReleaseSchemaMismatch:
                 continue
             matches += 1
         if (
@@ -964,13 +1003,21 @@ def _validate_release_schema_instance(
             or keyword == "anyOf" and matches < 1
             or keyword == "oneOf" and matches != 1
         ):
-            raise WorkspaceError(f"released sound manifest violates {keyword} at {location}")
+            raise _ReleaseSchemaMismatch(
+                f"released sound manifest violates {keyword} at {location}"
+            )
     if "const" in schema and instance != schema["const"]:
-        raise WorkspaceError(f"released sound manifest violates const at {location}")
+        raise _ReleaseSchemaMismatch(
+            f"released sound manifest violates const at {location}"
+        )
     if "enum" in schema:
         enum = schema["enum"]
-        if not isinstance(enum, list) or instance not in enum:
-            raise WorkspaceError(f"released sound manifest violates enum at {location}")
+        if not isinstance(enum, list) or not enum:
+            raise WorkspaceError("released sound packaged schema enum is invalid")
+        if instance not in enum:
+            raise _ReleaseSchemaMismatch(
+                f"released sound manifest violates enum at {location}"
+            )
     type_name = schema.get("type")
     type_checks = {
         "object": lambda value: isinstance(value, dict),
@@ -983,13 +1030,14 @@ def _validate_release_schema_instance(
     }
     if type_name is not None:
         allowed = [type_name] if isinstance(type_name, str) else type_name
-        if (
-            not isinstance(allowed, list)
-            or not allowed
-            or any(name not in type_checks for name in allowed)
-            or not any(type_checks[name](instance) for name in allowed)
+        if not isinstance(allowed, list) or not allowed or any(
+            name not in type_checks for name in allowed
         ):
-            raise WorkspaceError(f"released sound manifest has wrong type at {location}")
+            raise WorkspaceError("released sound packaged schema type is invalid")
+        if not any(type_checks[name](instance) for name in allowed):
+            raise _ReleaseSchemaMismatch(
+                f"released sound manifest has wrong type at {location}"
+            )
     if isinstance(instance, dict):
         required = schema.get("required", [])
         properties = schema.get("properties", {})
@@ -997,9 +1045,12 @@ def _validate_release_schema_instance(
             not isinstance(required, list)
             or any(not isinstance(name, str) for name in required)
             or not isinstance(properties, dict)
-            or any(name not in instance for name in required)
         ):
-            raise WorkspaceError(f"released sound manifest object is invalid at {location}")
+            raise WorkspaceError("released sound packaged schema object keywords are invalid")
+        if any(name not in instance for name in required):
+            raise _ReleaseSchemaMismatch(
+                f"released sound manifest object is invalid at {location}"
+            )
         additional = schema.get("additionalProperties", True)
         if not isinstance(additional, (bool, dict)):
             raise WorkspaceError("released sound packaged schema additionalProperties is invalid")
@@ -1016,8 +1067,10 @@ def _validate_release_schema_instance(
             )
         for keyword, comparison in (("minProperties", lambda a, b: a >= b), ("maxProperties", lambda a, b: a <= b)):
             limit = schema.get(keyword)
-            if limit is not None and (not isinstance(limit, int) or isinstance(limit, bool) or not comparison(len(instance), limit)):
-                raise WorkspaceError(f"released sound manifest violates {keyword} at {location}")
+            if limit is not None and (not isinstance(limit, int) or isinstance(limit, bool) or limit < 0):
+                raise WorkspaceError(f"released sound packaged schema {keyword} is invalid")
+            if limit is not None and not comparison(len(instance), limit):
+                raise _ReleaseSchemaMismatch(f"released sound manifest violates {keyword} at {location}")
     if isinstance(instance, list):
         item_schema = schema.get("items", True)
         for index, value in enumerate(instance):
@@ -1032,15 +1085,22 @@ def _validate_release_schema_instance(
             )
         for keyword, comparison in (("minItems", lambda a, b: a >= b), ("maxItems", lambda a, b: a <= b)):
             limit = schema.get(keyword)
-            if limit is not None and (not isinstance(limit, int) or isinstance(limit, bool) or not comparison(len(instance), limit)):
-                raise WorkspaceError(f"released sound manifest violates {keyword} at {location}")
-        if schema.get("uniqueItems") is True and len({_canonical_json(value) for value in instance}) != len(instance):
-            raise WorkspaceError(f"released sound manifest items are not unique at {location}")
+            if limit is not None and (not isinstance(limit, int) or isinstance(limit, bool) or limit < 0):
+                raise WorkspaceError(f"released sound packaged schema {keyword} is invalid")
+            if limit is not None and not comparison(len(instance), limit):
+                raise _ReleaseSchemaMismatch(f"released sound manifest violates {keyword} at {location}")
+        unique_items = schema.get("uniqueItems")
+        if unique_items is not None and not isinstance(unique_items, bool):
+            raise WorkspaceError("released sound packaged schema uniqueItems is invalid")
+        if unique_items is True and len({_canonical_json(value) for value in instance}) != len(instance):
+            raise _ReleaseSchemaMismatch(f"released sound manifest items are not unique at {location}")
     if isinstance(instance, str):
         for keyword, comparison in (("minLength", lambda a, b: a >= b), ("maxLength", lambda a, b: a <= b)):
             limit = schema.get(keyword)
-            if limit is not None and (not isinstance(limit, int) or isinstance(limit, bool) or not comparison(len(instance), limit)):
-                raise WorkspaceError(f"released sound manifest violates {keyword} at {location}")
+            if limit is not None and (not isinstance(limit, int) or isinstance(limit, bool) or limit < 0):
+                raise WorkspaceError(f"released sound packaged schema {keyword} is invalid")
+            if limit is not None and not comparison(len(instance), limit):
+                raise _ReleaseSchemaMismatch(f"released sound manifest violates {keyword} at {location}")
         pattern = schema.get("pattern")
         if pattern is not None:
             try:
@@ -1048,12 +1108,14 @@ def _validate_release_schema_instance(
             except re.error as error:
                 raise WorkspaceError("released sound packaged schema pattern is invalid") from error
             if not matches:
-                raise WorkspaceError(f"released sound manifest violates pattern at {location}")
+                raise _ReleaseSchemaMismatch(f"released sound manifest violates pattern at {location}")
     if isinstance(instance, (int, float)) and not isinstance(instance, bool):
         for keyword, comparison in (("minimum", lambda a, b: a >= b), ("maximum", lambda a, b: a <= b)):
             limit = schema.get(keyword)
-            if limit is not None and (not isinstance(limit, (int, float)) or isinstance(limit, bool) or not comparison(instance, limit)):
-                raise WorkspaceError(f"released sound manifest violates {keyword} at {location}")
+            if limit is not None and (not isinstance(limit, (int, float)) or isinstance(limit, bool) or not math.isfinite(limit)):
+                raise WorkspaceError(f"released sound packaged schema {keyword} is invalid")
+            if limit is not None and not comparison(instance, limit):
+                raise _ReleaseSchemaMismatch(f"released sound manifest violates {keyword} at {location}")
 
 
 def _release_checksums(root: Path) -> dict[str, str]:

--- a/atrinik_workspace/sound.py
+++ b/atrinik_workspace/sound.py
@@ -7,19 +7,51 @@ from pathlib import Path, PurePosixPath
 import re
 import stat
 import subprocess
+import tarfile
 from typing import Any
+import urllib.error
+import urllib.parse
+import urllib.request
 
 from .model import WorkspaceError
 
 
 PLAYTEST_MODE = "local-playtest"
+RELEASED_MODE = "released"
 SOURCE_MODE = "source"
-SOUND_MODES = {PLAYTEST_MODE, SOURCE_MODE}
+SOUND_MODES = {PLAYTEST_MODE, RELEASED_MODE, SOURCE_MODE}
 PLAYTEST_MANIFEST = "playtest-manifest.json"
 PLAYTEST_BLOCKERS = "playtest-blockers.json"
 PLAYTEST_MARKER = ".atrinik-playtest-tree.json"
 PLAYTEST_SCHEMA = "schemas/playtest-manifest-v1.schema.json"
 EXPECTED_PATHS = 339
+EXPECTED_COPIED_VORBIS = 189
+EXPECTED_CONVERTED_OPUS = 150
+RELEASE_PRODUCT = "atrinik-sound-classic-runtime"
+RELEASE_MANIFEST = "classic-runtime-manifest.json"
+RELEASE_MARKER = ".atrinik-classic-runtime.json"
+RELEASE_SCHEMA = "schemas/classic-runtime-manifest-v1.schema.json"
+RELEASE_CHECKSUMS = "SHA256SUMS"
+RELEASE_COORDINATE_KEYS = {
+    "archive_sha256",
+    "asset_url",
+    "manifest_schema_version",
+    "product",
+    "product_version",
+    "release_manifest_sha256",
+    "repository",
+    "schema_sha256",
+    "source_commit",
+    "source_manifest_sha256",
+    "source_tree",
+    "tag",
+    "toolchain_sha256",
+    "output_tree_sha256",
+}
+MAX_RELEASE_ARCHIVE_BYTES = 1024 * 1024 * 1024
+MAX_RELEASE_EXTRACTED_BYTES = 4 * 1024 * 1024 * 1024
+MAX_RELEASE_MEMBER_BYTES = 256 * 1024 * 1024
+MAX_RELEASE_MEMBERS = 4096
 SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 OBJECT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 LOGICAL_PATH_PATTERN = re.compile(
@@ -138,6 +170,235 @@ def cache_key(inputs: dict[str, str]) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:20]
 
 
+def validate_release_coordinates(value: object) -> dict[str, Any]:
+    """Validate the complete immutable identity of one released sound archive."""
+
+    if not isinstance(value, dict) or set(value) != RELEASE_COORDINATE_KEYS:
+        raise WorkspaceError("released sound coordinates fields are invalid")
+    hashes = RELEASE_COORDINATE_KEYS - {
+        "asset_url",
+        "manifest_schema_version",
+        "product",
+        "product_version",
+        "repository",
+        "source_commit",
+        "source_tree",
+        "tag",
+    }
+    if any(
+        not isinstance(value.get(name), str)
+        or not SHA256_PATTERN.fullmatch(value[name])
+        for name in hashes
+    ):
+        raise WorkspaceError("released sound coordinates contain an invalid SHA-256")
+    if (
+        value.get("repository") != "atrinik/sound"
+        or value.get("product") != RELEASE_PRODUCT
+        or value.get("manifest_schema_version") != 1
+        or not isinstance(value.get("product_version"), str)
+        or not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", value["product_version"])
+        or value.get("tag") != f"v{value.get('product_version')}"
+        or not isinstance(value.get("source_commit"), str)
+        or not OBJECT_PATTERN.fullmatch(value["source_commit"])
+        or not isinstance(value.get("source_tree"), str)
+        or not OBJECT_PATTERN.fullmatch(value["source_tree"])
+    ):
+        raise WorkspaceError("released sound coordinates contain an invalid product identity")
+    url = value.get("asset_url")
+    if not isinstance(url, str):
+        raise WorkspaceError("released sound asset URL is invalid")
+    parsed = urllib.parse.urlsplit(url)
+    expected_path = (
+        f"/atrinik/sound/releases/download/{value['tag']}/"
+        f"{RELEASE_PRODUCT}-{value['product_version']}.tar.gz"
+    )
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != "github.com"
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.port is not None
+        or parsed.query
+        or parsed.fragment
+        or parsed.path != expected_path
+    ):
+        raise WorkspaceError(
+            "released sound asset URL must be the exact atrinik/sound release asset"
+        )
+    return value
+
+
+def release_cache_key(coordinates: dict[str, Any]) -> str:
+    validated = validate_release_coordinates(coordinates)
+    payload = json.dumps(validated, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:20]
+
+
+def verify_release_archive(
+    archive_path: Path, coordinates: dict[str, Any], description: str
+) -> None:
+    expected = validate_release_coordinates(coordinates)
+    archive_hash, size, _prefix = _hash_regular(archive_path, description)
+    if size < 1 or archive_hash != expected["archive_sha256"]:
+        raise WorkspaceError(f"{description} checksum mismatch")
+
+
+def download_release_archive(url: str, destination: Path) -> None:
+    """Download one bounded release asset into a new caller-owned path."""
+
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "atrinik-workspace-released-sound/1"},
+    )
+    try:
+        response = urllib.request.urlopen(request, timeout=60)
+    except (OSError, urllib.error.URLError) as error:
+        raise WorkspaceError(f"cannot download released sound archive: {error}") from error
+    try:
+        length = response.headers.get("Content-Length")
+        if length is not None:
+            try:
+                declared = int(length)
+            except ValueError as error:
+                raise WorkspaceError(
+                    "released sound download has an invalid Content-Length"
+                ) from error
+            if declared < 1 or declared > MAX_RELEASE_ARCHIVE_BYTES:
+                raise WorkspaceError("released sound archive exceeds the download limit")
+        descriptor = os.open(
+            destination,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            0o600,
+        )
+        size = 0
+        with os.fdopen(descriptor, "wb") as output:
+            while chunk := response.read(1024 * 1024):
+                size += len(chunk)
+                if size > MAX_RELEASE_ARCHIVE_BYTES:
+                    raise WorkspaceError(
+                        "released sound archive exceeds the download limit"
+                    )
+                output.write(chunk)
+        if size < 1 or length is not None and size != declared:
+            raise WorkspaceError("released sound download is incomplete")
+    finally:
+        response.close()
+
+
+def extract_release_archive(
+    archive_path: Path, destination: Path, coordinates: dict[str, Any]
+) -> Path:
+    """Safely extract a bounded single-prefix release archive."""
+
+    expected = validate_release_coordinates(coordinates)
+    if destination.exists() or destination.is_symlink():
+        raise WorkspaceError("released sound extraction destination already exists")
+    _archive_hash, archive_size, _archive_prefix = _hash_regular(
+        archive_path, "released sound archive"
+    )
+    if archive_size < 1 or archive_size > MAX_RELEASE_ARCHIVE_BYTES:
+        raise WorkspaceError("released sound archive exceeds the extraction input limit")
+    try:
+        archive = tarfile.open(archive_path, mode="r:gz")
+    except (OSError, tarfile.TarError) as error:
+        raise WorkspaceError("released sound archive is invalid or corrupt") from error
+    with archive:
+        prefix: str | None = None
+        seen: set[str] = set()
+        folded: set[str] = set()
+        directories: set[str] = set()
+        files: list[tuple[tarfile.TarInfo, PurePosixPath]] = []
+        total = 0
+        member_count = 0
+        for member in archive:
+            member_count += 1
+            if member_count > MAX_RELEASE_MEMBERS:
+                raise WorkspaceError("released sound archive member count is invalid")
+            path = PurePosixPath(member.name)
+            if (
+                path.is_absolute()
+                or not path.parts
+                or any(part in {"", ".", ".."} for part in path.parts)
+                or member.name.endswith("/") and not member.isdir()
+            ):
+                raise WorkspaceError("released sound archive contains an unsafe path")
+            if prefix is None:
+                prefix = path.parts[0]
+            if path.parts[0] != prefix or len(path.parts) == 1 and not member.isdir():
+                raise WorkspaceError("released sound archive must use one directory prefix")
+            if member.issym() or member.islnk() or member.isdev() or member.isfifo():
+                raise WorkspaceError("released sound archive contains a special member")
+            if not member.isdir() and not member.isfile():
+                raise WorkspaceError("released sound archive contains an unsupported member")
+            relative = PurePosixPath(*path.parts[1:])
+            if not relative.parts:
+                continue
+            rendered = relative.as_posix()
+            folded_name = rendered.casefold()
+            if rendered in seen or folded_name in folded:
+                raise WorkspaceError("released sound archive has duplicate or case-colliding paths")
+            seen.add(rendered)
+            folded.add(folded_name)
+            if member.isfile():
+                if member.size < 0 or member.size > MAX_RELEASE_MEMBER_BYTES:
+                    raise WorkspaceError("released sound archive member exceeds the size limit")
+                total += member.size
+                if total > MAX_RELEASE_EXTRACTED_BYTES:
+                    raise WorkspaceError("released sound archive exceeds the extraction limit")
+                files.append((member, relative))
+            else:
+                directories.add(rendered)
+        if member_count == 0:
+            raise WorkspaceError("released sound archive member count is invalid")
+        if prefix != f"{RELEASE_PRODUCT}-{expected['product_version']}":
+            raise WorkspaceError("released sound archive has the wrong product prefix")
+        required_directories = {
+            PurePosixPath(*relative.parts[:index]).as_posix()
+            for _member, relative in files
+            for index in range(1, len(relative.parts))
+        }
+        if directories != required_directories:
+            raise WorkspaceError(
+                "released sound archive has missing or unexpected directories"
+            )
+        destination.mkdir(mode=0o700)
+        try:
+            for member, relative in files:
+                target = destination.joinpath(*relative.parts)
+                target.parent.mkdir(parents=True, exist_ok=True)
+                stream = archive.extractfile(member)
+                if stream is None:
+                    raise WorkspaceError("released sound archive member cannot be read")
+                descriptor = os.open(
+                    target,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                    0o600,
+                )
+                written = 0
+                try:
+                    with os.fdopen(descriptor, "wb") as output:
+                        descriptor = -1
+                        while chunk := stream.read(1024 * 1024):
+                            written += len(chunk)
+                            if written > member.size:
+                                raise WorkspaceError(
+                                    "released sound archive member exceeds its declared size"
+                                )
+                            output.write(chunk)
+                finally:
+                    if descriptor >= 0:
+                        os.close(descriptor)
+                    stream.close()
+                if written != member.size:
+                    raise WorkspaceError("released sound archive member is truncated")
+        except BaseException:
+            import shutil
+
+            shutil.rmtree(destination, ignore_errors=True)
+            raise
+    return destination
+
+
 def source_record(source: Path) -> dict[str, Any]:
     commit = _git(source, "rev-parse", "HEAD")
     tree = _git(source, "rev-parse", f"{commit}^{{tree}}")
@@ -158,19 +419,24 @@ def _require_dict(value: object, keys: set[str], description: str) -> dict[str, 
     return value
 
 
-def _tree_files(root: Path) -> set[str]:
+def _tree_files(root: Path, *, contract: str = "local-playtest") -> set[str]:
     result: set[str] = set()
-    for directory, directories, files in os.walk(root, followlinks=False):
+    def walk_error(error: OSError) -> None:
+        raise WorkspaceError(f"cannot inspect {contract} tree: {error.filename}") from error
+
+    for directory, directories, files in os.walk(
+        root, followlinks=False, onerror=walk_error
+    ):
         parent = Path(directory)
         for name in directories:
             path = parent / name
             try:
                 mode = path.lstat().st_mode
             except OSError as error:
-                raise WorkspaceError(f"cannot inspect local-playtest tree: {path}") from error
+                raise WorkspaceError(f"cannot inspect {contract} tree: {path}") from error
             if not stat.S_ISDIR(mode):
                 raise WorkspaceError(
-                    f"local-playtest tree contains a non-directory or symlink: {path}"
+                    f"{contract} tree contains a non-directory or symlink: {path}"
                 )
         for name in files:
             path = parent / name
@@ -179,12 +445,12 @@ def _tree_files(root: Path) -> set[str]:
                 descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
             except OSError as error:
                 raise WorkspaceError(
-                    f"local-playtest tree entry is not a readable regular file: {path}"
+                    f"{contract} tree entry is not a readable regular file: {path}"
                 ) from error
             try:
                 if not stat.S_ISREG(os.fstat(descriptor).st_mode):
                     raise WorkspaceError(
-                        f"local-playtest tree entry is not a regular file: {path}"
+                        f"{contract} tree entry is not a regular file: {path}"
                     )
             finally:
                 os.close(descriptor)
@@ -192,13 +458,15 @@ def _tree_files(root: Path) -> set[str]:
     return result
 
 
-def _validate_payload_codec(path: str, codec: str, prefix: bytes) -> None:
+def _validate_payload_codec(
+    path: str, codec: str, prefix: bytes, *, contract: str = "local-playtest"
+) -> None:
     if not prefix.startswith(b"OggS"):
-        raise WorkspaceError(f"local-playtest payload is not an Ogg stream: {path}")
+        raise WorkspaceError(f"{contract} payload is not an Ogg stream: {path}")
     signature = b"OpusHead" if codec == "opus" else b"\x01vorbis"
     if signature not in prefix:
         raise WorkspaceError(
-            f"local-playtest payload codec does not match its manifest: {path}"
+            f"{contract} payload codec does not match its manifest: {path}"
         )
 
 
@@ -490,6 +758,304 @@ def verify_playtest_tree(
     }
 
 
+def _safe_release_path(value: object, description: str) -> str:
+    if not isinstance(value, str):
+        raise WorkspaceError(f"released sound {description} path is invalid")
+    path = PurePosixPath(value)
+    if (
+        path.is_absolute()
+        or not path.parts
+        or any(part in {"", ".", ".."} for part in path.parts)
+        or "\\" in value
+    ):
+        raise WorkspaceError(f"released sound {description} path is unsafe")
+    return path.as_posix()
+
+
+def _release_checksums(root: Path) -> dict[str, str]:
+    payload = _read_regular(root / RELEASE_CHECKSUMS, "released sound checksums")
+    try:
+        text = payload.decode("ascii")
+    except UnicodeDecodeError as error:
+        raise WorkspaceError("released sound checksums are not ASCII") from error
+    checksums: dict[str, str] = {}
+    folded: set[str] = set()
+    lines = text.splitlines(keepends=True)
+    if not lines or any(not line.endswith("\n") for line in lines):
+        raise WorkspaceError("released sound checksums are not canonical")
+    for line in lines:
+        fields = line[:-1].split("  ", 1)
+        if len(fields) != 2 or not SHA256_PATTERN.fullmatch(fields[0]):
+            raise WorkspaceError("released sound checksums contain an invalid entry")
+        path = _safe_release_path(fields[1], "checksum")
+        folded_path = path.casefold()
+        if path == RELEASE_CHECKSUMS or path in checksums or folded_path in folded:
+            raise WorkspaceError("released sound checksums contain a duplicate entry")
+        checksums[path] = fields[0]
+        folded.add(folded_path)
+    canonical = "".join(
+        f"{checksums[path]}  {path}\n" for path in sorted(checksums)
+    ).encode("ascii")
+    if payload != canonical:
+        raise WorkspaceError("released sound checksums are not canonical")
+    return checksums
+
+
+def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, Any]:
+    """Independently verify the publishable Classic compatibility product."""
+
+    expected = validate_release_coordinates(coordinates)
+    if root.is_symlink() or not root.is_dir():
+        raise WorkspaceError(f"released sound root is not a regular directory: {root}")
+    manifest_payload = _read_regular(
+        root / RELEASE_MANIFEST, "released sound manifest"
+    )
+    if _hash_bytes(manifest_payload) != expected["release_manifest_sha256"]:
+        raise WorkspaceError("released sound manifest hash does not match the profile")
+    try:
+        manifest_value = json.loads(manifest_payload)
+    except json.JSONDecodeError as error:
+        raise WorkspaceError("released sound manifest is invalid JSON") from error
+    if manifest_payload != _canonical_json(manifest_value):
+        raise WorkspaceError("released sound manifest is not canonical JSON")
+    manifest_keys = {
+        "$schema",
+        "assets",
+        "converted_opus_count",
+        "copied_vorbis_count",
+        "logical_path_count",
+        "marker_sha256",
+        "notices",
+        "output_tree_sha256",
+        "playtest_only",
+        "product",
+        "product_version",
+        "publishable",
+        "release_tag",
+        "repository",
+        "schema_sha256",
+        "schema_version",
+        "source_commit",
+        "source_manifest_sha256",
+        "source_tree",
+        "toolchain_sha256",
+    }
+    if not isinstance(manifest_value, dict) or set(manifest_value) != manifest_keys:
+        raise WorkspaceError("released sound manifest fields are invalid")
+    manifest = manifest_value
+    identity_fields = {
+        "product": "product",
+        "product_version": "product_version",
+        "release_tag": "tag",
+        "repository": "repository",
+        "schema_version": "manifest_schema_version",
+        "source_commit": "source_commit",
+        "source_manifest_sha256": "source_manifest_sha256",
+        "source_tree": "source_tree",
+        "toolchain_sha256": "toolchain_sha256",
+        "schema_sha256": "schema_sha256",
+        "output_tree_sha256": "output_tree_sha256",
+    }
+    if (
+        manifest.get("$schema") != RELEASE_SCHEMA
+        or manifest.get("publishable") is not True
+        or manifest.get("playtest_only") is not False
+        or any(
+            manifest.get(manifest_name) != expected[coordinate_name]
+            for manifest_name, coordinate_name in identity_fields.items()
+        )
+    ):
+        raise WorkspaceError("released sound manifest identity does not match the profile")
+    marker_payload = _read_regular(root / RELEASE_MARKER, "released sound marker")
+    expected_marker = _canonical_json(
+        {
+            "format": RELEASE_PRODUCT,
+            "playtest_only": False,
+            "product_version": expected["product_version"],
+            "publishable": True,
+            "schema_version": 1,
+        }
+    )
+    if (
+        marker_payload != expected_marker
+        or manifest.get("marker_sha256") != _hash_bytes(marker_payload)
+    ):
+        raise WorkspaceError("released sound ownership marker is missing or tampered")
+    schema_hash, _schema_size, _schema_prefix = _hash_regular(
+        root / RELEASE_SCHEMA, "released sound packaged schema"
+    )
+    if schema_hash != expected["schema_sha256"]:
+        raise WorkspaceError("released sound packaged schema is missing or tampered")
+
+    notices = manifest.get("notices")
+    if not isinstance(notices, list) or not notices:
+        raise WorkspaceError("released sound notices must be a nonempty array")
+    notice_paths: set[str] = set()
+    notice_folded: set[str] = set()
+    for raw_notice in notices:
+        if not isinstance(raw_notice, dict) or set(raw_notice) != {"path", "sha256"}:
+            raise WorkspaceError("released sound notice fields are invalid")
+        path = _safe_release_path(raw_notice.get("path"), "notice")
+        digest = raw_notice.get("sha256")
+        if (
+            not isinstance(digest, str)
+            or not SHA256_PATTERN.fullmatch(digest)
+            or path in notice_paths
+            or path.casefold() in notice_folded
+            or path.casefold().endswith("-blocked.json")
+        ):
+            raise WorkspaceError("released sound notice identity is invalid")
+        actual_hash, _size, _prefix = _hash_regular(
+            root / path, f"released sound notice {path}"
+        )
+        if actual_hash != digest:
+            raise WorkspaceError(f"released sound notice hash mismatch: {path}")
+        notice_paths.add(path)
+        notice_folded.add(path.casefold())
+    if [notice["path"] for notice in notices] != sorted(notice_paths):
+        raise WorkspaceError("released sound notices are not canonically ordered")
+
+    assets = manifest.get("assets")
+    if not isinstance(assets, list):
+        raise WorkspaceError("released sound manifest assets must be an array")
+    logical_paths: set[str] = set()
+    logical_folded: set[str] = set()
+    copied = 0
+    converted = 0
+    tree_entries: list[tuple[str, str]] = []
+    for raw_asset in assets:
+        if not isinstance(raw_asset, dict) or set(raw_asset) != {
+            "logical_path", "mapping", "output", "source", "source_path"
+        }:
+            raise WorkspaceError("released sound asset fields are invalid")
+        logical_path = raw_asset.get("logical_path")
+        if (
+            not isinstance(logical_path, str)
+            or not LOGICAL_PATH_PATTERN.fullmatch(logical_path)
+            or logical_path in logical_paths
+            or logical_path.casefold() in logical_folded
+        ):
+            raise WorkspaceError("released sound manifest has an unsafe or duplicate path")
+        source_path = _safe_release_path(raw_asset.get("source_path"), "source")
+        source = raw_asset.get("source")
+        output = raw_asset.get("output")
+        if (
+            not isinstance(source, dict)
+            or set(source) != {"codec", "container", "sha256"}
+            or not isinstance(output, dict)
+            or set(output) != {
+                "channels", "codec", "container", "duration_seconds",
+                "sample_rate", "sha256", "size_bytes",
+            }
+        ):
+            raise WorkspaceError(f"released sound mapping is invalid: {logical_path}")
+        source_codec = source.get("codec")
+        mapping = raw_asset.get("mapping")
+        output_codec = output.get("codec")
+        if source_codec == "vorbis":
+            expected_mapping = "copy"
+            expected_codec = "vorbis"
+        elif source_codec in {"flac", "midi"}:
+            expected_mapping = "render-opus"
+            expected_codec = "opus"
+        else:
+            raise WorkspaceError(f"released sound source codec is invalid: {logical_path}")
+        if (
+            mapping != expected_mapping
+            or output_codec != expected_codec
+            or output.get("container") != "ogg"
+            or not isinstance(source.get("container"), str)
+            or not isinstance(source.get("sha256"), str)
+            or not SHA256_PATTERN.fullmatch(source["sha256"])
+            or not isinstance(output.get("sha256"), str)
+            or not SHA256_PATTERN.fullmatch(output["sha256"])
+            or not isinstance(output.get("size_bytes"), int)
+            or isinstance(output.get("size_bytes"), bool)
+            or output["size_bytes"] < 1
+            or not isinstance(output.get("sample_rate"), int)
+            or isinstance(output.get("sample_rate"), bool)
+            or output["sample_rate"] < 1
+            or output.get("channels") not in {1, 2}
+            or not isinstance(output.get("duration_seconds"), (int, float))
+            or isinstance(output.get("duration_seconds"), bool)
+            or output["duration_seconds"] <= 0
+            or expected_mapping == "copy" and output["sha256"] != source["sha256"]
+        ):
+            raise WorkspaceError(f"released sound mapping is invalid: {logical_path}")
+        payload_hash, payload_size, payload_prefix = _hash_regular(
+            root / logical_path, f"released sound payload {logical_path}"
+        )
+        if payload_hash != output["sha256"] or payload_size != output["size_bytes"]:
+            raise WorkspaceError(
+                f"released sound payload hash or size mismatch: {logical_path}"
+            )
+        _validate_payload_codec(
+            logical_path, expected_codec, payload_prefix, contract="released sound"
+        )
+        logical_paths.add(logical_path)
+        logical_folded.add(logical_path.casefold())
+        copied += expected_mapping == "copy"
+        converted += expected_mapping == "render-opus"
+        tree_entries.append((logical_path, payload_hash))
+        if not source_path:
+            raise WorkspaceError(f"released sound source path is invalid: {logical_path}")
+    if [asset["logical_path"] for asset in assets] != sorted(logical_paths):
+        raise WorkspaceError("released sound assets are not canonically ordered")
+    if (
+        len(assets) != EXPECTED_PATHS
+        or manifest.get("logical_path_count") != EXPECTED_PATHS
+        or copied != EXPECTED_COPIED_VORBIS
+        or manifest.get("copied_vorbis_count") != EXPECTED_COPIED_VORBIS
+        or converted != EXPECTED_CONVERTED_OPUS
+        or manifest.get("converted_opus_count") != EXPECTED_CONVERTED_OPUS
+    ):
+        raise WorkspaceError("released sound tree counts do not match the 339-path contract")
+    tree_digest = hashlib.sha256()
+    for logical_path, payload_hash in sorted(tree_entries):
+        tree_digest.update(f"{payload_hash}  {logical_path}\n".encode("ascii"))
+    if tree_digest.hexdigest() != expected["output_tree_sha256"]:
+        raise WorkspaceError("released sound output-tree digest mismatch")
+
+    checksums = _release_checksums(root)
+    files = _tree_files(root, contract="released sound")
+    expected_files = logical_paths | notice_paths | {
+        RELEASE_CHECKSUMS,
+        RELEASE_MANIFEST,
+        RELEASE_MARKER,
+        RELEASE_SCHEMA,
+    }
+    if files != expected_files or set(checksums) != files - {RELEASE_CHECKSUMS}:
+        raise WorkspaceError("released sound archive has missing or unexpected files")
+    for path, expected_hash in checksums.items():
+        actual_hash, _size, _prefix = _hash_regular(
+            root / path, f"released sound checksum member {path}"
+        )
+        if actual_hash != expected_hash:
+            raise WorkspaceError(f"released sound internal checksum mismatch: {path}")
+    return {
+        "mode": RELEASED_MODE,
+        "root": str(root.resolve()),
+        "repository": expected["repository"],
+        "tag": expected["tag"],
+        "product": expected["product"],
+        "product_version": expected["product_version"],
+        "asset_url": expected["asset_url"],
+        "archive_sha256": expected["archive_sha256"],
+        "release_manifest_sha256": expected["release_manifest_sha256"],
+        "manifest_schema_version": expected["manifest_schema_version"],
+        "source_commit": expected["source_commit"],
+        "source_tree": expected["source_tree"],
+        "source_manifest_sha256": expected["source_manifest_sha256"],
+        "toolchain_sha256": expected["toolchain_sha256"],
+        "schema_sha256": expected["schema_sha256"],
+        "marker_sha256": manifest["marker_sha256"],
+        "output_tree_sha256": expected["output_tree_sha256"],
+        "logical_path_count": EXPECTED_PATHS,
+        "copied_vorbis_count": EXPECTED_COPIED_VORBIS,
+        "converted_opus_count": EXPECTED_CONVERTED_OPUS,
+    }
+
+
 SOURCE_RECORD_KEYS = {
     "mode", "root", "source_commit", "source_tree", "source_clean",
 }
@@ -501,6 +1067,14 @@ PLAYTEST_RECORD_KEYS = {
     "output_tree_sha256", "logical_path_count", "copied_vorbis_count",
     "converted_opus_count",
 }
+RELEASE_RECORD_KEYS = {
+    "mode", "root", "repository", "tag", "product", "product_version",
+    "asset_url", "archive_sha256", "release_manifest_sha256",
+    "manifest_schema_version", "source_commit", "source_tree",
+    "source_manifest_sha256", "toolchain_sha256", "schema_sha256",
+    "marker_sha256", "output_tree_sha256", "logical_path_count",
+    "copied_vorbis_count", "converted_opus_count",
+}
 
 
 def validate_sound_record(value: object) -> dict[str, Any]:
@@ -509,7 +1083,11 @@ def validate_sound_record(value: object) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise WorkspaceError("sound provenance record is not an object")
     mode = value.get("mode")
-    expected = SOURCE_RECORD_KEYS if mode == SOURCE_MODE else PLAYTEST_RECORD_KEYS
+    expected = {
+        SOURCE_MODE: SOURCE_RECORD_KEYS,
+        PLAYTEST_MODE: PLAYTEST_RECORD_KEYS,
+        RELEASED_MODE: RELEASE_RECORD_KEYS,
+    }.get(mode)
     if mode not in SOUND_MODES or set(value) != expected:
         raise WorkspaceError("sound provenance record fields are invalid")
     root = value.get("root")
@@ -520,10 +1098,33 @@ def validate_sound_record(value: object) -> dict[str, Any]:
         or not OBJECT_PATTERN.fullmatch(value["source_commit"])
         or not isinstance(value.get("source_tree"), str)
         or not OBJECT_PATTERN.fullmatch(value["source_tree"])
-        or not isinstance(value.get("source_clean"), bool)
+        or mode != RELEASED_MODE and not isinstance(value.get("source_clean"), bool)
     ):
         raise WorkspaceError("sound provenance source identity is invalid")
     if mode == SOURCE_MODE:
+        return value
+    if mode == RELEASED_MODE:
+        coordinates = {
+            key: value[key] for key in RELEASE_COORDINATE_KEYS
+        }
+        validate_release_coordinates(coordinates)
+        hashes = RELEASE_RECORD_KEYS - {
+            "asset_url", "copied_vorbis_count", "converted_opus_count",
+            "logical_path_count", "manifest_schema_version", "mode", "product",
+            "product_version", "repository", "root", "source_commit",
+            "source_tree", "tag",
+        }
+        if (
+            any(
+                not isinstance(value.get(name), str)
+                or not SHA256_PATTERN.fullmatch(value[name])
+                for name in hashes
+            )
+            or value.get("logical_path_count") != EXPECTED_PATHS
+            or value.get("copied_vorbis_count") != EXPECTED_COPIED_VORBIS
+            or value.get("converted_opus_count") != EXPECTED_CONVERTED_OPUS
+        ):
+            raise WorkspaceError("released sound provenance is invalid")
         return value
     hashes = PLAYTEST_RECORD_KEYS - {
         "mode", "root", "playtest_schema_version", "source_commit",

--- a/atrinik_workspace/sound.py
+++ b/atrinik_workspace/sound.py
@@ -890,7 +890,12 @@ class _ReleaseSchemaMismatch(WorkspaceError):
 
 
 def _validate_release_schema_structure(
-    schema: object, *, budget: list[int] | None = None, depth: int = 0
+    schema: object,
+    *,
+    root_schema: dict[str, Any] | None = None,
+    active_refs: frozenset[str] = frozenset(),
+    budget: list[int] | None = None,
+    depth: int = 0,
 ) -> None:
     """Validate every schema node independently of instance applicability."""
 
@@ -903,6 +908,8 @@ def _validate_release_schema_structure(
         return
     if not isinstance(schema, dict):
         raise WorkspaceError("released sound packaged schema node is invalid")
+    if root_schema is None:
+        root_schema = schema
     supported = {
         "$defs", "$id", "$ref", "$schema", "additionalProperties", "allOf",
         "anyOf", "const", "default", "description", "enum", "examples", "format",
@@ -912,6 +919,25 @@ def _validate_release_schema_structure(
     }
     if set(schema) - supported:
         raise WorkspaceError("released sound packaged schema uses unsupported keywords")
+    reference = schema.get("$ref")
+    if reference is not None:
+        if not isinstance(reference, str) or not reference.startswith("#/$defs/"):
+            raise WorkspaceError("released sound packaged schema reference is invalid")
+        name = reference.removeprefix("#/$defs/")
+        definitions = root_schema.get("$defs")
+        if (
+            reference in active_refs
+            or not isinstance(definitions, dict)
+            or name not in definitions
+        ):
+            raise WorkspaceError("released sound packaged schema reference is unresolved")
+        _validate_release_schema_structure(
+            definitions[name],
+            root_schema=root_schema,
+            active_refs=active_refs | {reference},
+            budget=budget,
+            depth=depth + 1,
+        )
     for keyword in (
         "maxItems", "maxLength", "maxProperties", "minItems", "minLength",
         "minProperties",
@@ -966,11 +992,16 @@ def _validate_release_schema_structure(
     if not isinstance(properties, dict) or not isinstance(definitions, dict):
         raise WorkspaceError("released sound packaged schema properties are invalid")
     for child in [*properties.values(), *definitions.values()]:
-        _validate_release_schema_structure(child, budget=budget, depth=depth + 1)
+        _validate_release_schema_structure(
+            child, root_schema=root_schema, budget=budget, depth=depth + 1
+        )
     for keyword in ("items", "additionalProperties"):
         if keyword in schema:
             _validate_release_schema_structure(
-                schema[keyword], budget=budget, depth=depth + 1
+                schema[keyword],
+                root_schema=root_schema,
+                budget=budget,
+                depth=depth + 1,
             )
     for keyword in ("allOf", "anyOf", "oneOf"):
         branches = schema.get(keyword)
@@ -979,7 +1010,9 @@ def _validate_release_schema_structure(
         if not isinstance(branches, list) or not branches:
             raise WorkspaceError(f"released sound packaged schema {keyword} is invalid")
         for branch in branches:
-            _validate_release_schema_structure(branch, budget=budget, depth=depth + 1)
+            _validate_release_schema_structure(
+                branch, root_schema=root_schema, budget=budget, depth=depth + 1
+            )
 
 
 def _validate_release_schema_instance(

--- a/atrinik_workspace/sound.py
+++ b/atrinik_workspace/sound.py
@@ -4,6 +4,7 @@ import hashlib
 import gzip
 import http.client
 import json
+import math
 import os
 from pathlib import Path, PurePosixPath
 import re
@@ -29,6 +30,8 @@ PLAYTEST_SCHEMA = "schemas/playtest-manifest-v1.schema.json"
 EXPECTED_PATHS = 339
 EXPECTED_COPIED_VORBIS = 189
 EXPECTED_CONVERTED_OPUS = 150
+EXPECTED_SOURCE_MIDI = 122
+EXPECTED_SOURCE_FLAC = 28
 RELEASE_PRODUCT = "atrinik-sound-classic-runtime"
 RELEASE_MANIFEST = "classic-runtime-manifest.json"
 RELEASE_MARKER = ".atrinik-classic-runtime.json"
@@ -348,9 +351,9 @@ def _prescan_release_archive(archive_path: Path) -> None:
                     tarfile.XGLTYPE,
                     tarfile.GNUTYPE_LONGNAME,
                     tarfile.GNUTYPE_LONGLINK,
-                } and member.size > MAX_RELEASE_METADATA_BYTES:
+                }:
                     raise WorkspaceError(
-                        "released sound archive extended metadata exceeds the size limit"
+                        "released sound archive contains unsupported extended metadata"
                     )
                 if member.size < 0 or member.size > MAX_RELEASE_MEMBER_BYTES:
                     raise WorkspaceError("released sound archive member exceeds the size limit")
@@ -393,6 +396,7 @@ def _extract_release_archive(
         seen: set[str] = set()
         folded: set[str] = set()
         directories: set[str] = set()
+        root_seen = False
         files: list[tuple[tarfile.TarInfo, PurePosixPath]] = []
         total = 0
         member_count = 0
@@ -419,6 +423,11 @@ def _extract_release_archive(
                 raise WorkspaceError("released sound archive contains an unsupported member")
             relative = PurePosixPath(*path.parts[1:])
             if not relative.parts:
+                if root_seen:
+                    raise WorkspaceError(
+                        "released sound archive has duplicate or case-colliding paths"
+                    )
+                root_seen = True
                 continue
             rendered = relative.as_posix()
             folded_name = rendered.casefold()
@@ -495,7 +504,7 @@ def extract_release_archive(
         return _extract_release_archive(archive_path, destination, coordinates)
     except WorkspaceError:
         raise
-    except (OSError, EOFError, tarfile.TarError) as error:
+    except (OSError, EOFError, RecursionError, tarfile.TarError) as error:
         raise WorkspaceError("released sound archive is invalid or corrupt") from error
 
 
@@ -875,6 +884,126 @@ def _safe_release_path(value: object, description: str) -> str:
     return path.as_posix()
 
 
+def _validate_release_schema_instance(
+    instance: object,
+    schema: object,
+    root_schema: dict[str, Any],
+    location: str = "$",
+) -> None:
+    """Apply the bounded JSON Schema subset used by the sound release contract."""
+
+    if schema is True:
+        return
+    if schema is False or not isinstance(schema, dict):
+        raise WorkspaceError(f"released sound manifest violates its schema at {location}")
+    supported = {
+        "$defs", "$id", "$ref", "$schema", "additionalProperties", "allOf",
+        "anyOf", "const", "default", "description", "enum", "examples", "format",
+        "items", "maxItems", "maxLength", "maxProperties", "maximum", "minItems",
+        "minLength", "minProperties", "minimum", "oneOf", "pattern", "properties",
+        "required", "title", "type", "uniqueItems",
+    }
+    if set(schema) - supported:
+        raise WorkspaceError("released sound packaged schema uses unsupported keywords")
+    reference = schema.get("$ref")
+    if reference is not None:
+        if not isinstance(reference, str) or not reference.startswith("#/$defs/"):
+            raise WorkspaceError("released sound packaged schema reference is invalid")
+        name = reference.removeprefix("#/$defs/")
+        definitions = root_schema.get("$defs")
+        if not isinstance(definitions, dict) or name not in definitions:
+            raise WorkspaceError("released sound packaged schema reference is unresolved")
+        _validate_release_schema_instance(instance, definitions[name], root_schema, location)
+    for keyword, required_matches in (("allOf", None), ("anyOf", 1), ("oneOf", 1)):
+        branches = schema.get(keyword)
+        if branches is None:
+            continue
+        if not isinstance(branches, list) or not branches:
+            raise WorkspaceError(f"released sound packaged schema {keyword} is invalid")
+        matches = 0
+        for branch in branches:
+            try:
+                _validate_release_schema_instance(instance, branch, root_schema, location)
+            except WorkspaceError:
+                continue
+            matches += 1
+        if keyword == "allOf" and matches != len(branches) or required_matches == 1 and matches != 1:
+            raise WorkspaceError(f"released sound manifest violates {keyword} at {location}")
+    if "const" in schema and instance != schema["const"]:
+        raise WorkspaceError(f"released sound manifest violates const at {location}")
+    if "enum" in schema:
+        enum = schema["enum"]
+        if not isinstance(enum, list) or instance not in enum:
+            raise WorkspaceError(f"released sound manifest violates enum at {location}")
+    type_name = schema.get("type")
+    type_checks = {
+        "object": lambda value: isinstance(value, dict),
+        "array": lambda value: isinstance(value, list),
+        "string": lambda value: isinstance(value, str),
+        "integer": lambda value: isinstance(value, int) and not isinstance(value, bool),
+        "number": lambda value: isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value),
+        "boolean": lambda value: isinstance(value, bool),
+        "null": lambda value: value is None,
+    }
+    if type_name is not None:
+        allowed = [type_name] if isinstance(type_name, str) else type_name
+        if (
+            not isinstance(allowed, list)
+            or not allowed
+            or any(name not in type_checks for name in allowed)
+            or not any(type_checks[name](instance) for name in allowed)
+        ):
+            raise WorkspaceError(f"released sound manifest has wrong type at {location}")
+    if isinstance(instance, dict):
+        required = schema.get("required", [])
+        properties = schema.get("properties", {})
+        if (
+            not isinstance(required, list)
+            or any(not isinstance(name, str) for name in required)
+            or not isinstance(properties, dict)
+            or any(name not in instance for name in required)
+        ):
+            raise WorkspaceError(f"released sound manifest object is invalid at {location}")
+        additional = schema.get("additionalProperties", True)
+        if not isinstance(additional, (bool, dict)):
+            raise WorkspaceError("released sound packaged schema additionalProperties is invalid")
+        for name, value in instance.items():
+            child = properties.get(name, additional)
+            _validate_release_schema_instance(value, child, root_schema, f"{location}.{name}")
+        for keyword, comparison in (("minProperties", lambda a, b: a >= b), ("maxProperties", lambda a, b: a <= b)):
+            limit = schema.get(keyword)
+            if limit is not None and (not isinstance(limit, int) or isinstance(limit, bool) or not comparison(len(instance), limit)):
+                raise WorkspaceError(f"released sound manifest violates {keyword} at {location}")
+    if isinstance(instance, list):
+        item_schema = schema.get("items", True)
+        for index, value in enumerate(instance):
+            _validate_release_schema_instance(value, item_schema, root_schema, f"{location}[{index}]")
+        for keyword, comparison in (("minItems", lambda a, b: a >= b), ("maxItems", lambda a, b: a <= b)):
+            limit = schema.get(keyword)
+            if limit is not None and (not isinstance(limit, int) or isinstance(limit, bool) or not comparison(len(instance), limit)):
+                raise WorkspaceError(f"released sound manifest violates {keyword} at {location}")
+        if schema.get("uniqueItems") is True and len({_canonical_json(value) for value in instance}) != len(instance):
+            raise WorkspaceError(f"released sound manifest items are not unique at {location}")
+    if isinstance(instance, str):
+        for keyword, comparison in (("minLength", lambda a, b: a >= b), ("maxLength", lambda a, b: a <= b)):
+            limit = schema.get(keyword)
+            if limit is not None and (not isinstance(limit, int) or isinstance(limit, bool) or not comparison(len(instance), limit)):
+                raise WorkspaceError(f"released sound manifest violates {keyword} at {location}")
+        pattern = schema.get("pattern")
+        if pattern is not None:
+            try:
+                matches = isinstance(pattern, str) and re.search(pattern, instance)
+            except re.error as error:
+                raise WorkspaceError("released sound packaged schema pattern is invalid") from error
+            if not matches:
+                raise WorkspaceError(f"released sound manifest violates pattern at {location}")
+    if isinstance(instance, (int, float)) and not isinstance(instance, bool):
+        for keyword, comparison in (("minimum", lambda a, b: a >= b), ("maximum", lambda a, b: a <= b)):
+            limit = schema.get(keyword)
+            if limit is not None and (not isinstance(limit, (int, float)) or isinstance(limit, bool) or not comparison(instance, limit)):
+                raise WorkspaceError(f"released sound manifest violates {keyword} at {location}")
+
+
 def _release_checksums(root: Path) -> dict[str, str]:
     payload = _read_regular(
         root / RELEASE_CHECKSUMS,
@@ -922,8 +1051,11 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
     if _hash_bytes(manifest_payload) != expected["release_manifest_sha256"]:
         raise WorkspaceError("released sound manifest hash does not match the profile")
     try:
-        manifest_value = json.loads(manifest_payload)
-    except json.JSONDecodeError as error:
+        manifest_value = json.loads(
+            manifest_payload,
+            parse_constant=lambda value: (_ for _ in ()).throw(ValueError(value)),
+        )
+    except (json.JSONDecodeError, ValueError) as error:
         raise WorkspaceError("released sound manifest is invalid JSON") from error
     if manifest_payload != _canonical_json(manifest_value):
         raise WorkspaceError("released sound manifest is not canonical JSON")
@@ -1013,17 +1145,22 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
         )
     except (json.JSONDecodeError, ValueError) as error:
         raise WorkspaceError("released sound packaged schema is invalid JSON") from error
+    required = schema.get("required")
+    properties = schema.get("properties")
     if (
         not isinstance(schema, dict)
         or schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema"
         or schema.get("$id") != f"https://atrinik.org/{RELEASE_SCHEMA}"
         or schema.get("type") != "object"
         or schema.get("additionalProperties") is not False
-        or set(schema.get("required", [])) != manifest_keys
-        or not isinstance(schema.get("properties"), dict)
-        or set(schema["properties"]) != manifest_keys
+        or not isinstance(required, list)
+        or any(not isinstance(name, str) for name in required)
+        or set(required) != manifest_keys
+        or not isinstance(properties, dict)
+        or set(properties) != manifest_keys
     ):
         raise WorkspaceError("released sound packaged schema contract is invalid")
+    _validate_release_schema_instance(manifest, schema, schema)
 
     notices = manifest.get("notices")
     if not isinstance(notices, list) or not notices:
@@ -1060,6 +1197,8 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
     logical_folded: set[str] = set()
     copied = 0
     converted = 0
+    source_midi = 0
+    source_flac = 0
     tree_entries: list[tuple[str, str]] = []
     for raw_asset in assets:
         if not isinstance(raw_asset, dict) or set(raw_asset) != {
@@ -1093,16 +1232,18 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
         if source_codec == "vorbis":
             expected_mapping = "copy"
             expected_codec = "vorbis"
+            expected_source_container = "ogg"
         elif source_codec in {"flac", "midi"}:
             expected_mapping = "render-opus"
             expected_codec = "opus"
+            expected_source_container = source_codec
         else:
             raise WorkspaceError(f"released sound source codec is invalid: {logical_path}")
         if (
             mapping != expected_mapping
             or output_codec != expected_codec
             or output.get("container") != "ogg"
-            or not isinstance(source.get("container"), str)
+            or source.get("container") != expected_source_container
             or not isinstance(source.get("sha256"), str)
             or not SHA256_PATTERN.fullmatch(source["sha256"])
             or not isinstance(output.get("sha256"), str)
@@ -1116,6 +1257,7 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
             or output.get("channels") not in {1, 2}
             or not isinstance(output.get("duration_seconds"), (int, float))
             or isinstance(output.get("duration_seconds"), bool)
+            or not math.isfinite(output["duration_seconds"])
             or output["duration_seconds"] <= 0
             or expected_mapping == "copy" and output["sha256"] != source["sha256"]
         ):
@@ -1134,6 +1276,8 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
         logical_folded.add(logical_path.casefold())
         copied += expected_mapping == "copy"
         converted += expected_mapping == "render-opus"
+        source_midi += source_codec == "midi"
+        source_flac += source_codec == "flac"
         tree_entries.append((logical_path, payload_hash))
         if not source_path:
             raise WorkspaceError(f"released sound source path is invalid: {logical_path}")
@@ -1146,6 +1290,8 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
         or manifest.get("copied_vorbis_count") != EXPECTED_COPIED_VORBIS
         or converted != EXPECTED_CONVERTED_OPUS
         or manifest.get("converted_opus_count") != EXPECTED_CONVERTED_OPUS
+        or source_midi != EXPECTED_SOURCE_MIDI
+        or source_flac != EXPECTED_SOURCE_FLAC
     ):
         raise WorkspaceError("released sound tree counts do not match the 339-path contract")
     tree_digest = hashlib.sha256()

--- a/atrinik_workspace/sound.py
+++ b/atrinik_workspace/sound.py
@@ -920,7 +920,7 @@ def _validate_release_schema_structure(
     if set(schema) - supported:
         raise WorkspaceError("released sound packaged schema uses unsupported keywords")
     reference = schema.get("$ref")
-    if reference is not None:
+    if "$ref" in schema:
         if not isinstance(reference, str) or not reference.startswith("#/$defs/"):
             raise WorkspaceError("released sound packaged schema reference is invalid")
         name = reference.removeprefix("#/$defs/")
@@ -943,13 +943,13 @@ def _validate_release_schema_structure(
         "minProperties",
     ):
         value = schema.get(keyword)
-        if value is not None and (
+        if keyword in schema and (
             not isinstance(value, int) or isinstance(value, bool) or value < 0
         ):
             raise WorkspaceError(f"released sound packaged schema {keyword} is invalid")
     for keyword in ("maximum", "minimum"):
         value = schema.get(keyword)
-        if value is not None and (
+        if keyword in schema and (
             not isinstance(value, (int, float))
             or isinstance(value, bool)
             or not math.isfinite(value)
@@ -960,27 +960,30 @@ def _validate_release_schema_structure(
     ):
         raise WorkspaceError("released sound packaged schema enum is invalid")
     required = schema.get("required")
-    if required is not None and (
+    if "required" in schema and (
         not isinstance(required, list)
         or any(not isinstance(name, str) for name in required)
+        or len(set(required)) != len(required)
     ):
         raise WorkspaceError("released sound packaged schema required is invalid")
     type_name = schema.get("type")
     allowed_types = {
         "object", "array", "string", "integer", "number", "boolean", "null"
     }
-    if type_name is not None:
+    if "type" in schema:
         values = [type_name] if isinstance(type_name, str) else type_name
         if (
             not isinstance(values, list)
             or not values
+            or any(not isinstance(value, str) for value in values)
             or any(value not in allowed_types for value in values)
+            or len(set(values)) != len(values)
         ):
             raise WorkspaceError("released sound packaged schema type is invalid")
     if "uniqueItems" in schema and not isinstance(schema["uniqueItems"], bool):
         raise WorkspaceError("released sound packaged schema uniqueItems is invalid")
     pattern = schema.get("pattern")
-    if pattern is not None:
+    if "pattern" in schema:
         if not isinstance(pattern, str):
             raise WorkspaceError("released sound packaged schema pattern is invalid")
         try:
@@ -1005,7 +1008,7 @@ def _validate_release_schema_structure(
             )
     for keyword in ("allOf", "anyOf", "oneOf"):
         branches = schema.get(keyword)
-        if branches is None:
+        if keyword not in schema:
             continue
         if not isinstance(branches, list) or not branches:
             raise WorkspaceError(f"released sound packaged schema {keyword} is invalid")
@@ -1083,7 +1086,7 @@ def _validate_release_schema_instance(
     if "uniqueItems" in schema and not isinstance(schema["uniqueItems"], bool):
         raise WorkspaceError("released sound packaged schema uniqueItems is invalid")
     reference = schema.get("$ref")
-    if reference is not None:
+    if "$ref" in schema:
         if not isinstance(reference, str) or not reference.startswith("#/$defs/"):
             raise WorkspaceError("released sound packaged schema reference is invalid")
         name = reference.removeprefix("#/$defs/")

--- a/atrinik_workspace/sound.py
+++ b/atrinik_workspace/sound.py
@@ -349,6 +349,7 @@ def _prescan_release_archive(archive_path: Path) -> None:
                 if member.type in {
                     tarfile.XHDTYPE,
                     tarfile.XGLTYPE,
+                    tarfile.SOLARIS_XHDTYPE,
                     tarfile.GNUTYPE_LONGNAME,
                     tarfile.GNUTYPE_LONGLINK,
                 }:
@@ -889,9 +890,18 @@ def _validate_release_schema_instance(
     schema: object,
     root_schema: dict[str, Any],
     location: str = "$",
+    *,
+    active_refs: frozenset[str] = frozenset(),
+    budget: list[int] | None = None,
+    depth: int = 0,
 ) -> None:
     """Apply the bounded JSON Schema subset used by the sound release contract."""
 
+    if budget is None:
+        budget = [100_000]
+    budget[0] -= 1
+    if budget[0] < 0 or depth > 128:
+        raise WorkspaceError("released sound packaged schema exceeds evaluation limits")
     if schema is True:
         return
     if schema is False or not isinstance(schema, dict):
@@ -911,10 +921,22 @@ def _validate_release_schema_instance(
             raise WorkspaceError("released sound packaged schema reference is invalid")
         name = reference.removeprefix("#/$defs/")
         definitions = root_schema.get("$defs")
-        if not isinstance(definitions, dict) or name not in definitions:
+        if (
+            reference in active_refs
+            or not isinstance(definitions, dict)
+            or name not in definitions
+        ):
             raise WorkspaceError("released sound packaged schema reference is unresolved")
-        _validate_release_schema_instance(instance, definitions[name], root_schema, location)
-    for keyword, required_matches in (("allOf", None), ("anyOf", 1), ("oneOf", 1)):
+        _validate_release_schema_instance(
+            instance,
+            definitions[name],
+            root_schema,
+            location,
+            active_refs=active_refs | {reference},
+            budget=budget,
+            depth=depth + 1,
+        )
+    for keyword in ("allOf", "anyOf", "oneOf"):
         branches = schema.get(keyword)
         if branches is None:
             continue
@@ -923,11 +945,23 @@ def _validate_release_schema_instance(
         matches = 0
         for branch in branches:
             try:
-                _validate_release_schema_instance(instance, branch, root_schema, location)
+                _validate_release_schema_instance(
+                    instance,
+                    branch,
+                    root_schema,
+                    location,
+                    active_refs=active_refs,
+                    budget=budget,
+                    depth=depth + 1,
+                )
             except WorkspaceError:
                 continue
             matches += 1
-        if keyword == "allOf" and matches != len(branches) or required_matches == 1 and matches != 1:
+        if (
+            keyword == "allOf" and matches != len(branches)
+            or keyword == "anyOf" and matches < 1
+            or keyword == "oneOf" and matches != 1
+        ):
             raise WorkspaceError(f"released sound manifest violates {keyword} at {location}")
     if "const" in schema and instance != schema["const"]:
         raise WorkspaceError(f"released sound manifest violates const at {location}")
@@ -969,7 +1003,15 @@ def _validate_release_schema_instance(
             raise WorkspaceError("released sound packaged schema additionalProperties is invalid")
         for name, value in instance.items():
             child = properties.get(name, additional)
-            _validate_release_schema_instance(value, child, root_schema, f"{location}.{name}")
+            _validate_release_schema_instance(
+                value,
+                child,
+                root_schema,
+                f"{location}.{name}",
+                active_refs=active_refs,
+                budget=budget,
+                depth=depth + 1,
+            )
         for keyword, comparison in (("minProperties", lambda a, b: a >= b), ("maxProperties", lambda a, b: a <= b)):
             limit = schema.get(keyword)
             if limit is not None and (not isinstance(limit, int) or isinstance(limit, bool) or not comparison(len(instance), limit)):
@@ -977,7 +1019,15 @@ def _validate_release_schema_instance(
     if isinstance(instance, list):
         item_schema = schema.get("items", True)
         for index, value in enumerate(instance):
-            _validate_release_schema_instance(value, item_schema, root_schema, f"{location}[{index}]")
+            _validate_release_schema_instance(
+                value,
+                item_schema,
+                root_schema,
+                f"{location}[{index}]",
+                active_refs=active_refs,
+                budget=budget,
+                depth=depth + 1,
+            )
         for keyword, comparison in (("minItems", lambda a, b: a >= b), ("maxItems", lambda a, b: a <= b)):
             limit = schema.get(keyword)
             if limit is not None and (not isinstance(limit, int) or isinstance(limit, bool) or not comparison(len(instance), limit)):
@@ -1145,11 +1195,12 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
         )
     except (json.JSONDecodeError, ValueError) as error:
         raise WorkspaceError("released sound packaged schema is invalid JSON") from error
+    if not isinstance(schema, dict):
+        raise WorkspaceError("released sound packaged schema contract is invalid")
     required = schema.get("required")
     properties = schema.get("properties")
     if (
-        not isinstance(schema, dict)
-        or schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema"
+        schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema"
         or schema.get("$id") != f"https://atrinik.org/{RELEASE_SCHEMA}"
         or schema.get("type") != "object"
         or schema.get("additionalProperties") is not False

--- a/atrinik_workspace/sound.py
+++ b/atrinik_workspace/sound.py
@@ -889,6 +889,99 @@ class _ReleaseSchemaMismatch(WorkspaceError):
     """The instance does not match an otherwise structurally valid schema."""
 
 
+def _validate_release_schema_structure(
+    schema: object, *, budget: list[int] | None = None, depth: int = 0
+) -> None:
+    """Validate every schema node independently of instance applicability."""
+
+    if budget is None:
+        budget = [100_000]
+    budget[0] -= 1
+    if budget[0] < 0 or depth > 128:
+        raise WorkspaceError("released sound packaged schema exceeds evaluation limits")
+    if isinstance(schema, bool):
+        return
+    if not isinstance(schema, dict):
+        raise WorkspaceError("released sound packaged schema node is invalid")
+    supported = {
+        "$defs", "$id", "$ref", "$schema", "additionalProperties", "allOf",
+        "anyOf", "const", "default", "description", "enum", "examples", "format",
+        "items", "maxItems", "maxLength", "maxProperties", "maximum", "minItems",
+        "minLength", "minProperties", "minimum", "oneOf", "pattern", "properties",
+        "required", "title", "type", "uniqueItems",
+    }
+    if set(schema) - supported:
+        raise WorkspaceError("released sound packaged schema uses unsupported keywords")
+    for keyword in (
+        "maxItems", "maxLength", "maxProperties", "minItems", "minLength",
+        "minProperties",
+    ):
+        value = schema.get(keyword)
+        if value is not None and (
+            not isinstance(value, int) or isinstance(value, bool) or value < 0
+        ):
+            raise WorkspaceError(f"released sound packaged schema {keyword} is invalid")
+    for keyword in ("maximum", "minimum"):
+        value = schema.get(keyword)
+        if value is not None and (
+            not isinstance(value, (int, float))
+            or isinstance(value, bool)
+            or not math.isfinite(value)
+        ):
+            raise WorkspaceError(f"released sound packaged schema {keyword} is invalid")
+    if "enum" in schema and (
+        not isinstance(schema["enum"], list) or not schema["enum"]
+    ):
+        raise WorkspaceError("released sound packaged schema enum is invalid")
+    required = schema.get("required")
+    if required is not None and (
+        not isinstance(required, list)
+        or any(not isinstance(name, str) for name in required)
+    ):
+        raise WorkspaceError("released sound packaged schema required is invalid")
+    type_name = schema.get("type")
+    allowed_types = {
+        "object", "array", "string", "integer", "number", "boolean", "null"
+    }
+    if type_name is not None:
+        values = [type_name] if isinstance(type_name, str) else type_name
+        if (
+            not isinstance(values, list)
+            or not values
+            or any(value not in allowed_types for value in values)
+        ):
+            raise WorkspaceError("released sound packaged schema type is invalid")
+    if "uniqueItems" in schema and not isinstance(schema["uniqueItems"], bool):
+        raise WorkspaceError("released sound packaged schema uniqueItems is invalid")
+    pattern = schema.get("pattern")
+    if pattern is not None:
+        if not isinstance(pattern, str):
+            raise WorkspaceError("released sound packaged schema pattern is invalid")
+        try:
+            re.compile(pattern)
+        except re.error as error:
+            raise WorkspaceError("released sound packaged schema pattern is invalid") from error
+    properties = schema.get("properties", {})
+    definitions = schema.get("$defs", {})
+    if not isinstance(properties, dict) or not isinstance(definitions, dict):
+        raise WorkspaceError("released sound packaged schema properties are invalid")
+    for child in [*properties.values(), *definitions.values()]:
+        _validate_release_schema_structure(child, budget=budget, depth=depth + 1)
+    for keyword in ("items", "additionalProperties"):
+        if keyword in schema:
+            _validate_release_schema_structure(
+                schema[keyword], budget=budget, depth=depth + 1
+            )
+    for keyword in ("allOf", "anyOf", "oneOf"):
+        branches = schema.get(keyword)
+        if branches is None:
+            continue
+        if not isinstance(branches, list) or not branches:
+            raise WorkspaceError(f"released sound packaged schema {keyword} is invalid")
+        for branch in branches:
+            _validate_release_schema_structure(branch, budget=budget, depth=depth + 1)
+
+
 def _validate_release_schema_instance(
     instance: object,
     schema: object,
@@ -1261,6 +1354,7 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
         raise WorkspaceError("released sound packaged schema is invalid JSON") from error
     if not isinstance(schema, dict):
         raise WorkspaceError("released sound packaged schema contract is invalid")
+    _validate_release_schema_structure(schema)
     required = schema.get("required")
     properties = schema.get("properties")
     if (

--- a/atrinik_workspace/sound.py
+++ b/atrinik_workspace/sound.py
@@ -954,7 +954,9 @@ def _validate_release_schema_instance(
                     budget=budget,
                     depth=depth + 1,
                 )
-            except WorkspaceError:
+            except WorkspaceError as error:
+                if not str(error).startswith("released sound manifest"):
+                    raise
                 continue
             matches += 1
         if (

--- a/atrinik_workspace/sound.py
+++ b/atrinik_workspace/sound.py
@@ -88,6 +88,8 @@ MAX_RELEASE_MANIFEST_BYTES = 8 * 1024 * 1024
 MAX_RELEASE_CHECKSUM_BYTES = 256 * 1024
 MAX_RELEASE_REMEDIATION_BYTES = 16 * 1024 * 1024
 MAX_RELEASE_SCHEMA_BYTES = 1024 * 1024
+MAX_RELEASE_SOURCE_MANIFEST_BYTES = 8 * 1024 * 1024
+MAX_RELEASE_TOOLCHAIN_BYTES = 2 * 1024 * 1024
 MAX_RELEASE_METADATA_BYTES = 64 * 1024
 SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 OBJECT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
@@ -95,6 +97,19 @@ LOGICAL_PATH_PATTERN = re.compile(
     r"^(background|effects)/(?:[a-z0-9][a-z0-9_.-]*/)*"
     r"[a-z0-9][a-z0-9_.-]*\.(mid|mod|s3m|xm|ogg)$"
 )
+RELEASE_SCHEMA_PATTERNS = {
+    r"^v[0-9]+\.[0-9]+\.[0-9]+$": re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+$"),
+    r"^[0-9a-f]{64}$": SHA256_PATTERN,
+    r"^[0-9a-f]{40}$": OBJECT_PATTERN,
+    LOGICAL_PATH_PATTERN.pattern: LOGICAL_PATH_PATTERN,
+    (
+        r"^(background|effects)/(?:[a-z0-9][a-z0-9_.-]*/)*"
+        r"[a-z0-9][a-z0-9_.-]*\.(flac|mid|mod|s3m|xm|ogg)$"
+    ): re.compile(
+        r"^(background|effects)/(?:[a-z0-9][a-z0-9_.-]*/)*"
+        r"[a-z0-9][a-z0-9_.-]*\.(flac|mid|mod|s3m|xm|ogg)$"
+    ),
+}
 TOOL_NAMES = {
     "ffmpeg",
     "openmpt123",
@@ -106,7 +121,19 @@ TOOL_NAMES = {
 
 
 def _canonical_json(value: object) -> bytes:
-    return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    pending = [(value, 0)]
+    while pending:
+        current, depth = pending.pop()
+        if depth > 128:
+            raise WorkspaceError("released sound JSON exceeds the nesting limit")
+        if isinstance(current, dict):
+            pending.extend((child, depth + 1) for child in current.values())
+        elif isinstance(current, list):
+            pending.extend((child, depth + 1) for child in current)
+    try:
+        return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    except RecursionError as error:
+        raise WorkspaceError("released sound JSON exceeds the nesting limit") from error
 
 
 def _hash_bytes(value: bytes) -> str:
@@ -138,7 +165,9 @@ def _read_regular(
         os.close(descriptor)
 
 
-def _hash_regular(path: Path, description: str) -> tuple[str, int, bytes]:
+def _hash_regular(
+    path: Path, description: str, *, maximum_bytes: int | None = None
+) -> tuple[str, int, bytes]:
     try:
         descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
     except OSError as error:
@@ -149,12 +178,16 @@ def _hash_regular(path: Path, description: str) -> tuple[str, int, bytes]:
         metadata = os.fstat(descriptor)
         if not stat.S_ISREG(metadata.st_mode):
             raise WorkspaceError(f"{description} is not a regular file: {path}")
+        if maximum_bytes is not None and metadata.st_size > maximum_bytes:
+            raise WorkspaceError(f"{description} exceeds its size limit")
         digest = hashlib.sha256()
         prefix = bytearray()
         size = 0
         while chunk := os.read(descriptor, 1024 * 1024):
             digest.update(chunk)
             size += len(chunk)
+            if maximum_bytes is not None and size > maximum_bytes:
+                raise WorkspaceError(f"{description} exceeds its size limit")
             if len(prefix) < 65536:
                 prefix.extend(chunk[: 65536 - len(prefix)])
         return digest.hexdigest(), size, bytes(prefix)
@@ -283,7 +316,9 @@ def verify_release_archive(
     archive_path: Path, coordinates: dict[str, Any], description: str
 ) -> None:
     expected = validate_release_coordinates(coordinates)
-    archive_hash, size, _prefix = _hash_regular(archive_path, description)
+    archive_hash, size, _prefix = _hash_regular(
+        archive_path, description, maximum_bytes=MAX_RELEASE_ARCHIVE_BYTES
+    )
     if size < 1 or archive_hash != expected["archive_sha256"]:
         raise WorkspaceError(f"{description} checksum mismatch")
 
@@ -406,14 +441,16 @@ def _extract_release_archive(
     """Safely extract a bounded single-prefix release archive."""
 
     expected = validate_release_coordinates(coordinates)
-    _prescan_release_archive(archive_path)
     if destination.exists() or destination.is_symlink():
         raise WorkspaceError("released sound extraction destination already exists")
     _archive_hash, archive_size, _archive_prefix = _hash_regular(
-        archive_path, "released sound archive"
+        archive_path,
+        "released sound archive",
+        maximum_bytes=MAX_RELEASE_ARCHIVE_BYTES,
     )
     if archive_size < 1 or archive_size > MAX_RELEASE_ARCHIVE_BYTES:
         raise WorkspaceError("released sound archive exceeds the extraction input limit")
+    _prescan_release_archive(archive_path)
     try:
         archive = tarfile.open(archive_path, mode="r:gz")
     except (OSError, tarfile.TarError) as error:
@@ -1012,12 +1049,8 @@ def _validate_release_schema_structure(
         raise WorkspaceError("released sound packaged schema uniqueItems is invalid")
     pattern = schema.get("pattern")
     if "pattern" in schema:
-        if not isinstance(pattern, str):
-            raise WorkspaceError("released sound packaged schema pattern is invalid")
-        try:
-            re.compile(pattern)
-        except re.error as error:
-            raise WorkspaceError("released sound packaged schema pattern is invalid") from error
+        if not isinstance(pattern, str) or pattern not in RELEASE_SCHEMA_PATTERNS:
+            raise WorkspaceError("released sound packaged schema pattern is unsupported")
     properties = schema.get("properties", {})
     definitions = schema.get("$defs", {})
     if not isinstance(properties, dict) or not isinstance(definitions, dict):
@@ -1261,10 +1294,10 @@ def _validate_release_schema_instance(
                 raise _ReleaseSchemaMismatch(f"released sound manifest violates {keyword} at {location}")
         pattern = schema.get("pattern")
         if pattern is not None:
-            try:
-                matches = isinstance(pattern, str) and re.search(pattern, instance)
-            except re.error as error:
-                raise WorkspaceError("released sound packaged schema pattern is invalid") from error
+            expression = RELEASE_SCHEMA_PATTERNS.get(pattern) if isinstance(pattern, str) else None
+            if expression is None:
+                raise WorkspaceError("released sound packaged schema pattern is unsupported")
+            matches = expression.search(instance)
             if not matches:
                 raise _ReleaseSchemaMismatch(f"released sound manifest violates pattern at {location}")
     if isinstance(instance, (int, float)) and not isinstance(instance, bool):
@@ -1332,7 +1365,7 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
             manifest_payload,
             parse_constant=lambda value: (_ for _ in ()).throw(ValueError(value)),
         )
-    except (json.JSONDecodeError, ValueError) as error:
+    except (json.JSONDecodeError, ValueError, RecursionError) as error:
         raise WorkspaceError("released sound manifest is invalid JSON") from error
     if manifest_payload != _canonical_json(manifest_value):
         raise WorkspaceError("released sound manifest is not canonical JSON")
@@ -1403,7 +1436,7 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
             schema_payload,
             parse_constant=lambda value: (_ for _ in ()).throw(ValueError(value)),
         )
-    except (json.JSONDecodeError, ValueError) as error:
+    except (json.JSONDecodeError, ValueError, RecursionError) as error:
         raise WorkspaceError("released sound packaged schema is invalid JSON") from error
     if not isinstance(schema, dict):
         raise WorkspaceError("released sound packaged schema contract is invalid")
@@ -1425,6 +1458,85 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
         raise WorkspaceError("released sound packaged schema contract is invalid")
     _validate_release_schema_instance(manifest, schema, schema)
 
+    source_manifest_payload = _read_regular(
+        root / "manifests/source-assets.json",
+        "released sound source manifest",
+        maximum_bytes=MAX_RELEASE_SOURCE_MANIFEST_BYTES,
+    )
+    if _hash_bytes(source_manifest_payload) != expected["source_manifest_sha256"]:
+        raise WorkspaceError("released sound source manifest hash does not match the profile")
+    try:
+        source_manifest = json.loads(
+            source_manifest_payload,
+            parse_constant=lambda value: (_ for _ in ()).throw(ValueError(value)),
+        )
+    except (json.JSONDecodeError, ValueError, RecursionError) as error:
+        raise WorkspaceError("released sound source manifest is invalid JSON") from error
+    if (
+        source_manifest_payload != _canonical_json(source_manifest)
+        or not isinstance(source_manifest, dict)
+        or set(source_manifest) != {
+            "$schema", "assets", "audio_source_count", "schema_version",
+            "source_corpus_sha256", "source_size_bytes",
+        }
+        or source_manifest.get("$schema") != "../schemas/source-assets-v1.schema.json"
+        or source_manifest.get("schema_version") != 1
+        or source_manifest.get("audio_source_count") != EXPECTED_PATHS
+        or not isinstance(source_manifest.get("assets"), list)
+        or len(source_manifest["assets"]) != EXPECTED_PATHS
+    ):
+        raise WorkspaceError("released sound source manifest contract is invalid")
+
+    source_assets: dict[str, tuple[str, str, str, str]] = {}
+    for source_asset in source_manifest["assets"]:
+        if not isinstance(source_asset, dict):
+            raise WorkspaceError("released sound source manifest asset is invalid")
+        logical_path = source_asset.get("logical_path")
+        source_path = source_asset.get("source_path")
+        source_value = source_asset.get("source")
+        if (
+            not isinstance(logical_path, str)
+            or not LOGICAL_PATH_PATTERN.fullmatch(logical_path)
+            or logical_path in source_assets
+            or not isinstance(source_path, str)
+            or not isinstance(source_value, dict)
+            or not isinstance(source_value.get("codec"), str)
+            or not isinstance(source_value.get("container"), str)
+            or not isinstance(source_value.get("sha256"), str)
+            or not SHA256_PATTERN.fullmatch(source_value["sha256"])
+        ):
+            raise WorkspaceError("released sound source manifest asset is invalid")
+        source_assets[logical_path] = (
+            source_path,
+            source_value["codec"],
+            source_value["container"],
+            source_value["sha256"],
+        )
+
+    toolchain_payload = _read_regular(
+        root / "manifests/classic-audio-toolchain.json",
+        "released sound toolchain manifest",
+        maximum_bytes=MAX_RELEASE_TOOLCHAIN_BYTES,
+    )
+    if _hash_bytes(toolchain_payload) != expected["toolchain_sha256"]:
+        raise WorkspaceError("released sound toolchain hash does not match the profile")
+    try:
+        packaged_toolchain = json.loads(
+            toolchain_payload,
+            parse_constant=lambda value: (_ for _ in ()).throw(ValueError(value)),
+        )
+    except (json.JSONDecodeError, ValueError, RecursionError) as error:
+        raise WorkspaceError("released sound toolchain manifest is invalid JSON") from error
+    if (
+        not isinstance(packaged_toolchain, dict)
+        or packaged_toolchain.get("$schema")
+        != "../schemas/classic-audio-toolchain-v1.schema.json"
+        or packaged_toolchain.get("schema_version") != 1
+        or not isinstance(packaged_toolchain.get("tools"), dict)
+        or set(packaged_toolchain["tools"]) != TOOL_NAMES
+    ):
+        raise WorkspaceError("released sound toolchain manifest contract is invalid")
+
     remediation_payload = _read_regular(
         root / RELEASE_REMEDIATION,
         "released sound remediation report",
@@ -1437,7 +1549,7 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
             remediation_payload,
             parse_constant=lambda value: (_ for _ in ()).throw(ValueError(value)),
         )
-    except (json.JSONDecodeError, ValueError) as error:
+    except (json.JSONDecodeError, ValueError, RecursionError) as error:
         raise WorkspaceError("released sound remediation report is invalid JSON") from error
     remediation_keys = {
         "$schema", "category_counts", "classification", "count", "findings",
@@ -1514,6 +1626,15 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
             }
         ):
             raise WorkspaceError(f"released sound mapping is invalid: {logical_path}")
+        if source_assets.get(logical_path) != (
+            source_path,
+            source.get("codec"),
+            source.get("container"),
+            source.get("sha256"),
+        ):
+            raise WorkspaceError(
+                f"released sound source manifest closure mismatch: {logical_path}"
+            )
         source_codec = source.get("codec")
         mapping = raw_asset.get("mapping")
         output_codec = output.get("codec")

--- a/atrinik_workspace/sound.py
+++ b/atrinik_workspace/sound.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import hashlib
+import gzip
+import http.client
 import json
 import os
 from pathlib import Path, PurePosixPath
@@ -52,6 +54,12 @@ MAX_RELEASE_ARCHIVE_BYTES = 1024 * 1024 * 1024
 MAX_RELEASE_EXTRACTED_BYTES = 4 * 1024 * 1024 * 1024
 MAX_RELEASE_MEMBER_BYTES = 256 * 1024 * 1024
 MAX_RELEASE_MEMBERS = 4096
+MAX_RELEASE_TAR_BYTES = MAX_RELEASE_EXTRACTED_BYTES + MAX_RELEASE_MEMBERS * 1024
+MAX_RELEASE_MANIFEST_BYTES = 8 * 1024 * 1024
+MAX_RELEASE_CHECKSUM_BYTES = 256 * 1024
+MAX_RELEASE_MARKER_BYTES = 4096
+MAX_RELEASE_SCHEMA_BYTES = 1024 * 1024
+MAX_RELEASE_METADATA_BYTES = 64 * 1024
 SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 OBJECT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 LOGICAL_PATH_PATTERN = re.compile(
@@ -76,7 +84,9 @@ def _hash_bytes(value: bytes) -> str:
     return hashlib.sha256(value).hexdigest()
 
 
-def _read_regular(path: Path, description: str) -> bytes:
+def _read_regular(
+    path: Path, description: str, *, maximum_bytes: int | None = None
+) -> bytes:
     try:
         descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
     except OSError as error:
@@ -85,8 +95,14 @@ def _read_regular(path: Path, description: str) -> bytes:
         metadata = os.fstat(descriptor)
         if not stat.S_ISREG(metadata.st_mode):
             raise WorkspaceError(f"{description} is not a regular file: {path}")
+        if maximum_bytes is not None and metadata.st_size > maximum_bytes:
+            raise WorkspaceError(f"{description} exceeds its size limit")
         chunks: list[bytes] = []
+        size = 0
         while chunk := os.read(descriptor, 1024 * 1024):
+            size += len(chunk)
+            if maximum_bytes is not None and size > maximum_bytes:
+                raise WorkspaceError(f"{description} exceeds its size limit")
             chunks.append(chunk)
         return b"".join(chunks)
     finally:
@@ -281,16 +297,86 @@ def download_release_archive(url: str, destination: Path) -> None:
                 output.write(chunk)
         if size < 1 or length is not None and size != declared:
             raise WorkspaceError("released sound download is incomplete")
+    except WorkspaceError:
+        raise
+    except (OSError, urllib.error.URLError, http.client.HTTPException) as error:
+        raise WorkspaceError("released sound download was interrupted") from error
     finally:
-        response.close()
+        try:
+            response.close()
+        except (OSError, http.client.HTTPException):
+            pass
 
 
-def extract_release_archive(
+def _prescan_release_archive(archive_path: Path) -> None:
+    """Bound raw tar expansion and reject metadata parsed eagerly by tarfile."""
+
+    consumed = 0
+    members = 0
+    try:
+        with gzip.open(archive_path, "rb") as stream:
+            while True:
+                header = stream.read(tarfile.BLOCKSIZE)
+                consumed += len(header)
+                if consumed > MAX_RELEASE_TAR_BYTES:
+                    raise WorkspaceError("released sound archive exceeds the extraction limit")
+                if not header:
+                    raise WorkspaceError("released sound archive is truncated")
+                if len(header) != tarfile.BLOCKSIZE:
+                    raise WorkspaceError("released sound archive has a truncated header")
+                if header == tarfile.NUL * tarfile.BLOCKSIZE:
+                    trailer = stream.read(tarfile.BLOCKSIZE)
+                    consumed += len(trailer)
+                    if trailer != tarfile.NUL * tarfile.BLOCKSIZE:
+                        raise WorkspaceError("released sound archive has an invalid trailer")
+                    while chunk := stream.read(1024 * 1024):
+                        consumed += len(chunk)
+                        if consumed > MAX_RELEASE_TAR_BYTES or any(chunk):
+                            raise WorkspaceError("released sound archive has invalid trailing data")
+                    return
+                try:
+                    member = tarfile.TarInfo.frombuf(
+                        header, encoding="utf-8", errors="surrogateescape"
+                    )
+                except tarfile.HeaderError as error:
+                    raise WorkspaceError("released sound archive header is invalid") from error
+                members += 1
+                if members > MAX_RELEASE_MEMBERS:
+                    raise WorkspaceError("released sound archive member count is invalid")
+                if member.type in {
+                    tarfile.XHDTYPE,
+                    tarfile.XGLTYPE,
+                    tarfile.GNUTYPE_LONGNAME,
+                    tarfile.GNUTYPE_LONGLINK,
+                } and member.size > MAX_RELEASE_METADATA_BYTES:
+                    raise WorkspaceError(
+                        "released sound archive extended metadata exceeds the size limit"
+                    )
+                if member.size < 0 or member.size > MAX_RELEASE_MEMBER_BYTES:
+                    raise WorkspaceError("released sound archive member exceeds the size limit")
+                padded = (member.size + tarfile.BLOCKSIZE - 1) // tarfile.BLOCKSIZE
+                remaining = padded * tarfile.BLOCKSIZE
+                consumed += remaining
+                if consumed > MAX_RELEASE_TAR_BYTES:
+                    raise WorkspaceError("released sound archive exceeds the extraction limit")
+                while remaining:
+                    chunk = stream.read(min(1024 * 1024, remaining))
+                    if not chunk:
+                        raise WorkspaceError("released sound archive member is truncated")
+                    remaining -= len(chunk)
+    except WorkspaceError:
+        raise
+    except (OSError, EOFError, gzip.BadGzipFile) as error:
+        raise WorkspaceError("released sound archive is invalid or corrupt") from error
+
+
+def _extract_release_archive(
     archive_path: Path, destination: Path, coordinates: dict[str, Any]
 ) -> Path:
     """Safely extract a bounded single-prefix release archive."""
 
     expected = validate_release_coordinates(coordinates)
+    _prescan_release_archive(archive_path)
     if destination.exists() or destination.is_symlink():
         raise WorkspaceError("released sound extraction destination already exists")
     _archive_hash, archive_size, _archive_prefix = _hash_regular(
@@ -319,6 +405,7 @@ def extract_release_archive(
                 path.is_absolute()
                 or not path.parts
                 or any(part in {"", ".", ".."} for part in path.parts)
+                or "\\" in member.name
                 or member.name.endswith("/") and not member.isdir()
             ):
                 raise WorkspaceError("released sound archive contains an unsafe path")
@@ -397,6 +484,19 @@ def extract_release_archive(
             shutil.rmtree(destination, ignore_errors=True)
             raise
     return destination
+
+
+def extract_release_archive(
+    archive_path: Path, destination: Path, coordinates: dict[str, Any]
+) -> Path:
+    """Extract a verified release archive with privacy-safe failure diagnostics."""
+
+    try:
+        return _extract_release_archive(archive_path, destination, coordinates)
+    except WorkspaceError:
+        raise
+    except (OSError, EOFError, tarfile.TarError) as error:
+        raise WorkspaceError("released sound archive is invalid or corrupt") from error
 
 
 def source_record(source: Path) -> dict[str, Any]:
@@ -479,8 +579,11 @@ def verify_playtest_tree(
         raise WorkspaceError(f"local-playtest sound root is not a regular directory: {root}")
     manifest_payload = _read_regular(root / PLAYTEST_MANIFEST, "playtest manifest")
     try:
-        manifest_value = json.loads(manifest_payload)
-    except json.JSONDecodeError as error:
+        manifest_value = json.loads(
+            manifest_payload,
+            parse_constant=lambda value: (_ for _ in ()).throw(ValueError(value)),
+        )
+    except (json.JSONDecodeError, ValueError) as error:
         raise WorkspaceError("local-playtest manifest is invalid JSON") from error
     if manifest_payload != _canonical_json(manifest_value):
         raise WorkspaceError("local-playtest manifest is not canonical JSON")
@@ -773,7 +876,11 @@ def _safe_release_path(value: object, description: str) -> str:
 
 
 def _release_checksums(root: Path) -> dict[str, str]:
-    payload = _read_regular(root / RELEASE_CHECKSUMS, "released sound checksums")
+    payload = _read_regular(
+        root / RELEASE_CHECKSUMS,
+        "released sound checksums",
+        maximum_bytes=MAX_RELEASE_CHECKSUM_BYTES,
+    )
     try:
         text = payload.decode("ascii")
     except UnicodeDecodeError as error:
@@ -808,7 +915,9 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
     if root.is_symlink() or not root.is_dir():
         raise WorkspaceError(f"released sound root is not a regular directory: {root}")
     manifest_payload = _read_regular(
-        root / RELEASE_MANIFEST, "released sound manifest"
+        root / RELEASE_MANIFEST,
+        "released sound manifest",
+        maximum_bytes=MAX_RELEASE_MANIFEST_BYTES,
     )
     if _hash_bytes(manifest_payload) != expected["release_manifest_sha256"]:
         raise WorkspaceError("released sound manifest hash does not match the profile")
@@ -866,7 +975,11 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
         )
     ):
         raise WorkspaceError("released sound manifest identity does not match the profile")
-    marker_payload = _read_regular(root / RELEASE_MARKER, "released sound marker")
+    marker_payload = _read_regular(
+        root / RELEASE_MARKER,
+        "released sound marker",
+        maximum_bytes=MAX_RELEASE_MARKER_BYTES,
+    )
     expected_marker = _canonical_json(
         {
             "format": RELEASE_PRODUCT,
@@ -884,8 +997,33 @@ def verify_release_tree(root: Path, coordinates: dict[str, Any]) -> dict[str, An
     schema_hash, _schema_size, _schema_prefix = _hash_regular(
         root / RELEASE_SCHEMA, "released sound packaged schema"
     )
+    if _schema_size > MAX_RELEASE_SCHEMA_BYTES:
+        raise WorkspaceError("released sound packaged schema exceeds its size limit")
     if schema_hash != expected["schema_sha256"]:
         raise WorkspaceError("released sound packaged schema is missing or tampered")
+    schema_payload = _read_regular(
+        root / RELEASE_SCHEMA,
+        "released sound packaged schema",
+        maximum_bytes=MAX_RELEASE_SCHEMA_BYTES,
+    )
+    try:
+        schema = json.loads(
+            schema_payload,
+            parse_constant=lambda value: (_ for _ in ()).throw(ValueError(value)),
+        )
+    except (json.JSONDecodeError, ValueError) as error:
+        raise WorkspaceError("released sound packaged schema is invalid JSON") from error
+    if (
+        not isinstance(schema, dict)
+        or schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema"
+        or schema.get("$id") != f"https://atrinik.org/{RELEASE_SCHEMA}"
+        or schema.get("type") != "object"
+        or schema.get("additionalProperties") is not False
+        or set(schema.get("required", [])) != manifest_keys
+        or not isinstance(schema.get("properties"), dict)
+        or set(schema["properties"]) != manifest_keys
+    ):
+        raise WorkspaceError("released sound packaged schema contract is invalid")
 
     notices = manifest.get("notices")
     if not isinstance(notices, list) or not notices:

--- a/atrinik_workspace/supply_chain.py
+++ b/atrinik_workspace/supply_chain.py
@@ -17,6 +17,7 @@ from .model import (
     load_json,
     require_keys,
 )
+from .sound import validate_release_coordinates
 
 
 SCHEMA_VERSION = 3
@@ -601,6 +602,7 @@ class Inventory:
         format_name: str,
         component_commits: dict[str, str | None] | None = None,
         selected_stack: str | None = None,
+        sound_release: dict[str, Any] | None = None,
     ) -> str:
         if selected_stack is not None and not any(
             selected_stack in repository.stacks for repository in self.repositories
@@ -611,17 +613,22 @@ class Inventory:
         resolved_commits = self._resolved_first_party_commits(
             component_commits, selected_stack
         )
+        release = (
+            validate_release_coordinates(sound_release)
+            if sound_release is not None
+            else None
+        )
         if format_name == "licenses":
-            return self._license_report(resolved_commits, selected_stack)
+            return self._license_report(resolved_commits, selected_stack, release)
         if format_name == "cyclonedx":
             return json.dumps(
-                self._cyclonedx(resolved_commits, selected_stack),
+                self._cyclonedx(resolved_commits, selected_stack, release),
                 indent=2,
                 sort_keys=True,
             ) + "\n"
         if format_name == "spdx":
             return json.dumps(
-                self._spdx(resolved_commits, selected_stack),
+                self._spdx(resolved_commits, selected_stack, release),
                 indent=2,
                 sort_keys=True,
             ) + "\n"
@@ -677,7 +684,10 @@ class Inventory:
         )
 
     def _license_report(
-        self, commits: dict[str, str | None], selected_stack: str | None
+        self,
+        commits: dict[str, str | None],
+        selected_stack: str | None,
+        sound_release: dict[str, Any] | None,
     ) -> str:
         lines = [
             "# Atrinik component, dependency, and provenance report",
@@ -715,6 +725,22 @@ class Inventory:
             lines.append(
                 f"| {dependency.name} | {dependency.version} | {dependency.license} | "
                 f"{dependency.owner} | {dependency.disposition} | {dependency.source_url} |"
+            )
+        if sound_release is not None:
+            lines.extend(
+                [
+                    "",
+                    "## Profile-selected released sound runtime",
+                    "",
+                    "| Product | Version | Repository | Tag | Source commit | Source tree | Archive SHA-256 | Logical tree SHA-256 | Asset |",
+                    "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+                    f"| {sound_release['product']} | {sound_release['product_version']} | "
+                    f"{sound_release['repository']} | {sound_release['tag']} | "
+                    f"{sound_release['source_commit']} | {sound_release['source_tree']} | "
+                    f"{sound_release['archive_sha256']} | "
+                    f"{sound_release['output_tree_sha256']} | "
+                    f"{sound_release['asset_url']} |",
+                ]
             )
         return "\n".join(lines) + "\n"
 
@@ -758,7 +784,10 @@ class Inventory:
         ]
 
     def _cyclonedx(
-        self, commits: dict[str, str | None], selected_stack: str | None
+        self,
+        commits: dict[str, str | None],
+        selected_stack: str | None,
+        sound_release: dict[str, Any] | None,
     ) -> dict[str, Any]:
         components: list[dict[str, Any]] = []
         for repository in self._first_party_repositories():
@@ -820,6 +849,32 @@ class Inventory:
                     {"alg": "SHA-256", "content": dependency.checksum.removeprefix("sha256:")}
                 ]
             components.append(component)
+        if sound_release is not None:
+            components.append(
+                {
+                    "type": "file",
+                    "bom-ref": f"atrinik:sound-release:{sound_release['archive_sha256']}",
+                    "name": sound_release["product"],
+                    "version": sound_release["product_version"],
+                    "hashes": [
+                        {"alg": "SHA-256", "content": sound_release["archive_sha256"]}
+                    ],
+                    "externalReferences": [
+                        {"type": "distribution", "url": sound_release["asset_url"]},
+                        {
+                            "type": "vcs",
+                            "url": (
+                                f"https://github.com/{sound_release['repository']}/commit/"
+                                f"{sound_release['source_commit']}"
+                            ),
+                        },
+                    ],
+                    "properties": [
+                        {"name": f"atrinik:sound:{key}", "value": str(value)}
+                        for key, value in sorted(sound_release.items())
+                    ],
+                }
+            )
         return {
             "bomFormat": "CycloneDX",
             "specVersion": "1.6",
@@ -829,7 +884,10 @@ class Inventory:
         }
 
     def _spdx(
-        self, commits: dict[str, str | None], selected_stack: str | None
+        self,
+        commits: dict[str, str | None],
+        selected_stack: str | None,
+        sound_release: dict[str, Any] | None,
     ) -> dict[str, Any]:
         packages: list[dict[str, Any]] = []
         relationships: list[dict[str, str]] = []
@@ -926,6 +984,47 @@ class Inventory:
                     ),
                     "name": dependency.license,
                 }
+        if sound_release is not None:
+            suffix = sound_release["archive_sha256"][:16]
+            spdx_id = f"SPDXRef-SoundRelease-{suffix}"
+            packages.append(
+                {
+                    "SPDXID": spdx_id,
+                    "name": sound_release["product"],
+                    "versionInfo": sound_release["product_version"],
+                    "downloadLocation": sound_release["asset_url"],
+                    "filesAnalyzed": False,
+                    "checksums": [
+                        {
+                            "algorithm": "SHA256",
+                            "checksumValue": sound_release["archive_sha256"],
+                        }
+                    ],
+                    "licenseConcluded": "NOASSERTION",
+                    "licenseDeclared": "NOASSERTION",
+                    "supplier": "Organization: Atrinik",
+                    "externalRefs": [
+                        {
+                            "referenceCategory": "OTHER",
+                            "referenceType": "atrinik-released-sound-coordinates",
+                            "referenceLocator": json.dumps(
+                                sound_release, sort_keys=True, separators=(",", ":")
+                            ),
+                        }
+                    ],
+                    "packageComment": (
+                        "Profile-selected publishable Classic runtime; logical tree "
+                        f"SHA-256: {sound_release['output_tree_sha256']}."
+                    ),
+                }
+            )
+            relationships.append(
+                {
+                    "spdxElementId": "SPDXRef-DOCUMENT",
+                    "relationshipType": "DESCRIBES",
+                    "relatedSpdxElement": spdx_id,
+                }
+            )
         document = {
             "spdxVersion": "SPDX-2.3",
             "dataLicense": "CC0-1.0",

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -59,6 +59,9 @@ from .migration import (
 )
 from .supervisor import process_matches
 from .sound import (
+    EXPECTED_CONVERTED_OPUS,
+    EXPECTED_COPIED_VORBIS,
+    EXPECTED_PATHS,
     PLAYTEST_MODE,
     RELEASED_MODE,
     RELEASE_PRODUCT,
@@ -2648,18 +2651,21 @@ class Workspace:
                 f"profile {profile_name} has unsupported sound mode {mode}"
             )
         if mode == RELEASED_MODE:
-            coordinates = validate_release_coordinates(profile["sound_release"])
-            identity = (
-                f"{coordinates['repository']} {coordinates['tag']} "
-                f"commit {coordinates['source_commit']} tree {coordinates['source_tree']} "
-                f"archive sha256 {coordinates['archive_sha256']}"
-            )
-            runtime = root / "runtime"
-            archive_path = runtime / (
-                f"sound-released-{release_cache_key(coordinates)}.tar.gz"
-            )
-            staged = runtime / "sound-released"
+            identity = "invalid or incomplete"
             try:
+                coordinates = validate_release_coordinates(profile["sound_release"])
+                identity = json.dumps(
+                    coordinates, sort_keys=True, separators=(",", ":")
+                )
+                contract = (
+                    f"product={RELEASE_PRODUCT}; paths={EXPECTED_PATHS}; "
+                    f"vorbis={EXPECTED_COPIED_VORBIS}; opus={EXPECTED_CONVERTED_OPUS}"
+                )
+                runtime = root / "runtime"
+                archive_path = runtime / (
+                    f"sound-released-{release_cache_key(coordinates)}.tar.gz"
+                )
+                staged = runtime / "sound-released"
                 if runtime.exists() or runtime.is_symlink():
                     if runtime.is_symlink() or not runtime.is_dir():
                         raise WorkspaceError(
@@ -2739,7 +2745,8 @@ class Workspace:
             except (OSError, WorkspaceError) as error:
                 raise WorkspaceError(
                     f"profile {profile_name} mode {mode} coordinates ({identity}) "
-                    f"failed contract: {error}"
+                    f"expected contract ({contract if 'contract' in locals() else RELEASE_PRODUCT}) "
+                    f"failed check: {error}"
                 ) from error
             print(
                 "sound: staged released tree "

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -60,20 +60,33 @@ from .migration import (
 from .supervisor import process_matches
 from .sound import (
     PLAYTEST_MODE,
+    RELEASED_MODE,
+    RELEASE_PRODUCT,
     SOUND_MODES,
     SOURCE_MODE,
     cache_key as sound_cache_key,
     clean_source_inputs,
+    download_release_archive,
+    extract_release_archive,
+    release_cache_key,
     source_record as sound_source_record,
+    validate_release_coordinates,
     validate_sound_record,
     verify_playtest_tree,
+    verify_release_archive,
+    verify_release_tree,
 )
 
 
-PROFILE_SCHEMA_VERSION = 4
-LEGACY_PROFILE_SCHEMA_VERSION = 3
-PROFILE_KEYS = {"schema_version", "name", "stack", "components", "sound_mode"}
-LEGACY_PROFILE_KEYS = {"schema_version", "name", "stack", "components"}
+PROFILE_SCHEMA_VERSION = 5
+LEGACY_PROFILE_SCHEMA_VERSION = 4
+OLDEST_PROFILE_SCHEMA_VERSION = 3
+PROFILE_KEYS = {
+    "schema_version", "name", "stack", "components", "sound_mode",
+    "sound_release",
+}
+LEGACY_PROFILE_KEYS = {"schema_version", "name", "stack", "components", "sound_mode"}
+OLDEST_PROFILE_KEYS = {"schema_version", "name", "stack", "components"}
 SELECTOR_KEYS = {"kind", "value"}
 EXPECTED_SERVER_DATA = {
     "files": ("bans", "motd"),
@@ -1892,6 +1905,11 @@ class Workspace:
             "name": name,
             "stack": source_profile["stack"],
             "sound_mode": source_profile["sound_mode"],
+            "sound_release": (
+                dict(source_profile["sound_release"])
+                if source_profile["sound_release"] is not None
+                else None
+            ),
             "components": {
                 component_name: dict(selector)
                 for component_name, selector in source_profile["components"].items()
@@ -1941,7 +1959,12 @@ class Workspace:
             profile["components"][component.name] = {"kind": kind, "value": value}
         atomic_json(self.paths.profiles / f"{name}.json", profile)
 
-    def set_profile_sound_mode(self, name: str, mode: str) -> None:
+    def set_profile_sound_mode(
+        self,
+        name: str,
+        mode: str,
+        release_coordinates: dict[str, Any] | None = None,
+    ) -> None:
         self.paths.ensure()
         with exclusive_lock(
             self.paths.workspace / "repository-layout.lock",
@@ -1954,12 +1977,25 @@ class Workspace:
             profile = self._load_profile(name, require_file=True)
             if profile["stack"] != "classic":
                 raise WorkspaceError(
-                    "local-playtest sound mode is available only to Classic-derived profiles"
+                    "non-source sound modes are available only to Classic-derived profiles"
                 )
             if mode not in SOUND_MODES:
                 raise WorkspaceError(f"invalid profile sound mode: {mode}")
+            if mode == RELEASED_MODE:
+                if release_coordinates is None:
+                    raise WorkspaceError(
+                        "released sound mode requires complete immutable release coordinates"
+                    )
+                release_coordinates = dict(
+                    validate_release_coordinates(release_coordinates)
+                )
+            elif release_coordinates is not None:
+                raise WorkspaceError(
+                    f"profile sound mode {mode} does not accept release coordinates"
+                )
             profile["schema_version"] = PROFILE_SCHEMA_VERSION
             profile["sound_mode"] = mode
+            profile["sound_release"] = release_coordinates
             atomic_json(self.paths.profiles / f"{name}.json", profile)
 
     def _profile_components(
@@ -2170,6 +2206,7 @@ class Workspace:
                 "name": name,
                 "stack": name,
                 "sound_mode": SOURCE_MODE,
+                "sound_release": None,
                 "components": {
                     component.name: {"kind": "primary", "value": ""}
                     for component in stack.components
@@ -2182,9 +2219,21 @@ class Workspace:
         if not isinstance(profile, dict):
             raise WorkspaceError(f"profile must be an object: {name}")
         schema_version = profile.get("schema_version")
-        if schema_version == LEGACY_PROFILE_SCHEMA_VERSION:
+        if schema_version == OLDEST_PROFILE_SCHEMA_VERSION:
+            require_keys(profile, OLDEST_PROFILE_KEYS, f"profile {name}")
+            profile = {
+                **profile,
+                "schema_version": PROFILE_SCHEMA_VERSION,
+                "sound_mode": SOURCE_MODE,
+                "sound_release": None,
+            }
+        elif schema_version == LEGACY_PROFILE_SCHEMA_VERSION:
             require_keys(profile, LEGACY_PROFILE_KEYS, f"profile {name}")
-            profile = {**profile, "schema_version": PROFILE_SCHEMA_VERSION, "sound_mode": SOURCE_MODE}
+            profile = {
+                **profile,
+                "schema_version": PROFILE_SCHEMA_VERSION,
+                "sound_release": None,
+            }
         else:
             require_keys(profile, PROFILE_KEYS, f"profile {name}")
         if profile["schema_version"] != PROFILE_SCHEMA_VERSION or profile["name"] != name:
@@ -2194,9 +2243,20 @@ class Workspace:
         stack_name = profile["stack"]
         if not isinstance(stack_name, str) or stack_name not in self.manifest.stacks:
             raise WorkspaceError(f"profile stack is invalid: {name}")
-        if profile["sound_mode"] == PLAYTEST_MODE and stack_name != "classic":
+        if profile["sound_mode"] != SOURCE_MODE and stack_name != "classic":
             raise WorkspaceError(
-                f"local-playtest sound mode requires a Classic-derived profile: {name}"
+                f"non-source sound mode requires a Classic-derived profile: {name}"
+            )
+        if profile["sound_mode"] == RELEASED_MODE:
+            try:
+                validate_release_coordinates(profile["sound_release"])
+            except WorkspaceError as error:
+                raise WorkspaceError(
+                    f"profile released sound coordinates are invalid: {name}: {error}"
+                ) from error
+        elif profile["sound_release"] is not None:
+            raise WorkspaceError(
+                f"profile sound release must be null outside released mode: {name}"
             )
         stack = self.manifest.stack(stack_name)
         selectors = profile["components"]
@@ -2296,6 +2356,7 @@ class Workspace:
             "name": name,
             "stack": stack.name,
             "sound_mode": profile["sound_mode"],
+            "sound_release": profile["sound_release"],
             "components": rows,
         }
 
@@ -2582,7 +2643,110 @@ class Workspace:
         mode = profile["sound_mode"]
         if mode == SOURCE_MODE:
             return source, sound_source_record(source)
-        if mode != PLAYTEST_MODE or profile["stack"] != "classic":
+        if profile["stack"] != "classic":
+            raise WorkspaceError(
+                f"profile {profile_name} has unsupported sound mode {mode}"
+            )
+        if mode == RELEASED_MODE:
+            coordinates = validate_release_coordinates(profile["sound_release"])
+            identity = (
+                f"{coordinates['repository']} {coordinates['tag']} "
+                f"commit {coordinates['source_commit']} tree {coordinates['source_tree']} "
+                f"archive sha256 {coordinates['archive_sha256']}"
+            )
+            runtime = root / "runtime"
+            archive_path = runtime / (
+                f"sound-released-{release_cache_key(coordinates)}.tar.gz"
+            )
+            staged = runtime / "sound-released"
+            try:
+                if runtime.exists() or runtime.is_symlink():
+                    if runtime.is_symlink() or not runtime.is_dir():
+                        raise WorkspaceError(
+                            "released sound handoff parent is not a safe directory"
+                        )
+                else:
+                    runtime.mkdir()
+                try:
+                    if runtime.resolve() != root.resolve() / "runtime":
+                        raise WorkspaceError(
+                            "released sound handoff parent escapes the profile build"
+                        )
+                except RuntimeError as error:
+                    raise WorkspaceError(
+                        "released sound handoff parent cannot be resolved"
+                    ) from error
+                archive_present = archive_path.exists() or archive_path.is_symlink()
+                tree_present = staged.exists() or staged.is_symlink()
+                if tree_present and not archive_present:
+                    raise WorkspaceError(
+                        "released sound cache lacks its verified archive; "
+                        "use preview-first build cleanup"
+                    )
+                if archive_present:
+                    verify_release_archive(
+                        archive_path, coordinates, "cached released sound archive"
+                    )
+                    if not tree_present:
+                        with tempfile.TemporaryDirectory(
+                            prefix=".sound-released-recovery-", dir=runtime
+                        ) as temporary:
+                            candidate_tree = Path(temporary) / "tree"
+                            extract_release_archive(
+                                archive_path, candidate_tree, coordinates
+                            )
+                            verify_release_tree(candidate_tree, coordinates)
+                            rename_no_replace(candidate_tree, staged)
+                    record = verify_release_tree(staged, coordinates)
+                else:
+                    with tempfile.TemporaryDirectory(
+                        prefix=".sound-released-", dir=runtime
+                    ) as temporary:
+                        temporary_root = Path(temporary)
+                        candidate_archive = temporary_root / "archive.tar.gz"
+                        candidate_tree = temporary_root / "tree"
+                        download_release_archive(
+                            coordinates["asset_url"], candidate_archive
+                        )
+                        verify_release_archive(
+                            candidate_archive,
+                            coordinates,
+                            "downloaded released sound archive",
+                        )
+                        extract_release_archive(
+                            candidate_archive, candidate_tree, coordinates
+                        )
+                        candidate_record = verify_release_tree(
+                            candidate_tree, coordinates
+                        )
+                        rename_no_replace(candidate_archive, archive_path)
+                        try:
+                            rename_no_replace(candidate_tree, staged)
+                        except BaseException:
+                            archive_path.unlink(missing_ok=True)
+                            raise
+                    record = verify_release_tree(staged, coordinates)
+                    if {
+                        **record,
+                        "root": "<verified-root>",
+                    } != {
+                        **candidate_record,
+                        "root": "<verified-root>",
+                    }:
+                        raise WorkspaceError(
+                            "installed released sound handoff differs from verified download"
+                        )
+            except (OSError, WorkspaceError) as error:
+                raise WorkspaceError(
+                    f"profile {profile_name} mode {mode} coordinates ({identity}) "
+                    f"failed contract: {error}"
+                ) from error
+            print(
+                "sound: staged released tree "
+                f"{record['output_tree_sha256']} for {coordinates['tag']}"
+            )
+            return staged, record
+        if mode != PLAYTEST_MODE:
             raise WorkspaceError(
                 f"profile {profile_name} has unsupported sound mode {mode}"
             )
@@ -2732,6 +2896,8 @@ class Workspace:
         namespace = (
             f"profile-schema:{PROFILE_SCHEMA_VERSION};stack:{stack.name};"
             f"generation:{stack.generation};sound-mode:{profile['sound_mode']};"
+            "sound-release:"
+            f"{json.dumps(profile['sound_release'], sort_keys=True, separators=(',', ':'))};"
             f"providers:{providers}"
         )
         return profile_key(selected, namespace=namespace)
@@ -6423,6 +6589,7 @@ class Workspace:
             "stack": stack.name,
             "sound": {
                 "mode": profile["sound_mode"],
+                "release": profile["sound_release"],
                 "source_path": str(resolved["sound"])
                 if "sound" in resolved
                 else None,
@@ -7625,6 +7792,16 @@ class Workspace:
                             raise WorkspaceError(
                                 f"profile {profile_name} local-playtest sound "
                                 "record changed before topology preparation"
+                            )
+                    elif validated_sound["mode"] == RELEASED_MODE:
+                        coordinates = validate_release_coordinates(
+                            profile["sound_release"]
+                        )
+                        verified = verify_release_tree(sound_root, coordinates)
+                        if verified != validated_sound:
+                            raise WorkspaceError(
+                                f"profile {profile_name} released sound record "
+                                "changed before topology preparation"
                             )
                     elif sound_root.resolve() != selected["sound"].resolve():
                         raise WorkspaceError(

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -5166,6 +5166,59 @@ class Workspace:
                 root_fd = os.open(root, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
                 runtime_fd: int | None = None
                 try:
+                    root_identity = os.fstat(root_fd)
+
+                    @contextmanager
+                    def pinned_temporary(prefix: str) -> Iterator[Path]:
+                        created = Path(
+                            tempfile.mkdtemp(
+                                prefix=prefix, dir=f"/proc/self/fd/{runtime_fd}"
+                            )
+                        )
+                        name = created.name
+                        descriptor = os.open(
+                            name,
+                            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                            dir_fd=runtime_fd,
+                        )
+                        identity = os.fstat(descriptor)
+                        mount_id = _descriptor_mount_id(descriptor)
+                        try:
+                            yield Path(f"/proc/self/fd/{descriptor}")
+                        finally:
+                            try:
+                                _prepare_owned_tree_removal(
+                                    descriptor,
+                                    identity.st_dev,
+                                    mount_id,
+                                    created,
+                                    stat.S_IMODE(identity.st_mode),
+                                    reject_links=True,
+                                )
+                                _remove_owned_tree_contents(
+                                    descriptor,
+                                    identity.st_dev,
+                                    mount_id,
+                                    created,
+                                    reject_links=True,
+                                )
+                                visible = os.stat(
+                                    name,
+                                    dir_fd=runtime_fd,
+                                    follow_symlinks=False,
+                                )
+                                if (
+                                    not stat.S_ISDIR(visible.st_mode)
+                                    or (visible.st_dev, visible.st_ino)
+                                    != (identity.st_dev, identity.st_ino)
+                                ):
+                                    raise WorkspaceError(
+                                        "released sound temporary directory changed"
+                                    )
+                                os.rmdir(name, dir_fd=runtime_fd)
+                            finally:
+                                os.close(descriptor)
+
                     try:
                         os.mkdir("runtime", dir_fd=root_fd)
                     except FileExistsError:
@@ -5194,10 +5247,10 @@ class Workspace:
                             archive_path, coordinates, "cached released sound archive"
                         )
                         if not tree_present:
-                            with tempfile.TemporaryDirectory(
-                                prefix=".sound-released-recovery-", dir=runtime
+                            with pinned_temporary(
+                                ".sound-released-recovery-"
                             ) as temporary:
-                                candidate_tree = Path(temporary) / "tree"
+                                candidate_tree = temporary / "tree"
                                 extract_release_archive(
                                     archive_path, candidate_tree, coordinates
                                 )
@@ -5205,10 +5258,7 @@ class Workspace:
                                 rename_no_replace(candidate_tree, staged)
                         record = verify_release_tree(staged, coordinates)
                     else:
-                        with tempfile.TemporaryDirectory(
-                            prefix=".sound-released-", dir=runtime
-                        ) as temporary:
-                            temporary_root = Path(temporary)
+                        with pinned_temporary(".sound-released-") as temporary_root:
                             candidate_archive = temporary_root / "archive.tar.gz"
                             candidate_tree = temporary_root / "tree"
                             download_release_archive(
@@ -5252,6 +5302,15 @@ class Workspace:
                     ):
                         raise WorkspaceError(
                             "released sound handoff parent changed during publication"
+                        )
+                    visible_root = os.stat(root, follow_symlinks=False)
+                    if (
+                        not stat.S_ISDIR(visible_root.st_mode)
+                        or (visible_root.st_dev, visible_root.st_ino)
+                        != (root_identity.st_dev, root_identity.st_ino)
+                    ):
+                        raise WorkspaceError(
+                            "profile build root changed during released sound publication"
                         )
                     staged = root / "runtime" / "sound-released"
                     record["root"] = str(staged)

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -5163,87 +5163,102 @@ class Workspace:
                     f"midi-sources={EXPECTED_SOURCE_MIDI}; "
                     f"flac-sources={EXPECTED_SOURCE_FLAC}"
                 )
-                runtime = root / "runtime"
-                archive_path = runtime / (
-                    f"sound-released-{release_cache_key(coordinates)}.tar.gz"
-                )
-                staged = runtime / "sound-released"
-                if runtime.exists() or runtime.is_symlink():
-                    if runtime.is_symlink() or not runtime.is_dir():
-                        raise WorkspaceError(
-                            "released sound handoff parent is not a safe directory"
-                        )
-                else:
-                    runtime.mkdir()
+                root_fd = os.open(root, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+                runtime_fd: int | None = None
                 try:
-                    if runtime.resolve() != root.resolve() / "runtime":
+                    try:
+                        os.mkdir("runtime", dir_fd=root_fd)
+                    except FileExistsError:
+                        pass
+                    runtime_fd = os.open(
+                        "runtime",
+                        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                        dir_fd=root_fd,
+                    )
+                    runtime_identity = os.fstat(runtime_fd)
+                    runtime = Path(f"/proc/self/fd/{runtime_fd}")
+                    archive_name = (
+                        f"sound-released-{release_cache_key(coordinates)}.tar.gz"
+                    )
+                    archive_path = runtime / archive_name
+                    staged = runtime / "sound-released"
+                    archive_present = archive_path.exists() or archive_path.is_symlink()
+                    tree_present = staged.exists() or staged.is_symlink()
+                    if tree_present and not archive_present:
                         raise WorkspaceError(
-                            "released sound handoff parent escapes the profile build"
+                            "released sound cache lacks its verified archive; "
+                            "use preview-first build cleanup"
                         )
-                except RuntimeError as error:
-                    raise WorkspaceError(
-                        "released sound handoff parent cannot be resolved"
-                    ) from error
-                archive_present = archive_path.exists() or archive_path.is_symlink()
-                tree_present = staged.exists() or staged.is_symlink()
-                if tree_present and not archive_present:
-                    raise WorkspaceError(
-                        "released sound cache lacks its verified archive; "
-                        "use preview-first build cleanup"
-                    )
-                if archive_present:
-                    verify_release_archive(
-                        archive_path, coordinates, "cached released sound archive"
-                    )
-                    if not tree_present:
-                        with tempfile.TemporaryDirectory(
-                            prefix=".sound-released-recovery-", dir=runtime
-                        ) as temporary:
-                            candidate_tree = Path(temporary) / "tree"
-                            extract_release_archive(
-                                archive_path, candidate_tree, coordinates
-                            )
-                            verify_release_tree(candidate_tree, coordinates)
-                            rename_no_replace(candidate_tree, staged)
-                    record = verify_release_tree(staged, coordinates)
-                else:
-                    with tempfile.TemporaryDirectory(
-                        prefix=".sound-released-", dir=runtime
-                    ) as temporary:
-                        temporary_root = Path(temporary)
-                        candidate_archive = temporary_root / "archive.tar.gz"
-                        candidate_tree = temporary_root / "tree"
-                        download_release_archive(
-                            coordinates["asset_url"], candidate_archive
-                        )
+                    if archive_present:
                         verify_release_archive(
-                            candidate_archive,
-                            coordinates,
-                            "downloaded released sound archive",
+                            archive_path, coordinates, "cached released sound archive"
                         )
-                        extract_release_archive(
-                            candidate_archive, candidate_tree, coordinates
-                        )
-                        candidate_record = verify_release_tree(
-                            candidate_tree, coordinates
-                        )
-                        rename_no_replace(candidate_archive, archive_path)
-                        try:
-                            rename_no_replace(candidate_tree, staged)
-                        except BaseException:
-                            archive_path.unlink(missing_ok=True)
-                            raise
-                    record = verify_release_tree(staged, coordinates)
-                    if {
-                        **record,
-                        "root": "<verified-root>",
-                    } != {
-                        **candidate_record,
-                        "root": "<verified-root>",
-                    }:
+                        if not tree_present:
+                            with tempfile.TemporaryDirectory(
+                                prefix=".sound-released-recovery-", dir=runtime
+                            ) as temporary:
+                                candidate_tree = Path(temporary) / "tree"
+                                extract_release_archive(
+                                    archive_path, candidate_tree, coordinates
+                                )
+                                verify_release_tree(candidate_tree, coordinates)
+                                rename_no_replace(candidate_tree, staged)
+                        record = verify_release_tree(staged, coordinates)
+                    else:
+                        with tempfile.TemporaryDirectory(
+                            prefix=".sound-released-", dir=runtime
+                        ) as temporary:
+                            temporary_root = Path(temporary)
+                            candidate_archive = temporary_root / "archive.tar.gz"
+                            candidate_tree = temporary_root / "tree"
+                            download_release_archive(
+                                coordinates["asset_url"], candidate_archive
+                            )
+                            verify_release_archive(
+                                candidate_archive,
+                                coordinates,
+                                "downloaded released sound archive",
+                            )
+                            extract_release_archive(
+                                candidate_archive, candidate_tree, coordinates
+                            )
+                            candidate_record = verify_release_tree(
+                                candidate_tree, coordinates
+                            )
+                            rename_no_replace(candidate_archive, archive_path)
+                            try:
+                                rename_no_replace(candidate_tree, staged)
+                            except BaseException:
+                                archive_path.unlink(missing_ok=True)
+                                raise
+                        record = verify_release_tree(staged, coordinates)
+                        if {
+                            **record,
+                            "root": "<verified-root>",
+                        } != {
+                            **candidate_record,
+                            "root": "<verified-root>",
+                        }:
+                            raise WorkspaceError(
+                                "installed released sound handoff differs from verified download"
+                            )
+                    current_runtime = os.stat(
+                        "runtime", dir_fd=root_fd, follow_symlinks=False
+                    )
+                    if (
+                        not stat.S_ISDIR(current_runtime.st_mode)
+                        or (current_runtime.st_dev, current_runtime.st_ino)
+                        != (runtime_identity.st_dev, runtime_identity.st_ino)
+                    ):
                         raise WorkspaceError(
-                            "installed released sound handoff differs from verified download"
+                            "released sound handoff parent changed during publication"
                         )
+                    staged = root / "runtime" / "sound-released"
+                    record["root"] = str(staged)
+                finally:
+                    if runtime_fd is not None:
+                        os.close(runtime_fd)
+                    os.close(root_fd)
             except (OSError, WorkspaceError) as error:
                 raise WorkspaceError(
                     f"profile {profile_name} mode {mode} coordinates ({identity}) "

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -62,6 +62,8 @@ from .sound import (
     EXPECTED_CONVERTED_OPUS,
     EXPECTED_COPIED_VORBIS,
     EXPECTED_PATHS,
+    EXPECTED_SOURCE_FLAC,
+    EXPECTED_SOURCE_MIDI,
     PLAYTEST_MODE,
     RELEASED_MODE,
     RELEASE_PRODUCT,
@@ -2659,7 +2661,9 @@ class Workspace:
                 )
                 contract = (
                     f"product={RELEASE_PRODUCT}; paths={EXPECTED_PATHS}; "
-                    f"vorbis={EXPECTED_COPIED_VORBIS}; opus={EXPECTED_CONVERTED_OPUS}"
+                    f"vorbis={EXPECTED_COPIED_VORBIS}; opus={EXPECTED_CONVERTED_OPUS}; "
+                    f"midi-sources={EXPECTED_SOURCE_MIDI}; "
+                    f"flac-sources={EXPECTED_SOURCE_FLAC}"
                 )
                 runtime = root / "runtime"
                 archive_path = runtime / (

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -12031,6 +12031,7 @@ class Workspace:
         sound_root: Path | None,
     ) -> dict[str, str]:
         directories: dict[str, tuple[Path, set[str]]] = {}
+        files: dict[str, Path] = {}
         if "client" in services:
             directories.update(
                 {
@@ -12069,8 +12070,14 @@ class Workspace:
             if custom.is_file() and not custom.is_symlink():
                 files["server-server-custom.cfg"] = custom
         return {
-            name: _tree_digest(path, exclusions, reject_symlinks=True)
-            for name, (path, exclusions) in sorted(directories.items())
+            **{
+                name: _tree_digest(path, exclusions, reject_symlinks=True)
+                for name, (path, exclusions) in sorted(directories.items())
+            },
+            **{
+                name: _file_digest(path, "runtime publication input")
+                for name, path in sorted(files.items())
+            },
         }
 
     def _publish_runtime_generation(

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -10907,7 +10907,7 @@ class Workspace:
                     except OSError as error:
                         raise WorkspaceError(
                             "topology runtime staging destination changed during "
-                            f"copy: {destination_child}"
+                            f"copy: {destination_child}: {error}"
                         ) from error
                     try:
                         self._copy_topology_runtime_directory(
@@ -10950,7 +10950,7 @@ class Workspace:
                     except OSError as error:
                         raise WorkspaceError(
                             "topology runtime staging destination changed during "
-                            f"copy: {destination_child}"
+                            f"copy: {destination_child}: {error}"
                         ) from error
                     try:
                         with os.fdopen(child_fd, "rb", closefd=False) as source_file:
@@ -11053,7 +11053,7 @@ class Workspace:
             except OSError as error:
                 raise WorkspaceError(
                     "topology runtime staging destination changed during copy: "
-                    f"{destination}"
+                    f"{destination}: {error}"
                 ) from error
             self._copy_topology_runtime_directory(
                 source_fd,
@@ -11965,15 +11965,14 @@ class Workspace:
                         selected["client"],
                         {".git", "build", "sound", MANAGED_MARKER},
                     ),
-                    "client-binary": (
-                        self._classic_binary_directory(build_root, "client"),
-                        set(),
-                    ),
                     "sound": (
                         sound_root or selected["sound"],
                         {".git", "build", MANAGED_MARKER},
                     ),
                 }
+            )
+            files["client-executable"] = (
+                self._classic_binary_directory(build_root, "client") / "atrinik"
             )
         if "server" in services:
             source = selected["server"]
@@ -12067,9 +12066,9 @@ class Workspace:
                     client_runtime / "sound",
                     frozenset({".git", "build", MANAGED_MARKER}),
                 )
-                self._copy_runtime_directory_contents(
-                    self._classic_binary_directory(build_root, "client"),
-                    client_runtime,
+                self._copy_runtime_regular_file(
+                    self._classic_binary_directory(build_root, "client") / "atrinik",
+                    client_runtime / "atrinik",
                 )
             if "server" in services:
                 if state is None:
@@ -15776,6 +15775,13 @@ class Workspace:
                 ):
                     raise WorkspaceError(
                         f"profile {profile_name} local-playtest sound record changed "
+                        "before foreground publication"
+                    )
+            elif validated_sound["mode"] == RELEASED_MODE:
+                coordinates = validate_release_coordinates(profile["sound_release"])
+                if verify_release_tree(sound_root, coordinates) != validated_sound:
+                    raise WorkspaceError(
+                        f"profile {profile_name} released sound record changed "
                         "before foreground publication"
                     )
             elif sound_root.resolve() != selected["sound"].resolve():

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -465,6 +465,9 @@ selected Classic + content + resources ---> offline worldmaker -> region-map cac
 clean selected sound + local-playtest mode -> sound-owned builder/verifier
                                              -> nonpublishing compatibility tree
                                              -> client source view + topology
+immutable sound release + released mode -> bounded download/safe extraction
+                                          -> wrapper verification/cache
+                                          -> client source view + topology
 selected Worker -> keyed npm ci cache -> isolated reconciled view -> npm run check
 ~~~
 
@@ -505,7 +508,7 @@ only tracked regular files below those paths enter the runtime view. This keeps
 repository metadata, local untracked files, and symlinks out of the asset
 protocol.
 
-Sound composition has two explicit profile states. `source` preserves the
+Sound composition has three explicit profile states. `source` preserves the
 historical raw-checkout link. `local-playtest` is accepted only on a saved
 Classic-derived profile and never changes the built-in profile or a replacement
 stack. It invokes the public builder and full-decoder verifier in the clean,
@@ -526,6 +529,26 @@ and topology metadata carry this evidence, and the same verified directory is
 linked into both the client source view and supervised client working tree.
 There is no archive, upload, installer, container-layer, release, or raw-source
 fallback path for this mode.
+
+`released` is likewise limited to a saved Classic-derived profile but is
+independent of the selected sound checkout's working tree. Profile schema 5
+binds repository, tag, product/version, source commit/tree, exact versioned
+GitHub asset URL, outer archive checksum, manifest/source-manifest/schema/
+toolchain hashes, and logical-tree digest. These values participate directly in
+the profile build key. The coordinate-keyed profile build owns the bounded
+download and extracted cache, so ordinary build retention and preview-first
+cleanup cover both without introducing another mutable global cache.
+
+Extraction accepts regular files beneath one exact product/version prefix and
+rejects traversal, absolute, duplicate, case-colliding, linked, special,
+oversized, multi-prefix, source, and playtest archives. Independent verification
+then requires the canonical publishable manifest and marker, internal checksum
+closure, packaged schema, hashed notice set, 339 safe unique legacy paths, 189
+byte-preserved Vorbis payloads, 150 Opus payloads, content-based codec
+signatures, and the complete tree digest. The same verified root enters the
+Classic client source view and supervised client topology. Build and topology
+records persist the coordinates and verifier evidence; old or mismatched
+records remain inert and no released-mode failure can select either other mode.
 
 Each CMake binary tree stores an atomic configure fingerprint covering the
 source-view identity, Ninja generator, CMake and compiler identities, toolchain

--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -2731,6 +2731,38 @@
       ]
     },
     {
+      "id": "source/atrinik-sound-classic-runtime",
+      "name": "Profile-selected Atrinik Classic sound runtime",
+      "kind": "source-archive",
+      "owner": "sound",
+      "scope": [
+        "atrinik",
+        "classic-client"
+      ],
+      "required": false,
+      "version": "profile-selected",
+      "version_source": "Atrinik profile sound_release immutable coordinates",
+      "license": "LicenseRef-Atrinik-Asset-Per-File",
+      "source_url": "https://github.com/atrinik/sound/releases",
+      "locator": "pkg:github/atrinik/sound@profile-selected?product=classic-runtime",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Atrinik wrapper downloads a profile-pinned release asset into a profile-build-owned verified cache",
+      "update_cadence_days": 30,
+      "update_mechanism": "Set reviewed immutable profile coordinates from an atrinik/sound release",
+      "eol_response": "Select a supported publishable runtime release or return the profile to source mode",
+      "validation": "Exact URL and archive checksum, bounded safe extraction, internal checksums, schema and manifest identity, 339-path codec contract, and logical tree checksum",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": "atrinik_workspace/sound.py",
+          "contains": "atrinik-sound-classic-runtime"
+        }
+      ]
+    },
+    {
       "id": "source/atrinik-sound-runtime",
       "name": "Atrinik sound archive",
       "kind": "source-archive",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -619,6 +619,36 @@ class ParserTests(unittest.TestCase):
             "audio-review", "local-playtest"
         )
 
+    def test_profile_released_sound_dispatches_complete_coordinates(self) -> None:
+        sha256 = "a" * 64
+        commit = "b" * 40
+        tree = "c" * 40
+        arguments = [
+            "profile", "sound-mode", "audio-release", "released",
+            "--release-repository", "atrinik/sound",
+            "--release-tag", "v1.4.0",
+            "--release-product-version", "1.4.0",
+            "--release-source-commit", commit,
+            "--release-source-tree", tree,
+            "--release-asset-url",
+            "https://github.com/atrinik/sound/releases/download/v1.4.0/"
+            "atrinik-sound-classic-runtime-1.4.0.tar.gz",
+            "--release-archive-sha256", sha256,
+            "--release-manifest-sha256", sha256,
+            "--release-source-manifest-sha256", sha256,
+            "--release-schema-sha256", sha256,
+            "--release-toolchain-sha256", sha256,
+            "--release-tree-sha256", sha256,
+        ]
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            result = main(arguments)
+
+        self.assertEqual(result, 0)
+        coordinates = workspace_type.return_value.set_profile_sound_mode.call_args.args[2]
+        self.assertEqual(coordinates["product"], "atrinik-sound-classic-runtime")
+        self.assertEqual(coordinates["manifest_schema_version"], 1)
+        self.assertEqual(coordinates["archive_sha256"], sha256)
+
     def test_path_prints_resolved_component_checkout(self) -> None:
         with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
             workspace_type.return_value.component_path.return_value = Path(

--- a/tests/test_cohorts.py
+++ b/tests/test_cohorts.py
@@ -930,6 +930,49 @@ class CohortWorkspaceTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "Classic-derived"):
             self.workspace.profile_summary("replacement-audio")
 
+    def test_released_sound_coordinates_bind_profile_and_build_key(self) -> None:
+        coordinates = {
+            "repository": "atrinik/sound",
+            "tag": "v1.4.0",
+            "product": "atrinik-sound-classic-runtime",
+            "product_version": "1.4.0",
+            "manifest_schema_version": 1,
+            "source_commit": "a" * 40,
+            "source_tree": "b" * 40,
+            "asset_url": (
+                "https://github.com/atrinik/sound/releases/download/v1.4.0/"
+                "atrinik-sound-classic-runtime-1.4.0.tar.gz"
+            ),
+            "archive_sha256": "c" * 64,
+            "release_manifest_sha256": "d" * 64,
+            "source_manifest_sha256": "e" * 64,
+            "schema_sha256": "f" * 64,
+            "toolchain_sha256": "1" * 64,
+            "output_tree_sha256": "2" * 64,
+        }
+        self.workspace.create_profile("classic-release", "classic")
+        selected_root = self.root / "selected-client"
+        selected_root.mkdir()
+        selected = {"client": selected_root}
+        source_key = self.workspace._profile_build_key("classic-release", selected)
+        self.workspace.set_profile_sound_mode(
+            "classic-release", "released", coordinates
+        )
+        summary = self.workspace.profile_summary("classic-release")
+        self.assertEqual(summary["sound_mode"], "released")
+        self.assertEqual(summary["sound_release"], coordinates)
+        released_key = self.workspace._profile_build_key("classic-release", selected)
+        self.assertNotEqual(released_key, source_key)
+
+        changed = {**coordinates, "archive_sha256": "3" * 64}
+        self.workspace.set_profile_sound_mode("classic-release", "released", changed)
+        self.assertNotEqual(
+            self.workspace._profile_build_key("classic-release", selected),
+            released_key,
+        )
+        with self.assertRaisesRegex(WorkspaceError, "complete immutable"):
+            self.workspace.set_profile_sound_mode("classic-release", "released")
+
     def test_local_playtest_staging_invokes_builder_and_rechecks_inputs(self) -> None:
         self.workspace.create_profile("classic-audio", "classic")
         self.workspace.set_profile_sound_mode("classic-audio", "local-playtest")

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -254,15 +254,32 @@ class CompletionTests(unittest.TestCase):
         malformed = dict(released)
         malformed["name"] = "malformed-sound"
         malformed["sound_release"] = None
+        invalid_coordinates = json.loads(json.dumps(released))
+        invalid_coordinates["name"] = "invalid-coordinates"
+        invalid_coordinates["sound_release"]["asset_url"] = (
+            "https://example.invalid/mutable.tar.gz"
+        )
+        cross_stack = self.profile_record("cross-stack-sound", "default")
+        cross_stack.update(
+            {
+                "schema_version": 5,
+                "sound_mode": "local-playtest",
+                "sound_release": None,
+            }
+        )
         profiles = self.workspace / "profiles"
         self.write_json(profiles / "source-sound.json", source)
         self.write_json(profiles / "released-sound.json", released)
         self.write_json(profiles / "malformed-sound.json", malformed)
+        self.write_json(profiles / "invalid-coordinates.json", invalid_coordinates)
+        self.write_json(profiles / "cross-stack-sound.json", cross_stack)
 
         _, names = self.candidates("profile", "show", "")
         self.assertIn("source-sound", names)
         self.assertIn("released-sound", names)
         self.assertNotIn("malformed-sound", names)
+        self.assertNotIn("invalid-coordinates", names)
+        self.assertNotIn("cross-stack-sound", names)
 
     def test_profiles_reject_cross_checkout_and_invalid_migration_selectors(self) -> None:
         record = self.profile_record("broken", "classic")

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -196,6 +196,54 @@ class CompletionTests(unittest.TestCase):
         _, after = self.candidates("profile", "show", "")
         self.assertNotIn("review", after)
 
+    def test_current_sound_profiles_are_available_to_completion(self) -> None:
+        source = self.profile_record("source-sound", "classic")
+        source.update(
+            {
+                "schema_version": 5,
+                "sound_mode": "source",
+                "sound_release": None,
+            }
+        )
+        released = self.profile_record("released-sound", "classic")
+        released.update(
+            {
+                "schema_version": 5,
+                "sound_mode": "released",
+                "sound_release": {
+                    "archive_sha256": "a" * 64,
+                    "asset_url": (
+                        "https://github.com/atrinik/sound/releases/download/v1.2.3/"
+                        "atrinik-sound-classic-runtime-1.2.3.tar.gz"
+                    ),
+                    "manifest_schema_version": 1,
+                    "output_tree_sha256": "b" * 64,
+                    "product": "atrinik-sound-classic-runtime",
+                    "product_version": "1.2.3",
+                    "release_manifest_sha256": "c" * 64,
+                    "repository": "atrinik/sound",
+                    "schema_sha256": "d" * 64,
+                    "source_commit": "e" * 40,
+                    "source_manifest_sha256": "f" * 64,
+                    "source_tree": "1" * 40,
+                    "tag": "v1.2.3",
+                    "toolchain_sha256": "2" * 64,
+                },
+            }
+        )
+        malformed = dict(released)
+        malformed["name"] = "malformed-sound"
+        malformed["sound_release"] = None
+        profiles = self.workspace / "profiles"
+        self.write_json(profiles / "source-sound.json", source)
+        self.write_json(profiles / "released-sound.json", released)
+        self.write_json(profiles / "malformed-sound.json", malformed)
+
+        _, names = self.candidates("profile", "show", "")
+        self.assertIn("source-sound", names)
+        self.assertIn("released-sound", names)
+        self.assertNotIn("malformed-sound", names)
+
     def test_profiles_reject_cross_checkout_and_invalid_migration_selectors(self) -> None:
         record = self.profile_record("broken", "classic")
         record["components"]["classic-client"] = {

--- a/tests/test_content_migration.py
+++ b/tests/test_content_migration.py
@@ -845,6 +845,47 @@ class ContentMigrationTests(unittest.TestCase):
         )
         self.assertEqual(row["status"], "inert")
 
+        coordinates = {
+            "archive_sha256": "a" * 64,
+            "asset_url": (
+                "https://github.com/atrinik/sound/releases/download/v1.2.3/"
+                "atrinik-sound-classic-runtime-1.2.3.tar.gz"
+            ),
+            "manifest_schema_version": 1,
+            "output_tree_sha256": "b" * 64,
+            "product": "atrinik-sound-classic-runtime",
+            "product_version": "1.2.3",
+            "release_manifest_sha256": "c" * 64,
+            "repository": "atrinik/sound",
+            "schema_sha256": "d" * 64,
+            "source_commit": "e" * 40,
+            "source_manifest_sha256": "f" * 64,
+            "source_tree": "1" * 40,
+            "tag": "v1.2.3",
+            "toolchain_sha256": "2" * 64,
+        }
+        default = self.workspace._load_profile("default", require_file=False)
+        for action in ("dry-run", "audit", "apply"):
+            for mode in ("local-playtest", "released"):
+                name = f"invalid-{action}-{mode}"
+                invalid = {
+                    **default,
+                    "schema_version": 5,
+                    "name": name,
+                    "sound_mode": mode,
+                    "sound_release": coordinates if mode == "released" else None,
+                }
+                invalid_path = self.workspace.paths.profiles / f"{name}.json"
+                raw = json.dumps(invalid).encode()
+                invalid_path.write_bytes(raw)
+                result = self.migration().execute(action)
+                invalid_row = next(
+                    item for item in result["profiles"] if item["name"] == name
+                )
+                self.assertEqual(invalid_row["status"], "blocked")
+                self.assertEqual(invalid_path.read_bytes(), raw)
+                invalid_path.unlink()
+
     def test_profile_inventory_fails_closed_on_unsafe_storage_shapes(self) -> None:
         profiles = self.workspace.paths.profiles
         shutil.rmtree(profiles)

--- a/tests/test_content_migration.py
+++ b/tests/test_content_migration.py
@@ -725,11 +725,21 @@ class ContentMigrationTests(unittest.TestCase):
 
     def test_profile_schema_and_selector_failures_preserve_exact_bytes(self) -> None:
         current = self.workspace._load_profile("classic", require_file=False)
+        legacy_released = {
+            key: value
+            for key, value in {
+                **current,
+                "schema_version": 4,
+                "sound_mode": "released",
+            }.items()
+            if key != "sound_release"
+        }
         cases: dict[str, object] = {
             "not-object": [],
             "wrong-name": {**current, "name": "elsewhere"},
             "schema": {**current, "schema_version": 99},
             "sound": {**current, "sound_mode": "surround"},
+            "legacy-released": legacy_released,
             "components": {**current, "components": []},
             "component-set": {
                 **current,

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -313,7 +313,7 @@ class RepositoryMigrationTests(unittest.TestCase):
         self.assertTrue(source.is_dir())
         self.assertEqual(profile.read_bytes(), before)
 
-    def test_apply_archives_clean_source_and_rewrites_profile_to_schema_v4(self) -> None:
+    def test_apply_archives_clean_source_and_rewrites_profile_to_schema_v5(self) -> None:
         source = self.make_repository("client", "client")
         classic = self.make_classic({"client": source})
         head = command("git", "rev-parse", "HEAD", cwd=source).decode().strip()
@@ -342,8 +342,9 @@ class RepositoryMigrationTests(unittest.TestCase):
         self.assertEqual(self.status_bytes(archive), b"")
         self.assertEqual(self.status_bytes(classic), b"")
         value = json.loads(profile.read_text(encoding="utf-8"))
-        self.assertEqual(value["schema_version"], 4)
+        self.assertEqual(value["schema_version"], 5)
         self.assertEqual(value["sound_mode"], "source")
+        self.assertIsNone(value["sound_release"])
         self.assertEqual(value["stack"], "classic")
         self.assertEqual(stat.S_IMODE(profile.stat().st_mode), 0o600)
         self.assertEqual(
@@ -407,8 +408,9 @@ class RepositoryMigrationTests(unittest.TestCase):
             rewritten,
             {
                 **value,
-                "schema_version": 4,
+                "schema_version": 5,
                 "sound_mode": "source",
+                "sound_release": None,
             },
         )
 
@@ -420,10 +422,11 @@ class RepositoryMigrationTests(unittest.TestCase):
             for name in migration._classic_profile_component_names()
         }
         current = {
-            "schema_version": 4,
+            "schema_version": 5,
             "name": "classic",
             "stack": "classic",
             "sound_mode": "source",
+            "sound_release": None,
             "components": components,
         }
         current_mutations = {
@@ -471,10 +474,11 @@ class RepositoryMigrationTests(unittest.TestCase):
     def test_replacement_profile_cannot_enable_local_playtest_sound(self) -> None:
         profile = self.paths.profiles / "replacement.json"
         value = {
-            "schema_version": 4,
+            "schema_version": 5,
             "name": "replacement",
             "stack": "default",
             "sound_mode": "local-playtest",
+            "sound_release": None,
             "components": {},
         }
 

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -485,6 +485,32 @@ class RepositoryMigrationTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "Classic-derived"):
             self.migration()._rewrite_profile(profile, value, {}, None)
 
+    def test_schema_v4_replacement_profiles_are_validated_and_left_inert(self) -> None:
+        profile = self.paths.profiles / "replacement.json"
+        value = {
+            "schema_version": 4,
+            "name": "replacement",
+            "stack": "default",
+            "sound_mode": "source",
+            "components": {},
+        }
+        rewritten, composite = self.migration()._rewrite_profile(
+            profile, value, {}, None
+        )
+        self.assertIsNone(rewritten)
+        self.assertIsNone(composite)
+        for malformed in (
+            {**value, "name": "other"},
+            {**value, "sound_mode": "local-playtest"},
+            {**value, "unexpected": True},
+            {**value, "components": []},
+        ):
+            with self.subTest(malformed=malformed):
+                with self.assertRaisesRegex(
+                    WorkspaceError, "schema-v4 replacement profile"
+                ):
+                    self.migration()._rewrite_profile(profile, malformed, {}, None)
+
     def test_audit_accepts_manifest_owned_replacement_at_reused_source_path(
         self,
     ) -> None:

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 import shutil
 import subprocess
+import tarfile
 import tempfile
 import unittest
 from unittest import mock
@@ -18,10 +19,18 @@ from atrinik_workspace.sound import (
     PLAYTEST_MANIFEST,
     PLAYTEST_MARKER,
     PLAYTEST_SCHEMA,
+    RELEASE_CHECKSUMS,
+    RELEASE_MANIFEST,
+    RELEASE_MARKER,
+    RELEASE_PRODUCT,
+    RELEASE_SCHEMA,
     cache_key,
     clean_source_inputs,
+    extract_release_archive,
+    validate_release_coordinates,
     validate_sound_record,
     verify_playtest_tree,
+    verify_release_tree,
 )
 from atrinik_workspace.workspace import BUILD_METADATA, Workspace
 
@@ -195,6 +204,8 @@ class PlaytestSoundTests(unittest.TestCase):
         self.assertEqual(
             validate_sound_record(replacement_record), replacement_record
         )
+
+
         replacement_record["converted_opus_count"] = 149
         with self.assertRaisesRegex(WorkspaceError, "provenance is invalid"):
             validate_sound_record(replacement_record)
@@ -851,6 +862,211 @@ class PlaytestSoundTests(unittest.TestCase):
                 "verify-playtest-tree",
             ],
         )
+
+
+class ReleasedSoundTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.tree = self.root / "tree"
+        self.tree.mkdir()
+        schema = self.tree / RELEASE_SCHEMA
+        schema.parent.mkdir()
+        schema.write_bytes(b"{}\n")
+        marker = {
+            "format": RELEASE_PRODUCT,
+            "playtest_only": False,
+            "product_version": "1.4.0",
+            "publishable": True,
+            "schema_version": 1,
+        }
+        (self.tree / RELEASE_MARKER).write_bytes(canonical(marker))
+        notices = []
+        for path in ("background/LICENSE", "effects/LICENSE"):
+            notice = self.tree / path
+            notice.parent.mkdir(exist_ok=True)
+            notice.write_text(f"fixture notice {path}\n", encoding="utf-8")
+            notices.append({"path": path, "sha256": digest(notice)})
+        assets: list[dict[str, object]] = []
+        for index in range(339):
+            copied = index >= 150
+            logical = (
+                f"effects/copy-{index - 150:03}.ogg"
+                if copied else f"background/convert-{index:03}.mid"
+            )
+            payload = (
+                b"OggS\x00fixture\x01vorbis" if copied
+                else b"OggS\x00fixtureOpusHead"
+            ) + str(index).encode()
+            path = self.tree / logical
+            path.parent.mkdir(exist_ok=True)
+            path.write_bytes(payload)
+            payload_hash = digest(path)
+            source_codec = "vorbis" if copied else ("flac" if index < 28 else "midi")
+            assets.append({
+                "logical_path": logical,
+                "source_path": logical if copied else f"background/source-{index:03}.flac",
+                "mapping": "copy" if copied else "render-opus",
+                "source": {
+                    "codec": source_codec,
+                    "container": "ogg" if copied else source_codec,
+                    "sha256": payload_hash if copied else hashlib.sha256(
+                        f"source-{index}".encode()
+                    ).hexdigest(),
+                },
+                "output": {
+                    "sha256": payload_hash,
+                    "size_bytes": len(payload),
+                    "codec": "vorbis" if copied else "opus",
+                    "container": "ogg",
+                    "sample_rate": 48000,
+                    "channels": 2,
+                    "duration_seconds": 1.0,
+                },
+            })
+        assets.sort(key=lambda asset: str(asset["logical_path"]))
+        tree_hash = hashlib.sha256()
+        for asset in assets:
+            output = asset["output"]
+            assert isinstance(output, dict)
+            tree_hash.update(
+                f"{output['sha256']}  {asset['logical_path']}\n".encode()
+            )
+        self.manifest = {
+            "$schema": RELEASE_SCHEMA,
+            "schema_version": 1,
+            "product": RELEASE_PRODUCT,
+            "product_version": "1.4.0",
+            "release_tag": "v1.4.0",
+            "repository": "atrinik/sound",
+            "playtest_only": False,
+            "publishable": True,
+            "source_commit": "a" * 40,
+            "source_tree": "b" * 40,
+            "source_manifest_sha256": "c" * 64,
+            "toolchain_sha256": "d" * 64,
+            "schema_sha256": digest(schema),
+            "marker_sha256": digest(self.tree / RELEASE_MARKER),
+            "logical_path_count": 339,
+            "copied_vorbis_count": 189,
+            "converted_opus_count": 150,
+            "output_tree_sha256": tree_hash.hexdigest(),
+            "notices": notices,
+            "assets": assets,
+        }
+        (self.tree / RELEASE_MANIFEST).write_bytes(canonical(self.manifest))
+        self.rewrite_checksums()
+        self.archive = self.root / f"{RELEASE_PRODUCT}-1.4.0.tar.gz"
+        with tarfile.open(self.archive, "w:gz") as archive:
+            archive.add(self.tree, arcname=f"{RELEASE_PRODUCT}-1.4.0")
+        self.coordinates = {
+            "repository": "atrinik/sound",
+            "tag": "v1.4.0",
+            "product": RELEASE_PRODUCT,
+            "product_version": "1.4.0",
+            "manifest_schema_version": 1,
+            "source_commit": "a" * 40,
+            "source_tree": "b" * 40,
+            "asset_url": (
+                "https://github.com/atrinik/sound/releases/download/v1.4.0/"
+                f"{RELEASE_PRODUCT}-1.4.0.tar.gz"
+            ),
+            "archive_sha256": digest(self.archive),
+            "release_manifest_sha256": digest(self.tree / RELEASE_MANIFEST),
+            "source_manifest_sha256": "c" * 64,
+            "schema_sha256": digest(schema),
+            "toolchain_sha256": "d" * 64,
+            "output_tree_sha256": tree_hash.hexdigest(),
+        }
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def rewrite_checksums(self) -> None:
+        files = sorted(
+            path for path in self.tree.rglob("*")
+            if path.is_file() and path.name != RELEASE_CHECKSUMS
+        )
+        (self.tree / RELEASE_CHECKSUMS).write_text(
+            "".join(
+                f"{digest(path)}  {path.relative_to(self.tree).as_posix()}\n"
+                for path in files
+            ), encoding="ascii"
+        )
+
+    def test_complete_tree_archive_and_record_are_accepted(self) -> None:
+        self.assertEqual(validate_release_coordinates(self.coordinates), self.coordinates)
+        record = verify_release_tree(self.tree, self.coordinates)
+        self.assertEqual(record["mode"], "released")
+        self.assertEqual(validate_sound_record(record), record)
+        extracted = self.root / "extracted"
+        extract_release_archive(self.archive, extracted, self.coordinates)
+        self.assertEqual(verify_release_tree(extracted, self.coordinates), {
+            **record, "root": str(extracted.resolve())
+        })
+
+    def test_wrapper_downloads_once_and_reuses_exact_verified_cache(self) -> None:
+        wrapper = self.root / "wrapper"
+        wrapper.mkdir()
+        shutil.copy2(Path(__file__).resolve().parents[1] / "components.json", wrapper)
+        workspace = Workspace(wrapper)
+        build = self.root / "build"
+        build.mkdir()
+        profile = {
+            "stack": "classic",
+            "sound_mode": "released",
+            "sound_release": self.coordinates,
+        }
+        with (
+            mock.patch.object(workspace, "_load_profile", return_value=profile),
+            mock.patch(
+                "atrinik_workspace.workspace.download_release_archive",
+                side_effect=lambda _url, destination: shutil.copy2(
+                    self.archive, destination
+                ),
+            ) as download,
+        ):
+            first_root, first_record = workspace._prepare_sound(
+                build, {"sound": self.root / "unused-source"}, "classic-release"
+            )
+            shutil.rmtree(first_root)
+            second_root, second_record = workspace._prepare_sound(
+                build, {"sound": self.root / "unused-source"}, "classic-release"
+            )
+        self.assertEqual(download.call_count, 1)
+        self.assertEqual(first_root, second_root)
+        self.assertEqual(first_record, second_record)
+        self.assertEqual(first_record["archive_sha256"], self.coordinates["archive_sha256"])
+
+    def test_coordinates_marker_payload_and_archive_fail_closed(self) -> None:
+        for coordinates in (
+            {**self.coordinates, "asset_url": "https://example.com/a"},
+            {**self.coordinates, "repository": "atrinik/classic"},
+            {**self.coordinates, "tag": "v1.4.1"},
+            {**self.coordinates, "archive_sha256": "bad"},
+        ):
+            with self.assertRaises(WorkspaceError):
+                validate_release_coordinates(coordinates)
+
+        payload = self.tree / "background/convert-000.mid"
+        payload.write_bytes(b"MThd" + b"\0" * 20)
+        first = self.manifest["assets"][0]
+        assert isinstance(first, dict) and isinstance(first["output"], dict)
+        first["output"]["sha256"] = digest(payload)
+        first["output"]["size_bytes"] = payload.stat().st_size
+        (self.tree / RELEASE_MANIFEST).write_bytes(canonical(self.manifest))
+        self.coordinates["release_manifest_sha256"] = digest(self.tree / RELEASE_MANIFEST)
+        self.rewrite_checksums()
+        with self.assertRaisesRegex(WorkspaceError, "not an Ogg stream"):
+            verify_release_tree(self.tree, self.coordinates)
+
+        unsafe = self.root / "unsafe.tar.gz"
+        with tarfile.open(unsafe, "w:gz") as archive:
+            member = tarfile.TarInfo(f"{RELEASE_PRODUCT}-1.4.0/../escape")
+            member.size = 0
+            archive.addfile(member)
+        with self.assertRaisesRegex(WorkspaceError, "unsafe path"):
+            extract_release_archive(unsafe, self.root / "unsafe", self.coordinates)
 
 
 if __name__ == "__main__":

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -1284,6 +1284,28 @@ class ReleasedSoundTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "schema reference"):
             verify_release_tree(self.tree, self.coordinates)
 
+    def test_combinators_do_not_swallow_malformed_keyword_values(self) -> None:
+        for index, invalid in enumerate((
+            {"enum": "invalid"},
+            {"type": "bogus"},
+            {"required": "invalid"},
+            {"maxItems": -1},
+        )):
+            with self.subTest(invalid=invalid):
+                schema_path = self.tree / RELEASE_SCHEMA
+                schema = json.loads(schema_path.read_text())
+                schema["properties"]["assets"] = {"anyOf": [True, invalid]}
+                schema_path.write_bytes(canonical(schema))
+                self.coordinates["schema_sha256"] = digest(schema_path)
+                self.manifest["schema_sha256"] = self.coordinates["schema_sha256"]
+                (self.tree / RELEASE_MANIFEST).write_bytes(canonical(self.manifest))
+                self.coordinates["release_manifest_sha256"] = digest(
+                    self.tree / RELEASE_MANIFEST
+                )
+                self.rewrite_checksums()
+                with self.assertRaisesRegex(WorkspaceError, "packaged schema"):
+                    verify_release_tree(self.tree, self.coordinates)
+
     def test_build_metadata_and_supervised_topology_reuse_verified_root(self) -> None:
         wrapper = self.root / "topology-wrapper"
         wrapper.mkdir()

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -1138,6 +1138,14 @@ class ReleasedSoundTests(unittest.TestCase):
         oversized = archive_with("oversized-pax", [extended])
         with self.assertRaisesRegex(WorkspaceError, "extended metadata"):
             extract_release_archive(oversized, self.root / "oversized", self.coordinates)
+        solaris = tarfile.TarInfo(f"{prefix}/solaris-metadata")
+        solaris.type = tarfile.SOLARIS_XHDTYPE
+        solaris.size = 1
+        solaris_archive = archive_with("solaris-pax", [solaris])
+        with self.assertRaisesRegex(WorkspaceError, "extended metadata"):
+            extract_release_archive(
+                solaris_archive, self.root / "solaris", self.coordinates
+            )
 
     def test_interrupted_download_is_a_workspace_error(self) -> None:
         response = mock.Mock()
@@ -1214,6 +1222,19 @@ class ReleasedSoundTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "schema contract"):
             verify_release_tree(self.tree, self.coordinates)
 
+    def test_packaged_schema_must_be_an_object(self) -> None:
+        schema_path = self.tree / RELEASE_SCHEMA
+        schema_path.write_text("[]\n", encoding="utf-8")
+        self.coordinates["schema_sha256"] = digest(schema_path)
+        self.manifest["schema_sha256"] = self.coordinates["schema_sha256"]
+        (self.tree / RELEASE_MANIFEST).write_bytes(canonical(self.manifest))
+        self.coordinates["release_manifest_sha256"] = digest(
+            self.tree / RELEASE_MANIFEST
+        )
+        self.rewrite_checksums()
+        with self.assertRaisesRegex(WorkspaceError, "schema contract"):
+            verify_release_tree(self.tree, self.coordinates)
+
     def test_packaged_schema_property_constraints_are_applied(self) -> None:
         schema_path = self.tree / RELEASE_SCHEMA
         schema = json.loads(schema_path.read_text())
@@ -1227,6 +1248,22 @@ class ReleasedSoundTests(unittest.TestCase):
         )
         self.rewrite_checksums()
         with self.assertRaisesRegex(WorkspaceError, "violates its schema"):
+            verify_release_tree(self.tree, self.coordinates)
+
+    def test_packaged_schema_reference_cycles_fail_closed(self) -> None:
+        schema_path = self.tree / RELEASE_SCHEMA
+        schema = json.loads(schema_path.read_text())
+        schema["$defs"] = {"loop": {"$ref": "#/$defs/loop"}}
+        schema["properties"]["assets"] = {"$ref": "#/$defs/loop"}
+        schema_path.write_bytes(canonical(schema))
+        self.coordinates["schema_sha256"] = digest(schema_path)
+        self.manifest["schema_sha256"] = self.coordinates["schema_sha256"]
+        (self.tree / RELEASE_MANIFEST).write_bytes(canonical(self.manifest))
+        self.coordinates["release_manifest_sha256"] = digest(
+            self.tree / RELEASE_MANIFEST
+        )
+        self.rewrite_checksums()
+        with self.assertRaisesRegex(WorkspaceError, "schema reference"):
             verify_release_tree(self.tree, self.coordinates)
 
     def test_build_metadata_and_supervised_topology_reuse_verified_root(self) -> None:

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import copy
 import hashlib
+import http.client
+import io
 import json
 import os
 from pathlib import Path
@@ -872,7 +874,22 @@ class ReleasedSoundTests(unittest.TestCase):
         self.tree.mkdir()
         schema = self.tree / RELEASE_SCHEMA
         schema.parent.mkdir()
-        schema.write_bytes(b"{}\n")
+        schema_fields = [
+            "$schema", "assets", "converted_opus_count",
+            "copied_vorbis_count", "logical_path_count", "marker_sha256",
+            "notices", "output_tree_sha256", "playtest_only", "product",
+            "product_version", "publishable", "release_tag", "repository",
+            "schema_sha256", "schema_version", "source_commit",
+            "source_manifest_sha256", "source_tree", "toolchain_sha256",
+        ]
+        schema.write_bytes(canonical({
+            "$id": f"https://atrinik.org/{RELEASE_SCHEMA}",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": False,
+            "properties": {name: {} for name in schema_fields},
+            "required": schema_fields,
+            "type": "object",
+        }))
         marker = {
             "format": RELEASE_PRODUCT,
             "playtest_only": False,
@@ -1067,6 +1084,139 @@ class ReleasedSoundTests(unittest.TestCase):
             archive.addfile(member)
         with self.assertRaisesRegex(WorkspaceError, "unsafe path"):
             extract_release_archive(unsafe, self.root / "unsafe", self.coordinates)
+
+    def test_archive_member_and_stream_failures_are_bounded_and_safe(self) -> None:
+        prefix = f"{RELEASE_PRODUCT}-1.4.0"
+
+        def archive_with(name: str, members: list[tarfile.TarInfo]) -> Path:
+            path = self.root / f"{name}.tar.gz"
+            with tarfile.open(path, "w:gz") as archive:
+                root = tarfile.TarInfo(prefix)
+                root.type = tarfile.DIRTYPE
+                archive.addfile(root)
+                for member in members:
+                    payload = b"x" * member.size
+                    archive.addfile(member, io.BytesIO(payload) if member.size else None)
+            return path
+
+        cases: list[tuple[str, list[tarfile.TarInfo], str]] = []
+        for name in (f"{prefix}/..\\escape", "/absolute"):
+            member = tarfile.TarInfo(name)
+            cases.append((name.replace("/", "-").replace("\\", "-"), [member], "unsafe path"))
+        first = tarfile.TarInfo(f"{prefix}/sound.ogg")
+        second = tarfile.TarInfo(f"{prefix}/SOUND.ogg")
+        cases.append(("case-collision", [first, second], "case-colliding"))
+        link = tarfile.TarInfo(f"{prefix}/escape")
+        link.type = tarfile.SYMTYPE
+        link.linkname = "../../escape"
+        cases.append(("symlink", [link], "special member"))
+        device = tarfile.TarInfo(f"{prefix}/device")
+        device.type = tarfile.CHRTYPE
+        cases.append(("device", [device], "special member"))
+        other = tarfile.TarInfo("other-product/file")
+        cases.append(("multiple-prefixes", [other], "one directory prefix"))
+        for index, (name, members, message) in enumerate(cases):
+            with self.subTest(name=name):
+                archive = archive_with(f"unsafe-{index}", members)
+                with self.assertRaisesRegex(WorkspaceError, message):
+                    extract_release_archive(
+                        archive, self.root / f"destination-{index}", self.coordinates
+                    )
+
+        truncated = self.root / "truncated.tar.gz"
+        truncated.write_bytes(self.archive.read_bytes()[:128])
+        with self.assertRaisesRegex(WorkspaceError, "invalid|truncated|corrupt"):
+            extract_release_archive(truncated, self.root / "truncated", self.coordinates)
+
+        extended = tarfile.TarInfo(f"{prefix}/file")
+        extended.pax_headers = {"comment": "x" * (sound_module.MAX_RELEASE_METADATA_BYTES + 1)}
+        oversized = archive_with("oversized-pax", [extended])
+        with self.assertRaisesRegex(WorkspaceError, "extended metadata"):
+            extract_release_archive(oversized, self.root / "oversized", self.coordinates)
+
+    def test_interrupted_download_is_a_workspace_error(self) -> None:
+        response = mock.Mock()
+        response.headers = {}
+        response.read.side_effect = http.client.IncompleteRead(b"partial", 100)
+        with mock.patch("urllib.request.urlopen", return_value=response):
+            with self.assertRaisesRegex(WorkspaceError, "interrupted"):
+                sound_module.download_release_archive(
+                    self.coordinates["asset_url"], self.root / "partial.tar.gz"
+                )
+        response.close.assert_called_once()
+
+    def test_marker_tampering_fails_closed(self) -> None:
+        (self.tree / RELEASE_MARKER).write_text("{}\n", encoding="utf-8")
+        self.rewrite_checksums()
+        with self.assertRaisesRegex(WorkspaceError, "marker"):
+            verify_release_tree(self.tree, self.coordinates)
+
+    def test_notice_tampering_fails_closed(self) -> None:
+        notice = self.tree / "background/LICENSE"
+        notice.write_text("tampered\n", encoding="utf-8")
+        self.rewrite_checksums()
+        with self.assertRaisesRegex(WorkspaceError, "notice"):
+            verify_release_tree(self.tree, self.coordinates)
+
+    def test_missing_checksums_fail_closed(self) -> None:
+        (self.tree / RELEASE_CHECKSUMS).unlink()
+        with self.assertRaisesRegex(WorkspaceError, "checksums"):
+            verify_release_tree(self.tree, self.coordinates)
+
+    def test_manifest_counts_and_schema_contract_fail_closed(self) -> None:
+        self.manifest["logical_path_count"] = 338
+        (self.tree / RELEASE_MANIFEST).write_bytes(canonical(self.manifest))
+        self.coordinates["release_manifest_sha256"] = digest(
+            self.tree / RELEASE_MANIFEST
+        )
+        self.rewrite_checksums()
+        with self.assertRaisesRegex(WorkspaceError, "counts.*339-path"):
+            verify_release_tree(self.tree, self.coordinates)
+
+    def test_packaged_schema_must_be_valid_and_applicable(self) -> None:
+        schema = self.tree / RELEASE_SCHEMA
+        schema.write_text("{}\n", encoding="utf-8")
+        self.coordinates["schema_sha256"] = digest(schema)
+        self.manifest["schema_sha256"] = self.coordinates["schema_sha256"]
+        (self.tree / RELEASE_MANIFEST).write_bytes(canonical(self.manifest))
+        self.coordinates["release_manifest_sha256"] = digest(
+            self.tree / RELEASE_MANIFEST
+        )
+        self.rewrite_checksums()
+        with self.assertRaisesRegex(WorkspaceError, "schema contract"):
+            verify_release_tree(self.tree, self.coordinates)
+
+    def test_racing_cache_install_leaves_no_partial_runtime(self) -> None:
+        wrapper = self.root / "race-wrapper"
+        wrapper.mkdir()
+        shutil.copy2(Path(__file__).resolve().parents[1] / "components.json", wrapper)
+        workspace = Workspace(wrapper)
+        build = self.root / "race-build"
+        build.mkdir()
+        profile = {
+            "stack": "classic",
+            "sound_mode": "released",
+            "sound_release": self.coordinates,
+        }
+        with (
+            mock.patch.object(workspace, "_load_profile", return_value=profile),
+            mock.patch(
+                "atrinik_workspace.workspace.download_release_archive",
+                side_effect=lambda _url, destination: shutil.copy2(
+                    self.archive, destination
+                ),
+            ),
+            mock.patch(
+                "atrinik_workspace.workspace.rename_no_replace",
+                side_effect=FileExistsError("raced install"),
+            ),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "raced install"):
+                workspace._prepare_sound(
+                    build, {"sound": self.root / "unused-source"}, "classic-release"
+                )
+        runtime = build / "runtime"
+        self.assertEqual(list(runtime.iterdir()), [])
 
 
 if __name__ == "__main__":

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -1294,6 +1294,10 @@ class ReleasedSoundTests(unittest.TestCase):
             {"pattern": "["},
             {"items": "invalid"},
             {"properties": {"absent": {"$ref": "invalid"}}},
+            {"anyOf": None},
+            {"maxItems": None},
+            {"type": None},
+            {"type": [{}]},
         )):
             with self.subTest(invalid=invalid):
                 schema_path = self.tree / RELEASE_SCHEMA

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -1293,6 +1293,7 @@ class ReleasedSoundTests(unittest.TestCase):
             {"additionalProperties": "invalid"},
             {"pattern": "["},
             {"items": "invalid"},
+            {"properties": {"absent": {"$ref": "invalid"}}},
         )):
             with self.subTest(invalid=invalid):
                 schema_path = self.tree / RELEASE_SCHEMA

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -1266,6 +1266,24 @@ class ReleasedSoundTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "schema reference"):
             verify_release_tree(self.tree, self.coordinates)
 
+    def test_combinators_do_not_swallow_invalid_schema_branches(self) -> None:
+        schema_path = self.tree / RELEASE_SCHEMA
+        schema = json.loads(schema_path.read_text())
+        schema["$defs"] = {"loop": {"$ref": "#/$defs/loop"}}
+        schema["properties"]["assets"] = {
+            "anyOf": [True, {"$ref": "#/$defs/loop"}]
+        }
+        schema_path.write_bytes(canonical(schema))
+        self.coordinates["schema_sha256"] = digest(schema_path)
+        self.manifest["schema_sha256"] = self.coordinates["schema_sha256"]
+        (self.tree / RELEASE_MANIFEST).write_bytes(canonical(self.manifest))
+        self.coordinates["release_manifest_sha256"] = digest(
+            self.tree / RELEASE_MANIFEST
+        )
+        self.rewrite_checksums()
+        with self.assertRaisesRegex(WorkspaceError, "schema reference"):
+            verify_release_tree(self.tree, self.coordinates)
+
     def test_build_metadata_and_supervised_topology_reuse_verified_root(self) -> None:
         wrapper = self.root / "topology-wrapper"
         wrapper.mkdir()

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import gzip
 import hashlib
 import http.client
 import io
@@ -1148,6 +1149,81 @@ class ReleasedSoundTests(unittest.TestCase):
                 solaris_archive, self.root / "solaris", self.coordinates
             )
 
+    def test_archive_envelope_and_layout_failures_are_bounded(self) -> None:
+        def compressed(name: str, payload: bytes) -> Path:
+            path = self.root / name
+            with gzip.open(path, "wb") as stream:
+                stream.write(payload)
+            return path
+
+        for name, payload, message in (
+            ("empty.tar.gz", b"", "truncated"),
+            ("short-header.tar.gz", b"x" * 100, "truncated header"),
+            (
+                "invalid-trailer.tar.gz",
+                tarfile.NUL * tarfile.BLOCKSIZE + b"x" * tarfile.BLOCKSIZE,
+                "invalid trailer",
+            ),
+            ("invalid-header.tar.gz", b"x" * tarfile.BLOCKSIZE, "header is invalid"),
+        ):
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(WorkspaceError, message):
+                    sound_module._prescan_release_archive(
+                        compressed(name, payload)
+                    )
+
+        with mock.patch.object(sound_module, "MAX_RELEASE_MEMBERS", 0):
+            with self.assertRaisesRegex(WorkspaceError, "member count"):
+                sound_module._prescan_release_archive(self.archive)
+        with mock.patch.object(sound_module, "MAX_RELEASE_MEMBER_BYTES", 0):
+            with self.assertRaisesRegex(WorkspaceError, "member exceeds"):
+                sound_module._prescan_release_archive(self.archive)
+        with mock.patch.object(sound_module, "MAX_RELEASE_TAR_BYTES", 1):
+            with self.assertRaisesRegex(WorkspaceError, "extraction limit"):
+                sound_module._prescan_release_archive(self.archive)
+
+        existing = self.root / "existing-destination"
+        existing.mkdir()
+        with self.assertRaisesRegex(WorkspaceError, "already exists"):
+            extract_release_archive(self.archive, existing, self.coordinates)
+        with mock.patch.object(sound_module, "MAX_RELEASE_ARCHIVE_BYTES", 1):
+            with self.assertRaisesRegex(WorkspaceError, "extraction input limit"):
+                extract_release_archive(
+                    self.archive, self.root / "input-too-large", self.coordinates
+                )
+
+        empty = self.root / "empty-members.tar.gz"
+        with tarfile.open(empty, "w:gz", format=tarfile.USTAR_FORMAT):
+            pass
+        with self.assertRaisesRegex(WorkspaceError, "member count"):
+            extract_release_archive(empty, self.root / "empty-members", self.coordinates)
+
+        wrong_prefix = self.root / "wrong-prefix.tar.gz"
+        with tarfile.open(wrong_prefix, "w:gz", format=tarfile.USTAR_FORMAT) as archive:
+            root = tarfile.TarInfo("wrong-product-1.4.0")
+            root.type = tarfile.DIRTYPE
+            archive.addfile(root)
+        with self.assertRaisesRegex(WorkspaceError, "wrong product prefix"):
+            extract_release_archive(
+                wrong_prefix, self.root / "wrong-prefix", self.coordinates
+            )
+
+        missing_directory = self.root / "missing-directory.tar.gz"
+        prefix = f"{RELEASE_PRODUCT}-1.4.0"
+        with tarfile.open(
+            missing_directory, "w:gz", format=tarfile.USTAR_FORMAT
+        ) as archive:
+            root = tarfile.TarInfo(prefix)
+            root.type = tarfile.DIRTYPE
+            archive.addfile(root)
+            member = tarfile.TarInfo(f"{prefix}/nested/file")
+            member.size = 1
+            archive.addfile(member, io.BytesIO(b"x"))
+        with self.assertRaisesRegex(WorkspaceError, "directories"):
+            extract_release_archive(
+                missing_directory, self.root / "missing-directory", self.coordinates
+            )
+
     def test_interrupted_download_is_a_workspace_error(self) -> None:
         response = mock.Mock()
         response.headers = {}
@@ -1232,6 +1308,80 @@ class ReleasedSoundTests(unittest.TestCase):
         self.rewrite_checksums()
         with self.assertRaisesRegex(WorkspaceError, "counts.*339-path"):
             verify_release_tree(self.tree, self.coordinates)
+
+    def test_manifest_and_schema_envelope_failures_are_distinguished(self) -> None:
+        manifest_path = self.tree / RELEASE_MANIFEST
+        schema_path = self.tree / RELEASE_SCHEMA
+        original_manifest = canonical(self.manifest)
+        original_schema = schema_path.read_bytes()
+        original_coordinates = dict(self.coordinates)
+
+        def restore() -> None:
+            self.manifest = json.loads(original_manifest)
+            manifest_path.write_bytes(original_manifest)
+            schema_path.write_bytes(original_schema)
+            self.coordinates.clear()
+            self.coordinates.update(original_coordinates)
+            self.rewrite_checksums()
+
+        try:
+            for name, payload, message in (
+                ("invalid-json", b"{\n", "invalid JSON"),
+                (
+                    "noncanonical-json",
+                    json.dumps(self.manifest, indent=2).encode() + b"\n",
+                    "not canonical JSON",
+                ),
+            ):
+                with self.subTest(name=name):
+                    manifest_path.write_bytes(payload)
+                    self.coordinates["release_manifest_sha256"] = hashlib.sha256(
+                        payload
+                    ).hexdigest()
+                    with self.assertRaisesRegex(WorkspaceError, message):
+                        verify_release_tree(self.tree, self.coordinates)
+                    restore()
+
+            del self.manifest["assets"]
+            manifest_path.write_bytes(canonical(self.manifest))
+            self.coordinates["release_manifest_sha256"] = digest(manifest_path)
+            with self.assertRaisesRegex(WorkspaceError, "manifest fields"):
+                verify_release_tree(self.tree, self.coordinates)
+            restore()
+
+            self.manifest["product"] = "wrong-product"
+            manifest_path.write_bytes(canonical(self.manifest))
+            self.coordinates["release_manifest_sha256"] = digest(manifest_path)
+            with self.assertRaisesRegex(WorkspaceError, "manifest identity"):
+                verify_release_tree(self.tree, self.coordinates)
+            restore()
+
+            with mock.patch.object(
+                sound_module, "MAX_RELEASE_SCHEMA_BYTES", len(original_schema) - 1
+            ):
+                with self.assertRaisesRegex(WorkspaceError, "schema exceeds"):
+                    verify_release_tree(self.tree, self.coordinates)
+            restore()
+
+            wrong_hash = "e" * 64
+            self.coordinates["schema_sha256"] = wrong_hash
+            self.manifest["schema_sha256"] = wrong_hash
+            manifest_path.write_bytes(canonical(self.manifest))
+            self.coordinates["release_manifest_sha256"] = digest(manifest_path)
+            with self.assertRaisesRegex(WorkspaceError, "schema.*tampered"):
+                verify_release_tree(self.tree, self.coordinates)
+            restore()
+
+            schema_path.write_bytes(b"{\n")
+            self.coordinates["schema_sha256"] = digest(schema_path)
+            self.manifest["schema_sha256"] = self.coordinates["schema_sha256"]
+            manifest_path.write_bytes(canonical(self.manifest))
+            self.coordinates["release_manifest_sha256"] = digest(manifest_path)
+            self.rewrite_checksums()
+            with self.assertRaisesRegex(WorkspaceError, "schema is invalid JSON"):
+                verify_release_tree(self.tree, self.coordinates)
+        finally:
+            restore()
 
     def test_exact_source_codec_split_and_finite_metadata_are_required(self) -> None:
         for asset in self.manifest["assets"]:

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -1948,42 +1948,68 @@ class ReleasedSoundTests(unittest.TestCase):
         runtime = build / "runtime"
         self.assertEqual(list(runtime.iterdir()), [])
 
-    def test_raced_runtime_parent_identity_fails_closed(self) -> None:
-        wrapper = self.root / "parent-race-wrapper"
-        wrapper.mkdir()
-        shutil.copy2(Path(__file__).resolve().parents[1] / "components.json", wrapper)
-        workspace = Workspace(wrapper)
-        build = self.root / "parent-race-build"
-        build.mkdir()
-        profile = {
-            "stack": "classic",
-            "sound_mode": "released",
-            "sound_release": self.coordinates,
-        }
+    def test_raced_publication_directory_identities_fail_closed(self) -> None:
         real_stat = workspace_module.os.stat
-
-        def raced_stat(path: object, *args: object, **kwargs: object) -> os.stat_result:
-            result = real_stat(path, *args, **kwargs)
-            if path == "runtime" and kwargs.get("dir_fd") is not None:
-                fields = list(result)
-                fields[1] += 1
-                return os.stat_result(fields)
-            return result
-
-        with (
-            mock.patch.object(workspace, "_load_profile", return_value=profile),
-            mock.patch(
-                "atrinik_workspace.workspace.download_release_archive",
-                side_effect=lambda _url, destination: shutil.copy2(
-                    self.archive, destination
-                ),
-            ),
-            mock.patch.object(workspace_module.os, "stat", side_effect=raced_stat),
+        for case, message in (
+            ("runtime", "parent changed"),
+            ("root", "build root changed"),
+            ("temporary", "temporary directory changed"),
         ):
-            with self.assertRaisesRegex(WorkspaceError, "parent changed"):
-                workspace._prepare_sound(
-                    build, {"sound": self.root / "unused-source"}, "classic-release"
+            with self.subTest(case=case):
+                wrapper = self.root / f"{case}-race-wrapper"
+                wrapper.mkdir()
+                shutil.copy2(
+                    Path(__file__).resolve().parents[1] / "components.json", wrapper
                 )
+                workspace = Workspace(wrapper)
+                build = self.root / f"{case}-race-build"
+                build.mkdir()
+                profile = {
+                    "stack": "classic",
+                    "sound_mode": "released",
+                    "sound_release": self.coordinates,
+                }
+
+                def raced_stat(
+                    path: object, *args: object, **kwargs: object
+                ) -> os.stat_result:
+                    result = real_stat(path, *args, **kwargs)
+                    raced = (
+                        case == "runtime"
+                        and path == "runtime"
+                        and kwargs.get("dir_fd") is not None
+                    ) or (case == "root" and path == build) or (
+                        case == "temporary"
+                        and isinstance(path, str)
+                        and path.startswith(".sound-released-")
+                        and kwargs.get("dir_fd") is not None
+                    )
+                    if raced:
+                        fields = list(result)
+                        fields[1] += 1
+                        return os.stat_result(fields)
+                    return result
+
+                with (
+                    mock.patch.object(
+                        workspace, "_load_profile", return_value=profile
+                    ),
+                    mock.patch(
+                        "atrinik_workspace.workspace.download_release_archive",
+                        side_effect=lambda _url, destination: shutil.copy2(
+                            self.archive, destination
+                        ),
+                    ),
+                    mock.patch.object(
+                        workspace_module.os, "stat", side_effect=raced_stat
+                    ),
+                ):
+                    with self.assertRaisesRegex(WorkspaceError, message):
+                        workspace._prepare_sound(
+                            build,
+                            {"sound": self.root / "unused-source"},
+                            "classic-release",
+                        )
 
 
 if __name__ == "__main__":

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -974,7 +974,9 @@ class ReleasedSoundTests(unittest.TestCase):
         (self.tree / RELEASE_MANIFEST).write_bytes(canonical(self.manifest))
         self.rewrite_checksums()
         self.archive = self.root / f"{RELEASE_PRODUCT}-1.4.0.tar.gz"
-        with tarfile.open(self.archive, "w:gz") as archive:
+        with tarfile.open(
+            self.archive, "w:gz", format=tarfile.USTAR_FORMAT
+        ) as archive:
             archive.add(self.tree, arcname=f"{RELEASE_PRODUCT}-1.4.0")
         self.coordinates = {
             "repository": "atrinik/sound",
@@ -1113,6 +1115,9 @@ class ReleasedSoundTests(unittest.TestCase):
         device = tarfile.TarInfo(f"{prefix}/device")
         device.type = tarfile.CHRTYPE
         cases.append(("device", [device], "special member"))
+        duplicate_root = tarfile.TarInfo(prefix)
+        duplicate_root.type = tarfile.DIRTYPE
+        cases.append(("duplicate-root", [duplicate_root], "duplicate"))
         other = tarfile.TarInfo("other-product/file")
         cases.append(("multiple-prefixes", [other], "one directory prefix"))
         for index, (name, members, message) in enumerate(cases):
@@ -1173,6 +1178,29 @@ class ReleasedSoundTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "counts.*339-path"):
             verify_release_tree(self.tree, self.coordinates)
 
+    def test_exact_source_codec_split_and_finite_metadata_are_required(self) -> None:
+        for asset in self.manifest["assets"]:
+            if asset["source"]["codec"] == "flac":
+                asset["source"]["codec"] = "midi"
+                asset["source"]["container"] = "midi"
+        (self.tree / RELEASE_MANIFEST).write_bytes(canonical(self.manifest))
+        self.coordinates["release_manifest_sha256"] = digest(
+            self.tree / RELEASE_MANIFEST
+        )
+        self.rewrite_checksums()
+        with self.assertRaisesRegex(WorkspaceError, "counts.*339-path"):
+            verify_release_tree(self.tree, self.coordinates)
+
+    def test_nonstandard_json_numbers_are_rejected(self) -> None:
+        self.manifest["assets"][0]["output"]["duration_seconds"] = float("nan")
+        (self.tree / RELEASE_MANIFEST).write_bytes(canonical(self.manifest))
+        self.coordinates["release_manifest_sha256"] = digest(
+            self.tree / RELEASE_MANIFEST
+        )
+        self.rewrite_checksums()
+        with self.assertRaisesRegex(WorkspaceError, "invalid JSON"):
+            verify_release_tree(self.tree, self.coordinates)
+
     def test_packaged_schema_must_be_valid_and_applicable(self) -> None:
         schema = self.tree / RELEASE_SCHEMA
         schema.write_text("{}\n", encoding="utf-8")
@@ -1185,6 +1213,126 @@ class ReleasedSoundTests(unittest.TestCase):
         self.rewrite_checksums()
         with self.assertRaisesRegex(WorkspaceError, "schema contract"):
             verify_release_tree(self.tree, self.coordinates)
+
+    def test_packaged_schema_property_constraints_are_applied(self) -> None:
+        schema_path = self.tree / RELEASE_SCHEMA
+        schema = json.loads(schema_path.read_text())
+        schema["properties"]["assets"] = False
+        schema_path.write_bytes(canonical(schema))
+        self.coordinates["schema_sha256"] = digest(schema_path)
+        self.manifest["schema_sha256"] = self.coordinates["schema_sha256"]
+        (self.tree / RELEASE_MANIFEST).write_bytes(canonical(self.manifest))
+        self.coordinates["release_manifest_sha256"] = digest(
+            self.tree / RELEASE_MANIFEST
+        )
+        self.rewrite_checksums()
+        with self.assertRaisesRegex(WorkspaceError, "violates its schema"):
+            verify_release_tree(self.tree, self.coordinates)
+
+    def test_build_metadata_and_supervised_topology_reuse_verified_root(self) -> None:
+        wrapper = self.root / "topology-wrapper"
+        wrapper.mkdir()
+        shutil.copy2(Path(__file__).resolve().parents[1] / "components.json", wrapper)
+        workspace_root = self.root / "topology-workspace"
+        previous = os.environ.get("ATRINIK_WORKSPACE_DIR")
+        os.environ["ATRINIK_WORKSPACE_DIR"] = str(workspace_root)
+        topology_name = "released-client"
+        workspace: Workspace | None = None
+        try:
+            workspace = Workspace(wrapper)
+            workspace.paths.ensure()
+            workspace.create_profile("classic-release", "classic")
+            workspace.set_profile_sound_mode(
+                "classic-release", "released", self.coordinates
+            )
+            build_root = workspace.paths.builds / "released-fixture"
+            build_root.mkdir(parents=True)
+            with mock.patch(
+                "atrinik_workspace.workspace.download_release_archive",
+                side_effect=lambda _url, destination: shutil.copy2(
+                    self.archive, destination
+                ),
+            ):
+                sound_root, sound_record = workspace._prepare_sound(
+                    build_root,
+                    {"sound": self.root / "unused-source"},
+                    "classic-release",
+                )
+            executable = build_root / "build" / "client" / "atrinik"
+            executable.parent.mkdir(parents=True)
+            executable.write_text(
+                "#!/usr/bin/env python3\nimport time\n"
+                "print('released client ready', flush=True)\ntime.sleep(5)\n",
+                encoding="utf-8",
+            )
+            executable.chmod(0o755)
+            (build_root / BUILD_METADATA).write_text(
+                json.dumps({"sound": sound_record}), encoding="utf-8"
+            )
+            client = self.root / "client"
+            client.mkdir()
+            (client / "tracked").write_text("fixture\n", encoding="utf-8")
+            selected = {"client": client, "sound": self.root / "unused-source"}
+            resolved = {
+                role: {
+                    "path": str(path),
+                    "checkout_path": str(path),
+                    "checkout": role,
+                    "repository": f"atrinik/{role}",
+                    "branch": "main",
+                    "source": ".",
+                    "head": ("a" if role == "client" else "b") * 40,
+                    "dirty": False,
+                }
+                for role, path in selected.items()
+            }
+            classic_stack = mock.Mock()
+            classic_stack.name = "classic"
+            classic_stack.components = workspace.manifest.stack("classic").components
+            classic_stack.providers = {
+                "client": workspace.manifest.by_name["client"],
+                "sound": workspace.manifest.by_name["sound"],
+            }
+            with (
+                mock.patch.object(
+                    workspace.manifest, "stack", return_value=classic_stack
+                ),
+                mock.patch.object(workspace, "_require_classic_contracts"),
+                mock.patch.object(workspace, "_require_client_display"),
+                mock.patch.object(
+                    workspace, "_resolve_build_profile", return_value=selected
+                ),
+                mock.patch.object(workspace, "_build_resolved", return_value=build_root),
+                mock.patch.object(
+                    workspace, "_topology_resolved_status", return_value=resolved
+                ),
+            ):
+                status = workspace.topology_up(
+                    topology_name, "classic-release", "default", ["client"]
+                )
+            self.assertEqual(status["sound"], sound_record)
+            runtime = Path(status["services"]["client"]["cwd"])
+            self.assertEqual((runtime / "sound").resolve(), sound_root.resolve())
+            spec = json.loads(
+                (workspace.paths.topologies / topology_name / "spec.json").read_text()
+            )
+            self.assertEqual(spec["sound"], sound_record)
+        finally:
+            if workspace is not None:
+                try:
+                    if "classic_stack" in locals():
+                        with mock.patch.object(
+                            workspace.manifest, "stack", return_value=classic_stack
+                        ):
+                            workspace.topology_down(topology_name, timeout=5)
+                    else:
+                        workspace.topology_down(topology_name, timeout=5)
+                except WorkspaceError:
+                    pass
+            if previous is None:
+                os.environ.pop("ATRINIK_WORKSPACE_DIR", None)
+            else:
+                os.environ["ATRINIK_WORKSPACE_DIR"] = previous
 
     def test_racing_cache_install_leaves_no_partial_runtime(self) -> None:
         wrapper = self.root / "race-wrapper"

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -12,6 +12,7 @@ import subprocess
 import tarfile
 import tempfile
 import unittest
+import urllib.error
 from unittest import mock
 
 from atrinik_workspace import sound as sound_module
@@ -1158,6 +1159,52 @@ class ReleasedSoundTests(unittest.TestCase):
                 )
         response.close.assert_called_once()
 
+    def test_download_headers_limits_and_completion_fail_closed(self) -> None:
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=urllib.error.URLError("offline")
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "cannot download"):
+                sound_module.download_release_archive(
+                    self.coordinates["asset_url"], self.root / "offline.tar.gz"
+                )
+        for index, (length, chunks, message) in enumerate((
+            ("invalid", [b""], "invalid Content-Length"),
+            ("0", [b""], "download limit"),
+            ("2", [b"x", b""], "incomplete"),
+            (None, [b""], "incomplete"),
+        )):
+            response = mock.Mock()
+            response.headers = {} if length is None else {"Content-Length": length}
+            response.read.side_effect = chunks
+            with self.subTest(length=length):
+                with mock.patch("urllib.request.urlopen", return_value=response):
+                    with self.assertRaisesRegex(WorkspaceError, message):
+                        sound_module.download_release_archive(
+                            self.coordinates["asset_url"],
+                            self.root / f"download-{index}.tar.gz",
+                        )
+            response.close.assert_called_once()
+        response = mock.Mock()
+        response.headers = {"Content-Length": "3"}
+        response.read.side_effect = [b"abc", b""]
+        response.close.side_effect = OSError("close failed")
+        with mock.patch("urllib.request.urlopen", return_value=response):
+            sound_module.download_release_archive(
+                self.coordinates["asset_url"], self.root / "complete.tar.gz"
+            )
+        self.assertEqual((self.root / "complete.tar.gz").read_bytes(), b"abc")
+        response = mock.Mock()
+        response.headers = {}
+        response.read.side_effect = [b"abc", b""]
+        with (
+            mock.patch("urllib.request.urlopen", return_value=response),
+            mock.patch.object(sound_module, "MAX_RELEASE_ARCHIVE_BYTES", 2),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "download limit"):
+                sound_module.download_release_archive(
+                    self.coordinates["asset_url"], self.root / "too-large.tar.gz"
+                )
+
     def test_marker_tampering_fails_closed(self) -> None:
         (self.tree / RELEASE_MARKER).write_text("{}\n", encoding="utf-8")
         self.rewrite_checksums()
@@ -1360,6 +1407,19 @@ class ReleasedSoundTests(unittest.TestCase):
             validate("value", {}, {}, budget=[0])
         with self.assertRaisesRegex(WorkspaceError, "unsupported"):
             validate("value", {"unknown": True}, {})
+        for schema, message in (
+            ({"maxItems": -1}, "maxItems"),
+            ({"maximum": float("inf")}, "maximum"),
+            ({"enum": []}, "enum"),
+            ({"required": "invalid"}, "required"),
+            ({"properties": []}, "properties"),
+            ({"pattern": 1}, "pattern"),
+            ({"uniqueItems": 1}, "uniqueItems"),
+            ({"type": "invalid"}, "type"),
+        ):
+            with self.subTest(instance_schema=schema):
+                with self.assertRaisesRegex(WorkspaceError, message):
+                    validate("value", schema, {})
         with self.assertRaisesRegex(WorkspaceError, "reference is invalid"):
             validate("value", {"$ref": "invalid"}, {})
         with self.assertRaisesRegex(WorkspaceError, "reference is unresolved"):

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -1290,6 +1290,9 @@ class ReleasedSoundTests(unittest.TestCase):
             {"type": "bogus"},
             {"required": "invalid"},
             {"maxItems": -1},
+            {"additionalProperties": "invalid"},
+            {"pattern": "["},
+            {"items": "invalid"},
         )):
             with self.subTest(invalid=invalid):
                 schema_path = self.tree / RELEASE_SCHEMA

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -1314,6 +1314,101 @@ class ReleasedSoundTests(unittest.TestCase):
                 with self.assertRaisesRegex(WorkspaceError, "packaged schema"):
                     verify_release_tree(self.tree, self.coordinates)
 
+    def test_schema_subset_validation_covers_supported_boundaries(self) -> None:
+        structure_failures = (
+            ([], "node"),
+            ({"unknown": True}, "unsupported"),
+            ({"maximum": float("inf")}, "maximum"),
+            ({"minimum": False}, "minimum"),
+            ({"enum": []}, "enum"),
+            ({"required": ["a", "a"]}, "required"),
+            ({"type": []}, "type"),
+            ({"uniqueItems": 1}, "uniqueItems"),
+            ({"pattern": "["}, "pattern"),
+            ({"properties": []}, "properties"),
+            ({"$defs": []}, "properties"),
+            ({"additionalProperties": []}, "node"),
+            ({"allOf": []}, "allOf"),
+        )
+        for schema, message in structure_failures:
+            with self.subTest(schema=schema):
+                with self.assertRaisesRegex(WorkspaceError, message):
+                    sound_module._validate_release_schema_structure(schema)
+        with self.assertRaisesRegex(WorkspaceError, "evaluation limits"):
+            sound_module._validate_release_schema_structure({}, budget=[0])
+        sound_module._validate_release_schema_structure(
+            {
+                "$defs": {"value": {"type": "string"}},
+                "properties": {"name": {"$ref": "#/$defs/value"}},
+                "items": True,
+                "additionalProperties": False,
+                "allOf": [True],
+                "maxItems": 1,
+                "minimum": 0,
+                "required": ["name"],
+                "type": ["object", "null"],
+                "uniqueItems": False,
+            }
+        )
+
+        validate = sound_module._validate_release_schema_instance
+        with self.assertRaises(sound_module._ReleaseSchemaMismatch):
+            validate("value", False, {})
+        with self.assertRaisesRegex(WorkspaceError, "node"):
+            validate("value", [], {})
+        with self.assertRaisesRegex(WorkspaceError, "evaluation limits"):
+            validate("value", {}, {}, budget=[0])
+        with self.assertRaisesRegex(WorkspaceError, "unsupported"):
+            validate("value", {"unknown": True}, {})
+        with self.assertRaisesRegex(WorkspaceError, "reference is invalid"):
+            validate("value", {"$ref": "invalid"}, {})
+        with self.assertRaisesRegex(WorkspaceError, "reference is unresolved"):
+            validate("value", {"$ref": "#/$defs/missing"}, {"$defs": {}})
+        root = {"$defs": {"text": {"type": "string"}}}
+        validate("value", {"$ref": "#/$defs/text"}, root)
+        for keyword in ("allOf", "anyOf", "oneOf"):
+            with self.subTest(keyword=keyword):
+                with self.assertRaisesRegex(WorkspaceError, keyword):
+                    validate("value", {keyword: []}, {})
+        validate("value", {"allOf": [True, True]}, {})
+        validate("value", {"anyOf": [False, True, True]}, {})
+        validate("value", {"oneOf": [False, True]}, {})
+        for schema, value, message in (
+            ({"allOf": [True, False]}, "x", "allOf"),
+            ({"anyOf": [False, False]}, "x", "anyOf"),
+            ({"oneOf": [True, True]}, "x", "oneOf"),
+            ({"const": "expected"}, "other", "const"),
+            ({"enum": ["expected"]}, "other", "enum"),
+            ({"type": "integer"}, "other", "wrong type"),
+            ({"type": "number"}, float("inf"), "wrong type"),
+            ({"type": "object", "required": ["name"]}, {}, "object"),
+            ({"type": "object", "minProperties": 2}, {"a": 1}, "minProperties"),
+            ({"type": "object", "maxProperties": 0}, {"a": 1}, "maxProperties"),
+            ({"type": "array", "minItems": 2}, [1], "minItems"),
+            ({"type": "array", "maxItems": 0}, [1], "maxItems"),
+            ({"type": "array", "uniqueItems": True}, [1, 1], "unique"),
+            ({"type": "string", "minLength": 2}, "x", "minLength"),
+            ({"type": "string", "maxLength": 0}, "x", "maxLength"),
+            ({"type": "string", "pattern": "^a"}, "x", "pattern"),
+            ({"type": "number", "minimum": 2}, 1, "minimum"),
+            ({"type": "number", "maximum": 0}, 1, "maximum"),
+        ):
+            with self.subTest(schema=schema, value=value):
+                with self.assertRaisesRegex(
+                    sound_module._ReleaseSchemaMismatch, message
+                ):
+                    validate(value, schema, {})
+        validate(
+            {"name": "value", "extra": 1},
+            {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "additionalProperties": {"type": "integer"},
+            },
+            {},
+        )
+        validate(["a", "b"], {"type": "array", "items": {"type": "string"}}, {})
+
     def test_build_metadata_and_supervised_topology_reuse_verified_root(self) -> None:
         wrapper = self.root / "topology-wrapper"
         wrapper.mkdir()

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -17,6 +17,7 @@ import urllib.error
 from unittest import mock
 
 from atrinik_workspace import sound as sound_module
+from atrinik_workspace import workspace as workspace_module
 from atrinik_workspace.model import WorkspaceError
 from atrinik_workspace.sound import (
     PLAYTEST_BLOCKERS,
@@ -970,6 +971,34 @@ class ReleasedSoundTests(unittest.TestCase):
             tree_hash.update(
                 f"{output['sha256']}  {asset['logical_path']}\n".encode()
             )
+        source_manifest = {
+            "$schema": "../schemas/source-assets-v1.schema.json",
+            "assets": [
+                {
+                    "logical_path": asset["logical_path"],
+                    "source_path": asset["source_path"],
+                    "source": asset["source"],
+                }
+                for asset in assets
+            ],
+            "audio_source_count": 339,
+            "schema_version": 1,
+            "source_corpus_sha256": "e" * 64,
+            "source_size_bytes": 1,
+        }
+        source_manifest_path = self.tree / "manifests/source-assets.json"
+        source_manifest_path.write_bytes(canonical(source_manifest))
+        source_manifest_hash = digest(source_manifest_path)
+        toolchain = {
+            "$schema": "../schemas/classic-audio-toolchain-v1.schema.json",
+            "schema_version": 1,
+            "tools": {name: {} for name in sorted(sound_module.TOOL_NAMES)},
+        }
+        toolchain_path = self.tree / "manifests/classic-audio-toolchain.json"
+        toolchain_path.write_bytes(canonical(toolchain))
+        toolchain_hash = digest(toolchain_path)
+        remediation["source_manifest_sha256"] = source_manifest_hash
+        (self.tree / RELEASE_REMEDIATION).write_bytes(canonical(remediation))
         self.manifest = {
             "$schema": RELEASE_SCHEMA,
             "schema_version": 1,
@@ -978,8 +1007,8 @@ class ReleasedSoundTests(unittest.TestCase):
             "publishable": True,
             "source_commit": "a" * 40,
             "source_tree": "b" * 40,
-            "source_manifest_sha256": "c" * 64,
-            "toolchain_sha256": "d" * 64,
+            "source_manifest_sha256": source_manifest_hash,
+            "toolchain_sha256": toolchain_hash,
             "tool_versions": {name: "fixture" for name in sorted(sound_module.TOOL_NAMES)},
             "schema_sha256": digest(schema),
             "remediation_report_sha256": digest(self.tree / RELEASE_REMEDIATION),
@@ -1011,9 +1040,9 @@ class ReleasedSoundTests(unittest.TestCase):
             ),
             "archive_sha256": digest(self.archive),
             "release_manifest_sha256": digest(self.tree / RELEASE_MANIFEST),
-            "source_manifest_sha256": "c" * 64,
+            "source_manifest_sha256": source_manifest_hash,
             "schema_sha256": digest(schema),
-            "toolchain_sha256": "d" * 64,
+            "toolchain_sha256": toolchain_hash,
             "output_tree_sha256": tree_hash.hexdigest(),
         }
 
@@ -1204,7 +1233,7 @@ class ReleasedSoundTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "already exists"):
             extract_release_archive(self.archive, existing, self.coordinates)
         with mock.patch.object(sound_module, "MAX_RELEASE_ARCHIVE_BYTES", 1):
-            with self.assertRaisesRegex(WorkspaceError, "extraction input limit"):
+            with self.assertRaisesRegex(WorkspaceError, "size limit"):
                 extract_release_archive(
                     self.archive, self.root / "input-too-large", self.coordinates
                 )
@@ -1258,6 +1287,24 @@ class ReleasedSoundTests(unittest.TestCase):
                 self.root / "unexpected-directory",
                 self.coordinates,
             )
+
+    def test_oversized_cached_archive_is_rejected_before_decompression(self) -> None:
+        oversized = self.root / "oversized-cache.tar.gz"
+        with oversized.open("wb") as stream:
+            stream.truncate(2)
+        with (
+            mock.patch.object(sound_module, "MAX_RELEASE_ARCHIVE_BYTES", 1),
+            mock.patch.object(sound_module, "_prescan_release_archive") as prescan,
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "size limit"):
+                sound_module.verify_release_archive(
+                    oversized, self.coordinates, "cached released sound archive"
+                )
+            with self.assertRaisesRegex(WorkspaceError, "size limit"):
+                extract_release_archive(
+                    oversized, self.root / "oversized-output", self.coordinates
+                )
+            prescan.assert_not_called()
 
     def test_interrupted_download_is_a_workspace_error(self) -> None:
         response = mock.Mock()
@@ -1427,7 +1474,52 @@ class ReleasedSoundTests(unittest.TestCase):
             self.tree / RELEASE_MANIFEST
         )
         self.rewrite_checksums()
-        with self.assertRaisesRegex(WorkspaceError, "counts.*339-path"):
+        with self.assertRaisesRegex(WorkspaceError, "source manifest closure"):
+            verify_release_tree(self.tree, self.coordinates)
+
+    def test_source_manifest_and_toolchain_pins_and_closure_are_required(self) -> None:
+        source_path = self.tree / "manifests/source-assets.json"
+        source_manifest = json.loads(source_path.read_text(encoding="utf-8"))
+        source_manifest["assets"][0]["source"]["sha256"] = "0" * 64
+        source_path.write_bytes(canonical(source_manifest))
+        source_hash = digest(source_path)
+        self.coordinates["source_manifest_sha256"] = source_hash
+        self.manifest["source_manifest_sha256"] = source_hash
+        remediation_path = self.tree / RELEASE_REMEDIATION
+        remediation = json.loads(remediation_path.read_text(encoding="utf-8"))
+        remediation["source_manifest_sha256"] = source_hash
+        remediation_path.write_bytes(canonical(remediation))
+        self.manifest["remediation_report_sha256"] = digest(remediation_path)
+        (self.tree / RELEASE_MANIFEST).write_bytes(canonical(self.manifest))
+        self.coordinates["release_manifest_sha256"] = digest(
+            self.tree / RELEASE_MANIFEST
+        )
+        self.rewrite_checksums()
+        with self.assertRaisesRegex(WorkspaceError, "source manifest closure"):
+            verify_release_tree(self.tree, self.coordinates)
+
+        self.manifest["assets"][0]["source"]["sha256"] = "0" * 64
+        (self.tree / RELEASE_MANIFEST).write_bytes(canonical(self.manifest))
+        self.coordinates["release_manifest_sha256"] = digest(
+            self.tree / RELEASE_MANIFEST
+        )
+        toolchain_path = self.tree / "manifests/classic-audio-toolchain.json"
+        toolchain_path.write_bytes(toolchain_path.read_bytes() + b" ")
+        self.rewrite_checksums()
+        with self.assertRaisesRegex(WorkspaceError, "toolchain hash"):
+            verify_release_tree(self.tree, self.coordinates)
+
+    def test_schema_regex_and_json_nesting_are_bounded(self) -> None:
+        with self.assertRaisesRegex(WorkspaceError, "pattern is unsupported"):
+            sound_module._validate_release_schema_structure(
+                {"type": "string", "pattern": "(a+)+$"}
+            )
+
+        manifest_path = self.tree / RELEASE_MANIFEST
+        nested = (b'{"x":' * 1500) + b"0" + (b"}" * 1500)
+        manifest_path.write_bytes(nested)
+        self.coordinates["release_manifest_sha256"] = hashlib.sha256(nested).hexdigest()
+        with self.assertRaisesRegex(WorkspaceError, "nesting limit"):
             verify_release_tree(self.tree, self.coordinates)
 
     def test_nonstandard_json_numbers_are_rejected(self) -> None:
@@ -1637,7 +1729,7 @@ class ReleasedSoundTests(unittest.TestCase):
             ({"type": "array", "uniqueItems": True}, [1, 1], "unique"),
             ({"type": "string", "minLength": 2}, "x", "minLength"),
             ({"type": "string", "maxLength": 0}, "x", "maxLength"),
-            ({"type": "string", "pattern": "^a"}, "x", "pattern"),
+            ({"type": "string", "pattern": r"^[0-9a-f]{64}$"}, "x", "pattern"),
             ({"type": "number", "minimum": 2}, 1, "minimum"),
             ({"type": "number", "maximum": 0}, 1, "maximum"),
         ):
@@ -1855,6 +1947,43 @@ class ReleasedSoundTests(unittest.TestCase):
                 )
         runtime = build / "runtime"
         self.assertEqual(list(runtime.iterdir()), [])
+
+    def test_raced_runtime_parent_identity_fails_closed(self) -> None:
+        wrapper = self.root / "parent-race-wrapper"
+        wrapper.mkdir()
+        shutil.copy2(Path(__file__).resolve().parents[1] / "components.json", wrapper)
+        workspace = Workspace(wrapper)
+        build = self.root / "parent-race-build"
+        build.mkdir()
+        profile = {
+            "stack": "classic",
+            "sound_mode": "released",
+            "sound_release": self.coordinates,
+        }
+        real_stat = workspace_module.os.stat
+
+        def raced_stat(path: object, *args: object, **kwargs: object) -> os.stat_result:
+            result = real_stat(path, *args, **kwargs)
+            if path == "runtime" and kwargs.get("dir_fd") is not None:
+                fields = list(result)
+                fields[1] += 1
+                return os.stat_result(fields)
+            return result
+
+        with (
+            mock.patch.object(workspace, "_load_profile", return_value=profile),
+            mock.patch(
+                "atrinik_workspace.workspace.download_release_archive",
+                side_effect=lambda _url, destination: shutil.copy2(
+                    self.archive, destination
+                ),
+            ),
+            mock.patch.object(workspace_module.os, "stat", side_effect=raced_stat),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "parent changed"):
+                workspace._prepare_sound(
+                    build, {"sound": self.root / "unused-source"}, "classic-release"
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -25,8 +25,9 @@ from atrinik_workspace.sound import (
     PLAYTEST_SCHEMA,
     RELEASE_CHECKSUMS,
     RELEASE_MANIFEST,
-    RELEASE_MARKER,
+    RELEASE_METADATA_FILES,
     RELEASE_PRODUCT,
+    RELEASE_REMEDIATION,
     RELEASE_SCHEMA,
     cache_key,
     clean_source_inputs,
@@ -888,34 +889,39 @@ class ReleasedSoundTests(unittest.TestCase):
         schema.parent.mkdir()
         schema_fields = [
             "$schema", "assets", "converted_opus_count",
-            "copied_vorbis_count", "logical_path_count", "marker_sha256",
-            "notices", "output_tree_sha256", "playtest_only", "product",
-            "product_version", "publishable", "release_tag", "repository",
+            "copied_vorbis_count", "logical_path_count", "output_tree_sha256",
+            "playtest_only", "publishable", "release_tag",
+            "remediation_finding_count", "remediation_report_sha256",
             "schema_sha256", "schema_version", "source_commit",
-            "source_manifest_sha256", "source_tree", "toolchain_sha256",
+            "source_manifest_sha256", "source_tree", "tool_versions",
+            "toolchain_sha256",
         ]
         schema.write_bytes(canonical({
-            "$id": f"https://atrinik.org/{RELEASE_SCHEMA}",
+            "$id": "https://atrinik.org/schemas/sound/classic-runtime-manifest-v1.schema.json",
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "additionalProperties": False,
             "properties": {name: {} for name in schema_fields},
             "required": schema_fields,
             "type": "object",
         }))
-        marker = {
-            "format": RELEASE_PRODUCT,
-            "playtest_only": False,
-            "product_version": "1.4.0",
-            "publishable": True,
+        for relative in RELEASE_METADATA_FILES - {RELEASE_SCHEMA, RELEASE_REMEDIATION}:
+            metadata = self.tree / relative
+            metadata.parent.mkdir(parents=True, exist_ok=True)
+            metadata.write_text(f"fixture metadata {relative}\n", encoding="utf-8")
+        remediation = {
+            "$schema": "schemas/classic-remediation-v1.schema.json",
+            "category_counts": {},
+            "classification": "nonblocking-modernization",
+            "count": 0,
+            "findings": [],
+            "release_boundary": "Fixture modernization boundary.",
             "schema_version": 1,
+            "source_commit": "a" * 40,
+            "source_count": 339,
+            "source_manifest_sha256": "c" * 64,
+            "source_tree": "b" * 40,
         }
-        (self.tree / RELEASE_MARKER).write_bytes(canonical(marker))
-        notices = []
-        for path in ("background/LICENSE", "effects/LICENSE"):
-            notice = self.tree / path
-            notice.parent.mkdir(exist_ok=True)
-            notice.write_text(f"fixture notice {path}\n", encoding="utf-8")
-            notices.append({"path": path, "sha256": digest(notice)})
+        (self.tree / RELEASE_REMEDIATION).write_bytes(canonical(remediation))
         assets: list[dict[str, object]] = []
         for index in range(339):
             copied = index >= 150
@@ -938,7 +944,10 @@ class ReleasedSoundTests(unittest.TestCase):
                 "mapping": "copy" if copied else "render-opus",
                 "source": {
                     "codec": source_codec,
-                    "container": "ogg" if copied else source_codec,
+                    "container": (
+                        "ogg" if copied else
+                        "standard-midi-file" if source_codec == "midi" else "flac"
+                    ),
                     "sha256": payload_hash if copied else hashlib.sha256(
                         f"source-{index}".encode()
                     ).hexdigest(),
@@ -964,23 +973,21 @@ class ReleasedSoundTests(unittest.TestCase):
         self.manifest = {
             "$schema": RELEASE_SCHEMA,
             "schema_version": 1,
-            "product": RELEASE_PRODUCT,
-            "product_version": "1.4.0",
             "release_tag": "v1.4.0",
-            "repository": "atrinik/sound",
             "playtest_only": False,
             "publishable": True,
             "source_commit": "a" * 40,
             "source_tree": "b" * 40,
             "source_manifest_sha256": "c" * 64,
             "toolchain_sha256": "d" * 64,
+            "tool_versions": {name: "fixture" for name in sorted(sound_module.TOOL_NAMES)},
             "schema_sha256": digest(schema),
-            "marker_sha256": digest(self.tree / RELEASE_MARKER),
+            "remediation_report_sha256": digest(self.tree / RELEASE_REMEDIATION),
+            "remediation_finding_count": 0,
             "logical_path_count": 339,
             "copied_vorbis_count": 189,
             "converted_opus_count": 150,
             "output_tree_sha256": tree_hash.hexdigest(),
-            "notices": notices,
             "assets": assets,
         }
         (self.tree / RELEASE_MANIFEST).write_bytes(canonical(self.manifest))
@@ -1069,7 +1076,7 @@ class ReleasedSoundTests(unittest.TestCase):
         self.assertEqual(first_record, second_record)
         self.assertEqual(first_record["archive_sha256"], self.coordinates["archive_sha256"])
 
-    def test_coordinates_marker_payload_and_archive_fail_closed(self) -> None:
+    def test_coordinates_payload_and_archive_fail_closed(self) -> None:
         for coordinates in (
             {**self.coordinates, "asset_url": "https://example.com/a"},
             {**self.coordinates, "repository": "atrinik/classic"},
@@ -1218,10 +1225,10 @@ class ReleasedSoundTests(unittest.TestCase):
                 wrong_prefix, self.root / "wrong-prefix", self.coordinates
             )
 
-        missing_directory = self.root / "missing-directory.tar.gz"
+        implicit_directory = self.root / "implicit-directory.tar.gz"
         prefix = f"{RELEASE_PRODUCT}-1.4.0"
         with tarfile.open(
-            missing_directory, "w:gz", format=tarfile.USTAR_FORMAT
+            implicit_directory, "w:gz", format=tarfile.USTAR_FORMAT
         ) as archive:
             root = tarfile.TarInfo(prefix)
             root.type = tarfile.DIRTYPE
@@ -1229,9 +1236,27 @@ class ReleasedSoundTests(unittest.TestCase):
             member = tarfile.TarInfo(f"{prefix}/nested/file")
             member.size = 1
             archive.addfile(member, io.BytesIO(b"x"))
-        with self.assertRaisesRegex(WorkspaceError, "directories"):
+        implicit_destination = self.root / "implicit-directory"
+        extract_release_archive(
+            implicit_directory, implicit_destination, self.coordinates
+        )
+        self.assertEqual((implicit_destination / "nested" / "file").read_bytes(), b"x")
+
+        unexpected_directory = self.root / "unexpected-directory.tar.gz"
+        with tarfile.open(
+            unexpected_directory, "w:gz", format=tarfile.USTAR_FORMAT
+        ) as archive:
+            root = tarfile.TarInfo(prefix)
+            root.type = tarfile.DIRTYPE
+            archive.addfile(root)
+            extra = tarfile.TarInfo(f"{prefix}/empty")
+            extra.type = tarfile.DIRTYPE
+            archive.addfile(extra)
+        with self.assertRaisesRegex(WorkspaceError, "unexpected directories"):
             extract_release_archive(
-                missing_directory, self.root / "missing-directory", self.coordinates
+                unexpected_directory,
+                self.root / "unexpected-directory",
+                self.coordinates,
             )
 
     def test_interrupted_download_is_a_workspace_error(self) -> None:
@@ -1291,17 +1316,16 @@ class ReleasedSoundTests(unittest.TestCase):
                     self.coordinates["asset_url"], self.root / "too-large.tar.gz"
                 )
 
-    def test_marker_tampering_fails_closed(self) -> None:
-        (self.tree / RELEASE_MARKER).write_text("{}\n", encoding="utf-8")
+    def test_remediation_tampering_fails_closed(self) -> None:
+        (self.tree / RELEASE_REMEDIATION).write_text("{}\n", encoding="utf-8")
         self.rewrite_checksums()
-        with self.assertRaisesRegex(WorkspaceError, "marker"):
+        with self.assertRaisesRegex(WorkspaceError, "remediation"):
             verify_release_tree(self.tree, self.coordinates)
 
     def test_notice_tampering_fails_closed(self) -> None:
         notice = self.tree / "background/LICENSE"
         notice.write_text("tampered\n", encoding="utf-8")
-        self.rewrite_checksums()
-        with self.assertRaisesRegex(WorkspaceError, "notice"):
+        with self.assertRaisesRegex(WorkspaceError, "checksum"):
             verify_release_tree(self.tree, self.coordinates)
 
     def test_missing_checksums_fail_closed(self) -> None:
@@ -1359,7 +1383,7 @@ class ReleasedSoundTests(unittest.TestCase):
                 verify_release_tree(self.tree, self.coordinates)
             restore()
 
-            self.manifest["product"] = "wrong-product"
+            self.manifest["release_tag"] = "v9.9.9"
             manifest_path.write_bytes(canonical(self.manifest))
             self.coordinates["release_manifest_sha256"] = digest(manifest_path)
             with self.assertRaisesRegex(WorkspaceError, "manifest identity"):
@@ -1397,7 +1421,7 @@ class ReleasedSoundTests(unittest.TestCase):
         for asset in self.manifest["assets"]:
             if asset["source"]["codec"] == "flac":
                 asset["source"]["codec"] = "midi"
-                asset["source"]["container"] = "midi"
+                asset["source"]["container"] = "standard-midi-file"
         (self.tree / RELEASE_MANIFEST).write_bytes(canonical(self.manifest))
         self.coordinates["release_manifest_sha256"] = digest(
             self.tree / RELEASE_MANIFEST
@@ -1525,6 +1549,8 @@ class ReleasedSoundTests(unittest.TestCase):
         structure_failures = (
             ([], "node"),
             ({"unknown": True}, "unsupported"),
+            ({"exclusiveMaximum": float("inf")}, "exclusiveMaximum"),
+            ({"exclusiveMinimum": False}, "exclusiveMinimum"),
             ({"maximum": float("inf")}, "maximum"),
             ({"minimum": False}, "minimum"),
             ({"enum": []}, "enum"),
@@ -1601,6 +1627,8 @@ class ReleasedSoundTests(unittest.TestCase):
             ({"enum": ["expected"]}, "other", "enum"),
             ({"type": "integer"}, "other", "wrong type"),
             ({"type": "number"}, float("inf"), "wrong type"),
+            ({"type": "number", "exclusiveMinimum": 1}, 1, "exclusiveMinimum"),
+            ({"type": "number", "exclusiveMaximum": 1}, 1, "exclusiveMaximum"),
             ({"type": "object", "required": ["name"]}, {}, "object"),
             ({"type": "object", "minProperties": 2}, {"a": 1}, "minProperties"),
             ({"type": "object", "maxProperties": 0}, {"a": 1}, "maxProperties"),

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -1044,6 +1044,49 @@ class InventoryTests(unittest.TestCase):
         self.assertIn("| Dependency | Version |", inventory.report("licenses"))
         self.assertIn("| Component | Repository | Branch |", inventory.report("licenses"))
 
+    def test_reports_bind_profile_selected_sound_release_coordinates(self) -> None:
+        release = {
+            "archive_sha256": "a" * 64,
+            "asset_url": (
+                "https://github.com/atrinik/sound/releases/download/v1.2.3/"
+                "atrinik-sound-classic-runtime-1.2.3.tar.gz"
+            ),
+            "manifest_schema_version": 1,
+            "output_tree_sha256": "b" * 64,
+            "product": "atrinik-sound-classic-runtime",
+            "product_version": "1.2.3",
+            "release_manifest_sha256": "c" * 64,
+            "repository": "atrinik/sound",
+            "schema_sha256": "d" * 64,
+            "source_commit": "e" * 40,
+            "source_manifest_sha256": "f" * 64,
+            "source_tree": "1" * 40,
+            "tag": "v1.2.3",
+            "toolchain_sha256": "2" * 64,
+        }
+        inventory = self.load_inventory()
+        cyclonedx = json.loads(inventory.report("cyclonedx", sound_release=release))
+        component = next(
+            item for item in cyclonedx["components"]
+            if item["name"] == "atrinik-sound-classic-runtime"
+            and item["version"] == "1.2.3"
+        )
+        self.assertEqual(component["hashes"][0]["content"], "a" * 64)
+        properties = {item["name"]: item["value"] for item in component["properties"]}
+        self.assertEqual(properties["atrinik:sound:source_commit"], "e" * 40)
+        self.assertEqual(properties["atrinik:sound:output_tree_sha256"], "b" * 64)
+
+        spdx = json.loads(inventory.report("spdx", sound_release=release))
+        package = next(
+            item for item in spdx["packages"]
+            if item["name"] == "atrinik-sound-classic-runtime"
+            and item["versionInfo"] == "1.2.3"
+        )
+        self.assertEqual(package["checksums"][0]["checksumValue"], "a" * 64)
+        licenses = inventory.report("licenses", sound_release=release)
+        self.assertIn("## Profile-selected released sound runtime", licenses)
+        self.assertIn("e" * 40, licenses)
+
     def test_reports_resolve_one_content_commit_for_both_stacks(self) -> None:
         inventory = self.load_inventory()
         default_commit = "a" * 40

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -6294,7 +6294,11 @@ class WorkspaceTests(unittest.TestCase):
         self.assertIn("default-", summary["build_root"])
         self.assertEqual(
             summary["sound"],
-            {"mode": "source", "source_path": str(self.wrapper / "sound")},
+            {
+                "mode": "source",
+                "release": None,
+                "source_path": str(self.wrapper / "sound"),
+            },
         )
 
     def test_supervised_topology_lifecycle_and_logs(self) -> None:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -11228,6 +11228,9 @@ class WorkspaceTests(unittest.TestCase):
         (source / "tools").mkdir()
         for name in ("ca-bundle.crt", "permissions.cfg", "server.cfg"):
             (source / name).write_text("test\n", encoding="utf-8")
+        client_source = self.workspace.paths.repositories / "client" / "src"
+        client_source.mkdir()
+        (client_source / "authored.c").write_text("source\n", encoding="utf-8")
         build_root = self.workspace.paths.builds / "fake-server-topology"
         binary = build_root / "build" / "server"
         binary.mkdir(parents=True)
@@ -11283,6 +11286,11 @@ class WorkspaceTests(unittest.TestCase):
         self.make_region_map_cache(build_root)
         client = build_root / "build" / "client" / "atrinik"
         client.parent.mkdir(parents=True)
+        build_only_source = client.parent / "src"
+        build_only_source.mkdir()
+        (build_only_source / "generated.c").write_text(
+            "build-only\n", encoding="utf-8"
+        )
         (build_root / "sources" / "client").mkdir(parents=True)
         client.write_text(
             "#!/usr/bin/env python3\n"
@@ -11406,6 +11414,13 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual(
             Path(status["services"]["client"]["cwd"]),
             generation_root / "client",
+        )
+        self.assertFalse(
+            (generation_root / "client" / "src" / "generated.c").exists()
+        )
+        self.assertEqual(
+            (generation_root / "client" / "src" / "authored.c").read_text(),
+            "source\n",
         )
         client_log = self.workspace.paths.topologies / "server-review" / "client.log"
         server_log = self.workspace.paths.topologies / "server-review" / "server.log"


### PR DESCRIPTION
Closes #313.

## Summary

- add an explicit Classic-only `released` sound mode pinned to the immutable `atrinik/sound` v1.4.1 runtime product
- independently verify the bounded archive, schema, remediation report, source/toolchain manifests, 339-entry source/runtime closure, and logical output tree before use
- publish and reuse the verified cache atomically with descriptor-pinned build/runtime/staging paths and fail-closed race handling
- carry exact release coordinates through profile migration/completion, build and topology records, diagnostics, licenses, CycloneDX, SPDX, documentation, and supply-chain audit output
- preserve authored Classic client sources while publishing the complete generated runtime tree

## Exact release

- asset: `atrinik-sound-classic-runtime-1.4.1.tar.gz`
- archive SHA-256: `8373868ab4632eda58ae7959909f414a10a43ce519dd1ef9e7f911d4fa208a52`
- source commit/tree: `49a169bf41568e4e3b3ac70dfaf42b1a3eabe985` / `92b81774820dfd55944f4d7b005c1dc344b43561`
- output tree SHA-256: `2c3d42ea91ca088ac37e5215e3452dad31e5f1fb17018941ed5ad0a3c53060da`
- contents: 339 logical paths (189 Vorbis, 150 Opus)

## Verification

- 869 Python tests passed; total coverage 83%
- 76 native Classic client tests passed against the released root
- exact closed-proxy cache reuse passed; changed provider identity invalidated the build key and failed offline until explicitly rebuilt
- post-merge supervised client topology `issue-313-released-sound-v141-head` reached ready/live, initialized `STBVORBIS` and `OPUS`, and stopped cleanly with client exit 0
- compileall, guidance inventory, MCP contract, manifest, provenance, supply-chain validation, complete-profile supply-chain audit, and `git diff --check` passed
- cleanup previews found zero candidates and zero errors; no cleanup was applied
- three independent latest-base whole-diff reviews (requirements, security/concurrency, tests/operations) report zero actionable findings

Base reviewed: `3c21ce575076be9effee102b5e95b52399bfceed`

Head: `f5fe656ca5129b06da7a9db0d9e742586fd2a841`
