### PR TITLE
perf(runtime): reserve ports without serializing topology startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -939,11 +939,13 @@ supervisor. A server gets an available UDP port by default; `--port 0` has the
 same automatic-allocation meaning, while `--port 1` through `--port 65535`
 requests that exact port. Automatic selection briefly holds the workspace
 allocator only while it chooses and publishes a unique generation-bound
-reservation. Every server then retains its own mode-0600 per-port lease through
+reservation. Every port uses a short mode-0600 transaction file, and every
+server retains its own immutable mode-0600 generation lease through
 supervisor and guardian recovery, so startup preparation and readiness waits
 for different ports overlap. An exact-port conflict fails without waiting for
 an unrelated port and names the owning topology and generation plus the safe
-`ps`/`down` action. The supervisor rechecks kernel availability immediately
+retry action; once startup has published supervisor status, `ps` and `down`
+are available. The supervisor rechecks kernel availability immediately
 before launching the server; an external process that wins the bind race
 produces a bounded startup error without changing another topology's
 reservation. The supervisor waits for both the QUIC certificate fingerprint and
@@ -974,7 +976,7 @@ not interrupt a reader, topology, build, or mutation. The pending announcement,
 writer-intent gate, and layout lock are always acquired before topology,
 scenario, port allocator/per-port reservation, state, build-root, registry, or
 cache locks. The allocator is released before state/build/runtime preparation;
-the exact per-port reservation remains held. Foreground
+the exact generation reservation remains held. Foreground
 processes inherit their layout and exact build-root leases. Supervised services
 inherit both leases through the daemon and keep them until every service exits
 or `down` completes. Mutation
@@ -992,7 +994,8 @@ client configuration/cache root and its own copies of the collected content and
 resource caches, so changing or removing one topology cannot affect another
 topology or the retained build caches. The inherited identity lease atomically
 prevents the same topology name from restarting while any generation remains.
-Server services do not inherit allocator or per-port reservation descriptors;
+Server services do not inherit allocator, transaction, or generation
+reservation descriptors;
 the supervisor and same-generation guardian retain the exact reservation and
 release it after orderly shutdown or exact process-tree recovery. `ps --json`
 exposes its port, owner, generation, and retained/released observation without

--- a/README.md
+++ b/README.md
@@ -935,9 +935,18 @@ runnable implementation; the `default` replacement profile will become
 runnable as its component contracts land. For a runnable profile, `up` builds
 the requested targets, reuses or refreshes content and resource caches, stages
 sound, prepares an isolated runtime, and starts both game processes under one
-supervisor. A server
-gets an available UDP port by default; use `--port` when a stable port is
-useful. The supervisor waits for both the QUIC certificate fingerprint and
+supervisor. A server gets an available UDP port by default; `--port 0` has the
+same automatic-allocation meaning, while `--port 1` through `--port 65535`
+requests that exact port. Automatic selection briefly holds the workspace
+allocator only while it chooses and publishes a unique generation-bound
+reservation. Every server then retains its own mode-0600 per-port lease through
+supervisor and guardian recovery, so startup preparation and readiness waits
+for different ports overlap. An exact-port conflict fails without waiting for
+an unrelated port and names the owning topology and generation plus the safe
+`ps`/`down` action. The supervisor rechecks kernel availability immediately
+before launching the server; an external process that wins the bind race
+produces a bounded startup error without changing another topology's
+reservation. The supervisor waits for both the QUIC certificate fingerprint and
 completed server initialization, then gives the paired client an authenticated
 loopback endpoint, disables metaserver and STUN discovery in that client, and
 disables STUN discovery and automatic port mapping in the server before
@@ -963,7 +972,9 @@ fails closed when advisory shared locking is unavailable. A wait longer than 10
 seconds emits one diagnostic naming safe `ps` and worktree inventories; it does
 not interrupt a reader, topology, build, or mutation. The pending announcement,
 writer-intent gate, and layout lock are always acquired before topology,
-scenario, state, build-root, port, registry, or cache locks. Foreground
+scenario, port allocator/per-port reservation, state, build-root, registry, or
+cache locks. The allocator is released before state/build/runtime preparation;
+the exact per-port reservation remains held. Foreground
 processes inherit their layout and exact build-root leases. Supervised services
 inherit both leases through the daemon and keep them until every service exits
 or `down` completes. Mutation
@@ -981,6 +992,11 @@ client configuration/cache root and its own copies of the collected content and
 resource caches, so changing or removing one topology cannot affect another
 topology or the retained build caches. The inherited identity lease atomically
 prevents the same topology name from restarting while any generation remains.
+Server services do not inherit allocator or per-port reservation descriptors;
+the supervisor and same-generation guardian retain the exact reservation and
+release it after orderly shutdown or exact process-tree recovery. `ps --json`
+exposes its port, owner, generation, and retained/released observation without
+credentials. Reservation records are never reclaimed from recorded PIDs.
 Logs live below `workspace/topologies/`
 and rotate at 10 MiB with three backups.
 

--- a/README.md
+++ b/README.md
@@ -978,8 +978,9 @@ scenario, port allocator/per-port reservation, state, build-root, registry, or
 cache locks. The allocator is released before state/build/runtime preparation;
 the exact generation reservation remains held. Foreground
 processes inherit their layout and exact build-root leases. Supervised services
-inherit both leases through the daemon and keep them until every service exits
-or `down` completes. Mutation
+inherit only the process-tree identity through the daemon. The supervisor and
+same-generation guardian keep layout, build-root, state, and generation
+reservation leases until every service exits or `down` completes. Mutation
 subprocesses inherit all three writer leases. Build and scenario
 subprocesses inherit every active layout, build-root, state, registry, and cache
 lease so an orphan cannot outlive its protection.

