### PR TITLE
fix(workspace): prevent layout writer starvation

### DIFF
--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -92,9 +92,8 @@ Classic selection is checkout-wide; subdirectories are not worktrees. Clean
 exact-coordinate content, resource, and region-map caches are reused; runtimes
 copy independent topology-owned snapshots.
 
-Readers share the layout lock. Mutations gate readers before taking it;
-both precede finer locks, and waits diagnose after 10 seconds. Fail closed
-without sharing.
+Readers share the layout lock. Writers announce, gate, then lock; all leases
+precede finer locks and diagnose 10-second waits. Fail closed without sharing.
 Incomplete coordinates are inert; wrapper owns paths, locks, state, PIDs, logs,
 content/resources and cleanup. Completion is bounded, local, read-only,
 secret-free and parser-driven before `Workspace`; stops at `--` or a `run`

--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -92,8 +92,9 @@ Classic selection is checkout-wide; subdirectories are not worktrees. Clean
 exact-coordinate content, resource, and region-map caches are reused; runtimes
 copy independent topology-owned snapshots.
 
-Readers share the layout lock: roots overlap; exact roots and mutations
-stay exclusive. Take it before finer locks; fail closed without sharing.
+Readers share the layout lock. Mutations gate readers before taking it;
+both precede finer locks, and waits diagnose after 10 seconds. Fail closed
+without sharing.
 Incomplete coordinates are inert; wrapper owns paths, locks, state, PIDs, logs,
 content/resources and cleanup. Completion is bounded, local, read-only,
 secret-free and parser-driven before `Workspace`; stops at `--` or a `run`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@
   concurrent topologies distinct names, states, ports, and client config.
 - Keep shell completion parser-driven, bounded, local-only, secret-free, and
   ahead of `Workspace` construction.
-- Layout writers gate readers; both locks precede finer locks and diagnose
+- Layout writers announce, gate, lock; they precede finer locks and diagnose
   10-second waits.
 - Unbound persisted records are historical and inert.
 - On touch, refresh existing Atrinik-owned copyright terminal years and blanket

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,8 @@
   concurrent topologies distinct names, states, ports, and client config.
 - Keep shell completion parser-driven, bounded, local-only, secret-free, and
   ahead of `Workspace` construction.
-- Build/runtime readers share the outer layout lock; mutations are exclusive
-  then finer locks.
+- Layout writers gate readers; both locks precede finer locks and diagnose
+  10-second waits.
 - Unbound persisted records are historical and inert.
 - On touch, refresh existing Atrinik-owned copyright terminal years and blanket
   holders per `CONTRIBUTING.md`; preserve precise attribution.

--- a/README.md
+++ b/README.md
@@ -918,21 +918,24 @@ repository-layout lock.
 Different profile build roots may compile concurrently; an exclusive per-root
 lock still serializes the same root. Initialization, synchronization, worktree
 or profile changes, and cleanup apply take the layout lock exclusively, so they
-wait until every build or runtime reader finishes. A blocking mutation first
-holds the exclusive `repository-layout.writer-intent.lock` admission gate. New readers
-briefly pass through that same exclusive gate before taking their shared layout
-lease, so readers admitted before the mutation finish normally while later
-arrivals cannot bypass the queued writer. Readers release the gate immediately
-after admission and continue to overlap. Repository migration uses the same
+wait until every build or runtime reader finishes. A mutation first announces
+itself with a shared `repository-layout.writer-pending.lock`, then holds the
+exclusive `repository-layout.writer-intent.lock` admission gate. New readers
+briefly take the admission gate and proceed only when they can exclusively
+probe the pending lock; otherwise they release admission, wait for the announced
+writers, and retry. Readers admitted before a mutation finish normally while
+later arrivals cannot bypass it, and admitted readers continue to overlap.
+Repository migration uses the same
 exclusive layout mode but reports a busy result instead of waiting. The wrapper
 fails closed when advisory shared locking is unavailable. A wait longer than 10
 seconds emits one diagnostic naming safe `ps` and worktree inventories; it does
-not interrupt a reader, topology, build, or mutation. The writer-intent gate and
-layout lock are always acquired before topology, scenario, state, build-root,
-port, registry, or cache locks. Foreground processes inherit their layout and
-exact build-root leases. Supervised services inherit both leases through the
-daemon and keep them until every service exits or `down` completes. Mutation
-subprocesses inherit the intent and layout leases. Build and scenario
+not interrupt a reader, topology, build, or mutation. The pending announcement,
+writer-intent gate, and layout lock are always acquired before topology,
+scenario, state, build-root, port, registry, or cache locks. Foreground
+processes inherit their layout and exact build-root leases. Supervised services
+inherit both leases through the daemon and keep them until every service exits
+or `down` completes. Mutation
+subprocesses inherit all three writer leases. Build and scenario
 subprocesses inherit every active layout, build-root, state, registry, and cache
 lease so an orphan cannot outlive its protection.
 

--- a/README.md
+++ b/README.md
@@ -895,15 +895,23 @@ repository-layout lock.
 Different profile build roots may compile concurrently; an exclusive per-root
 lock still serializes the same root. Initialization, synchronization, worktree
 or profile changes, and cleanup apply take the layout lock exclusively, so they
-wait until every build or runtime reader finishes. Repository migration uses
-the same exclusive mode but reports a busy result instead of waiting. The
-wrapper fails closed when advisory shared locking is unavailable. The layout
-lock is always acquired before topology, scenario, state, build-root, port,
-registry, or cache locks. Foreground processes inherit their layout and exact
-build-root leases. Supervised services inherit both leases through the daemon
-and keep them until every service exits or `down` completes. Build and scenario
+wait until every build or runtime reader finishes. A blocking mutation first
+holds the exclusive `repository-layout.writer-intent.lock` admission gate. New readers
+briefly pass through that same exclusive gate before taking their shared layout
+lease, so readers admitted before the mutation finish normally while later
+arrivals cannot bypass the queued writer. Readers release the gate immediately
+after admission and continue to overlap. Repository migration uses the same
+exclusive layout mode but reports a busy result instead of waiting. The wrapper
+fails closed when advisory shared locking is unavailable. A wait longer than 10
+seconds emits one diagnostic naming safe `ps` and worktree inventories; it does
+not interrupt a reader, topology, build, or mutation. The writer-intent gate and
+layout lock are always acquired before topology, scenario, state, build-root,
+port, registry, or cache locks. Foreground processes inherit their layout and
+exact build-root leases. Supervised services inherit both leases through the
+daemon and keep them until every service exits or `down` completes. Mutation
+subprocesses inherit the intent and layout leases. Build and scenario
 subprocesses inherit every active layout, build-root, state, registry, and cache
-lease so an orphan cannot outlive its reader protection.
+lease so an orphan cannot outlive its protection.
 
 The supervisor records exact source commits, build and state paths, and process
 start identities. `ps` without a name lists every recorded topology; a name

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -36,6 +36,7 @@ from .workspace import (
     COMPILER_CACHE_PURPOSE,
     _remote_matches,
     exclusive_lock,
+    exclusive_layout_lock,
     remove_owned_tree,
 )
 
@@ -458,7 +459,7 @@ class Cleanup:
             raise WorkspaceError(
                 f"workspace ownership marker is invalid: {self.paths.marker}"
             )
-        with exclusive_lock(
+        with exclusive_layout_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
         ):

--- a/atrinik_workspace/content_migration.py
+++ b/atrinik_workspace/content_migration.py
@@ -2,19 +2,18 @@ from __future__ import annotations
 
 import base64
 import binascii
+from contextlib import ExitStack
 from datetime import datetime, timezone
-import fcntl
 import hashlib
 import json
 import os
 from pathlib import Path
 import re
-import stat
 import subprocess
 import tempfile
-from typing import Any, TextIO
+from typing import Any
 
-from .locking import inherit_lock_fds
+from .locking import LockBusyError, active_lock_fds, exclusive_layout_lock
 from .model import WorkspaceError, atomic_json, load_json
 from .process_tree import holders_exist
 from .supervisor import process_matches
@@ -65,7 +64,7 @@ def _git(path: Path, *arguments: str, check: bool = True) -> str:
             check=check,
             capture_output=True,
             text=True,
-            pass_fds=(),
+            pass_fds=active_lock_fds(),
         )
     except FileNotFoundError as error:
         raise WorkspaceError("required command not found: git") from error
@@ -85,7 +84,7 @@ def _git_succeeds(path: Path, *arguments: str) -> bool:
             check=False,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
-            pass_fds=(),
+            pass_fds=active_lock_fds(),
         ).returncode == 0
     except FileNotFoundError as error:
         raise WorkspaceError("required command not found: git") from error
@@ -141,20 +140,6 @@ def _atomic_bytes(path: Path, value: bytes) -> None:
         raise
 
 
-def _open_layout_lock(path: Path) -> TextIO:
-    flags = os.O_RDWR | os.O_CREAT | os.O_CLOEXEC
-    if hasattr(os, "O_NOFOLLOW"):
-        flags |= os.O_NOFOLLOW
-    try:
-        descriptor = os.open(path, flags, 0o600)
-    except OSError as error:
-        raise WorkspaceError(f"cannot open repository layout lock {path}: {error}") from error
-    if not stat.S_ISREG(os.fstat(descriptor).st_mode):
-        os.close(descriptor)
-        raise WorkspaceError(f"repository layout lock is not a regular file: {path}")
-    return os.fdopen(descriptor, "a+")
-
-
 class ContentMigration:
     """Retire active ``content-1x`` selectors without rewriting history."""
 
@@ -181,20 +166,26 @@ class ContentMigration:
 
     def _locked_apply(self) -> dict[str, Any]:
         lock_path = self.workspace / "repository-layout.lock"
