### PR TITLE
fix(scenarios): keep stale profiles from breaking inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,7 +847,12 @@ the selected server, creates the dedicated `scenario-issue-42` state, stores a
 generated password in a mode-0600 ignored file, and prints exact
 `topology show`/`up`/`ps`/`logs`/`down` commands. `show` and `list` never reveal
 the password; request it explicitly with `credentials` immediately before
-login.
+login. `scenario list` keeps the global inventory usable when a retained
+scenario can no longer resolve its profile or fails current validation. JSON
+output represents that entry with its `name`, `path`, `inert: true`, and a
+stable `inert_reason`; bounded human output labels the same entry `inert`.
+Control characters in inert names and paths are escaped. Exact `show`,
+credential, and reset operations continue to fail closed.
 
 Scenarios live below ignored `workspace/scenarios/`. Their metadata records the
 profile plus every resolved provisioning dependency's checkout, source root,

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -847,10 +847,18 @@ def main(arguments: list[str] | None = None) -> int:
                     print(json.dumps(summaries, indent=2, sort_keys=True))
                 else:
                     for summary in summaries:
-                        print(
-                            f"{summary['name']}\t{summary['profile']}\t"
-                            f"{summary['preset']}\t{summary['state']}"
-                        )
+                        if summary.get("inert"):
+                            name = json.dumps(str(summary["name"]))[1:-1]
+                            path = json.dumps(str(summary["path"]))[1:-1]
+                            print(
+                                f"{name}\tinert\t"
+                                f"{summary['inert_reason']}\t{path}"
+                            )
+                        else:
+                            print(
+                                f"{summary['name']}\t{summary['profile']}\t"
+                                f"{summary['preset']}\t{summary['state']}"
+                            )
             elif options.scenario_command == "show":
                 summary = workspace.scenario_show(options.name)
                 if options.json:

--- a/atrinik_workspace/model.py
+++ b/atrinik_workspace/model.py
@@ -164,7 +164,7 @@ def load_json(path: Path) -> Any:
     try:
         with path.open(encoding="utf-8") as stream:
             return json.load(stream, object_pairs_hook=_reject_duplicate_keys)
-    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+    except (OSError, UnicodeError, ValueError, RecursionError) as error:
         raise WorkspaceError(f"cannot read {path}: {error}") from error
 
 

--- a/atrinik_workspace/model.py
+++ b/atrinik_workspace/model.py
@@ -164,7 +164,7 @@ def load_json(path: Path) -> Any:
     try:
         with path.open(encoding="utf-8") as stream:
             return json.load(stream, object_pairs_hook=_reject_duplicate_keys)
-    except (OSError, json.JSONDecodeError) as error:
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
         raise WorkspaceError(f"cannot read {path}: {error}") from error
 
 

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -2158,7 +2158,10 @@ class Workspace:
             require_keys(profile, PROFILE_KEYS, f"profile {name}")
         if profile["schema_version"] != PROFILE_SCHEMA_VERSION or profile["name"] != name:
             raise WorkspaceError(f"profile identity/schema mismatch: {name}")
-        if profile["sound_mode"] not in SOUND_MODES:
+        if (
+            not isinstance(profile["sound_mode"], str)
+            or profile["sound_mode"] not in SOUND_MODES
+        ):
             raise WorkspaceError(f"profile sound mode is invalid: {name}")
         stack_name = profile["stack"]
         if not isinstance(stack_name, str) or stack_name not in self.manifest.stacks:
@@ -2179,12 +2182,17 @@ class Workspace:
             require_keys(selector, SELECTOR_KEYS, f"profile selector {component_name}")
             kind = selector["kind"]
             value = selector["value"]
-            if kind not in {
-                "primary",
-                "worktree",
-                "path",
-                MIGRATED_CONTENT_WORKTREE_KIND,
-            } or not isinstance(value, str):
+            if (
+                not isinstance(kind, str)
+                or kind
+                not in {
+                    "primary",
+                    "worktree",
+                    "path",
+                    MIGRATED_CONTENT_WORKTREE_KIND,
+                }
+                or not isinstance(value, str)
+            ):
                 raise WorkspaceError(f"invalid profile selector: {component_name}")
             if kind == "primary" and value:
                 raise WorkspaceError(f"primary selector must not have a value: {component_name}")

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -6287,8 +6287,9 @@ class Workspace:
         scenarios: list[dict[str, Any]] = []
         for path in sorted(self.paths.scenarios.iterdir()):
             if path.is_dir() and not path.name.startswith("."):
-                scenario_path = self._scenario_directory(path.name)
+                scenario_path = path
                 try:
+                    scenario_path = self._scenario_directory(path.name)
                     metadata = self._load_scenario(path.name, registered_states)
                     scenarios.append({**metadata, "path": str(scenario_path)})
                 except _InertScenarioError as error:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -2198,15 +2198,26 @@ class Workspace:
                 raise WorkspaceError(f"primary selector must not have a value: {component_name}")
             if kind == "worktree":
                 validate_name(value, f"profile selector {component_name}")
-            if kind == "path" and not Path(value).is_absolute():
-                raise WorkspaceError(f"profile path must be absolute: {component_name}")
+            selected_path: Path | None = None
+            if kind in {"path", MIGRATED_CONTENT_WORKTREE_KIND}:
+                selected_path = Path(value)
+                if kind == "path" and not selected_path.is_absolute():
+                    raise WorkspaceError(
+                        f"profile path must be absolute: {component_name}"
+                    )
+                try:
+                    selected_path = selected_path.resolve(strict=False)
+                except (OSError, RuntimeError, ValueError) as error:
+                    raise WorkspaceError(
+                        f"invalid profile selector: {component_name}"
+                    ) from error
             if kind == MIGRATED_CONTENT_WORKTREE_KIND:
