### PR TITLE
chore(provenance): authorize landed-main component reviews

### DIFF
--- a/docs/PROVENANCE_IDENTITIES.md
+++ b/docs/PROVENANCE_IDENTITIES.md
@@ -138,10 +138,11 @@ history, or consult a local alias copy. A signed-release mode is not implemented
 in schema v1 and therefore fails closed.
 
 The synthetic component-owned records for `atrinik/client` and
-`atrinik/server` exercise the bounded audit path before merge. The copies in
-this repository are test fixtures; each component keeps its own identical
-reference record and validates it without copying the canonical registry,
-schema, or reviewer roster:
+`atrinik/server` pin coordinator commit
+`6f6040212f0fa0cb6b8e4e695d1488a403d966be`, the squash merge of PR #381
+already on canonical `origin/main`. The copies in this repository are test
+fixtures; each component keeps its own identical reference record and validates
+it without copying the canonical registry, schema, or reviewer roster:
 
 ```sh
 ./atrinik provenance validate \
@@ -149,15 +150,11 @@ schema, or reviewer roster:
   --reference tests/fixtures/provenance-identities/positive/synthetic-beta.json
 ```
 
-Their pinned URLs become online after this branch is pushed. They may be
-exercised only with `--non-authorizing-audit-ref
-origin/feat/privacy-preserving-provenance-registry`; that mode is visibly not an
-approval for reuse. They carry an authenticated `synthetic: true` boundary and
-are test evidence, not permission for real material. Because the branch is
-squash-merged, these exact intermediate commits do not become default-branch
-ancestors. Completing the production-path demonstration is therefore an
-explicit post-merge dependency: new records must be reviewed and signed only
-after their coordinator revision has landed on the default branch.
+Use the default command exactly as shown: do not set a trusted-ref override and
+do not add `--non-authorizing-audit-ref`. Current revocation state and reviewer
+authority come from canonical `origin/main`; the immutable evidence bytes come
+from the pinned landed commit. The records carry an authenticated `synthetic:
+true` boundary and remain test evidence, not permission for real material.
 
 ## Migration and review
 

--- a/governance/provenance-identities/reviewers.json
+++ b/governance/provenance-identities/reviewers.json
@@ -2,6 +2,15 @@
   "schema_version": 1,
   "reviewers": [
     {
+      "key_id": "synthetic-component-reviewer-2026",
+      "identity": "github:synthetic-reviewer",
+      "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJIxqjJr/zPvtDRRUyyBSt5LifOHeWRZFkL18ivkHoQ6",
+      "effective_on": "2026-08-13",
+      "expires_on": "2027-08-13",
+      "status": "active",
+      "synthetic": true
+    },
+    {
       "key_id": "synthetic-reviewer-2026",
       "identity": "github:synthetic-reviewer",
       "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAa7lVgb+BRLmh78l9c9d6kTvQVE1xA9AxgI02lg8dTQ",

--- a/tests/fixtures/provenance-identities/negative/broken-reference.json
+++ b/tests/fixtures/provenance-identities/negative/broken-reference.json
@@ -18,11 +18,11 @@
   },
   "evidence_reference": {
     "repository": "atrinik/atrinik",
-    "revision": "51aa7ac9d5ae9c0ff0b2a24a46b5d3e97739bbe0",
+    "revision": "6f6040212f0fa0cb6b8e4e695d1488a403d966be",
     "record_id": "pir-c-11111111111111111111111111111111",
     "registry_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
     "schema_sha256": "9c726627c8679b4b437db2b54b2480fe0c45eef788de7cd76de1dec5c3ce3409",
     "reviewers_sha256": "b7a44ad27cec663a9092b924a0f6a9c95bf95a2ce74cf75ba8873e7938782240",
-    "url": "https://github.com/atrinik/atrinik/blob/51aa7ac9d5ae9c0ff0b2a24a46b5d3e97739bbe0/governance/provenance-identities/registry.json#pir-c-11111111111111111111111111111111"
+    "url": "https://github.com/atrinik/atrinik/blob/6f6040212f0fa0cb6b8e4e695d1488a403d966be/governance/provenance-identities/registry.json#pir-c-11111111111111111111111111111111"
   }
 }

