### PR TITLE
fix(runtime): accept server-only status without sound

### DIFF
--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -7256,8 +7256,6 @@ class Workspace:
                 validate_sound_record(status["sound"])
             except WorkspaceError as error:
                 raise WorkspaceError(f"topology status is invalid: {name}") from error
-        if not historical_record and "client" in status["dependencies"] and "sound" not in status:
-            raise WorkspaceError(f"topology status is invalid: {name}")
         if historical_record:
             status["stack"] = "classic"
             status["providers"] = {
@@ -7466,6 +7464,8 @@ class Workspace:
             or not set(services) <= set(TOPOLOGY_SERVICES)
         ):
             raise WorkspaceError(f"topology service status is invalid: {name}")
+        if not historical_record and "client" in services and "sound" not in status:
+            raise WorkspaceError(f"topology status is invalid: {name}")
         for service in services.values():
             if (
                 not isinstance(service, dict)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -6720,6 +6720,14 @@ class WorkspaceTests(unittest.TestCase):
         stopped = self.workspace.topology_status("review")
         self.assertFalse(stopped["supervisor"]["running"])
         self.assertFalse(stopped["services"]["client"]["running"])
+        status_path = self.workspace.paths.topologies / "review" / "status.json"
+        missing_sound = load_json(status_path)
+        sound = missing_sound.pop("sound")
+        atomic_json(status_path, missing_sound)
+        with self.assertRaisesRegex(WorkspaceError, "topology status is invalid"):
+            self.workspace.topology_status("review")
+        missing_sound["sound"] = sound
+        atomic_json(status_path, missing_sound)
         with mock.patch(
             "atrinik_workspace.workspace.process_matches", return_value=True
         ):
@@ -6945,6 +6953,7 @@ class WorkspaceTests(unittest.TestCase):
         )
         second_build_root.parent.mkdir(parents=True, exist_ok=True)
         shutil.copytree(build_root, second_build_root, symlinks=True)
+        atomic_json(second_build_root / workspace_module.BUILD_METADATA, {})
 
         with (
             mock.patch.object(
@@ -7052,6 +7061,9 @@ class WorkspaceTests(unittest.TestCase):
                 )
             self.assertTrue(second["ready"])
             self.assertEqual(second["endpoint"]["port"], 17301)
+            self.assertIn("client", second["dependencies"])
+            self.assertNotIn("client", second["services"])
+            self.assertNotIn("sound", second)
             for topology in ("server-review", "server-review-two"):
                 snapshot = self.workspace.paths.topologies / topology / "runtime"
                 self.assertEqual(


### PR DESCRIPTION
## Summary

- require sound metadata only when the persisted topology actually launches a client service
- keep complete-profile dependency coordinates unchanged for server-only topologies
- cover both the accepted server-only record and the rejected client-without-sound record through supervised lifecycle tests

Closes #395.

## Coordinates

- Base: `main@82def5250bb136862f7abb3981c5047b206525e2`
- Head: `fix/395-server-only-sound-status@b757903db56933d3e6a89c96ca772298f8e82e63`
- Worktree: `/workspaces/atrinik/workspace/worktrees/atrinik/issue-395-server-only-sound-status`
- Commit: `b757903db fix(runtime): validate sound for launched clients`

## Validation

- focused supervised topology regression tests: 2 passed
- `python3 -m coverage run -m unittest discover -v`: 635 passed
- `python3 -m coverage report --show-missing`: 82% total coverage
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `git diff --check`

## Verification

The supervised integration tests exercise the exact persisted-status boundary with real wrapper supervisor processes and isolated temporary state: a complete dependency closure containing `client` succeeds when `services` contains only `server` and `sound` is absent, while a launched client service without `sound` remains invalid. No component source, gameplay state, account, scenario, or external runtime is required.

## Review and checks

- fresh complete base-to-head review at `b757903db56933d3e6a89c96ca772298f8e82e63`: zero known actionable findings
- Integration validation: passed
- CodeQL (`actions`, `python`, and aggregate): passed
- Conventional PR title: passed
- Codecov patch coverage: passed; all modified coverable lines are covered
- review threads and human reviews: none
- GitHub merge state: clean and mergeable; live ruleset requires zero approving reviews
