### PR TITLE
fix(sound): verify playtest digest in path order

### DIFF
--- a/atrinik_workspace/sound.py
+++ b/atrinik_workspace/sound.py
@@ -362,7 +362,7 @@ def verify_playtest_tree(
     if not isinstance(assets, list):
         raise WorkspaceError("local-playtest manifest assets must be an array")
     actual_by_path: dict[str, dict[str, Any]] = {}
-    tree_digest = hashlib.sha256()
+    tree_entries: list[tuple[str, str]] = []
     copied = 0
     converted = 0
     for value in assets:
@@ -441,7 +441,7 @@ def verify_playtest_tree(
         _validate_payload_codec(logical_path, expected_codec, payload_prefix)
         copied += expected_mapping == "copy"
         converted += expected_mapping == "render-opus"
-        tree_digest.update(f"{payload_hash}  {logical_path}\n".encode("ascii"))
+        tree_entries.append((logical_path, payload_hash))
 
     if set(actual_by_path) != set(expected_by_path):
         missing = sorted(set(expected_by_path) - set(actual_by_path))
@@ -465,6 +465,9 @@ def verify_playtest_tree(
     }
     if _tree_files(root) != allowed:
         raise WorkspaceError("local-playtest tree has missing or unexpected files")
+    tree_digest = hashlib.sha256()
+    for logical_path, payload_hash in sorted(tree_entries):
+        tree_digest.update(f"{payload_hash}  {logical_path}\n".encode("ascii"))
     digest = tree_digest.hexdigest()
     if manifest.get("output_tree_sha256") != digest:
         raise WorkspaceError("local-playtest output-tree digest mismatch")

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -130,7 +130,7 @@ class PlaytestSoundTests(unittest.TestCase):
         }
         (self.output / PLAYTEST_BLOCKERS).write_bytes(canonical(blockers))
         tree_hash = hashlib.sha256()
-        for asset in playtest_assets:
+        for asset in sorted(playtest_assets, key=lambda value: str(value["logical_path"])):
             logical = str(asset["logical_path"])
             tree_hash.update(f"{digest(self.output / logical)}  {logical}\n".encode())
         self.inputs = {
@@ -203,6 +203,16 @@ class PlaytestSoundTests(unittest.TestCase):
         incomplete.pop("blocker_report_sha256")
         with self.assertRaisesRegex(WorkspaceError, "fields are invalid"):
             validate_sound_record(incomplete)
+
+    def test_output_tree_digest_is_independent_of_manifest_asset_order(self) -> None:
+        self.manifest["assets"] = list(reversed(self.manifest["assets"]))
+        self.rewrite_manifest(self.manifest)
+
+        record = verify_playtest_tree(self.source, self.output, self.inputs)
+
+        self.assertEqual(
+            record["output_tree_sha256"], self.manifest["output_tree_sha256"]
+        )
 
     def test_sound_record_validation_rejects_each_invalid_identity(self) -> None:
         record = verify_playtest_tree(self.source, self.output, self.inputs)


### PR DESCRIPTION
## Summary

- compute the wrapper's local-playtest output-tree digest in lexicographic logical-path order
- add a regression where manifest asset order differs from logical path order
- preserve the existing tamper, mapping, payload, count, and exact-tree checks

Closes #391

## Coordinates

- Base: `main` at `7ac57237aa634158912945a720cadb73ad264bcc`
- Head: `fix/sound-digest-order` at `4e08e88d7b3843147f069e6e32265d8cb71dfc11`
- Worktree: `/workspaces/atrinik/workspace/worktrees/atrinik/391-sound-digest-order`
- Commit: `cf4e40741 fix(sound): verify playtest digest in path order`

## Validation

- `python3 -m unittest -v tests.test_sound.PlaytestSoundTests.test_complete_current_tree_is_accepted tests.test_sound.PlaytestSoundTests.test_output_tree_digest_is_independent_of_manifest_asset_order`
- `python3 -m unittest -v tests.test_sound`
- `build/validation-venv/bin/python -m coverage run -m unittest discover -v` (614 tests)
- `build/validation-venv/bin/python -m coverage report --show-missing` (82% total)
- `build/validation-venv/bin/python -m compileall -q atrinik atrinik_workspace tests`
- `build/validation-venv/bin/python -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `git diff --check`

## Verification

Managed runtime is not applicable: this is deterministic wrapper-side verification of a produced sound tree. Run the focused order-independence test above; it reverses a deliberately non-lexicographic manifest and expects the producer-declared sorted-path digest. The full `tests.test_sound` module exercises the preserved tamper and exact-tree failures.

Two independent fresh-context whole-diff reviews found zero actionable findings. Latest-head Integration, CodeQL, PR-title policy, and Codecov patch checks pass.