### PR TITLE
fix(runtime): make topology liveness namespace-independent

### DIFF
--- a/.agents/skills/atrinik-server-runtime/SKILL.md
+++ b/.agents/skills/atrinik-server-runtime/SKILL.md
@@ -27,6 +27,15 @@ state or restore a bundled HTTP listener.
 ./atrinik down NAME
 ```
 
+`ps --json` reports generation-bound `live`, `exited`, `stale`, or
+`unreachable` liveness and an `observation` naming any topology that retains
+the repository-layout lease. Cross-session `down` uses the matching filesystem
+control endpoint, never a PID from the caller's namespace. For `unreachable`,
+follow the reported safe action: wait for bounded guardian recovery and retry
+`ps` and `down`; if the exact lease remains retained, use the starting session.
+Never inspect `/proc`, signal the recorded PIDs, unlink control or lease files,
+or reuse the name as recovery.
+
 Let `up` allocate a port unless a distinct fixed port is required. Diagnose
 build, state, plugin, network, and gameplay failures separately. Use
 `atrinik-test-scenario` for accounts; never handcraft saves. Record actions and

--- a/.agents/skills/atrinik-server-runtime/SKILL.md
+++ b/.agents/skills/atrinik-server-runtime/SKILL.md
@@ -35,8 +35,8 @@ follow the reported safe action: wait for bounded guardian recovery and retry
 `ps` and `down`; if the exact lease remains retained, use the starting session.
 Never inspect `/proc`, signal the recorded PIDs, unlink control or lease files,
 or reuse the name as recovery.
-The wrapper uses a bounded descriptor-relative address for deep managed socket
-paths and binds the process-tree lease to its generation and file identity.
+The wrapper uses a short generation-derived endpoint in the shared workspace
+and binds the process-tree lease to its generation and file identity.
 Missing, replaced, linked, or malformed current lease files are unsafe and
 must remain untouched for fail-closed diagnosis.
 

--- a/.agents/skills/atrinik-server-runtime/SKILL.md
+++ b/.agents/skills/atrinik-server-runtime/SKILL.md
@@ -35,6 +35,10 @@ follow the reported safe action: wait for bounded guardian recovery and retry
 `ps` and `down`; if the exact lease remains retained, use the starting session.
 Never inspect `/proc`, signal the recorded PIDs, unlink control or lease files,
 or reuse the name as recovery.
+The wrapper uses a bounded descriptor-relative address for deep managed socket
+paths and binds the process-tree lease to its generation and file identity.
+Missing, replaced, linked, or malformed current lease files are unsafe and
+must remain untouched for fail-closed diagnosis.
 
 Let `up` allocate a port unless a distinct fixed port is required. Diagnose
 build, state, plugin, network, and gameplay failures separately. Use

--- a/.agents/skills/atrinik-server-runtime/SKILL.md
+++ b/.agents/skills/atrinik-server-runtime/SKILL.md
@@ -32,7 +32,7 @@ state or restore a bundled HTTP listener.
 the repository-layout lease. Cross-session `down` uses the matching filesystem
 control endpoint, never a PID from the caller's namespace. For `unreachable`,
 follow the reported safe action: wait for bounded guardian recovery and retry
-`ps` and `down`; if the exact lease remains retained, use the starting session.
+`ps` and `down`; preserve an exact retained lease for operator diagnosis.
 Never inspect `/proc`, signal the recorded PIDs, unlink control or lease files,
 or reuse the name as recovery.
 The wrapper uses a short generation-derived endpoint in the shared workspace

--- a/README.md
+++ b/README.md
@@ -526,15 +526,15 @@ identity; never replace,
 unlink, or repair it by hand because an invalid current lease fails closed.
 
 If a supervisor is killed rather than shut down, its same-namespace guardian
-terminates exact lease holders and pidfd-revalidated members of registered
-service groups, including descendants that closed the lease. It retains the
-generation until absence is proven and releases inherited layout, build-root,
-and state leases after recovery. During that
+terminates exact process-tree lease holders and retains the generation until
+their absence is proven. Layout, build-root, and state leases are held only by
+the supervisor, so a descendant that closes its process-tree identity cannot
+retain those workspace leases. During that
 interval another session reports `unreachable` and fails closed: wait, retry
 `./atrinik ps TOPOLOGY --json`, then retry `./atrinik down TOPOLOGY`. If the
-lease remains retained and control remains unreachable, run `down` from the
-session that started the topology; do not scan `/proc`, signal recorded PIDs,
-remove lease files, or reuse the topology name.
+lease remains retained and control remains unreachable, preserve the exact
+record and lease for operator diagnosis; do not scan `/proc`, signal recorded
+PIDs, remove lease files, or reuse the topology name.
 
 The handoff should name any display or runtime prerequisite, list the exact
 manual actions and expected results, and include `down` for cleanup. When no

--- a/README.md
+++ b/README.md
@@ -519,9 +519,10 @@ namespace cannot see the namespace-local process numbers. JSON status reports
 the safe next action. Text status prints the same retained-lease owner and
 action. A control response must match both the topology name and generation;
 `down` never falls back to signaling a mismatched or recycled PID.
-The canonical socket may live beneath a deep managed worktree: the runtime
-addresses it through a bounded topology-directory descriptor. The process-tree
-lease is tied to both the generation and exact file identity; never replace,
+The runtime places the socket under a short generation-derived name in the
+shared workspace, avoiding ordinary managed-worktree and topology-name path
+growth. The process-tree lease is tied to both the generation and exact file
+identity; never replace,
 unlink, or repair it by hand because an invalid current lease fails closed.
 
 If a supervisor is killed rather than shut down, its same-namespace guardian

--- a/README.md
+++ b/README.md
@@ -527,9 +527,10 @@ unlink, or repair it by hand because an invalid current lease fails closed.
 
 If a supervisor is killed rather than shut down, its same-namespace guardian
 terminates exact process-tree lease holders and retains the generation until
-their absence is proven. Layout, build-root, and state leases are held only by
-the supervisor, so a descendant that closes its process-tree identity cannot
-retain those workspace leases. During that
+their absence is proven. Layout, build-root, and state leases are held by the
+supervisor and guardian, not services, so a descendant that closes its
+process-tree identity cannot retain those workspace leases; the guardian
+releases them after recovery. During that
 interval another session reports `unreachable` and fails closed: wait, retry
 `./atrinik ps TOPOLOGY --json`, then retry `./atrinik down TOPOLOGY`. If the
 lease remains retained and control remains unreachable, preserve the exact

--- a/README.md
+++ b/README.md
@@ -510,6 +510,25 @@ contracts land, `PROFILE` must be `classic` or derived from it:
 ./atrinik down TOPOLOGY
 ~~~
 
+Each current topology persists a random generation identity and a mode-0600
+filesystem control endpoint. `ps` and `down` therefore work from another
+supported devcontainer or sandbox that shares the workspace even when its PID
+namespace cannot see the namespace-local process numbers. JSON status reports
+`live`, `exited`, `stale`, or fail-closed `unreachable` liveness plus an
+`observation` naming the topology that retains the repository-layout lease and
+the safe next action. Text status prints the same retained-lease owner and
+action. A control response must match both the topology name and generation;
+`down` never falls back to signaling a mismatched or recycled PID.
+
+If a supervisor is killed rather than shut down, its same-namespace guardian
+terminates the exact inherited process-tree lease holders and releases their
+layout, build-root, and state leases within a bounded interval. During that
+interval another session reports `unreachable` and fails closed: wait, retry
+`./atrinik ps TOPOLOGY --json`, then retry `./atrinik down TOPOLOGY`. If the
+lease remains retained and control remains unreachable, run `down` from the
+session that started the topology; do not scan `/proc`, signal recorded PIDs,
+remove lease files, or reuse the topology name.
+
 The handoff should name any display or runtime prerequisite, list the exact
 manual actions and expected results, and include `down` for cleanup. When no
 runtime check applies, it should say so and still provide the relevant wrapper

--- a/README.md
+++ b/README.md
@@ -526,8 +526,10 @@ identity; never replace,
 unlink, or repair it by hand because an invalid current lease fails closed.
 
 If a supervisor is killed rather than shut down, its same-namespace guardian
-terminates the exact inherited process-tree lease holders and releases their
-layout, build-root, and state leases within a bounded interval. During that
+terminates exact lease holders and pidfd-revalidated members of registered
+service groups, including descendants that closed the lease. It retains the
+generation until absence is proven and releases inherited layout, build-root,
+and state leases after recovery. During that
 interval another session reports `unreachable` and fails closed: wait, retry
 `./atrinik ps TOPOLOGY --json`, then retry `./atrinik down TOPOLOGY`. If the
 lease remains retained and control remains unreachable, run `down` from the

--- a/README.md
+++ b/README.md
@@ -519,6 +519,10 @@ namespace cannot see the namespace-local process numbers. JSON status reports
 the safe next action. Text status prints the same retained-lease owner and
 action. A control response must match both the topology name and generation;
 `down` never falls back to signaling a mismatched or recycled PID.
+The canonical socket may live beneath a deep managed worktree: the runtime
+addresses it through a bounded topology-directory descriptor. The process-tree
+lease is tied to both the generation and exact file identity; never replace,
+unlink, or repair it by hand because an invalid current lease fails closed.
 
 If a supervisor is killed rather than shut down, its same-namespace guardian
 terminates the exact inherited process-tree lease holders and releases their

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -24,7 +24,7 @@ from .model import (
     load_json,
     managed_remove,
 )
-from .process_tree import lease_locked
+from .process_tree import bound_lease_locked, lease_locked
 from .supervisor import process_matches
 from .sound import PLAYTEST_MARKER
 from .workspace import (
@@ -1106,7 +1106,24 @@ class Cleanup:
                 lease_path = root / "process-tree.lease"
                 if lease_path.is_symlink():
                     raise WorkspaceError("topology process-tree lease is invalid")
-                live = lease_path.is_file() and lease_locked(lease_path)
+                control = status_value.get("control")
+                if control is not None:
+                    if (
+                        not isinstance(control, dict)
+                        or set(control) != {"socket", "generation", "lease"}
+                        or control.get("socket")
+                        != str((root / "control.sock").resolve())
+                        or not isinstance(control.get("generation"), str)
+                        or re.fullmatch(r"[0-9a-f]{64}", control["generation"])
+                        is None
+                        or not isinstance(control.get("lease"), dict)
+                    ):
+                        raise WorkspaceError("topology control identity is invalid")
+                    live = bound_lease_locked(
+                        lease_path, control["generation"], control["lease"]
+                    )
+                else:
+                    live = lease_path.is_file() and lease_locked(lease_path)
                 for record in process_records:
                     if not isinstance(record, dict):
                         raise WorkspaceError("topology process status is invalid")

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -1134,7 +1134,8 @@ class Cleanup:
                         or not isinstance(start_time, str)
                     ):
                         raise WorkspaceError("topology process identity is invalid")
-                    live = live or process_matches(pid, start_time)
+                    if control is None:
+                        live = live or process_matches(pid, start_time)
                 if not live:
                     continue
                 build_root = status_value.get("build_root")

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -24,7 +24,7 @@ from .model import (
     load_json,
     managed_remove,
 )
-from .process_tree import bound_lease_locked, lease_locked
+from .process_tree import bound_lease_locked, control_socket_path, lease_locked
 from .supervisor import process_matches
 from .sound import PLAYTEST_MARKER
 from .workspace import (
@@ -1111,11 +1111,11 @@ class Cleanup:
                     if (
                         not isinstance(control, dict)
                         or set(control) != {"socket", "generation", "lease"}
-                        or control.get("socket")
-                        != str((root / "control.sock").resolve())
                         or not isinstance(control.get("generation"), str)
                         or re.fullmatch(r"[0-9a-f]{64}", control["generation"])
                         is None
+                        or control.get("socket")
+                        != str(control_socket_path(root, control["generation"]))
                         or not isinstance(control.get("lease"), dict)
                     ):
                         raise WorkspaceError("topology control identity is invalid")

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -24,6 +24,7 @@ from .model import (
     load_json,
     managed_remove,
 )
+from .process_tree import lease_locked
 from .supervisor import process_matches
 from .sound import PLAYTEST_MARKER
 from .workspace import (
@@ -1101,7 +1102,10 @@ class Cleanup:
                 if not isinstance(services, dict):
                     raise WorkspaceError("topology service status is invalid")
                 process_records.extend(services.values())
-                live = False
+                lease_path = root / "process-tree.lease"
+                if lease_path.is_symlink():
+                    raise WorkspaceError("topology process-tree lease is invalid")
+                live = lease_path.is_file() and lease_locked(lease_path)
                 for record in process_records:
                     if not isinstance(record, dict):
                         raise WorkspaceError("topology process status is invalid")

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -787,8 +787,9 @@ def main(arguments: list[str] | None = None) -> int:
                             print()
                         print(f"==> {status['name']} <==")
                     supervisor = status["supervisor"]
-                    supervisor_state = (
-                        "running" if supervisor["running"] else "stopped"
+                    supervisor_state = supervisor.get(
+                        "liveness",
+                        "running" if supervisor["running"] else "stopped",
                     )
                     print(
                         f"supervisor\t{supervisor_state}\t{supervisor['pid']}\t"
@@ -802,8 +803,19 @@ def main(arguments: list[str] | None = None) -> int:
                         )
                     for service, row in status["services"].items():
                         print(
-                            f"{service}\t{row['status']}\t{row['pid']}\t"
+                            f"{service}\t{row.get('liveness', row['status'])}\t"
+                            f"{row['pid']}\t"
                             f"{row['log']}"
+                        )
+                    observation = status.get("observation")
+                    if (
+                        isinstance(observation, dict)
+                        and observation.get("process_tree_lease") == "retained"
+                    ):
+                        print(
+                            "repository-layout-lease\tretained\t"
+                            f"{observation['repository_layout_lease_owner']}\t"
+                            f"{observation['safe_action']}"
                         )
         elif options.command == "logs":
             workspace.topology_logs(

--- a/atrinik_workspace/completion.py
+++ b/atrinik_workspace/completion.py
@@ -680,7 +680,12 @@ def _topology_names(manifest: Manifest | None, paths: Paths | None) -> list[str]
                 status = _json_at(record, "status.json", _MAX_RECORD_BYTES)
                 if (
                     marker == {"schema_version": 1, "purpose": f"topology:{name}"}
-                    and _valid_topology(manifest, name, status)
+                    and _valid_topology(
+                        manifest,
+                        name,
+                        status,
+                        paths.topologies / name,
+                    )
                 ):
                     names.append(name)
             finally:
@@ -692,7 +697,7 @@ def _topology_names(manifest: Manifest | None, paths: Paths | None) -> list[str]
 
 
 def _valid_topology(
-    manifest: Manifest, name: str, status: Any
+    manifest: Manifest, name: str, status: Any, topology_root: Path
 ) -> bool:
     required = {
         "schema_version", "name", "profile", "stack", "providers",
@@ -755,12 +760,19 @@ def _valid_topology(
     control = status.get("control")
     if control is not None and (
         not isinstance(control, dict)
-        or set(control) != {"socket", "generation"}
+        or set(control) != {"socket", "generation", "lease"}
         or not isinstance(control.get("socket"), str)
-        or not Path(control["socket"]).is_absolute()
-        or Path(control["socket"]).name != "control.sock"
+        or control["socket"] != str((topology_root / "control.sock").resolve())
         or not isinstance(control.get("generation"), str)
         or re.fullmatch(r"[0-9a-f]{64}", control["generation"]) is None
+        or not isinstance(control.get("lease"), dict)
+        or set(control["lease"]) != {"device", "inode"}
+        or not all(
+            isinstance(value, int)
+            and not isinstance(value, bool)
+            and value >= 0
+            for value in control["lease"].values()
+        )
     ):
         return False
     process_keys = (

--- a/atrinik_workspace/completion.py
+++ b/atrinik_workspace/completion.py
@@ -701,7 +701,7 @@ def _valid_topology(
     }
     if (
         not isinstance(status, dict)
-        or not required <= set(status) <= required | {"error"}
+        or not required <= set(status) <= required | {"error", "sound", "control"}
         or "error" in status
         and not isinstance(status["error"], str)
     ):
@@ -752,9 +752,27 @@ def _valid_topology(
         if not _valid_resolution(provider, resolved.get(component_name)):
             return False
     supervisor = status.get("supervisor")
+    control = status.get("control")
+    if control is not None and (
+        not isinstance(control, dict)
+        or set(control) != {"socket", "generation"}
+        or not isinstance(control.get("socket"), str)
+        or not Path(control["socket"]).is_absolute()
+        or Path(control["socket"]).name != "control.sock"
+        or not isinstance(control.get("generation"), str)
+        or re.fullmatch(r"[0-9a-f]{64}", control["generation"]) is None
+    ):
+        return False
+    process_keys = (
+        {"pid", "start_time", "generation"}
+        if control is not None
+        else {"pid", "start_time"}
+    )
     if (
         not _valid_process(supervisor)
-        or set(supervisor) != {"pid", "start_time"}
+        or set(supervisor) != process_keys
+        or control is not None
+        and supervisor.get("generation") != control["generation"]
     ):
         return False
     endpoint = status.get("endpoint")
@@ -783,7 +801,7 @@ def _valid_topology(
         if (
             not _valid_process(service)
             or set(service)
-            != {"pid", "start_time", "status", "exit_code", "log", "cwd"}
+            != process_keys | {"status", "exit_code", "log", "cwd"}
             or service.get("status") not in {"starting", "running", "exited"}
             or service.get("exit_code") is not None
             and (
@@ -794,6 +812,8 @@ def _valid_topology(
             or not Path(service["log"]).is_absolute()
             or not isinstance(service.get("cwd"), str)
             or not Path(service["cwd"]).is_absolute()
+            or control is not None
+            and service.get("generation") != control["generation"]
         ):
             return False
     return (

--- a/atrinik_workspace/completion.py
+++ b/atrinik_workspace/completion.py
@@ -9,6 +9,7 @@ import stat
 from typing import Any, Iterable
 
 from .model import MANAGED_MARKER, Manifest, Paths, WorkspaceError, validate_name
+from .process_tree import control_socket_path
 
 
 _PROTOCOL_COMMAND = "__complete"
@@ -762,9 +763,10 @@ def _valid_topology(
         not isinstance(control, dict)
         or set(control) != {"socket", "generation", "lease"}
         or not isinstance(control.get("socket"), str)
-        or control["socket"] != str((topology_root / "control.sock").resolve())
         or not isinstance(control.get("generation"), str)
         or re.fullmatch(r"[0-9a-f]{64}", control["generation"]) is None
+        or control["socket"]
+        != str(control_socket_path(topology_root, control["generation"]))
         or not isinstance(control.get("lease"), dict)
         or set(control["lease"]) != {"device", "inode"}
         or not all(

--- a/atrinik_workspace/content_migration.py
+++ b/atrinik_workspace/content_migration.py
@@ -16,7 +16,7 @@ from typing import Any, TextIO
 
 from .locking import inherit_lock_fds
 from .model import WorkspaceError, atomic_json, load_json
-from .process_tree import holders_exist
+from .process_tree import holders_exist, lease_locked
 from .supervisor import process_matches
 
 
@@ -802,6 +802,10 @@ class ContentMigration:
                             raise WorkspaceError("invalid topology process identity")
                         if process_matches(pid, start):
                             running.append(pid)
+                    lease_path = directory / "process-tree.lease"
+                    if lease_path.is_symlink():
+                        raise WorkspaceError("invalid topology process-tree lease")
+                    lease_active = lease_path.is_file() and lease_locked(lease_path)
                     affected = (
                         value.get("profile") in changed_profiles
                         or "content-1x" in json.dumps(value, sort_keys=True)
@@ -813,10 +817,10 @@ class ContentMigration:
                             "profile": value.get("profile"),
                             "affected": affected,
                             "running_pids": running,
-                            "status": "blocked" if affected and running else "historical-inert",
+                            "status": "blocked" if affected and (running or lease_active) else "historical-inert",
                         }
                     )
-                    if affected and running:
+                    if affected and (running or lease_active):
                         refusals.append(
                             _refusal(
                                 "live_topology",

--- a/atrinik_workspace/content_migration.py
+++ b/atrinik_workspace/content_migration.py
@@ -808,7 +808,7 @@ class ContentMigration:
                             or not start.isdigit()
                         ):
                             raise WorkspaceError("invalid topology process identity")
-                        if process_matches(pid, start):
+                        if value.get("control") is None and process_matches(pid, start):
                             running.append(pid)
                     lease_path = directory / "process-tree.lease"
                     if lease_path.is_symlink():

--- a/atrinik_workspace/content_migration.py
+++ b/atrinik_workspace/content_migration.py
@@ -21,7 +21,12 @@ from .locking import (
     layout_writer_pending_path,
 )
 from .model import WorkspaceError, atomic_json, load_json
-from .process_tree import bound_lease_locked, holders_exist, lease_locked
+from .process_tree import (
+    bound_lease_locked,
+    control_socket_path,
+    holders_exist,
+    lease_locked,
+)
 from .supervisor import process_matches
 
 
@@ -814,13 +819,17 @@ class ContentMigration:
                             not isinstance(control, dict)
                             or set(control)
                             != {"socket", "generation", "lease"}
-                            or control.get("socket")
-                            != str((directory / "control.sock").resolve())
                             or not isinstance(control.get("generation"), str)
                             or re.fullmatch(
                                 r"[0-9a-f]{64}", control["generation"]
                             )
                             is None
+                            or control.get("socket")
+                            != str(
+                                control_socket_path(
+                                    directory, control["generation"]
+                                )
+                            )
                             or not isinstance(control.get("lease"), dict)
                         ):
                             raise WorkspaceError(

--- a/atrinik_workspace/content_migration.py
+++ b/atrinik_workspace/content_migration.py
@@ -21,7 +21,7 @@ from .locking import (
     layout_writer_pending_path,
 )
 from .model import WorkspaceError, atomic_json, load_json
-from .process_tree import holders_exist, lease_locked
+from .process_tree import bound_lease_locked, holders_exist, lease_locked
 from .supervisor import process_matches
 
 
@@ -808,7 +808,33 @@ class ContentMigration:
                     lease_path = directory / "process-tree.lease"
                     if lease_path.is_symlink():
                         raise WorkspaceError("invalid topology process-tree lease")
-                    lease_active = lease_path.is_file() and lease_locked(lease_path)
+                    control = value.get("control")
+                    if control is not None:
+                        if (
+                            not isinstance(control, dict)
+                            or set(control)
+                            != {"socket", "generation", "lease"}
+                            or control.get("socket")
+                            != str((directory / "control.sock").resolve())
+                            or not isinstance(control.get("generation"), str)
+                            or re.fullmatch(
+                                r"[0-9a-f]{64}", control["generation"]
+                            )
+                            is None
+                            or not isinstance(control.get("lease"), dict)
+                        ):
+                            raise WorkspaceError(
+                                "invalid topology control identity"
+                            )
+                        lease_active = bound_lease_locked(
+                            lease_path,
+                            control["generation"],
+                            control["lease"],
+                        )
+                    else:
+                        lease_active = (
+                            lease_path.is_file() and lease_locked(lease_path)
+                        )
                     affected = (
                         value.get("profile") in changed_profiles
                         or "content-1x" in json.dumps(value, sort_keys=True)

--- a/atrinik_workspace/migration.py
+++ b/atrinik_workspace/migration.py
@@ -19,7 +19,7 @@ from typing import Any, Iterable
 
 from .locking import LockBusyError, active_lock_fds, exclusive_layout_lock
 from .model import WorkspaceError, atomic_json, load_json
-from .process_tree import bound_lease_locked, lease_locked
+from .process_tree import bound_lease_locked, control_socket_path, lease_locked
 from .supervisor import process_matches
 
 
@@ -2924,11 +2924,11 @@ class RepositoryMigration:
                 if control is not None and (
                     not isinstance(control, dict)
                     or set(control) != {"socket", "generation", "lease"}
-                    or control.get("socket")
-                    != str((directory / "control.sock").resolve())
                     or not isinstance(control.get("generation"), str)
                     or re.fullmatch(r"[0-9a-f]{64}", control["generation"])
                     is None
+                    or control.get("socket")
+                    != str(control_socket_path(directory, control["generation"]))
                     or not isinstance(control.get("lease"), dict)
                     or set(control["lease"]) != {"device", "inode"}
                 ):

--- a/atrinik_workspace/migration.py
+++ b/atrinik_workspace/migration.py
@@ -2971,7 +2971,9 @@ class RepositoryMigration:
                         and record.get("generation") != generation
                     ):
                         raise WorkspaceError("topology supervisor status is invalid")
-                    if process_matches(record["pid"], record["start_time"]):
+                    if control is None and process_matches(
+                        record["pid"], record["start_time"]
+                    ):
                         running_records.append(label)
                 lease_path = directory / "process-tree.lease"
                 if lease_path.is_symlink():

--- a/atrinik_workspace/migration.py
+++ b/atrinik_workspace/migration.py
@@ -19,7 +19,7 @@ from typing import Any, Iterable
 
 from .locking import LockBusyError, active_lock_fds, exclusive_layout_lock
 from .model import WorkspaceError, atomic_json, load_json
-from .process_tree import lease_locked
+from .process_tree import bound_lease_locked, lease_locked
 from .supervisor import process_matches
 
 
@@ -2921,7 +2921,21 @@ class RepositoryMigration:
                 )
                 running_records: list[str] = []
                 control = status_value.get("control")
-                generation = control.get("generation") if isinstance(control, dict) else None
+                if control is not None and (
+                    not isinstance(control, dict)
+                    or set(control) != {"socket", "generation", "lease"}
+                    or control.get("socket")
+                    != str((directory / "control.sock").resolve())
+                    or not isinstance(control.get("generation"), str)
+                    or re.fullmatch(r"[0-9a-f]{64}", control["generation"])
+                    is None
+                    or not isinstance(control.get("lease"), dict)
+                    or set(control["lease"]) != {"device", "inode"}
+                ):
+                    raise WorkspaceError("topology control identity is invalid")
+                generation = (
+                    control["generation"] if control is not None else None
+                )
                 process_keys = (
                     {"pid", "start_time", "generation"}
                     if control is not None
@@ -2962,11 +2976,14 @@ class RepositoryMigration:
                 lease_path = directory / "process-tree.lease"
                 if lease_path.is_symlink():
                     raise WorkspaceError("topology process-tree lease is invalid")
-                if (
-                    lease_path.is_file()
-                    and lease_locked(lease_path)
-                    and not running_records
-                ):
+                lease_active = (
+                    bound_lease_locked(
+                        lease_path, control["generation"], control["lease"]
+                    )
+                    if control is not None
+                    else lease_path.is_file() and lease_locked(lease_path)
+                )
+                if lease_active and not running_records:
                     running_records.append("namespace-independent process tree")
             except (OSError, WorkspaceError) as error:
                 refusals.append(

--- a/atrinik_workspace/migration.py
+++ b/atrinik_workspace/migration.py
@@ -19,6 +19,7 @@ from typing import Any, Iterable
 
 from .locking import active_lock_fds, inherit_lock_fds
 from .model import WorkspaceError, atomic_json, load_json
+from .process_tree import lease_locked
 from .supervisor import process_matches
 
 
@@ -2904,7 +2905,7 @@ class RepositoryMigration:
                     or status_value.get("name") != directory.name
                     or not required <= set(status_value)
                     or not set(status_value)
-                    <= required | {"stack", "providers", "error"}
+                    <= required | {"stack", "providers", "sound", "control", "error"}
                     or not isinstance(status_value.get("profile"), str)
                     or not isinstance(status_value.get("dependencies"), list)
                     or not isinstance(status_value.get("resolved"), dict)
@@ -2925,6 +2926,13 @@ class RepositoryMigration:
                     for name, value in status_value["services"].items()
                 )
                 running_records: list[str] = []
+                control = status_value.get("control")
+                generation = control.get("generation") if isinstance(control, dict) else None
+                process_keys = (
+                    {"pid", "start_time", "generation"}
+                    if control is not None
+                    else {"pid", "start_time"}
+                )
                 for label, record in records:
                     if (
                         not isinstance(record, dict)
@@ -2939,18 +2947,33 @@ class RepositoryMigration:
                         )
                     if label != "supervisor" and (
                         set(record)
-                        != {"pid", "start_time", "status", "exit_code", "log", "cwd"}
+                        != process_keys | {"status", "exit_code", "log", "cwd"}
                         or record.get("status") not in {"starting", "running", "exited"}
                         or not isinstance(record.get("log"), str)
                         or not Path(record["log"]).is_absolute()
                         or not isinstance(record.get("cwd"), str)
                         or not Path(record["cwd"]).is_absolute()
+                        or control is not None
+                        and record.get("generation") != generation
                     ):
                         raise WorkspaceError(f"topology {label} status is invalid")
-                    if label == "supervisor" and set(record) != {"pid", "start_time"}:
+                    if label == "supervisor" and (
+                        set(record) != process_keys
+                        or control is not None
+                        and record.get("generation") != generation
+                    ):
                         raise WorkspaceError("topology supervisor status is invalid")
                     if process_matches(record["pid"], record["start_time"]):
                         running_records.append(label)
+                lease_path = directory / "process-tree.lease"
+                if lease_path.is_symlink():
+                    raise WorkspaceError("topology process-tree lease is invalid")
+                if (
+                    lease_path.is_file()
+                    and lease_locked(lease_path)
+                    and not running_records
+                ):
+                    running_records.append("namespace-independent process tree")
             except (OSError, WorkspaceError) as error:
                 refusals.append(
                     self._refusal(

--- a/atrinik_workspace/process_tree.py
+++ b/atrinik_workspace/process_tree.py
@@ -1,9 +1,30 @@
 from __future__ import annotations
 
+import fcntl
 import os
 from pathlib import Path
 import signal
+import stat
 from typing import Iterable
+
+
+def lease_locked(path: Path) -> bool:
+    """Observe one inherited lease without depending on visible process IDs."""
+    flags = os.O_RDONLY | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags)
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise OSError(f"process-tree lease is not a regular file: {path}")
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return True
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        return False
+    finally:
+        os.close(descriptor)
 
 
 def _holds_identity(pid: int, identity: tuple[int, int]) -> bool:

--- a/atrinik_workspace/process_tree.py
+++ b/atrinik_workspace/process_tree.py
@@ -8,6 +8,15 @@ import stat
 from typing import Iterable
 
 
+def control_socket_path(topology_root: Path, generation: str) -> Path:
+    """Return the bounded workspace-shared endpoint for one topology generation."""
+    workspace = topology_root.parent.parent
+    path = workspace / "c" / generation[:12]
+    if len(os.fsencode(path)) > 107:
+        raise OSError(f"workspace path is too long for topology control: {workspace}")
+    return path
+
+
 def initialize_lease(descriptor: int, generation: str) -> dict[str, int]:
     """Bind a locked lease inode to one topology generation."""
     payload = f"{generation}\n".encode()
@@ -102,6 +111,10 @@ def _holds_identity(pid: int, identity: tuple[int, int]) -> bool:
         # This lets the controlling `down` process inspect and signal holders
         # without becoming a target of the supervisor's own descendant cleanup.
         if flags & getattr(os, "O_PATH", 0):
+            continue
+        # Services inherit the topology's read/write open-file description.
+        # Read-only liveness observers must never become cleanup targets.
+        if flags & os.O_ACCMODE != os.O_RDWR:
             continue
         if (metadata.st_dev, metadata.st_ino) == identity:
             return True

--- a/atrinik_workspace/process_tree.py
+++ b/atrinik_workspace/process_tree.py
@@ -8,6 +8,56 @@ import stat
 from typing import Iterable
 
 
+def initialize_lease(descriptor: int, generation: str) -> dict[str, int]:
+    """Bind a locked lease inode to one topology generation."""
+    payload = f"{generation}\n".encode()
+    os.ftruncate(descriptor, 0)
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    if os.write(descriptor, payload) != len(payload):
+        raise OSError("short write while initializing process-tree lease")
+    os.fsync(descriptor)
+    metadata = os.fstat(descriptor)
+    return {"device": metadata.st_dev, "inode": metadata.st_ino}
+
+
+def bound_lease_locked(
+    path: Path, generation: str, identity: dict[str, int]
+) -> bool:
+    """Observe the exact generation-bound lease named by a status record."""
+    if (
+        set(identity) != {"device", "inode"}
+        or not all(
+            isinstance(value, int) and not isinstance(value, bool) and value >= 0
+            for value in identity.values()
+        )
+    ):
+        raise OSError("process-tree lease identity is invalid")
+    flags = os.O_RDONLY | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags)
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise OSError(f"process-tree lease is not a regular file: {path}")
+        if (metadata.st_dev, metadata.st_ino) != (
+            identity["device"],
+            identity["inode"],
+        ):
+            raise OSError(f"process-tree lease identity changed: {path}")
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        if os.read(descriptor, 66) != f"{generation}\n".encode():
+            raise OSError(f"process-tree lease generation changed: {path}")
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return True
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        return False
+    finally:
+        os.close(descriptor)
+
+
 def lease_locked(path: Path) -> bool:
     """Observe one inherited lease without depending on visible process IDs."""
     flags = os.O_RDONLY | os.O_CLOEXEC

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -287,103 +287,33 @@ def _initial_status(spec: dict[str, Any], supervisor_start_time: str) -> dict[st
     return status
 
 
-def _guardian(read_fd: int, process_tree_fd: int, orderly_fd: int) -> None:
+def _guardian(read_fd: int, process_tree_fd: int) -> None:
     """Release one orphaned topology tree after its supervisor disappears."""
-    registrations = bytearray()
-    process_groups: set[int] = set()
     try:
-        while chunk := os.read(read_fd, 4096):
-            if len(registrations) + len(chunk) > 4096:
-                registrations.clear()
-                break
-            registrations.extend(chunk)
-            while b"\n" in registrations:
-                value, _, remainder = registrations.partition(b"\n")
-                registrations = bytearray(remainder)
-                if value.isdigit() and int(value) > 0:
-                    process_group = int(value)
-                    process_groups.add(process_group)
+        while os.read(read_fd, 4096):
+            pass
     except OSError:
         pass
     finally:
         os.close(read_fd)
 
-    try:
-        orderly = os.read(orderly_fd, 1) == b"1"
-    except OSError:
-        orderly = False
-    finally:
-        os.close(orderly_fd)
-
-    def signal_groups(signum: signal.Signals) -> None:
-        try:
-            entries = list(Path("/proc").iterdir())
-        except OSError:
-            return
-        for entry in entries:
-            if not entry.name.isdigit():
-                continue
-            try:
-                fields = (entry / "stat").read_text().rsplit(")", 1)[1].split()
-                if fields[0] == "Z" or int(fields[2]) not in process_groups:
-                    continue
-                pidfd = os.pidfd_open(int(entry.name))
-            except (OSError, IndexError, ValueError):
-                continue
-            try:
-                # Revalidate the exact process through its pinned descriptor;
-                # never signal a bare, potentially reused PID or group.
-                current = (entry / "stat").read_text().rsplit(")", 1)[1].split()
-                if current[0] != "Z" and int(current[2]) in process_groups:
-                    signal.pidfd_send_signal(pidfd, signum)
-            except (ProcessLookupError, OSError, IndexError, ValueError):
-                continue
-            finally:
-                os.close(pidfd)
-
-    def groups_exist() -> bool:
-        try:
-            entries = list(Path("/proc").iterdir())
-        except OSError:
-            return True
-        for entry in entries:
-            if not entry.name.isdigit():
-                continue
-            try:
-                fields = (entry / "stat").read_text().rsplit(")", 1)[1].split()
-                if fields[0] != "Z" and int(fields[2]) in process_groups:
-                    return True
-            except (OSError, IndexError, ValueError):
-                continue
-        return False
-
     # Pipe EOF proves the supervisor is gone. Do not exclude its bare numeric
     # PID: it may already have been reused by an exact lease-holding descendant.
     excluded = (os.getpid(),)
-    if not orderly:
-        signal_groups(signal.SIGTERM)
     signal_holders(process_tree_fd, signal.SIGTERM, exclude=excluded)
     deadline = time.monotonic() + 10
     while time.monotonic() < deadline and (
-        (not orderly and groups_exist())
-        or holders_exist(process_tree_fd, exclude=excluded)
+        holders_exist(process_tree_fd, exclude=excluded)
     ):
         time.sleep(0.1)
-    if not orderly:
-        signal_groups(signal.SIGKILL)
     signal_holders(process_tree_fd, signal.SIGKILL, exclude=excluded)
     deadline = time.monotonic() + 2
     while time.monotonic() < deadline and (
-        (not orderly and groups_exist())
-        or holders_exist(process_tree_fd, exclude=excluded)
+        holders_exist(process_tree_fd, exclude=excluded)
     ):
-        if not orderly:
-            signal_groups(signal.SIGKILL)
         signal_holders(process_tree_fd, signal.SIGKILL, exclude=excluded)
         time.sleep(0.05)
-    while (not orderly and groups_exist()) or holders_exist(
-        process_tree_fd, exclude=excluded
-    ):
+    while holders_exist(process_tree_fd, exclude=excluded):
         time.sleep(0.5)
     os.close(process_tree_fd)
 
@@ -391,19 +321,16 @@ def _guardian(read_fd: int, process_tree_fd: int, orderly_fd: int) -> None:
 def _start_guardian(
     process_tree_fd: int | None,
     *unneeded_fds: int | None,
-) -> tuple[int | None, int | None, int | None]:
+) -> tuple[int | None, int | None]:
     if process_tree_fd is None:
-        return None, None, None
+        return None, None
     read_fd, write_fd = os.pipe2(os.O_CLOEXEC)
-    orderly_read_fd, orderly_write_fd = os.pipe2(os.O_CLOEXEC)
     guardian_pid = os.fork()
     if guardian_pid:
         os.close(read_fd)
-        os.close(orderly_read_fd)
-        return guardian_pid, write_fd, orderly_write_fd
+        return guardian_pid, write_fd
 
     os.close(write_fd)
-    os.close(orderly_write_fd)
     for descriptor in unneeded_fds:
         if descriptor is not None and descriptor != process_tree_fd:
             try:
@@ -413,7 +340,7 @@ def _start_guardian(
     try:
         signal.signal(signal.SIGINT, signal.SIG_IGN)
         signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        _guardian(read_fd, process_tree_fd, orderly_read_fd)
+        _guardian(read_fd, process_tree_fd)
     finally:
         os._exit(0)
 
@@ -523,7 +450,6 @@ def supervise(
     control_socket: socket.socket | None = None
     guardian_pid: int | None = None
     guardian_write_fd: int | None = None
-    guardian_orderly_fd: int | None = None
 
     def request_stop(_signum: int, _frame: object) -> None:
         nonlocal stop
@@ -562,12 +488,6 @@ def supervise(
                 spec["profile"], spec["name"]
             )
         inherited_locks: list[int] = []
-        if name == "server" and lock_fd is not None:
-            inherited_locks.append(lock_fd)
-        if layout_lock_fd is not None:
-            inherited_locks.append(layout_lock_fd)
-        if build_lock_fd is not None:
-            inherited_locks.append(build_lock_fd)
         if process_tree_fd is not None:
             inherited_locks.append(process_tree_fd)
         process = subprocess.Popen(
@@ -580,8 +500,6 @@ def supervise(
             start_new_session=True,
             pass_fds=tuple(inherited_locks),
         )
-        if guardian_write_fd is not None:
-            os.write(guardian_write_fd, f"{process.pid}\n".encode())
         processes[name] = process
         start_time = process_start_time(process.pid)
         if start_time is None:
@@ -611,7 +529,7 @@ def supervise(
         return process
 
     try:
-        guardian_pid, guardian_write_fd, guardian_orderly_fd = _start_guardian(
+        guardian_pid, guardian_write_fd = _start_guardian(
             process_tree_fd, lock_fd, layout_lock_fd, build_lock_fd
         )
         control_socket = _open_control(spec, spec_path.parent)
@@ -705,10 +623,6 @@ def supervise(
             os.close(process_tree_fd)
             process_tree_fd = None
         if guardian_write_fd is not None:
-            if guardian_orderly_fd is not None:
-                os.write(guardian_orderly_fd, b"1")
-                os.close(guardian_orderly_fd)
-                guardian_orderly_fd = None
             os.close(guardian_write_fd)
         if guardian_pid is not None:
             try:
@@ -721,8 +635,6 @@ def supervise(
             os.close(layout_lock_fd)
         if build_lock_fd is not None:
             os.close(build_lock_fd)
-        if guardian_orderly_fd is not None:
-            os.close(guardian_orderly_fd)
     return 0
 
 

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 import re
 import signal
+import socket
 import stat
 import subprocess
 import sys
@@ -94,6 +95,8 @@ def terminate(
     processes: dict[str, subprocess.Popen[bytes]],
     process_tree_fd: int | None,
     timeout: float = 10,
+    *,
+    exclude: tuple[int | None, ...] = (),
 ) -> None:
     # An unreaped session leader pins its numeric process-group identity, so
     # these groups remain safe to signal until the final waits below. The lease
@@ -133,14 +136,17 @@ def terminate(
     signal_groups(signal.SIGTERM)
     if process_tree_fd is not None:
         signal_holders(
-            process_tree_fd, signal.SIGTERM, exclude=(os.getpid(),)
+            process_tree_fd,
+            signal.SIGTERM,
+            exclude=(os.getpid(), *(pid for pid in exclude if pid is not None)),
         )
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         running = groups_exist()
         if process_tree_fd is not None:
             running = running or holders_exist(
-                process_tree_fd, exclude=(os.getpid(),)
+                process_tree_fd,
+                exclude=(os.getpid(), *(pid for pid in exclude if pid is not None)),
             )
         if not running:
             break
@@ -148,16 +154,23 @@ def terminate(
     signal_groups(signal.SIGKILL)
     if process_tree_fd is not None:
         signal_holders(
-            process_tree_fd, signal.SIGKILL, exclude=(os.getpid(),)
+            process_tree_fd,
+            signal.SIGKILL,
+            exclude=(os.getpid(), *(pid for pid in exclude if pid is not None)),
         )
         kill_deadline = time.monotonic() + 2
         while time.monotonic() < kill_deadline and (
             groups_exist()
-            or holders_exist(process_tree_fd, exclude=(os.getpid(),))
+            or holders_exist(
+                process_tree_fd,
+                exclude=(os.getpid(), *(pid for pid in exclude if pid is not None)),
+            )
         ):
             signal_groups(signal.SIGKILL)
             signal_holders(
-                process_tree_fd, signal.SIGKILL, exclude=(os.getpid(),)
+                process_tree_fd,
+                signal.SIGKILL,
+                exclude=(os.getpid(), *(pid for pid in exclude if pid is not None)),
             )
             time.sleep(0.05)
     for process in processes.values():
@@ -235,6 +248,8 @@ def pump_output(
 
 
 def _initial_status(spec: dict[str, Any], supervisor_start_time: str) -> dict[str, Any]:
+    control = spec.get("control")
+    generation = control.get("generation") if isinstance(control, dict) else None
     status: dict[str, Any] = {
         "schema_version": 1,
         "name": spec["name"],
@@ -254,9 +269,12 @@ def _initial_status(spec: dict[str, Any], supervisor_start_time: str) -> dict[st
         "supervisor": {
             "pid": os.getpid(),
             "start_time": supervisor_start_time,
+            **({"generation": generation} if generation is not None else {}),
         },
         "services": {},
     }
+    if control is not None:
+        status["control"] = control
     if "stack" in spec or "providers" in spec:
         if not isinstance(spec.get("stack"), str) or not isinstance(
             spec.get("providers"), dict
@@ -267,6 +285,133 @@ def _initial_status(spec: dict[str, Any], supervisor_start_time: str) -> dict[st
     if "sound" in spec:
         status["sound"] = spec["sound"]
     return status
+
+
+def _guardian(read_fd: int, process_tree_fd: int, supervisor_pid: int) -> None:
+    """Release one orphaned topology tree after its supervisor disappears."""
+    try:
+        while os.read(read_fd, 4096):
+            pass
+    except OSError:
+        pass
+    finally:
+        os.close(read_fd)
+
+    excluded = (os.getpid(), supervisor_pid)
+    signal_holders(process_tree_fd, signal.SIGTERM, exclude=excluded)
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline and holders_exist(
+        process_tree_fd, exclude=excluded
+    ):
+        time.sleep(0.1)
+    signal_holders(process_tree_fd, signal.SIGKILL, exclude=excluded)
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline and holders_exist(
+        process_tree_fd, exclude=excluded
+    ):
+        signal_holders(process_tree_fd, signal.SIGKILL, exclude=excluded)
+        time.sleep(0.05)
+    os.close(process_tree_fd)
+
+
+def _start_guardian(
+    process_tree_fd: int | None,
+    *unneeded_fds: int | None,
+) -> tuple[int | None, int | None]:
+    if process_tree_fd is None:
+        return None, None
+    read_fd, write_fd = os.pipe2(os.O_CLOEXEC)
+    guardian_pid = os.fork()
+    if guardian_pid:
+        os.close(read_fd)
+        return guardian_pid, write_fd
+
+    os.close(write_fd)
+    for descriptor in unneeded_fds:
+        if descriptor is not None and descriptor != process_tree_fd:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+    try:
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        _guardian(read_fd, process_tree_fd, os.getppid())
+    finally:
+        os._exit(0)
+
+
+def _open_control(spec: dict[str, Any], topology_root: Path) -> socket.socket | None:
+    control = spec.get("control")
+    if control is None:
+        return None
+    if (
+        not isinstance(control, dict)
+        or set(control) != {"socket", "generation"}
+        or not isinstance(control.get("socket"), str)
+        or control["socket"] != str((topology_root / "control.sock").resolve())
+        or not isinstance(control.get("generation"), str)
+        or not re.fullmatch(r"[0-9a-f]{64}", control["generation"])
+    ):
+        raise RuntimeError("topology control identity is invalid")
+    endpoint = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        endpoint.bind(control["socket"])
+        os.chmod(control["socket"], 0o600)
+        endpoint.listen(4)
+        endpoint.setblocking(False)
+    except BaseException:
+        endpoint.close()
+        raise
+    return endpoint
+
+
+def _receive_control(connection: socket.socket) -> Any:
+    payload = bytearray()
+    while len(payload) <= 4096:
+        chunk = connection.recv(4097 - len(payload))
+        if not chunk:
+            break
+        payload.extend(chunk)
+        if b"\n" in chunk:
+            break
+    if len(payload) > 4096:
+        raise ValueError("control message is too large")
+    return json.loads(payload)
+
+
+def _serve_control(
+    endpoint: socket.socket | None,
+    spec: dict[str, Any],
+) -> bool:
+    """Serve at most one bounded request and return whether shutdown was asked."""
+    if endpoint is None:
+        return False
+    try:
+        connection, _address = endpoint.accept()
+    except BlockingIOError:
+        return False
+    with connection:
+        connection.settimeout(0.5)
+        try:
+            request = _receive_control(connection)
+            control = spec["control"]
+            valid = (
+                isinstance(request, dict)
+                and set(request) == {"action", "name", "generation"}
+                and request.get("action") in {"status", "stop"}
+                and request.get("name") == spec["name"]
+                and request.get("generation") == control["generation"]
+            )
+            response = {
+                "ok": valid,
+                "name": spec["name"],
+                "generation": control["generation"],
+            }
+            connection.sendall(json.dumps(response, sort_keys=True).encode() + b"\n")
+            return bool(valid and request["action"] == "stop")
+        except (OSError, TimeoutError, ValueError, json.JSONDecodeError):
+            return False
 
 
 def supervise(
@@ -280,6 +425,9 @@ def supervise(
         spec = json.load(stream)
     status_path = spec_path.parent / "status.json"
     stop = False
+    control_socket: socket.socket | None = None
+    guardian_pid: int | None = None
+    guardian_write_fd: int | None = None
 
     def request_stop(_signum: int, _frame: object) -> None:
         nonlocal stop
@@ -351,6 +499,11 @@ def supervise(
         status["services"][name] = {
             "pid": process.pid,
             "start_time": start_time,
+            **(
+                {"generation": spec["control"]["generation"]}
+                if "control" in spec
+                else {}
+            ),
             "status": "starting" if capture is not None else "running",
             "exit_code": None,
             "log": str(log),
@@ -360,11 +513,16 @@ def supervise(
         return process
 
     try:
+        guardian_pid, guardian_write_fd = _start_guardian(
+            process_tree_fd, lock_fd, layout_lock_fd, build_lock_fd
+        )
+        control_socket = _open_control(spec, spec_path.parent)
         if "server" in spec["services"]:
             capture = ServerReadinessCapture()
             server = start_service("server", capture=capture)
             deadline = time.monotonic() + SERVER_READY_TIMEOUT
             while not capture.event.wait(timeout=0.1):
+                stop = stop or _serve_control(control_socket, spec)
                 code = _peek_exit_code(server)
                 if code is not None:
                     raise RuntimeError(
@@ -398,6 +556,7 @@ def supervise(
         atomic_status(status_path, status)
 
         while not stop:
+            stop = _serve_control(control_socket, spec)
             changed = False
             running = True
             for name, process in processes.items():
@@ -418,7 +577,7 @@ def supervise(
         atomic_status(status_path, status)
         return 1
     finally:
-        terminate(processes, process_tree_fd)
+        terminate(processes, process_tree_fd, exclude=(guardian_pid,))
         for pump in pumps:
             pump.join(timeout=2)
         for name, process in processes.items():
@@ -433,6 +592,21 @@ def supervise(
         atomic_status(status_path, status)
         for output in logs:
             output.close()
+        if control_socket is not None:
+            control_socket.close()
+            control_path = Path(spec["control"]["socket"])
+            try:
+                if stat.S_ISSOCK(control_path.lstat().st_mode):
+                    control_path.unlink()
+            except FileNotFoundError:
+                pass
+        if guardian_write_fd is not None:
+            os.close(guardian_write_fd)
+        if guardian_pid is not None:
+            try:
+                os.waitpid(guardian_pid, 0)
+            except ChildProcessError:
+                pass
         if lock_fd is not None:
             os.close(lock_fd)
         if layout_lock_fd is not None:

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -17,7 +17,7 @@ import time
 from typing import Any, BinaryIO
 
 from .launch_identity import CLIENT_LAUNCH_LABEL_ENV, client_launch_label
-from .process_tree import holders_exist, signal_holders
+from .process_tree import control_socket_path, holders_exist, signal_holders
 
 
 LOG_LIMIT = 10 * 1024 * 1024
@@ -287,7 +287,7 @@ def _initial_status(spec: dict[str, Any], supervisor_start_time: str) -> dict[st
     return status
 
 
-def _guardian(read_fd: int, process_tree_fd: int, supervisor_pid: int) -> None:
+def _guardian(read_fd: int, process_tree_fd: int) -> None:
     """Release one orphaned topology tree after its supervisor disappears."""
     try:
         while os.read(read_fd, 4096):
@@ -297,7 +297,9 @@ def _guardian(read_fd: int, process_tree_fd: int, supervisor_pid: int) -> None:
     finally:
         os.close(read_fd)
 
-    excluded = (os.getpid(), supervisor_pid)
+    # Pipe EOF proves the supervisor is gone. Do not exclude its bare numeric
+    # PID: it may already have been reused by an exact lease-holding descendant.
+    excluded = (os.getpid(),)
     signal_holders(process_tree_fd, signal.SIGTERM, exclude=excluded)
     deadline = time.monotonic() + 10
     while time.monotonic() < deadline and holders_exist(
@@ -336,7 +338,7 @@ def _start_guardian(
     try:
         signal.signal(signal.SIGINT, signal.SIG_IGN)
         signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        _guardian(read_fd, process_tree_fd, os.getppid())
+        _guardian(read_fd, process_tree_fd)
     finally:
         os._exit(0)
 
@@ -349,9 +351,10 @@ def _open_control(spec: dict[str, Any], topology_root: Path) -> socket.socket | 
         not isinstance(control, dict)
         or set(control) != {"socket", "generation", "lease"}
         or not isinstance(control.get("socket"), str)
-        or control["socket"] != str((topology_root / "control.sock").resolve())
         or not isinstance(control.get("generation"), str)
         or not re.fullmatch(r"[0-9a-f]{64}", control["generation"])
+        or control["socket"]
+        != str(control_socket_path(topology_root, control["generation"]))
         or not isinstance(control.get("lease"), dict)
         or set(control["lease"]) != {"device", "inode"}
         or not all(
@@ -363,19 +366,14 @@ def _open_control(spec: dict[str, Any], topology_root: Path) -> socket.socket | 
     ):
         raise RuntimeError("topology control identity is invalid")
     endpoint = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    directory_fd: int | None = None
     try:
-        directory_fd = os.open(topology_root, os.O_RDONLY | os.O_CLOEXEC)
-        endpoint.bind(f"/proc/self/fd/{directory_fd}/control.sock")
+        endpoint.bind(control["socket"])
         os.chmod(control["socket"], 0o600)
-        endpoint.listen(4)
+        endpoint.listen(32)
         endpoint.setblocking(False)
     except BaseException:
         endpoint.close()
         raise
-    finally:
-        if directory_fd is not None:
-            os.close(directory_fd)
     return endpoint
 
 
@@ -400,31 +398,35 @@ def _serve_control(
     """Serve at most one bounded request and return whether shutdown was asked."""
     if endpoint is None:
         return False
-    try:
-        connection, _address = endpoint.accept()
-    except BlockingIOError:
-        return False
-    with connection:
-        connection.settimeout(0.5)
+    stop = False
+    while True:
         try:
-            request = _receive_control(connection)
-            control = spec["control"]
-            valid = (
-                isinstance(request, dict)
-                and set(request) == {"action", "name", "generation"}
-                and request.get("action") in {"status", "stop"}
-                and request.get("name") == spec["name"]
-                and request.get("generation") == control["generation"]
-            )
-            response = {
-                "ok": valid,
-                "name": spec["name"],
-                "generation": control["generation"],
-            }
-            connection.sendall(json.dumps(response, sort_keys=True).encode() + b"\n")
-            return bool(valid and request["action"] == "stop")
-        except (OSError, TimeoutError, ValueError, json.JSONDecodeError):
-            return False
+            connection, _address = endpoint.accept()
+        except BlockingIOError:
+            return stop
+        with connection:
+            connection.settimeout(0.5)
+            try:
+                request = _receive_control(connection)
+                control = spec["control"]
+                valid = (
+                    isinstance(request, dict)
+                    and set(request) == {"action", "name", "generation"}
+                    and request.get("action") in {"status", "stop"}
+                    and request.get("name") == spec["name"]
+                    and request.get("generation") == control["generation"]
+                )
+                response = {
+                    "ok": valid,
+                    "name": spec["name"],
+                    "generation": control["generation"],
+                }
+                connection.sendall(
+                    json.dumps(response, sort_keys=True).encode() + b"\n"
+                )
+                stop = stop or bool(valid and request["action"] == "stop")
+            except (OSError, TimeoutError, ValueError, json.JSONDecodeError):
+                continue
 
 
 def supervise(
@@ -613,6 +615,12 @@ def supervise(
                     control_path.unlink()
             except FileNotFoundError:
                 pass
+        # On orderly shutdown stop being a lease holder before telling the
+        # guardian to perform its final exact-holder sweep. On a crash the
+        # kernel closes this descriptor before pipe EOF instead.
+        if process_tree_fd is not None:
+            os.close(process_tree_fd)
+            process_tree_fd = None
         if guardian_write_fd is not None:
             os.close(guardian_write_fd)
         if guardian_pid is not None:
@@ -626,8 +634,6 @@ def supervise(
             os.close(layout_lock_fd)
         if build_lock_fd is not None:
             os.close(build_lock_fd)
-        if process_tree_fd is not None:
-            os.close(process_tree_fd)
     return 0
 
 

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -287,7 +287,11 @@ def _initial_status(spec: dict[str, Any], supervisor_start_time: str) -> dict[st
     return status
 
 
-def _guardian(read_fd: int, process_tree_fd: int) -> None:
+def _guardian(
+    read_fd: int,
+    process_tree_fd: int,
+    retained_fds: tuple[int | None, ...],
+) -> None:
     """Release one orphaned topology tree after its supervisor disappears."""
     try:
         while os.read(read_fd, 4096):
@@ -316,11 +320,14 @@ def _guardian(read_fd: int, process_tree_fd: int) -> None:
     while holders_exist(process_tree_fd, exclude=excluded):
         time.sleep(0.5)
     os.close(process_tree_fd)
+    for descriptor in retained_fds:
+        if descriptor is not None:
+            os.close(descriptor)
 
 
 def _start_guardian(
     process_tree_fd: int | None,
-    *unneeded_fds: int | None,
+    *retained_fds: int | None,
 ) -> tuple[int | None, int | None]:
     if process_tree_fd is None:
         return None, None
@@ -331,16 +338,10 @@ def _start_guardian(
         return guardian_pid, write_fd
 
     os.close(write_fd)
-    for descriptor in unneeded_fds:
-        if descriptor is not None and descriptor != process_tree_fd:
-            try:
-                os.close(descriptor)
-            except OSError:
-                pass
     try:
         signal.signal(signal.SIGINT, signal.SIG_IGN)
         signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        _guardian(read_fd, process_tree_fd)
+        _guardian(read_fd, process_tree_fd, retained_fds)
     finally:
         os._exit(0)
 

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -347,22 +347,35 @@ def _open_control(spec: dict[str, Any], topology_root: Path) -> socket.socket | 
         return None
     if (
         not isinstance(control, dict)
-        or set(control) != {"socket", "generation"}
+        or set(control) != {"socket", "generation", "lease"}
         or not isinstance(control.get("socket"), str)
         or control["socket"] != str((topology_root / "control.sock").resolve())
         or not isinstance(control.get("generation"), str)
         or not re.fullmatch(r"[0-9a-f]{64}", control["generation"])
+        or not isinstance(control.get("lease"), dict)
+        or set(control["lease"]) != {"device", "inode"}
+        or not all(
+            isinstance(value, int)
+            and not isinstance(value, bool)
+            and value >= 0
+            for value in control["lease"].values()
+        )
     ):
         raise RuntimeError("topology control identity is invalid")
     endpoint = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    directory_fd: int | None = None
     try:
-        endpoint.bind(control["socket"])
+        directory_fd = os.open(topology_root, os.O_RDONLY | os.O_CLOEXEC)
+        endpoint.bind(f"/proc/self/fd/{directory_fd}/control.sock")
         os.chmod(control["socket"], 0o600)
         endpoint.listen(4)
         endpoint.setblocking(False)
     except BaseException:
         endpoint.close()
         raise
+    finally:
+        if directory_fd is not None:
+            os.close(directory_fd)
     return endpoint
 
 

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -289,28 +289,64 @@ def _initial_status(spec: dict[str, Any], supervisor_start_time: str) -> dict[st
 
 def _guardian(read_fd: int, process_tree_fd: int) -> None:
     """Release one orphaned topology tree after its supervisor disappears."""
+    registrations = bytearray()
     try:
-        while os.read(read_fd, 4096):
-            pass
+        while chunk := os.read(read_fd, 4096):
+            if len(registrations) + len(chunk) > 4096:
+                registrations.clear()
+                break
+            registrations.extend(chunk)
     except OSError:
         pass
     finally:
         os.close(read_fd)
 
+    process_groups = {
+        int(value)
+        for value in registrations.splitlines()
+        if value.isdigit() and int(value) > 0
+    }
+
+    def signal_groups(signum: signal.Signals) -> None:
+        for process_group in process_groups:
+            try:
+                os.killpg(process_group, signum)
+            except ProcessLookupError:
+                pass
+
+    def groups_exist() -> bool:
+        try:
+            entries = list(Path("/proc").iterdir())
+        except OSError:
+            return True
+        for entry in entries:
+            if not entry.name.isdigit():
+                continue
+            try:
+                fields = (entry / "stat").read_text().rsplit(")", 1)[1].split()
+                if fields[0] != "Z" and int(fields[2]) in process_groups:
+                    return True
+            except (OSError, IndexError, ValueError):
+                continue
+        return False
+
     # Pipe EOF proves the supervisor is gone. Do not exclude its bare numeric
     # PID: it may already have been reused by an exact lease-holding descendant.
     excluded = (os.getpid(),)
+    signal_groups(signal.SIGTERM)
     signal_holders(process_tree_fd, signal.SIGTERM, exclude=excluded)
     deadline = time.monotonic() + 10
-    while time.monotonic() < deadline and holders_exist(
-        process_tree_fd, exclude=excluded
+    while time.monotonic() < deadline and (
+        groups_exist() or holders_exist(process_tree_fd, exclude=excluded)
     ):
         time.sleep(0.1)
+    signal_groups(signal.SIGKILL)
     signal_holders(process_tree_fd, signal.SIGKILL, exclude=excluded)
     deadline = time.monotonic() + 2
-    while time.monotonic() < deadline and holders_exist(
-        process_tree_fd, exclude=excluded
+    while time.monotonic() < deadline and (
+        groups_exist() or holders_exist(process_tree_fd, exclude=excluded)
     ):
+        signal_groups(signal.SIGKILL)
         signal_holders(process_tree_fd, signal.SIGKILL, exclude=excluded)
         time.sleep(0.05)
     os.close(process_tree_fd)
@@ -499,6 +535,8 @@ def supervise(
             start_new_session=True,
             pass_fds=tuple(inherited_locks),
         )
+        if guardian_write_fd is not None:
+            os.write(guardian_write_fd, f"{process.pid}\n".encode())
         processes[name] = process
         start_time = process_start_time(process.pid)
         if start_time is None:

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -287,32 +287,59 @@ def _initial_status(spec: dict[str, Any], supervisor_start_time: str) -> dict[st
     return status
 
 
-def _guardian(read_fd: int, process_tree_fd: int) -> None:
+def _guardian(read_fd: int, process_tree_fd: int, orderly_fd: int) -> None:
     """Release one orphaned topology tree after its supervisor disappears."""
     registrations = bytearray()
+    process_groups: set[int] = set()
     try:
         while chunk := os.read(read_fd, 4096):
             if len(registrations) + len(chunk) > 4096:
                 registrations.clear()
                 break
             registrations.extend(chunk)
+            while b"\n" in registrations:
+                value, _, remainder = registrations.partition(b"\n")
+                registrations = bytearray(remainder)
+                if value.isdigit() and int(value) > 0:
+                    process_group = int(value)
+                    process_groups.add(process_group)
     except OSError:
         pass
     finally:
         os.close(read_fd)
 
-    process_groups = {
-        int(value)
-        for value in registrations.splitlines()
-        if value.isdigit() and int(value) > 0
-    }
+    try:
+        orderly = os.read(orderly_fd, 1) == b"1"
+    except OSError:
+        orderly = False
+    finally:
+        os.close(orderly_fd)
 
     def signal_groups(signum: signal.Signals) -> None:
-        for process_group in process_groups:
+        try:
+            entries = list(Path("/proc").iterdir())
+        except OSError:
+            return
+        for entry in entries:
+            if not entry.name.isdigit():
+                continue
             try:
-                os.killpg(process_group, signum)
-            except ProcessLookupError:
-                pass
+                fields = (entry / "stat").read_text().rsplit(")", 1)[1].split()
+                if fields[0] == "Z" or int(fields[2]) not in process_groups:
+                    continue
+                pidfd = os.pidfd_open(int(entry.name))
+            except (OSError, IndexError, ValueError):
+                continue
+            try:
+                # Revalidate the exact process through its pinned descriptor;
+                # never signal a bare, potentially reused PID or group.
+                current = (entry / "stat").read_text().rsplit(")", 1)[1].split()
+                if current[0] != "Z" and int(current[2]) in process_groups:
+                    signal.pidfd_send_signal(pidfd, signum)
+            except (ProcessLookupError, OSError, IndexError, ValueError):
+                continue
+            finally:
+                os.close(pidfd)
 
     def groups_exist() -> bool:
         try:
@@ -333,38 +360,50 @@ def _guardian(read_fd: int, process_tree_fd: int) -> None:
     # Pipe EOF proves the supervisor is gone. Do not exclude its bare numeric
     # PID: it may already have been reused by an exact lease-holding descendant.
     excluded = (os.getpid(),)
-    signal_groups(signal.SIGTERM)
+    if not orderly:
+        signal_groups(signal.SIGTERM)
     signal_holders(process_tree_fd, signal.SIGTERM, exclude=excluded)
     deadline = time.monotonic() + 10
     while time.monotonic() < deadline and (
-        groups_exist() or holders_exist(process_tree_fd, exclude=excluded)
+        (not orderly and groups_exist())
+        or holders_exist(process_tree_fd, exclude=excluded)
     ):
         time.sleep(0.1)
-    signal_groups(signal.SIGKILL)
+    if not orderly:
+        signal_groups(signal.SIGKILL)
     signal_holders(process_tree_fd, signal.SIGKILL, exclude=excluded)
     deadline = time.monotonic() + 2
     while time.monotonic() < deadline and (
-        groups_exist() or holders_exist(process_tree_fd, exclude=excluded)
+        (not orderly and groups_exist())
+        or holders_exist(process_tree_fd, exclude=excluded)
     ):
-        signal_groups(signal.SIGKILL)
+        if not orderly:
+            signal_groups(signal.SIGKILL)
         signal_holders(process_tree_fd, signal.SIGKILL, exclude=excluded)
         time.sleep(0.05)
+    while (not orderly and groups_exist()) or holders_exist(
+        process_tree_fd, exclude=excluded
+    ):
+        time.sleep(0.5)
     os.close(process_tree_fd)
 
 
 def _start_guardian(
     process_tree_fd: int | None,
     *unneeded_fds: int | None,
-) -> tuple[int | None, int | None]:
+) -> tuple[int | None, int | None, int | None]:
     if process_tree_fd is None:
-        return None, None
+        return None, None, None
     read_fd, write_fd = os.pipe2(os.O_CLOEXEC)
+    orderly_read_fd, orderly_write_fd = os.pipe2(os.O_CLOEXEC)
     guardian_pid = os.fork()
     if guardian_pid:
         os.close(read_fd)
-        return guardian_pid, write_fd
+        os.close(orderly_read_fd)
+        return guardian_pid, write_fd, orderly_write_fd
 
     os.close(write_fd)
+    os.close(orderly_write_fd)
     for descriptor in unneeded_fds:
         if descriptor is not None and descriptor != process_tree_fd:
             try:
@@ -374,7 +413,7 @@ def _start_guardian(
     try:
         signal.signal(signal.SIGINT, signal.SIG_IGN)
         signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        _guardian(read_fd, process_tree_fd)
+        _guardian(read_fd, process_tree_fd, orderly_read_fd)
     finally:
         os._exit(0)
 
@@ -435,13 +474,17 @@ def _serve_control(
     if endpoint is None:
         return False
     stop = False
-    while True:
+    deadline = time.monotonic() + 0.2
+    for _request_index in range(32):
         try:
             connection, _address = endpoint.accept()
         except BlockingIOError:
             return stop
         with connection:
-            connection.settimeout(0.5)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return stop
+            connection.settimeout(min(0.05, remaining))
             try:
                 request = _receive_control(connection)
                 control = spec["control"]
@@ -463,6 +506,7 @@ def _serve_control(
                 stop = stop or bool(valid and request["action"] == "stop")
             except (OSError, TimeoutError, ValueError, json.JSONDecodeError):
                 continue
+    return stop
 
 
 def supervise(
@@ -479,6 +523,7 @@ def supervise(
     control_socket: socket.socket | None = None
     guardian_pid: int | None = None
     guardian_write_fd: int | None = None
+    guardian_orderly_fd: int | None = None
 
     def request_stop(_signum: int, _frame: object) -> None:
         nonlocal stop
@@ -566,7 +611,7 @@ def supervise(
         return process
 
     try:
-        guardian_pid, guardian_write_fd = _start_guardian(
+        guardian_pid, guardian_write_fd, guardian_orderly_fd = _start_guardian(
             process_tree_fd, lock_fd, layout_lock_fd, build_lock_fd
         )
         control_socket = _open_control(spec, spec_path.parent)
@@ -660,6 +705,10 @@ def supervise(
             os.close(process_tree_fd)
             process_tree_fd = None
         if guardian_write_fd is not None:
+            if guardian_orderly_fd is not None:
+                os.write(guardian_orderly_fd, b"1")
+                os.close(guardian_orderly_fd)
+                guardian_orderly_fd = None
             os.close(guardian_write_fd)
         if guardian_pid is not None:
             try:
@@ -672,6 +721,8 @@ def supervise(
             os.close(layout_lock_fd)
         if build_lock_fd is not None:
             os.close(build_lock_fd)
+        if guardian_orderly_fd is not None:
+            os.close(guardian_orderly_fd)
     return 0
 
 

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -7339,7 +7339,9 @@ class Workspace:
         process_tree_active = self._topology_process_tree_active(
             root, control if current_control else None
         )
-        supervisor_local = self._recorded_process_running(supervisor)
+        supervisor_local = bool(
+            not current_control and self._recorded_process_running(supervisor)
+        )
         if control_reachable or supervisor_local:
             supervisor_liveness = "live"
         elif process_tree_active:
@@ -7404,7 +7406,9 @@ class Workspace:
                 and service.get("generation") != control["generation"]
             ):
                 raise WorkspaceError(f"topology service status is invalid: {name}")
-            service_local = self._recorded_process_running(service)
+            service_local = bool(
+                not current_control and self._recorded_process_running(service)
+            )
             if service.get("status") == "exited":
                 service_liveness = "exited"
             elif control_reachable or service_local:
@@ -7631,6 +7635,10 @@ class Workspace:
                     ) from error
                 if holders_exist(process_tree_fd, exclude=(os.getpid(),)):
                     raise WorkspaceError(f"topology is already running: {name}")
+                # The operation lock serializes lifecycle mutation. Retire the
+                # stopped generation before rebinding its lease inode so status
+                # readers never compare old identity with new lease contents.
+                status_path.unlink(missing_ok=True)
                 for _attempt in range(16):
                     generation = secrets.token_hex(32)
                     control_path = control_socket_path(topology_root, generation)
@@ -7832,7 +7840,6 @@ class Workspace:
                         f"topology control endpoint already exists: {control_path}"
                     )
                 atomic_json(spec_path, spec)
-                status_path.unlink(missing_ok=True)
                 startup_error_path.unlink(missing_ok=True)
 
                 supervisor_log_path = topology_root / "supervisor.log"

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -32,7 +32,7 @@ from typing import Any, Callable, Iterator, TextIO
 from .launch_identity import CLIENT_LAUNCH_LABEL_ENV, client_launch_label
 from .content_migration import ContentMigration
 from .locking import active_lock_fds, inherit_lock_fds
-from .process_tree import holders_exist, signal_holders
+from .process_tree import holders_exist, lease_locked, signal_holders
 
 from .model import (
     MANAGED_MARKER,
@@ -97,6 +97,7 @@ COMPILER_CACHE_PURPOSE = "compiler-cache"
 COMPILER_CACHE_MAX_SIZE = "5G"
 TOPOLOGY_SERVICES = ("server", "client")
 TOPOLOGY_PROCESS_TREE_LEASE = "process-tree.lease"
+TOPOLOGY_CONTROL_SOCKET = "control.sock"
 PRE_MONOREPO_REPOSITORIES = {
     "client": "legacy-client",
     "server": "legacy-server",
@@ -7033,6 +7034,64 @@ class Workspace:
             and process_matches(pid, start_time)
         )
 
+    @staticmethod
+    def _topology_control_request(
+        name: str,
+        control: dict[str, str],
+        action: str,
+    ) -> bool:
+        request = {
+            "action": action,
+            "name": name,
+            "generation": control["generation"],
+        }
+        try:
+            endpoint = Path(control["socket"])
+            metadata = endpoint.lstat()
+            if (
+                not stat.S_ISSOCK(metadata.st_mode)
+                or stat.S_IMODE(metadata.st_mode) != 0o600
+                or metadata.st_uid != os.geteuid()
+            ):
+                return False
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+                client.settimeout(0.5)
+                client.connect(str(endpoint))
+                client.sendall(json.dumps(request, sort_keys=True).encode())
+                client.shutdown(socket.SHUT_WR)
+                payload = bytearray()
+                while len(payload) <= 4096:
+                    chunk = client.recv(4097 - len(payload))
+                    if not chunk:
+                        break
+                    payload.extend(chunk)
+                    if b"\n" in chunk:
+                        break
+            if len(payload) > 4096:
+                return False
+            response = json.loads(payload)
+        except (FileNotFoundError, OSError, TimeoutError, json.JSONDecodeError):
+            return False
+        return bool(
+            isinstance(response, dict)
+            and set(response) == {"generation", "name", "ok"}
+            and response.get("ok") is True
+            and response.get("name") == name
+            and response.get("generation") == control["generation"]
+        )
+
+    @staticmethod
+    def _topology_process_tree_active(root: Path) -> bool:
+        path = root / TOPOLOGY_PROCESS_TREE_LEASE
+        if path.is_symlink() or not path.is_file():
+            return False
+        try:
+            return lease_locked(path)
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot inspect topology process-tree lease {path}: {error}"
+            ) from error
+
     def topology_status(self, name: str) -> dict[str, Any]:
         root = self._topology_directory(name)
         status_path = root / "status.json"
@@ -7054,7 +7113,7 @@ class Workspace:
             "supervisor",
             "services",
         }
-        optional = {"stack", "providers", "sound"}
+        optional = {"stack", "providers", "sound", "control"}
         historical_record = isinstance(status, dict) and not (
             {"stack", "providers"} & set(status)
         )
@@ -7265,18 +7324,51 @@ class Workspace:
                         f"topology component identity is invalid: {name}/{component}"
                     )
         supervisor = status.get("supervisor")
+        control = status.get("control")
+        current_control = control is not None
+        if current_control and (
+            not isinstance(control, dict)
+            or set(control) != {"socket", "generation"}
+            or control.get("socket")
+            != str((root / TOPOLOGY_CONTROL_SOCKET).resolve())
+            or not isinstance(control.get("generation"), str)
+            or not re.fullmatch(r"[0-9a-f]{64}", control["generation"])
+        ):
+            raise WorkspaceError(f"topology control identity is invalid: {name}")
+        process_keys = (
+            {"pid", "start_time", "generation"}
+            if current_control
+            else {"pid", "start_time"}
+        )
         if (
             not isinstance(supervisor, dict)
-            or set(supervisor) != {"pid", "start_time"}
+            or set(supervisor) != process_keys
             or not isinstance(supervisor.get("pid"), int)
             or isinstance(supervisor.get("pid"), bool)
             or supervisor["pid"] <= 0
             or not isinstance(supervisor.get("start_time"), str)
             or not supervisor["start_time"].isdigit()
+            or current_control
+            and supervisor.get("generation") != control["generation"]
         ):
             raise WorkspaceError(f"topology supervisor status is invalid: {name}")
-        supervisor_running = self._recorded_process_running(supervisor)
+        control_reachable = bool(
+            current_control
+            and self._topology_control_request(name, control, "status")
+        )
+        process_tree_active = self._topology_process_tree_active(root)
+        supervisor_local = self._recorded_process_running(supervisor)
+        if control_reachable or supervisor_local:
+            supervisor_liveness = "live"
+        elif process_tree_active:
+            supervisor_liveness = "unreachable"
+        elif status.get("stopped_at") is not None:
+            supervisor_liveness = "exited"
+        else:
+            supervisor_liveness = "stale"
+        supervisor_running = supervisor_liveness in {"live", "unreachable"}
         supervisor["running"] = supervisor_running
+        supervisor["liveness"] = supervisor_liveness
         endpoint = status.get("endpoint")
         if endpoint is not None:
             fingerprint = endpoint.get("fingerprint") if isinstance(endpoint, dict) else None
@@ -7308,7 +7400,7 @@ class Workspace:
             if (
                 not isinstance(service, dict)
                 or set(service)
-                != {"pid", "start_time", "status", "exit_code", "log", "cwd"}
+                != process_keys | {"status", "exit_code", "log", "cwd"}
                 or not isinstance(service.get("pid"), int)
                 or isinstance(service.get("pid"), bool)
                 or service["pid"] <= 0
@@ -7326,14 +7418,28 @@ class Workspace:
                 or not Path(service["log"]).is_absolute()
                 or not isinstance(service.get("cwd"), str)
                 or not Path(service["cwd"]).is_absolute()
+                or current_control
+                and service.get("generation") != control["generation"]
             ):
                 raise WorkspaceError(f"topology service status is invalid: {name}")
-            service["running"] = self._recorded_process_running(service)
+            service_local = self._recorded_process_running(service)
+            if service.get("status") == "exited":
+                service_liveness = "exited"
+            elif control_reachable or service_local:
+                service_liveness = "live"
+            elif process_tree_active:
+                service_liveness = "unreachable"
+            elif status.get("stopped_at") is not None:
+                service_liveness = "exited"
+            else:
+                service_liveness = "stale"
+            service["liveness"] = service_liveness
+            service["running"] = service_liveness in {"live", "unreachable"}
             if (
                 service.get("status") in {"starting", "running"}
-                and not service["running"]
+                and service_liveness in {"stale", "exited"}
             ):
-                service["status"] = "stale"
+                service["status"] = service_liveness
         if (
             ("server" in services) != (endpoint is not None)
             or (
@@ -7345,6 +7451,29 @@ class Workspace:
             raise WorkspaceError(f"topology endpoint status is invalid: {name}")
         if not supervisor_running:
             status["ready"] = False
+        retained = process_tree_active or supervisor_running or any(
+            service["running"] for service in services.values()
+        )
+        if control_reachable:
+            safe_action = f"run ./atrinik down {name} from any supported session"
+        elif process_tree_active:
+            safe_action = (
+                "wait for bounded orphan recovery, then retry; if the control "
+                "endpoint remains unreachable, use the starting session"
+            )
+        else:
+            safe_action = f"restart topology {name} or retain its historical record"
+        status["observation"] = {
+            "control": (
+                "reachable" if control_reachable else "unreachable"
+                if current_control
+                else "legacy"
+            ),
+            "generation": control["generation"] if current_control else None,
+            "process_tree_lease": "retained" if retained else "released",
+            "repository_layout_lease_owner": name if retained else None,
+            "safe_action": safe_action,
+        }
         return status
 
     def topology_statuses(self) -> list[dict[str, Any]]:
@@ -7671,11 +7800,28 @@ class Workspace:
                     "build_root": str(root),
                     "resolved": resolved_status,
                     "endpoint": endpoint,
+                    "control": {
+                        "socket": str(
+                            (topology_root / TOPOLOGY_CONTROL_SOCKET).resolve()
+                        ),
+                        "generation": secrets.token_hex(32),
+                    },
                     "services": service_specs,
                 }
                 if sound_status is not None:
                     spec["sound"] = sound_status
                 spec_path = topology_root / "spec.json"
+                control_path = topology_root / TOPOLOGY_CONTROL_SOCKET
+                try:
+                    control_mode = control_path.lstat().st_mode
+                except FileNotFoundError:
+                    pass
+                else:
+                    if not stat.S_ISSOCK(control_mode):
+                        raise WorkspaceError(
+                            f"topology control endpoint is invalid: {name}"
+                        )
+                    control_path.unlink()
                 atomic_json(spec_path, spec)
                 status_path.unlink(missing_ok=True)
                 startup_error_path.unlink(missing_ok=True)
@@ -7781,6 +7927,8 @@ class Workspace:
             root / "operation.lock", f"topology {name} operation", nonblocking=True
         ):
             status = self.topology_status(name)
+            if "control" in status:
+                return self._controlled_topology_down(name, status, timeout)
             process_tree_path = root / TOPOLOGY_PROCESS_TREE_LEASE
             if process_tree_path.is_symlink():
                 raise WorkspaceError(
@@ -7849,6 +7997,31 @@ class Workspace:
             raise WorkspaceError(
                 f"topology did not stop within {timeout:g} seconds: {name}"
             )
+
+    def _controlled_topology_down(
+        self, name: str, status: dict[str, Any], timeout: float
+    ) -> dict[str, Any]:
+        root = self._topology_directory(name)
+        control = status["control"]
+        requested = self._topology_control_request(name, control, "stop")
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            current = self.topology_status(name)
+            active = self._topology_process_tree_active(root)
+            if not active and not current["supervisor"]["running"] and not any(
+                service["running"] for service in current["services"].values()
+            ):
+                return current
+            time.sleep(0.1)
+        if not requested:
+            raise WorkspaceError(
+                f"topology {name} retains the repository-layout lease but its "
+                "supervisor control endpoint is unreachable; wait for bounded "
+                "orphan recovery and retry, or run down from the starting session"
+            )
+        raise WorkspaceError(
+            f"topology did not stop within {timeout:g} seconds: {name}"
+        )
 
     def _legacy_topology_down(
         self, name: str, status: dict[str, Any], timeout: float

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -42,6 +42,7 @@ from .locking import (
 )
 from .process_tree import (
     bound_lease_locked,
+    control_socket_path,
     holders_exist,
     initialize_lease,
     lease_locked,
@@ -111,7 +112,6 @@ COMPILER_CACHE_PURPOSE = "compiler-cache"
 COMPILER_CACHE_MAX_SIZE = "5G"
 TOPOLOGY_SERVICES = ("server", "client")
 TOPOLOGY_PROCESS_TREE_LEASE = "process-tree.lease"
-TOPOLOGY_CONTROL_SOCKET = "control.sock"
 PRE_MONOREPO_REPOSITORIES = {
     "client": "legacy-client",
     "server": "legacy-server",
@@ -7020,24 +7020,19 @@ class Workspace:
                 or metadata.st_uid != os.geteuid()
             ):
                 return False
-            directory_fd = os.open(endpoint.parent, os.O_RDONLY | os.O_CLOEXEC)
-            try:
-                address = f"/proc/self/fd/{directory_fd}/{endpoint.name}"
-                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
-                    client.settimeout(0.5)
-                    client.connect(address)
-                    client.sendall(json.dumps(request, sort_keys=True).encode())
-                    client.shutdown(socket.SHUT_WR)
-                    payload = bytearray()
-                    while len(payload) <= 4096:
-                        chunk = client.recv(4097 - len(payload))
-                        if not chunk:
-                            break
-                        payload.extend(chunk)
-                        if b"\n" in chunk:
-                            break
-            finally:
-                os.close(directory_fd)
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+                client.settimeout(0.5)
+                client.connect(str(endpoint))
+                client.sendall(json.dumps(request, sort_keys=True).encode())
+                client.shutdown(socket.SHUT_WR)
+                payload = bytearray()
+                while len(payload) <= 4096:
+                    chunk = client.recv(4097 - len(payload))
+                    if not chunk:
+                        break
+                    payload.extend(chunk)
+                    if b"\n" in chunk:
+                        break
             if len(payload) > 4096:
                 return False
             response = json.loads(payload)
@@ -7306,10 +7301,10 @@ class Workspace:
         if current_control and (
             not isinstance(control, dict)
             or set(control) != {"socket", "generation", "lease"}
-            or control.get("socket")
-            != str((root / TOPOLOGY_CONTROL_SOCKET).resolve())
             or not isinstance(control.get("generation"), str)
             or not re.fullmatch(r"[0-9a-f]{64}", control["generation"])
+            or control.get("socket")
+            != str(control_socket_path(root, control["generation"]))
             or not isinstance(control.get("lease"), dict)
             or set(control["lease"]) != {"device", "inode"}
             or not all(
@@ -7428,7 +7423,8 @@ class Workspace:
             ):
                 service["status"] = service_liveness
         if (
-            ("server" in services) != (endpoint is not None)
+            not status.get("error")
+            and ("server" in services) != (endpoint is not None)
             or (
                 status["ready"]
                 and endpoint is not None
@@ -7615,7 +7611,12 @@ class Workspace:
                     os.O_RDWR | os.O_CREAT,
                     "topology process-tree lease",
                 )
-                stack.callback(os.close, process_tree_fd)
+                process_tree_owner = [process_tree_fd]
+                stack.callback(
+                    lambda: os.close(process_tree_owner.pop())
+                    if process_tree_owner
+                    else None
+                )
                 try:
                     fcntl.flock(
                         process_tree_fd, fcntl.LOCK_EX | fcntl.LOCK_NB
@@ -7630,8 +7631,27 @@ class Workspace:
                     ) from error
                 if holders_exist(process_tree_fd, exclude=(os.getpid(),)):
                     raise WorkspaceError(f"topology is already running: {name}")
-                generation = secrets.token_hex(32)
+                for _attempt in range(16):
+                    generation = secrets.token_hex(32)
+                    control_path = control_socket_path(topology_root, generation)
+                    if not control_path.exists() and not control_path.is_symlink():
+                        break
+                else:
+                    raise WorkspaceError(
+                        "cannot allocate a unique topology control endpoint"
+                    )
                 lease_identity = initialize_lease(process_tree_fd, generation)
+                control_directory = control_path.parent
+                control_directory.mkdir(mode=0o700, exist_ok=True)
+                control_metadata = control_directory.lstat()
+                if (
+                    not stat.S_ISDIR(control_metadata.st_mode)
+                    or stat.S_IMODE(control_metadata.st_mode) != 0o700
+                    or control_metadata.st_uid != os.geteuid()
+                ):
+                    raise WorkspaceError(
+                        f"topology control directory is invalid: {control_directory}"
+                    )
 
                 state_location: Path | None = None
                 state_lock: TextIO | None = None
@@ -7794,9 +7814,7 @@ class Workspace:
                     "resolved": resolved_status,
                     "endpoint": endpoint,
                     "control": {
-                        "socket": str(
-                            (topology_root / TOPOLOGY_CONTROL_SOCKET).resolve()
-                        ),
+                        "socket": str(control_path),
                         "generation": generation,
                         "lease": lease_identity,
                     },
@@ -7805,17 +7823,14 @@ class Workspace:
                 if sound_status is not None:
                     spec["sound"] = sound_status
                 spec_path = topology_root / "spec.json"
-                control_path = topology_root / TOPOLOGY_CONTROL_SOCKET
                 try:
                     control_mode = control_path.lstat().st_mode
                 except FileNotFoundError:
                     pass
                 else:
-                    if not stat.S_ISSOCK(control_mode):
-                        raise WorkspaceError(
-                            f"topology control endpoint is invalid: {name}"
-                        )
-                    control_path.unlink()
+                    raise WorkspaceError(
+                        f"topology control endpoint already exists: {control_path}"
+                    )
                 atomic_json(spec_path, spec)
                 status_path.unlink(missing_ok=True)
                 startup_error_path.unlink(missing_ok=True)
@@ -7874,6 +7889,7 @@ class Workspace:
                         start_new_session=True,
                         pass_fds=tuple(inherited_locks),
                     )
+                    os.close(process_tree_owner.pop())
                 except OSError as error:
                     raise WorkspaceError(f"cannot start topology supervisor: {error}") from error
                 finally:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -7445,8 +7445,8 @@ class Workspace:
             safe_action = f"run ./atrinik down {name} from any supported session"
         elif process_tree_active:
             safe_action = (
-                "wait for bounded orphan recovery, then retry; if the control "
-                "endpoint remains unreachable, use the starting session"
+                "wait for bounded orphan recovery, then retry; if the exact "
+                "lease remains retained, preserve it for operator diagnosis"
             )
         else:
             safe_action = f"restart topology {name} or retain its historical record"
@@ -8034,7 +8034,8 @@ class Workspace:
             raise WorkspaceError(
                 f"topology {name} retains the repository-layout lease but its "
                 "supervisor control endpoint is unreachable; wait for bounded "
-                "orphan recovery and retry, or run down from the starting session"
+                "orphan recovery and retry; preserve a retained exact lease "
+                "for operator diagnosis"
             )
         raise WorkspaceError(
             f"topology did not stop within {timeout:g} seconds: {name}"

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -7635,10 +7635,6 @@ class Workspace:
                     ) from error
                 if holders_exist(process_tree_fd, exclude=(os.getpid(),)):
                     raise WorkspaceError(f"topology is already running: {name}")
-                # The operation lock serializes lifecycle mutation. Retire the
-                # stopped generation before rebinding its lease inode so status
-                # readers never compare old identity with new lease contents.
-                status_path.unlink(missing_ok=True)
                 for _attempt in range(16):
                     generation = secrets.token_hex(32)
                     control_path = control_socket_path(topology_root, generation)
@@ -7648,7 +7644,6 @@ class Workspace:
                     raise WorkspaceError(
                         "cannot allocate a unique topology control endpoint"
                     )
-                lease_identity = initialize_lease(process_tree_fd, generation)
                 control_directory = control_path.parent
                 control_directory.mkdir(mode=0o700, exist_ok=True)
                 control_metadata = control_directory.lstat()
@@ -7807,6 +7802,11 @@ class Workspace:
                 resolved_status = self._topology_resolved_status(
                     profile_name, selected
                 )
+                # All fallible preparation is complete. Retire the stopped
+                # record and bind/publish the new generation without exposing
+                # old status against rewritten lease contents.
+                status_path.unlink(missing_ok=True)
+                lease_identity = initialize_lease(process_tree_fd, generation)
                 spec: dict[str, Any] = {
                     "schema_version": SCHEMA_VERSION,
                     "name": name,

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -40,7 +40,13 @@ from .locking import (
     shared_layout_lock,
     shared_lock,
 )
-from .process_tree import holders_exist, lease_locked, signal_holders
+from .process_tree import (
+    bound_lease_locked,
+    holders_exist,
+    initialize_lease,
+    lease_locked,
+    signal_holders,
+)
 
 from .model import (
     MANAGED_MARKER,
@@ -7014,19 +7020,24 @@ class Workspace:
                 or metadata.st_uid != os.geteuid()
             ):
                 return False
-            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
-                client.settimeout(0.5)
-                client.connect(str(endpoint))
-                client.sendall(json.dumps(request, sort_keys=True).encode())
-                client.shutdown(socket.SHUT_WR)
-                payload = bytearray()
-                while len(payload) <= 4096:
-                    chunk = client.recv(4097 - len(payload))
-                    if not chunk:
-                        break
-                    payload.extend(chunk)
-                    if b"\n" in chunk:
-                        break
+            directory_fd = os.open(endpoint.parent, os.O_RDONLY | os.O_CLOEXEC)
+            try:
+                address = f"/proc/self/fd/{directory_fd}/{endpoint.name}"
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+                    client.settimeout(0.5)
+                    client.connect(address)
+                    client.sendall(json.dumps(request, sort_keys=True).encode())
+                    client.shutdown(socket.SHUT_WR)
+                    payload = bytearray()
+                    while len(payload) <= 4096:
+                        chunk = client.recv(4097 - len(payload))
+                        if not chunk:
+                            break
+                        payload.extend(chunk)
+                        if b"\n" in chunk:
+                            break
+            finally:
+                os.close(directory_fd)
             if len(payload) > 4096:
                 return False
             response = json.loads(payload)
@@ -7041,11 +7052,17 @@ class Workspace:
         )
 
     @staticmethod
-    def _topology_process_tree_active(root: Path) -> bool:
+    def _topology_process_tree_active(
+        root: Path, control: dict[str, Any] | None = None
+    ) -> bool:
         path = root / TOPOLOGY_PROCESS_TREE_LEASE
-        if path.is_symlink() or not path.is_file():
+        if control is None and (path.is_symlink() or not path.is_file()):
             return False
         try:
+            if control is not None:
+                return bound_lease_locked(
+                    path, control["generation"], control["lease"]
+                )
             return lease_locked(path)
         except OSError as error:
             raise WorkspaceError(
@@ -7288,11 +7305,19 @@ class Workspace:
         current_control = control is not None
         if current_control and (
             not isinstance(control, dict)
-            or set(control) != {"socket", "generation"}
+            or set(control) != {"socket", "generation", "lease"}
             or control.get("socket")
             != str((root / TOPOLOGY_CONTROL_SOCKET).resolve())
             or not isinstance(control.get("generation"), str)
             or not re.fullmatch(r"[0-9a-f]{64}", control["generation"])
+            or not isinstance(control.get("lease"), dict)
+            or set(control["lease"]) != {"device", "inode"}
+            or not all(
+                isinstance(value, int)
+                and not isinstance(value, bool)
+                and value >= 0
+                for value in control["lease"].values()
+            )
         ):
             raise WorkspaceError(f"topology control identity is invalid: {name}")
         process_keys = (
@@ -7316,7 +7341,9 @@ class Workspace:
             current_control
             and self._topology_control_request(name, control, "status")
         )
-        process_tree_active = self._topology_process_tree_active(root)
+        process_tree_active = self._topology_process_tree_active(
+            root, control if current_control else None
+        )
         supervisor_local = self._recorded_process_running(supervisor)
         if control_reachable or supervisor_local:
             supervisor_liveness = "live"
@@ -7438,11 +7465,15 @@ class Workspace:
 
     def topology_statuses(self) -> list[dict[str, Any]]:
         self.paths.ensure()
-        statuses: list[dict[str, Any]] = []
-        for path in sorted(self.paths.topologies.iterdir()):
-            if path.is_dir() and not path.is_symlink() and (path / "status.json").is_file():
-                statuses.append(self.topology_status(path.name))
-        return statuses
+        names = [
+            path.name
+            for path in sorted(self.paths.topologies.iterdir())
+            if path.is_dir()
+            and not path.is_symlink()
+            and (path / "status.json").is_file()
+        ]
+        with ThreadPoolExecutor(max_workers=min(8, len(names) or 1)) as executor:
+            return list(executor.map(self.topology_status, names))
 
     @staticmethod
     def _select_topology_port(requested: int | None) -> int:
@@ -7599,6 +7630,8 @@ class Workspace:
                     ) from error
                 if holders_exist(process_tree_fd, exclude=(os.getpid(),)):
                     raise WorkspaceError(f"topology is already running: {name}")
+                generation = secrets.token_hex(32)
+                lease_identity = initialize_lease(process_tree_fd, generation)
 
                 state_location: Path | None = None
                 state_lock: TextIO | None = None
@@ -7764,7 +7797,8 @@ class Workspace:
                         "socket": str(
                             (topology_root / TOPOLOGY_CONTROL_SOCKET).resolve()
                         ),
-                        "generation": secrets.token_hex(32),
+                        "generation": generation,
+                        "lease": lease_identity,
                     },
                     "services": service_specs,
                 }
@@ -7967,7 +8001,7 @@ class Workspace:
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             current = self.topology_status(name)
-            active = self._topology_process_tree_active(root)
+            active = self._topology_process_tree_active(root, control)
             if not active and not current["supervisor"]["running"] and not any(
                 service["running"] for service in current["services"].values()
             ):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -615,11 +615,25 @@ descriptor through a short forking bootstrap to a detached native supervisor
 and its server child. The lock remains held for the server lifetime without a
 long-lived invoking CLI process.
 
-The supervisor owns child lifetimes and size-bounded rotating logs. Status
-records include Linux process start ticks in addition to PIDs; `ps` and `down`
-require both to match, preventing an old status file from targeting an
-unrelated reused PID. Shutdown signals the supervisor, which gracefully stops
-children before releasing state. For a paired topology it starts the server
+The supervisor owns child lifetimes and size-bounded rotating logs. Each
+current status record binds the namespace-local supervisor and service
+PID/start-tick coordinates to one random topology generation and mode-0600
+filesystem Unix control endpoint. `ps` probes that name/generation endpoint,
+so another supported sandbox sharing the workspace can distinguish `live`,
+`exited`, `stale`, and fail-closed `unreachable` processes without resolving
+their PID namespace. The independently observable process-tree generation
+lease identifies the exact topology retaining the repository-layout lease and
+keeps an unreachable process tree active rather than mislabeled stale.
+
+`down` requests shutdown only through an exact matching current-generation
+endpoint; it never signals a namespace-local, recycled, or unrelated PID.
+Legacy records retain the PID/start-tick fallback. A same-namespace guardian
+holds the process-tree generation until every inherited descendant is gone. If
+the supervisor dies, pipe closure makes the guardian terminate only holders of
+that exact lease, then release it within a bounded interval; another namespace
+waits or fails closed with the owning topology and recovery action. Normal
+shutdown asks the supervisor to gracefully stop children before releasing
+state. For a paired topology it starts the server
 first, waits for its fingerprint and final ready signal, and then pins the
 client to that authenticated loopback endpoint. Available UDP ports are
 allocated under a workspace-wide lock, or callers may request an explicit

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -646,8 +646,10 @@ reuse while holders of an unlinked lease remain alive.
 endpoint; it never signals a namespace-local, recycled, or unrelated PID.
 Legacy records retain the PID/start-tick fallback. A same-namespace guardian
 holds the process-tree generation until every inherited descendant is gone. If
-the supervisor dies, pipe closure makes the guardian terminate only holders of
-that exact lease, then release it within a bounded interval; another namespace
+the supervisor dies, pipe closure makes the guardian terminate exact lease
+holders and pidfd-revalidated members of registered service groups, including
+descendants that closed the lease. It retains the generation until absence is
+proven; another namespace
 waits or fails closed with the owning topology and recovery action. Normal
 shutdown asks the supervisor to gracefully stop children before releasing
 state. For a paired topology it starts the server

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -647,9 +647,10 @@ endpoint; it never signals a namespace-local, recycled, or unrelated PID.
 Legacy records retain the PID/start-tick fallback. A same-namespace guardian
 holds the process-tree generation until every inherited descendant is gone. If
 the supervisor dies, pipe closure makes the guardian terminate exact lease
-holders and pidfd-revalidated members of registered service groups, including
-descendants that closed the lease. It retains the generation until absence is
-proven; another namespace
+holders and retain the generation until their absence is proven. Layout,
+build, and state leases remain supervisor-owned rather than service-inherited,
+so a descendant that closes its process-tree identity cannot retain those
+workspace leases. Another namespace
 waits or fails closed with the owning topology and recovery action. Normal
 shutdown asks the supervisor to gracefully stop children before releasing
 state. For a paired topology it starts the server

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -635,9 +635,9 @@ PID/start-tick coordinates to one random topology generation and mode-0600
 filesystem Unix control endpoint. `ps` probes that name/generation endpoint,
 so another supported sandbox sharing the workspace can distinguish `live`,
 `exited`, `stale`, and fail-closed `unreachable` processes without resolving
-their PID namespace. Bind and connect use a bounded descriptor-relative socket
-address, so the canonical managed endpoint remains usable below arbitrarily
-deep supported worktree paths. The independently observable process-tree lease
+their PID namespace. The endpoint uses a short generation-derived name in the
+shared workspace, avoiding topology-name and ordinary managed-worktree path
+growth. The independently observable process-tree lease
 is bound to the status generation and exact file identity. Missing, replaced,
 or malformed current leases fail closed instead of allowing topology-name
 reuse while holders of an unlinked lease remain alive.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -648,9 +648,10 @@ Legacy records retain the PID/start-tick fallback. A same-namespace guardian
 holds the process-tree generation until every inherited descendant is gone. If
 the supervisor dies, pipe closure makes the guardian terminate exact lease
 holders and retain the generation until their absence is proven. Layout,
-build, and state leases remain supervisor-owned rather than service-inherited,
-so a descendant that closes its process-tree identity cannot retain those
-workspace leases. Another namespace
+build, and state leases remain held by the supervisor and guardian rather than
+service-inherited, so a descendant that closes its process-tree identity cannot
+retain those workspace leases. The guardian releases them only after exact
+process-tree recovery completes. Another namespace
 waits or fails closed with the owning topology and recovery action. Normal
 shutdown asks the supervisor to gracefully stop children before releasing
 state. For a paired topology it starts the server

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -635,9 +635,12 @@ PID/start-tick coordinates to one random topology generation and mode-0600
 filesystem Unix control endpoint. `ps` probes that name/generation endpoint,
 so another supported sandbox sharing the workspace can distinguish `live`,
 `exited`, `stale`, and fail-closed `unreachable` processes without resolving
-their PID namespace. The independently observable process-tree generation
-lease identifies the exact topology retaining the repository-layout lease and
-keeps an unreachable process tree active rather than mislabeled stale.
+their PID namespace. Bind and connect use a bounded descriptor-relative socket
+address, so the canonical managed endpoint remains usable below arbitrarily
+deep supported worktree paths. The independently observable process-tree lease
+is bound to the status generation and exact file identity. Missing, replaced,
+or malformed current leases fail closed instead of allowing topology-name
+reuse while holders of an unlinked lease remain alive.
 
 `down` requests shutdown only through an exact matching current-generation
 endpoint; it never signals a namespace-local, recycled, or unrelated PID.

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -33,6 +33,7 @@ from atrinik_workspace.model import (
     managed_directory,
     managed_remove as real_managed_remove,
 )
+from atrinik_workspace.process_tree import initialize_lease
 from atrinik_workspace.workspace import (
     WORKER_DEPENDENCY_SCHEMA_VERSION,
     Workspace,
@@ -2132,6 +2133,12 @@ class CleanupTests(unittest.TestCase):
         worktree = self.make_component_worktree()
         topology = self.workspace.paths.topologies / "live-current"
         topology.mkdir()
+        lease_fd = os.open(
+            topology / "process-tree.lease", os.O_RDWR | os.O_CREAT, 0o600
+        )
+        fcntl.flock(lease_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        generation = "a" * 64
+        lease = initialize_lease(lease_fd, generation)
         atomic_json(
             topology / MANAGED_MARKER,
             {"schema_version": SCHEMA_VERSION, "purpose": "topology:live-current"},
@@ -2144,7 +2151,16 @@ class CleanupTests(unittest.TestCase):
                 "stack": "default",
                 "providers": {"client": "client"},
                 "dependencies": ["client"],
-                "supervisor": {"pid": 123, "start_time": "1"},
+                "control": {
+                    "socket": str((topology / "control.sock").resolve()),
+                    "generation": generation,
+                    "lease": lease,
+                },
+                "supervisor": {
+                    "pid": 123,
+                    "start_time": "1",
+                    "generation": generation,
+                },
                 "services": {},
                 "build_root": str(self.workspace.paths.builds / "profiles" / "live"),
                 "resolved": {
@@ -2162,10 +2178,15 @@ class CleanupTests(unittest.TestCase):
             },
         )
 
-        with mock.patch(
-            "atrinik_workspace.cleanup.process_matches", return_value=True
-        ), mock.patch.object(Cleanup, "_github_pulls") as pulls:
-            report = self.workspace.cleanup(["worktrees"], 0, ["client"], False)
+        try:
+            with mock.patch(
+                "atrinik_workspace.cleanup.process_matches", return_value=False
+            ), mock.patch.object(Cleanup, "_github_pulls") as pulls:
+                report = self.workspace.cleanup(
+                    ["worktrees"], 0, ["client"], False
+                )
+        finally:
+            os.close(lease_fd)
 
         item = next(row for row in report["items"] if row["path"] == str(worktree))
         self.assertIn("topology_reference", item["reasons"])

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -33,7 +33,7 @@ from atrinik_workspace.model import (
     managed_directory,
     managed_remove as real_managed_remove,
 )
-from atrinik_workspace.process_tree import initialize_lease
+from atrinik_workspace.process_tree import control_socket_path, initialize_lease
 from atrinik_workspace.workspace import (
     WORKER_DEPENDENCY_SCHEMA_VERSION,
     Workspace,
@@ -2152,7 +2152,7 @@ class CleanupTests(unittest.TestCase):
                 "providers": {"client": "client"},
                 "dependencies": ["client"],
                 "control": {
-                    "socket": str((topology / "control.sock").resolve()),
+                    "socket": str(control_socket_path(topology, generation)),
                     "generation": generation,
                     "lease": lease,
                 },

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -2180,7 +2180,7 @@ class CleanupTests(unittest.TestCase):
 
         try:
             with mock.patch(
-                "atrinik_workspace.cleanup.process_matches", return_value=False
+                "atrinik_workspace.cleanup.process_matches", return_value=True
             ), mock.patch.object(Cleanup, "_github_pulls") as pulls:
                 report = self.workspace.cleanup(
                     ["worktrees"], 0, ["client"], False

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -372,6 +372,34 @@ class CompletionTests(unittest.TestCase):
 
         status_path = self.workspace / "topologies" / "completion-review" / "status.json"
         status = json.loads(status_path.read_text(encoding="utf-8"))
+        generation = "d" * 64
+        status["control"] = {
+            "socket": str(
+                self.workspace
+                / "topologies"
+                / "completion-review"
+                / "control.sock"
+            ),
+            "generation": generation,
+            "lease": {"device": 1, "inode": 2},
+        }
+        status["supervisor"]["generation"] = generation
+        status["services"]["server"]["generation"] = generation
+        self.write_json(status_path, status)
+        self.assertEqual(
+            self.candidates("logs", ""),
+            ("candidates", ["completion-review"]),
+        )
+        status["control"]["socket"] = "/tmp/external/control.sock"
+        self.write_json(status_path, status)
+        self.assertEqual(self.candidates("logs", ""), ("candidates", []))
+        status["control"]["socket"] = str(
+            self.workspace
+            / "topologies"
+            / "completion-review"
+            / "control.sock"
+        )
+
         status["profile"] = "deleted-profile"
         self.write_json(status_path, status)
         self.assertEqual(

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -16,6 +16,7 @@ from unittest import mock
 
 from atrinik_workspace.cli import main, parser
 from atrinik_workspace import completion
+from atrinik_workspace.process_tree import control_socket_path
 from atrinik_workspace.completion import classified_actions, complete, shell_script
 from atrinik_workspace.model import Manifest
 
@@ -375,10 +376,10 @@ class CompletionTests(unittest.TestCase):
         generation = "d" * 64
         status["control"] = {
             "socket": str(
-                self.workspace
-                / "topologies"
-                / "completion-review"
-                / "control.sock"
+                control_socket_path(
+                    self.workspace / "topologies" / "completion-review",
+                    generation,
+                )
             ),
             "generation": generation,
             "lease": {"device": 1, "inode": 2},
@@ -394,10 +395,10 @@ class CompletionTests(unittest.TestCase):
         self.write_json(status_path, status)
         self.assertEqual(self.candidates("logs", ""), ("candidates", []))
         status["control"]["socket"] = str(
-            self.workspace
-            / "topologies"
-            / "completion-review"
-            / "control.sock"
+            control_socket_path(
+                self.workspace / "topologies" / "completion-review",
+                generation,
+            )
         )
 
         status["profile"] = "deleted-profile"

--- a/tests/test_content_migration.py
+++ b/tests/test_content_migration.py
@@ -18,7 +18,7 @@ from atrinik_workspace.locking import (
     layout_writer_intent_path,
     layout_writer_pending_path,
 )
-from atrinik_workspace.process_tree import initialize_lease
+from atrinik_workspace.process_tree import control_socket_path, initialize_lease
 from atrinik_workspace.workspace import Workspace
 
 
@@ -573,7 +573,7 @@ class ContentMigrationTests(unittest.TestCase):
                     "stack": "classic",
                     "profile": "classic-review",
                     "control": {
-                        "socket": str((topology / "control.sock").resolve()),
+                        "socket": str(control_socket_path(topology, generation)),
                         "generation": generation,
                         "lease": lease,
                     },

--- a/tests/test_content_migration.py
+++ b/tests/test_content_migration.py
@@ -18,6 +18,7 @@ from atrinik_workspace.locking import (
     layout_writer_intent_path,
     layout_writer_pending_path,
 )
+from atrinik_workspace.process_tree import initialize_lease
 from atrinik_workspace.workspace import Workspace
 
 
@@ -560,22 +561,46 @@ class ContentMigrationTests(unittest.TestCase):
         self._legacy_profile()
         topology = self.workspace.paths.topologies / "live-classic"
         topology.mkdir()
+        lease_fd = os.open(
+            topology / "process-tree.lease", os.O_RDWR | os.O_CREAT, 0o600
+        )
+        fcntl.flock(lease_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        generation = "a" * 64
+        lease = initialize_lease(lease_fd, generation)
         (topology / "status.json").write_text(
             json.dumps(
                 {
                     "stack": "classic",
                     "profile": "classic-review",
-                    "supervisor": {"pid": 100, "start_time": "1"},
+                    "control": {
+                        "socket": str((topology / "control.sock").resolve()),
+                        "generation": generation,
+                        "lease": lease,
+                    },
+                    "supervisor": {
+                        "pid": 100,
+                        "start_time": "1",
+                        "generation": generation,
+                    },
                     "services": {
-                        "server": {"pid": 101, "start_time": "2"}
+                        "server": {
+                            "pid": 101,
+                            "start_time": "2",
+                            "generation": generation,
+                        }
                     },
                 }
             ),
             encoding="utf-8",
         )
 
-        with mock.patch.object(migration_module, "process_matches", return_value=True):
-            result = self.migration().execute("apply")
+        try:
+            with mock.patch.object(
+                migration_module, "process_matches", return_value=False
+            ):
+                result = self.migration().execute("apply")
+        finally:
+            os.close(lease_fd)
 
         self.assertEqual(result["status"], "refused")
         self.assertIn("live_topology", {row["code"] for row in result["refusals"]})

--- a/tests/test_content_migration.py
+++ b/tests/test_content_migration.py
@@ -596,7 +596,7 @@ class ContentMigrationTests(unittest.TestCase):
 
         try:
             with mock.patch.object(
-                migration_module, "process_matches", return_value=False
+                migration_module, "process_matches", return_value=True
             ):
                 result = self.migration().execute("apply")
         finally:

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1386,7 +1386,7 @@ class RepositoryMigrationTests(unittest.TestCase):
 
         try:
             with mock.patch.object(
-                migration_module, "process_matches", return_value=False
+                migration_module, "process_matches", return_value=True
             ):
                 result = self.migration().execute("apply")
         finally:

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -21,7 +21,7 @@ from atrinik_workspace.locking import (
 )
 from atrinik_workspace.migration import RepositoryMigration
 from atrinik_workspace.model import Paths, WorkspaceError
-from atrinik_workspace.process_tree import initialize_lease
+from atrinik_workspace.process_tree import control_socket_path, initialize_lease
 
 
 def command(
@@ -1368,7 +1368,7 @@ class RepositoryMigrationTests(unittest.TestCase):
                     "started_at": "now",
                     "stopped_at": None,
                     "control": {
-                        "socket": str((topology / "control.sock").resolve()),
+                        "socket": str(control_socket_path(topology, generation)),
                         "generation": generation,
                         "lease": lease,
                     },

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -21,6 +21,7 @@ from atrinik_workspace.locking import (
 )
 from atrinik_workspace.migration import RepositoryMigration
 from atrinik_workspace.model import Paths, WorkspaceError
+from atrinik_workspace.process_tree import initialize_lease
 
 
 def command(
@@ -1346,6 +1347,12 @@ class RepositoryMigrationTests(unittest.TestCase):
         self.make_classic({"client": source})
         topology = self.paths.topologies / "live"
         topology.mkdir(parents=True)
+        lease_fd = os.open(
+            topology / "process-tree.lease", os.O_RDWR | os.O_CREAT, 0o600
+        )
+        fcntl.flock(lease_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        generation = "a" * 64
+        lease = initialize_lease(lease_fd, generation)
         (topology / "status.json").write_text(
             json.dumps(
                 {
@@ -1360,7 +1367,16 @@ class RepositoryMigrationTests(unittest.TestCase):
                     "ready": False,
                     "started_at": "now",
                     "stopped_at": None,
-                    "supervisor": {"pid": 123, "start_time": "1"},
+                    "control": {
+                        "socket": str((topology / "control.sock").resolve()),
+                        "generation": generation,
+                        "lease": lease,
+                    },
+                    "supervisor": {
+                        "pid": 123,
+                        "start_time": "1",
+                        "generation": generation,
+                    },
                     "services": {},
                 }
             )
@@ -1368,8 +1384,13 @@ class RepositoryMigrationTests(unittest.TestCase):
             encoding="utf-8",
         )
 
-        with mock.patch.object(migration_module, "process_matches", return_value=True):
-            result = self.migration().execute("apply")
+        try:
+            with mock.patch.object(
+                migration_module, "process_matches", return_value=False
+            ):
+                result = self.migration().execute("apply")
+        finally:
+            os.close(lease_fd)
 
         self.assertEqual(result["status"], "refused")
         self.assertIn("live_topology", {row["code"] for row in result["refusals"]})

--- a/tests/test_process_tree.py
+++ b/tests/test_process_tree.py
@@ -23,6 +23,41 @@ class ProcessTreeIdentityTests(unittest.TestCase):
             finally:
                 os.close(descriptor)
 
+    def test_bound_lease_rejects_replacement_and_generation_reuse(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "process-tree.lease"
+            descriptor = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                identity = process_tree.initialize_lease(descriptor, "a" * 64)
+                self.assertTrue(
+                    process_tree.bound_lease_locked(path, "a" * 64, identity)
+                )
+                path.unlink()
+                path.write_text("a" * 64 + "\n", encoding="utf-8")
+                with self.assertRaisesRegex(OSError, "identity changed"):
+                    process_tree.bound_lease_locked(path, "a" * 64, identity)
+            finally:
+                os.close(descriptor)
+
+    def test_bound_lease_rejects_missing_symlink_and_changed_generation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            path = root / "process-tree.lease"
+            descriptor = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+            identity = process_tree.initialize_lease(descriptor, "a" * 64)
+            os.close(descriptor)
+            with self.assertRaisesRegex(OSError, "generation changed"):
+                process_tree.bound_lease_locked(path, "b" * 64, identity)
+            path.unlink()
+            with self.assertRaises(FileNotFoundError):
+                process_tree.bound_lease_locked(path, "a" * 64, identity)
+            target = root / "target"
+            target.write_text("a" * 64 + "\n", encoding="utf-8")
+            path.symlink_to(target)
+            with self.assertRaises(OSError):
+                process_tree.bound_lease_locked(path, "a" * 64, identity)
+
     def test_malformed_fdinfo_is_ignored(self) -> None:
         descriptor = mock.Mock()
         descriptor.name = "7"

--- a/tests/test_process_tree.py
+++ b/tests/test_process_tree.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import fcntl
 import os
 from pathlib import Path
+import tempfile
 from types import SimpleNamespace
 import unittest
 from unittest import mock
@@ -10,6 +12,17 @@ from atrinik_workspace import process_tree
 
 
 class ProcessTreeIdentityTests(unittest.TestCase):
+    def test_lease_lock_is_namespace_independent_liveness_coordinate(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "process-tree.lease"
+            descriptor = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+            try:
+                self.assertFalse(process_tree.lease_locked(path))
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                self.assertTrue(process_tree.lease_locked(path))
+            finally:
+                os.close(descriptor)
+
     def test_malformed_fdinfo_is_ignored(self) -> None:
         descriptor = mock.Mock()
         descriptor.name = "7"

--- a/tests/test_process_tree.py
+++ b/tests/test_process_tree.py
@@ -88,9 +88,17 @@ class ProcessTreeIdentityTests(unittest.TestCase):
 
         with (
             mock.patch.object(Path, "iterdir", return_value=[descriptor]),
-            mock.patch.object(Path, "read_text", return_value="flags:\t0\n"),
+            mock.patch.object(
+                Path, "read_text", return_value=f"flags:\t{os.O_RDWR:o}\n"
+            ),
         ):
             self.assertTrue(process_tree._holds_identity(123, (11, 22)))
+
+        with (
+            mock.patch.object(Path, "iterdir", return_value=[descriptor]),
+            mock.patch.object(Path, "read_text", return_value="flags:\t0\n"),
+        ):
+            self.assertFalse(process_tree._holds_identity(123, (11, 22)))
 
 
 if __name__ == "__main__":

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -15,11 +15,37 @@ from atrinik_workspace import supervisor as supervisor_module
 from atrinik_workspace.supervisor import (
     ServerReadinessCapture,
     _initial_status,
+    _open_control,
+    _receive_control,
     supervise,
 )
 
 
 class ServerReadinessCaptureTests(unittest.TestCase):
+    def test_control_messages_are_bounded_and_may_arrive_in_chunks(self) -> None:
+        connection = mock.Mock()
+        connection.recv.side_effect = [b'{"action": "sta', b'tus"}\n']
+
+        self.assertEqual(_receive_control(connection), {"action": "status"})
+
+        oversized = mock.Mock()
+        oversized.recv.return_value = b"x" * 4097
+        with self.assertRaisesRegex(ValueError, "too large"):
+            _receive_control(oversized)
+
+    def test_control_endpoint_is_fixed_below_topology_root(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            spec = {
+                "control": {
+                    "socket": str(root.parent / "unowned.sock"),
+                    "generation": "a" * 64,
+                }
+            }
+
+            with self.assertRaisesRegex(RuntimeError, "identity is invalid"):
+                _open_control(spec, root)
+
     def test_peek_exit_code_observes_without_reaping(self) -> None:
         process = mock.Mock(pid=1234, returncode=7)
         with mock.patch.object(supervisor_module.os, "waitid", return_value=None):

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -40,11 +40,33 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                 "control": {
                     "socket": str(root.parent / "unowned.sock"),
                     "generation": "a" * 64,
+                    "lease": {"device": 1, "inode": 2},
                 }
             }
 
             with self.assertRaisesRegex(RuntimeError, "identity is invalid"):
                 _open_control(spec, root)
+
+    def test_control_endpoint_supports_long_managed_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / ("managed-" + "x" * 110)
+            root.mkdir()
+            control = root / "control.sock"
+            spec = {
+                "control": {
+                    "socket": str(control.resolve()),
+                    "generation": "a" * 64,
+                    "lease": {"device": 1, "inode": 2},
+                }
+            }
+
+            endpoint = _open_control(spec, root)
+            try:
+                self.assertTrue(control.is_socket())
+            finally:
+                assert endpoint is not None
+                endpoint.close()
+                control.unlink()
 
     def test_peek_exit_code_observes_without_reaping(self) -> None:
         process = mock.Mock(pid=1234, returncode=7)

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -4,9 +4,11 @@ import json
 import os
 from pathlib import Path
 import signal
+import socket
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import unittest
 from unittest import mock
@@ -17,8 +19,10 @@ from atrinik_workspace.supervisor import (
     _initial_status,
     _open_control,
     _receive_control,
+    _serve_control,
     supervise,
 )
+from atrinik_workspace.process_tree import control_socket_path
 
 
 class ServerReadinessCaptureTests(unittest.TestCase):
@@ -49,13 +53,16 @@ class ServerReadinessCaptureTests(unittest.TestCase):
 
     def test_control_endpoint_supports_long_managed_paths(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory) / ("managed-" + "x" * 110)
-            root.mkdir()
-            control = root / "control.sock"
+            workspace = Path(directory) / "workspace"
+            root = workspace / "topologies" / ("managed-" + "x" * 110)
+            root.mkdir(parents=True)
+            generation = "a" * 64
+            control = control_socket_path(root, generation)
+            control.parent.mkdir(mode=0o700)
             spec = {
                 "control": {
-                    "socket": str(control.resolve()),
-                    "generation": "a" * 64,
+                    "socket": str(control),
+                    "generation": generation,
                     "lease": {"device": 1, "inode": 2},
                 }
             }
@@ -67,6 +74,55 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                 assert endpoint is not None
                 endpoint.close()
                 control.unlink()
+
+    def test_control_endpoint_drains_concurrent_status_requests(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "workspace" / "topologies" / "review"
+            root.mkdir(parents=True)
+            generation = "a" * 64
+            control = control_socket_path(root, generation)
+            control.parent.mkdir(mode=0o700)
+            spec = {
+                "name": "review",
+                "control": {
+                    "socket": str(control),
+                    "generation": generation,
+                    "lease": {"device": 1, "inode": 2},
+                },
+            }
+            endpoint = _open_control(spec, root)
+            responses: list[dict[str, object]] = []
+
+            def request() -> None:
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+                    client.settimeout(2)
+                    client.connect(str(control))
+                    client.sendall(
+                        json.dumps(
+                            {
+                                "action": "status",
+                                "name": "review",
+                                "generation": generation,
+                            }
+                        ).encode()
+                    )
+                    client.shutdown(socket.SHUT_WR)
+                    responses.append(json.loads(client.recv(4096)))
+
+            clients = [threading.Thread(target=request) for _index in range(12)]
+            try:
+                for client in clients:
+                    client.start()
+                time.sleep(0.05)
+                self.assertFalse(_serve_control(endpoint, spec))
+                for client in clients:
+                    client.join(timeout=2)
+                self.assertEqual(len(responses), len(clients))
+                self.assertTrue(all(response["ok"] is True for response in responses))
+            finally:
+                assert endpoint is not None
+                endpoint.close()
+                control.unlink(missing_ok=True)
 
     def test_peek_exit_code_observes_without_reaping(self) -> None:
         process = mock.Mock(pid=1234, returncode=7)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7241,12 +7241,25 @@ class WorkspaceTests(unittest.TestCase):
             orphaned = self.workspace.topology_status("server-lease")
             self.assertFalse(orphaned["supervisor"]["running"])
             self.assertFalse(orphaned["services"]["server"]["running"])
-            self.assertFalse(Path(f"/proc/{descendant_pid}").exists())
+            self.assertTrue(Path(f"/proc/{descendant_pid}").exists())
             self.assertEqual(
                 orphaned["observation"]["process_tree_lease"], "released"
             )
+            for path, description in (
+                (layout_lock, "repository layout"),
+                (profile_lock, "profile build default"),
+            ):
+                with exclusive_lock(path, description, nonblocking=True):
+                    pass
             self.workspace.topology_down("server-lease", timeout=0.5)
         finally:
+            if "descendant_pid" in locals() and Path(
+                f"/proc/{descendant_pid}"
+            ).exists():
+                try:
+                    os.kill(descendant_pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
             self.workspace.topology_down("server-lease", timeout=5)
 
         with exclusive_lock(Path(f"{state}.lock"), "server state", nonblocking=True):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -6680,6 +6680,11 @@ class WorkspaceTests(unittest.TestCase):
             persisted_status = load_json(status_path)
             reused = copy.deepcopy(persisted_status)
             reused["control"]["generation"] = "b" * 64
+            reused["control"]["socket"] = str(
+                workspace_module.control_socket_path(
+                    self.workspace.paths.topologies / "review", "b" * 64
+                )
+            )
             reused["supervisor"]["generation"] = "b" * 64
             for service in reused["services"].values():
                 service["generation"] = "b" * 64

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -6400,6 +6400,64 @@ class WorkspaceTests(unittest.TestCase):
             with mock.patch("builtins.print") as output:
                 self.workspace.topology_logs("review", "client", 10, False)
             self.assertIn("client ready", "".join(call.args[0] for call in output.call_args_list))
+            with mock.patch(
+                "atrinik_workspace.workspace.process_matches", return_value=False
+            ):
+                cross_namespace = self.workspace.topology_status("review")
+            self.assertEqual(
+                cross_namespace["supervisor"]["liveness"], "live"
+            )
+            self.assertEqual(
+                cross_namespace["services"]["client"]["liveness"], "live"
+            )
+            self.assertEqual(
+                cross_namespace["observation"]["control"], "reachable"
+            )
+            self.assertEqual(
+                cross_namespace["observation"][
+                    "repository_layout_lease_owner"
+                ],
+                "review",
+            )
+            status_path = (
+                self.workspace.paths.topologies / "review" / "status.json"
+            )
+            persisted_status = load_json(status_path)
+            reused = copy.deepcopy(persisted_status)
+            reused["control"]["generation"] = "b" * 64
+            reused["supervisor"]["generation"] = "b" * 64
+            for service in reused["services"].values():
+                service["generation"] = "b" * 64
+            atomic_json(status_path, reused)
+            try:
+                with mock.patch(
+                    "atrinik_workspace.workspace.process_matches",
+                    return_value=False,
+                ):
+                    mismatched = self.workspace.topology_status("review")
+                self.assertEqual(
+                    mismatched["supervisor"]["liveness"], "unreachable"
+                )
+                self.assertEqual(
+                    mismatched["services"]["client"]["liveness"],
+                    "unreachable",
+                )
+                with (
+                    mock.patch(
+                        "atrinik_workspace.workspace.process_matches",
+                        return_value=False,
+                    ),
+                    mock.patch(
+                        "atrinik_workspace.workspace.signal_holders"
+                    ) as signaled,
+                    self.assertRaisesRegex(
+                        WorkspaceError, "control endpoint is unreachable"
+                    ),
+                ):
+                    self.workspace.topology_down("review", timeout=0.1)
+                signaled.assert_not_called()
+            finally:
+                atomic_json(status_path, persisted_status)
             process_tree_path = (
                 self.workspace.paths.topologies
                 / "review"
@@ -6779,42 +6837,21 @@ class WorkspaceTests(unittest.TestCase):
                 signal.pidfd_send_signal(pidfd, signal.SIGKILL)
             finally:
                 os.close(pidfd)
-            deadline = time.monotonic() + 5
-            while (
-                time.monotonic() < deadline
-                and self.workspace.topology_status("server-review")["supervisor"][
-                    "running"
+            deadline = time.monotonic() + 15
+            while time.monotonic() < deadline and (
+                self.workspace.topology_status("server-review")["observation"][
+                    "process_tree_lease"
                 ]
+                == "retained"
             ):
                 time.sleep(0.05)
             orphaned = self.workspace.topology_status("server-review")
             self.assertFalse(orphaned["supervisor"]["running"])
             self.assertFalse(orphaned["ready"])
-            self.assertTrue(orphaned["services"]["server"]["running"])
-            with self.assertRaisesRegex(WorkspaceError, "already running"):
-                self.workspace.topology_up(
-                    "server-review", "default", "default", None, 17300
-                )
-            with self.assertRaisesRegex(WorkspaceError, "already in use"):
-                with exclusive_lock(
-                    Path(f"{state}.lock"), "server state", nonblocking=True
-                ):
-                    self.fail("orphaned server released its state lock")
-            with self.assertRaisesRegex(WorkspaceError, "already in use"):
-                with exclusive_lock(
-                    layout_lock, "repository layout", nonblocking=True
-                ):
-                    self.fail("orphaned client released its layout lock")
-            with self.assertRaisesRegex(WorkspaceError, "already in use"):
-                with exclusive_lock(
-                    profile_lock, "profile build default", nonblocking=True
-                ):
-                    self.fail("orphaned services released their build-root lock")
-            (
-                self.workspace.paths.topologies
-                / "server-review"
-                / workspace_module.TOPOLOGY_PROCESS_TREE_LEASE
-            ).unlink()
+            self.assertFalse(orphaned["services"]["server"]["running"])
+            self.assertEqual(
+                orphaned["observation"]["process_tree_lease"], "released"
+            )
             recovered = self.workspace.topology_down("server-review", timeout=5)
             self.assertFalse(
                 any(service["running"] for service in recovered["services"].values())
@@ -6899,33 +6936,22 @@ class WorkspaceTests(unittest.TestCase):
                 signal.pidfd_send_signal(pidfd, signal.SIGKILL)
             finally:
                 os.close(pidfd)
-            deadline = time.monotonic() + 5
-            while (
-                time.monotonic() < deadline
-                and self.workspace.topology_status("server-lease")["supervisor"][
-                    "running"
+            deadline = time.monotonic() + 15
+            while time.monotonic() < deadline and (
+                self.workspace.topology_status("server-lease")["observation"][
+                    "process_tree_lease"
                 ]
+                == "retained"
             ):
                 time.sleep(0.05)
             orphaned = self.workspace.topology_status("server-lease")
             self.assertFalse(orphaned["supervisor"]["running"])
             self.assertFalse(orphaned["services"]["server"]["running"])
-            self.assertTrue(Path(f"/proc/{descendant_pid}").exists())
-            for path, description in (
-                (layout_lock, "repository layout"),
-                (profile_lock, "profile build default"),
-            ):
-                with self.assertRaisesRegex(WorkspaceError, "already in use"):
-                    with exclusive_lock(path, description, nonblocking=True):
-                        self.fail(f"orphaned server released {description}")
-            self.workspace.topology_down("server-lease", timeout=0.5)
-            deadline = time.monotonic() + 2
-            while (
-                time.monotonic() < deadline
-                and Path(f"/proc/{descendant_pid}").exists()
-            ):
-                time.sleep(0.05)
             self.assertFalse(Path(f"/proc/{descendant_pid}").exists())
+            self.assertEqual(
+                orphaned["observation"]["process_tree_lease"], "released"
+            )
+            self.workspace.topology_down("server-lease", timeout=0.5)
         finally:
             self.workspace.topology_down("server-lease", timeout=5)
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -6685,18 +6685,6 @@ class WorkspaceTests(unittest.TestCase):
                 service["generation"] = "b" * 64
             atomic_json(status_path, reused)
             try:
-                with mock.patch(
-                    "atrinik_workspace.workspace.process_matches",
-                    return_value=False,
-                ):
-                    mismatched = self.workspace.topology_status("review")
-                self.assertEqual(
-                    mismatched["supervisor"]["liveness"], "unreachable"
-                )
-                self.assertEqual(
-                    mismatched["services"]["client"]["liveness"],
-                    "unreachable",
-                )
                 with (
                     mock.patch(
                         "atrinik_workspace.workspace.process_matches",
@@ -6706,19 +6694,13 @@ class WorkspaceTests(unittest.TestCase):
                         "atrinik_workspace.workspace.signal_holders"
                     ) as signaled,
                     self.assertRaisesRegex(
-                        WorkspaceError, "control endpoint is unreachable"
+                        WorkspaceError, "lease generation changed"
                     ),
                 ):
                     self.workspace.topology_down("review", timeout=0.1)
                 signaled.assert_not_called()
             finally:
                 atomic_json(status_path, persisted_status)
-            process_tree_path = (
-                self.workspace.paths.topologies
-                / "review"
-                / workspace_module.TOPOLOGY_PROCESS_TREE_LEASE
-            )
-            process_tree_path.unlink()
         finally:
             try:
                 if self.workspace.topology_status("review-two")["supervisor"][
@@ -6733,6 +6715,28 @@ class WorkspaceTests(unittest.TestCase):
         stopped = self.workspace.topology_status("review")
         self.assertFalse(stopped["supervisor"]["running"])
         self.assertFalse(stopped["services"]["client"]["running"])
+
+    def test_topology_status_inventory_probes_with_bounded_concurrency(self) -> None:
+        for index in range(24):
+            root = self.workspace.paths.topologies / f"probe-{index}"
+            root.mkdir()
+            (root / "status.json").write_text("{}\n", encoding="utf-8")
+
+        def delayed(name: str) -> dict[str, str]:
+            time.sleep(0.05)
+            return {"name": name}
+
+        started = time.monotonic()
+        with mock.patch.object(
+            self.workspace, "topology_status", side_effect=delayed
+        ):
+            statuses = self.workspace.topology_statuses()
+
+        self.assertLess(time.monotonic() - started, 0.5)
+        self.assertEqual(
+            [status["name"] for status in statuses],
+            [f"probe-{index}" for index in sorted(range(24), key=str)],
+        )
 
     def test_supervised_local_playtest_client_uses_recorded_verified_root(self) -> None:
         self.workspace.create_profile("classic-audio", "classic")
@@ -7111,6 +7115,23 @@ class WorkspaceTests(unittest.TestCase):
             self.assertFalse(
                 any(service["running"] for service in recovered["services"].values())
             )
+            with (
+                mock.patch.object(
+                    self.workspace, "_build_resolved", return_value=build_root
+                ),
+                mock.patch.object(
+                    self.workspace, "_select_topology_port", return_value=17300
+                ),
+                mock.patch.object(self.workspace, "_require_client_display"),
+            ):
+                restarted = self.workspace.topology_up(
+                    "server-review", "default", "default", None, 17300
+                )
+            self.assertNotEqual(
+                restarted["control"]["generation"],
+                recovered["control"]["generation"],
+            )
+            self.workspace.topology_down("server-review", timeout=5)
         finally:
             second_remaining = self.workspace.topology_status("server-review-two")
             if second_remaining["supervisor"]["running"] or any(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -6720,6 +6720,12 @@ class WorkspaceTests(unittest.TestCase):
         stopped = self.workspace.topology_status("review")
         self.assertFalse(stopped["supervisor"]["running"])
         self.assertFalse(stopped["services"]["client"]["running"])
+        with mock.patch(
+            "atrinik_workspace.workspace.process_matches", return_value=True
+        ):
+            reused_local_pid = self.workspace.topology_status("review")
+        self.assertEqual(reused_local_pid["supervisor"]["liveness"], "exited")
+        self.assertFalse(reused_local_pid["services"]["client"]["running"])
 
     def test_topology_status_inventory_probes_with_bounded_concurrency(self) -> None:
         for index in range(24):
@@ -7163,6 +7169,13 @@ class WorkspaceTests(unittest.TestCase):
                 "import os, signal, time\n"
                 "child = os.fork()\n"
                 "if child == 0:\n"
+                "    for fd in os.listdir('/proc/self/fd'):\n"
+                "        try:\n"
+                "            target = os.readlink('/proc/self/fd/' + fd)\n"
+                "            if target.endswith('/process-tree.lease'):\n"
+                "                os.close(int(fd))\n"
+                "        except OSError:\n"
+                "            pass\n"
                 "    signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
                 "    while True:\n"
                 "        time.sleep(0.1)\n"


### PR DESCRIPTION
Fixes #383.

## Scope

- Add a generation-bound, mode-0600 filesystem control endpoint with a short workspace-shared path, exact name/generation request validation, bounded framing, and bounded concurrent servicing.
- Bind current topology liveness to the exact process-tree lease generation and device/inode identity; report `live`, `exited`, `stale`, or fail-closed `unreachable` with the retained layout-lease owner and safe action.
- Route current-generation `down` only through the matching control endpoint. Namespace-local PID/start ticks remain compatibility data for legacy records and are never authoritative for current records.
- Add an orphan guardian that signals only exact read/write process-tree lease holders and retains layout, build-root, and state locks until recovery absence is proven. Services do not inherit those workspace locks.
- Synchronize completion, cleanup, repository migration, and content migration validation with the current control/lease schema.
- Document cross-session operation, fail-closed recovery, and prohibited manual PID/lease intervention.

## Coordinates

- Base: `main` at `347866423f2e40fbae4cf5cbad276dc49fd95eb0`
- Head: `fix/supervisor-liveness` at `f422b4235`
- Worktree: `/workspaces/atrinik/workspace/worktrees/atrinik/issue-383-supervisor-liveness`
- Review report: `/workspaces/atrinik/build/reviews/atrinik-atrinik-383.md` (ignored local evidence)

## Validation

- `.venv/bin/python -m coverage run -m unittest discover` — 635 tests passed at exact head `f422b4235`
- `.venv/bin/python -m coverage report --show-missing` — 81% overall
- focused control, lease identity/replacement, PID invisibility/reuse, orphan/closed-identity, restart, lock-retention, cleanup, completion, and migration suites — passed
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- runtime skill `quick_validate.py` — valid
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `./atrinik provenance validate`
- `git diff --check`
- final three-track fresh-context whole-diff review — zero actionable findings

## Verification

No gameplay scenario or credentials are required. The available Classic primary checkout was dirty and no exact issue topology existed, so this delivery did not build or mutate that shared runtime. Deterministic temporary-workspace integration tests exercised the full supervisor/client/server lifecycle.

A reviewer with a clean buildable Classic profile can verify manually:

```sh
./atrinik profile show classic --json
./atrinik topology show classic --state default --json
./atrinik up --name issue-383-review --profile classic --state default --service server
./atrinik ps issue-383-review --json
# From another supported sandbox/session sharing this workspace:
./atrinik ps issue-383-review --json
./atrinik down issue-383-review
```

Both status calls should report generation-bound live liveness, a reachable control endpoint, and `repository_layout_lease_owner: issue-383-review`. Cross-session `down` must stop the topology without numeric PID signaling. If control becomes unreachable, wait for guardian recovery and retry; preserve any exact retained record/lease for diagnosis. Do not scan `/proc`, signal recorded PIDs, remove lease files, or reuse the name.