-        with _open_layout_lock(lock_path) as lock, inherit_lock_fds(lock):
-            try:
-                fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except BlockingIOError:
-                plan = self._inspect()
-                plan["refusals"].append(
-                    _refusal(
-                        "repository_layout_busy",
-                        "the repository layout is in use by another wrapper operation",
-                        "wait for that operation to finish and rerun the migration",
-                    )
+        lock_stack = ExitStack()
+        try:
+            lock_stack.enter_context(
+                exclusive_layout_lock(
+                    lock_path, "repository layout", nonblocking=True
                 )
-                plan["status"] = "refused"
-                return plan
+            )
+        except LockBusyError:
+            lock_stack.close()
+            plan = self._inspect()
+            plan["refusals"].append(
+                _refusal(
+                    "repository_layout_busy",
+                    "the repository layout is in use by another wrapper operation",
+                    "wait for that operation to finish and rerun the migration",
+                )
+            )
+            plan["status"] = "refused"
+            return plan
+        with lock_stack:
             if self.record_path.is_file() and not self.record_path.is_symlink():
                 result = self._audit()
                 if result["status"] == "complete":
@@ -244,22 +235,28 @@ class ContentMigration:
 
     def _locked_restore(self) -> dict[str, Any]:
         lock_path = self.workspace / "repository-layout.lock"
-        with _open_layout_lock(lock_path) as lock, inherit_lock_fds(lock):
-            try:
-                fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except BlockingIOError:
-                return {
-                    "migration": CONTENT_MIGRATION_NAME,
-                    "schema_version": CONTENT_MIGRATION_SCHEMA_VERSION,
-                    "status": "refused",
-                    "refusals": [
-                        _refusal(
-                            "repository_layout_busy",
-                            "the repository layout is in use by another wrapper operation",
-                            "wait for that operation to finish and rerun the restore",
-                        )
-                    ],
-                }
+        lock_stack = ExitStack()
+        try:
+            lock_stack.enter_context(
+                exclusive_layout_lock(
+                    lock_path, "repository layout", nonblocking=True
+                )
+            )
+        except LockBusyError:
+            lock_stack.close()
+            return {
+                "migration": CONTENT_MIGRATION_NAME,
+                "schema_version": CONTENT_MIGRATION_SCHEMA_VERSION,
+                "status": "refused",
+                "refusals": [
+                    _refusal(
+                        "repository_layout_busy",
+                        "the repository layout is in use by another wrapper operation",
+                        "wait for that operation to finish and rerun the restore",
+                    )
+                ],
+            }
+        with lock_stack:
             return self._restore()
 
     def _inspect(self) -> dict[str, Any]:

--- a/atrinik_workspace/content_migration.py
+++ b/atrinik_workspace/content_migration.py
@@ -13,7 +13,13 @@ import subprocess
 import tempfile
 from typing import Any
 
-from .locking import LockBusyError, active_lock_fds, exclusive_layout_lock
+from .locking import (
+    LockBusyError,
+    active_lock_fds,
+    exclusive_layout_lock,
+    layout_writer_intent_path,
+    layout_writer_pending_path,
+)
 from .model import WorkspaceError, atomic_json, load_json
 from .process_tree import holders_exist
 from .supervisor import process_matches
@@ -829,13 +835,16 @@ class ContentMigration:
                             "stop or repair the topology before migration",
                         )
                     )
+        layout_lock = self.workspace / "repository-layout.lock"
         lock_roots = [
-            self.workspace / "repository-layout.lock",
-            Path(self.paths.builds) / "locks",
+            (layout_lock, False),
+            (layout_writer_intent_path(layout_lock), False),
+            (layout_writer_pending_path(layout_lock), False),
+            (Path(self.paths.builds) / "locks", True),
         ]
-        for root in lock_roots:
+        for root, allow_directory in lock_roots:
             if root.is_symlink() or root.exists() and not (
-                root.is_file() or root.is_dir()
+                root.is_file() or allow_directory and root.is_dir()
             ):
                 resources["locks"].append(
                     {"path": str(root), "active": True, "status": "unsafe"}
@@ -852,7 +861,7 @@ class ContentMigration:
                 [root]
                 if root.is_file()
                 else sorted(root.glob("*"))
-                if root.is_dir()
+                if allow_directory and root.is_dir()
                 else []
             )
             for path in paths:

--- a/atrinik_workspace/locking.py
+++ b/atrinik_workspace/locking.py
@@ -1,8 +1,25 @@
 from __future__ import annotations
 
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from contextvars import ContextVar
-from typing import BinaryIO, Iterator
+import fcntl
+import os
+from pathlib import Path
+import stat
+import sys
+import threading
+from typing import BinaryIO, Iterator, TextIO
+
+from .model import WorkspaceError
+
+
+LAYOUT_WRITER_INTENT_SUFFIX = ".writer-intent"
+LAYOUT_WRITER_PENDING_SUFFIX = ".writer-pending"
+LOCK_WAIT_DIAGNOSTIC_SECONDS = 10.0
+
+
+class LockBusyError(WorkspaceError):
+    """Raised when a requested nonblocking advisory lock is held."""
 
 
 _ACTIVE_LOCK_FDS: ContextVar[tuple[int, ...]] = ContextVar(
@@ -23,3 +40,211 @@ def inherit_lock_fds(*leases: BinaryIO) -> Iterator[None]:
         yield
     finally:
         _ACTIVE_LOCK_FDS.reset(token)
+
+
+def _open_lock(path: Path, description: str) -> TextIO:
+    flags = os.O_RDWR | os.O_CREAT | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags, 0o600)
+    except OSError as error:
+        raise WorkspaceError(
+            f"cannot open {description} lock {path}: {error}"
+        ) from error
+    if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+        os.close(descriptor)
+        raise WorkspaceError(f"{description} lock is not a regular file: {path}")
+    return os.fdopen(descriptor, "a+")
+
+
+@contextmanager
+def _advisory_lock(
+    path: Path,
+    description: str,
+    operation: int,
+    *,
+    nonblocking: bool = False,
+    diagnose_wait: bool = False,
+) -> Iterator[TextIO]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with _open_lock(path, description) as lock:
+        try:
+            fcntl.flock(lock, operation | fcntl.LOCK_NB)
+        except BlockingIOError as error:
+            if nonblocking:
+                raise LockBusyError(f"{description} is already in use") from error
+            acquired = threading.Event()
+            warning: threading.Thread | None = None
+            if diagnose_wait:
+
+                def warn_about_wait() -> None:
+                    if acquired.wait(LOCK_WAIT_DIAGNOSTIC_SECONDS):
+                        return
+                    print(
+                        f"waiting more than {LOCK_WAIT_DIAGNOSTIC_SECONDS:g}s "
+                        f"for {description} lock at {path}; inspect "
+                        "`./atrinik ps --json` and "
+                        "`./atrinik worktree list --json`; do not bypass the "
+                        "wrapper or stop unrelated processes",
+                        file=sys.stderr,
+                    )
+
+                warning = threading.Thread(target=warn_about_wait, daemon=True)
+                warning.start()
+            try:
+                try:
+                    fcntl.flock(lock, operation)
+                except OSError as wait_error:
+                    raise WorkspaceError(
+                        f"cannot acquire {description} lock: {wait_error}"
+                    ) from wait_error
+            finally:
+                acquired.set()
+                if warning is not None:
+                    warning.join(timeout=0.1)
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot acquire {description} lock: {error}"
+            ) from error
+        yield lock
+
+
+@contextmanager
+def exclusive_lock(
+    path: Path,
+    description: str,
+    nonblocking: bool = False,
+    *,
+    diagnose_wait: bool = False,
+) -> Iterator[TextIO]:
+    with _advisory_lock(
+        path,
+        description,
+        fcntl.LOCK_EX,
+        nonblocking=nonblocking,
+        diagnose_wait=diagnose_wait,
+    ) as lock:
+        with inherit_lock_fds(lock):
+            yield lock
+
+
+@contextmanager
+def shared_lock(
+    path: Path,
+    description: str,
+    nonblocking: bool = False,
+    *,
+    diagnose_wait: bool = False,
+) -> Iterator[TextIO]:
+    operation = getattr(fcntl, "LOCK_SH", None)
+    if not isinstance(operation, int):
+        raise WorkspaceError(
+            f"shared locking is unavailable for {description}; refusing to continue"
+        )
+    with _advisory_lock(
+        path,
+        description,
+        operation,
+        nonblocking=nonblocking,
+        diagnose_wait=diagnose_wait,
+    ) as lock:
+        with inherit_lock_fds(lock):
+            yield lock
+
+
+def layout_writer_intent_path(path: Path) -> Path:
+    return path.with_name(
+        f"{path.stem}{LAYOUT_WRITER_INTENT_SUFFIX}{path.suffix}"
+    )
+
+
+def layout_writer_pending_path(path: Path) -> Path:
+    return path.with_name(
+        f"{path.stem}{LAYOUT_WRITER_PENDING_SUFFIX}{path.suffix}"
+    )
+
+
+@contextmanager
+def exclusive_layout_lock(
+    path: Path, description: str, nonblocking: bool = False
+) -> Iterator[TextIO]:
+    with shared_lock(
+        layout_writer_pending_path(path),
+        f"{description} writer pending",
+        nonblocking,
+        diagnose_wait=True,
+    ):
+        with exclusive_lock(
+            layout_writer_intent_path(path),
+            f"{description} writer intent",
+            nonblocking,
+            diagnose_wait=True,
+        ):
+            with exclusive_lock(
+                path,
+                description,
+                nonblocking,
+                diagnose_wait=True,
+            ) as lock:
+                yield lock
+
+
+@contextmanager
+def shared_layout_lock(path: Path, description: str) -> Iterator[TextIO]:
+    operation = getattr(fcntl, "LOCK_EX", None)
+    if not isinstance(operation, int):
+        raise WorkspaceError(
+            f"exclusive locking is unavailable for {description} writer intent; "
+            "refusing to continue"
+        )
+    while True:
+        layout_stack = ExitStack()
+        admitted = False
+        with _advisory_lock(
+            layout_writer_intent_path(path),
+            f"{description} reader admission",
+            operation,
+            diagnose_wait=True,
+        ):
+            pending_stack = ExitStack()
+            try:
+                pending_stack.enter_context(
+                    _advisory_lock(
+                        layout_writer_pending_path(path),
+                        f"{description} writer pending",
+                        operation,
+                        nonblocking=True,
+                    )
+                )
+            except LockBusyError:
+                pending_stack.close()
+            else:
+                with pending_stack:
+                    shared_operation = getattr(fcntl, "LOCK_SH", None)
+                    if not isinstance(shared_operation, int):
+                        raise WorkspaceError(
+                            f"shared locking is unavailable for {description}; "
+                            "refusing to continue"
+                        )
+                    lock = layout_stack.enter_context(
+                        _advisory_lock(
+                            path,
+                            description,
+                            shared_operation,
+                            diagnose_wait=True,
+                        )
+                    )
+                    admitted = True
+        if admitted:
+            with layout_stack, inherit_lock_fds(lock):
+                yield lock
+            return
+        layout_stack.close()
+        with _advisory_lock(
+            layout_writer_pending_path(path),
+            f"{description} writer pending",
+            operation,
+            diagnose_wait=True,
+        ):
+            pass