--- a/tests/fixtures/provenance-identities/positive/synthetic-alpha.json
+++ b/tests/fixtures/provenance-identities/positive/synthetic-alpha.json
@@ -13,16 +13,16 @@
   "transformation": "Synthetic translation used only to verify the reference contract.",
   "scope_binding": "psb-11111111111111111111111111111111",
   "scope_approval": {
-    "key_id": "synthetic-reviewer-2026",
-    "signature": "-----BEGIN SSH SIGNATURE-----\nU1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgBruVWBv4FEuaHvyX1z13qRO9BU\nTXED0DGAjTaWDx1NAAAAAVYXRyaW5pay1wcm92ZW5hbmNlLXYxAAAAAAAAAAZzaGE1MTIA\nAABTAAAAC3NzaC1lZDI1NTE5AAAAQItDk43Z/DT32bCWwTUrmCW5qtS9sCzETIeVGSoe9b\n9Rw2rjYAFWY+c2vV2Ix/U8ZkX7ljYhq1ejCjHSzIBlHww=\n-----END SSH SIGNATURE-----"
+    "key_id": "synthetic-component-reviewer-2026",
+    "signature": "-----BEGIN SSH SIGNATURE-----\nU1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgkjGqMmv/M++0NFFTLIFK3kuJ84\nd5ZFkWQvXyK+QehDoAAAAVYXRyaW5pay1wcm92ZW5hbmNlLXYxAAAAAAAAAAZzaGE1MTIA\nAABTAAAAC3NzaC1lZDI1NTE5AAAAQNukHJqV+oT3QtlFzXxPkIK3v99k6wrQZtYazIirrH\nQ+KUhiush2SDPRPmzRDckm3KNPF/NSD7OFCDTCaUs1fQk=\n-----END SSH SIGNATURE-----"
   },
   "evidence_reference": {
     "repository": "atrinik/atrinik",
-    "revision": "51aa7ac9d5ae9c0ff0b2a24a46b5d3e97739bbe0",
+    "revision": "6f6040212f0fa0cb6b8e4e695d1488a403d966be",
     "record_id": "pir-c-11111111111111111111111111111111",
     "registry_sha256": "0a04fcadccb37e64f6c1209bc0b7e8d5762639ce4c5521c3bba028d9eba037bd",
     "schema_sha256": "9c726627c8679b4b437db2b54b2480fe0c45eef788de7cd76de1dec5c3ce3409",
     "reviewers_sha256": "b7a44ad27cec663a9092b924a0f6a9c95bf95a2ce74cf75ba8873e7938782240",
-    "url": "https://github.com/atrinik/atrinik/blob/51aa7ac9d5ae9c0ff0b2a24a46b5d3e97739bbe0/governance/provenance-identities/registry.json#pir-c-11111111111111111111111111111111"
+    "url": "https://github.com/atrinik/atrinik/blob/6f6040212f0fa0cb6b8e4e695d1488a403d966be/governance/provenance-identities/registry.json#pir-c-11111111111111111111111111111111"
   }
 }