--- a/atrinik_workspace/port_reservation.py
+++ b/atrinik_workspace/port_reservation.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+from pathlib import Path
+import re
+import stat
+from typing import Any
+
+
+PORT_RESERVATION_SCHEMA_VERSION = 1
+PORT_RESERVATION_DIRECTORY = "port-reservations"
+PORT_RESERVATION_KEYS = {
+    "schema_version",
+    "port",
+    "topology",
+    "generation",
+    "path",
+    "lease",
+}
+GENERATION_PATTERN = re.compile(r"[0-9a-f]{64}")
+TOPOLOGY_PATTERN = re.compile(r"[a-z0-9][a-z0-9._-]*")
+MAX_RECORD_SIZE = 4096
+
+
+class PortReservationError(RuntimeError):
+    """A topology UDP-port reservation cannot be trusted or acquired."""
+
+
+def _validate_port(port: Any) -> int:
+    if (
+        not isinstance(port, int)
+        or isinstance(port, bool)
+        or not 1 <= port <= 65535
+    ):
+        raise PortReservationError("reserved topology port must be between 1 and 65535")
+    return port
+
+
+def _validate_lease_identity(value: Any) -> dict[str, int]:
+    if (
+        not isinstance(value, dict)
+        or set(value) != {"device", "inode"}
+        or not all(
+            isinstance(item, int) and not isinstance(item, bool) and item >= 0
+            for item in value.values()
+        )
+    ):
+        raise PortReservationError("topology port reservation lease identity is invalid")
+    return value
+
+
+def validate_record(value: Any, *, expected_path: Path | None = None) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != PORT_RESERVATION_KEYS:
+        raise PortReservationError("topology port reservation record is invalid")
+    if (
+        not isinstance(value.get("schema_version"), int)
+        or isinstance(value.get("schema_version"), bool)
+        or value["schema_version"] != PORT_RESERVATION_SCHEMA_VERSION
+    ):
+        raise PortReservationError("topology port reservation schema is unsupported")
+    port = _validate_port(value.get("port"))
+    topology = value.get("topology")
+    generation = value.get("generation")
+    path = value.get("path")
+    if not isinstance(topology, str) or not TOPOLOGY_PATTERN.fullmatch(topology):
+        raise PortReservationError("topology port reservation owner is invalid")
+    if not isinstance(generation, str) or not GENERATION_PATTERN.fullmatch(generation):
+        raise PortReservationError("topology port reservation generation is invalid")
+    if not isinstance(path, str) or not Path(path).is_absolute():
+        raise PortReservationError("topology port reservation path is invalid")
+    reservation_path = Path(path)
+    if reservation_path.name != f"{port}.lease":
+        raise PortReservationError("topology port reservation path does not match its port")
+    if expected_path is not None and reservation_path != expected_path:
+        raise PortReservationError("topology port reservation path is not the expected lease")
+    _validate_lease_identity(value.get("lease"))
+    return value
+
+
+def _secure_directory(topologies: Path) -> Path:
+    directory = topologies / PORT_RESERVATION_DIRECTORY
+    try:
+        directory.mkdir(mode=0o700)
+    except FileExistsError:
+        pass
+    try:
+        metadata = directory.lstat()
+    except OSError as error:
+        raise PortReservationError(
+            f"cannot inspect topology port reservation directory {directory}: {error}"
+        ) from error
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_IMODE(metadata.st_mode) != 0o700
+        or metadata.st_uid != os.geteuid()
+    ):
+        raise PortReservationError(
+            f"topology port reservation directory is invalid: {directory}"
+        )
+    return directory
+
+
+def _validate_descriptor(descriptor: int, path: Path) -> os.stat_result:
+    try:
+        metadata = os.fstat(descriptor)
+        path_metadata = path.lstat()
+    except OSError as error:
+        raise PortReservationError(
+            f"cannot inspect topology port reservation lease {path}: {error}"
+        ) from error
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or stat.S_IMODE(metadata.st_mode) != 0o600
+        or metadata.st_uid != os.geteuid()
+        or metadata.st_nlink != 1
+        or not stat.S_ISREG(path_metadata.st_mode)
+        or (path_metadata.st_dev, path_metadata.st_ino)
+        != (metadata.st_dev, metadata.st_ino)
+    ):
+        raise PortReservationError(
+            f"topology port reservation lease identity is invalid: {path}"
+        )
+    return metadata
+
+
+def open_lease(topologies: Path, port: int) -> tuple[int, Path]:
+    port = _validate_port(port)
+    path = _secure_directory(topologies) / f"{port}.lease"
+    flags = os.O_RDWR | os.O_CREAT | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags, 0o600)
+    except OSError as error:
+        raise PortReservationError(
+            f"cannot open topology port reservation lease {path}: {error}"
+        ) from error
+    try:
+        _validate_descriptor(descriptor, path)
+    except BaseException:
+        os.close(descriptor)
+        raise
+    return descriptor, path
+
+
+def try_lock(descriptor: int) -> bool:
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except BlockingIOError:
+        return False
+    except OSError as error:
+        raise PortReservationError(
+            f"cannot lock topology port reservation lease: {error}"
+        ) from error
+
+
+def read_record(descriptor: int, path: Path) -> dict[str, Any]:
+    def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        value: dict[str, Any] = {}
+        for key, item in pairs:
+            if key in value:
+                raise ValueError(f"duplicate JSON key: {key}")
+            value[key] = item
+        return value
+
+    try:
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        content = os.read(descriptor, MAX_RECORD_SIZE + 1)
+        if len(content) > MAX_RECORD_SIZE:
+            raise PortReservationError("topology port reservation record is too large")
+        value = json.loads(
+            content.decode("utf-8"), object_pairs_hook=reject_duplicate_keys
+        )
+    except PortReservationError:
+        raise
+    except (OSError, UnicodeError, ValueError) as error:
+        raise PortReservationError(
+            f"cannot read topology port reservation record {path}: {error}"
+        ) from error
+    return validate_record(value, expected_path=path)
+
+
+def bind_record(
+    descriptor: int,
+    path: Path,
+    *,
+    port: int,
+    topology: str,
+    generation: str,
+) -> dict[str, Any]:
+    metadata = _validate_descriptor(descriptor, path)
+    record = validate_record(
+        {
+            "schema_version": PORT_RESERVATION_SCHEMA_VERSION,
+            "port": port,
+            "topology": topology,
+            "generation": generation,
+            "path": str(path),
+            "lease": {"device": metadata.st_dev, "inode": metadata.st_ino},
+        },
+        expected_path=path,
+    )
+    payload = (json.dumps(record, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    try:
+        os.ftruncate(descriptor, 0)
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        view = memoryview(payload)
+        while view:
+            written = os.write(descriptor, view)
+            if written <= 0:
+                raise OSError("short write")
+            view = view[written:]
+        os.fsync(descriptor)
+    except OSError as error:
+        raise PortReservationError(
+            f"cannot publish topology port reservation {path}: {error}"
+        ) from error
+    _validate_descriptor(descriptor, path)
+    return record
+
+
+def validate_held(descriptor: int, record: Any) -> dict[str, Any]:
+    validated = validate_record(record)
+    path = Path(validated["path"])
+    metadata = _validate_descriptor(descriptor, path)
+    identity = validated["lease"]
+    if (metadata.st_dev, metadata.st_ino) != (
+        identity["device"],
+        identity["inode"],
+    ):
+        raise PortReservationError("topology port reservation lease was replaced")
+    return validated
+
+
+def reservation_locked(record: Any) -> bool:
+    validated = validate_record(record)
+    path = Path(validated["path"])
+    flags = os.O_RDWR | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as error:
+        raise PortReservationError(
+            f"cannot inspect topology port reservation lease {path}: {error}"
+        ) from error
+    try:
+        validate_held(descriptor, validated)
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return True
+        except OSError as error:
+            raise PortReservationError(
+                f"cannot inspect topology port reservation lock {path}: {error}"
+            ) from error
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        return False
+    finally:
+        os.close(descriptor)

--- a/atrinik_workspace/port_reservation.py
+++ b/atrinik_workspace/port_reservation.py
@@ -121,9 +121,15 @@ def open_directory(topologies: Path) -> tuple[int, Path, dict[str, int]]:
         flags |= os.O_NOFOLLOW
     try:
         descriptor = os.open(directory, flags)
+    except OSError as error:
+        raise PortReservationError(
+            f"cannot open topology port reservation directory {directory}: {error}"
+        ) from error
+    try:
         metadata = os.fstat(descriptor)
         path_metadata = directory.lstat()
     except OSError as error:
+        os.close(descriptor)
         raise PortReservationError(
             f"cannot open topology port reservation directory {directory}: {error}"
         ) from error
@@ -218,6 +224,12 @@ def try_lock(descriptor: int) -> bool:
         raise PortReservationError(
             f"cannot lock topology port reservation lease: {error}"
         ) from error
+
+
+def validate_transaction(
+    descriptor: int, directory_descriptor: int, port: int
+) -> None:
+    _validate_child(descriptor, directory_descriptor, f"{_validate_port(port)}.lock")
 
 
 def _decode_record(content: bytes, path: Path) -> dict[str, Any]:
@@ -330,11 +342,18 @@ def create_lease(
         _validate_directory_path(directory, directory_identity)
         return descriptor, record
     except BaseException:
-        os.close(descriptor)
         try:
-            os.unlink(path.name, dir_fd=directory_descriptor)
+            created = os.fstat(descriptor)
+            current = os.stat(
+                path.name,
+                dir_fd=directory_descriptor,
+                follow_symlinks=False,
+            )
+            if (created.st_dev, created.st_ino) == (current.st_dev, current.st_ino):
+                os.unlink(path.name, dir_fd=directory_descriptor)
         except OSError:
             pass
+        os.close(descriptor)
         raise
 
 

--- a/atrinik_workspace/port_reservation.py
+++ b/atrinik_workspace/port_reservation.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 import re
 import stat
+import time
 from typing import Any
 
 
@@ -252,7 +253,19 @@ def reservation_locked(record: Any) -> bool:
         try:
             fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
         except BlockingIOError:
-            return True
+            # A normal later owner rewrites the same lease inode. Attribute a
+            # conflicting lock only when the record currently protected by it
+            # still names this exact topology generation.
+            deadline = time.monotonic() + 1
+            while True:
+                try:
+                    current = read_record(descriptor, path)
+                    validate_held(descriptor, current)
+                    return current == validated
+                except PortReservationError:
+                    if time.monotonic() >= deadline:
+                        raise
+                    time.sleep(0.01)
         except OSError as error:
             raise PortReservationError(
                 f"cannot inspect topology port reservation lock {path}: {error}"

--- a/atrinik_workspace/port_reservation.py
+++ b/atrinik_workspace/port_reservation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import ctypes
+import errno
 import fcntl
 import json
 import os
@@ -199,6 +201,49 @@ def _open_child(
     return descriptor
 
 
+def _rename_no_replace(
+    directory_descriptor: int, source: str, destination: str
+) -> None:
+    try:
+        renameat2 = ctypes.CDLL(None, use_errno=True).renameat2
+    except AttributeError as error:
+        raise PortReservationError(
+            "atomic no-replace reservation publication is unsupported"
+        ) from error
+    renameat2.argtypes = [
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_uint,
+    ]
+    renameat2.restype = ctypes.c_int
+    if (
+        renameat2(
+            directory_descriptor,
+            os.fsencode(source),
+            directory_descriptor,
+            os.fsencode(destination),
+            1,
+        )
+        == 0
+    ):
+        return
+    error_number = ctypes.get_errno()
+    if error_number == errno.EEXIST:
+        raise PortReservationError(
+            f"topology port reservation generation already exists: {destination}"
+        )
+    if error_number in {errno.ENOSYS, errno.EINVAL}:
+        raise PortReservationError(
+            "atomic no-replace reservation publication is unsupported"
+        )
+    raise PortReservationError(
+        f"cannot publish topology port reservation {destination}: "
+        f"{os.strerror(error_number)}"
+    )
+
+
 def open_transaction(
     topologies: Path, port: int
 ) -> tuple[int, int, Path, dict[str, int]]:
@@ -304,12 +349,13 @@ def create_lease(
     generation: str,
 ) -> tuple[int, dict[str, Any]]:
     path = directory / f"{port}-{generation}.lease"
+    staging_name = f".staging-{port}-{generation}-{secrets.token_hex(16)}"
     descriptor = _open_child(
-        directory_descriptor, path.name, os.O_RDWR, exclusive=True
+        directory_descriptor, staging_name, os.O_RDWR, exclusive=True
     )
     try:
         fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        metadata = _validate_child(descriptor, directory_descriptor, path.name)
+        metadata = _validate_child(descriptor, directory_descriptor, staging_name)
         token = secrets.token_hex(32)
         try:
             os.setxattr(descriptor, "user.atrinik.port-reservation", token.encode())
@@ -338,21 +384,13 @@ def create_lease(
                 raise OSError("short write")
             view = view[written:]
         os.fsync(descriptor)
+        _validate_child(descriptor, directory_descriptor, staging_name)
+        _validate_directory_path(directory, directory_identity)
+        _rename_no_replace(directory_descriptor, staging_name, path.name)
         _validate_child(descriptor, directory_descriptor, path.name)
         _validate_directory_path(directory, directory_identity)
         return descriptor, record
     except BaseException:
-        try:
-            created = os.fstat(descriptor)
-            current = os.stat(
-                path.name,
-                dir_fd=directory_descriptor,
-                follow_symlinks=False,
-            )
-            if (created.st_dev, created.st_ino) == (current.st_dev, current.st_ino):
-                os.unlink(path.name, dir_fd=directory_descriptor)
-        except OSError:
-            pass
         os.close(descriptor)
         raise
 

--- a/atrinik_workspace/port_reservation.py
+++ b/atrinik_workspace/port_reservation.py
@@ -5,8 +5,8 @@ import json
 import os
 from pathlib import Path
 import re
+import secrets
 import stat
-import time
 from typing import Any
 
 
@@ -18,7 +18,9 @@ PORT_RESERVATION_KEYS = {
     "topology",
     "generation",
     "path",
+    "directory",
     "lease",
+    "token",
 }
 GENERATION_PATTERN = re.compile(r"[0-9a-f]{64}")
 TOPOLOGY_PATTERN = re.compile(r"[a-z0-9][a-z0-9._-]*")
@@ -39,7 +41,7 @@ def _validate_port(port: Any) -> int:
     return port
 
 
-def _validate_lease_identity(value: Any) -> dict[str, int]:
+def _validate_identity(value: Any, description: str) -> dict[str, int]:
     if (
         not isinstance(value, dict)
         or set(value) != {"device", "inode"}
@@ -48,7 +50,9 @@ def _validate_lease_identity(value: Any) -> dict[str, int]:
             for item in value.values()
         )
     ):
-        raise PortReservationError("topology port reservation lease identity is invalid")
+        raise PortReservationError(
+            f"topology port reservation {description} identity is invalid"
+        )
     return value
 
 
@@ -72,20 +76,23 @@ def validate_record(value: Any, *, expected_path: Path | None = None) -> dict[st
     if not isinstance(path, str) or not Path(path).is_absolute():
         raise PortReservationError("topology port reservation path is invalid")
     reservation_path = Path(path)
-    if reservation_path.name != f"{port}.lease":
-        raise PortReservationError("topology port reservation path does not match its port")
+    if reservation_path.name != f"{port}-{generation}.lease":
+        raise PortReservationError("topology port reservation path does not match its owner")
     if expected_path is not None and reservation_path != expected_path:
         raise PortReservationError("topology port reservation path is not the expected lease")
-    _validate_lease_identity(value.get("lease"))
+    _validate_identity(value.get("directory"), "directory")
+    _validate_identity(value.get("lease"), "lease")
+    token = value.get("token")
+    if not isinstance(token, str) or not GENERATION_PATTERN.fullmatch(token):
+        raise PortReservationError("topology port reservation creation token is invalid")
     return value
 
 
-def _secure_directory(topologies: Path) -> Path:
-    directory = topologies / PORT_RESERVATION_DIRECTORY
-    try:
-        directory.mkdir(mode=0o700)
-    except FileExistsError:
-        pass
+def _directory_identity(metadata: os.stat_result) -> dict[str, int]:
+    return {"device": metadata.st_dev, "inode": metadata.st_ino}
+
+
+def _validate_directory_path(directory: Path, identity: dict[str, int]) -> None:
     try:
         metadata = directory.lstat()
     except OSError as error:
@@ -94,22 +101,60 @@ def _secure_directory(topologies: Path) -> Path:
         ) from error
     if (
         not stat.S_ISDIR(metadata.st_mode)
+        or _directory_identity(metadata) != identity
+    ):
+        raise PortReservationError(
+            f"topology port reservation directory was replaced: {directory}"
+        )
+
+
+def open_directory(topologies: Path) -> tuple[int, Path, dict[str, int]]:
+    directory = topologies / PORT_RESERVATION_DIRECTORY
+    try:
+        directory.mkdir(mode=0o700)
+    except FileExistsError:
+        pass
+    flags = os.O_RDONLY | os.O_CLOEXEC
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(directory, flags)
+        metadata = os.fstat(descriptor)
+        path_metadata = directory.lstat()
+    except OSError as error:
+        raise PortReservationError(
+            f"cannot open topology port reservation directory {directory}: {error}"
+        ) from error
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
         or stat.S_IMODE(metadata.st_mode) != 0o700
         or metadata.st_uid != os.geteuid()
+        or not stat.S_ISDIR(path_metadata.st_mode)
+        or (path_metadata.st_dev, path_metadata.st_ino)
+        != (metadata.st_dev, metadata.st_ino)
     ):
+        os.close(descriptor)
         raise PortReservationError(
             f"topology port reservation directory is invalid: {directory}"
         )
-    return directory
+    return descriptor, directory, _directory_identity(metadata)
 
 
-def _validate_descriptor(descriptor: int, path: Path) -> os.stat_result:
+def _validate_child(
+    descriptor: int,
+    directory_descriptor: int,
+    name: str,
+) -> os.stat_result:
     try:
         metadata = os.fstat(descriptor)
-        path_metadata = path.lstat()
+        path_metadata = os.stat(
+            name, dir_fd=directory_descriptor, follow_symlinks=False
+        )
     except OSError as error:
         raise PortReservationError(
-            f"cannot inspect topology port reservation lease {path}: {error}"
+            f"cannot inspect topology port reservation lease {name}: {error}"
         ) from error
     if (
         not stat.S_ISREG(metadata.st_mode)
@@ -121,29 +166,46 @@ def _validate_descriptor(descriptor: int, path: Path) -> os.stat_result:
         != (metadata.st_dev, metadata.st_ino)
     ):
         raise PortReservationError(
-            f"topology port reservation lease identity is invalid: {path}"
+            f"topology port reservation lease identity is invalid: {name}"
         )
     return metadata
 
 
-def open_lease(topologies: Path, port: int) -> tuple[int, Path]:
-    port = _validate_port(port)
-    path = _secure_directory(topologies) / f"{port}.lease"
-    flags = os.O_RDWR | os.O_CREAT | os.O_CLOEXEC
+def _open_child(
+    directory_descriptor: int, name: str, flags: int, *, exclusive: bool = False
+) -> int:
+    flags |= os.O_CLOEXEC
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
+    if exclusive:
+        flags |= os.O_CREAT | os.O_EXCL
     try:
-        descriptor = os.open(path, flags, 0o600)
+        descriptor = os.open(name, flags, 0o600, dir_fd=directory_descriptor)
     except OSError as error:
         raise PortReservationError(
-            f"cannot open topology port reservation lease {path}: {error}"
+            f"cannot open topology port reservation lease {name}: {error}"
         ) from error
     try:
-        _validate_descriptor(descriptor, path)
+        _validate_child(descriptor, directory_descriptor, name)
     except BaseException:
         os.close(descriptor)
         raise
-    return descriptor, path
+    return descriptor
+
+
+def open_transaction(
+    topologies: Path, port: int
+) -> tuple[int, int, Path, dict[str, int]]:
+    port = _validate_port(port)
+    directory_fd, directory, identity = open_directory(topologies)
+    try:
+        descriptor = _open_child(
+            directory_fd, f"{port}.lock", os.O_RDWR | os.O_CREAT
+        )
+    except BaseException:
+        os.close(directory_fd)
+        raise
+    return descriptor, directory_fd, directory, identity
 
 
 def try_lock(descriptor: int) -> bool:
@@ -158,7 +220,7 @@ def try_lock(descriptor: int) -> bool:
         ) from error
 
 
-def read_record(descriptor: int, path: Path) -> dict[str, Any]:
+def _decode_record(content: bytes, path: Path) -> dict[str, Any]:
     def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
         value: dict[str, Any] = {}
         for key, item in pairs:
@@ -168,8 +230,6 @@ def read_record(descriptor: int, path: Path) -> dict[str, Any]:
         return value
 
     try:
-        os.lseek(descriptor, 0, os.SEEK_SET)
-        content = os.read(descriptor, MAX_RECORD_SIZE + 1)
         if len(content) > MAX_RECORD_SIZE:
             raise PortReservationError("topology port reservation record is too large")
         value = json.loads(
@@ -177,37 +237,88 @@ def read_record(descriptor: int, path: Path) -> dict[str, Any]:
         )
     except PortReservationError:
         raise
-    except (OSError, UnicodeError, ValueError) as error:
+    except (UnicodeError, ValueError) as error:
         raise PortReservationError(
             f"cannot read topology port reservation record {path}: {error}"
         ) from error
     return validate_record(value, expected_path=path)
 
 
-def bind_record(
-    descriptor: int,
-    path: Path,
+def read_record(descriptor: int, path: Path) -> dict[str, Any]:
+    try:
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        content = os.read(descriptor, MAX_RECORD_SIZE + 1)
+    except OSError as error:
+        raise PortReservationError(
+            f"cannot read topology port reservation record {path}: {error}"
+        ) from error
+    return _decode_record(content, path)
+
+
+def active_owner(
+    directory_descriptor: int, directory: Path, port: int
+) -> dict[str, Any] | None:
+    prefix = f"{_validate_port(port)}-"
+    try:
+        names = sorted(os.listdir(directory_descriptor))
+    except OSError as error:
+        raise PortReservationError(
+            f"cannot list topology port reservations {directory}: {error}"
+        ) from error
+    for name in names:
+        if not name.startswith(prefix) or not name.endswith(".lease"):
+            continue
+        descriptor = _open_child(directory_descriptor, name, os.O_RDONLY)
+        try:
+            record = read_record(descriptor, directory / name)
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_SH | fcntl.LOCK_NB)
+            except BlockingIOError:
+                validate_held(descriptor, record)
+                return record
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+        finally:
+            os.close(descriptor)
+    return None
+
+
+def create_lease(
+    directory_descriptor: int,
+    directory: Path,
+    directory_identity: dict[str, int],
     *,
     port: int,
     topology: str,
     generation: str,
-) -> dict[str, Any]:
-    metadata = _validate_descriptor(descriptor, path)
-    record = validate_record(
-        {
-            "schema_version": PORT_RESERVATION_SCHEMA_VERSION,
-            "port": port,
-            "topology": topology,
-            "generation": generation,
-            "path": str(path),
-            "lease": {"device": metadata.st_dev, "inode": metadata.st_ino},
-        },
-        expected_path=path,
+) -> tuple[int, dict[str, Any]]:
+    path = directory / f"{port}-{generation}.lease"
+    descriptor = _open_child(
+        directory_descriptor, path.name, os.O_RDWR, exclusive=True
     )
-    payload = (json.dumps(record, indent=2, sort_keys=True) + "\n").encode("utf-8")
     try:
-        os.ftruncate(descriptor, 0)
-        os.lseek(descriptor, 0, os.SEEK_SET)
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        metadata = _validate_child(descriptor, directory_descriptor, path.name)
+        token = secrets.token_hex(32)
+        try:
+            os.setxattr(descriptor, "user.atrinik.port-reservation", token.encode())
+        except OSError as error:
+            raise PortReservationError(
+                f"cannot bind topology port reservation creation identity: {error}"
+            ) from error
+        record = validate_record(
+            {
+                "schema_version": PORT_RESERVATION_SCHEMA_VERSION,
+                "port": port,
+                "topology": topology,
+                "generation": generation,
+                "path": str(path),
+                "directory": directory_identity,
+                "lease": {"device": metadata.st_dev, "inode": metadata.st_ino},
+                "token": token,
+            },
+            expected_path=path,
+        )
+        payload = (json.dumps(record, indent=2, sort_keys=True) + "\n").encode()
         view = memoryview(payload)
         while view:
             written = os.write(descriptor, view)
@@ -215,62 +326,71 @@ def bind_record(
                 raise OSError("short write")
             view = view[written:]
         os.fsync(descriptor)
-    except OSError as error:
-        raise PortReservationError(
-            f"cannot publish topology port reservation {path}: {error}"
-        ) from error
-    _validate_descriptor(descriptor, path)
-    return record
+        _validate_child(descriptor, directory_descriptor, path.name)
+        _validate_directory_path(directory, directory_identity)
+        return descriptor, record
+    except BaseException:
+        os.close(descriptor)
+        try:
+            os.unlink(path.name, dir_fd=directory_descriptor)
+        except OSError:
+            pass
+        raise
 
 
 def validate_held(descriptor: int, record: Any) -> dict[str, Any]:
     validated = validate_record(record)
     path = Path(validated["path"])
-    metadata = _validate_descriptor(descriptor, path)
+    directory_fd, directory, directory_identity = open_directory(path.parent.parent)
+    try:
+        if directory != path.parent or directory_identity != validated["directory"]:
+            raise PortReservationError(
+                "topology port reservation directory was replaced"
+            )
+        metadata = _validate_child(descriptor, directory_fd, path.name)
+    finally:
+        os.close(directory_fd)
     identity = validated["lease"]
     if (metadata.st_dev, metadata.st_ino) != (
         identity["device"],
         identity["inode"],
     ):
         raise PortReservationError("topology port reservation lease was replaced")
+    if read_record(descriptor, path) != validated:
+        raise PortReservationError("topology port reservation record changed")
+    try:
+        token = os.getxattr(descriptor, "user.atrinik.port-reservation").decode()
+    except (OSError, UnicodeError) as error:
+        raise PortReservationError(
+            f"cannot validate topology port reservation creation identity: {error}"
+        ) from error
+    if token != validated["token"]:
+        raise PortReservationError(
+            "topology port reservation creation identity changed"
+        )
     return validated
 
 
 def reservation_locked(record: Any) -> bool:
     validated = validate_record(record)
     path = Path(validated["path"])
-    flags = os.O_RDWR | os.O_CLOEXEC
-    if hasattr(os, "O_NOFOLLOW"):
-        flags |= os.O_NOFOLLOW
+    directory_fd, directory, directory_identity = open_directory(path.parent.parent)
     try:
-        descriptor = os.open(path, flags)
-    except OSError as error:
-        raise PortReservationError(
-            f"cannot inspect topology port reservation lease {path}: {error}"
-        ) from error
-    try:
-        validate_held(descriptor, validated)
-        try:
-            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError:
-            # A normal later owner rewrites the same lease inode. Attribute a
-            # conflicting lock only when the record currently protected by it
-            # still names this exact topology generation.
-            deadline = time.monotonic() + 1
-            while True:
-                try:
-                    current = read_record(descriptor, path)
-                    validate_held(descriptor, current)
-                    return current == validated
-                except PortReservationError:
-                    if time.monotonic() >= deadline:
-                        raise
-                    time.sleep(0.01)
-        except OSError as error:
+        if directory != path.parent or directory_identity != validated["directory"]:
             raise PortReservationError(
-                f"cannot inspect topology port reservation lock {path}: {error}"
-            ) from error
-        fcntl.flock(descriptor, fcntl.LOCK_UN)
-        return False
+                "topology port reservation directory was replaced"
+            )
+        descriptor = _open_child(directory_fd, path.name, os.O_RDONLY)
+        try:
+            validate_held(descriptor, validated)
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_SH | fcntl.LOCK_NB)
+            except BlockingIOError:
+                validate_held(descriptor, validated)
+                return True
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+            return False
+        finally:
+            os.close(descriptor)
     finally:
-        os.close(descriptor)
+        os.close(directory_fd)

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -317,7 +317,7 @@ def _validate_port_reservation(
         or Path(validated["path"])
         != topology_root.parent
         / PORT_RESERVATION_DIRECTORY
-        / f"{validated['port']}.lease"
+        / f"{validated['port']}-{validated['generation']}.lease"
     ):
         raise RuntimeError("topology port reservation does not match the topology")
 

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -18,6 +18,11 @@ from typing import Any, BinaryIO
 
 from .launch_identity import CLIENT_LAUNCH_LABEL_ENV, client_launch_label
 from .process_tree import control_socket_path, holders_exist, signal_holders
+from .port_reservation import (
+    PORT_RESERVATION_DIRECTORY,
+    PortReservationError,
+    validate_held,
+)
 
 
 LOG_LIMIT = 10 * 1024 * 1024
@@ -284,7 +289,51 @@ def _initial_status(spec: dict[str, Any], supervisor_start_time: str) -> dict[st
         status["providers"] = spec["providers"]
     if "sound" in spec:
         status["sound"] = spec["sound"]
+    if "port_reservation" in spec:
+        status["port_reservation"] = spec["port_reservation"]
     return status
+
+
+def _validate_port_reservation(
+    spec: dict[str, Any], descriptor: int | None, topology_root: Path
+) -> None:
+    reservation = spec.get("port_reservation")
+    if reservation is None and descriptor is None:
+        return
+    if reservation is None or descriptor is None:
+        raise RuntimeError("topology port reservation descriptor is incomplete")
+    try:
+        validated = validate_held(descriptor, reservation)
+    except PortReservationError as error:
+        raise RuntimeError(str(error)) from error
+    control = spec.get("control")
+    endpoint = spec.get("endpoint")
+    if (
+        not isinstance(control, dict)
+        or validated["topology"] != spec.get("name")
+        or validated["generation"] != control.get("generation")
+        or not isinstance(endpoint, dict)
+        or validated["port"] != endpoint.get("port")
+        or Path(validated["path"])
+        != topology_root.parent
+        / PORT_RESERVATION_DIRECTORY
+        / f"{validated['port']}.lease"
+    ):
+        raise RuntimeError("topology port reservation does not match the topology")
+
+
+def _require_server_port_available(spec: dict[str, Any]) -> None:
+    endpoint = spec.get("endpoint")
+    if not isinstance(endpoint, dict) or not isinstance(endpoint.get("port"), int):
+        raise RuntimeError("topology server endpoint is invalid")
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as candidate:
+            candidate.bind(("0.0.0.0", endpoint["port"]))
+    except OSError as error:
+        raise RuntimeError(
+            f"reserved topology UDP port {endpoint['port']} was claimed by an "
+            f"external process before server startup: {error}"
+        ) from error
 
 
 def _guardian(
@@ -443,6 +492,7 @@ def supervise(
     layout_lock_fd: int | None,
     build_lock_fd: int | None,
     process_tree_fd: int | None,
+    port_reservation_fd: int | None,
 ) -> int:
     with spec_path.open(encoding="utf-8") as stream:
         spec = json.load(stream)
@@ -463,6 +513,7 @@ def supervise(
     if supervisor_start_time is None:
         raise RuntimeError("cannot identify topology supervisor process")
     status = _initial_status(spec, supervisor_start_time)
+    _validate_port_reservation(spec, port_reservation_fd, spec_path.parent)
     processes: dict[str, subprocess.Popen[bytes]] = {}
     logs: list[RotatingLog] = []
     pumps: list[threading.Thread] = []
@@ -531,10 +582,15 @@ def supervise(
 
     try:
         guardian_pid, guardian_write_fd = _start_guardian(
-            process_tree_fd, lock_fd, layout_lock_fd, build_lock_fd
+            process_tree_fd,
+            lock_fd,
+            layout_lock_fd,
+            build_lock_fd,
+            port_reservation_fd,
         )
         control_socket = _open_control(spec, spec_path.parent)
         if "server" in spec["services"]:
+            _require_server_port_available(spec)
             capture = ServerReadinessCapture()
             server = start_service("server", capture=capture)
             deadline = time.monotonic() + SERVER_READY_TIMEOUT
@@ -636,6 +692,8 @@ def supervise(
             os.close(layout_lock_fd)
         if build_lock_fd is not None:
             os.close(build_lock_fd)
+        if port_reservation_fd is not None:
+            os.close(port_reservation_fd)
     return 0
 
 
@@ -646,6 +704,7 @@ def main() -> int:
     parser.add_argument("--layout-lock-fd", type=int)
     parser.add_argument("--build-lock-fd", type=int)
     parser.add_argument("--process-tree-fd", type=int)
+    parser.add_argument("--port-reservation-fd", type=int)
     parser.add_argument("--daemonize", action="store_true")
     options = parser.parse_args()
     if options.daemonize and os.fork() != 0:
@@ -657,6 +716,7 @@ def main() -> int:
             options.layout_lock_fd,
             options.build_lock_fd,
             options.process_tree_fd,
+            options.port_reservation_fd,
         )
     except BaseException as error:
         message = f"{type(error).__name__}: {error}"
@@ -683,6 +743,11 @@ def main() -> int:
         if options.process_tree_fd is not None:
             try:
                 os.close(options.process_tree_fd)
+            except OSError:
+                pass
+        if options.port_reservation_fd is not None:
+            try:
+                os.close(options.port_reservation_fd)
             except OSError:
                 pass
         return 1

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -7697,25 +7697,28 @@ class Workspace:
                     self.paths.topologies, port
                 )
                 if not try_lock_port_reservation(descriptor):
-                    try:
-                        deadline = time.monotonic() + 1
-                        while True:
-                            try:
-                                owner = read_port_reservation(descriptor, path)
-                                break
-                            except PortReservationError:
-                                if time.monotonic() >= deadline:
-                                    raise WorkspaceError(
-                                        f"topology UDP port {port} is reserved but "
-                                        "its owner record is not yet valid; preserve "
-                                        "the lease and retry"
-                                    )
-                                time.sleep(0.01)
-                    finally:
+                    if automatic:
                         os.close(descriptor)
-                    if not automatic:
-                        conflict(owner)
-                    return None
+                        return None
+                    deadline = time.monotonic() + 1
+                    owner: dict[str, Any] | None = None
+                    while True:
+                        try:
+                            owner = read_port_reservation(descriptor, path)
+                        except PortReservationError:
+                            owner = None
+                        if time.monotonic() >= deadline:
+                            os.close(descriptor)
+                            if owner is None:
+                                raise WorkspaceError(
+                                    f"topology UDP port {port} is reserved but "
+                                    "its owner record is not yet valid; preserve "
+                                    "the lease and retry"
+                                )
+                            conflict(owner)
+                        time.sleep(0.01)
+                        if try_lock_port_reservation(descriptor):
+                            break
                 try:
                     self._select_topology_port(port)
                     record = bind_port_reservation(

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -56,6 +56,7 @@ from .port_reservation import (
     open_transaction as open_port_transaction,
     reservation_locked as port_reservation_locked,
     try_lock as try_lock_port_reservation,
+    validate_transaction as validate_port_transaction,
     validate_record as validate_port_reservation,
 )
 
@@ -7693,25 +7694,22 @@ class Workspace:
                 validate_known_evidence(port)
                 transaction, directory_fd, directory, directory_identity = (
                     open_port_transaction(
-                    self.paths.topologies, port
+                        self.paths.topologies, port
                     )
                 )
-                if not try_lock_port_reservation(transaction):
-                    if automatic:
-                        os.close(transaction)
-                        os.close(directory_fd)
-                        return None
-                    deadline = time.monotonic() + 1
-                    while not try_lock_port_reservation(transaction):
-                        if time.monotonic() >= deadline:
-                            os.close(transaction)
-                            os.close(directory_fd)
-                            raise WorkspaceError(
-                                f"topology UDP port {port} reservation transaction "
-                                "is busy; retry"
-                            )
-                        time.sleep(0.01)
                 try:
+                    if not try_lock_port_reservation(transaction):
+                        if automatic:
+                            return None
+                        deadline = time.monotonic() + 1
+                        while not try_lock_port_reservation(transaction):
+                            if time.monotonic() >= deadline:
+                                raise WorkspaceError(
+                                    f"topology UDP port {port} reservation "
+                                    "transaction is busy; retry"
+                                )
+                            time.sleep(0.01)
+                    validate_port_transaction(transaction, directory_fd, port)
                     owner = active_port_reservation(directory_fd, directory, port)
                     if owner is not None:
                         if automatic:
@@ -7726,8 +7724,11 @@ class Workspace:
                         topology=topology,
                         generation=generation,
                     )
-                except BaseException:
-                    raise
+                    try:
+                        validate_port_transaction(transaction, directory_fd, port)
+                    except BaseException:
+                        os.close(descriptor)
+                        raise
                 finally:
                     os.close(transaction)
                     os.close(directory_fd)

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -48,6 +48,16 @@ from .process_tree import (
     lease_locked,
     signal_holders,
 )
+from .port_reservation import (
+    PORT_RESERVATION_DIRECTORY,
+    PortReservationError,
+    bind_record as bind_port_reservation,
+    open_lease as open_port_reservation,
+    read_record as read_port_reservation,
+    reservation_locked as port_reservation_locked,
+    try_lock as try_lock_port_reservation,
+    validate_record as validate_port_reservation,
+)
 
 from .model import (
     MANAGED_MARKER,
@@ -112,6 +122,7 @@ COMPILER_CACHE_PURPOSE = "compiler-cache"
 COMPILER_CACHE_MAX_SIZE = "5G"
 TOPOLOGY_SERVICES = ("server", "client")
 TOPOLOGY_PROCESS_TREE_LEASE = "process-tree.lease"
+TOPOLOGY_PORT_RESERVATION_RECORD = "port-reservation.json"
 PRE_MONOREPO_REPOSITORIES = {
     "client": "legacy-client",
     "server": "legacy-server",
@@ -7171,7 +7182,7 @@ class Workspace:
             "supervisor",
             "services",
         }
-        optional = {"stack", "providers", "sound", "control"}
+        optional = {"stack", "providers", "sound", "control", "port_reservation"}
         historical_record = isinstance(status, dict) and not (
             {"stack", "providers"} & set(status)
         )
@@ -7457,6 +7468,39 @@ class Workspace:
                 )
             ):
                 raise WorkspaceError(f"topology endpoint status is invalid: {name}")
+        port_reservation = status.get("port_reservation")
+        if port_reservation is not None:
+            reservation_port = (
+                port_reservation.get("port")
+                if isinstance(port_reservation, dict)
+                else None
+            )
+            try:
+                validate_port_reservation(
+                    port_reservation,
+                    expected_path=(
+                        self.paths.topologies
+                        / PORT_RESERVATION_DIRECTORY
+                        / f"{reservation_port}.lease"
+                    ),
+                )
+                reservation_retained = port_reservation_locked(port_reservation)
+            except PortReservationError as error:
+                raise WorkspaceError(
+                    f"topology port reservation status is invalid: {name}"
+                ) from error
+            if (
+                endpoint is None
+                or port_reservation["port"] != endpoint["port"]
+                or port_reservation["topology"] != name
+                or not current_control
+                or port_reservation["generation"] != control["generation"]
+            ):
+                raise WorkspaceError(
+                    f"topology port reservation status is invalid: {name}"
+                )
+        else:
+            reservation_retained = False
         services = status.get("services")
         if (
             not isinstance(services, dict)
@@ -7524,8 +7568,11 @@ class Workspace:
             raise WorkspaceError(f"topology endpoint status is invalid: {name}")
         if not supervisor_running:
             status["ready"] = False
-        retained = process_tree_active or supervisor_running or any(
-            service["running"] for service in services.values()
+        retained = (
+            reservation_retained
+            or process_tree_active
+            or supervisor_running
+            or any(service["running"] for service in services.values())
         )
         if control_reachable:
             safe_action = f"run ./atrinik down {name} from any supported session"
@@ -7547,6 +7594,13 @@ class Workspace:
             "repository_layout_lease_owner": name if retained else None,
             "safe_action": safe_action,
         }
+        if port_reservation is not None:
+            status["observation"]["port_reservation"] = {
+                "port": port_reservation["port"],
+                "owner": port_reservation["topology"],
+                "generation": port_reservation["generation"],
+                "lease": "retained" if reservation_retained else "released",
+            }
         return status
 
     def topology_statuses(self) -> list[dict[str, Any]]:
@@ -7579,6 +7633,123 @@ class Workspace:
                     f"topology UDP port {requested} is unavailable: {error}"
                 ) from error
             raise WorkspaceError(f"cannot allocate a topology UDP port: {error}") from error
+
+    def _reserve_topology_port(
+        self, requested: int | None, topology: str, generation: str
+    ) -> tuple[int, dict[str, Any]]:
+        if requested is not None and (
+            not isinstance(requested, int)
+            or isinstance(requested, bool)
+            or not 0 <= requested <= 65535
+        ):
+            raise WorkspaceError("topology port must be between 0 and 65535")
+
+        automatic = requested in (None, 0)
+
+        def conflict(owner: dict[str, Any]) -> None:
+            raise WorkspaceError(
+                f"topology UDP port {owner['port']} is reserved by topology "
+                f"{owner['topology']} generation {owner['generation']}; "
+                f"inspect ./atrinik ps {owner['topology']} --json and "
+                f"run ./atrinik down {owner['topology']} only when safe"
+            )
+
+        def known_owner(port: int) -> dict[str, Any] | None:
+            expected_path = (
+                self.paths.topologies
+                / PORT_RESERVATION_DIRECTORY
+                / f"{port}.lease"
+            )
+            for root in sorted(self.paths.topologies.iterdir()):
+                record_path = root / TOPOLOGY_PORT_RESERVATION_RECORD
+                if not record_path.exists() and not record_path.is_symlink():
+                    continue
+                if record_path.is_symlink() or not record_path.is_file():
+                    raise WorkspaceError(
+                        f"topology port reservation evidence is invalid: {record_path}"
+                    )
+                value = load_json(record_path)
+                if not isinstance(value, dict) or value.get("port") != port:
+                    continue
+                try:
+                    owner = validate_port_reservation(
+                        value, expected_path=expected_path
+                    )
+                except PortReservationError as error:
+                    raise WorkspaceError(
+                        f"topology port reservation evidence is invalid: {record_path}"
+                    ) from error
+                try:
+                    if port_reservation_locked(owner):
+                        return owner
+                except PortReservationError as error:
+                    raise WorkspaceError(
+                        f"topology port reservation evidence for port {port} "
+                        "does not match its exact lease; preserve it for diagnosis"
+                    ) from error
+            return None
+
+        def claim(port: int) -> tuple[int, dict[str, Any]] | None:
+            try:
+                owner = known_owner(port)
+                if owner is not None:
+                    if automatic:
+                        return None
+                    conflict(owner)
+                descriptor, path = open_port_reservation(
+                    self.paths.topologies, port
+                )
+                if not try_lock_port_reservation(descriptor):
+                    try:
+                        deadline = time.monotonic() + 1
+                        while True:
+                            try:
+                                owner = read_port_reservation(descriptor, path)
+                                break
+                            except PortReservationError:
+                                if time.monotonic() >= deadline:
+                                    raise WorkspaceError(
+                                        f"topology UDP port {port} is reserved but "
+                                        "its owner record is not yet valid; preserve "
+                                        "the lease and retry"
+                                    )
+                                time.sleep(0.01)
+                    finally:
+                        os.close(descriptor)
+                    if not automatic:
+                        conflict(owner)
+                    return None
+                try:
+                    self._select_topology_port(port)
+                    record = bind_port_reservation(
+                        descriptor,
+                        path,
+                        port=port,
+                        topology=topology,
+                        generation=generation,
+                    )
+                except BaseException:
+                    os.close(descriptor)
+                    raise
+                return descriptor, record
+            except PortReservationError as error:
+                raise WorkspaceError(str(error)) from error
+
+        if not automatic:
+            reserved = claim(requested)
+            assert reserved is not None
+            return reserved
+
+        with exclusive_lock(
+            self.paths.topologies / "ports.lock",
+            "topology automatic port allocation",
+        ):
+            for _attempt in range(64):
+                candidate = self._select_topology_port(None)
+                reserved = claim(candidate)
+                if reserved is not None:
+                    return reserved
+        raise WorkspaceError("cannot allocate a unique topology UDP port after 64 attempts")
 
     @staticmethod
     def _require_client_display() -> None:
@@ -7742,6 +7913,28 @@ class Workspace:
                         f"topology control directory is invalid: {control_directory}"
                     )
 
+                endpoint: dict[str, Any] | None = None
+                port_reservation: dict[str, Any] | None = None
+                port_reservation_owner: list[int] = []
+                if "server" in selected_services:
+                    port_reservation_fd, port_reservation = (
+                        self._reserve_topology_port(port, name, generation)
+                    )
+                    port_reservation_owner.append(port_reservation_fd)
+                    stack.callback(
+                        lambda: os.close(port_reservation_owner.pop())
+                        if port_reservation_owner
+                        else None
+                    )
+                    endpoint = {
+                        "host": "127.0.0.1",
+                        "port": port_reservation["port"],
+                    }
+                    atomic_json(
+                        topology_root / TOPOLOGY_PORT_RESERVATION_RECORD,
+                        port_reservation,
+                    )
+
                 state_location: Path | None = None
                 state_lock: TextIO | None = None
                 if "server" in selected_services:
@@ -7766,18 +7959,6 @@ class Workspace:
                     if isinstance(build_metadata, dict)
                     else None
                 )
-                endpoint: dict[str, Any] | None = None
-                if "server" in selected_services:
-                    stack.enter_context(
-                        exclusive_lock(
-                            self.paths.topologies / "ports.lock",
-                            "topology port allocation",
-                        )
-                    )
-                    endpoint = {
-                        "host": "127.0.0.1",
-                        "port": self._select_topology_port(port),
-                    }
                 service_specs: dict[str, dict[str, Any]] = {}
                 if "server" in selected_services:
                     assert state_location is not None
@@ -7914,6 +8095,8 @@ class Workspace:
                     },
                     "services": service_specs,
                 }