-                migrated = Path(value)
                 expected_parent = (self.paths.worktrees / "content").resolve()
                 if (
                     component_name != "content-1x"
-                    or not migrated.is_absolute()
-                    or migrated.resolve(strict=False).parent != expected_parent
+                    or selected_path is None
+                    or not Path(value).is_absolute()
+                    or selected_path.parent != expected_parent
                 ):
                     raise WorkspaceError(
                         "invalid migrated content worktree selector: "

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -137,6 +137,9 @@ SCENARIO_PRESETS = {
     "lighting-radiance-inside": {"archetype": "human_male"},
 }
 SCENARIO_PASSWORD_MAX_SIZE = 128
+SCENARIO_INERT_HISTORICAL_IDENTITY = "historical_identity"
+SCENARIO_INERT_PROFILE_UNRESOLVABLE = "profile_unresolvable"
+SCENARIO_INERT_INVALID_RECORD = "invalid_record"
 BUILD_METADATA = ".atrinik-build.json"
 BUILD_METADATA_SCHEMA_VERSION = 2
 CACHE_METADATA = ".atrinik-cache.json"
@@ -171,6 +174,12 @@ RUNTIME_INPUT_SCHEMA_VERSION = 1
 REGION_MAP_METADATA = ".atrinik-region-maps.json"
 REGION_MAP_SCHEMA_VERSION = 1
 EXPECTED_REGION_MAP = "incuna_-1"
+
+
+class _InertScenarioError(WorkspaceError):
+    def __init__(self, reason: str, message: str) -> None:
+        super().__init__(message)
+        self.reason = reason
 
 
 def display_arguments(arguments: list[str]) -> str:
@@ -5992,19 +6001,28 @@ class Workspace:
             actual_keys == historical_keys
             and metadata.get("schema_version") == SCHEMA_VERSION
         ):