--- a/tests/fixtures/provenance-identities/positive/synthetic-beta.json
+++ b/tests/fixtures/provenance-identities/positive/synthetic-beta.json
@@ -13,16 +13,16 @@
   "transformation": "Synthetic port used only to verify the reference contract.",
   "scope_binding": "psb-22222222222222222222222222222222",
   "scope_approval": {
-    "key_id": "synthetic-reviewer-2026",
-    "signature": "-----BEGIN SSH SIGNATURE-----\nU1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgBruVWBv4FEuaHvyX1z13qRO9BU\nTXED0DGAjTaWDx1NAAAAAVYXRyaW5pay1wcm92ZW5hbmNlLXYxAAAAAAAAAAZzaGE1MTIA\nAABTAAAAC3NzaC1lZDI1NTE5AAAAQIIntFyZwxlBb8JrL5UGvsL55gDCSPrsD63OUhQdDz\n1u0Aiv3EtOOR5D79Ort0aOsVmoADkKb3IVmxYRM7vt3wI=\n-----END SSH SIGNATURE-----"
+    "key_id": "synthetic-component-reviewer-2026",
+    "signature": "-----BEGIN SSH SIGNATURE-----\nU1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgkjGqMmv/M++0NFFTLIFK3kuJ84\nd5ZFkWQvXyK+QehDoAAAAVYXRyaW5pay1wcm92ZW5hbmNlLXYxAAAAAAAAAAZzaGE1MTIA\nAABTAAAAC3NzaC1lZDI1NTE5AAAAQNRLaQRiwLHs8L7csYA7tI5RLLZNWARYbHp8VASw+C\nAmjNuEKeafM9Xlv3er28KlBF3qXpxTB2C/WQLNZ6CsfgY=\n-----END SSH SIGNATURE-----"
   },
   "evidence_reference": {
     "repository": "atrinik/atrinik",
-    "revision": "51aa7ac9d5ae9c0ff0b2a24a46b5d3e97739bbe0",
+    "revision": "6f6040212f0fa0cb6b8e4e695d1488a403d966be",
     "record_id": "pir-c-22222222222222222222222222222222",
     "registry_sha256": "0a04fcadccb37e64f6c1209bc0b7e8d5762639ce4c5521c3bba028d9eba037bd",
     "schema_sha256": "9c726627c8679b4b437db2b54b2480fe0c45eef788de7cd76de1dec5c3ce3409",
     "reviewers_sha256": "b7a44ad27cec663a9092b924a0f6a9c95bf95a2ce74cf75ba8873e7938782240",
-    "url": "https://github.com/atrinik/atrinik/blob/51aa7ac9d5ae9c0ff0b2a24a46b5d3e97739bbe0/governance/provenance-identities/registry.json#pir-c-22222222222222222222222222222222"
+    "url": "https://github.com/atrinik/atrinik/blob/6f6040212f0fa0cb6b8e4e695d1488a403d966be/governance/provenance-identities/registry.json#pir-c-22222222222222222222222222222222"
   }
 }

--- a/tests/test_provenance_identity.py
+++ b/tests/test_provenance_identity.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import subprocess
 import tempfile
 import unittest
 from unittest import mock
@@ -417,13 +418,63 @@ class ProvenanceIdentityTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "reviewer signature is invalid"):
             validate_registry(value, schema(), reviewers(), as_of=AS_OF)
 
-    def test_squash_internal_anchor_requires_explicit_non_authorizing_ref(self) -> None:
-        revision = _git_output(
-            ROOT, ["rev-parse", "HEAD"], "cannot resolve test HEAD"
-        ).decode().strip()
-        with self.assertRaisesRegex(WorkspaceError, "not reachable from trusted ref"):
-            _validate_repository_trust(ROOT, revision, "main")
-        _validate_repository_trust(ROOT, revision, revision)
+    def test_branch_only_anchor_requires_explicit_non_authorizing_ref(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            checkout = root / "checkout"
+            subprocess.run(
+                ["git", "init", "-b", "main", checkout],
+                check=True,
+                capture_output=True,
+            )
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    checkout,
+                    "remote",
+                    "add",
+                    "origin",
+                    "https://github.com/atrinik/atrinik.git",
+                ],
+                check=True,
+            )
+            environment = {
+                **os.environ,
+                "GIT_AUTHOR_NAME": "Test",
+                "GIT_AUTHOR_EMAIL": "test@example.invalid",
+                "GIT_COMMITTER_NAME": "Test",
+                "GIT_COMMITTER_EMAIL": "test@example.invalid",
+            }
+            (checkout / "fixture").write_text("main\n", encoding="utf-8")
+            subprocess.run(["git", "-C", checkout, "add", "fixture"], check=True)
+            subprocess.run(
+                ["git", "-C", checkout, "commit", "-m", "main"],
+                check=True,
+                env=environment,
+                capture_output=True,
+            )
+            subprocess.run(["git", "-C", checkout, "branch", "audit"], check=True)
+            subprocess.run(
+                ["git", "-C", checkout, "checkout", "audit"],
+                check=True,
+                capture_output=True,
+            )
+            (checkout / "fixture").write_text("audit\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "-C", checkout, "commit", "-am", "audit"],
+                check=True,
+                env=environment,
+                capture_output=True,
+            )
+            revision = _git_output(
+                checkout, ["rev-parse", "HEAD"], "cannot resolve audit HEAD"
+            ).decode().strip()
+            with self.assertRaisesRegex(
+                WorkspaceError, "not reachable from trusted ref"
+            ):
+                _validate_repository_trust(checkout, revision, "main")
+            _validate_repository_trust(checkout, revision, revision)
 
     def test_repository_trust_accepts_github_actions_canonical_origin(self) -> None:
         outputs = [b"false\n", b"/tmp/coordinator.git\n", b"https://github.com/atrinik/atrinik\n", b""]