--- a/atrinik_workspace/locking.py
+++ b/atrinik_workspace/locking.py
@@ -65,7 +65,6 @@ def _advisory_lock(
     operation: int,
     *,
     nonblocking: bool = False,
-    diagnose_wait: bool = False,
 ) -> Iterator[TextIO]:
     path.parent.mkdir(parents=True, exist_ok=True)
     with _open_lock(path, description) as lock:
@@ -74,35 +73,12 @@ def _advisory_lock(
         except BlockingIOError as error:
             if nonblocking:
                 raise LockBusyError(f"{description} is already in use") from error
-            acquired = threading.Event()
-            warning: threading.Thread | None = None
-            if diagnose_wait:
-
-                def warn_about_wait() -> None:
-                    if acquired.wait(LOCK_WAIT_DIAGNOSTIC_SECONDS):
-                        return
-                    print(
-                        f"waiting more than {LOCK_WAIT_DIAGNOSTIC_SECONDS:g}s "
-                        f"for {description} lock at {path}; inspect "
-                        "`./atrinik ps --json` and "
-                        "`./atrinik worktree list --json`; do not bypass the "
-                        "wrapper or stop unrelated processes",
-                        file=sys.stderr,
-                    )
-
-                warning = threading.Thread(target=warn_about_wait, daemon=True)
-                warning.start()
             try:
-                try:
-                    fcntl.flock(lock, operation)
-                except OSError as wait_error:
-                    raise WorkspaceError(
-                        f"cannot acquire {description} lock: {wait_error}"
-                    ) from wait_error
-            finally:
-                acquired.set()
-                if warning is not None:
-                    warning.join(timeout=0.1)
+                fcntl.flock(lock, operation)
+            except OSError as wait_error:
+                raise WorkspaceError(
+                    f"cannot acquire {description} lock: {wait_error}"
+                ) from wait_error
         except OSError as error:
             raise WorkspaceError(
                 f"cannot acquire {description} lock: {error}"
@@ -140,15 +116,12 @@ def exclusive_lock(
     path: Path,
     description: str,
     nonblocking: bool = False,
-    *,
-    diagnose_wait: bool = False,
 ) -> Iterator[TextIO]:
     with _advisory_lock(
         path,
         description,
         fcntl.LOCK_EX,
         nonblocking=nonblocking,
-        diagnose_wait=diagnose_wait,
     ) as lock:
         with inherit_lock_fds(lock):
             yield lock
@@ -159,8 +132,6 @@ def shared_lock(
     path: Path,
     description: str,
     nonblocking: bool = False,
-    *,
-    diagnose_wait: bool = False,
 ) -> Iterator[TextIO]:
     operation = getattr(fcntl, "LOCK_SH", None)
     if not isinstance(operation, int):
@@ -172,7 +143,6 @@ def shared_lock(
         description,
         operation,
         nonblocking=nonblocking,
-        diagnose_wait=diagnose_wait,
     ) as lock:
         with inherit_lock_fds(lock):
             yield lock
@@ -228,6 +198,11 @@ def shared_layout_lock(path: Path, description: str) -> Iterator[TextIO]:
             f"exclusive locking is unavailable for {description} writer intent; "
             "refusing to continue"
         )
+    shared_operation = getattr(fcntl, "LOCK_SH", None)
+    if not isinstance(shared_operation, int):
+        raise WorkspaceError(
+            f"shared locking is unavailable for {description}; refusing to continue"
+        )
     with ExitStack() as layout_stack:
         with _diagnose_layout_wait(path, description):
             pending_busy = False
@@ -255,7 +230,7 @@ def shared_layout_lock(path: Path, description: str) -> Iterator[TextIO]:
                             _advisory_lock(
                                 path,
                                 description,
-                                fcntl.LOCK_SH,
+                                shared_operation,
                             )
                         )
             if pending_busy:
@@ -273,7 +248,7 @@ def shared_layout_lock(path: Path, description: str) -> Iterator[TextIO]:
                             _advisory_lock(
                                 path,
                                 description,
-                                fcntl.LOCK_SH,
+                                shared_operation,
                             )
                         )
         with inherit_lock_fds(lock):