-            raise WorkspaceError(
+            raise _InertScenarioError(
+                SCENARIO_INERT_HISTORICAL_IDENTITY,
                 "historical scenario lacks immutable stack/provider identity and is "
                 f"inert; recreate it explicitly: {name}"
             )
         if actual_keys != SCENARIO_KEYS:
             raise WorkspaceError(f"scenario fields are invalid: {name}")
         if metadata.get("schema_version") != SCENARIO_SCHEMA_VERSION:
-            raise WorkspaceError(
+            raise _InertScenarioError(
+                SCENARIO_INERT_HISTORICAL_IDENTITY,
                 "historical scenario lacks immutable repository/branch identity and "
                 f"is inert; recreate it explicitly: {name}"
             )
         resolved = metadata.get("resolved")
-        profile = self._load_profile(metadata.get("profile", ""), require_file=False)
+        try:
+            profile = self._load_profile(
+                metadata.get("profile", ""), require_file=False
+            )
+        except WorkspaceError as error:
+            raise _InertScenarioError(
+                SCENARIO_INERT_PROFILE_UNRESOLVABLE, str(error)
+            ) from error
         stack = self.manifest.stack(profile["stack"])
         required = self._dependency_roles(profile, {"server"})
         expected_providers = {
@@ -6223,7 +6241,26 @@ class Workspace:
         scenarios: list[dict[str, Any]] = []
         for path in sorted(self.paths.scenarios.iterdir()):
             if path.is_dir() and not path.name.startswith("."):
-                scenarios.append(self.scenario_show(path.name))
+                try:
+                    scenarios.append(self.scenario_show(path.name))
+                except _InertScenarioError as error:
+                    scenarios.append(
+                        {
+                            "name": path.name,
+                            "path": str(path),
+                            "inert": True,
+                            "inert_reason": error.reason,
+                        }
+                    )
+                except WorkspaceError:
+                    scenarios.append(
+                        {
+                            "name": path.name,
+                            "path": str(path),
+                            "inert": True,
+                            "inert_reason": SCENARIO_INERT_INVALID_RECORD,
+                        }
+                    )
         return scenarios
 
     def scenario_credentials(self, name: str) -> dict[str, str]:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -6287,14 +6287,15 @@ class Workspace:
         scenarios: list[dict[str, Any]] = []
         for path in sorted(self.paths.scenarios.iterdir()):
             if path.is_dir() and not path.name.startswith("."):
+                scenario_path = self._scenario_directory(path.name)
                 try:
                     metadata = self._load_scenario(path.name, registered_states)
-                    scenarios.append({**metadata, "path": str(path)})
+                    scenarios.append({**metadata, "path": str(scenario_path)})
                 except _InertScenarioError as error:
                     scenarios.append(
                         {
                             "name": path.name,
-                            "path": str(path),
+                            "path": str(scenario_path),
                             "inert": True,
                             "inert_reason": error.reason,
                         }
@@ -6303,7 +6304,7 @@ class Workspace:
                     scenarios.append(
                         {
                             "name": path.name,
-                            "path": str(path),
+                            "path": str(scenario_path),
                             "inert": True,
                             "inert_reason": SCENARIO_INERT_INVALID_RECORD,
                         }

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -6087,18 +6087,26 @@ class Workspace:
                     f"scenario component metadata is invalid: {name}/{component}"
                 )
             provider = stack.providers[component]
-            checkout_path = Path(record["checkout_path"]).resolve(strict=False)
-            expected_path = (
-                checkout_path
-                if provider.source == "."
-                else checkout_path.joinpath(*PurePosixPath(provider.source).parts)
-            ).resolve(strict=False)
+            try:
+                checkout_path = Path(record["checkout_path"]).resolve(strict=False)
+                expected_path = (
+                    checkout_path
+                    if provider.source == "."
+                    else checkout_path.joinpath(
+                        *PurePosixPath(provider.source).parts
+                    )
+                ).resolve(strict=False)
+                resolved_path = Path(record["path"]).resolve(strict=False)
+            except (OSError, RuntimeError, ValueError) as error:
+                raise WorkspaceError(
+                    f"scenario component metadata is invalid: {name}/{component}"
+                ) from error
             if (
                 record["checkout"] != provider.checkout_name
                 or record["repository"] != provider.repository
                 or record["branch"] != provider.branch
                 or record["source"] != provider.source
-                or Path(record["path"]).resolve(strict=False) != expected_path
+                or resolved_path != expected_path
             ):
                 raise WorkspaceError(
                     f"scenario component identity is invalid: {name}/{component}"
@@ -6111,7 +6119,17 @@ class Workspace:
             self._load_states() if registered_states is None else registered_states
         )
         registered = states.get(metadata["state"])
-        if registered is None or Path(registered).resolve(strict=False) != state.resolve():
+        try:
+            registered_path = (
+                None
+                if registered is None
+                else Path(registered).resolve(strict=False)
+            )
+        except (OSError, RuntimeError, ValueError) as error:
+            raise WorkspaceError(
+                f"scenario state registration is invalid: {name}"
+            ) from error
+        if registered_path is None or registered_path != state.resolve():
             raise WorkspaceError(f"scenario state registration is invalid: {name}")
         os.close(self._open_scenario_password(root / "password"))
         return metadata

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -5978,7 +5978,11 @@ class Workspace:
             raise WorkspaceError(f"scenario password file is invalid: {path}")
         return password
 
-    def _load_scenario(self, name: str) -> dict[str, Any]:
+    def _load_scenario(
+        self,
+        name: str,
+        registered_states: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
         self.paths.ensure()
         root = self._scenario_directory(name)
         if not root.is_dir() or root.is_symlink():
@@ -6031,7 +6035,8 @@ class Workspace:
         if (
             metadata.get("name") != name
             or not isinstance(metadata.get("profile"), str)
-            or metadata.get("preset") not in SCENARIO_PRESETS
+            or not isinstance(metadata.get("preset"), str)
+            or metadata["preset"] not in SCENARIO_PRESETS
             or metadata.get("state") != f"scenario-{name}"
             or not isinstance(metadata.get("account"), str)
             or not isinstance(metadata.get("character"), str)
@@ -6094,7 +6099,10 @@ class Workspace:
         if state.is_symlink():
             raise WorkspaceError(f"scenario state is invalid: {name}")
         self._validate_state(state)
-        registered = self._load_states().get(metadata["state"])
+        states = (
+            self._load_states() if registered_states is None else registered_states
+        )
+        registered = states.get(metadata["state"])
         if registered is None or Path(registered).resolve(strict=False) != state.resolve():
             raise WorkspaceError(f"scenario state registration is invalid: {name}")
         os.close(self._open_scenario_password(root / "password"))
@@ -6238,11 +6246,13 @@ class Workspace:
 
     def scenario_list(self) -> list[dict[str, Any]]:
         self.paths.ensure()
+        registered_states = self._load_states()
         scenarios: list[dict[str, Any]] = []
         for path in sorted(self.paths.scenarios.iterdir()):
             if path.is_dir() and not path.name.startswith("."):
                 try:
-                    scenarios.append(self.scenario_show(path.name))
+                    metadata = self._load_scenario(path.name, registered_states)
+                    scenarios.append({**metadata, "path": str(path)})
                 except _InertScenarioError as error:
                     scenarios.append(
                         {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -399,7 +399,11 @@ state directories, build trees, collected runtimes, scenario data, topology
 records, or logs. Typed state ownership is a separate migration boundary.
 Scenario metadata records its stack and exact checkout/component/source
 providers. An old scenario without that immutable identity is kept as an inert
-record and cannot inherit the current meaning of a reused profile name.
+record and cannot inherit the current meaning of a reused profile name. Global
+scenario inventory isolates resolution and validation failures per record and
+emits only a stable inert-reason code; it never rewrites the scenario, profile,
+state, worktree, or mutable data while listing. Exact scenario operations still
+validate the complete record and fail closed.
 
 Content selector retirement has its own preview/apply/audit transaction. Its
 certified anchors bind the merged consolidation commits on `main` and the final

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -402,8 +402,9 @@ providers. An old scenario without that immutable identity is kept as an inert
 record and cannot inherit the current meaning of a reused profile name. Global
 scenario inventory isolates resolution and validation failures per record and
 emits only a stable inert-reason code; it never rewrites the scenario, profile,
-state, worktree, or mutable data while listing. Exact scenario operations still
-validate the complete record and fail closed.
+state, worktree, or mutable data while listing. Shared workspace registries are
+validated once and still fail the complete inventory closed. Exact scenario
+operations validate the complete record and fail closed.
 
 Content selector retirement has its own preview/apply/audit transaction. Its
 certified anchors bind the merged consolidation commits on `main` and the final

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -870,6 +870,56 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(result, 0)
         self.assertEqual(json.loads(output.call_args.args[0]), summary)
 
+    def test_scenario_list_human_output_identifies_inert_records(self) -> None:
+        summaries = [
+            {
+                "name": "current",
+                "profile": "default",
+                "preset": "basic-player",
+                "state": "scenario-current",
+            },
+            {
+                "name": "historical",
+                "path": "/workspace/scenarios/historical",
+                "inert": True,
+                "inert_reason": "profile_unresolvable",
+            },
+        ]
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.scenario_list.return_value = summaries
+            with mock.patch("builtins.print") as output:
+                result = main(["scenario", "list"])
+
+        self.assertEqual(result, 0)
+        self.assertEqual(
+            [call.args[0] for call in output.call_args_list],
+            [
+                "current\tdefault\tbasic-player\tscenario-current",
+                "historical\tinert\tprofile_unresolvable\t"
+                "/workspace/scenarios/historical",
+            ],
+        )
+
+    def test_scenario_list_human_output_escapes_inert_control_characters(self) -> None:
+        summaries = [
+            {
+                "name": "unsafe\nname",
+                "path": "/workspace/scenarios/unsafe\tname",
+                "inert": True,
+                "inert_reason": "invalid_record",
+            }
+        ]
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.scenario_list.return_value = summaries
+            with mock.patch("builtins.print") as output:
+                result = main(["scenario", "list"])
+
+        self.assertEqual(result, 0)
+        output.assert_called_once_with(
+            "unsafe\\nname\tinert\tinvalid_record\t"
+            "/workspace/scenarios/unsafe\\tname"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -900,6 +900,29 @@ class ParserTests(unittest.TestCase):
             ],
         )
 
+    def test_scenario_list_json_preserves_valid_and_inert_records(self) -> None:
+        summaries = [
+            {
+                "name": "current",
+                "profile": "default",
+                "preset": "basic-player",
+                "state": "scenario-current",
+            },
+            {
+                "name": "historical",
+                "path": "/workspace/scenarios/historical",
+                "inert": True,
+                "inert_reason": "profile_unresolvable",
+            },
+        ]
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.scenario_list.return_value = summaries
+            with mock.patch("builtins.print") as output:
+                result = main(["scenario", "list", "--json"])
+
+        self.assertEqual(result, 0)
+        self.assertEqual(json.loads(output.call_args.args[0]), summaries)
+
     def test_scenario_list_human_output_escapes_inert_control_characters(self) -> None:
         summaries = [
             {

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -13,6 +13,7 @@ from atrinik_workspace.model import (
     Paths,
     WorkspaceError,
     atomic_json,
+    load_json,
     managed_directory,
     managed_remove,
     managed_reset,
@@ -500,6 +501,14 @@ class ManifestTests(unittest.TestCase):
             )
             with self.assertRaisesRegex(WorkspaceError, "duplicate JSON key"):
                 Manifest.load(path)
+
+    def test_load_json_rejects_non_utf8_input(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "invalid-utf8.json"
+            path.write_bytes(b"\xff")
+
+            with self.assertRaisesRegex(WorkspaceError, "cannot read"):
+                load_json(path)
 
     def test_rejects_unknown_fields(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -510,6 +510,17 @@ class ManifestTests(unittest.TestCase):
             with self.assertRaisesRegex(WorkspaceError, "cannot read"):
                 load_json(path)
 
+    def test_load_json_rejects_decoder_resource_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "invalid-resource.json"
+            for payload in (
+                b"1" * 5000,
+                b"[" * 100_000 + b"0" + b"]" * 100_000,
+            ):
+                path.write_bytes(payload)
+                with self.assertRaisesRegex(WorkspaceError, "cannot read"):
+                    load_json(path)
+
     def test_rejects_unknown_fields(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             components = self.valid_components()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,6 +4,7 @@ import copy
 import json
 import os
 from pathlib import Path
+import sys
 import tempfile
 import unittest
 from unittest import mock
@@ -513,13 +514,22 @@ class ManifestTests(unittest.TestCase):
     def test_load_json_rejects_decoder_resource_errors(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             path = Path(temporary) / "invalid-resource.json"
-            for payload in (
-                b"1" * 5000,
-                b"[" * 100_000 + b"0" + b"]" * 100_000,
-            ):
-                path.write_bytes(payload)
-                with self.assertRaisesRegex(WorkspaceError, "cannot read"):
-                    load_json(path)
+            previous_limit = sys.get_int_max_str_digits()
+            try:
+                sys.set_int_max_str_digits(4300)
+                for name, payload in (
+                    ("integer", b"1" * 5000),
+                    (
+                        "nesting",
+                        b"[" * 100_000 + b"0" + b"]" * 100_000,
+                    ),
+                ):
+                    with self.subTest(name=name):
+                        path.write_bytes(payload)
+                        with self.assertRaisesRegex(WorkspaceError, "cannot read"):
+                            load_json(path)
+            finally:
+                sys.set_int_max_str_digits(previous_limit)
 
     def test_rejects_unknown_fields(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7583,6 +7583,66 @@ class WorkspaceTests(unittest.TestCase):
         ):
             self.workspace.scenario_show("historical-coordinate")
 
+    def test_scenario_list_preserves_inert_record_and_continues_inventory(self) -> None:
+        resolved = self.scenario_resolved_fixture()
+        self.workspace.create_profile("stale-profile")
+        with mock.patch.object(
+            self.workspace, "_scenario_provision_state", return_value=resolved
+        ):
+            self.workspace.scenario_create("current", "default")
+            self.workspace.scenario_create("historical", "stale-profile")
+
+        profile_path = self.workspace.paths.profiles / "stale-profile.json"
+        profile = load_json(profile_path)
+        profile["components"].pop("content")
+        atomic_json(profile_path, profile)
+        scenario_path = (
+            self.workspace.paths.scenarios / "historical" / "scenario.json"
+        )
+        profile_before = profile_path.read_bytes()
+        scenario_before = scenario_path.read_bytes()
+        states_before = self.workspace.paths.states_file.read_bytes()
+
+        summaries = self.workspace.scenario_list()
+
+        self.assertEqual(
+            [summary["name"] for summary in summaries],
+            ["current", "historical"],
+        )
+        self.assertEqual(summaries[0]["profile"], "default")
+        self.assertEqual(
+            summaries[1],
+            {
+                "name": "historical",
+                "path": str(self.workspace.paths.scenarios / "historical"),
+                "inert": True,
+                "inert_reason": "profile_unresolvable",
+            },
+        )
+        with self.assertRaisesRegex(
+            WorkspaceError, "profile component set does not match manifest"
+        ):
+            self.workspace.scenario_show("historical")
+        self.assertEqual(profile_path.read_bytes(), profile_before)
+        self.assertEqual(scenario_path.read_bytes(), scenario_before)
+        self.assertEqual(self.workspace.paths.states_file.read_bytes(), states_before)
+
+    def test_scenario_list_reports_invalid_record_without_error_detail(self) -> None:
+        root = self.workspace.paths.scenarios / "malformed"
+        root.mkdir(parents=True)
+
+        self.assertEqual(
+            self.workspace.scenario_list(),
+            [
+                {
+                    "name": "malformed",
+                    "path": str(root),
+                    "inert": True,
+                    "inert_reason": "invalid_record",
+                }
+            ],
+        )
+
     def test_scenario_audit_records_only_server_dependency_closure(self) -> None:
         required = {"server", "content", "resources", "libatrinik", "protocol"}
         selected = {

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7643,6 +7643,77 @@ class WorkspaceTests(unittest.TestCase):
             ],
         )
 
+    def test_scenario_list_isolates_unhashable_metadata_fields(self) -> None:
+        resolved = self.scenario_resolved_fixture()
+        with mock.patch.object(
+            self.workspace, "_scenario_provision_state", return_value=resolved
+        ):
+            self.workspace.scenario_create("current", "default")
+            self.workspace.scenario_create("malformed", "default")
+
+        metadata_path = (
+            self.workspace.paths.scenarios / "malformed" / "scenario.json"
+        )
+        metadata = load_json(metadata_path)
+        metadata["preset"] = {"invalid": "object"}
+        atomic_json(metadata_path, metadata)
+
+        summaries = self.workspace.scenario_list()
+
+        self.assertEqual(
+            [summary["name"] for summary in summaries],
+            ["current", "malformed"],
+        )
+        self.assertEqual(summaries[0]["profile"], "default")
+        self.assertEqual(summaries[1]["inert_reason"], "invalid_record")
+
+    def test_scenario_list_isolates_non_utf8_scenario_and_profile(self) -> None:
+        resolved = self.scenario_resolved_fixture()
+        self.workspace.create_profile("invalid-profile")
+        with mock.patch.object(
+            self.workspace, "_scenario_provision_state", return_value=resolved
+        ):
+            self.workspace.scenario_create("current", "default")
+            self.workspace.scenario_create("invalid-metadata", "default")
+            self.workspace.scenario_create("invalid-profile", "invalid-profile")
+
+        metadata_path = (
+            self.workspace.paths.scenarios / "invalid-metadata" / "scenario.json"
+        )
+        profile_path = self.workspace.paths.profiles / "invalid-profile.json"
+        metadata_path.write_bytes(b"\xff")
+        profile_path.write_bytes(b"\xff")
+        metadata_before = metadata_path.read_bytes()
+        profile_before = profile_path.read_bytes()
+
+        summaries = self.workspace.scenario_list()
+
+        self.assertEqual(
+            [summary["name"] for summary in summaries],
+            ["current", "invalid-metadata", "invalid-profile"],
+        )
+        self.assertEqual(summaries[0]["profile"], "default")
+        self.assertEqual(summaries[1]["inert_reason"], "invalid_record")
+        self.assertEqual(summaries[2]["inert_reason"], "profile_unresolvable")
+        self.assertEqual(metadata_path.read_bytes(), metadata_before)
+        self.assertEqual(profile_path.read_bytes(), profile_before)
+
+    def test_scenario_list_fails_closed_for_invalid_shared_state_registry(self) -> None:
+        resolved = self.scenario_resolved_fixture()
+        with mock.patch.object(
+            self.workspace, "_scenario_provision_state", return_value=resolved
+        ):
+            self.workspace.scenario_create("current", "default")
+
+        states = load_json(self.workspace.paths.states_file)
+        states["schema_version"] = 999
+        atomic_json(self.workspace.paths.states_file, states)
+
+        with self.assertRaisesRegex(
+            WorkspaceError, "states registry schema is invalid"
+        ):
+            self.workspace.scenario_list()
+
     def test_scenario_audit_records_only_server_dependency_closure(self) -> None:
         required = {"server", "content", "resources", "libatrinik", "protocol"}
         selected = {

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7698,6 +7698,42 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual(metadata_path.read_bytes(), metadata_before)
         self.assertEqual(profile_path.read_bytes(), profile_before)
 
+    def test_scenario_list_isolates_unhashable_profile_fields(self) -> None:
+        resolved = self.scenario_resolved_fixture()
+        self.workspace.create_profile("invalid-sound-mode")
+        self.workspace.create_profile("invalid-selector-kind")
+        with mock.patch.object(
+            self.workspace, "_scenario_provision_state", return_value=resolved
+        ):
+            self.workspace.scenario_create("current", "default")
+            self.workspace.scenario_create(
+                "invalid-sound-mode", "invalid-sound-mode"
+            )
+            self.workspace.scenario_create(
+                "invalid-selector-kind", "invalid-selector-kind"
+            )
+
+        sound_path = self.workspace.paths.profiles / "invalid-sound-mode.json"
+        sound_profile = load_json(sound_path)
+        sound_profile["sound_mode"] = {"invalid": "object"}
+        atomic_json(sound_path, sound_profile)
+        selector_path = (
+            self.workspace.paths.profiles / "invalid-selector-kind.json"
+        )
+        selector_profile = load_json(selector_path)
+        selector_profile["components"]["content"]["kind"] = ["invalid"]
+        atomic_json(selector_path, selector_profile)
+
+        summaries = self.workspace.scenario_list()
+
+        self.assertEqual(
+            [summary["name"] for summary in summaries],
+            ["current", "invalid-selector-kind", "invalid-sound-mode"],
+        )
+        self.assertEqual(summaries[0]["profile"], "default")
+        self.assertEqual(summaries[1]["inert_reason"], "profile_unresolvable")
+        self.assertEqual(summaries[2]["inert_reason"], "profile_unresolvable")
+
     def test_scenario_list_fails_closed_for_invalid_shared_state_registry(self) -> None:
         resolved = self.scenario_resolved_fixture()
         with mock.patch.object(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7726,9 +7726,10 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual(nesting_path.read_bytes(), nesting_before)
         self.assertEqual(profile_path.read_bytes(), profile_before)
 
-    def test_scenario_list_isolates_unhashable_profile_fields(self) -> None:
+    def test_scenario_list_isolates_invalid_profile_fields(self) -> None:
         resolved = self.scenario_resolved_fixture()
         self.workspace.create_profile("invalid-path")
+        self.workspace.create_profile("relative-path")
         self.workspace.create_profile("invalid-sound-mode")
         self.workspace.create_profile("invalid-selector-kind")
         with mock.patch.object(
@@ -7736,6 +7737,7 @@ class WorkspaceTests(unittest.TestCase):
         ):
             self.workspace.scenario_create("current", "default")
             self.workspace.scenario_create("invalid-path", "invalid-path")
+            self.workspace.scenario_create("relative-path", "relative-path")
             self.workspace.scenario_create(
                 "invalid-sound-mode", "invalid-sound-mode"
             )
@@ -7760,6 +7762,13 @@ class WorkspaceTests(unittest.TestCase):
             "value": "/tmp/\0invalid",
         }
         atomic_json(path_profile_path, path_profile)
+        relative_path = self.workspace.paths.profiles / "relative-path.json"
+        relative_profile = load_json(relative_path)
+        relative_profile["components"]["content"] = {
+            "kind": "path",
+            "value": "relative/content",
+        }
+        atomic_json(relative_path, relative_profile)
         path_profile_before = path_profile_path.read_bytes()
 
         summaries = self.workspace.scenario_list()
@@ -7771,12 +7780,14 @@ class WorkspaceTests(unittest.TestCase):
                 "invalid-path",
                 "invalid-selector-kind",
                 "invalid-sound-mode",
+                "relative-path",
             ],
         )
         self.assertEqual(summaries[0]["profile"], "default")
         self.assertEqual(summaries[1]["inert_reason"], "profile_unresolvable")
         self.assertEqual(summaries[2]["inert_reason"], "profile_unresolvable")
         self.assertEqual(summaries[3]["inert_reason"], "profile_unresolvable")
+        self.assertEqual(summaries[4]["inert_reason"], "profile_unresolvable")
         self.assertEqual(path_profile_path.read_bytes(), path_profile_before)
         with self.assertRaisesRegex(WorkspaceError, "invalid profile selector"):
             self.workspace.scenario_show("invalid-path")
@@ -7805,6 +7816,7 @@ class WorkspaceTests(unittest.TestCase):
             self.workspace.scenario_create("current", "default")
             self.workspace.scenario_create("invalid-component-path", "default")
             self.workspace.scenario_create("invalid-state-path", "default")
+            self.workspace.scenario_create("unregistered-state", "default")
 
         metadata_path = (
             self.workspace.paths.scenarios
@@ -7816,6 +7828,7 @@ class WorkspaceTests(unittest.TestCase):
         atomic_json(metadata_path, metadata)
         states = load_json(self.workspace.paths.states_file)
         states["states"]["scenario-invalid-state-path"] = "/tmp/\0invalid"
+        states["states"].pop("scenario-unregistered-state")
         atomic_json(self.workspace.paths.states_file, states)
         metadata_before = metadata_path.read_bytes()
         states_before = self.workspace.paths.states_file.read_bytes()
@@ -7824,11 +7837,17 @@ class WorkspaceTests(unittest.TestCase):
 
         self.assertEqual(
             [summary["name"] for summary in summaries],
-            ["current", "invalid-component-path", "invalid-state-path"],
+            [
+                "current",
+                "invalid-component-path",
+                "invalid-state-path",
+                "unregistered-state",
+            ],
         )
         self.assertEqual(summaries[0]["profile"], "default")
         self.assertEqual(summaries[1]["inert_reason"], "invalid_record")
         self.assertEqual(summaries[2]["inert_reason"], "invalid_record")
+        self.assertEqual(summaries[3]["inert_reason"], "invalid_record")
         self.assertEqual(metadata_path.read_bytes(), metadata_before)
         self.assertEqual(self.workspace.paths.states_file.read_bytes(), states_before)
         with self.assertRaisesRegex(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7750,6 +7750,45 @@ class WorkspaceTests(unittest.TestCase):
         ):
             self.workspace.scenario_list()
 
+    def test_scenario_list_isolates_invalid_resolved_paths(self) -> None:
+        resolved = self.scenario_resolved_fixture()
+        with mock.patch.object(
+            self.workspace, "_scenario_provision_state", return_value=resolved
+        ):
+            self.workspace.scenario_create("current", "default")
+            self.workspace.scenario_create("invalid-component-path", "default")
+            self.workspace.scenario_create("invalid-state-path", "default")
+
+        metadata_path = (
+            self.workspace.paths.scenarios
+            / "invalid-component-path"
+            / "scenario.json"
+        )
+        metadata = load_json(metadata_path)
+        metadata["resolved"]["server"]["checkout_path"] = "/tmp/\0invalid"
+        atomic_json(metadata_path, metadata)
+        states = load_json(self.workspace.paths.states_file)
+        states["states"]["scenario-invalid-state-path"] = "/tmp/\0invalid"
+        atomic_json(self.workspace.paths.states_file, states)
+        metadata_before = metadata_path.read_bytes()
+        states_before = self.workspace.paths.states_file.read_bytes()
+
+        summaries = self.workspace.scenario_list()
+
+        self.assertEqual(
+            [summary["name"] for summary in summaries],
+            ["current", "invalid-component-path", "invalid-state-path"],
+        )
+        self.assertEqual(summaries[0]["profile"], "default")
+        self.assertEqual(summaries[1]["inert_reason"], "invalid_record")
+        self.assertEqual(summaries[2]["inert_reason"], "invalid_record")
+        self.assertEqual(metadata_path.read_bytes(), metadata_before)
+        self.assertEqual(self.workspace.paths.states_file.read_bytes(), states_before)
+        with self.assertRaisesRegex(
+            WorkspaceError, "scenario component metadata is invalid"
+        ):
+            self.workspace.scenario_show("invalid-component-path")
+
     def test_scenario_audit_records_only_server_dependency_closure(self) -> None:
         required = {"server", "content", "resources", "libatrinik", "protocol"}
         selected = {

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7638,19 +7638,52 @@ class WorkspaceTests(unittest.TestCase):
         external = self.root / "external-scenarios"
         scenarios.rename(external)
         scenarios.symlink_to(external, target_is_directory=True)
+        invalid = scenarios / "invalid\nname"
+        invalid.mkdir()
+        outside = self.root / "outside-scenario"
+        outside.mkdir()
+        escaped = scenarios / "escaped"
+        escaped.symlink_to(outside, target_is_directory=True)
 
+        summaries = {row["name"]: row for row in self.workspace.scenario_list()}
         self.assertEqual(
-            self.workspace.scenario_list()[0]["path"],
+            summaries["current"]["path"],
             self.workspace.scenario_show("current")["path"],
+        )
+        self.assertEqual(
+            summaries["invalid\nname"],
+            {
+                "name": "invalid\nname",
+                "path": str(invalid),
+                "inert": True,
+                "inert_reason": "invalid_record",
+            },
+        )
+        self.assertEqual(
+            summaries["escaped"],
+            {
+                "name": "escaped",
+                "path": str(escaped),
+                "inert": True,
+                "inert_reason": "invalid_record",
+            },
         )
 
     def test_scenario_list_reports_invalid_record_without_error_detail(self) -> None:
         root = self.workspace.paths.scenarios / "malformed"
         root.mkdir(parents=True)
+        invalid_name = self.workspace.paths.scenarios / "invalid\nname"
+        invalid_name.mkdir()
 
         self.assertEqual(
             self.workspace.scenario_list(),
             [
+                {
+                    "name": "invalid\nname",
+                    "path": str(invalid_name),
+                    "inert": True,
+                    "inert_reason": "invalid_record",
+                },
                 {
                     "name": "malformed",
                     "path": str(root),

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7627,6 +7627,23 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual(scenario_path.read_bytes(), scenario_before)
         self.assertEqual(self.workspace.paths.states_file.read_bytes(), states_before)
 
+    def test_scenario_list_preserves_resolved_path_for_symlinked_container(self) -> None:
+        resolved = self.scenario_resolved_fixture()
+        with mock.patch.object(
+            self.workspace, "_scenario_provision_state", return_value=resolved
+        ):
+            self.workspace.scenario_create("current", "default")
+
+        scenarios = self.workspace.paths.scenarios
+        external = self.root / "external-scenarios"
+        scenarios.rename(external)
+        scenarios.symlink_to(external, target_is_directory=True)
+
+        self.assertEqual(
+            self.workspace.scenario_list()[0]["path"],
+            self.workspace.scenario_show("current")["path"],
+        )
+
     def test_scenario_list_reports_invalid_record_without_error_detail(self) -> None:
         root = self.workspace.paths.scenarios / "malformed"
         root.mkdir(parents=True)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7700,12 +7700,14 @@ class WorkspaceTests(unittest.TestCase):
 
     def test_scenario_list_isolates_unhashable_profile_fields(self) -> None:
         resolved = self.scenario_resolved_fixture()
+        self.workspace.create_profile("invalid-path")
         self.workspace.create_profile("invalid-sound-mode")
         self.workspace.create_profile("invalid-selector-kind")
         with mock.patch.object(
             self.workspace, "_scenario_provision_state", return_value=resolved
         ):
             self.workspace.scenario_create("current", "default")
+            self.workspace.scenario_create("invalid-path", "invalid-path")
             self.workspace.scenario_create(
                 "invalid-sound-mode", "invalid-sound-mode"
             )
@@ -7723,16 +7725,33 @@ class WorkspaceTests(unittest.TestCase):
         selector_profile = load_json(selector_path)
         selector_profile["components"]["content"]["kind"] = ["invalid"]
         atomic_json(selector_path, selector_profile)
+        path_profile_path = self.workspace.paths.profiles / "invalid-path.json"
+        path_profile = load_json(path_profile_path)
+        path_profile["components"]["content"] = {
+            "kind": "path",
+            "value": "/tmp/\0invalid",
+        }
+        atomic_json(path_profile_path, path_profile)
+        path_profile_before = path_profile_path.read_bytes()
 
         summaries = self.workspace.scenario_list()
 
         self.assertEqual(
             [summary["name"] for summary in summaries],
-            ["current", "invalid-selector-kind", "invalid-sound-mode"],
+            [
+                "current",
+                "invalid-path",
+                "invalid-selector-kind",
+                "invalid-sound-mode",
+            ],
         )
         self.assertEqual(summaries[0]["profile"], "default")
         self.assertEqual(summaries[1]["inert_reason"], "profile_unresolvable")
         self.assertEqual(summaries[2]["inert_reason"], "profile_unresolvable")
+        self.assertEqual(summaries[3]["inert_reason"], "profile_unresolvable")
+        self.assertEqual(path_profile_path.read_bytes(), path_profile_before)
+        with self.assertRaisesRegex(WorkspaceError, "invalid profile selector"):
+            self.workspace.scenario_show("invalid-path")
 
     def test_scenario_list_fails_closed_for_invalid_shared_state_registry(self) -> None:
         resolved = self.scenario_resolved_fixture()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7699,7 +7699,12 @@ class WorkspaceTests(unittest.TestCase):
         nesting_before = nesting_path.read_bytes()
         profile_before = profile_path.read_bytes()
 
-        summaries = self.workspace.scenario_list()
+        previous_limit = sys.get_int_max_str_digits()
+        try:
+            sys.set_int_max_str_digits(4300)
+            summaries = self.workspace.scenario_list()
+        finally:
+            sys.set_int_max_str_digits(previous_limit)
 
         self.assertEqual(
             [summary["name"] for summary in summaries],

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7669,33 +7669,56 @@ class WorkspaceTests(unittest.TestCase):
 
     def test_scenario_list_isolates_non_utf8_scenario_and_profile(self) -> None:
         resolved = self.scenario_resolved_fixture()
+        self.workspace.create_profile("invalid-nesting")
         self.workspace.create_profile("invalid-profile")
         with mock.patch.object(
             self.workspace, "_scenario_provision_state", return_value=resolved
         ):
             self.workspace.scenario_create("current", "default")
+            self.workspace.scenario_create("invalid-integer", "default")
             self.workspace.scenario_create("invalid-metadata", "default")
+            self.workspace.scenario_create("invalid-nesting", "invalid-nesting")
             self.workspace.scenario_create("invalid-profile", "invalid-profile")
 
         metadata_path = (
             self.workspace.paths.scenarios / "invalid-metadata" / "scenario.json"
         )
         profile_path = self.workspace.paths.profiles / "invalid-profile.json"
+        integer_path = (
+            self.workspace.paths.scenarios / "invalid-integer" / "scenario.json"
+        )
+        nesting_path = self.workspace.paths.profiles / "invalid-nesting.json"
+        integer_path.write_bytes(b"1" * 5000)
         metadata_path.write_bytes(b"\xff")
+        nesting_path.write_bytes(
+            b"[" * 100_000 + b"0" + b"]" * 100_000
+        )
         profile_path.write_bytes(b"\xff")
+        integer_before = integer_path.read_bytes()
         metadata_before = metadata_path.read_bytes()
+        nesting_before = nesting_path.read_bytes()
         profile_before = profile_path.read_bytes()
 
         summaries = self.workspace.scenario_list()
 
         self.assertEqual(
             [summary["name"] for summary in summaries],
-            ["current", "invalid-metadata", "invalid-profile"],
+            [
+                "current",
+                "invalid-integer",
+                "invalid-metadata",
+                "invalid-nesting",
+                "invalid-profile",
+            ],
         )
         self.assertEqual(summaries[0]["profile"], "default")
         self.assertEqual(summaries[1]["inert_reason"], "invalid_record")
-        self.assertEqual(summaries[2]["inert_reason"], "profile_unresolvable")
+        self.assertEqual(summaries[2]["inert_reason"], "invalid_record")
+        self.assertEqual(summaries[3]["inert_reason"], "profile_unresolvable")
+        self.assertEqual(summaries[4]["inert_reason"], "profile_unresolvable")
+        self.assertEqual(integer_path.read_bytes(), integer_before)
         self.assertEqual(metadata_path.read_bytes(), metadata_before)
+        self.assertEqual(nesting_path.read_bytes(), nesting_before)
         self.assertEqual(profile_path.read_bytes(), profile_before)
 
     def test_scenario_list_isolates_unhashable_profile_fields(self) -> None:


### PR DESCRIPTION
Closes #390.

## Summary

- keep `scenario list` usable when an individual persisted scenario or profile can no longer be resolved
- report inert records with stable reason codes while preserving compatible current records unchanged
- keep exact scenario operations fail closed, normalize malformed persisted JSON and path failures, and avoid exposing internal error detail
- escape inert names and paths in bounded human output and document the list-versus-exact-operation contract

## Coordinates

- Base: `main` at `ed51aaabf1484ab14f96d3425e0b7d07b7bab59b`
- Head: `fix/stale-scenario-inventory` at `bc48ab8a6d6e2de64e81c8fa5d7640a7c101924a`
- Worktree: `/workspaces/atrinik/workspace/worktrees/atrinik/390-stale-scenario-inventory`
- Scope: 8 authored files; no cross-repository changes or new dependencies

## Validation

- `/workspaces/atrinik/.venv/bin/python -m coverage run -m unittest discover -v` — 627 passed
- `/workspaces/atrinik/.venv/bin/python -m coverage report --show-missing` — passed, 81% total
- changed executable and branch lines in `workspace.py`, `model.py`, and `cli.py` — 100% covered locally
- `/workspaces/atrinik/.venv/bin/python -m compileall -q atrinik atrinik_workspace tests` — passed
- `/workspaces/atrinik/.venv/bin/python -m atrinik_workspace.guidance_inventory --check` — passed
- `./atrinik manifest validate` — passed
- `./atrinik supply-chain validate` — passed, 109 dependencies
- `git diff --check` — passed
- two independent final whole-diff reviews at the listed head — zero known actionable findings
- preserved real scenario inventory — exit 0 with stale and current records, stable inert summaries, and no mutation

## Verification

Runtime is not applicable: this is a read-only wrapper inventory path and requires no game process, build, credentials, or scenario mutation.

```sh
./atrinik scenario list --json
./atrinik scenario list
```

Expected: both commands exit 0; stale or malformed per-record data produces an inert summary with `inert: true` and a stable `inert_reason`; compatible current records retain their full summaries; no password or internal error detail is displayed. Both commands are safe to repeat. Exact operations such as `scenario show`, reset, and credential access continue to reject an unusable record. No shutdown or runtime cleanup is required; keep the issue worktree and ignored review report while this PR is open.