--- a/tests/test_provenance_identity.py
+++ b/tests/test_provenance_identity.py
@@ -37,6 +37,8 @@ REGISTRY = ROOT / "governance/provenance-identities/registry.json"
 SCHEMA = ROOT / "governance/provenance-identities/schema-v1.json"
 FIXTURES = ROOT / "tests/fixtures/provenance-identities"
 REVIEWERS = ROOT / "governance/provenance-identities/reviewers.json"
+PINNED_REVISION = "6f6040212f0fa0cb6b8e4e695d1488a403d966be"
+PINNED_REVIEWERS_PATH = "governance/provenance-identities/reviewers.json"
 AS_OF = date(2026, 8, 13)
 
 
@@ -189,6 +191,7 @@ class ProvenanceIdentityTests(unittest.TestCase):
     def test_reference_validation_uses_current_state_from_trusted_ref(self) -> None:
         reference = FIXTURES / "positive" / "synthetic-alpha.json"
         pinned_registry = REGISTRY.read_bytes()
+        pinned_reviewers = _git_blob(ROOT, PINNED_REVISION, PINNED_REVIEWERS_PATH)
         revoked = registry()
         revoked["records"][0]["status"] = "revoked"
         revoked["records"][0]["status_detail"] = {
@@ -203,7 +206,7 @@ class ProvenanceIdentityTests(unittest.TestCase):
                 return trusted_registry if revision == "trusted" else pinned_registry
             if path.endswith("schema-v1.json"):
                 return SCHEMA.read_bytes()
-            return REVIEWERS.read_bytes()
+            return REVIEWERS.read_bytes() if revision == "trusted" else pinned_reviewers
 
         with mock.patch(
             "atrinik_workspace.provenance_identity._validate_repository_trust"
@@ -414,16 +417,11 @@ class ProvenanceIdentityTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "reviewer signature is invalid"):
             validate_registry(value, schema(), reviewers(), as_of=AS_OF)
 
-    def test_unmerged_anchor_requires_explicit_non_authorizing_ref(self) -> None:
+    def test_squash_internal_anchor_requires_explicit_non_authorizing_ref(self) -> None:
+        revision = "51aa7ac9d5ae9c0ff0b2a24a46b5d3e97739bbe0"
         with self.assertRaisesRegex(WorkspaceError, "not reachable from trusted ref"):
-            _validate_repository_trust(
-                ROOT, "51aa7ac9d5ae9c0ff0b2a24a46b5d3e97739bbe0", "main"
-            )
-        _validate_repository_trust(
-            ROOT,
-            "51aa7ac9d5ae9c0ff0b2a24a46b5d3e97739bbe0",
-            "HEAD",
-        )
+            _validate_repository_trust(ROOT, revision, "main")
+        _validate_repository_trust(ROOT, revision, revision)
 
     def test_repository_trust_accepts_github_actions_canonical_origin(self) -> None:
         outputs = [b"false\n", b"/tmp/coordinator.git\n", b"https://github.com/atrinik/atrinik\n", b""]
@@ -562,6 +560,7 @@ class ProvenanceIdentityTests(unittest.TestCase):
 
     def test_reference_to_revoked_attestation_fails_closed(self) -> None:
         reference = load_document(FIXTURES / "positive" / "synthetic-alpha.json")
+        pinned_reviewers = _git_blob(ROOT, PINNED_REVISION, PINNED_REVIEWERS_PATH)
         registry_blob = json.loads(
             REGISTRY.read_text(encoding="utf-8")
         )
@@ -581,7 +580,7 @@ class ProvenanceIdentityTests(unittest.TestCase):
                 return encoded_registry
             if path.endswith("schema-v1.json"):
                 return SCHEMA.read_bytes()
-            return REVIEWERS.read_bytes()
+            return pinned_reviewers
 
         records, reviewer_keys = current()
         with mock.patch(

--- a/tests/test_provenance_identity.py
+++ b/tests/test_provenance_identity.py
@@ -418,7 +418,9 @@ class ProvenanceIdentityTests(unittest.TestCase):
             validate_registry(value, schema(), reviewers(), as_of=AS_OF)
 
     def test_squash_internal_anchor_requires_explicit_non_authorizing_ref(self) -> None:
-        revision = "51aa7ac9d5ae9c0ff0b2a24a46b5d3e97739bbe0"
+        revision = _git_output(
+            ROOT, ["rev-parse", "HEAD"], "cannot resolve test HEAD"
+        ).decode().strip()
         with self.assertRaisesRegex(WorkspaceError, "not reachable from trusted ref"):
             _validate_repository_trust(ROOT, revision, "main")
         _validate_repository_trust(ROOT, revision, revision)


### PR DESCRIPTION
## Summary

- authorize a fresh synthetic-only reviewer key for landed-main component demonstrations
- repin the coordinator's positive fixtures to the #381 squash commit already on `main`
- preserve the original reviewer authority for existing registry and fixture signatures
- update the squash-boundary regression to remain valid after #381 landed
- replace obsolete pre-merge audit guidance with the default authoritative workflow

Closes #387.

Supports #386.

## Trust boundary

The added public key can validate only records whose canonical attestation is already marked synthetic. The private signing key was generated only to review the two #386 component records, stayed outside the repository, and was removed after the signatures passed verification. No restricted identity evidence or real-material authorization is published.

## Coordinates

- base: `main` at `e1e2b85fc5118259ba83e1a9d85d771a932566a0`
- head: `chore/386-synthetic-reviewer` at `d8d2860f4f5dadda09c23ed4e34054a0a322f372`
- worktree: `/workspaces/atrinik/workspace/worktrees/atrinik/issue-387-synthetic-reviewer`
- commits:
  - `b7e6d5680 chore(provenance): authorize landed-main component reviews`
  - `28d5a8986 docs(provenance): describe landed-main validation`
  - `9c52ade86 test(provenance): avoid unreachable audit fixture`
  - `ce169f7f3 test(provenance): isolate audit ancestry fixture`
  - `d8d2860f4 Merge branch 'main' into chore/386-synthetic-reviewer`

## Validation

- `python3 -m unittest discover -v` — 581 passed
- `python3 -m unittest tests.test_provenance_identity -v` — 33 passed
- focused provenance and guidance suites — 46 passed after the review fix
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `git diff --check`
- default-path landed-main simulation with both component records — `valid (2 records, 2 references)`

The local environment lacks the optional `coverage` module; latest-head CI owns the coverage report. The first post-review CI run exposed a historical branch object absent from GitHub's checkout. A follow-up review showed that using the checkout head would fail after merge, so `ce169f7f3` now exercises the same audit-ref boundary in a bounded temporary Git repository. The complete latest-head CI suite passes at `d8d2860f4`.

## Verification

Runtime provisioning is not applicable: this changes offline provenance authority and deterministic fixtures, not a replacement runtime adapter. After this PR lands, validate both component records from a coordinator checkout with no trusted-ref or audit override:

```sh
./atrinik provenance validate \
  --reference /path/to/client/provenance/identity-reference.synthetic.json \
  --reference /path/to/server/provenance/identity-reference.synthetic.json
```

Expected result: `valid (2 records, 2 references)`. Repeating the command is read-only; no service, state, scenario, shutdown, or cleanup is required.