--- a/atrinik_workspace/locking.py
+++ b/atrinik_workspace/locking.py
@@ -111,6 +111,31 @@ def _advisory_lock(
 
 
 @contextmanager
+def _diagnose_layout_wait(path: Path, description: str) -> Iterator[None]:
+    acquired = threading.Event()
+
+    def warn_about_wait() -> None:
+        if acquired.wait(LOCK_WAIT_DIAGNOSTIC_SECONDS):
+            return
+        print(
+            f"waiting more than {LOCK_WAIT_DIAGNOSTIC_SECONDS:g}s "
+            f"for {description} lock at {path}; inspect "
+            "`./atrinik ps --json` and "
+            "`./atrinik worktree list --json`; do not bypass the "
+            "wrapper or stop unrelated processes",
+            file=sys.stderr,
+        )
+
+    warning = threading.Thread(target=warn_about_wait, daemon=True)
+    warning.start()
+    try:
+        yield
+    finally:
+        acquired.set()
+        warning.join(timeout=0.1)
+
+
+@contextmanager
 def exclusive_lock(
     path: Path,
     description: str,
@@ -169,25 +194,31 @@ def layout_writer_pending_path(path: Path) -> Path:
 def exclusive_layout_lock(
     path: Path, description: str, nonblocking: bool = False
 ) -> Iterator[TextIO]:
-    with shared_lock(
-        layout_writer_pending_path(path),
-        f"{description} writer pending",
-        nonblocking,
-        diagnose_wait=True,
-    ):
-        with exclusive_lock(
-            layout_writer_intent_path(path),
-            f"{description} writer intent",
-            nonblocking,
-            diagnose_wait=True,
-        ):
-            with exclusive_lock(
+    locks = ExitStack()
+    with _diagnose_layout_wait(path, description):
+        locks.enter_context(
+            shared_lock(
+                layout_writer_pending_path(path),
+                f"{description} writer pending",
+                nonblocking,
+            )
+        )
+        locks.enter_context(
+            exclusive_lock(
+                layout_writer_intent_path(path),
+                f"{description} writer intent",
+                nonblocking,
+            )
+        )
+        lock = locks.enter_context(
+            exclusive_lock(
                 path,
                 description,
                 nonblocking,
-                diagnose_wait=True,
-            ) as lock:
-                yield lock
+            )
+        )
+    with locks:
+        yield lock
 
 
 @contextmanager
@@ -198,53 +229,51 @@ def shared_layout_lock(path: Path, description: str) -> Iterator[TextIO]:
             f"exclusive locking is unavailable for {description} writer intent; "
             "refusing to continue"
         )
-    while True:
-        layout_stack = ExitStack()
-        admitted = False
-        with _advisory_lock(
-            layout_writer_intent_path(path),
-            f"{description} reader admission",
-            operation,
-            diagnose_wait=True,
-        ):
-            pending_stack = ExitStack()
-            try:
-                pending_stack.enter_context(
-                    _advisory_lock(
-                        layout_writer_pending_path(path),
-                        f"{description} writer pending",
-                        operation,
-                        nonblocking=True,
-                    )
-                )
-            except LockBusyError:
-                pending_stack.close()
-            else:
-                with pending_stack:
-                    shared_operation = getattr(fcntl, "LOCK_SH", None)
-                    if not isinstance(shared_operation, int):
-                        raise WorkspaceError(
-                            f"shared locking is unavailable for {description}; "
-                            "refusing to continue"
-                        )
-                    lock = layout_stack.enter_context(
+    with _diagnose_layout_wait(path, description):
+        while True:
+            layout_stack = ExitStack()
+            admitted = False
+            with _advisory_lock(
+                layout_writer_intent_path(path),
+                f"{description} reader admission",
+                operation,
+            ):
+                pending_stack = ExitStack()
+                try:
+                    pending_stack.enter_context(
                         _advisory_lock(
-                            path,
-                            description,
-                            shared_operation,
-                            diagnose_wait=True,
+                            layout_writer_pending_path(path),
+                            f"{description} writer pending",
+                            operation,
+                            nonblocking=True,
                         )
                     )
-                    admitted = True
-        if admitted:
-            with layout_stack, inherit_lock_fds(lock):
-                yield lock
-            return
-        layout_stack.close()
-        with _advisory_lock(
-            layout_writer_pending_path(path),
-            f"{description} writer pending",
-            operation,
-            diagnose_wait=True,
-        ):
-            pass
+                except LockBusyError:
+                    pending_stack.close()
+                else:
+                    with pending_stack:
+                        shared_operation = getattr(fcntl, "LOCK_SH", None)
+                        if not isinstance(shared_operation, int):
+                            raise WorkspaceError(
+                                f"shared locking is unavailable for {description}; "
+                                "refusing to continue"
+                            )
+                        lock = layout_stack.enter_context(
+                            _advisory_lock(
+                                path,
+                                description,
+                                shared_operation,
+                            )
+                        )
+                        admitted = True
+            if admitted:
+                break
+            layout_stack.close()
+            with _advisory_lock(
+                layout_writer_pending_path(path),
+                f"{description} writer pending",
+                operation,
+            ):
+                pass
+    with layout_stack, inherit_lock_fds(lock):
+        yield lock

--- a/atrinik_workspace/locking.py
+++ b/atrinik_workspace/locking.py
@@ -194,30 +194,29 @@ def layout_writer_pending_path(path: Path) -> Path:
 def exclusive_layout_lock(
     path: Path, description: str, nonblocking: bool = False
 ) -> Iterator[TextIO]:
-    locks = ExitStack()
-    with _diagnose_layout_wait(path, description):
-        locks.enter_context(
-            shared_lock(
-                layout_writer_pending_path(path),
-                f"{description} writer pending",
-                nonblocking,
+    with ExitStack() as locks:
+        with _diagnose_layout_wait(path, description):
+            locks.enter_context(
+                shared_lock(
+                    layout_writer_pending_path(path),
+                    f"{description} writer pending",
+                    nonblocking,
+                )
             )
-        )
-        locks.enter_context(
-            exclusive_lock(
-                layout_writer_intent_path(path),
-                f"{description} writer intent",
-                nonblocking,
+            locks.enter_context(
+                exclusive_lock(
+                    layout_writer_intent_path(path),
+                    f"{description} writer intent",
+                    nonblocking,
+                )
             )
-        )
-        lock = locks.enter_context(
-            exclusive_lock(
-                path,
-                description,
-                nonblocking,
+            lock = locks.enter_context(
+                exclusive_lock(
+                    path,
+                    description,
+                    nonblocking,
+                )
             )
-        )
-    with locks:
         yield lock
 
 
@@ -229,10 +228,9 @@ def shared_layout_lock(path: Path, description: str) -> Iterator[TextIO]:
             f"exclusive locking is unavailable for {description} writer intent; "
             "refusing to continue"
         )
-    with _diagnose_layout_wait(path, description):
-        while True:
-            layout_stack = ExitStack()
-            admitted = False
+    with ExitStack() as layout_stack:
+        with _diagnose_layout_wait(path, description):
+            pending_busy = False
             with _advisory_lock(
                 layout_writer_intent_path(path),
                 f"{description} reader admission",
@@ -250,30 +248,33 @@ def shared_layout_lock(path: Path, description: str) -> Iterator[TextIO]:
                     )
                 except LockBusyError:
                     pending_stack.close()
+                    pending_busy = True
                 else:
                     with pending_stack:
-                        shared_operation = getattr(fcntl, "LOCK_SH", None)
-                        if not isinstance(shared_operation, int):
-                            raise WorkspaceError(
-                                f"shared locking is unavailable for {description}; "
-                                "refusing to continue"
-                            )
                         lock = layout_stack.enter_context(
                             _advisory_lock(
                                 path,
                                 description,
-                                shared_operation,
+                                fcntl.LOCK_SH,
                             )
                         )
-                        admitted = True
-            if admitted:
-                break
-            layout_stack.close()
-            with _advisory_lock(
-                layout_writer_pending_path(path),
-                f"{description} writer pending",
-                operation,
-            ):
-                pass
-    with layout_stack, inherit_lock_fds(lock):
-        yield lock
+            if pending_busy:
+                with _advisory_lock(
+                    layout_writer_pending_path(path),
+                    f"{description} writer pending",
+                    operation,
+                ):
+                    with _advisory_lock(
+                        layout_writer_intent_path(path),
+                        f"{description} reader admission",
+                        operation,
+                    ):
+                        lock = layout_stack.enter_context(
+                            _advisory_lock(
+                                path,
+                                description,
+                                fcntl.LOCK_SH,
+                            )
+                        )
+        with inherit_lock_fds(lock):
+            yield lock

--- a/atrinik_workspace/migration.py
+++ b/atrinik_workspace/migration.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import base64
 import copy
 import ctypes
+from contextlib import ExitStack
 from dataclasses import dataclass
 import errno
-import fcntl
 import hashlib
 import json
 import os
@@ -17,7 +17,7 @@ import subprocess
 import tempfile
 from typing import Any, Iterable
 
-from .locking import active_lock_fds, inherit_lock_fds
+from .locking import LockBusyError, active_lock_fds, exclusive_layout_lock
 from .model import WorkspaceError, atomic_json, load_json
 from .supervisor import process_matches
 
@@ -406,28 +406,22 @@ class RepositoryMigration:
             )
 
         lock_path = self.workspace / "repository-layout.lock"
-        flags = os.O_RDWR | os.O_CREAT | os.O_CLOEXEC
-        if hasattr(os, "O_NOFOLLOW"):
-            flags |= os.O_NOFOLLOW
+        lock_stack = ExitStack()
         try:
-            descriptor = os.open(lock_path, flags, 0o600)
-        except OSError as error:
-            raise WorkspaceError(f"cannot open repository migration lock: {error}") from error
-        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
-            os.close(descriptor)
-            raise WorkspaceError(
-                f"repository migration lock is not a regular file: {lock_path}"
-            )
-        with os.fdopen(descriptor, "a+") as lock, inherit_lock_fds(lock):
-            try:
-                fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except BlockingIOError:
-                return self._with_refusal(
-                    inspection.plan,
-                    "repository_layout_busy",
-                    "the repository layout is in use by another wrapper operation",
-                    "wait for the active wrapper operation to finish, then rerun",
+            lock_stack.enter_context(
+                exclusive_layout_lock(
+                    lock_path, "repository layout", nonblocking=True
                 )
+            )
+        except LockBusyError:
+            lock_stack.close()
+            return self._with_refusal(
+                inspection.plan,
+                "repository_layout_busy",
+                "the repository layout is in use by another wrapper operation",
+                "wait for the active wrapper operation to finish, then rerun",
+            )
+        with lock_stack:
             if self.record_path.is_file() and not self.record_path.is_symlink():
                 audited = self._audit()
                 if audited["status"] == "complete":

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -32,7 +32,6 @@ from typing import Any, Callable, Iterator, TextIO
 from .launch_identity import CLIENT_LAUNCH_LABEL_ENV, client_launch_label
 from .content_migration import ContentMigration
 from .locking import (
-    LOCK_WAIT_DIAGNOSTIC_SECONDS,
     active_lock_fds,
     exclusive_layout_lock,
     exclusive_lock,

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -89,6 +89,8 @@ ALL_BUILD_TARGETS = (
     "server",
     "metaserver-worker",
 )
+LAYOUT_WRITER_INTENT_SUFFIX = ".writer-intent"
+LOCK_WAIT_DIAGNOSTIC_SECONDS = 10.0
 SOURCE_VIEW_METADATA = ".atrinik-source-view.json"
 SOURCE_VIEW_SCHEMA_VERSION = 2
 CONFIGURE_METADATA = ".atrinik-configure.json"
@@ -1160,25 +1162,77 @@ def open_regular_file(
 
 @contextmanager
 def exclusive_lock(
-    path: Path, description: str, nonblocking: bool = False
+    path: Path,
+    description: str,
+    nonblocking: bool = False,
+    *,
+    diagnose_wait: bool = False,
 ) -> Iterator[TextIO]:
     with _advisory_lock(
-        path, description, fcntl.LOCK_EX, nonblocking=nonblocking
+        path,
+        description,
+        fcntl.LOCK_EX,
+        nonblocking=nonblocking,
+        diagnose_wait=diagnose_wait,
     ) as lock:
         with inherit_lock_fds(lock):
             yield lock
 
 
 @contextmanager
-def shared_lock(path: Path, description: str) -> Iterator[TextIO]:
+def shared_lock(
+    path: Path, description: str, *, diagnose_wait: bool = False
+) -> Iterator[TextIO]:
     operation = getattr(fcntl, "LOCK_SH", None)
     if not isinstance(operation, int):
         raise WorkspaceError(
             f"shared locking is unavailable for {description}; refusing to continue"
         )
-    with _advisory_lock(path, description, operation) as lock:
+    with _advisory_lock(
+        path, description, operation, diagnose_wait=diagnose_wait
+    ) as lock:
         with inherit_lock_fds(lock):
             yield lock
+
+
+def _layout_writer_intent_path(path: Path) -> Path:
+    return path.with_name(
+        f"{path.stem}{LAYOUT_WRITER_INTENT_SUFFIX}{path.suffix}"
+    )
+
+
+@contextmanager
+def exclusive_layout_lock(
+    path: Path, description: str, nonblocking: bool = False
+) -> Iterator[TextIO]:
+    with exclusive_lock(
+        _layout_writer_intent_path(path),
+        f"{description} writer intent",
+        nonblocking,
+        diagnose_wait=True,
+    ):
+        with exclusive_lock(
+            path,
+            description,
+            nonblocking,
+            diagnose_wait=True,
+        ) as lock:
+            yield lock
+
+
+@contextmanager
+def shared_layout_lock(path: Path, description: str) -> Iterator[TextIO]:
+    layout = ExitStack()
+    with exclusive_lock(
+        _layout_writer_intent_path(path),
+        f"{description} writer intent",
+        diagnose_wait=True,
+    ):
+        lock = layout.enter_context(
+            shared_lock(path, description, diagnose_wait=True)
+        )
+    with layout:
+        yield lock
 
 
 @contextmanager
@@ -1188,17 +1242,47 @@ def _advisory_lock(
     operation: int,
     *,
     nonblocking: bool = False,
+    diagnose_wait: bool = False,
 ) -> Iterator[TextIO]:
     path.parent.mkdir(parents=True, exist_ok=True)
     descriptor = open_regular_file(
         path, os.O_RDWR | os.O_CREAT, f"{description} lock"
     )
     with os.fdopen(descriptor, "a+") as lock:
-        operation |= fcntl.LOCK_NB if nonblocking else 0
         try:
-            fcntl.flock(lock, operation)
+            fcntl.flock(lock, operation | fcntl.LOCK_NB)
         except BlockingIOError as error:
-            raise WorkspaceError(f"{description} is already in use") from error
+            if nonblocking:
+                raise WorkspaceError(f"{description} is already in use") from error
+            acquired = threading.Event()
+            warning: threading.Thread | None = None
+            if diagnose_wait:
+
+                def warn_about_wait() -> None:
+                    if acquired.wait(LOCK_WAIT_DIAGNOSTIC_SECONDS):
+                        return
+                    print(
+                        f"waiting more than {LOCK_WAIT_DIAGNOSTIC_SECONDS:g}s "
+                        f"for {description} lock at {path}; inspect "
+                        "`./atrinik ps --json` and "
+                        "`./atrinik worktree list --json`; do not bypass the "
+                        "wrapper or stop unrelated processes",
+                        file=sys.stderr,
+                    )
+
+                warning = threading.Thread(target=warn_about_wait, daemon=True)
+                warning.start()
+            try:
+                try:
+                    fcntl.flock(lock, operation)
+                except OSError as wait_error:
+                    raise WorkspaceError(
+                        f"cannot acquire {description} lock: {wait_error}"
+                    ) from wait_error
+            finally:
+                acquired.set()
+                if warning is not None:
+                    warning.join(timeout=0.1)
         except OSError as error:
             raise WorkspaceError(
                 f"cannot acquire {description} lock: {error}"
@@ -1328,7 +1412,7 @@ class Workspace:
         self.paths.ensure()
         checkouts = self._operation_checkouts(names, include_classic)
         failures: list[str] = []
-        with exclusive_lock(
+        with exclusive_layout_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
         ):
@@ -1622,7 +1706,7 @@ class Workspace:
         if worktree_strategy not in {"none", "merge", "rebase"}:
             raise WorkspaceError(f"unknown worktree strategy: {worktree_strategy}")
         checkouts = self._operation_checkouts(names, include_classic)
-        with exclusive_lock(
+        with exclusive_layout_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
         ):
@@ -1768,7 +1852,7 @@ class Workspace:
         existing: bool,
     ) -> Path:
         self.paths.ensure()
-        with exclusive_lock(
+        with exclusive_layout_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
         ):
@@ -1825,7 +1909,7 @@ class Workspace:
 
     def remove_worktree(self, component_name: str, label: str) -> None:
         self.paths.ensure()
-        with exclusive_lock(
+        with exclusive_layout_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
         ):
@@ -1872,7 +1956,7 @@ class Workspace:
 
     def create_profile(self, name: str, source: str = "default") -> Path:
         self.paths.ensure()
-        with exclusive_lock(
+        with exclusive_layout_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
         ):
@@ -1905,7 +1989,7 @@ class Workspace:
         self, name: str, component_name: str, kind: str, value: str = ""
     ) -> None:
         self.paths.ensure()
-        with exclusive_lock(
+        with exclusive_layout_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
         ):
@@ -1943,7 +2027,7 @@ class Workspace:
 
     def set_profile_sound_mode(self, name: str, mode: str) -> None:
         self.paths.ensure()
-        with exclusive_lock(
+        with exclusive_layout_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
         ):
@@ -2424,7 +2508,7 @@ class Workspace:
         use_ccache: bool = True,
     ) -> Path:
         self.paths.ensure()
-        with shared_lock(
+        with shared_layout_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
         ):
@@ -6180,7 +6264,7 @@ class Workspace:
         self, name: str, profile: str, preset: str = "basic-player"
     ) -> dict[str, Any]:
         self.paths.ensure()
-        with shared_lock(
+        with shared_layout_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
         ):
@@ -6278,7 +6362,7 @@ class Workspace:
 
     def scenario_reset(self, name: str) -> dict[str, Any]:
         self.paths.ensure()
-        with shared_lock(
+        with shared_layout_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
         ):
@@ -7401,7 +7485,7 @@ class Workspace:
         port: int | None = None,
     ) -> dict[str, Any]:
         self.paths.ensure()
-        with shared_lock(
+        with shared_layout_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
         ) as layout_lock:
@@ -8007,7 +8091,7 @@ class Workspace:
         dry_run: bool,
     ) -> Path:
         self.paths.ensure()
-        with shared_lock(
+        with shared_layout_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
         ) as layout_lock:
@@ -8079,7 +8163,7 @@ class Workspace:
         dry_run: bool,
     ) -> Path:
         self.paths.ensure()