+                if port_reservation is not None:
+                    spec["port_reservation"] = port_reservation
                 if sound_status is not None:
                     spec["sound"] = sound_status
                 spec_path = topology_root / "spec.json"
@@ -7964,6 +8147,14 @@ class Workspace:
                         ["--process-tree-fd", str(process_tree_fd)]
                     )
                     inherited_locks.append(process_tree_fd)
+                    if port_reservation_owner:
+                        command.extend(
+                            [
+                                "--port-reservation-fd",
+                                str(port_reservation_owner[0]),
+                            ]
+                        )
+                        inherited_locks.append(port_reservation_owner[0])
                     environment = os.environ.copy()
                     source_root = str(Path(__file__).resolve().parents[1])
                     python_path = environment.get("PYTHONPATH")
@@ -7983,6 +8174,8 @@ class Workspace:
                         pass_fds=tuple(inherited_locks),
                     )
                     os.close(process_tree_owner.pop())
+                    if port_reservation_owner:
+                        os.close(port_reservation_owner.pop())
                 except OSError as error:
                     raise WorkspaceError(f"cannot start topology supervisor: {error}") from error
                 finally:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -7654,7 +7654,7 @@ class Workspace:
                 f"run ./atrinik down {owner['topology']} only when safe"
             )
 
-        def known_owner(port: int) -> dict[str, Any] | None:
+        def validate_known_evidence(port: int) -> None:
             expected_path = (
                 self.paths.topologies
                 / PORT_RESERVATION_DIRECTORY
@@ -7680,22 +7680,19 @@ class Workspace:
                         f"topology port reservation evidence is invalid: {record_path}"
                     ) from error
                 try:
-                    if port_reservation_locked(owner):
-                        return owner
+                    port_reservation_locked(owner)
                 except PortReservationError as error:
                     raise WorkspaceError(
                         f"topology port reservation evidence for port {port} "
                         "does not match its exact lease; preserve it for diagnosis"
                     ) from error
-            return None
 
         def claim(port: int) -> tuple[int, dict[str, Any]] | None:
             try:
-                owner = known_owner(port)
-                if owner is not None:
-                    if automatic:
-                        return None
-                    conflict(owner)
+                # Historical pending evidence authenticates the lease inode, but
+                # its owner fields can be stale after an unlocked inode is reused.
+                # The locked lease record below is the authoritative current owner.
+                validate_known_evidence(port)
                 descriptor, path = open_port_reservation(
                     self.paths.topologies, port
                 )
@@ -8209,6 +8206,11 @@ class Workspace:
                         if status["supervisor"]["running"] and status["ready"]:
                             process.wait(timeout=2)
                             return status
+                        if not status["supervisor"]["running"]:
+                            raise WorkspaceError(
+                                "topology supervisor exited during startup; inspect "
+                                f"{topology_root / 'supervisor.log'}"
+                            )
                     if process.poll() not in (None, 0):
                         break
                     time.sleep(0.1)

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -51,9 +51,9 @@ from .process_tree import (
 from .port_reservation import (
     PORT_RESERVATION_DIRECTORY,
     PortReservationError,
-    bind_record as bind_port_reservation,
-    open_lease as open_port_reservation,
-    read_record as read_port_reservation,
+    active_owner as active_port_reservation,
+    create_lease as create_port_reservation,
+    open_transaction as open_port_transaction,
     reservation_locked as port_reservation_locked,
     try_lock as try_lock_port_reservation,
     validate_record as validate_port_reservation,
@@ -7481,7 +7481,7 @@ class Workspace:
                     expected_path=(
                         self.paths.topologies
                         / PORT_RESERVATION_DIRECTORY
-                        / f"{reservation_port}.lease"
+                        / f"{reservation_port}-{port_reservation.get('generation')}.lease"
                     ),
                 )
                 reservation_retained = port_reservation_locked(port_reservation)
@@ -7650,16 +7650,11 @@ class Workspace:
             raise WorkspaceError(
                 f"topology UDP port {owner['port']} is reserved by topology "
                 f"{owner['topology']} generation {owner['generation']}; "
-                f"inspect ./atrinik ps {owner['topology']} --json and "
-                f"run ./atrinik down {owner['topology']} only when safe"
+                "retry after its startup transaction completes; if contention "
+                f"persists inspect ./atrinik ps {owner['topology']} --json"
             )
 
         def validate_known_evidence(port: int) -> None:
-            expected_path = (
-                self.paths.topologies
-                / PORT_RESERVATION_DIRECTORY
-                / f"{port}.lease"
-            )
             for root in sorted(self.paths.topologies.iterdir()):
                 record_path = root / TOPOLOGY_PORT_RESERVATION_RECORD
                 if not record_path.exists() and not record_path.is_symlink():
@@ -7672,9 +7667,15 @@ class Workspace:
                 if not isinstance(value, dict) or value.get("port") != port:
                     continue
                 try:
-                    owner = validate_port_reservation(
-                        value, expected_path=expected_path
+                    owner = validate_port_reservation(value)
+                    if owner["port"] != port:
+                        continue
+                    expected_path = (
+                        self.paths.topologies
+                        / PORT_RESERVATION_DIRECTORY
+                        / f"{port}-{owner['generation']}.lease"
                     )
+                    validate_port_reservation(owner, expected_path=expected_path)
                 except PortReservationError as error:
                     raise WorkspaceError(
                         f"topology port reservation evidence is invalid: {record_path}"
@@ -7689,48 +7690,47 @@ class Workspace:
 
         def claim(port: int) -> tuple[int, dict[str, Any]] | None:
             try:
-                # Historical pending evidence authenticates the lease inode, but
-                # its owner fields can be stale after an unlocked inode is reused.
-                # The locked lease record below is the authoritative current owner.
                 validate_known_evidence(port)
-                descriptor, path = open_port_reservation(
+                transaction, directory_fd, directory, directory_identity = (
+                    open_port_transaction(
                     self.paths.topologies, port
+                    )
                 )
-                if not try_lock_port_reservation(descriptor):
+                if not try_lock_port_reservation(transaction):
                     if automatic:
-                        os.close(descriptor)
+                        os.close(transaction)
+                        os.close(directory_fd)
                         return None
                     deadline = time.monotonic() + 1
-                    owner: dict[str, Any] | None = None
-                    while True:
-                        try:
-                            owner = read_port_reservation(descriptor, path)
-                        except PortReservationError:
-                            owner = None
+                    while not try_lock_port_reservation(transaction):
                         if time.monotonic() >= deadline:
-                            os.close(descriptor)
-                            if owner is None:
-                                raise WorkspaceError(
-                                    f"topology UDP port {port} is reserved but "
-                                    "its owner record is not yet valid; preserve "
-                                    "the lease and retry"
-                                )
-                            conflict(owner)
+                            os.close(transaction)
+                            os.close(directory_fd)
+                            raise WorkspaceError(
+                                f"topology UDP port {port} reservation transaction "
+                                "is busy; retry"
+                            )
                         time.sleep(0.01)
-                        if try_lock_port_reservation(descriptor):
-                            break
                 try:
+                    owner = active_port_reservation(directory_fd, directory, port)
+                    if owner is not None:
+                        if automatic:
+                            return None
+                        conflict(owner)
                     self._select_topology_port(port)
-                    record = bind_port_reservation(
-                        descriptor,
-                        path,
+                    descriptor, record = create_port_reservation(
+                        directory_fd,
+                        directory,
+                        directory_identity,
                         port=port,
                         topology=topology,
                         generation=generation,
                     )
                 except BaseException:
-                    os.close(descriptor)
                     raise
+                finally:
+                    os.close(transaction)
+                    os.close(directory_fd)
                 return descriptor, record
             except PortReservationError as error:
                 raise WorkspaceError(str(error)) from error

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -222,12 +222,15 @@ interrupt the holder. The diagnostic is emitted at most once per acquisition.
 If the platform cannot provide a working advisory shared lock, the consuming
 operation fails closed.
 
-A supervised topology transfers its shared layout and exact build-root lock
-descriptors through the daemon supervisor into every service. Client runtimes
+A supervised topology transfers its shared layout, exact build-root, state,
+process-tree, and generation-reservation descriptors through the daemon
+supervisor. The supervisor and its same-generation guardian retain the
+workspace/state/reservation leases; services inherit only the process-tree
+identity needed for exact descendant recovery. Client runtimes
 retain links to selected client and sound checkouts, while server runtimes link
 selected server configuration and tool inputs. Inherited descriptors preserve
-both leases if the supervisor dies; topology shutdown terminates orphaned
-services and releases the last descriptors. A topology-unique inherited
+the leases if the supervisor dies; topology shutdown terminates orphaned
+services before the guardian releases the last descriptors. A topology-unique inherited
 process-tree lease is also held as an advisory generation lock, so a topology
 name cannot restart until its prior process tree releases the lease. Shutdown
 uses the same lease identity to find and pidfd-signal surviving descendants
@@ -242,10 +245,11 @@ which remain
 outermost relative to all operational locks; private helpers never reacquire
 either boundary. A direct build or foreground client then takes its build-root
 lock and subordinate cache locks; the foreground process retains that root
-lease. Topology startup
-takes the topology-operation lock, the server-state lock when needed, the
-build-root lock, and finally the port-allocation lock, and transfers the layout
-and build-root leases into its services.
+lease. Topology startup takes the topology-operation/process-tree lock, the
+automatic allocator when applicable, the per-port transaction and immutable
+generation lease, the server-state lock when needed, and finally the build-root
+lock. It transfers workspace leases into the supervisor/guardian rather than
+services.
 Independent CMake roots briefly serialize first-use compiler-cache marker and
 metadata publication, then release that cache lock before compilation.
 Scenario create takes the scenario-operation lock, then build-root and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -663,23 +663,28 @@ state. For a paired topology it starts the server
 first, waits for its fingerprint and final ready signal, and then pins the
 client to that authenticated loopback endpoint. Omitted ports and explicit port
 zero use automatic allocation. A short workspace allocator transaction probes a
-candidate and publishes its unique exact-port lease, then releases the
+candidate and publishes its unique immutable generation lease, then releases the
 allocator before state, build, runtime-copy, supervisor-launch, or readiness
 work. Explicit nonzero ports bypass the allocator and contend only on their own
-lease. Each mode-0600 lease record binds port, topology, generation, path, and
-device/inode identity; no-follow opens, single-link validation, and a final
+short per-port transaction. Each mode-0600 generation record binds port,
+topology, generation, path, verified directory identity, and lease identity;
+descriptor-relative no-follow opens, single-link validation, and a final
 supervisor identity check reject symlink, hard-link, record-replacement, and
 generation substitution. The supervisor revalidates kernel availability before
 server launch and reports an external bind winner as a bounded startup failure.
-The per-port descriptor is retained by the supervisor and guardian, never the
-service, until orderly shutdown or exact process-tree recovery. Same-port
-contenders fail with the exact owning topology/generation and safe action;
+The short per-port transaction descriptor is released before preparation. An
+immutable generation-specific descriptor is retained by the supervisor and
+guardian, never the service, until orderly shutdown or exact process-tree
+recovery. Shared status probes of released generations neither conflict with
+one another nor resemble an owner. Same-port contenders fail with the exact
+owning topology/generation and a truthful retry action;
 status reports the reservation identity and retained/released disposition.
-Stale records are overwritten only after the exact inode is exclusively locked,
-never from PID observations. Lock order is repository layout, topology
-operation/process-tree identity, automatic allocator when applicable, exact
-port, state, then build root; independent exact ports therefore overlap through
-readiness. Each runtime name owns an isolated persistent client configuration base.
+Immutable generation records are never overwritten or reclaimed from PID
+observations. Lock order is repository layout, topology operation/process-tree
+identity, automatic allocator when applicable, per-port transaction,
+generation lease, state, then build root; independent exact ports therefore
+overlap through readiness. Each runtime name owns an isolated persistent client
+configuration base.
 A supervised client also receives a bounded, process-only launch label naming
 its topology and profile; a foreground client receives its profile and direct
 run mode. The client uses this label only for its native window title. It is

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -661,9 +661,25 @@ waits or fails closed with the owning topology and recovery action. Normal
 shutdown asks the supervisor to gracefully stop children before releasing
 state. For a paired topology it starts the server
 first, waits for its fingerprint and final ready signal, and then pins the
-client to that authenticated loopback endpoint. Available UDP ports are
-allocated under a workspace-wide lock, or callers may request an explicit
-port. Each runtime name owns an isolated persistent client configuration base.
+client to that authenticated loopback endpoint. Omitted ports and explicit port
+zero use automatic allocation. A short workspace allocator transaction probes a
+candidate and publishes its unique exact-port lease, then releases the
+allocator before state, build, runtime-copy, supervisor-launch, or readiness
+work. Explicit nonzero ports bypass the allocator and contend only on their own
+lease. Each mode-0600 lease record binds port, topology, generation, path, and
+device/inode identity; no-follow opens, single-link validation, and a final
+supervisor identity check reject symlink, hard-link, record-replacement, and
+generation substitution. The supervisor revalidates kernel availability before
+server launch and reports an external bind winner as a bounded startup failure.
+The per-port descriptor is retained by the supervisor and guardian, never the
+service, until orderly shutdown or exact process-tree recovery. Same-port
+contenders fail with the exact owning topology/generation and safe action;
+status reports the reservation identity and retained/released disposition.
+Stale records are overwritten only after the exact inode is exclusively locked,
+never from PID observations. Lock order is repository layout, topology
+operation/process-tree identity, automatic allocator when applicable, exact
+port, state, then build root; independent exact ports therefore overlap through
+readiness. Each runtime name owns an isolated persistent client configuration base.
 A supervised client also receives a bounded, process-only launch label naming
 its topology and profile; a foreground client receives its profile and direct
 run mode. The client uses this label only for its native window title. It is

--- a/tests/test_port_reservation.py
+++ b/tests/test_port_reservation.py
@@ -273,6 +273,31 @@ class PortReservationTests(unittest.TestCase):
         finally:
             os.close(replacement)
 
+    def test_reused_lease_reports_its_current_owner_not_stale_evidence(self) -> None:
+        port = self.free_port()
+        descriptor, record = self.workspace._reserve_topology_port(
+            port, "stale-owner", "b" * 64
+        )
+        owner = self.topologies / "stale-owner"
+        owner.mkdir()
+        atomic_json(owner / TOPOLOGY_PORT_RESERVATION_RECORD, record)
+        os.close(descriptor)
+
+        replacement, replacement_record = self.workspace._reserve_topology_port(
+            port, "current-owner", "c" * 64
+        )
+        try:
+            with self.assertRaises(WorkspaceError) as raised:
+                self.workspace._reserve_topology_port(
+                    port, "contender", "d" * 64
+                )
+            message = str(raised.exception)
+            self.assertIn("topology current-owner", message)
+            self.assertIn(str(replacement_record["generation"]), message)
+            self.assertNotIn("topology stale-owner", message)
+        finally:
+            os.close(replacement)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_port_reservation.py
+++ b/tests/test_port_reservation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import fcntl
 import json
 import os
@@ -15,14 +16,19 @@ from unittest import mock
 from atrinik_workspace.model import WorkspaceError, atomic_json
 from atrinik_workspace.locking import exclusive_lock
 from atrinik_workspace.port_reservation import (
+    MAX_RECORD_SIZE,
     PORT_RESERVATION_DIRECTORY,
     PortReservationError,
+    _decode_record,
+    _rename_no_replace,
     active_owner,
     create_lease,
     open_directory,
     open_transaction,
+    read_record,
     reservation_locked,
     try_lock,
+    validate_record,
     validate_held,
     validate_transaction,
 )
@@ -44,6 +50,149 @@ class PortReservationTests(unittest.TestCase):
         with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as candidate:
             candidate.bind(("0.0.0.0", 0))
             return int(candidate.getsockname()[1])
+
+    def valid_record(self) -> dict[str, object]:
+        generation = "1" * 64
+        return {
+            "schema_version": 1,
+            "port": 17300,
+            "topology": "validation-owner",
+            "generation": generation,
+            "path": str(
+                self.topologies
+                / PORT_RESERVATION_DIRECTORY
+                / f"17300-{generation}.lease"
+            ),
+            "directory": {"device": 1, "inode": 2},
+            "lease": {"device": 3, "inode": 4},
+            "token": "2" * 64,
+        }
+
+    def test_record_validation_rejects_malformed_evidence(self) -> None:
+        valid = self.valid_record()
+        malformed: list[tuple[str, object]] = [
+            ("record", {}),
+            ("schema", {**valid, "schema_version": False}),
+            ("port", {**valid, "port": 0}),
+            ("owner", {**valid, "topology": "Invalid Owner"}),
+            ("generation", {**valid, "generation": "not-a-generation"}),
+            ("path", {**valid, "path": "relative.lease"}),
+            ("owner path", {**valid, "path": "/tmp/wrong.lease"}),
+            ("directory", {**valid, "directory": {"device": True, "inode": 2}}),
+            ("lease", {**valid, "lease": {"device": 3}}),
+            ("token", {**valid, "token": "not-a-token"}),
+        ]
+        for description, record in malformed:
+            with self.subTest(description=description):
+                with self.assertRaises(PortReservationError):
+                    validate_record(record)
+        with self.assertRaisesRegex(PortReservationError, "expected lease"):
+            validate_record(valid, expected_path=Path("/tmp/unexpected.lease"))
+
+    def test_record_decoding_rejects_oversize_duplicate_and_invalid_json(self) -> None:
+        path = Path(str(self.valid_record()["path"]))
+        cases = [
+            b"x" * (MAX_RECORD_SIZE + 1),
+            b'{"schema_version": 1, "schema_version": 1}',
+            b"\xff",
+        ]
+        for content in cases:
+            with self.subTest(content=content[:20]):
+                with self.assertRaises(PortReservationError):
+                    _decode_record(content, path)
+
+    def test_atomic_publication_reports_each_kernel_failure(self) -> None:
+        class FailedRename:
+            argtypes: object
+            restype: object
+
+            def __call__(self, *_args: object) -> int:
+                return -1
+
+        with (
+            mock.patch(
+                "atrinik_workspace.port_reservation.ctypes.CDLL",
+                return_value=SimpleNamespace(),
+            ),
+            self.assertRaisesRegex(PortReservationError, "unsupported"),
+        ):
+            _rename_no_replace(1, "source", "destination")
+
+        failures = [
+            (errno.EEXIST, "already exists"),
+            (errno.ENOSYS, "unsupported"),
+            (errno.EPERM, "cannot publish"),
+        ]
+        for error_number, message in failures:
+            with (
+                self.subTest(error_number=error_number),
+                mock.patch(
+                    "atrinik_workspace.port_reservation.ctypes.CDLL",
+                    return_value=SimpleNamespace(renameat2=FailedRename()),
+                ),
+                mock.patch(
+                    "atrinik_workspace.port_reservation.ctypes.get_errno",
+                    return_value=error_number,
+                ),
+                self.assertRaisesRegex(PortReservationError, message),
+            ):
+                _rename_no_replace(1, "source", "destination")
+
+    def test_directory_and_descriptor_errors_fail_closed(self) -> None:
+        with (
+            mock.patch(
+                "atrinik_workspace.port_reservation.os.open",
+                side_effect=PermissionError("denied"),
+            ),
+            self.assertRaisesRegex(PortReservationError, "cannot open"),
+        ):
+            open_directory(self.topologies)
+
+        with (
+            mock.patch(
+                "atrinik_workspace.port_reservation.os.fstat",
+                side_effect=OSError("fstat failed"),
+            ),
+            self.assertRaisesRegex(PortReservationError, "cannot open"),
+        ):
+            open_directory(self.topologies)
+
+        directory = self.topologies / PORT_RESERVATION_DIRECTORY
+        directory.chmod(0o755)
+        with self.assertRaisesRegex(PortReservationError, "directory is invalid"):
+            open_directory(self.topologies)
+
+    def test_lock_list_and_read_errors_fail_closed(self) -> None:
+        with (
+            mock.patch(
+                "atrinik_workspace.port_reservation.fcntl.flock",
+                side_effect=OSError("lock failed"),
+            ),
+            self.assertRaisesRegex(PortReservationError, "cannot lock"),
+        ):
+            try_lock(1)
+
+        directory_fd, directory, _identity = open_directory(self.topologies)
+        try:
+            with (
+                mock.patch(
+                    "atrinik_workspace.port_reservation.os.listdir",
+                    side_effect=OSError("list failed"),
+                ),
+                self.assertRaisesRegex(PortReservationError, "cannot list"),
+            ):
+                active_owner(directory_fd, directory, 17300)
+        finally:
+            os.close(directory_fd)
+
+        with (
+            mock.patch(
+                "atrinik_workspace.port_reservation.os.lseek",
+                side_effect=OSError("seek failed"),
+            ),
+            self.assertRaisesRegex(PortReservationError, "cannot read"),
+        ):
+            read_record(1, Path(str(self.valid_record()["path"])))
 
     def test_distinct_explicit_ports_do_not_share_a_reservation_lock(self) -> None:
         ports = [self.free_port(), self.free_port()]

--- a/tests/test_port_reservation.py
+++ b/tests/test_port_reservation.py
@@ -442,20 +442,19 @@ class PortReservationTests(unittest.TestCase):
         valuable.chmod(0o600)
         generation = "5" * 64
         lease = directory / f"17382-{generation}.lease"
-        real_fsync = os.fsync
-
-        def replace_before_validation(descriptor: int) -> None:
-            real_fsync(descriptor)
-            lease.unlink()
+        def race_publication(
+            _directory_descriptor: int, _source: str, _destination: str
+        ) -> None:
             valuable.rename(lease)
+            raise PortReservationError("simulated no-replace publication race")
 
         try:
             with (
                 mock.patch(
-                    "atrinik_workspace.port_reservation.os.fsync",
-                    side_effect=replace_before_validation,
+                    "atrinik_workspace.port_reservation._rename_no_replace",
+                    side_effect=race_publication,
                 ),
-                self.assertRaisesRegex(PortReservationError, "identity is invalid"),
+                self.assertRaisesRegex(PortReservationError, "publication race"),
             ):
                 create_lease(
                     directory_fd,
@@ -466,6 +465,9 @@ class PortReservationTests(unittest.TestCase):
                     generation=generation,
                 )
             self.assertEqual(lease.read_text(encoding="utf-8"), "valuable\n")
+            self.assertEqual(
+                len(list(directory.glob(".staging-17382-*"))), 1
+            )
         finally:
             os.close(directory_fd)
 

--- a/tests/test_port_reservation.py
+++ b/tests/test_port_reservation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import fcntl
 import os
 from pathlib import Path
 import socket
@@ -8,16 +9,16 @@ import tempfile
 import threading
 import time
 import unittest
-from unittest import mock
 
 from atrinik_workspace.model import WorkspaceError, atomic_json
 from atrinik_workspace.locking import exclusive_lock
 from atrinik_workspace.port_reservation import (
     PORT_RESERVATION_DIRECTORY,
     PortReservationError,
-    bind_record,
-    open_lease,
-    read_record,
+    active_owner,
+    create_lease,
+    open_directory,
+    open_transaction,
     reservation_locked,
     try_lock,
     validate_held,
@@ -207,26 +208,28 @@ class PortReservationTests(unittest.TestCase):
         target = directory / "target"
         target.write_text("valuable\n", encoding="utf-8")
         target.chmod(0o600)
-        symlink = directory / "17300.lease"
+        symlink = directory / "17300.lock"
         symlink.symlink_to(target)
         with self.assertRaisesRegex(PortReservationError, "cannot open"):
-            open_lease(self.topologies, 17300)
+            open_transaction(self.topologies, 17300)
         symlink.unlink()
-        hardlink = directory / "17301.lease"
+        hardlink = directory / "17301.lock"
         os.link(target, hardlink)
         with self.assertRaisesRegex(PortReservationError, "identity is invalid"):
-            open_lease(self.topologies, 17301)
+            open_transaction(self.topologies, 17301)
 
         port = self.free_port()
-        descriptor, path = open_lease(self.topologies, port)
-        self.assertTrue(try_lock(descriptor))
-        record = bind_record(
-            descriptor,
-            path,
+        directory_fd, directory, identity = open_directory(self.topologies)
+        descriptor, record = create_lease(
+            directory_fd,
+            directory,
+            identity,
             port=port,
             topology="replacement-test",
             generation="4" * 64,
         )
+        os.close(directory_fd)
+        path = Path(record["path"])
         path.unlink()
         path.write_text("{}\n", encoding="utf-8")
         path.chmod(0o600)
@@ -301,7 +304,7 @@ class PortReservationTests(unittest.TestCase):
         finally:
             os.close(replacement)
 
-    def test_reused_locked_inode_is_retained_only_for_current_record(self) -> None:
+    def test_immutable_generations_are_observed_independently(self) -> None:
         port = self.free_port()
         descriptor, old_record = self.workspace._reserve_topology_port(
             port, "old-status", "e" * 64
@@ -316,50 +319,62 @@ class PortReservationTests(unittest.TestCase):
         finally:
             os.close(replacement)
 
-    def test_explicit_claim_retries_a_stale_status_probe_lock(self) -> None:
+    def test_concurrent_status_observers_do_not_impersonate_owner(self) -> None:
         port = self.free_port()
         descriptor, record = self.workspace._reserve_topology_port(
             port, "stopped-probe", "1" * 64
         )
-        owner = self.topologies / "stopped-probe"
-        owner.mkdir()
-        atomic_json(owner / TOPOLOGY_PORT_RESERVATION_RECORD, record)
         os.close(descriptor)
-
-        probe, _path = open_lease(self.topologies, port)
-        self.assertTrue(try_lock(probe))
-        entered = threading.Event()
-        result: list[tuple[int, dict[str, object]]] = []
-        errors: list[BaseException] = []
-
-        def observe_read(current_descriptor: int, path: Path) -> dict[str, object]:
-            entered.set()
-            return read_record(current_descriptor, path)
-
-        def reserve() -> None:
+        path = Path(record["path"])
+        probe = os.open(path, os.O_RDONLY | os.O_CLOEXEC)
+        try:
+            fcntl.flock(probe, fcntl.LOCK_SH | fcntl.LOCK_NB)
+            self.assertFalse(reservation_locked(record))
+            replacement, replacement_record = self.workspace._reserve_topology_port(
+                port, "after-probe", "2" * 64
+            )
             try:
-                result.append(
-                    self.workspace._reserve_topology_port(
-                        port, "after-probe", "2" * 64
-                    )
-                )
-            except BaseException as error:
-                errors.append(error)
-
-        with mock.patch(
-            "atrinik_workspace.workspace.read_port_reservation",
-            side_effect=observe_read,
-        ):
-            thread = threading.Thread(target=reserve)
-            thread.start()
-            self.assertTrue(entered.wait(timeout=2))
+                self.assertEqual(replacement_record["topology"], "after-probe")
+            finally:
+                os.close(replacement)
+        finally:
             os.close(probe)
-            thread.join(timeout=2)
 
-        self.assertFalse(thread.is_alive())
-        self.assertEqual(errors, [])
-        self.assertEqual(result[0][1]["topology"], "after-probe")
-        os.close(result[0][0])
+    def test_directory_substitution_cannot_redirect_child_open(self) -> None:
+        directory_fd, directory, identity = open_directory(self.topologies)
+        moved = self.topologies / "original-reservations"
+        directory.rename(moved)
+        attacker = self.topologies / "attacker"
+        attacker.mkdir(mode=0o700)
+        valuable = attacker / "valuable"
+        valuable.write_text("valuable\n", encoding="utf-8")
+        valuable.chmod(0o600)
+        directory.symlink_to(attacker, target_is_directory=True)
+        try:
+            with self.assertRaisesRegex(PortReservationError, "was replaced"):
+                create_lease(
+                    directory_fd,
+                    directory,
+                    identity,
+                    port=17300,
+                    topology="safe-owner",
+                    generation="3" * 64,
+                )
+            self.assertEqual(valuable.read_text(encoding="utf-8"), "valuable\n")
+        finally:
+            os.close(directory_fd)
+
+    def test_prepublication_owner_is_not_visible_until_immutable_record_exists(self) -> None:
+        port = 17379
+        transaction, directory_fd, directory, _identity = open_transaction(
+            self.topologies, port
+        )
+        try:
+            self.assertTrue(try_lock(transaction))
+            self.assertIsNone(active_owner(directory_fd, directory, port))
+        finally:
+            os.close(transaction)
+            os.close(directory_fd)
 
 
 if __name__ == "__main__":

--- a/tests/test_port_reservation.py
+++ b/tests/test_port_reservation.py
@@ -8,6 +8,7 @@ import tempfile
 import threading
 import time
 import unittest
+from unittest import mock
 
 from atrinik_workspace.model import WorkspaceError, atomic_json
 from atrinik_workspace.locking import exclusive_lock
@@ -16,6 +17,7 @@ from atrinik_workspace.port_reservation import (
     PortReservationError,
     bind_record,
     open_lease,
+    read_record,
     reservation_locked,
     try_lock,
     validate_held,
@@ -313,6 +315,51 @@ class PortReservationTests(unittest.TestCase):
             self.assertTrue(reservation_locked(current_record))
         finally:
             os.close(replacement)
+
+    def test_explicit_claim_retries_a_stale_status_probe_lock(self) -> None:
+        port = self.free_port()
+        descriptor, record = self.workspace._reserve_topology_port(
+            port, "stopped-probe", "1" * 64
+        )
+        owner = self.topologies / "stopped-probe"
+        owner.mkdir()
+        atomic_json(owner / TOPOLOGY_PORT_RESERVATION_RECORD, record)
+        os.close(descriptor)
+
+        probe, _path = open_lease(self.topologies, port)
+        self.assertTrue(try_lock(probe))
+        entered = threading.Event()
+        result: list[tuple[int, dict[str, object]]] = []
+        errors: list[BaseException] = []
+
+        def observe_read(current_descriptor: int, path: Path) -> dict[str, object]:
+            entered.set()
+            return read_record(current_descriptor, path)
+
+        def reserve() -> None:
+            try:
+                result.append(
+                    self.workspace._reserve_topology_port(
+                        port, "after-probe", "2" * 64
+                    )
+                )
+            except BaseException as error:
+                errors.append(error)
+
+        with mock.patch(
+            "atrinik_workspace.workspace.read_port_reservation",
+            side_effect=observe_read,
+        ):
+            thread = threading.Thread(target=reserve)
+            thread.start()
+            self.assertTrue(entered.wait(timeout=2))
+            os.close(probe)
+            thread.join(timeout=2)
+
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(errors, [])
+        self.assertEqual(result[0][1]["topology"], "after-probe")
+        os.close(result[0][0])
 
 
 if __name__ == "__main__":

--- a/tests/test_port_reservation.py
+++ b/tests/test_port_reservation.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import socket
+from types import SimpleNamespace
+import tempfile
+import threading
+import time
+import unittest
+
+from atrinik_workspace.model import WorkspaceError, atomic_json
+from atrinik_workspace.locking import exclusive_lock
+from atrinik_workspace.port_reservation import (
+    PORT_RESERVATION_DIRECTORY,
+    PortReservationError,
+    bind_record,
+    open_lease,
+    try_lock,
+    validate_held,
+)
+from atrinik_workspace.supervisor import _require_server_port_available
+from atrinik_workspace.workspace import TOPOLOGY_PORT_RESERVATION_RECORD, Workspace
+
+
+class PortReservationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.topologies = Path(self.temporary.name) / "topologies"
+        self.topologies.mkdir()
+        self.workspace = object.__new__(Workspace)
+        self.workspace.paths = SimpleNamespace(topologies=self.topologies)
+
+    @staticmethod
+    def free_port() -> int:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as candidate:
+            candidate.bind(("0.0.0.0", 0))
+            return int(candidate.getsockname()[1])
+
+    def test_distinct_explicit_ports_do_not_share_a_reservation_lock(self) -> None:
+        ports = [self.free_port(), self.free_port()]
+        while ports[0] == ports[1]:
+            ports[1] = self.free_port()
+        entered = threading.Barrier(3)
+        release = threading.Event()
+        results: list[tuple[int, dict[str, object]]] = []
+        errors: list[BaseException] = []
+
+        def reserve(index: int) -> None:
+            try:
+                reservation = self.workspace._reserve_topology_port(
+                    ports[index], f"explicit-{index}", f"{index + 1:064x}"
+                )
+                results.append(reservation)
+                entered.wait(timeout=2)
+                release.wait(timeout=2)
+            except BaseException as error:
+                errors.append(error)
+
+        threads = [threading.Thread(target=reserve, args=(index,)) for index in range(2)]
+        for thread in threads:
+            thread.start()
+        entered.wait(timeout=2)
+        self.assertEqual(errors, [])
+        self.assertEqual({record["port"] for _fd, record in results}, set(ports))
+        release.set()
+        for thread in threads:
+            thread.join(timeout=2)
+        for descriptor, _record in results:
+            os.close(descriptor)
+
+    def test_concurrent_automatic_allocations_are_unique(self) -> None:
+        start = threading.Barrier(3)
+        held = threading.Barrier(3)
+        release = threading.Event()
+        results: list[tuple[int, dict[str, object]]] = []
+        errors: list[BaseException] = []
+
+        def reserve(index: int) -> None:
+            try:
+                start.wait(timeout=2)
+                reservation = self.workspace._reserve_topology_port(
+                    None, f"automatic-{index}", f"{index + 1:064x}"
+                )
+                results.append(reservation)
+                held.wait(timeout=2)
+                release.wait(timeout=2)
+            except BaseException as error:
+                errors.append(error)
+
+        threads = [threading.Thread(target=reserve, args=(index,)) for index in range(2)]
+        for thread in threads:
+            thread.start()
+        start.wait(timeout=2)
+        held.wait(timeout=2)
+        self.assertEqual(errors, [])
+        self.assertEqual(len({record["port"] for _fd, record in results}), 2)
+        release.set()
+        for thread in threads:
+            thread.join(timeout=2)
+        for descriptor, _record in results:
+            os.close(descriptor)
+
+    def test_allocator_is_released_while_automatic_reservation_is_held(self) -> None:
+        descriptor, record = self.workspace._reserve_topology_port(
+            0, "automatic-zero", "5" * 64
+        )
+        try:
+            self.assertGreater(record["port"], 0)
+            with exclusive_lock(
+                self.topologies / "ports.lock",
+                "topology automatic port allocation",
+                nonblocking=True,
+            ):
+                pass
+        finally:
+            os.close(descriptor)
+
+    def test_explicit_port_does_not_enter_busy_automatic_allocator(self) -> None:
+        port = self.free_port()
+        with exclusive_lock(
+            self.topologies / "ports.lock",
+            "topology automatic port allocation",
+            nonblocking=True,
+        ):
+            descriptor, record = self.workspace._reserve_topology_port(
+                port, "explicit-independent", "6" * 64
+            )
+        try:
+            self.assertEqual(record["port"], port)
+        finally:
+            os.close(descriptor)
+
+    def test_same_explicit_port_has_one_winner_and_names_it(self) -> None:
+        port = self.free_port()
+        start = threading.Barrier(3)
+        release = threading.Event()
+        results: list[tuple[int, dict[str, object]]] = []
+        errors: list[str] = []
+
+        def reserve(index: int) -> None:
+            try:
+                start.wait(timeout=2)
+                reservation = self.workspace._reserve_topology_port(
+                    port, f"same-{index}", f"{index + 1:064x}"
+                )
+                results.append(reservation)
+                release.wait(timeout=2)
+            except WorkspaceError as error:
+                errors.append(str(error))
+
+        threads = [threading.Thread(target=reserve, args=(index,)) for index in range(2)]
+        for thread in threads:
+            thread.start()
+        start.wait(timeout=2)
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline and len(results) + len(errors) < 2:
+            time.sleep(0.01)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(len(errors), 1)
+        winner = results[0][1]
+        self.assertIn(f"topology {winner['topology']}", errors[0])
+        self.assertIn(str(winner["generation"]), errors[0])
+        release.set()
+        for thread in threads:
+            thread.join(timeout=2)
+        os.close(results[0][0])
+
+    def test_released_and_aborted_reservations_can_be_reacquired(self) -> None:
+        port = self.free_port()
+        descriptor, _record = self.workspace._reserve_topology_port(
+            port, "aborted", "1" * 64
+        )
+        os.close(descriptor)
+        replacement, record = self.workspace._reserve_topology_port(
+            port, "replacement", "2" * 64
+        )
+        try:
+            self.assertEqual(record["topology"], "replacement")
+        finally:
+            os.close(replacement)
+
+    def test_external_claim_after_reservation_is_actionable(self) -> None:
+        port = self.free_port()
+        descriptor, record = self.workspace._reserve_topology_port(
+            port, "external-race", "3" * 64
+        )
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as external:
+                external.bind(("0.0.0.0", port))
+                with self.assertRaisesRegex(
+                    RuntimeError, "external process before server startup"
+                ):
+                    _require_server_port_available(
+                        {"endpoint": {"host": "127.0.0.1", "port": record["port"]}}
+                    )
+        finally:
+            os.close(descriptor)
+
+    def test_lease_rejects_links_and_record_replacement(self) -> None:
+        directory = self.topologies / PORT_RESERVATION_DIRECTORY
+        directory.mkdir(mode=0o700)
+        target = directory / "target"
+        target.write_text("valuable\n", encoding="utf-8")
+        target.chmod(0o600)
+        symlink = directory / "17300.lease"
+        symlink.symlink_to(target)
+        with self.assertRaisesRegex(PortReservationError, "cannot open"):
+            open_lease(self.topologies, 17300)
+        symlink.unlink()
+        hardlink = directory / "17301.lease"
+        os.link(target, hardlink)
+        with self.assertRaisesRegex(PortReservationError, "identity is invalid"):
+            open_lease(self.topologies, 17301)
+
+        port = self.free_port()
+        descriptor, path = open_lease(self.topologies, port)
+        self.assertTrue(try_lock(descriptor))
+        record = bind_record(
+            descriptor,
+            path,
+            port=port,
+            topology="replacement-test",
+            generation="4" * 64,
+        )
+        path.unlink()
+        path.write_text("{}\n", encoding="utf-8")
+        path.chmod(0o600)
+        try:
+            with self.assertRaisesRegex(PortReservationError, "identity is invalid"):
+                validate_held(descriptor, record)
+        finally:
+            os.close(descriptor)
+
+    def test_pending_evidence_prevents_replaced_lease_from_being_stolen(self) -> None:
+        port = self.free_port()
+        descriptor, record = self.workspace._reserve_topology_port(
+            port, "original", "7" * 64
+        )
+        owner = self.topologies / "original"
+        owner.mkdir()
+        atomic_json(owner / TOPOLOGY_PORT_RESERVATION_RECORD, record)
+        path = Path(record["path"])
+        path.unlink()
+        path.write_text("{}\n", encoding="utf-8")
+        path.chmod(0o600)
+        try:
+            with self.assertRaisesRegex(
+                WorkspaceError, "does not match its exact lease"
+            ):
+                self.workspace._reserve_topology_port(
+                    port, "attacker", "8" * 64
+                )
+        finally:
+            os.close(descriptor)
+
+    def test_unlocked_pending_evidence_is_reusable_without_pid_observation(self) -> None:
+        port = self.free_port()
+        descriptor, record = self.workspace._reserve_topology_port(
+            port, "stopped", "9" * 64
+        )
+        owner = self.topologies / "stopped"
+        owner.mkdir()
+        atomic_json(owner / TOPOLOGY_PORT_RESERVATION_RECORD, record)
+        os.close(descriptor)
+
+        replacement, replacement_record = self.workspace._reserve_topology_port(
+            port, "restarted", "a" * 64
+        )
+        try:
+            self.assertEqual(replacement_record["topology"], "restarted")
+        finally:
+            os.close(replacement)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_port_reservation.py
+++ b/tests/test_port_reservation.py
@@ -10,6 +10,7 @@ import tempfile
 import threading
 import time
 import unittest
+from unittest import mock
 
 from atrinik_workspace.model import WorkspaceError, atomic_json
 from atrinik_workspace.locking import exclusive_lock
@@ -23,6 +24,7 @@ from atrinik_workspace.port_reservation import (
     reservation_locked,
     try_lock,
     validate_held,
+    validate_transaction,
 )
 from atrinik_workspace.supervisor import _require_server_port_available
 from atrinik_workspace.workspace import TOPOLOGY_PORT_RESERVATION_RECORD, Workspace
@@ -407,6 +409,64 @@ class PortReservationTests(unittest.TestCase):
         finally:
             os.close(replacement)
             os.close(descriptor)
+            os.close(directory_fd)
+
+    def test_replaced_transaction_cannot_publish_two_owners(self) -> None:
+        port = 17381
+        first, first_directory, _directory, _identity = open_transaction(
+            self.topologies, port
+        )
+        self.assertTrue(try_lock(first))
+        transaction_path = (
+            self.topologies / PORT_RESERVATION_DIRECTORY / f"{port}.lock"
+        )
+        transaction_path.unlink()
+        second, second_directory, _directory, _identity = open_transaction(
+            self.topologies, port
+        )
+        try:
+            self.assertTrue(try_lock(second))
+            with self.assertRaisesRegex(PortReservationError, "identity is invalid"):
+                validate_transaction(first, first_directory, port)
+            validate_transaction(second, second_directory, port)
+        finally:
+            os.close(first)
+            os.close(first_directory)
+            os.close(second)
+            os.close(second_directory)
+
+    def test_failed_publication_preserves_replacement_path(self) -> None:
+        directory_fd, directory, identity = open_directory(self.topologies)
+        valuable = directory / "valuable"
+        valuable.write_text("valuable\n", encoding="utf-8")
+        valuable.chmod(0o600)
+        generation = "5" * 64
+        lease = directory / f"17382-{generation}.lease"
+        real_fsync = os.fsync
+
+        def replace_before_validation(descriptor: int) -> None:
+            real_fsync(descriptor)
+            lease.unlink()
+            valuable.rename(lease)
+
+        try:
+            with (
+                mock.patch(
+                    "atrinik_workspace.port_reservation.os.fsync",
+                    side_effect=replace_before_validation,
+                ),
+                self.assertRaisesRegex(PortReservationError, "identity is invalid"),
+            ):
+                create_lease(
+                    directory_fd,
+                    directory,
+                    identity,
+                    port=17382,
+                    topology="cleanup-owner",
+                    generation=generation,
+                )
+            self.assertEqual(lease.read_text(encoding="utf-8"), "valuable\n")
+        finally:
             os.close(directory_fd)
 
 

--- a/tests/test_port_reservation.py
+++ b/tests/test_port_reservation.py
@@ -16,6 +16,7 @@ from atrinik_workspace.port_reservation import (
     PortReservationError,
     bind_record,
     open_lease,
+    reservation_locked,
     try_lock,
     validate_held,
 )
@@ -295,6 +296,21 @@ class PortReservationTests(unittest.TestCase):
             self.assertIn("topology current-owner", message)
             self.assertIn(str(replacement_record["generation"]), message)
             self.assertNotIn("topology stale-owner", message)
+        finally:
+            os.close(replacement)
+
+    def test_reused_locked_inode_is_retained_only_for_current_record(self) -> None:
+        port = self.free_port()
+        descriptor, old_record = self.workspace._reserve_topology_port(
+            port, "old-status", "e" * 64
+        )
+        os.close(descriptor)
+        replacement, current_record = self.workspace._reserve_topology_port(
+            port, "new-status", "f" * 64
+        )
+        try:
+            self.assertFalse(reservation_locked(old_record))
+            self.assertTrue(reservation_locked(current_record))
         finally:
             os.close(replacement)
 

--- a/tests/test_port_reservation.py
+++ b/tests/test_port_reservation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import fcntl
+import json
 import os
 from pathlib import Path
 import socket
@@ -374,6 +375,38 @@ class PortReservationTests(unittest.TestCase):
             self.assertIsNone(active_owner(directory_fd, directory, port))
         finally:
             os.close(transaction)
+            os.close(directory_fd)
+
+    def test_creation_token_rejects_identity_matching_replacement(self) -> None:
+        directory_fd, directory, identity = open_directory(self.topologies)
+        descriptor, record = create_lease(
+            directory_fd,
+            directory,
+            identity,
+            port=17380,
+            topology="token-owner",
+            generation="4" * 64,
+        )
+        path = Path(record["path"])
+        path.unlink()
+        path.write_text("{}\n", encoding="utf-8")
+        path.chmod(0o600)
+        replacement = os.open(path, os.O_RDWR | os.O_CLOEXEC)
+        forged = dict(record)
+        replacement_metadata = os.fstat(replacement)
+        forged["lease"] = {
+            "device": replacement_metadata.st_dev,
+            "inode": replacement_metadata.st_ino,
+        }
+        payload = (json.dumps(forged, indent=2, sort_keys=True) + "\n").encode()
+        os.ftruncate(replacement, 0)
+        os.write(replacement, payload)
+        try:
+            with self.assertRaisesRegex(PortReservationError, "creation identity"):
+                validate_held(replacement, forged)
+        finally:
+            os.close(replacement)
+            os.close(descriptor)
             os.close(directory_fd)
 
 

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -182,7 +182,7 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                 mock.patch.object(supervisor_module, "terminate") as terminate,
                 mock.patch.object(supervisor_module.os, "close") as close,
             ):
-                self.assertEqual(supervise(spec_path, None, 7, 8, None), 1)
+                self.assertEqual(supervise(spec_path, None, 7, 8, None, None), 1)
 
             terminate.assert_called_once()
             self.assertEqual(terminate.call_args.args[0], {"client": process})

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import queue
 import shutil
 import signal
+import socket
 import stat
 import subprocess
 import sys
@@ -630,6 +631,65 @@ class WorkspaceTests(unittest.TestCase):
             {"schema_version": 1, "purpose": "region-map-cache"},
         )
         return output
+
+    def make_rendezvous_server_build(
+        self,
+        root: Path,
+        rendezvous: Path,
+        marker: str,
+        *,
+        peers: int = 2,
+        bind_after_gate: bool = False,
+    ) -> None:
+        binary = root / "build" / "server"
+        binary.mkdir(parents=True)
+        executable = binary / "atrinik-server"
+        executable.write_text(
+            "#!/usr/bin/env python3\n"
+            "import os, pathlib, socket, sys, time\n"
+            "port = int(next(value.split('=', 1)[1] for value in sys.argv "
+            "if value.startswith('--port_quic=')))\n"
+            f"rendezvous = pathlib.Path({str(rendezvous)!r})\n"
+            f"marker = rendezvous / {marker!r}\n"
+            "udp = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\n"
+            + ("marker.write_text('entered\\n', encoding='utf-8')\n" if bind_after_gate else "udp.bind(('0.0.0.0', port))\nmarker.write_text('bound\\n', encoding='utf-8')\n")
+            + "deadline = time.monotonic() + 10\n"
+            f"while len(list(rendezvous.glob('*.entered'))) + len(list(rendezvous.glob('*.bound'))) < {peers}:\n"
+            "    if time.monotonic() >= deadline:\n"
+            "        raise RuntimeError('rendezvous timed out')\n"
+            "    time.sleep(0.01)\n"
+            + ("udp.bind(('0.0.0.0', port))\n" if bind_after_gate else "")
+            + "for descriptor in os.listdir('/proc/self/fd'):\n"
+            "    try:\n"
+            "        target = os.readlink('/proc/self/fd/' + descriptor)\n"
+            "    except OSError:\n"
+            "        continue\n"
+            "    assert '/port-reservations/' not in target, target\n"
+            f"print('QUIC certificate SHA-256: {'e' * 64}', flush=True)\n"
+            "print('Server ready. Waiting for connections...', flush=True)\n"
+            "while True:\n"
+            "    time.sleep(0.1)\n",
+            encoding="utf-8",
+        )
+        executable.chmod(0o755)
+        for name in ("libplugin_arena.so", "libplugin_python.so"):
+            (binary / name).write_text("test\n", encoding="utf-8")
+        for path in (
+            root / "runtime" / "content" / "lib",
+            root / "runtime" / "content" / "maps",
+            root / "runtime" / "resources",
+        ):
+            path.mkdir(parents=True, exist_ok=True)
+        atomic_json(
+            root / "runtime" / "content" / MANAGED_MARKER,
+            {"schema_version": 1, "purpose": "collected-content"},
+        )
+        atomic_json(
+            root / "runtime" / "resources" / MANAGED_MARKER,
+            {"schema_version": 1, "purpose": "resource-view"},
+        )
+        self.make_region_map_cache(root)
+        atomic_json(root / workspace_module.BUILD_METADATA, {})
 
     @staticmethod
     def make_content_candidate(output: Path, commit: str, payload: str) -> None:
@@ -6886,6 +6946,198 @@ class WorkspaceTests(unittest.TestCase):
                     "playtest-client", timeout=5
                 )
         self.assertFalse(stopped["services"]["client"]["running"])
+
+    def test_concurrent_server_topologies_overlap_through_readiness(self) -> None:
+        source = self.workspace.paths.repositories / "server"
+        (source / "tools").mkdir()
+        for name in ("ca-bundle.crt", "permissions.cfg", "server.cfg"):
+            (source / name).write_text("test\n", encoding="utf-8")
+
+        def free_port() -> int:
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as candidate:
+                candidate.bind(("0.0.0.0", 0))
+                return int(candidate.getsockname()[1])
+
+        for mode in ("explicit", "automatic"):
+            with self.subTest(mode=mode):
+                rendezvous = self.root / f"{mode}-port-rendezvous"
+                rendezvous.mkdir()
+                roots = [
+                    self.workspace.paths.builds / f"{mode}-server-{index}"
+                    for index in range(2)
+                ]
+                for index, root in enumerate(roots):
+                    self.make_rendezvous_server_build(
+                        root, rendezvous, f"{index}.bound"
+                    )
+                states = [f"{mode}-state-{index}" for index in range(2)]
+                for state in states:
+                    self.workspace.state_add(state, None)
+                names = [f"{mode}-topology-{index}" for index in range(2)]
+                if mode == "explicit":
+                    ports: list[int | None] = [free_port(), free_port()]
+                    while ports[0] == ports[1]:
+                        ports[1] = free_port()
+                else:
+                    ports = [None, None]
+                sessions = [Workspace(self.wrapper), Workspace(self.wrapper)]
+                try:
+                    with (
+                        mock.patch.object(
+                            sessions[0], "_build_resolved", return_value=roots[0]
+                        ),
+                        mock.patch.object(
+                            sessions[1], "_build_resolved", return_value=roots[1]
+                        ),
+                        ThreadPoolExecutor(max_workers=2) as executor,
+                    ):
+                        futures = [
+                            executor.submit(
+                                sessions[index].topology_up,
+                                names[index],
+                                "default",
+                                states[index],
+                                ["server"],
+                                ports[index],
+                            )
+                            for index in range(2)
+                        ]
+                        statuses = [future.result(timeout=20) for future in futures]
+                    self.assertTrue(all(status["ready"] for status in statuses))
+                    self.assertEqual(
+                        len({status["endpoint"]["port"] for status in statuses}), 2
+                    )
+                    self.assertEqual(
+                        {path.name for path in rendezvous.glob("*.bound")},
+                        {"0.bound", "1.bound"},
+                    )
+                    observer = Workspace(self.wrapper)
+                    for index, name in enumerate(names):
+                        observed = observer.topology_status(name)
+                        self.assertTrue(observed["ready"])
+                        self.assertEqual(
+                            observed["observation"]["port_reservation"]["lease"],
+                            "retained",
+                        )
+                        if mode == "explicit":
+                            self.assertEqual(observed["endpoint"]["port"], ports[index])
+
+                    supervisor = statuses[0]["supervisor"]
+                    pidfd = os.pidfd_open(supervisor["pid"])
+                    try:
+                        signal.pidfd_send_signal(pidfd, signal.SIGKILL)
+                    finally:
+                        os.close(pidfd)
+                    deadline = time.monotonic() + 15
+                    while time.monotonic() < deadline:
+                        crashed = observer.topology_status(names[0])
+                        if (
+                            not crashed["supervisor"]["running"]
+                            and crashed["observation"]["port_reservation"]["lease"]
+                            == "released"
+                        ):
+                            break
+                        time.sleep(0.05)
+                    self.assertFalse(crashed["supervisor"]["running"])
+                    self.assertEqual(
+                        crashed["observation"]["port_reservation"]["lease"],
+                        "released",
+                    )
+                finally:
+                    observer = Workspace(self.wrapper)
+                    for name in names:
+                        remaining = observer.topology_status(name)
+                        if remaining["supervisor"]["running"] or any(
+                            service["running"]
+                            for service in remaining["services"].values()
+                        ):
+                            observer.topology_down(name, timeout=5)
+
+    def test_supervisor_loss_before_server_bind_releases_reservation(self) -> None:
+        source = self.workspace.paths.repositories / "server"
+        (source / "tools").mkdir()
+        for name in ("ca-bundle.crt", "permissions.cfg", "server.cfg"):
+            (source / name).write_text("test\n", encoding="utf-8")
+        rendezvous = self.root / "pre-bind-rendezvous"
+        rendezvous.mkdir()
+        build_root = self.workspace.paths.builds / "pre-bind-server"
+        self.make_rendezvous_server_build(
+            build_root,
+            rendezvous,
+            "server.entered",
+            peers=2,
+            bind_after_gate=True,
+        )
+        state = "pre-bind-state"
+        self.workspace.state_add(state, None)
+        name = "pre-bind-topology"
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as candidate:
+            candidate.bind(("0.0.0.0", 0))
+            port = int(candidate.getsockname()[1])
+        session = Workspace(self.wrapper)
+        observer = Workspace(self.wrapper)
+        try:
+            with (
+                mock.patch.object(
+                    session, "_build_resolved", return_value=build_root
+                ),
+                ThreadPoolExecutor(max_workers=1) as executor,
+            ):
+                startup = executor.submit(
+                    session.topology_up,
+                    name,
+                    "default",
+                    state,
+                    ["server"],
+                    port,
+                )
+                marker = rendezvous / "server.entered"
+                deadline = time.monotonic() + 10
+                while time.monotonic() < deadline and not marker.is_file():
+                    time.sleep(0.02)
+                self.assertTrue(marker.is_file())
+                pending = observer.topology_status(name)
+                self.assertEqual(
+                    pending["observation"]["port_reservation"]["lease"],
+                    "retained",
+                )
+                supervisor = pending["supervisor"]
+                pidfd = os.pidfd_open(supervisor["pid"])
+                try:
+                    signal.pidfd_send_signal(pidfd, signal.SIGKILL)
+                finally:
+                    os.close(pidfd)
+                with self.assertRaisesRegex(
+                    WorkspaceError, "supervisor exited during startup"
+                ):
+                    startup.result(timeout=10)
+
+            deadline = time.monotonic() + 15
+            while time.monotonic() < deadline:
+                failed = observer.topology_status(name)
+                if (
+                    not failed["supervisor"]["running"]
+                    and failed["observation"]["port_reservation"]["lease"]
+                    == "released"
+                ):
+                    break
+                time.sleep(0.05)
+            self.assertEqual(
+                failed["observation"]["port_reservation"]["lease"], "released"
+            )
+            replacement_fd, replacement = observer._reserve_topology_port(
+                port, "post-crash", "f" * 64
+            )
+            try:
+                self.assertEqual(replacement["port"], port)
+            finally:
+                os.close(replacement_fd)
+        finally:
+            remaining = observer.topology_status(name)
+            if remaining["supervisor"]["running"] or any(
+                service["running"] for service in remaining["services"].values()
+            ):
+                observer.topology_down(name, timeout=5)
 
     def test_supervised_pair_pins_client_and_holds_state_lock_until_down(self) -> None:
         source = self.workspace.paths.repositories / "server"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7043,6 +7043,22 @@ class WorkspaceTests(unittest.TestCase):
                         crashed["observation"]["port_reservation"]["lease"],
                         "released",
                     )
+                    reassigned_fd, reassigned = observer._reserve_topology_port(
+                        crashed["endpoint"]["port"],
+                        f"{mode}-replacement",
+                        "f" * 64,
+                    )
+                    try:
+                        self.assertTrue(
+                            workspace_module.port_reservation_locked(reassigned)
+                        )
+                        self.assertEqual(
+                            observer.topology_status(names[0])["observation"]
+                            ["port_reservation"]["lease"],
+                            "released",
+                        )
+                    finally:
+                        os.close(reassigned_fd)
                 finally:
                     observer = Workspace(self.wrapper)
                     for name in names:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -6898,7 +6898,14 @@ class WorkspaceTests(unittest.TestCase):
         executable = binary / "atrinik-server"
         executable.write_text(
             "#!/usr/bin/env python3\n"
-            "import sys, time\n"
+            "import os, sys, time\n"
+            "for descriptor in os.listdir('/proc/self/fd'):\n"
+            "    try:\n"
+            "        target = os.readlink('/proc/self/fd/' + descriptor)\n"
+            "    except OSError:\n"
+            "        continue\n"
+            "    assert not target.endswith('/ports.lock'), target\n"
+            "    assert '/port-reservations/' not in target, target\n"
             f"print('QUIC certificate SHA-256: {'a' * 64}', flush=True)\n"
             "print('Server ready. Waiting for connections...', flush=True)\n"
             "print(repr(sys.argv[1:]), flush=True)\n"
@@ -6973,6 +6980,11 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertTrue(status["ready"])
         self.assertEqual(status["endpoint"]["port"], 17300)
+        self.assertEqual(status["port_reservation"]["port"], 17300)
+        self.assertEqual(status["port_reservation"]["topology"], "server-review")
+        self.assertEqual(
+            status["observation"]["port_reservation"]["lease"], "retained"
+        )
         self.assertEqual(status["endpoint"]["fingerprint"], "a" * 64)
         server_runtime = Path(status["services"]["server"]["cwd"])
         self.assertEqual(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -465,6 +465,10 @@ def synthetic_server_start_process(
             reservation_received.set()
             if not release_reservation.wait(10):
                 raise TimeoutError("port reservation was not released")
+            # The parent reserves an exact free port across process spawn. The
+            # child closes its inherited copy immediately before the wrapper's
+            # kernel availability check.
+            reserved_port.close()
 
             with (
                 mock.patch.object(
@@ -6334,39 +6338,27 @@ class WorkspaceTests(unittest.TestCase):
             self.fail(f"{description} was not reached; children={child_errors}")
 
         try:
-            processes[0].start()
-            started.append(processes[0])
-            wait_for_process_event(
-                reservation_received[0],
-                "server A port reservation transfer",
-                results,
-            )
-            reservations[0].close()
-            release_reservation[0].set()
+            for process in processes:
+                process.start()
+                started.append(process)
+            for index, received in enumerate(reservation_received):
+                wait_for_process_event(
+                    received,
+                    f"server {index} port reservation transfer",
+                    results,
+                )
+                reservations[index].close()
+            for event in release_reservation:
+                event.set()
             wait_for_path(pre_ready[0], "server A pre-ready barrier")
-
-            processes[1].start()
-            started.append(processes[1])
-            wait_for_process_event(
-                reservation_received[1],
-                "server B port reservation transfer",
-                results,
-            )
-            reservations[1].close()
-            release_reservation[1].set()
-            wait_for_process_event(
-                port_blocked[1], "server B confirmed port-lock block", results
-            )
-            self.assertFalse(pre_ready[1].exists())
-
-            # Both starts use distinct topology, profile/build, state, and
-            # explicit-port coordinates. P0 positively records that the global
-            # allocator lease serializes B until A leaves its pre-ready stage.
-            # The #401 cutover will replace this lock-specific expectation with
-            # per-port ownership and concurrent pre-ready rendezvous assertions.
-            releases[0].write_text("release\n", encoding="utf-8")
             wait_for_path(pre_ready[1], "server B pre-ready barrier")
-            releases[1].write_text("release\n", encoding="utf-8")
+            self.assertTrue(all(not blocked.is_set() for blocked in port_blocked))
+
+            # Distinct explicit ports, build roots, states, and topology names
+            # reach the server pre-ready barrier concurrently. Neither waits on
+            # the automatic allocator or the other generation's owner lease.
+            for release in releases:
+                release.write_text("release\n", encoding="utf-8")
         finally:
             for reservation in reservations:
                 reservation.close()


### PR DESCRIPTION
Closes #401

## Summary

- replace the long-lived global runtime port lock with secure exact-port lease records
- keep automatic/zero allocation bounded while allowing unrelated explicit ports and build roots to start concurrently
- retain reservations across supervisor/guardian recovery, expose ownership in status, and fail boundedly on external bind races
- document the reservation and lock-order contract

## Coordinates

- Base: `main` at `029bbfcba5368187d616bba613eff2c5b908be3b`
- Head: `perf/port-reservation-leases` at `17ec258fa8619d847bd3ce1e0d3d31d9f903494e`
- Worktree: `/workspaces/atrinik/workspace/worktrees/atrinik/issue-401-port-reservations`
- Commits: `285e5a40a` through `17ec258fa` (plus merge `d7398d0ee` of advanced `main`)

## Validation

- full unittest discovery — 662 tests passed
- `.venv/bin/python -m coverage report --show-missing` — 82% total
- focused reservation/supervisor suite — 35 tests passed; reservation module 94%
- Codecov patch coverage — 83%
- P0 explicit overlap plus three end-to-end concurrency/recovery tests — 4 tests passed
- `.venv/bin/python -m compileall -q atrinik atrinik_workspace tests`
- `.venv/bin/python -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `git diff --check`

## Runtime verification

Deterministic isolated integration tests run independent fake server builds and states through real supervisor processes. They verify explicit and automatic topology pairs overlap through actual UDP bind/readiness, exact same-port conflicts report the current topology and generation, and reservation leases are retained and released correctly across supervisor loss before and after bind. No mutable Classic data, persistent topology, or gameplay scenario is required.

To repeat:

```sh
.venv/bin/python -m unittest -v tests.test_port_reservation tests.test_workspace.WorkspaceTests.test_concurrent_server_topologies_overlap_through_readiness tests.test_workspace.WorkspaceTests.test_supervisor_loss_before_server_bind_releases_reservation
```

The tests create isolated temporary profiles/build roots, states, supervisors, and sockets; teardown stops their services and removes their temporary data.
