### PR TITLE
test(workspace): reproduce P0 lifecycle convoys

### DIFF
--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import queue
 import shutil
 import signal
+import socket
 import stat
 import subprocess
 import sys
@@ -294,63 +295,36 @@ def fair_layout_writer_process(
         raise
 
 
-def retained_topology_leases_process(
-    layout_path: str,
-    build_path: str,
-    state_path: str,
-    entered: object,
-    release: object,
-    results: object,
-) -> None:
-    try:
-        with (
-            shared_layout_lock(Path(layout_path), "repository layout"),
-            exclusive_lock(Path(build_path), "profile build topology-a"),
-            exclusive_lock(Path(state_path), "server state topology-a"),
-        ):
-            entered.set()
-            if not release.wait(10):
-                raise TimeoutError("retained topology leases were not released")
-        results.put(None)
-    except BaseException as error:
-        results.put(f"{type(error).__name__}: {error}")
-        raise
-
-
-def observed_layout_writer_process(
-    layout_path: str,
+def profile_mutation_process(
+    wrapper: str,
+    workspace_directory: str,
     pending_acquired: object,
-    intent_acquired: object,
     entered: object,
-    release: object,
     results: object,
 ) -> None:
     try:
-        intent_path = workspace_module._layout_writer_intent_path(
-            Path(layout_path)
-        ).resolve()
-        pending_path = locking_module.layout_writer_pending_path(
-            Path(layout_path)
-        ).resolve()
-        real_flock = locking_module.fcntl.flock
-
-        def observe_flock(lock: object, operation: int) -> None:
-            real_flock(lock, operation)
-            descriptor_path = Path(
-                os.readlink(f"/proc/self/fd/{lock.fileno()}")
-            )
-            if operation & fcntl.LOCK_SH and descriptor_path == pending_path:
-                pending_acquired.set()
-            if operation & fcntl.LOCK_EX and descriptor_path == intent_path:
-                intent_acquired.set()
-
-        with mock.patch.object(
-            locking_module.fcntl, "flock", side_effect=observe_flock
+        with mock.patch.dict(
+            os.environ, {"ATRINIK_WORKSPACE_DIR": workspace_directory}
         ):
-            with exclusive_layout_lock(Path(layout_path), "repository layout"):
-                entered.set()
-                if not release.wait(10):
-                    raise TimeoutError("layout writer was not released")
+            workspace = Workspace(Path(wrapper))
+            pending_path = locking_module.layout_writer_pending_path(
+                workspace.paths.workspace / "repository-layout.lock"
+            ).resolve()
+            real_flock = locking_module.fcntl.flock
+
+            def observe_flock(lock: object, operation: int) -> None:
+                real_flock(lock, operation)
+                descriptor_path = Path(
+                    os.readlink(f"/proc/self/fd/{lock.fileno()}")
+                )
+                if operation & fcntl.LOCK_SH and descriptor_path == pending_path:
+                    pending_acquired.set()
+
+            with mock.patch.object(
+                locking_module.fcntl, "flock", side_effect=observe_flock
+            ):
+                workspace.set_profile("profile-a", "client", "primary")
+            entered.set()
         results.put(None)
     except BaseException as error:
         results.put(f"{type(error).__name__}: {error}")
@@ -361,6 +335,7 @@ def public_lifecycle_reader_process(
     wrapper: str,
     workspace_directory: str,
     operation: str,
+    build_root: str,
     attempting: object,
     entered: object,
     results: object,
@@ -370,45 +345,34 @@ def public_lifecycle_reader_process(
             os.environ, {"ATRINIK_WORKSPACE_DIR": workspace_directory}
         ):
             workspace = Workspace(Path(wrapper))
-            intent_path = workspace_module._layout_writer_intent_path(
-                workspace.paths.workspace / "repository-layout.lock"
-            ).resolve()
-            real_flock = locking_module.fcntl.flock
-
-            def observe_flock(lock: object, lock_operation: int) -> None:
-                descriptor_path = Path(
-                    os.readlink(f"/proc/self/fd/{lock.fileno()}")
-                )
-                if (
-                    lock_operation & fcntl.LOCK_EX
-                    and descriptor_path == intent_path
+            attempting.set()
+            if operation == "build-b":
+                workspace.build("sound", "profile-b", False)
+            else:
+                with (
+                    mock.patch.object(workspace, "_require_client_display"),
+                    mock.patch.object(
+                        workspace,
+                        "_build_resolved",
+                        return_value=Path(build_root),
+                    ),
                 ):
-                    attempting.set()
-                real_flock(lock, lock_operation)
-
-            def record_entry(*_arguments: object, **_keywords: object) -> Path:
-                entered.set()
-                return Path(wrapper)
-
-            with mock.patch.object(
-                locking_module.fcntl, "flock", side_effect=observe_flock
-            ):
-                if operation == "build-b":
-                    with mock.patch.object(
-                        workspace, "_build", side_effect=record_entry
-                    ):
-                        workspace.build("client", "profile-b", False)
-                else:
-                    with mock.patch.object(
-                        workspace, "_topology_up", side_effect=record_entry
-                    ):
+                    try:
                         workspace.topology_up(
                             "topology-b",
                             "profile-b",
-                            "state-b",
-                            ["server"],
-                            17302,
+                            "default",
+                            ["client"],
                         )
+                    finally:
+                        status_path = (
+                            workspace.paths.topologies
+                            / "topology-b"
+                            / "status.json"
+                        )
+                        if status_path.is_file():
+                            workspace.topology_down("topology-b", timeout=5)
+            entered.set()
         results.put(None)
     except BaseException as error:
         results.put(f"{type(error).__name__}: {error}")
@@ -423,18 +387,14 @@ def synthetic_server_start_process(
     build_root: str,
     port: int,
     port_attempting: object,
-    pre_ready: object,
-    release: object,
     results: object,
 ) -> None:
-    stop_message = "synthetic startup reached release boundary"
     try:
         with mock.patch.dict(
             os.environ, {"ATRINIK_WORKSPACE_DIR": workspace_directory}
         ):
             workspace = Workspace(Path(wrapper))
             ports_path = (workspace.paths.topologies / "ports.lock").resolve()
-            selected = {"server": Path(wrapper)}
             state = Path(state_path)
             root = Path(build_root)
             real_flock = locking_module.fcntl.flock
@@ -448,22 +408,18 @@ def synthetic_server_start_process(
                     port_attempting.set()
                 real_flock(lock, operation)
 
-            def pause_before_readiness(
-                *_arguments: object, **_keywords: object
-            ) -> dict[str, Path]:
-                pre_ready.set()
-                if not release.wait(10):
-                    raise TimeoutError(f"server startup {name} was not released")
-                raise RuntimeError(stop_message)
+            runtime_inputs = {
+                key: root / key
+                for key in ("content", "resources", "client-maps")
+            }
+            for path in runtime_inputs.values():
+                path.mkdir(parents=True, exist_ok=True)
 
             with (
                 mock.patch.object(
                     locking_module.fcntl, "flock", side_effect=observe_flock
                 ),
                 mock.patch.object(workspace, "_require_classic_contracts"),
-                mock.patch.object(
-                    workspace, "_resolve_build_profile", return_value=selected
-                ),
                 mock.patch.object(
                     workspace, "_state_location", return_value=state
                 ),
@@ -472,21 +428,24 @@ def synthetic_server_start_process(
                     workspace, "_build_resolved", return_value=root
                 ),
                 mock.patch.object(
-                    workspace, "_select_topology_port", return_value=port
-                ),
-                mock.patch.object(
                     workspace,
                     "_copy_topology_runtime_inputs",
-                    side_effect=pause_before_readiness,
+                    return_value=runtime_inputs,
+                ),
+                mock.patch.object(
+                    workspace, "_prepare_server_runtime", return_value=root
                 ),
             ):
                 try:
-                    workspace.topology_up(
+                    status = workspace.topology_up(
                         name, name, name, ["server"], port
                     )
-                except RuntimeError as error:
-                    if str(error) != stop_message:
-                        raise
+                    if status["endpoint"]["port"] != port:
+                        raise AssertionError("topology published the wrong port")
+                finally:
+                    status_path = workspace.paths.topologies / name / "status.json"
+                    if status_path.is_file():
+                        workspace.topology_down(name, timeout=5)
         results.put(None)
     except BaseException as error:
         results.put(f"{type(error).__name__}: {error}")
@@ -687,6 +646,26 @@ def join_or_stop_processes(
         if process.is_alive():
             process.kill()
             process.join(timeout=2)
+
+
+def wait_for_process_event(
+    event: object,
+    description: str,
+    results: object,
+    timeout: float = 5,
+) -> None:
+    if event.wait(timeout):
+        return
+    child_results = []
+    while True:
+        try:
+            child_results.append(results.get_nowait())
+        except queue.Empty:
+            break
+    raise AssertionError(
+        f"{description} was not reached within {timeout:g}s; "
+        f"child results: {child_results or 'none'}"
+    )
 
 
 COMPONENTS = (
@@ -6026,37 +6005,73 @@ class WorkspaceTests(unittest.TestCase):
 
     def test_p0_harness_reproduces_current_lifecycle_layout_convoy(self) -> None:
         context = multiprocessing.get_context("spawn")
-        layout = self.workspace.paths.workspace / "repository-layout.lock"
-        topology_build = self.workspace.paths.builds / "locks" / "topology-a.lock"
-        topology_state = self.workspace.paths.state / "topology-a.lock"
-        topology_entered = context.Event()
-        release_topology = context.Event()
+        for label in ("source-a", "source-b"):
+            self.workspace.create_worktree(
+                "client", label, f"test/{label}", None, False
+            )
+        self.workspace.create_worktree(
+            "sound", "source-b", "test/sound-source-b", None, False
+        )
+        for profile in ("profile-a", "profile-b"):
+            self.workspace.create_profile(profile)
+        self.workspace.set_profile(
+            "profile-a", "client", "worktree", "source-a"
+        )
+        self.workspace.set_profile(
+            "profile-b", "client", "worktree", "source-b"
+        )
+        self.workspace.set_profile(
+            "profile-b", "sound", "worktree", "source-b"
+        )
+
+        def client_build_root(profile: str) -> Path:
+            root = self.workspace.paths.builds / "profiles" / profile
+            executable = root / "build" / "client" / "atrinik"
+            executable.parent.mkdir(parents=True)
+            (root / "sources" / "client").mkdir(parents=True)
+            executable.write_text(
+                "#!/usr/bin/env python3\n"
+                "import time\n"
+                "print('client ready', flush=True)\n"
+                "while True:\n"
+                "    time.sleep(0.1)\n",
+                encoding="utf-8",
+            )
+            executable.chmod(0o755)
+            selected_sound = self.workspace.resolve_profile(
+                profile, {"sound"}
+            )["sound"]
+            atomic_json(
+                root / workspace_module.BUILD_METADATA,
+                {"sound": workspace_module.sound_source_record(selected_sound)},
+            )
+            return root
+
+        topology_a_root = client_build_root("profile-a")
+        topology_b_root = client_build_root("profile-b")
+        with (
+            mock.patch.object(
+                self.workspace, "_build_resolved", return_value=topology_a_root
+            ),
+            mock.patch.object(self.workspace, "_require_client_display"),
+        ):
+            topology_a = self.workspace.topology_up(
+                "topology-a", "profile-a", "default", ["client"]
+            )
+        self.assertTrue(topology_a["ready"])
+
         writer_pending = context.Event()
-        writer_intent = context.Event()
         writer_entered = context.Event()
-        release_writer = context.Event()
         reader_attempting = [context.Event(), context.Event()]
         readers_entered = [context.Event(), context.Event()]
         results = context.Queue()
-        topology = context.Process(
-            target=retained_topology_leases_process,
-            args=(
-                str(layout),
-                str(topology_build),
-                str(topology_state),
-                topology_entered,
-                release_topology,
-                results,
-            ),
-        )
         writer = context.Process(
-            target=observed_layout_writer_process,
+            target=profile_mutation_process,
             args=(
-                str(layout),
+                str(self.wrapper),
+                str(self.workspace_directory),
                 writer_pending,
-                writer_intent,
                 writer_entered,
-                release_writer,
                 results,
             ),
         )
@@ -6067,6 +6082,7 @@ class WorkspaceTests(unittest.TestCase):
                     str(self.wrapper),
                     str(self.workspace_directory),
                     operation,
+                    str(topology_b_root),
                     reader_attempting[index],
                     readers_entered[index],
                     results,
@@ -6074,44 +6090,50 @@ class WorkspaceTests(unittest.TestCase):
             )
             for index, operation in enumerate(("build-b", "topology-b"))
         ]
-        processes = [topology, writer, *readers]
+        processes = [writer, *readers]
         started: list[multiprocessing.Process] = []
         try:
-            topology.start()
-            started.append(topology)
-            self.assertTrue(topology_entered.wait(5))
-
             writer.start()
             started.append(writer)
-            self.assertTrue(writer_pending.wait(5))
-            self.assertTrue(writer_intent.wait(5))
+            wait_for_process_event(
+                writer_pending, "profile A mutation queue", results
+            )
             self.assertFalse(writer_entered.is_set())
 
             for reader in readers:
                 reader.start()
                 started.append(reader)
-            self.assertTrue(
-                all(attempt.wait(5) for attempt in reader_attempting)
-            )
+            for index, attempt in enumerate(reader_attempting):
+                wait_for_process_event(
+                    attempt, f"B reader {index} attempt", results
+                )
             self.assertFalse(writer_entered.is_set())
             self.assertTrue(all(not entered.is_set() for entered in readers_entered))
 
             # This is the P0 current-behavior assertion. The #399 cutover will
             # invert it: disjoint B readers must enter while A's writer waits.
-            release_topology.set()
-            self.assertTrue(writer_entered.wait(5))
-            self.assertTrue(all(not entered.is_set() for entered in readers_entered))
-            release_writer.set()
-            self.assertTrue(
-                all(entered.wait(5) for entered in readers_entered)
+            self.workspace.topology_down("topology-a", timeout=5)
+            wait_for_process_event(
+                writer_entered, "profile A mutation entry", results
             )
+            for index, entered in enumerate(readers_entered):
+                wait_for_process_event(
+                    entered, f"B reader {index} completion", results
+                )
         finally:
-            release_topology.set()
-            release_writer.set()
+            status_path = (
+                self.workspace.paths.topologies / "topology-a" / "status.json"
+            )
+            if status_path.is_file():
+                try:
+                    if self.workspace.topology_status("topology-a")["ready"]:
+                        self.workspace.topology_down("topology-a", timeout=5)
+                except WorkspaceError:
+                    pass
             join_or_stop_processes(started, 10)
         self.assertEqual(started, processes)
-        self.assertEqual([process.exitcode for process in processes], [0] * 4)
-        self.assertEqual([results.get(timeout=2) for _ in processes], [None] * 4)
+        self.assertEqual([process.exitcode for process in processes], [0] * 3)
+        self.assertEqual([results.get(timeout=2) for _ in processes], [None] * 3)
 
     def test_p0_harness_reproduces_current_server_startup_port_convoy(
         self,
@@ -6119,16 +6141,44 @@ class WorkspaceTests(unittest.TestCase):
         context = multiprocessing.get_context("spawn")
         results = context.Queue()
         attempting = [context.Event(), context.Event()]
-        pre_ready = [context.Event(), context.Event()]
-        releases = [context.Event(), context.Event()]
+        pre_ready = [self.root / "pre-ready-a", self.root / "pre-ready-b"]
+        releases = [self.root / "release-a", self.root / "release-b"]
+
+        def available_port() -> int:
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as candidate:
+                candidate.bind(("127.0.0.1", 0))
+                return candidate.getsockname()[1]
+
         coordinates = (
-            ("server-a", "state-a", "build-a", 17310),
-            ("server-b", "state-b", "build-b", 17311),
+            ("server-a", "state-a", "build-a", available_port()),
+            ("server-b", "state-b", "build-b", available_port()),
         )
-        for _name, _state, build, _port in coordinates:
+        self.assertNotEqual(coordinates[0][3], coordinates[1][3])
+        for index, (name, _state, build, _port) in enumerate(coordinates):
+            self.workspace.create_profile(name)
             root = self.workspace.paths.builds / "profiles" / build
             root.mkdir(parents=True)
             atomic_json(root / workspace_module.BUILD_METADATA, {})
+            executable = root / "atrinik-server"
+            executable.write_text(
+                "#!/usr/bin/env python3\n"
+                "from pathlib import Path\n"
+                "import socket, sys, time\n"
+                "port = int(next(value.split('=', 1)[1] for value in sys.argv "
+                "if value.startswith('--port_quic=')))\n"
+                "server = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\n"
+                "server.bind(('127.0.0.1', port))\n"
+                f"Path({str(pre_ready[index])!r}).write_text('ready\\n')\n"
+                f"release = Path({str(releases[index])!r})\n"
+                "while not release.exists():\n"
+                "    time.sleep(0.01)\n"
+                "print('QUIC certificate SHA-256: ' + 'a' * 64, flush=True)\n"
+                "print('Server ready. Waiting for connections...', flush=True)\n"
+                "while True:\n"
+                "    time.sleep(0.1)\n",
+                encoding="utf-8",
+            )
+            executable.chmod(0o755)
         processes = [
             context.Process(
                 target=synthetic_server_start_process,
@@ -6140,35 +6190,52 @@ class WorkspaceTests(unittest.TestCase):
                     str(self.workspace.paths.builds / "profiles" / build),
                     port,
                     attempting[index],
-                    pre_ready[index],
-                    releases[index],
                     results,
                 ),
             )
             for index, (name, state, build, port) in enumerate(coordinates)
         ]
         started: list[multiprocessing.Process] = []
+
+        def wait_for_path(path: Path, description: str) -> None:
+            deadline = time.monotonic() + 10
+            while time.monotonic() < deadline:
+                if path.is_file():
+                    return
+                time.sleep(0.01)
+            child_errors = []
+            while True:
+                try:
+                    child_errors.append(results.get_nowait())
+                except queue.Empty:
+                    break
+            self.fail(f"{description} was not reached; children={child_errors}")
+
         try:
             processes[0].start()
             started.append(processes[0])
-            self.assertTrue(attempting[0].wait(5))
-            self.assertTrue(pre_ready[0].wait(5))
+            wait_for_process_event(
+                attempting[0], "server A port-lock attempt", results
+            )
+            wait_for_path(pre_ready[0], "server A pre-ready barrier")
 
             processes[1].start()
             started.append(processes[1])
-            self.assertTrue(attempting[1].wait(5))
-            self.assertFalse(pre_ready[1].is_set())
+            wait_for_process_event(
+                attempting[1], "server B port-lock attempt", results
+            )
+            self.assertFalse(pre_ready[1].exists())
 
             # Both starts use distinct topology, profile/build, state, and
             # explicit-port coordinates. P0 records that the global allocator
             # lease still serializes B until A leaves its pre-ready stage; #401
             # will flip this assertion to require concurrent rendezvous entry.
-            releases[0].set()
-            self.assertTrue(pre_ready[1].wait(5))
-            releases[1].set()
+            releases[0].write_text("release\n", encoding="utf-8")
+            wait_for_path(pre_ready[1], "server B pre-ready barrier")
+            releases[1].write_text("release\n", encoding="utf-8")
         finally:
             for release in releases:
-                release.set()
+                release.write_text("release\n", encoding="utf-8")
             join_or_stop_processes(started, 10)
         self.assertEqual(started, processes)
         self.assertEqual([process.exitcode for process in processes], [0, 0])

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -294,6 +294,205 @@ def fair_layout_writer_process(
         raise
 
 
+def retained_topology_leases_process(
+    layout_path: str,
+    build_path: str,
+    state_path: str,
+    entered: object,
+    release: object,
+    results: object,
+) -> None:
+    try:
+        with (
+            shared_layout_lock(Path(layout_path), "repository layout"),
+            exclusive_lock(Path(build_path), "profile build topology-a"),
+            exclusive_lock(Path(state_path), "server state topology-a"),
+        ):
+            entered.set()
+            if not release.wait(10):
+                raise TimeoutError("retained topology leases were not released")
+        results.put(None)
+    except BaseException as error:
+        results.put(f"{type(error).__name__}: {error}")
+        raise
+
+
+def observed_layout_writer_process(
+    layout_path: str,
+    pending_acquired: object,
+    intent_acquired: object,
+    entered: object,
+    release: object,
+    results: object,
+) -> None:
+    try:
+        intent_path = workspace_module._layout_writer_intent_path(
+            Path(layout_path)
+        ).resolve()
+        pending_path = locking_module.layout_writer_pending_path(
+            Path(layout_path)
+        ).resolve()
+        real_flock = locking_module.fcntl.flock
+
+        def observe_flock(lock: object, operation: int) -> None:
+            real_flock(lock, operation)
+            descriptor_path = Path(
+                os.readlink(f"/proc/self/fd/{lock.fileno()}")
+            )
+            if operation & fcntl.LOCK_SH and descriptor_path == pending_path:
+                pending_acquired.set()
+            if operation & fcntl.LOCK_EX and descriptor_path == intent_path:
+                intent_acquired.set()
+
+        with mock.patch.object(
+            locking_module.fcntl, "flock", side_effect=observe_flock
+        ):
+            with exclusive_layout_lock(Path(layout_path), "repository layout"):
+                entered.set()
+                if not release.wait(10):
+                    raise TimeoutError("layout writer was not released")
+        results.put(None)
+    except BaseException as error:
+        results.put(f"{type(error).__name__}: {error}")
+        raise
+
+
+def public_lifecycle_reader_process(
+    wrapper: str,
+    workspace_directory: str,
+    operation: str,
+    attempting: object,
+    entered: object,
+    results: object,
+) -> None:
+    try:
+        with mock.patch.dict(
+            os.environ, {"ATRINIK_WORKSPACE_DIR": workspace_directory}
+        ):
+            workspace = Workspace(Path(wrapper))
+            intent_path = workspace_module._layout_writer_intent_path(
+                workspace.paths.workspace / "repository-layout.lock"
+            ).resolve()
+            real_flock = locking_module.fcntl.flock
+
+            def observe_flock(lock: object, lock_operation: int) -> None:
+                descriptor_path = Path(
+                    os.readlink(f"/proc/self/fd/{lock.fileno()}")
+                )
+                if (
+                    lock_operation & fcntl.LOCK_EX
+                    and descriptor_path == intent_path
+                ):
+                    attempting.set()
+                real_flock(lock, lock_operation)
+
+            def record_entry(*_arguments: object, **_keywords: object) -> Path:
+                entered.set()
+                return Path(wrapper)
+
+            with mock.patch.object(
+                locking_module.fcntl, "flock", side_effect=observe_flock
+            ):
+                if operation == "build-b":
+                    with mock.patch.object(
+                        workspace, "_build", side_effect=record_entry
+                    ):
+                        workspace.build("client", "profile-b", False)
+                else:
+                    with mock.patch.object(
+                        workspace, "_topology_up", side_effect=record_entry
+                    ):
+                        workspace.topology_up(
+                            "topology-b",
+                            "profile-b",
+                            "state-b",
+                            ["server"],
+                            17302,
+                        )
+        results.put(None)
+    except BaseException as error:
+        results.put(f"{type(error).__name__}: {error}")
+        raise
+
+
+def synthetic_server_start_process(
+    wrapper: str,
+    workspace_directory: str,
+    name: str,
+    state_path: str,
+    build_root: str,
+    port: int,
+    port_attempting: object,
+    pre_ready: object,
+    release: object,
+    results: object,
+) -> None:
+    stop_message = "synthetic startup reached release boundary"
+    try:
+        with mock.patch.dict(
+            os.environ, {"ATRINIK_WORKSPACE_DIR": workspace_directory}
+        ):
+            workspace = Workspace(Path(wrapper))
+            ports_path = (workspace.paths.topologies / "ports.lock").resolve()
+            selected = {"server": Path(wrapper)}
+            state = Path(state_path)
+            root = Path(build_root)
+            real_flock = locking_module.fcntl.flock
+
+            def observe_flock(lock: object, operation: int) -> None:
+                descriptor = lock if isinstance(lock, int) else lock.fileno()
+                descriptor_path = Path(
+                    os.readlink(f"/proc/self/fd/{descriptor}")
+                )
+                if operation & fcntl.LOCK_EX and descriptor_path == ports_path:
+                    port_attempting.set()
+                real_flock(lock, operation)
+
+            def pause_before_readiness(
+                *_arguments: object, **_keywords: object
+            ) -> dict[str, Path]:
+                pre_ready.set()
+                if not release.wait(10):
+                    raise TimeoutError(f"server startup {name} was not released")
+                raise RuntimeError(stop_message)
+
+            with (
+                mock.patch.object(
+                    locking_module.fcntl, "flock", side_effect=observe_flock
+                ),
+                mock.patch.object(workspace, "_require_classic_contracts"),
+                mock.patch.object(
+                    workspace, "_resolve_build_profile", return_value=selected
+                ),
+                mock.patch.object(
+                    workspace, "_state_location", return_value=state
+                ),
+                mock.patch.object(workspace, "state_path", return_value=state),
+                mock.patch.object(
+                    workspace, "_build_resolved", return_value=root
+                ),
+                mock.patch.object(
+                    workspace, "_select_topology_port", return_value=port
+                ),
+                mock.patch.object(
+                    workspace,
+                    "_copy_topology_runtime_inputs",
+                    side_effect=pause_before_readiness,
+                ),
+            ):
+                try:
+                    workspace.topology_up(
+                        name, name, name, ["server"], port
+                    )
+                except RuntimeError as error:
+                    if str(error) != stop_message:
+                        raise
+        results.put(None)
+    except BaseException as error:
+        results.put(f"{type(error).__name__}: {error}")
+        raise
+
+
 def inherited_leases_wrapper_process(
     layout_path: str,
     build_path: str,
@@ -5824,6 +6023,156 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual(started, processes)
         self.assertEqual([process.exitcode for process in processes], [0] * 10)
         self.assertEqual([results.get(timeout=2) for _ in processes], [None] * 10)
+
+    def test_p0_harness_reproduces_current_lifecycle_layout_convoy(self) -> None:
+        context = multiprocessing.get_context("spawn")
+        layout = self.workspace.paths.workspace / "repository-layout.lock"
+        topology_build = self.workspace.paths.builds / "locks" / "topology-a.lock"
+        topology_state = self.workspace.paths.state / "topology-a.lock"
+        topology_entered = context.Event()
+        release_topology = context.Event()
+        writer_pending = context.Event()
+        writer_intent = context.Event()
+        writer_entered = context.Event()
+        release_writer = context.Event()
+        reader_attempting = [context.Event(), context.Event()]
+        readers_entered = [context.Event(), context.Event()]
+        results = context.Queue()
+        topology = context.Process(
+            target=retained_topology_leases_process,
+            args=(
+                str(layout),
+                str(topology_build),
+                str(topology_state),
+                topology_entered,
+                release_topology,
+                results,
+            ),
+        )
+        writer = context.Process(
+            target=observed_layout_writer_process,
+            args=(
+                str(layout),
+                writer_pending,
+                writer_intent,
+                writer_entered,
+                release_writer,
+                results,
+            ),
+        )
+        readers = [
+            context.Process(
+                target=public_lifecycle_reader_process,
+                args=(
+                    str(self.wrapper),
+                    str(self.workspace_directory),
+                    operation,
+                    reader_attempting[index],
+                    readers_entered[index],
+                    results,
+                ),
+            )
+            for index, operation in enumerate(("build-b", "topology-b"))
+        ]
+        processes = [topology, writer, *readers]
+        started: list[multiprocessing.Process] = []
+        try:
+            topology.start()
+            started.append(topology)
+            self.assertTrue(topology_entered.wait(5))
+
+            writer.start()
+            started.append(writer)
+            self.assertTrue(writer_pending.wait(5))
+            self.assertTrue(writer_intent.wait(5))
+            self.assertFalse(writer_entered.is_set())
+
+            for reader in readers:
+                reader.start()
+                started.append(reader)
+            self.assertTrue(
+                all(attempt.wait(5) for attempt in reader_attempting)
+            )
+            self.assertFalse(writer_entered.is_set())
+            self.assertTrue(all(not entered.is_set() for entered in readers_entered))
+
+            # This is the P0 current-behavior assertion. The #399 cutover will
+            # invert it: disjoint B readers must enter while A's writer waits.
+            release_topology.set()
+            self.assertTrue(writer_entered.wait(5))
+            self.assertTrue(all(not entered.is_set() for entered in readers_entered))
+            release_writer.set()
+            self.assertTrue(
+                all(entered.wait(5) for entered in readers_entered)
+            )
+        finally:
+            release_topology.set()
+            release_writer.set()
+            join_or_stop_processes(started, 10)
+        self.assertEqual(started, processes)
+        self.assertEqual([process.exitcode for process in processes], [0] * 4)
+        self.assertEqual([results.get(timeout=2) for _ in processes], [None] * 4)
+
+    def test_p0_harness_reproduces_current_server_startup_port_convoy(
+        self,
+    ) -> None:
+        context = multiprocessing.get_context("spawn")
+        results = context.Queue()
+        attempting = [context.Event(), context.Event()]
+        pre_ready = [context.Event(), context.Event()]
+        releases = [context.Event(), context.Event()]
+        coordinates = (
+            ("server-a", "state-a", "build-a", 17310),
+            ("server-b", "state-b", "build-b", 17311),
+        )
+        for _name, _state, build, _port in coordinates:
+            root = self.workspace.paths.builds / "profiles" / build
+            root.mkdir(parents=True)
+            atomic_json(root / workspace_module.BUILD_METADATA, {})
+        processes = [
+            context.Process(
+                target=synthetic_server_start_process,
+                args=(
+                    str(self.wrapper),
+                    str(self.workspace_directory),
+                    name,
+                    str(self.workspace.paths.state / state),
+                    str(self.workspace.paths.builds / "profiles" / build),
+                    port,
+                    attempting[index],
+                    pre_ready[index],
+                    releases[index],
+                    results,
+                ),
+            )
+            for index, (name, state, build, port) in enumerate(coordinates)
+        ]
+        started: list[multiprocessing.Process] = []
+        try:
+            processes[0].start()
+            started.append(processes[0])
+            self.assertTrue(attempting[0].wait(5))
+            self.assertTrue(pre_ready[0].wait(5))
+
+            processes[1].start()
+            started.append(processes[1])
+            self.assertTrue(attempting[1].wait(5))
+            self.assertFalse(pre_ready[1].is_set())
+
+            # Both starts use distinct topology, profile/build, state, and
+            # explicit-port coordinates. P0 records that the global allocator
+            # lease still serializes B until A leaves its pre-ready stage; #401
+            # will flip this assertion to require concurrent rendezvous entry.
+            releases[0].set()
+            self.assertTrue(pre_ready[1].wait(5))
+            releases[1].set()
+        finally:
+            for release in releases:
+                release.set()
+            join_or_stop_processes(started, 10)
+        self.assertEqual(started, processes)
+        self.assertEqual([process.exitcode for process in processes], [0, 0])
+        self.assertEqual([results.get(timeout=2) for _ in processes], [None, None])
 
     def test_layout_lock_reports_one_actionable_prolonged_wait(self) -> None:
         layout = self.workspace.paths.workspace / "repository-layout.lock"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -323,7 +323,7 @@ def profile_mutation_process(
             with mock.patch.object(
                 locking_module.fcntl, "flock", side_effect=observe_flock
             ):
-                workspace.set_profile("profile-a", "client", "primary")
+                workspace.set_profile("profile-b", "client", "primary")
             entered.set()
         results.put(None)
     except BaseException as error:
@@ -336,7 +336,7 @@ def public_lifecycle_reader_process(
     workspace_directory: str,
     operation: str,
     build_root: str,
-    attempting: object,
+    blocked: object,
     entered: object,
     results: object,
 ) -> None:
@@ -345,33 +345,62 @@ def public_lifecycle_reader_process(
             os.environ, {"ATRINIK_WORKSPACE_DIR": workspace_directory}
         ):
             workspace = Workspace(Path(wrapper))
-            attempting.set()
-            if operation == "build-b":
-                workspace.build("sound", "profile-b", False)
-            else:
-                with (
-                    mock.patch.object(workspace, "_require_client_display"),
-                    mock.patch.object(
-                        workspace,
-                        "_build_resolved",
-                        return_value=Path(build_root),
-                    ),
+            pending_path = locking_module.layout_writer_pending_path(
+                workspace.paths.workspace / "repository-layout.lock"
+            ).resolve()
+            intent_path = locking_module.layout_writer_intent_path(
+                workspace.paths.workspace / "repository-layout.lock"
+            ).resolve()
+            real_flock = locking_module.fcntl.flock
+
+            def observe_flock(lock: object, operation: int) -> None:
+                descriptor = lock if isinstance(lock, int) else lock.fileno()
+                descriptor_path = Path(
+                    os.readlink(f"/proc/self/fd/{descriptor}")
+                )
+                if (
+                    operation & fcntl.LOCK_EX
+                    and not operation & fcntl.LOCK_NB
+                    and descriptor_path in {pending_path, intent_path}
                 ):
-                    try:
-                        workspace.topology_up(
-                            "topology-b",
-                            "profile-b",
-                            "default",
-                            ["client"],
-                        )
-                    finally:
-                        status_path = (
-                            workspace.paths.topologies
-                            / "topology-b"
-                            / "status.json"
-                        )
-                        if status_path.is_file():
-                            workspace.topology_down("topology-b", timeout=5)
+                    with descriptor_path.open("a+", encoding="utf-8") as probe:
+                        try:
+                            real_flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                        except BlockingIOError:
+                            blocked.set()
+                        else:
+                            real_flock(probe, fcntl.LOCK_UN)
+                real_flock(lock, operation)
+
+            with mock.patch.object(
+                locking_module.fcntl, "flock", side_effect=observe_flock
+            ):
+                if operation == "build-c":
+                    workspace.build("sound", "profile-c", False)
+                else:
+                    with (
+                        mock.patch.object(workspace, "_require_client_display"),
+                        mock.patch.object(
+                            workspace,
+                            "_build_resolved",
+                            return_value=Path(build_root),
+                        ),
+                    ):
+                        try:
+                            workspace.topology_up(
+                                "topology-c",
+                                "profile-c",
+                                "default",
+                                ["client"],
+                            )
+                        finally:
+                            status_path = (
+                                workspace.paths.topologies
+                                / "topology-c"
+                                / "status.json"
+                            )
+                            if status_path.is_file():
+                                workspace.topology_down("topology-c", timeout=5)
             entered.set()
         results.put(None)
     except BaseException as error:
@@ -386,7 +415,10 @@ def synthetic_server_start_process(
     state_path: str,
     build_root: str,
     port: int,
-    port_attempting: object,
+    reserved_port: socket.socket,
+    reservation_received: object,
+    release_reservation: object,
+    port_blocked: object,
     results: object,
 ) -> None:
     try:
@@ -404,8 +436,18 @@ def synthetic_server_start_process(
                 descriptor_path = Path(
                     os.readlink(f"/proc/self/fd/{descriptor}")
                 )
-                if operation & fcntl.LOCK_EX and descriptor_path == ports_path:
-                    port_attempting.set()
+                if (
+                    operation & fcntl.LOCK_EX
+                    and not operation & fcntl.LOCK_NB
+                    and descriptor_path == ports_path
+                ):
+                    with ports_path.open("a+", encoding="utf-8") as probe:
+                        try:
+                            real_flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                        except BlockingIOError:
+                            port_blocked.set()
+                        else:
+                            real_flock(probe, fcntl.LOCK_UN)
                 real_flock(lock, operation)
 
             runtime_inputs = {
@@ -414,6 +456,11 @@ def synthetic_server_start_process(
             }
             for path in runtime_inputs.values():
                 path.mkdir(parents=True, exist_ok=True)
+
+            reservation_received.set()
+            if not release_reservation.wait(10):
+                raise TimeoutError("port reservation was not released")
+            reserved_port.close()
 
             with (
                 mock.patch.object(
@@ -6005,14 +6052,14 @@ class WorkspaceTests(unittest.TestCase):
 
     def test_p0_harness_reproduces_current_lifecycle_layout_convoy(self) -> None:
         context = multiprocessing.get_context("spawn")
-        for label in ("source-a", "source-b"):
+        for label in ("source-a", "source-b", "source-c"):
             self.workspace.create_worktree(
                 "client", label, f"test/{label}", None, False
             )
         self.workspace.create_worktree(
-            "sound", "source-b", "test/sound-source-b", None, False
+            "sound", "source-c", "test/sound-source-c", None, False
         )
-        for profile in ("profile-a", "profile-b"):
+        for profile in ("profile-a", "profile-b", "profile-c"):
             self.workspace.create_profile(profile)
         self.workspace.set_profile(
             "profile-a", "client", "worktree", "source-a"
@@ -6021,7 +6068,10 @@ class WorkspaceTests(unittest.TestCase):
             "profile-b", "client", "worktree", "source-b"
         )
         self.workspace.set_profile(
-            "profile-b", "sound", "worktree", "source-b"
+            "profile-c", "client", "worktree", "source-c"
+        )
+        self.workspace.set_profile(
+            "profile-c", "sound", "worktree", "source-c"
         )
 
         def client_build_root(profile: str) -> Path:
@@ -6048,7 +6098,7 @@ class WorkspaceTests(unittest.TestCase):
             return root
 
         topology_a_root = client_build_root("profile-a")
-        topology_b_root = client_build_root("profile-b")
+        topology_c_root = client_build_root("profile-c")
         with (
             mock.patch.object(
                 self.workspace, "_build_resolved", return_value=topology_a_root
@@ -6062,7 +6112,7 @@ class WorkspaceTests(unittest.TestCase):
 
         writer_pending = context.Event()
         writer_entered = context.Event()
-        reader_attempting = [context.Event(), context.Event()]
+        readers_blocked = [context.Event(), context.Event()]
         readers_entered = [context.Event(), context.Event()]
         results = context.Queue()
         writer = context.Process(
@@ -6082,13 +6132,13 @@ class WorkspaceTests(unittest.TestCase):
                     str(self.wrapper),
                     str(self.workspace_directory),
                     operation,
-                    str(topology_b_root),
-                    reader_attempting[index],
+                    str(topology_c_root),
+                    readers_blocked[index],
                     readers_entered[index],
                     results,
                 ),
             )
-            for index, operation in enumerate(("build-b", "topology-b"))
+            for index, operation in enumerate(("build-c", "topology-c"))
         ]
         processes = [writer, *readers]
         started: list[multiprocessing.Process] = []
@@ -6103,18 +6153,20 @@ class WorkspaceTests(unittest.TestCase):
             for reader in readers:
                 reader.start()
                 started.append(reader)
-            for index, attempt in enumerate(reader_attempting):
+            for index, blocked in enumerate(readers_blocked):
                 wait_for_process_event(
-                    attempt, f"B reader {index} attempt", results
+                    blocked, f"C reader {index} confirmed lock block", results
                 )
             self.assertFalse(writer_entered.is_set())
             self.assertTrue(all(not entered.is_set() for entered in readers_entered))
 
-            # This is the P0 current-behavior assertion. The #399 cutover will
-            # invert it: disjoint B readers must enter while A's writer waits.
+            # This records the current global A-topology/B-writer/C-reader
+            # convoy through positive lock-contention rendezvous. The #399
+            # cutover will replace this lock-specific expectation with scoped
+            # admission assertions for the same public operations.
             self.workspace.topology_down("topology-a", timeout=5)
             wait_for_process_event(
-                writer_entered, "profile A mutation entry", results
+                writer_entered, "profile B mutation entry", results
             )
             for index, entered in enumerate(readers_entered):
                 wait_for_process_event(
@@ -6140,18 +6192,21 @@ class WorkspaceTests(unittest.TestCase):
     ) -> None:
         context = multiprocessing.get_context("spawn")
         results = context.Queue()
-        attempting = [context.Event(), context.Event()]
+        reservation_received = [context.Event(), context.Event()]
+        release_reservation = [context.Event(), context.Event()]
+        port_blocked = [context.Event(), context.Event()]
         pre_ready = [self.root / "pre-ready-a", self.root / "pre-ready-b"]
         releases = [self.root / "release-a", self.root / "release-b"]
 
-        def available_port() -> int:
-            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as candidate:
-                candidate.bind(("127.0.0.1", 0))
-                return candidate.getsockname()[1]
+        def reserved_port() -> socket.socket:
+            candidate = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            candidate.bind(("127.0.0.1", 0))
+            return candidate
 
+        reservations = [reserved_port(), reserved_port()]
         coordinates = (
-            ("server-a", "state-a", "build-a", available_port()),
-            ("server-b", "state-b", "build-b", available_port()),
+            ("server-a", "state-a", "build-a", reservations[0].getsockname()[1]),
+            ("server-b", "state-b", "build-b", reservations[1].getsockname()[1]),
         )
         self.assertNotEqual(coordinates[0][3], coordinates[1][3])
         for index, (name, _state, build, _port) in enumerate(coordinates):
@@ -6189,7 +6244,10 @@ class WorkspaceTests(unittest.TestCase):
                     str(self.workspace.paths.state / state),
                     str(self.workspace.paths.builds / "profiles" / build),
                     port,
-                    attempting[index],
+                    reservations[index],
+                    reservation_received[index],
+                    release_reservation[index],
+                    port_blocked[index],
                     results,
                 ),
             )
@@ -6215,25 +6273,41 @@ class WorkspaceTests(unittest.TestCase):
             processes[0].start()
             started.append(processes[0])
             wait_for_process_event(
-                attempting[0], "server A port-lock attempt", results
+                reservation_received[0],
+                "server A port reservation transfer",
+                results,
             )
+            reservations[0].close()
+            release_reservation[0].set()
             wait_for_path(pre_ready[0], "server A pre-ready barrier")
 
             processes[1].start()
             started.append(processes[1])
             wait_for_process_event(
-                attempting[1], "server B port-lock attempt", results
+                reservation_received[1],
+                "server B port reservation transfer",
+                results,
+            )
+            reservations[1].close()
+            release_reservation[1].set()
+            wait_for_process_event(
+                port_blocked[1], "server B confirmed port-lock block", results
             )
             self.assertFalse(pre_ready[1].exists())
 
             # Both starts use distinct topology, profile/build, state, and
-            # explicit-port coordinates. P0 records that the global allocator
-            # lease still serializes B until A leaves its pre-ready stage; #401
-            # will flip this assertion to require concurrent rendezvous entry.
+            # explicit-port coordinates. P0 positively records that the global
+            # allocator lease serializes B until A leaves its pre-ready stage.
+            # The #401 cutover will replace this lock-specific expectation with
+            # per-port ownership and concurrent pre-ready rendezvous assertions.
             releases[0].write_text("release\n", encoding="utf-8")
             wait_for_path(pre_ready[1], "server B pre-ready barrier")
             releases[1].write_text("release\n", encoding="utf-8")
         finally:
+            for reservation in reservations:
+                reservation.close()
+            for event in release_reservation:
+                event.set()
             for release in releases:
                 release.write_text("release\n", encoding="utf-8")
             join_or_stop_processes(started, 10)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -449,6 +449,11 @@ def synthetic_server_start_process(
                         else:
                             real_flock(probe, fcntl.LOCK_UN)
                 real_flock(lock, operation)
+                if (
+                    operation & fcntl.LOCK_EX
+                    and descriptor_path == ports_path
+                ):
+                    reserved_port.close()
 
             runtime_inputs = {
                 key: root / key
@@ -460,7 +465,6 @@ def synthetic_server_start_process(
             reservation_received.set()
             if not release_reservation.wait(10):
                 raise TimeoutError("port reservation was not released")
-            reserved_port.close()
 
             with (
                 mock.patch.object(
@@ -495,6 +499,7 @@ def synthetic_server_start_process(
                         workspace.topology_down(name, timeout=5)
         results.put(None)
     except BaseException as error:
+        reserved_port.close()
         results.put(f"{type(error).__name__}: {error}")
         raise
 
@@ -6146,7 +6151,7 @@ class WorkspaceTests(unittest.TestCase):
             writer.start()
             started.append(writer)
             wait_for_process_event(
-                writer_pending, "profile A mutation queue", results
+                writer_pending, "profile B mutation queue", results
             )
             self.assertFalse(writer_entered.is_set())
 
@@ -6170,7 +6175,7 @@ class WorkspaceTests(unittest.TestCase):
             )
             for index, entered in enumerate(readers_entered):
                 wait_for_process_event(
-                    entered, f"B reader {index} completion", results
+                    entered, f"C reader {index} completion", results
                 )
         finally:
             status_path = (
@@ -6200,7 +6205,7 @@ class WorkspaceTests(unittest.TestCase):
 
         def reserved_port() -> socket.socket:
             candidate = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            candidate.bind(("127.0.0.1", 0))
+            candidate.bind(("0.0.0.0", 0))
             return candidate
 
         reservations = [reserved_port(), reserved_port()]


### PR DESCRIPTION
## Scope

Delivers the P0 regression-harness portion of #404 defined by the #398 plan of record. This intentionally does not claim or close the full P1/P2 integration matrix.

- reproduces the current topology-A → unrelated writer-B → disjoint reader-C convoy with positive multiprocess lock-contention rendezvous;
- exercises two distinct server startup paths through a controlled pre-ready boundary and records the current readiness-duration global port-lock serialization;
- identifies the current lock-specific expectations that #399 and #401 will replace when scoped leases and per-port reservations land.

## Coordinates

- Base: `main` at `c273b75b69261d63b82d8abbd2c5f9d417b96658`
- Head: `test/concurrent-lifecycle-harness-404` at `9490c3ddd8dab5f12def6882a7befa5d77163321`
- Commits:
  - `0a0b53013 test(workspace): reproduce P0 lifecycle convoys`
  - `b0ed1986c test(workspace): exercise real lifecycle boundaries`
  - `76ebe3ef9 test(workspace): harden convoy rendezvous`
  - `9490c3ddd test(workspace): retain port reservations through admission`
- Worktree: `/workspaces/atrinik/workspace/worktrees/atrinik/issue-404-concurrent-lifecycle`
- Issue: Relates to #404; parent plan #398

## Validation

- Complete coverage-backed wrapper suite: 637 tests passed; 82% aggregate coverage.
- Focused current lock-contract matrix: 6 tests passed.
- Revised real-lifecycle P0 harness: 5 consecutive two-test stress runs passed independently; a separate 3-run final reservation review passed.
- `python -m compileall -q atrinik atrinik_workspace tests`: passed.
- Guidance inventory, manifest validation, and supply-chain validation: passed.
- Cleanup dry run: 0 candidates, 0 inventory errors; no cleanup was applied.
- `git diff --check`: passed.

## Verification

Runtime provisioning is not applicable to this test-only slice. Run:

```sh
/workspaces/atrinik/.venv/bin/python -m unittest -v \
  tests.test_workspace.WorkspaceTests.test_p0_harness_reproduces_current_lifecycle_layout_convoy \
  tests.test_workspace.WorkspaceTests.test_p0_harness_reproduces_current_server_startup_port_convoy
```

The lifecycle test provisions real temporary Git worktrees/profiles, keeps a
supervised topology A live, queues an unrelated public profile-B mutation, and
drives disjoint public build/topology readers. The startup test launches
controllable servers whose distinct wildcard UDP ports stay reserved through
allocator admission, bind those ports, and pause
immediately before the supervisor's readiness marker. Observable lease,
process, and filesystem transitions provide synchronization; timeouts are
failure bounds only. All fixture resources are temporary and joined/stopped by
test teardown.