-        with shared_lock(
+        with shared_layout_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
         ) as layout_lock:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -31,7 +31,16 @@ from typing import Any, Callable, Iterator, TextIO
 
 from .launch_identity import CLIENT_LAUNCH_LABEL_ENV, client_launch_label
 from .content_migration import ContentMigration
-from .locking import active_lock_fds, inherit_lock_fds
+from .locking import (
+    LOCK_WAIT_DIAGNOSTIC_SECONDS,
+    active_lock_fds,
+    exclusive_layout_lock,
+    exclusive_lock,
+    inherit_lock_fds,
+    layout_writer_intent_path as _layout_writer_intent_path,
+    shared_layout_lock,
+    shared_lock,
+)
 from .process_tree import holders_exist, signal_holders
 
 from .model import (
@@ -89,8 +98,6 @@ ALL_BUILD_TARGETS = (
     "server",
     "metaserver-worker",
 )
-LAYOUT_WRITER_INTENT_SUFFIX = ".writer-intent"
-LOCK_WAIT_DIAGNOSTIC_SECONDS = 10.0
 SOURCE_VIEW_METADATA = ".atrinik-source-view.json"
 SOURCE_VIEW_SCHEMA_VERSION = 2
 CONFIGURE_METADATA = ".atrinik-configure.json"
@@ -1158,136 +1165,6 @@ def open_regular_file(
         return descriptor
     except OSError as error:
         raise WorkspaceError(f"cannot open {description} {path}: {error}") from error
-
-
-@contextmanager
-def exclusive_lock(
-    path: Path,
-    description: str,
-    nonblocking: bool = False,
-    *,
-    diagnose_wait: bool = False,
-) -> Iterator[TextIO]:
-    with _advisory_lock(
-        path,
-        description,
-        fcntl.LOCK_EX,
-        nonblocking=nonblocking,
-        diagnose_wait=diagnose_wait,
-    ) as lock:
-        with inherit_lock_fds(lock):
-            yield lock
-
-
-@contextmanager
-def shared_lock(
-    path: Path, description: str, *, diagnose_wait: bool = False
-) -> Iterator[TextIO]:
-    operation = getattr(fcntl, "LOCK_SH", None)
-    if not isinstance(operation, int):
-        raise WorkspaceError(
-            f"shared locking is unavailable for {description}; refusing to continue"
-        )
-    with _advisory_lock(
-        path, description, operation, diagnose_wait=diagnose_wait
-    ) as lock:
-        with inherit_lock_fds(lock):
-            yield lock
-
-
-def _layout_writer_intent_path(path: Path) -> Path:
-    return path.with_name(
-        f"{path.stem}{LAYOUT_WRITER_INTENT_SUFFIX}{path.suffix}"
-    )
-
-
-@contextmanager
-def exclusive_layout_lock(
-    path: Path, description: str, nonblocking: bool = False
-) -> Iterator[TextIO]:
-    with exclusive_lock(
-        _layout_writer_intent_path(path),
-        f"{description} writer intent",
-        nonblocking,
-        diagnose_wait=True,
-    ):
-        with exclusive_lock(
-            path,
-            description,
-            nonblocking,
-            diagnose_wait=True,
-        ) as lock:
-            yield lock
-
-
-@contextmanager
-def shared_layout_lock(path: Path, description: str) -> Iterator[TextIO]:
-    layout = ExitStack()
-    with exclusive_lock(
-        _layout_writer_intent_path(path),
-        f"{description} writer intent",
-        diagnose_wait=True,
-    ):
-        lock = layout.enter_context(
-            shared_lock(path, description, diagnose_wait=True)
-        )
-    with layout:
-        yield lock
-
-
-@contextmanager
-def _advisory_lock(
-    path: Path,
-    description: str,
-    operation: int,
-    *,
-    nonblocking: bool = False,
-    diagnose_wait: bool = False,
-) -> Iterator[TextIO]:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    descriptor = open_regular_file(
-        path, os.O_RDWR | os.O_CREAT, f"{description} lock"
-    )
-    with os.fdopen(descriptor, "a+") as lock:
-        try:
-            fcntl.flock(lock, operation | fcntl.LOCK_NB)
-        except BlockingIOError as error:
-            if nonblocking:
-                raise WorkspaceError(f"{description} is already in use") from error
-            acquired = threading.Event()
-            warning: threading.Thread | None = None
-            if diagnose_wait:
-
-                def warn_about_wait() -> None:
-                    if acquired.wait(LOCK_WAIT_DIAGNOSTIC_SECONDS):
-                        return
-                    print(
-                        f"waiting more than {LOCK_WAIT_DIAGNOSTIC_SECONDS:g}s "
-                        f"for {description} lock at {path}; inspect "
-                        "`./atrinik ps --json` and "
-                        "`./atrinik worktree list --json`; do not bypass the "
-                        "wrapper or stop unrelated processes",
-                        file=sys.stderr,
-                    )
-
-                warning = threading.Thread(target=warn_about_wait, daemon=True)
-                warning.start()
-            try:
-                try:
-                    fcntl.flock(lock, operation)
-                except OSError as wait_error:
-                    raise WorkspaceError(
-                        f"cannot acquire {description} lock: {wait_error}"
-                    ) from wait_error
-            finally:
-                acquired.set()
-                if warning is not None:
-                    warning.join(timeout=0.1)
-        except OSError as error:
-            raise WorkspaceError(
-                f"cannot acquire {description} lock: {error}"
-            ) from error
-        yield lock
 
 
 class Workspace:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -207,8 +207,17 @@ foreground client and server runs, and scenario create/reset take it in shared
 mode while they consume selected checkout and profile coordinates. Independent
 build roots can therefore compile concurrently, while each root's existing
 exclusive build lock still serializes identical profile/key work. An exclusive
-writer cannot advance or remove a selected checkout until all readers exit. If
-the platform cannot provide a working advisory shared lock, the consuming
+writer cannot advance or remove a selected checkout until all readers exit.
+Waiting mutations first hold the exclusive
+`repository-layout.writer-intent.lock` admission gate. A new reader takes that
+gate exclusively only while acquiring its shared layout lease, then releases it
+for other readers. Once a writer establishes intent, existing readers complete
+normally but later readers wait at the gate instead of repeatedly bypassing the
+writer. The writer holds both locks through the mutation, and its subprocesses
+inherit both descriptors. A wait longer than 10 seconds emits one diagnostic
+with the supported process and worktree inventories, but does not time out or
+interrupt the holder. The diagnostic is emitted at most once per acquisition.
+If the platform cannot provide a working advisory shared lock, the consuming
 operation fails closed.
 
 A supervised topology transfers its shared layout and exact build-root lock
@@ -226,9 +235,11 @@ common command runner also inherits every active advisory-lock descriptor into
 build and scenario subprocesses, preserving layout, build-root, state,
 registry, and cache protection if their wrapper exits unexpectedly.
 
-The layout lock is always outermost; private helpers never reacquire it. A
-direct build or foreground client then takes its build-root lock and subordinate
-cache locks; the foreground process retains that root lease. Topology startup
+The writer-intent gate, when applicable, precedes the layout lock, which remains
+outermost relative to all operational locks; private helpers never reacquire
+either boundary. A direct build or foreground client then takes its build-root
+lock and subordinate cache locks; the foreground process retains that root
+lease. Topology startup
 takes the topology-operation lock, the server-state lock when needed, the
 build-root lock, and finally the port-allocation lock, and transfers the layout
 and build-root leases into its services.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -208,13 +208,15 @@ mode while they consume selected checkout and profile coordinates. Independent
 build roots can therefore compile concurrently, while each root's existing
 exclusive build lock still serializes identical profile/key work. An exclusive
 writer cannot advance or remove a selected checkout until all readers exit.
-Waiting mutations first hold the exclusive
-`repository-layout.writer-intent.lock` admission gate. A new reader takes that
-gate exclusively only while acquiring its shared layout lease, then releases it
-for other readers. Once a writer establishes intent, existing readers complete
-normally but later readers wait at the gate instead of repeatedly bypassing the
-writer. The writer holds both locks through the mutation, and its subprocesses
-inherit both descriptors. A wait longer than 10 seconds emits one diagnostic
+Waiting mutations first announce themselves with a shared
+`repository-layout.writer-pending.lock`, then hold the exclusive
+`repository-layout.writer-intent.lock` admission gate. A new reader briefly
+takes the admission gate and proceeds only if its exclusive pending-lock probe
+finds no announced writer; otherwise it releases admission, waits, and retries.
+Existing readers complete normally but later readers cannot repeatedly bypass
+a writer that has announced itself. The writer holds the pending, intent, and
+layout locks through the mutation, and its subprocesses inherit all three
+descriptors. A wait longer than 10 seconds emits one diagnostic
 with the supported process and worktree inventories, but does not time out or
 interrupt the holder. The diagnostic is emitted at most once per acquisition.
 If the platform cannot provide a working advisory shared lock, the consuming
@@ -235,7 +237,8 @@ common command runner also inherits every active advisory-lock descriptor into
 build and scenario subprocesses, preserving layout, build-root, state,
 registry, and cache protection if their wrapper exits unexpectedly.
 
-The writer-intent gate, when applicable, precedes the layout lock, which remains
+The writer-pending announcement precedes the writer-intent gate and layout lock,
+which remain
 outermost relative to all operational locks; private helpers never reacquire
 either boundary. A direct build or foreground client then takes its build-root
 lock and subordinate cache locks; the foreground process retains that root

--- a/tests/test_content_migration.py
+++ b/tests/test_content_migration.py
@@ -12,6 +12,11 @@ from unittest import mock
 
 from atrinik_workspace import content_migration as migration_module
 from atrinik_workspace.content_migration import ContentMigration
+from atrinik_workspace.locking import (
+    exclusive_layout_lock,
+    exclusive_lock,
+    layout_writer_intent_path,
+)
 from atrinik_workspace.workspace import Workspace
 
 
@@ -19,6 +24,21 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class ContentMigrationTests(unittest.TestCase):
+    def test_git_helper_inherits_all_exclusive_layout_descriptors(self) -> None:
+        completed = mock.MagicMock(returncode=0, stdout="", stderr="")
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            exclusive_layout_lock(
+                Path(directory) / "repository-layout.lock", "repository layout"
+            ),
+            mock.patch.object(
+                migration_module.subprocess, "run", return_value=completed
+            ) as invoke,
+        ):
+            migration_module._git(Path("/tmp/repository"), "status")
+
+        self.assertEqual(len(invoke.call_args.kwargs["pass_fds"]), 3)
+
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory()
         self.root = Path(self.temporary.name)
@@ -436,6 +456,19 @@ class ContentMigrationTests(unittest.TestCase):
         self.assertEqual(result["status"], "refused")
         self.assertEqual(result["refusals"][0]["code"], "repository_layout_busy")
 
+    def test_restore_refuses_when_writer_admission_is_held(self) -> None:
+        self._legacy_profile()
+        self.assertEqual(self.migration().execute("apply")["status"], "complete")
+        layout = self.workspace.paths.workspace / "repository-layout.lock"
+
+        with exclusive_lock(
+            layout_writer_intent_path(layout), "competing writer admission"
+        ):
+            result = self.migration().execute("restore")
+
+        self.assertEqual(result["status"], "refused")
+        self.assertEqual(result["refusals"][0]["code"], "repository_layout_busy")
+
     def test_tampered_journal_cannot_redirect_profile_restore(self) -> None:
         self._legacy_profile()
         self.assertEqual(self.migration().execute("apply")["status"], "complete")
@@ -626,9 +659,10 @@ class ContentMigrationTests(unittest.TestCase):
         unsafe = self.root / "unsafe-lock"
         unsafe.mkdir()
         with self.assertRaisesRegex(
-            migration_module.WorkspaceError, "cannot open repository layout lock"
+            migration_module.WorkspaceError, "repository layout lock"
         ):
-            migration_module._open_layout_lock(unsafe)
+            with exclusive_layout_lock(unsafe, "repository layout"):
+                self.fail("unsafe layout lock unexpectedly succeeded")
 
         self._legacy_profile()
         lock_path = self.workspace.paths.workspace / "repository-layout.lock"
@@ -640,6 +674,19 @@ class ContentMigrationTests(unittest.TestCase):
             os.close(descriptor)
         self.assertEqual(result["status"], "refused")
         self.assertEqual(result["refusals"][-1]["code"], "repository_layout_busy")
+
+    def test_apply_refuses_when_writer_admission_is_held(self) -> None:
+        self._legacy_profile()
+        layout = self.workspace.paths.workspace / "repository-layout.lock"
+
+        with exclusive_lock(
+            layout_writer_intent_path(layout), "competing writer admission"
+        ):
+            result = self.migration().execute("apply")
+
+        self.assertEqual(result["status"], "refused")
+        self.assertEqual(result["refusals"][-1]["code"], "repository_layout_busy")
+        self.assertFalse(self.migration().record_path.exists())
 
     def test_apply_is_idempotent_only_before_explicit_restore(self) -> None:
         self._legacy_profile()

--- a/tests/test_content_migration.py
+++ b/tests/test_content_migration.py
@@ -16,6 +16,7 @@ from atrinik_workspace.locking import (
     exclusive_layout_lock,
     exclusive_lock,
     layout_writer_intent_path,
+    layout_writer_pending_path,
 )
 from atrinik_workspace.workspace import Workspace
 
@@ -892,6 +893,8 @@ class ContentMigrationTests(unittest.TestCase):
         topologies.write_text("unsafe\n", encoding="utf-8")
         locks = self.workspace.paths.workspace / "repository-layout.lock"
         locks.symlink_to(self.root / "missing-lock")
+        layout_writer_intent_path(locks).mkdir()
+        layout_writer_pending_path(locks).symlink_to(self.root / "missing-pending")
 
         resources, refusals = self.migration()._resource_inventory(set())
 
@@ -899,7 +902,17 @@ class ContentMigrationTests(unittest.TestCase):
         self.assertIn("invalid_builds_directory", codes)
         self.assertIn("invalid_topologies_directory", codes)
         self.assertIn("invalid_lock_path", codes)
-        self.assertEqual(resources["locks"][0]["status"], "unsafe")
+        unsafe_locks = {
+            row["path"] for row in resources["locks"] if row["status"] == "unsafe"
+        }
+        self.assertEqual(
+            unsafe_locks,
+            {
+                str(locks),
+                str(layout_writer_intent_path(locks)),
+                str(layout_writer_pending_path(locks)),
+            },
+        )
 
     def test_resource_inventory_rejects_bad_entries_and_process_records(self) -> None:
         build = self.workspace.paths.builds / "bad"
@@ -934,6 +947,14 @@ class ContentMigrationTests(unittest.TestCase):
         lock_directory.mkdir()
         lock = lock_directory / "busy.lock"
         lock.write_text("lock\n", encoding="utf-8")
+        layout = self.workspace.paths.workspace / "repository-layout.lock"
+        coordination_locks = (
+            layout,
+            layout_writer_intent_path(layout),
+            layout_writer_pending_path(layout),
+        )
+        for coordination_lock in coordination_locks:
+            coordination_lock.write_text("lock\n", encoding="utf-8")
         with (
             mock.patch.object(migration_module, "RESOURCE_RECORD_MAX_BYTES", 1),
             mock.patch.object(
@@ -948,6 +969,10 @@ class ContentMigrationTests(unittest.TestCase):
         )
         observed = next(row for row in resources["locks"] if row["path"] == str(lock))
         self.assertTrue(observed["active"])
+        observed_paths = {
+            row["path"] for row in resources["locks"] if row["active"]
+        }
+        self.assertTrue({str(path) for path in coordination_locks} <= observed_paths)
 
     def test_apply_rolls_back_when_profile_changes_after_preflight(self) -> None:
         profile, original = self._legacy_profile()

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -13,7 +13,12 @@ import unittest
 from unittest import mock
 
 from atrinik_workspace import migration as migration_module
-from atrinik_workspace.locking import inherit_lock_fds
+from atrinik_workspace.locking import (
+    exclusive_layout_lock,
+    exclusive_lock,
+    inherit_lock_fds,
+    layout_writer_intent_path,
+)
 from atrinik_workspace.migration import RepositoryMigration
 from atrinik_workspace.model import Paths, WorkspaceError
 
@@ -56,6 +61,22 @@ SHARED = (
 
 
 class RepositoryMigrationTests(unittest.TestCase):
+    def test_git_helpers_inherit_all_exclusive_layout_descriptors(self) -> None:
+        completed = mock.MagicMock(returncode=0, stdout=b"", stderr=b"")
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            exclusive_layout_lock(
+                Path(directory) / "repository-layout.lock", "repository layout"
+            ),
+            mock.patch(
+                "atrinik_workspace.migration.subprocess.run",
+                return_value=completed,
+            ) as invoke,
+        ):
+            RepositoryMigration._git_process(Path("/tmp/repository"), "status")
+
+        self.assertEqual(len(invoke.call_args.kwargs["pass_fds"]), 3)
+
     def test_git_helpers_inherit_active_layout_descriptor(self) -> None:
         completed = mock.MagicMock(returncode=0, stdout=b"", stderr=b"")
         with (
@@ -1368,6 +1389,23 @@ class RepositoryMigrationTests(unittest.TestCase):
         self.assertIn(
             "repository_layout_busy",
             {row["code"] for row in locked["refusals"]},
+        )
+        self.assertTrue(source.is_dir())
+
+    def test_apply_refuses_when_writer_admission_is_held(self) -> None:
+        source = self.make_repository("client", "client")
+        self.make_classic({"client": source})
+        layout = self.workspace / "repository-layout.lock"
+
+        with exclusive_lock(
+            layout_writer_intent_path(layout), "competing writer admission"
+        ):
+            result = self.migration().execute("apply")
+
+        self.assertEqual(result["status"], "refused")
+        self.assertIn(
+            "repository_layout_busy",
+            {row["code"] for row in result["refusals"]},
         )
         self.assertTrue(source.is_dir())
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import copy
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import redirect_stderr
 import ctypes
 import errno
 import fcntl
 import hashlib
+import io
 import json
 import multiprocessing
 import os
@@ -47,7 +49,9 @@ from atrinik_workspace.workspace import (
     _remote_matches as real_remote_matches,
     display_arguments,
     exclusive_lock,
+    exclusive_layout_lock,
     shared_lock,
+    shared_layout_lock,
     remove_owned_tree,
     replace_directory as worker_replace_directory,
     replace_runtime_directory as workspace_replace_directory,
@@ -244,6 +248,41 @@ def timed_public_build_process(
                         "legacy repository layout",
                     ):
                         workspace._build("client", profile, False)
+        results.put(None)
+    except BaseException as error:
+        results.put(f"{type(error).__name__}: {error}")
+        raise
+
+
+def fair_layout_reader_process(
+    layout_path: str,
+    name: str,
+    entered: object,
+    release: object | None,
+    results: object,
+) -> None:
+    try:
+        with shared_layout_lock(Path(layout_path), "repository layout"):
+            entered.put(name)
+            if release is not None and not release.wait(10):
+                raise TimeoutError(f"{name} reader was not released")
+        results.put(None)
+    except BaseException as error:
+        results.put(f"{type(error).__name__}: {error}")
+        raise
+
+
+def fair_layout_writer_process(
+    layout_path: str,
+    entered: object,
+    release: object,
+    results: object,
+) -> None:
+    try:
+        with exclusive_layout_lock(Path(layout_path), "repository layout"):
+            entered.put("writer")
+            if not release.wait(10):
+                raise TimeoutError("writer was not released")
         results.put(None)
     except BaseException as error:
         results.put(f"{type(error).__name__}: {error}")
@@ -739,7 +778,7 @@ class WorkspaceTests(unittest.TestCase):
             self.workspace.initialize(["client", "server"], jobs=2)
 
         self.assertEqual(len(observed), 2)
-        self.assertTrue(all(len(descriptors) == 1 for descriptors in observed))
+        self.assertTrue(all(len(descriptors) == 2 for descriptors in observed))
 
     def test_failed_clone_does_not_strand_destination(self) -> None:
         destination = self.workspace.paths.repositories / "client"
@@ -5684,6 +5723,111 @@ class WorkspaceTests(unittest.TestCase):
             ):
                 with shared_lock(lock, "test resource"):
                     self.fail("unsupported shared lock unexpectedly succeeded")
+
+    def test_layout_writer_precedes_continuing_reader_arrivals(self) -> None:
+        context = multiprocessing.get_context("spawn")
+        layout = self.workspace.paths.workspace / "repository-layout.lock"
+        intent = workspace_module._layout_writer_intent_path(layout)
+        entered = context.Queue()
+        results = context.Queue()
+        release_initial = context.Event()
+        release_writer = context.Event()
+        initial = context.Process(
+            target=fair_layout_reader_process,
+            args=(
+                str(layout),
+                "initial",
+                entered,
+                release_initial,
+                results,
+            )
+        )
+        writer = context.Process(
+            target=fair_layout_writer_process,
+            args=(str(layout), entered, release_writer, results),
+        )
+        arrivals = [
+            context.Process(
+                target=fair_layout_reader_process,
+                args=(str(layout), f"reader-{index}", entered, None, results),
+            )
+            for index in range(8)
+        ]
+        processes = [initial, writer, *arrivals]
+        started: list[multiprocessing.Process] = []
+        try:
+            initial.start()
+            started.append(initial)
+            self.assertEqual(entered.get(timeout=5), "initial")
+            writer.start()
+            started.append(writer)
+            deadline = time.monotonic() + 2
+            while time.monotonic() < deadline:
+                try:
+                    with exclusive_lock(
+                        intent,
+                        "repository layout writer intent",
+                        nonblocking=True,
+                    ):
+                        pass
+                except WorkspaceError:
+                    break
+                time.sleep(0.005)
+            else:
+                self.fail("writer did not establish intent")
+
+            for arrival in arrivals:
+                arrival.start()
+                started.append(arrival)
+                time.sleep(0.01)
+            with self.assertRaises(queue.Empty):
+                entered.get(timeout=0.1)
+
+            release_initial.set()
+            self.assertEqual(entered.get(timeout=5), "writer")
+            with self.assertRaises(queue.Empty):
+                entered.get(timeout=0.1)
+            release_writer.set()
+            self.assertEqual(
+                {entered.get(timeout=5) for _ in arrivals},
+                {f"reader-{index}" for index in range(8)},
+            )
+        finally:
+            release_initial.set()
+            release_writer.set()
+            join_or_stop_processes(started, 10)
+        self.assertEqual(started, processes)
+        self.assertEqual([process.exitcode for process in processes], [0] * 10)
+        self.assertEqual([results.get(timeout=2) for _ in processes], [None] * 10)
+
+    def test_layout_lock_reports_one_actionable_prolonged_wait(self) -> None:
+        layout = self.workspace.paths.workspace / "repository-layout.lock"
+        waiter_entered = threading.Event()
+
+        def wait_for_reader_lease() -> None:
+            with shared_layout_lock(layout, "repository layout"):
+                waiter_entered.set()
+
+        output = io.StringIO()
+        with (
+            mock.patch.object(
+                workspace_module, "LOCK_WAIT_DIAGNOSTIC_SECONDS", 0.05
+            ),
+            redirect_stderr(output),
+            exclusive_layout_lock(layout, "repository layout"),
+        ):
+            waiter = threading.Thread(target=wait_for_reader_lease)
+            waiter.start()
+            time.sleep(0.12)
+            self.assertFalse(waiter_entered.is_set())
+        waiter.join(2)
+        self.assertFalse(waiter.is_alive())
+        self.assertTrue(waiter_entered.is_set())
+        diagnostic = output.getvalue()
+        self.assertEqual(diagnostic.count("waiting more than"), 1)
+        self.assertIn("./atrinik ps --json", diagnostic)
+        self.assertIn("./atrinik worktree list --json", diagnostic)
+        self.assertIn("do not bypass the wrapper", diagnostic)
 
     def test_independent_build_roots_overlap_across_processes(self) -> None:
         context = multiprocessing.get_context("spawn")

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -5806,6 +5806,7 @@ class WorkspaceTests(unittest.TestCase):
 
     def test_layout_lock_reports_one_actionable_prolonged_wait(self) -> None:
         layout = self.workspace.paths.workspace / "repository-layout.lock"
+        intent = workspace_module._layout_writer_intent_path(layout)
         waiter_entered = threading.Event()
 
         def wait_for_reader_lease() -> None:
@@ -5818,11 +5819,14 @@ class WorkspaceTests(unittest.TestCase):
                 locking_module, "LOCK_WAIT_DIAGNOSTIC_SECONDS", 0.05
             ),
             redirect_stderr(output),
-            exclusive_layout_lock(layout, "repository layout"),
+            exclusive_lock(layout, "held repository layout"),
         ):
-            waiter = threading.Thread(target=wait_for_reader_lease)
-            waiter.start()
-            time.sleep(0.12)
+            with exclusive_lock(intent, "held reader admission"):
+                waiter = threading.Thread(target=wait_for_reader_lease)
+                waiter.start()
+                time.sleep(0.08)
+                self.assertFalse(waiter_entered.is_set())
+            time.sleep(0.08)
             self.assertFalse(waiter_entered.is_set())
         waiter.join(2)
         self.assertFalse(waiter.is_alive())
@@ -5840,6 +5844,36 @@ class WorkspaceTests(unittest.TestCase):
         with shared_layout_lock(layout, "repository layout") as lease:
             self.assertEqual(active_lock_fds(), (lease.fileno(),))
         self.assertEqual(active_lock_fds(), ())
+
+    def test_layout_writer_reports_once_across_sequential_waits(self) -> None:
+        layout = self.workspace.paths.workspace / "repository-layout.lock"
+        intent = workspace_module._layout_writer_intent_path(layout)
+        pending = locking_module.layout_writer_pending_path(layout)
+        writer_entered = threading.Event()
+
+        def wait_for_writer_lease() -> None:
+            with exclusive_layout_lock(layout, "repository layout"):
+                writer_entered.set()
+
+        output = io.StringIO()
+        with (
+            mock.patch.object(
+                locking_module, "LOCK_WAIT_DIAGNOSTIC_SECONDS", 0.05
+            ),
+            redirect_stderr(output),
+            exclusive_lock(intent, "held writer admission"),
+        ):
+            with exclusive_lock(pending, "held writer announcement"):
+                writer = threading.Thread(target=wait_for_writer_lease)
+                writer.start()
+                time.sleep(0.08)
+                self.assertFalse(writer_entered.is_set())
+            time.sleep(0.08)
+            self.assertFalse(writer_entered.is_set())
+        writer.join(2)
+        self.assertFalse(writer.is_alive())
+        self.assertTrue(writer_entered.is_set())
+        self.assertEqual(output.getvalue().count("waiting more than"), 1)
 
     def test_independent_build_roots_overlap_across_processes(self) -> None:
         context = multiprocessing.get_context("spawn")

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -259,11 +259,14 @@ def timed_public_build_process(
 def fair_layout_reader_process(
     layout_path: str,
     name: str,
+    attempting: object | None,
     entered: object,
     release: object | None,
     results: object,
 ) -> None:
     try:
+        if attempting is not None:
+            attempting.set()
         with shared_layout_lock(Path(layout_path), "repository layout"):
             entered.put(name)
             if release is not None and not release.wait(10):
@@ -5726,6 +5729,13 @@ class WorkspaceTests(unittest.TestCase):
                 with shared_lock(lock, "test resource"):
                     self.fail("unsupported shared lock unexpectedly succeeded")
 
+        with mock.patch.object(locking_module.fcntl, "LOCK_SH", None):
+            with self.assertRaisesRegex(
+                WorkspaceError, "shared locking is unavailable"
+            ):
+                with shared_layout_lock(lock, "repository layout"):
+                    self.fail("unsupported shared layout lock unexpectedly succeeded")
+
     def test_layout_writer_precedes_continuing_reader_arrivals(self) -> None:
         context = multiprocessing.get_context("spawn")
         layout = self.workspace.paths.workspace / "repository-layout.lock"
@@ -5740,6 +5750,7 @@ class WorkspaceTests(unittest.TestCase):
             args=(
                 str(layout),
                 "initial",
+                None,
                 entered,
                 release_initial,
                 results,
@@ -5749,10 +5760,18 @@ class WorkspaceTests(unittest.TestCase):
             target=fair_layout_writer_process,
             args=(str(layout), entered, release_writer, results),
         )
+        arrival_attempts = [context.Event() for _ in range(8)]
         arrivals = [
             context.Process(
                 target=fair_layout_reader_process,
-                args=(str(layout), f"reader-{index}", entered, None, results),
+                args=(
+                    str(layout),
+                    f"reader-{index}",
+                    arrival_attempts[index],
+                    entered,
+                    None,
+                    results,
+                ),
             )
             for index in range(8)
         ]
@@ -5783,7 +5802,9 @@ class WorkspaceTests(unittest.TestCase):
                 for arrival in arrivals:
                     arrival.start()
                     started.append(arrival)
-                    time.sleep(0.01)
+                self.assertTrue(
+                    all(attempt.wait(5) for attempt in arrival_attempts)
+                )
                 with self.assertRaises(queue.Empty):
                     entered.get(timeout=0.1)
 
@@ -5866,18 +5887,23 @@ class WorkspaceTests(unittest.TestCase):
         layout = self.workspace.paths.workspace / "repository-layout.lock"
         entered = 0
         entered_lock = threading.Lock()
+        attempts = [threading.Event() for _ in range(16)]
 
-        def read_layout() -> None:
+        def read_layout(attempt: threading.Event) -> None:
             nonlocal entered
+            attempt.set()
             with shared_layout_lock(layout, "repository layout"):
                 with entered_lock:
                     entered += 1
 
         with exclusive_layout_lock(layout, "repository layout"):
-            readers = [threading.Thread(target=read_layout) for _ in range(16)]
+            readers = [
+                threading.Thread(target=read_layout, args=(attempt,))
+                for attempt in attempts
+            ]
             for reader in readers:
                 reader.start()
-            time.sleep(0.1)
+            self.assertTrue(all(attempt.wait(2) for attempt in attempts))
             self.assertEqual(entered, 0)
         for reader in readers:
             reader.join(2)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -25,6 +25,8 @@ import unittest
 from unittest import mock
 
 from atrinik_workspace import workspace as workspace_module
+from atrinik_workspace import locking as locking_module
+from atrinik_workspace.locking import active_lock_fds
 from atrinik_workspace.migration import rename_no_replace as real_rename_no_replace
 from atrinik_workspace.launch_identity import client_launch_label
 from atrinik_workspace.model import (
@@ -778,7 +780,7 @@ class WorkspaceTests(unittest.TestCase):
             self.workspace.initialize(["client", "server"], jobs=2)
 
         self.assertEqual(len(observed), 2)
-        self.assertTrue(all(len(descriptors) == 2 for descriptors in observed))
+        self.assertTrue(all(len(descriptors) == 3 for descriptors in observed))
 
     def test_failed_clone_does_not_strand_destination(self) -> None:
         destination = self.workspace.paths.repositories / "client"
@@ -5728,6 +5730,7 @@ class WorkspaceTests(unittest.TestCase):
         context = multiprocessing.get_context("spawn")
         layout = self.workspace.paths.workspace / "repository-layout.lock"
         intent = workspace_module._layout_writer_intent_path(layout)
+        pending = locking_module.layout_writer_pending_path(layout)
         entered = context.Queue()
         results = context.Queue()
         release_initial = context.Event()
@@ -5759,29 +5762,30 @@ class WorkspaceTests(unittest.TestCase):
             initial.start()
             started.append(initial)
             self.assertEqual(entered.get(timeout=5), "initial")
-            writer.start()
-            started.append(writer)
-            deadline = time.monotonic() + 2
-            while time.monotonic() < deadline:
-                try:
-                    with exclusive_lock(
-                        intent,
-                        "repository layout writer intent",
-                        nonblocking=True,
-                    ):
-                        pass
-                except WorkspaceError:
-                    break
-                time.sleep(0.005)
-            else:
-                self.fail("writer did not establish intent")
+            with exclusive_lock(intent, "held reader admission"):
+                writer.start()
+                started.append(writer)
+                deadline = time.monotonic() + 2
+                while time.monotonic() < deadline:
+                    try:
+                        with exclusive_lock(
+                            pending,
+                            "repository layout writer pending",
+                            nonblocking=True,
+                        ):
+                            pass
+                    except WorkspaceError:
+                        break
+                    time.sleep(0.005)
+                else:
+                    self.fail("writer did not publish its pending state")
 
-            for arrival in arrivals:
-                arrival.start()
-                started.append(arrival)
-                time.sleep(0.01)
-            with self.assertRaises(queue.Empty):
-                entered.get(timeout=0.1)
+                for arrival in arrivals:
+                    arrival.start()
+                    started.append(arrival)
+                    time.sleep(0.01)
+                with self.assertRaises(queue.Empty):
+                    entered.get(timeout=0.1)
 
             release_initial.set()
             self.assertEqual(entered.get(timeout=5), "writer")
@@ -5811,7 +5815,7 @@ class WorkspaceTests(unittest.TestCase):
         output = io.StringIO()
         with (
             mock.patch.object(
-                workspace_module, "LOCK_WAIT_DIAGNOSTIC_SECONDS", 0.05
+                locking_module, "LOCK_WAIT_DIAGNOSTIC_SECONDS", 0.05
             ),
             redirect_stderr(output),
             exclusive_layout_lock(layout, "repository layout"),
@@ -5828,6 +5832,14 @@ class WorkspaceTests(unittest.TestCase):
         self.assertIn("./atrinik ps --json", diagnostic)
         self.assertIn("./atrinik worktree list --json", diagnostic)
         self.assertIn("do not bypass the wrapper", diagnostic)
+
+    def test_shared_layout_lock_registers_only_live_layout_lease(self) -> None:
+        layout = self.workspace.paths.workspace / "repository-layout.lock"
+
+        self.assertEqual(active_lock_fds(), ())
+        with shared_layout_lock(layout, "repository layout") as lease:
+            self.assertEqual(active_lock_fds(), (lease.fileno(),))
+        self.assertEqual(active_lock_fds(), ())
 
     def test_independent_build_roots_overlap_across_processes(self) -> None:
         context = multiprocessing.get_context("spawn")

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -5845,6 +5845,45 @@ class WorkspaceTests(unittest.TestCase):
             self.assertEqual(active_lock_fds(), (lease.fileno(),))
         self.assertEqual(active_lock_fds(), ())
 
+    def test_layout_writer_partial_failures_release_earlier_leases(self) -> None:
+        layout = self.workspace.paths.workspace / "repository-layout.lock"
+        intent = workspace_module._layout_writer_intent_path(layout)
+        pending = locking_module.layout_writer_pending_path(layout)
+
+        for blocker in (intent, layout):
+            with exclusive_lock(blocker, "staged acquisition blocker"):
+                with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                    with exclusive_layout_lock(
+                        layout, "repository layout", nonblocking=True
+                    ):
+                        self.fail("partially blocked writer unexpectedly entered")
+            self.assertEqual(active_lock_fds(), ())
+            for path in (pending, intent, layout):
+                with exclusive_lock(path, "released writer stage", nonblocking=True):
+                    pass
+
+    def test_delayed_layout_readers_drain_after_writer(self) -> None:
+        layout = self.workspace.paths.workspace / "repository-layout.lock"
+        entered = 0
+        entered_lock = threading.Lock()
+
+        def read_layout() -> None:
+            nonlocal entered
+            with shared_layout_lock(layout, "repository layout"):
+                with entered_lock:
+                    entered += 1
+
+        with exclusive_layout_lock(layout, "repository layout"):
+            readers = [threading.Thread(target=read_layout) for _ in range(16)]
+            for reader in readers:
+                reader.start()
+            time.sleep(0.1)
+            self.assertEqual(entered, 0)
+        for reader in readers:
+            reader.join(2)
+        self.assertTrue(all(not reader.is_alive() for reader in readers))
+        self.assertEqual(entered, len(readers))
+
     def test_layout_writer_reports_once_across_sequential_waits(self) -> None:
         layout = self.workspace.paths.workspace / "repository-layout.lock"
         intent = workspace_module._layout_writer_intent_path(layout)


### PR DESCRIPTION
## Summary

- announce pending writers before the exclusive admission gate and repository-layout lock
- preserve concurrent admitted readers while preventing arrivals from bypassing even a pre-admission writer
- apply the same fair contract to repository/content migration and preserve every mutation lease in subprocesses
- emit one actionable diagnostic after a 10-second wait without timing out or interrupting a holder
- cover the ordering with spawned-process concurrency tests and synchronize wrapper guidance

Fixes #382.

## Coordinates

- base: `main` at `254595b3e`
- head: `fix/repository-layout-writer-starvation` at `93abc9dcb79e33c174718c6700c6d3ef14d570c5`
- worktree: `/workspaces/atrinik/workspace/worktrees/atrinik/issue-382-writer-fairness`
- commits:
  - `66fc9cc30 fix(workspace): prevent layout writer starvation`
  - `760aeb87d merge current main without rewriting published history`
  - `f5b77041c fix(workspace): close layout fairness gaps`
  - `6484e9687 fix(workspace): bound layout wait diagnostics`
  - `22fbb4877 merge current main without rewriting published history`
  - `afe1128e3 fix(workspace): drain delayed layout readers`
  - `93abc9dcb test(workspace): synchronize layout contention`

## Validation

- complete final-head wrapper suite — 613 passed in 167.570s
- five whole-diff review rounds — ten findings fixed; final three independent reviews reported zero actionable findings
- staged reader and writer contention — each forced two sequential waits and emitted exactly one diagnostic
- aggregate coverage report — 82%
- `python3 -m compileall -q atrinik atrinik_workspace tests` — passed
- `python3 -m atrinik_workspace.guidance_inventory --check` — passed at enforced budgets
- active Codex skill validator for `atrinik-multi-repo-workspace` — passed
- `./atrinik manifest validate` — 20 components valid
- `./atrinik provenance validate` — 2 records valid
- `./atrinik supply-chain validate` — 105 dependencies valid
- `./atrinik cleanup --scope all --older-than 7 --dry-run --json` — 313 protected, zero candidates, zero errors, zero removals
- `git diff --check` — passed

## Verification

Runtime provisioning is not applicable: this changes the wrapper's repository-layout coordination, not a component runtime adapter or game behavior. Repeat the deterministic process-level checks with:

```sh
/workspaces/atrinik/.venv/bin/python -m unittest -v \
  tests.test_workspace.WorkspaceTests.test_layout_writer_precedes_continuing_reader_arrivals \
  tests.test_workspace.WorkspaceTests.test_layout_lock_reports_one_actionable_prolonged_wait \
  tests.test_workspace.WorkspaceTests.test_shared_layout_lock_registers_only_live_layout_lease \
  tests.test_workspace.WorkspaceTests.test_layout_writers_wait_for_build_readers_across_processes \
  tests.test_workspace.WorkspaceTests.test_independent_build_roots_overlap_across_processes
```

Expected result: a writer announces while admission is deliberately held, then enters after the active reader and before every later reader; independent admitted readers still overlap; only the live layout lease reaches reader subprocesses; and a prolonged wait emits one safe diagnostic. The test owns temporary locks and processes and leaves no topology, state, scenario, account, or cleanup requirement.
