### PR TITLE
refactor(runtime): publish immutable runtime generations

### DIFF
--- a/.agents/skills/atrinik-server-runtime/SKILL.md
+++ b/.agents/skills/atrinik-server-runtime/SKILL.md
@@ -8,10 +8,12 @@ description: Run or diagnose isolated classic servers and supervised topologies 
 The wrapper owns builds, collection, state locks, supervision, logs, and
 cleanup. Never reconstruct its paths or invoke generated binaries.
 
-Classic preparation owns disposable `assets` staging. Generated `data/*`,
-exact-profile `client-maps/*`, and resources use authenticated QUIC by default;
-`http_url` only names an optional external HTTP(S) origin. Never stage assets in
-state or restore a bundled HTTP listener.
+Classic preparation owns disposable `assets` staging. Immutable
+exact-profile `client-maps/*` and resources use authenticated QUIC by default;
+server-generated `data/*` transport files live only in the generation-named
+runtime-output directory below the exclusively leased state. Do not place
+copied asset inputs in state. `http_url` only names an optional external
+HTTP(S) origin; never restore a bundled HTTP listener.
 
 1. Read the workspace and selected server/content/resource guides.
 2. Inspect a coherent classic-derived profile and topology.
@@ -28,17 +30,21 @@ state or restore a bundled HTTP listener.
 ```
 
 `ps --json` reports generation-bound `live`, `exited`, `stale`, or
-`unreachable` liveness and an `observation` naming any topology that retains
-the repository-layout lease. Cross-session `down` uses the matching filesystem
+`unreachable` liveness and exact runtime-generation, process-tree, state, and
+port observations. A ready topology retains no repository-layout or mutable
+build-root lease. Cross-session `down` uses the matching filesystem
 control endpoint, never a PID from the caller's namespace. For `unreachable`,
 follow the reported safe action: wait for bounded guardian recovery and retry
 `ps` and `down`; preserve an exact retained lease for operator diagnosis.
 Never inspect `/proc`, signal the recorded PIDs, unlink control or lease files,
 or reuse the name as recovery.
 The wrapper uses a short generation-derived endpoint in the shared workspace
-and binds the process-tree lease to its generation and file identity.
-Missing, replaced, linked, or malformed current lease files are unsafe and
-must remain untouched for fail-closed diagnosis.
+and binds both process-tree and immutable runtime-bundle leases to the exact
+generation and file identities. Missing, replaced, linked, or malformed
+current generations, manifests, or lease files are unsafe and must remain
+untouched for fail-closed diagnosis. Never edit a published generation; rebuild
+the profile while it is live only to verify that its recorded manifest digest
+and runtime bytes remain unchanged.
 
 Let `up` allocate a port unless a distinct fixed port is required. Diagnose
 build, state, plugin, network, and gameplay failures separately. Use

--- a/README.md
+++ b/README.md
@@ -514,9 +514,9 @@ Each current topology persists a random generation identity and a mode-0600
 filesystem control endpoint. `ps` and `down` therefore work from another
 supported devcontainer or sandbox that shares the workspace even when its PID
 namespace cannot see the namespace-local process numbers. JSON status reports
-`live`, `exited`, `stale`, or fail-closed `unreachable` liveness plus an
-`observation` naming the topology that retains the repository-layout lease and
-the safe next action. Text status prints the same retained-lease owner and
+`live`, `exited`, `stale`, or fail-closed `unreachable` liveness plus exact
+runtime-generation, process-tree, server-state, and port observations and the
+safe next action. Text status prints the retained generation identity and
 action. A control response must match both the topology name and generation;
 `down` never falls back to signaling a mismatched or recycled PID.
 The runtime places the socket under a short generation-derived name in the
@@ -526,11 +526,9 @@ identity; never replace,
 unlink, or repair it by hand because an invalid current lease fails closed.
 
 If a supervisor is killed rather than shut down, its same-namespace guardian
-terminates exact process-tree lease holders and retains the generation until
-their absence is proven. Layout, build-root, and state leases are held by the
-supervisor and guardian, not services, so a descendant that closes its
-process-tree identity cannot retain those workspace leases; the guardian
-releases them after recovery. During that
+terminates exact process-tree lease holders and retains the runtime generation
+and server state until their absence is proven. No layout or mutable build-root
+lease survives publication. During that
 interval another session reports `unreachable` and fails closed: wait, retry
 `./atrinik ps TOPOLOGY --json`, then retry `./atrinik down TOPOLOGY`. If the
 lease remains retained and control remains unreachable, preserve the exact
@@ -956,8 +954,7 @@ declaring the topology ready. Use
 `--service server` or `--service client` for a single service. Client startup
 requires a live forwarded display socket.
 
-Build, foreground run, and runtime-preparation commands hold a shared
-repository-layout lock.
+Build and runtime-publication preparation hold a shared repository-layout lock.
 Different profile build roots may compile concurrently; an exclusive per-root
 lock still serializes the same root. Initialization, synchronization, worktree
 or profile changes, and cleanup apply take the layout lock exclusively, so they
@@ -976,24 +973,28 @@ not interrupt a reader, topology, build, or mutation. The pending announcement,
 writer-intent gate, and layout lock are always acquired before topology,
 scenario, port allocator/per-port reservation, state, build-root, registry, or
 cache locks. The allocator is released before state/build/runtime preparation;
-the exact generation reservation remains held. Foreground
-processes inherit their layout and exact build-root leases. Supervised services
-inherit only the process-tree identity through the daemon. The supervisor and
-same-generation guardian keep layout, build-root, state, and generation
-reservation leases until every service exits or `down` completes. Mutation
+the exact generation reservation remains held. Foreground processes run from
+temporary immutable generations after releasing layout/build leases.
+Supervised services likewise run from topology-owned generations and retain
+only exact runtime-generation/process-tree resources plus server state and the
+selected port reservation when applicable. Mutation
 subprocesses inherit all three writer leases. Build and scenario
 subprocesses inherit every active layout, build-root, state, registry, and cache
 lease so an orphan cannot outlive its protection.
 
-The supervisor records exact source commits, build and state paths, and process
-start identities. `ps` without a name lists every recorded topology; a name
+The supervisor records exact source commits/trees, build metadata, runtime
+digests, state paths, and process start identities. `ps` without a name lists every recorded topology; a name
 selects one. It distinguishes a live process from a reused PID, and `down`
 signals only processes holding that topology's identity lease, including
 orphaned services and descendants. The server state remains locked for the
 complete supervised lifetime. Each topology also has a persistent isolated
-client configuration/cache root and its own copies of the collected content and
-resource caches, so changing or removing one topology cannot affect another
-topology or the retained build caches. The inherited identity lease atomically
+client configuration/cache root and a complete sealed executable runtime, so
+rebuilding a profile or changing/removing a selected worktree cannot alter a
+live topology. Server-generated transport files live below a generation-named
+directory inside the exclusively leased state and are reached through the
+published state exception; copied maps are sealed beside that output and bound
+into the manifest, while other served inputs remain sealed inside the runtime
+generation. The inherited identity lease atomically
 prevents the same topology name from restarting while any generation remains.
 Server services do not inherit allocator, transaction, or generation
 reservation descriptors;
@@ -1274,7 +1275,10 @@ protocol, or network user-agent version data. Clients started outside the
 wrapper retain the ordinary package title. Start the server first
 so that its persistent `quic-identity.pem` exists. Additional arguments are
 appended after these defaults, and join-password arguments are redacted from
-command logging. Prefer `up` for routine use because it allocates a port,
+command logging. Each command first publishes a random command-owned immutable
+generation, releases source/layout/build leases, runs with only that generation
+lease (and server state for the server), then reclaims the exact generation on
+normal exit. Prefer `up` for routine use because it allocates a port,
 captures the fingerprint, and sequences both processes automatically.
 
 ## Workspace location and recovery

--- a/README.md
+++ b/README.md
@@ -997,9 +997,9 @@ into the manifest, while other served inputs remain sealed inside the runtime
 generation. The inherited identity lease atomically
 prevents the same topology name from restarting while any generation remains.
 Server services do not inherit allocator, transaction, or generation
-reservation descriptors;
-the supervisor and same-generation guardian retain the exact reservation and
-release it after orderly shutdown or exact process-tree recovery. `ps --json`
+reservation descriptors; the supervisor and same-generation guardian retain
+the exact reservation and release it after orderly shutdown or exact
+process-tree recovery. `ps --json`
 exposes its port, owner, generation, and retained/released observation without
 credentials. Reservation records are never reclaimed from recorded PIDs.
 Logs live below `workspace/topologies/`

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -812,11 +812,19 @@ def main(arguments: list[str] | None = None) -> int:
                         isinstance(observation, dict)
                         and observation.get("process_tree_lease") == "retained"
                     ):
-                        print(
-                            "repository-layout-lease\tretained\t"
-                            f"{observation['repository_layout_lease_owner']}\t"
-                            f"{observation['safe_action']}"
-                        )
+                        if observation.get("runtime_generation") is not None:
+                            print(
+                                "runtime-generation\t"
+                                f"{observation['runtime_bundle_lease']}\t"
+                                f"{observation['runtime_generation']}\t"
+                                f"{observation['safe_action']}"
+                            )
+                        else:
+                            print(
+                                "repository-layout-lease\tretained\t"
+                                f"{observation['repository_layout_lease_owner']}\t"
+                                f"{observation['safe_action']}"
+                            )
         elif options.command == "logs":
             workspace.topology_logs(
                 options.name, options.service, options.tail, options.follow

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -591,7 +591,7 @@ def supervise(
 
     try:
         retained_fds = (
-            (lock_fd, runtime_lock_fd, port_reservation_fd)
+            (port_reservation_fd, lock_fd, runtime_lock_fd)
             if spec.get("schema_version") == 2
             else (
                 lock_fd,

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -256,7 +256,7 @@ def _initial_status(spec: dict[str, Any], supervisor_start_time: str) -> dict[st
     control = spec.get("control")
     generation = control.get("generation") if isinstance(control, dict) else None
     status: dict[str, Any] = {
-        "schema_version": 1,
+        "schema_version": spec.get("schema_version", 1),
         "name": spec["name"],
         "profile": spec["profile"],
         "dependencies": spec["dependencies"],
@@ -280,6 +280,8 @@ def _initial_status(spec: dict[str, Any], supervisor_start_time: str) -> dict[st
     }
     if control is not None:
         status["control"] = control
+    if "runtime" in spec:
+        status["runtime"] = spec["runtime"]
     if "stack" in spec or "providers" in spec:
         if not isinstance(spec.get("stack"), str) or not isinstance(
             spec.get("providers"), dict
@@ -493,9 +495,16 @@ def supervise(
     build_lock_fd: int | None,
     process_tree_fd: int | None,
     port_reservation_fd: int | None,
+    runtime_lock_fd: int | None = None,
 ) -> int:
     with spec_path.open(encoding="utf-8") as stream:
         spec = json.load(stream)
+    if spec.get("schema_version") == 2:
+        for descriptor in (layout_lock_fd, build_lock_fd):
+            if descriptor is not None:
+                os.close(descriptor)
+        layout_lock_fd = None
+        build_lock_fd = None
     status_path = spec_path.parent / "status.json"
     stop = False
     control_socket: socket.socket | None = None
@@ -581,12 +590,18 @@ def supervise(
         return process
 
     try:
+        retained_fds = (
+            (lock_fd, runtime_lock_fd, port_reservation_fd)
+            if spec.get("schema_version") == 2
+            else (
+                lock_fd,
+                layout_lock_fd,
+                build_lock_fd,
+                port_reservation_fd,
+            )
+        )
         guardian_pid, guardian_write_fd = _start_guardian(
-            process_tree_fd,
-            lock_fd,
-            layout_lock_fd,
-            build_lock_fd,
-            port_reservation_fd,
+            process_tree_fd, *retained_fds
         )
         control_socket = _open_control(spec, spec_path.parent)
         if "server" in spec["services"]:
@@ -694,6 +709,8 @@ def supervise(
             os.close(build_lock_fd)
         if port_reservation_fd is not None:
             os.close(port_reservation_fd)
+        if runtime_lock_fd is not None:
+            os.close(runtime_lock_fd)
     return 0
 
 
@@ -705,6 +722,7 @@ def main() -> int:
     parser.add_argument("--build-lock-fd", type=int)
     parser.add_argument("--process-tree-fd", type=int)
     parser.add_argument("--port-reservation-fd", type=int)
+    parser.add_argument("--runtime-lock-fd", type=int)
     parser.add_argument("--daemonize", action="store_true")
     options = parser.parse_args()
     if options.daemonize and os.fork() != 0:
@@ -717,6 +735,7 @@ def main() -> int:
             options.build_lock_fd,
             options.process_tree_fd,
             options.port_reservation_fd,
+            options.runtime_lock_fd,
         )
     except BaseException as error:
         message = f"{type(error).__name__}: {error}"
@@ -748,6 +767,11 @@ def main() -> int:
         if options.port_reservation_fd is not None:
             try:
                 os.close(options.port_reservation_fd)
+            except OSError:
+                pass
+        if options.runtime_lock_fd is not None:
+            try:
+                os.close(options.runtime_lock_fd)
             except OSError:
                 pass
         return 1

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -124,6 +124,10 @@ COMPILER_CACHE_MAX_SIZE = "5G"
 TOPOLOGY_SERVICES = ("server", "client")
 TOPOLOGY_PROCESS_TREE_LEASE = "process-tree.lease"
 TOPOLOGY_PORT_RESERVATION_RECORD = "port-reservation.json"
+TOPOLOGY_STATUS_SCHEMA_VERSION = 2
+RUNTIME_GENERATION_SCHEMA_VERSION = 1
+RUNTIME_GENERATION_LEASE = "generation.lease"
+RUNTIME_GENERATION_MANIFEST = "manifest.json"
 PRE_MONOREPO_REPOSITORIES = {
     "client": "legacy-client",
     "server": "legacy-server",
@@ -6729,6 +6733,7 @@ class Workspace:
         source_display: Path,
         destination_fd: int,
         destination_display: Path,
+        exclusions: frozenset[str] = frozenset(),
     ) -> None:
         directory_before = os.fstat(source_fd)
         if not stat.S_ISDIR(directory_before.st_mode):
@@ -6742,6 +6747,8 @@ class Workspace:
                 f"cannot list topology runtime input {source_display}: {error}"
             ) from error
         for name in names:
+            if name in exclusions:
+                continue
             source_child = source_display / name
             destination_child = destination_display / name
             try:
@@ -6788,6 +6795,7 @@ class Workspace:
                             source_child,
                             destination_child_fd,
                             destination_child,
+                            frozenset(),
                         )
                     finally:
                         os.close(destination_child_fd)
@@ -6870,7 +6878,10 @@ class Workspace:
         )
 
     def _copy_topology_runtime_tree(
-        self, source: Path, destination: Path
+        self,
+        source: Path,
+        destination: Path,
+        exclusions: frozenset[str] = frozenset(),
     ) -> int:
         flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
         retained_destination_fd: int | None = None
@@ -6918,7 +6929,11 @@ class Workspace:
                     f"{destination}"
                 ) from error
             self._copy_topology_runtime_directory(
-                source_fd, source, destination_fd, destination
+                source_fd,
+                source,
+                destination_fd,
+                destination,
+                exclusions,
             )
             destination_parent_after = os.fstat(destination_parent_fd)
             if (
@@ -6944,6 +6959,566 @@ class Workspace:
             if destination_parent_fd is not None:
                 os.close(destination_parent_fd)
             os.close(source_fd)
+
+    def _copy_runtime_directory_contents(
+        self,
+        source: Path,
+        destination: Path,
+        exclusions: frozenset[str] = frozenset(),
+    ) -> None:
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        source_fd: int | None = None
+        destination_fd: int | None = None
+        try:
+            source_before = source.stat(follow_symlinks=False)
+            source_fd = os.open(source, flags)
+            destination_before = destination.stat(follow_symlinks=False)
+            destination_fd = os.open(destination, flags)
+        except OSError as error:
+            if destination_fd is not None:
+                os.close(destination_fd)
+            if source_fd is not None:
+                os.close(source_fd)
+            raise WorkspaceError(
+                f"cannot open runtime publication directory: {error}"
+            ) from error
+        try:
+            if (
+                self._runtime_tree_identity(os.fstat(source_fd))
+                != self._runtime_tree_identity(source_before)
+                or self._runtime_tree_identity(os.fstat(destination_fd))
+                != self._runtime_tree_identity(destination_before)
+            ):
+                raise WorkspaceError(
+                    "runtime publication directory changed before copy"
+                )
+            self._copy_topology_runtime_directory(
+                source_fd,
+                source,
+                destination_fd,
+                destination,
+                exclusions,
+            )
+        finally:
+            os.close(destination_fd)
+            os.close(source_fd)
+
+    def _copy_runtime_tree(
+        self,
+        source: Path,
+        destination: Path,
+        exclusions: frozenset[str] = frozenset(),
+    ) -> None:
+        descriptor = self._copy_topology_runtime_tree(
+            source, destination, exclusions
+        )
+        os.close(descriptor)
+
+    def _copy_runtime_regular_file(self, source: Path, destination: Path) -> None:
+        flags = os.O_RDONLY | os.O_NOFOLLOW
+        source_fd: int | None = None
+        destination_fd: int | None = None
+        try:
+            before = source.stat(follow_symlinks=False)
+            source_fd = os.open(source, flags)
+            opened = os.fstat(source_fd)
+            if (
+                not stat.S_ISREG(opened.st_mode)
+                or self._runtime_tree_identity(opened)
+                != self._runtime_tree_identity(before)
+            ):
+                raise WorkspaceError(
+                    f"runtime publication input changed or is not regular: {source}"
+                )
+            destination_fd = os.open(
+                destination,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                stat.S_IMODE(opened.st_mode),
+            )
+            with os.fdopen(source_fd, "rb", closefd=False) as source_stream:
+                with os.fdopen(
+                    destination_fd, "wb", closefd=False
+                ) as destination_stream:
+                    shutil.copyfileobj(source_stream, destination_stream)
+                    destination_stream.flush()
+                    os.fsync(destination_stream.fileno())
+            if self._runtime_tree_identity(os.fstat(source_fd)) != (
+                self._runtime_tree_identity(opened)
+            ):
+                raise WorkspaceError(
+                    f"runtime publication input changed during copy: {source}"
+                )
+            os.fchmod(destination_fd, stat.S_IMODE(opened.st_mode))
+            os.utime(
+                destination,
+                ns=(opened.st_atime_ns, opened.st_mtime_ns),
+                follow_symlinks=False,
+            )
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot copy runtime publication input {source}: {error}"
+            ) from error
+        finally:
+            if destination_fd is not None:
+                os.close(destination_fd)
+            if source_fd is not None:
+                os.close(source_fd)
+
+    def _runtime_generation_entries(
+        self,
+        root: Path,
+        state: Path | None,
+    ) -> list[dict[str, Any]]:
+        entries: list[dict[str, Any]] = []
+        for directory, names, files in os.walk(root, followlinks=False):
+            current = Path(directory)
+            names.sort()
+            files.sort()
+            linked_directories: set[str] = set()
+            for name in list(names):
+                path = current / name
+                relative = path.relative_to(root).as_posix()
+                metadata = path.lstat()
+                if stat.S_ISLNK(metadata.st_mode):
+                    if state is not None and relative == "server/data":
+                        target = state
+                        kind = "external-state"
+                    else:
+                        raise WorkspaceError(
+                            f"runtime publication contains a link: {path}"
+                        )
+                    if path.resolve(strict=False) != target.resolve(strict=False):
+                        raise WorkspaceError(
+                            f"runtime publication state link changed: {path}"
+                        )
+                    linked_directories.add(name)
+                    entries.append(
+                        {
+                            "kind": kind,
+                            "path": relative,
+                            "target": str(target),
+                        }
+                    )
+                elif not stat.S_ISDIR(metadata.st_mode):
+                    raise WorkspaceError(
+                        f"runtime publication contains a special file: {path}"
+                    )
+                else:
+                    entries.append(
+                        {
+                            "kind": "directory",
+                            "path": relative,
+                            "mode": stat.S_IMODE(metadata.st_mode),
+                        }
+                    )
+            names[:] = [name for name in names if name not in linked_directories]
+            for name in files:
+                path = current / name
+                relative = path.relative_to(root).as_posix()
+                metadata = path.lstat()
+                if not stat.S_ISREG(metadata.st_mode):
+                    raise WorkspaceError(
+                        f"runtime publication contains a link or special file: {path}"
+                    )
+                entries.append(
+                    {
+                        "kind": "file",
+                        "path": relative,
+                        "mode": stat.S_IMODE(metadata.st_mode),
+                        "size": metadata.st_size,
+                        "sha256": _file_digest(path, "runtime publication file"),
+                    }
+                )
+        return sorted(entries, key=lambda entry: entry["path"])
+
+    @staticmethod
+    def _prepare_runtime_state_output(state: Path, generation: str) -> Path:
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        descriptors: list[int] = []
+        created_generation = False
+        output = state / "tmp" / "runtime-assets" / generation
+
+        def open_directory(parent: int, name: str, create: bool) -> int:
+            if create:
+                try:
+                    os.mkdir(name, 0o700, dir_fd=parent)
+                except FileExistsError:
+                    pass
+            metadata = os.stat(
+                name, dir_fd=parent, follow_symlinks=False
+            )
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise WorkspaceError(
+                    f"server runtime state output path is invalid: {output}"
+                )
+            descriptor = os.open(name, flags, dir_fd=parent)
+            if Workspace._runtime_tree_identity(os.fstat(descriptor)) != (
+                Workspace._runtime_tree_identity(metadata)
+            ):
+                os.close(descriptor)
+                raise WorkspaceError(
+                    f"server runtime state output path changed: {output}"
+                )
+            return descriptor
+
+        try:
+            state_before = state.stat(follow_symlinks=False)
+            state_fd = os.open(state, flags)
+            descriptors.append(state_fd)
+            if Workspace._runtime_tree_identity(os.fstat(state_fd)) != (
+                Workspace._runtime_tree_identity(state_before)
+            ):
+                raise WorkspaceError(
+                    f"server state changed before runtime publication: {state}"
+                )
+            tmp_fd = open_directory(state_fd, "tmp", True)
+            descriptors.append(tmp_fd)
+            container_fd = open_directory(tmp_fd, "runtime-assets", True)
+            descriptors.append(container_fd)
+            try:
+                os.mkdir(generation, 0o700, dir_fd=container_fd)
+            except FileExistsError as error:
+                raise WorkspaceError(
+                    f"server runtime state output already exists: {output}"
+                ) from error
+            created_generation = True
+            generation_fd = open_directory(container_fd, generation, False)
+            descriptors.append(generation_fd)
+            marker = json.dumps(
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "purpose": f"runtime-state-output:{generation}",
+                },
+                indent=2,
+                sort_keys=True,
+            ).encode() + b"\n"
+            marker_fd = os.open(
+                MANAGED_MARKER,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                0o600,
+                dir_fd=generation_fd,
+            )
+            try:
+                with os.fdopen(marker_fd, "wb", closefd=False) as stream:
+                    stream.write(marker)
+                    stream.flush()
+                    os.fsync(stream.fileno())
+            finally:
+                os.close(marker_fd)
+            return output
+        except BaseException as error:
+            if created_generation and output.is_dir() and not output.is_symlink():
+                remove_owned_tree(output)
+            if isinstance(error, WorkspaceError):
+                raise
+            if not isinstance(error, (OSError, ValueError)):
+                raise
+            raise WorkspaceError(
+                f"cannot prepare server runtime state output {output}: {error}"
+            ) from error
+        finally:
+            for descriptor in reversed(descriptors):
+                os.close(descriptor)
+
+    @staticmethod
+    def _remove_runtime_state_output(path: Path, generation: str) -> None:
+        marker = path / MANAGED_MARKER
+        if (
+            path.is_symlink()
+            or not path.is_dir()
+            or marker.is_symlink()
+            or not marker.is_file()
+            or load_json(marker)
+            != {
+                "schema_version": SCHEMA_VERSION,
+                "purpose": f"runtime-state-output:{generation}",
+            }
+        ):
+            raise WorkspaceError(
+                f"server runtime state output ownership is invalid: {path}"
+            )
+        remove_owned_tree(path)
+
+    @staticmethod
+    def _seal_runtime_generation(root: Path) -> None:
+        directories: list[Path] = []
+        for directory, names, files in os.walk(root, followlinks=False):
+            current = Path(directory)
+            directories.append(current)
+            for name in names:
+                path = current / name
+                metadata = path.lstat()
+                if stat.S_ISLNK(metadata.st_mode):
+                    continue
+                if not stat.S_ISDIR(metadata.st_mode):
+                    raise WorkspaceError(
+                        f"runtime generation contains a special entry: {path}"
+                    )
+            for name in files:
+                path = current / name
+                metadata = path.lstat()
+                if not stat.S_ISREG(metadata.st_mode):
+                    raise WorkspaceError(
+                        f"runtime generation contains a special entry: {path}"
+                    )
+                if path.name == RUNTIME_GENERATION_LEASE and path.parent == root:
+                    path.chmod(0o600)
+                else:
+                    path.chmod(stat.S_IMODE(metadata.st_mode) & ~0o222)
+        for directory in reversed(directories):
+            directory.chmod(stat.S_IMODE(directory.lstat().st_mode) & ~0o222)
+
+    def _runtime_publication_input_digests(
+        self,
+        build_root: Path,
+        selected: dict[str, Path],
+        services: list[str],
+        sound_root: Path | None,
+    ) -> dict[str, str]:
+        directories: dict[str, tuple[Path, set[str]]] = {}
+        files: dict[str, Path] = {}
+        if "client" in services:
+            directories.update(
+                {
+                    "client-source": (
+                        selected["client"],
+                        {".git", "build", "sound", MANAGED_MARKER},
+                    ),
+                    "client-binary": (
+                        self._classic_binary_directory(build_root, "client"),
+                        set(),
+                    ),
+                    "sound": (
+                        sound_root or selected["sound"],
+                        {".git", "build", MANAGED_MARKER},
+                    ),
+                }
+            )
+        if "server" in services:
+            source = selected["server"]
+            directories.update(
+                {
+                    "server-binary": (
+                        self._classic_binary_directory(build_root, "server"),
+                        set(),
+                    ),
+                    "server-tools": (source / "tools", set()),
+                    "content-lib": (build_root / "runtime" / "content" / "lib", set()),
+                    "content-maps": (build_root / "runtime" / "content" / "maps", set()),
+                    "resources": (build_root / "runtime" / "resources", set()),
+                    "client-maps": (build_root / "runtime" / "client-maps", set()),
+                }
+            )
+            for name in ("ca-bundle.crt", "permissions.cfg", "server.cfg"):
+                files[f"server-{name}"] = source / name
+            custom = source / "server-custom.cfg"
+            if custom.is_file() and not custom.is_symlink():
+                files["server-server-custom.cfg"] = custom
+        return {
+            **{
+                name: _tree_digest(
+                    path, exclusions, reject_symlinks=True
+                )
+                for name, (path, exclusions) in sorted(directories.items())
+            },
+            **{
+                name: _file_digest(path, "runtime publication input")
+                for name, path in sorted(files.items())
+            },
+        }
+
+    def _publish_runtime_generation(
+        self,
+        owner_root: Path,
+        generation: str,
+        profile_name: str,
+        build_root: Path,
+        selected: dict[str, Path],
+        resolved: dict[str, dict[str, Any]],
+        services: list[str],
+        *,
+        identity: dict[str, Any],
+        state: Path | None = None,
+        sound_root: Path | None = None,
+    ) -> tuple[Path, int, dict[str, Any]]:
+        generations = owner_root / "generations"
+        generations.mkdir(exist_ok=True)
+        if generations.is_symlink() or not generations.is_dir():
+            raise WorkspaceError(
+                f"runtime generation container is invalid: {generations}"
+            )
+        published = generations / generation
+        if published.exists() or published.is_symlink():
+            raise WorkspaceError(f"runtime generation already exists: {published}")
+        staging = Path(
+            tempfile.mkdtemp(prefix=f".{generation}-", dir=generations)
+        )
+        lease_fd: int | None = None
+        state_output: Path | None = None
+        try:
+            input_digests = self._runtime_publication_input_digests(
+                build_root, selected, services, sound_root
+            )
+            atomic_json(
+                staging / MANAGED_MARKER,
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "purpose": "immutable-runtime-generation",
+                },
+            )
+            if "client" in services:
+                client_runtime = staging / "client"
+                client_runtime.mkdir()
+                self._copy_runtime_directory_contents(
+                    selected["client"],
+                    client_runtime,
+                    frozenset({".git", "build", "sound", MANAGED_MARKER}),
+                )
+                self._copy_runtime_tree(
+                    sound_root or selected["sound"],
+                    client_runtime / "sound",
+                    frozenset({".git", "build", MANAGED_MARKER}),
+                )
+                self._copy_runtime_directory_contents(
+                    self._classic_binary_directory(build_root, "client"),
+                    client_runtime,
+                )
+            if "server" in services:
+                if state is None:
+                    raise WorkspaceError("server runtime generation lacks state")
+                server_runtime = staging / "server"
+                server_runtime.mkdir()
+                self._copy_runtime_directory_contents(
+                    self._classic_binary_directory(build_root, "server"),
+                    server_runtime,
+                )
+                source = selected["server"]
+                self._copy_runtime_tree(
+                    source / "tools", server_runtime / "tools"
+                )
+                for name in ("ca-bundle.crt", "permissions.cfg", "server.cfg"):
+                    self._copy_runtime_regular_file(source / name, server_runtime / name)
+                custom = source / "server-custom.cfg"
+                if custom.is_file() and not custom.is_symlink():
+                    self._copy_runtime_regular_file(
+                        custom, server_runtime / "server-custom.cfg"
+                    )
+                content = build_root / "runtime" / "content"
+                self._copy_runtime_tree(
+                    content / "lib", server_runtime / "lib"
+                )
+                self._copy_runtime_tree(
+                    content / "maps", server_runtime / "maps"
+                )
+                self._copy_runtime_tree(
+                    build_root / "runtime" / "resources",
+                    server_runtime / "resources",
+                )
+                (server_runtime / "data").symlink_to(state, target_is_directory=True)
+                state_output = self._prepare_runtime_state_output(
+                    state, generation
+                )
+                (state_output / "data").mkdir()
+                client_maps = build_root / "runtime" / "client-maps"
+                self._validate_region_maps(client_maps)
+                self._copy_runtime_tree(
+                    client_maps, state_output / "client-maps"
+                )
+                state_output_entries = self._runtime_generation_entries(
+                    state_output / "client-maps", None
+                )
+                self._seal_runtime_generation(state_output / "client-maps")
+            else:
+                state_output_entries = []
+
+            if self._runtime_publication_input_digests(
+                build_root, selected, services, sound_root
+            ) != input_digests:
+                raise WorkspaceError(
+                    "runtime publication inputs changed during staging"
+                )
+
+            build_metadata = build_root / BUILD_METADATA
+            source_trees: dict[str, str] = {}
+            for component, coordinate in resolved.items():
+                tree = git(
+                    Path(coordinate["checkout_path"]),
+                    "rev-parse",
+                    f"{coordinate['head']}^{{tree}}",
+                    capture=True,
+                    trace=False,
+                )
+                if not re.fullmatch(r"[0-9a-f]{40,64}", tree):
+                    raise WorkspaceError(
+                        f"runtime source tree identity is invalid: {component}"
+                    )
+                source_trees[component] = tree
+            manifest = {
+                "schema_version": RUNTIME_GENERATION_SCHEMA_VERSION,
+                "generation": generation,
+                "profile": profile_name,
+                "identity": identity,
+                "services": services,
+                "resolved": resolved,
+                "source_trees": source_trees,
+                "input_digests": input_digests,
+                "build": {
+                    "root": str(build_root),
+                    "metadata_sha256": (
+                        _file_digest(build_metadata, "build metadata")
+                        if build_metadata.is_file() and not build_metadata.is_symlink()
+                        else None
+                    ),
+                },
+                "external_state": str(state) if state is not None else None,
+                "mutable_state_outputs": (
+                    [str(state_output)] if state_output is not None else []
+                ),
+                "mutable_state_output_entries": state_output_entries,
+                "entries": self._runtime_generation_entries(staging, state),
+            }
+            atomic_json(staging / RUNTIME_GENERATION_MANIFEST, manifest)
+            lease_fd = open_regular_file(
+                staging / RUNTIME_GENERATION_LEASE,
+                os.O_RDWR | os.O_CREAT,
+                "runtime generation lease",
+            )
+            lease_identity = initialize_lease(lease_fd, generation)
+            try:
+                fcntl.flock(lease_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError as error:
+                raise WorkspaceError(
+                    f"cannot lock runtime generation lease: {error}"
+                ) from error
+            manifest_sha256 = _file_digest(
+                staging / RUNTIME_GENERATION_MANIFEST,
+                "runtime generation manifest",
+            )
+            self._seal_runtime_generation(staging)
+            staging.replace(published)
+            runtime_record = {
+                "schema_version": RUNTIME_GENERATION_SCHEMA_VERSION,
+                "generation": generation,
+                "path": str(published),
+                "manifest_sha256": manifest_sha256,
+                "lease": lease_identity,
+                "external_state": str(state) if state is not None else None,
+                "mutable_state_outputs": (
+                    [str(state_output)] if state_output is not None else []
+                ),
+            }
+            result_fd = lease_fd
+            lease_fd = None
+            return published, result_fd, runtime_record
+        except BaseException:
+            if staging.exists():
+                remove_owned_tree(staging)
+            if state_output is not None and state_output.exists():
+                self._remove_runtime_state_output(state_output, generation)
+            raise
+        finally:
+            if lease_fd is not None:
+                os.close(lease_fd)
 
     def _copy_topology_runtime_inputs(
         self,
@@ -7183,7 +7758,18 @@ class Workspace:
             "supervisor",
             "services",
         }
-        optional = {"stack", "providers", "sound", "control", "port_reservation"}
+        optional = {
+            "stack",
+            "providers",
+            "sound",
+            "control",
+            "port_reservation",
+            "runtime",
+        }
+        topology_schema = status.get("schema_version") if isinstance(status, dict) else None
+        current_runtime_record = topology_schema == TOPOLOGY_STATUS_SCHEMA_VERSION
+        if current_runtime_record:
+            required.add("runtime")
         historical_record = isinstance(status, dict) and not (
             {"stack", "providers"} & set(status)
         )
@@ -7234,7 +7820,7 @@ class Workspace:
         )
         if (
             not isinstance(status, dict)
-            or status.get("schema_version") != SCHEMA_VERSION
+            or topology_schema not in {SCHEMA_VERSION, TOPOLOGY_STATUS_SCHEMA_VERSION}
             or status.get("name") != name
             or not required <= set(status) <= required | optional | {"error"}
             or not isinstance(status.get("dependencies"), list)
@@ -7435,6 +8021,196 @@ class Workspace:
         process_tree_active = self._topology_process_tree_active(
             root, control if current_control else None
         )
+        runtime = status.get("runtime")
+        runtime_active = False
+        if current_runtime_record:
+            if not current_control:
+                raise WorkspaceError(f"topology runtime identity is invalid: {name}")
+            expected_runtime_path = root / "generations" / control["generation"]
+            if (
+                not isinstance(runtime, dict)
+                or set(runtime)
+                != {
+                    "schema_version",
+                    "generation",
+                    "path",
+                    "manifest_sha256",
+                    "lease",
+                    "external_state",
+                    "mutable_state_outputs",
+                }
+                or runtime.get("schema_version")
+                != RUNTIME_GENERATION_SCHEMA_VERSION
+                or runtime.get("generation") != control["generation"]
+                or runtime.get("path") != str(expected_runtime_path)
+                or not isinstance(runtime.get("manifest_sha256"), str)
+                or not re.fullmatch(r"[0-9a-f]{64}", runtime["manifest_sha256"])
+                or runtime.get("external_state") != status.get("state")
+                or runtime.get("mutable_state_outputs")
+                != (
+                    [
+                        str(
+                            Path(status["state"])
+                            / "tmp"
+                            / "runtime-assets"
+                            / control["generation"]
+                        )
+                    ]
+                    if status.get("state") is not None
+                    else []
+                )
+                or not isinstance(runtime.get("lease"), dict)
+                or set(runtime["lease"]) != {"device", "inode"}
+                or not all(
+                    isinstance(value, int)
+                    and not isinstance(value, bool)
+                    and value >= 0
+                    for value in runtime["lease"].values()
+                )
+            ):
+                raise WorkspaceError(f"topology runtime identity is invalid: {name}")
+            marker = expected_runtime_path / MANAGED_MARKER
+            manifest = expected_runtime_path / RUNTIME_GENERATION_MANIFEST
+            if (
+                expected_runtime_path.is_symlink()
+                or not expected_runtime_path.is_dir()
+                or marker.is_symlink()
+                or not marker.is_file()
+                or load_json(marker)
+                != {
+                    "schema_version": SCHEMA_VERSION,
+                    "purpose": "immutable-runtime-generation",
+                }
+                or manifest.is_symlink()
+                or not manifest.is_file()
+                or _file_digest(manifest, "runtime generation manifest")
+                != runtime["manifest_sha256"]
+            ):
+                raise WorkspaceError(f"topology runtime publication is invalid: {name}")
+            runtime_manifest = load_json(manifest)
+            expected_identity = {
+                "kind": "topology",
+                "name": name,
+                "stack": status["stack"],
+                "providers": status["providers"],
+            }
+            manifest_services = (
+                runtime_manifest.get("services")
+                if isinstance(runtime_manifest, dict)
+                else None
+            )
+            source_trees = (
+                runtime_manifest.get("source_trees")
+                if isinstance(runtime_manifest, dict)
+                else None
+            )
+            input_digests = (
+                runtime_manifest.get("input_digests")
+                if isinstance(runtime_manifest, dict)
+                else None
+            )
+            build = (
+                runtime_manifest.get("build")
+                if isinstance(runtime_manifest, dict)
+                else None
+            )
+            entries = (
+                runtime_manifest.get("entries")
+                if isinstance(runtime_manifest, dict)
+                else None
+            )
+            state_output_entries = (
+                runtime_manifest.get("mutable_state_output_entries")
+                if isinstance(runtime_manifest, dict)
+                else None
+            )
+            if (
+                not isinstance(runtime_manifest, dict)
+                or set(runtime_manifest)
+                != {
+                    "schema_version",
+                    "generation",
+                    "profile",
+                    "identity",
+                    "services",
+                    "resolved",
+                    "source_trees",
+                    "input_digests",
+                    "build",
+                    "external_state",
+                    "mutable_state_outputs",
+                    "mutable_state_output_entries",
+                    "entries",
+                }
+                or runtime_manifest.get("schema_version")
+                != RUNTIME_GENERATION_SCHEMA_VERSION
+                or runtime_manifest.get("generation") != control["generation"]
+                or runtime_manifest.get("profile") != status["profile"]
+                or runtime_manifest.get("identity") != expected_identity
+                or runtime_manifest.get("resolved") != status["resolved"]
+                or runtime_manifest.get("external_state") != status.get("state")
+                or runtime_manifest.get("mutable_state_outputs")
+                != runtime["mutable_state_outputs"]
+                or not isinstance(manifest_services, list)
+                or not manifest_services
+                or len(manifest_services) != len(set(manifest_services))
+                or not set(manifest_services) <= set(TOPOLOGY_SERVICES)
+                or not isinstance(source_trees, dict)
+                or set(source_trees) != set(status["resolved"])
+                or any(
+                    not isinstance(value, str)
+                    or not re.fullmatch(r"[0-9a-f]{40,64}", value)
+                    for value in source_trees.values()
+                )
+                or not isinstance(input_digests, dict)
+                or not input_digests
+                or any(
+                    not isinstance(key, str)
+                    or not key
+                    or not isinstance(value, str)
+                    or not re.fullmatch(r"[0-9a-f]{64}", value)
+                    for key, value in input_digests.items()
+                )
+                or not isinstance(build, dict)
+                or set(build) != {"root", "metadata_sha256"}
+                or build.get("root") != status["build_root"]
+                or (
+                    build.get("metadata_sha256") is not None
+                    and (
+                        not isinstance(build.get("metadata_sha256"), str)
+                        or not re.fullmatch(
+                            r"[0-9a-f]{64}", build["metadata_sha256"]
+                        )
+                    )
+                )
+                or not isinstance(entries, list)
+                or not entries
+                or any(not isinstance(entry, dict) for entry in entries)
+                or not isinstance(state_output_entries, list)
+                or (
+                    bool(runtime["mutable_state_outputs"])
+                    != bool(state_output_entries)
+                )
+                or any(
+                    not isinstance(entry, dict)
+                    for entry in state_output_entries
+                )
+            ):
+                raise WorkspaceError(
+                    f"topology runtime manifest identity is invalid: {name}"
+                )
+            try:
+                runtime_active = bound_lease_locked(
+                    expected_runtime_path / RUNTIME_GENERATION_LEASE,
+                    control["generation"],
+                    runtime["lease"],
+                )
+            except OSError as error:
+                raise WorkspaceError(
+                    f"cannot inspect topology runtime generation lease: {error}"
+                ) from error
+        elif runtime is not None:
+            raise WorkspaceError(f"historical topology runtime is invalid: {name}")
         supervisor_local = bool(
             not current_control and self._recorded_process_running(supervisor)
         )
@@ -7575,6 +8351,17 @@ class Workspace:
             or supervisor_running
             or any(service["running"] for service in services.values())
         )
+        if current_runtime_record and retained and not runtime_active:
+            raise WorkspaceError(
+                f"topology runtime generation lease is not retained: {name}"
+            )
+        if current_runtime_record and (
+            not set(services) <= set(manifest_services)
+            or status["ready"] and set(services) != set(manifest_services)
+        ):
+            raise WorkspaceError(
+                f"topology runtime manifest services are invalid: {name}"
+            )
         if control_reachable:
             safe_action = f"run ./atrinik down {name} from any supported session"
         elif process_tree_active:
@@ -7592,7 +8379,25 @@ class Workspace:
             ),
             "generation": control["generation"] if current_control else None,
             "process_tree_lease": "retained" if retained else "released",
-            "repository_layout_lease_owner": name if retained else None,
+            "runtime_generation": (
+                runtime["generation"] if current_runtime_record else None
+            ),
+            "runtime_bundle_lease": (
+                "retained" if runtime_active else "released"
+                if current_runtime_record
+                else "historical"
+            ),
+            "server_state_lease_owner": (
+                name if retained and status.get("state") is not None else None
+            ),
+            "port_reservation": (
+                status["endpoint"]["port"]
+                if retained and status.get("endpoint") is not None
+                else None
+            ),
+            "repository_layout_lease_owner": (
+                name if retained and not current_runtime_record else None
+            ),
             "safe_action": safe_action,
         }
         if port_reservation is not None:
@@ -7960,7 +8765,7 @@ class Workspace:
                     if isinstance(build_metadata, dict)
                     else None
                 )
-                service_specs: dict[str, dict[str, Any]] = {}
+                state: Path | None = None
                 if "server" in selected_services:
                     assert state_location is not None
                     state = self.state_path(
@@ -7968,55 +8773,8 @@ class Workspace:
                         selected["server"],
                         resolved_path=state_location,
                     )
-                    runtime_inputs = self._copy_topology_runtime_inputs(
-                        topology_root,
-                        (
-                            (
-                                "content",
-                                root / "runtime" / "content",
-                                "collected-content",
-                            ),
-                            (
-                                "resources",
-                                root / "runtime" / "resources",
-                                "resource-view",
-                            ),
-                            (
-                                "client-maps",
-                                root / "runtime" / "client-maps",
-                                "region-map-cache",
-                            ),
-                        ),
-                    )
-                    content = runtime_inputs["content"]
-                    resources = runtime_inputs["resources"]
-                    client_maps = runtime_inputs["client-maps"]
-                    runtime = self._prepare_server_runtime(
-                        root,
-                        selected,
-                        state,
-                        state_name,
-                        content,
-                        resources,
-                        client_maps,
-                    )
-                    executable = runtime / "atrinik-server"
-                    service_specs["server"] = {
-                        "command": [
-                            str(executable),
-                            f"--port_quic={endpoint['port']}",
-                            "--port_mapping=off",
-                            "--stun_server=off",
-                            f"--assetspath={runtime / 'assets'}",
-                            "--no_console",
-                        ],
-                        "cwd": str(runtime),
-                        "log": str(topology_root / "server.log"),
-                    }
+                sound_root: Path | None = None
                 if "client" in selected_services:
-                    executable = (
-                        self._classic_binary_directory(root, "client") / "atrinik"
-                    )
                     try:
                         validated_sound = validate_sound_record(sound_status)
                     except WorkspaceError as error:
@@ -8043,9 +8801,75 @@ class Workspace:
                         raise WorkspaceError(
                             f"profile {profile_name} source sound root changed before topology preparation"
                         )
-                    working = self._prepare_topology_client_runtime(
-                        topology_root, selected, sound_root
+                profile = self._load_profile(profile_name, require_file=False)
+                selected_stack = self.manifest.stack(profile["stack"])
+                resolved_status = self._topology_resolved_status(
+                    profile_name, selected
+                )
+                generation_root, runtime_lock_fd, runtime_record = (
+                    self._publish_runtime_generation(
+                        topology_root,
+                        generation,
+                        profile_name,
+                        root,
+                        selected,
+                        resolved_status,
+                        selected_services,
+                        identity={
+                            "kind": "topology",
+                            "name": name,
+                            "stack": selected_stack.name,
+                            "providers": {
+                                role: selected_stack.providers[role].name
+                                for role in sorted(required)
+                            },
+                        },
+                        state=state,
+                        sound_root=sound_root,
                     )
+                )
+                published_generation_owner = [generation_root]
+                stack.callback(
+                    lambda: remove_owned_tree(published_generation_owner.pop())
+                    if published_generation_owner
+                    else None
+                )
+                published_state_output_owner = [
+                    Path(runtime_record["mutable_state_outputs"][0])
+                ] if runtime_record["mutable_state_outputs"] else []
+                stack.callback(
+                    lambda: self._remove_runtime_state_output(
+                        published_state_output_owner.pop(), generation
+                    )
+                    if published_state_output_owner
+                    else None
+                )
+                runtime_lock_owner = [runtime_lock_fd]
+                stack.callback(
+                    lambda: os.close(runtime_lock_owner.pop())
+                    if runtime_lock_owner
+                    else None
+                )
+                service_specs: dict[str, dict[str, Any]] = {}
+                if "server" in selected_services:
+                    server_runtime = generation_root / "server"
+                    executable = server_runtime / "atrinik-server"
+                    service_specs["server"] = {
+                        "command": [
+                            str(executable),
+                            f"--port_quic={endpoint['port']}",
+                            "--port_mapping=off",
+                            "--stun_server=off",
+                            "--assetspath="
+                            f"{runtime_record['mutable_state_outputs'][0]}",
+                            "--no_console",
+                        ],
+                        "cwd": str(server_runtime),
+                        "log": str(topology_root / "server.log"),
+                    }
+                if "client" in selected_services:
+                    client_runtime = generation_root / "client"
+                    executable = client_runtime / "atrinik"
                     if not executable.is_file():
                         raise WorkspaceError(f"client executable is missing: {executable}")
                     client_config = topology_root / "client-config"
@@ -8058,25 +8882,19 @@ class Workspace:
                         client_config.mkdir()
                     service_specs["client"] = {
                         "command": [str(executable)],
-                        "cwd": str(working),
+                        "cwd": str(client_runtime),
                         "log": str(topology_root / "client.log"),
                         "environment": {
                             "ATRINIK_CONFIG_DIR": str(client_config.resolve())
                         },
                     }
-
-                profile = self._load_profile(profile_name, require_file=False)
-                selected_stack = self.manifest.stack(profile["stack"])
-                resolved_status = self._topology_resolved_status(
-                    profile_name, selected
-                )
                 # All fallible preparation is complete. Retire the stopped
                 # record and bind/publish the new generation without exposing
                 # old status against rewritten lease contents.
                 status_path.unlink(missing_ok=True)
                 lease_identity = initialize_lease(process_tree_fd, generation)
                 spec: dict[str, Any] = {
-                    "schema_version": SCHEMA_VERSION,
+                    "schema_version": TOPOLOGY_STATUS_SCHEMA_VERSION,
                     "name": name,
                     "profile": profile_name,
                     "stack": selected_stack.name,
@@ -8094,6 +8912,7 @@ class Workspace:
                         "generation": generation,
                         "lease": lease_identity,
                     },
+                    "runtime": runtime_record,
                     "services": service_specs,
                 }
                 if port_reservation is not None:
@@ -8135,15 +8954,10 @@ class Workspace:
                     if state_lock is not None:
                         command.extend(["--lock-fd", str(state_lock.fileno())])
                         inherited_locks.append(state_lock.fileno())
-                    if layout_lock is not None:
-                        command.extend(
-                            ["--layout-lock-fd", str(layout_lock.fileno())]
-                        )
-                        inherited_locks.append(layout_lock.fileno())
                     command.extend(
-                        ["--build-lock-fd", str(build_lock.fileno())]
+                        ["--runtime-lock-fd", str(runtime_lock_fd)]
                     )
-                    inherited_locks.append(build_lock.fileno())
+                    inherited_locks.append(runtime_lock_fd)
                     command.extend(
                         ["--process-tree-fd", str(process_tree_fd)]
                     )
@@ -8174,9 +8988,12 @@ class Workspace:
                         start_new_session=True,
                         pass_fds=tuple(inherited_locks),
                     )
+                    published_generation_owner.clear()
+                    published_state_output_owner.clear()
                     os.close(process_tree_owner.pop())
                     if port_reservation_owner:
                         os.close(port_reservation_owner.pop())
+                    os.close(runtime_lock_owner.pop())
                 except OSError as error:
                     raise WorkspaceError(f"cannot start topology supervisor: {error}") from error
                 finally:
@@ -8317,7 +9134,7 @@ class Workspace:
             time.sleep(0.1)
         if not requested:
             raise WorkspaceError(
-                f"topology {name} retains the repository-layout lease but its "
+                f"topology {name} retains its exact runtime generation but its "
                 "supervisor control endpoint is unreachable; wait for bounded "
                 "orphan recovery and retry; preserve a retained exact lease "
                 "for operator diagnosis"
@@ -8486,15 +9303,34 @@ class Workspace:
         with shared_layout_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
-        ) as layout_lock:
-            return self._run_client(
+        ):
+            prepared = self._run_client(
                 profile_name,
                 state_name,
                 port,
                 arguments,
                 dry_run,
-                layout_lock=layout_lock,
             )
+        if not isinstance(prepared, dict):
+            return prepared
+        runtime_fd = prepared["runtime_fd"]
+        generation_root = prepared["generation_root"]
+        try:
+            if not dry_run:
+                self._require_client_display()
+                environment = os.environ.copy()
+                environment[CLIENT_LAUNCH_LABEL_ENV] = prepared["launch_label"]
+                run(
+                    prepared["command"],
+                    cwd=prepared["cwd"],
+                    env=environment,
+                    diagnostics_to_stderr=False,
+                    pass_fds=(runtime_fd,),
+                )
+            return prepared["executable"]
+        finally:
+            os.close(runtime_fd)
+            remove_owned_tree(generation_root)
 
     def _run_client(
         self,
@@ -8505,19 +9341,71 @@ class Workspace:
         dry_run: bool,
         *,
         layout_lock: TextIO | None = None,
-    ) -> Path:
+    ) -> dict[str, Any] | Path:
         self._validate_run_port(port)
         launch_label = client_launch_label(profile_name)
         self._require_classic_contracts(profile_name, {"client"})
         state = self._state_location(state_name)
         self._validate_state(state)
         fingerprint = self._server_identity_fingerprint(state)
-        root = self._build("client", profile_name, tests=False)
-        with self._profile_build_lock(root, profile_name) as build_lock:
-            executable = self._classic_binary_directory(root, "client") / "atrinik"
-            working = root / "sources" / "client"
-            if not executable.is_file():
-                raise WorkspaceError(f"client executable is missing: {executable}")
+        targets = self._expand_build_target("client", profile_name)
+        selected = self._resolve_build_profile(profile_name, {"client"})
+        root = self._build_resolved(
+            "client", profile_name, False, targets, selected
+        )
+        with self._profile_build_lock(root, profile_name):
+            build_metadata = load_json(root / BUILD_METADATA)
+            try:
+                validated_sound = validate_sound_record(build_metadata.get("sound"))
+            except WorkspaceError as error:
+                raise WorkspaceError(
+                    f"build sound metadata is invalid for profile {profile_name}"
+                ) from error
+            profile = self._load_profile(profile_name, require_file=False)
+            selected_stack = self.manifest.stack(profile["stack"])
+            if validated_sound["mode"] != profile["sound_mode"]:
+                raise WorkspaceError(
+                    f"profile {profile_name} sound mode does not match build metadata"
+                )
+            sound_root = Path(validated_sound["root"])
+            if validated_sound["mode"] == PLAYTEST_MODE:
+                inputs = clean_source_inputs(selected["sound"])
+                if verify_playtest_tree(selected["sound"], sound_root, inputs) != (
+                    validated_sound
+                ):
+                    raise WorkspaceError(
+                        f"profile {profile_name} local-playtest sound record changed "
+                        "before foreground publication"
+                    )
+            elif sound_root.resolve() != selected["sound"].resolve():
+                raise WorkspaceError(
+                    f"profile {profile_name} source sound root changed before "
+                    "foreground publication"
+                )
+            resolved = self._topology_resolved_status(profile_name, selected)
+            generation = secrets.token_hex(32)
+            generation_root, runtime_fd, _runtime_record = (
+                self._publish_runtime_generation(
+                    self._foreground_runtime_owner(),
+                    generation,
+                    profile_name,
+                    root,
+                    selected,
+                    resolved,
+                    ["client"],
+                    identity={
+                        "kind": "foreground-client",
+                        "stack": selected_stack.name,
+                        "providers": {
+                            role: selected_stack.providers[role].name
+                            for role in sorted(selected)
+                        },
+                    },
+                    sound_root=sound_root,
+                )
+            )
+            working = generation_root / "client"
+            executable = working / "atrinik"
             command = [
                 str(executable),
                 f"--server=127.0.0.1 {port} {fingerprint}",
@@ -8527,24 +9415,17 @@ class Workspace:
             ]
             print(f"state: {state}")
             print(f"cwd: {working}")
+            print(f"runtime generation: {generation}")
             print(f"launch label: {launch_label}")
             print(f"command: {display_arguments(command)}")
-            if not dry_run:
-                self._require_client_display()
-                environment = os.environ.copy()
-                environment[CLIENT_LAUNCH_LABEL_ENV] = launch_label
-                run(
-                    command,
-                    cwd=working,
-                    env=environment,
-                    diagnostics_to_stderr=False,
-                    pass_fds=tuple(
-                        lease.fileno()
-                        for lease in (layout_lock, build_lock)
-                        if lease is not None
-                    ),
-                )
-            return executable
+            return {
+                "command": command,
+                "cwd": working,
+                "executable": executable,
+                "generation_root": generation_root,
+                "runtime_fd": runtime_fd,
+                "launch_label": launch_label,
+            }
 
     def run_server(
         self,
@@ -8558,15 +9439,37 @@ class Workspace:
         with shared_layout_lock(
             self.paths.workspace / "repository-layout.lock",
             "repository layout",
-        ) as layout_lock:
-            return self._run_server(
+        ):
+            prepared = self._run_server(
                 profile_name,
                 state_name,
                 port,
                 arguments,
                 dry_run,
-                layout_lock=layout_lock,
             )
+        if not isinstance(prepared, dict):
+            return prepared
+        runtime_fd = prepared["runtime_fd"]
+        state_fd = prepared["state_fd"]
+        generation_root = prepared["generation_root"]
+        state_output = prepared["state_output"]
+        try:
+            if not dry_run:
+                run(
+                    prepared["command"],
+                    cwd=prepared["cwd"],
+                    diagnostics_to_stderr=False,
+                    pass_fds=(runtime_fd, state_fd),
+                )
+            return prepared["executable"]
+        finally:
+            os.close(state_fd)
+            os.close(runtime_fd)
+            remove_owned_tree(generation_root)
+            if state_output is not None:
+                self._remove_runtime_state_output(
+                    state_output, generation_root.name
+                )
 
     def _run_server(
         self,
@@ -8577,7 +9480,7 @@ class Workspace:
         dry_run: bool,
         *,
         layout_lock: TextIO | None = None,
-    ) -> Path:
+    ) -> dict[str, Any] | Path:
         self._validate_run_port(port)
         self._require_classic_contracts(profile_name, {"server"})
         targets = self._expand_build_target("server", profile_name)
@@ -8590,13 +9493,36 @@ class Workspace:
             root = self._build_resolved(
                 "server", profile_name, False, targets, selected
             )
-            with self._profile_build_lock(root, profile_name) as build_lock:
+            with self._profile_build_lock(root, profile_name):
                 state = self.state_path(
                     state_name, selected["server"], resolved_path=state_location
                 )
-                runtime = self._prepare_server_runtime(
-                    root, selected, state, state_name
+                resolved = self._topology_resolved_status(profile_name, selected)
+                profile = self._load_profile(profile_name, require_file=False)
+                selected_stack = self.manifest.stack(profile["stack"])
+                generation = secrets.token_hex(32)
+                generation_root, runtime_fd, _runtime_record = (
+                    self._publish_runtime_generation(
+                        self._foreground_runtime_owner(),
+                        generation,
+                        profile_name,
+                        root,
+                        selected,
+                        resolved,
+                        ["server"],
+                        identity={
+                            "kind": "foreground-server",
+                            "stack": selected_stack.name,
+                            "providers": {
+                                role: selected_stack.providers[role].name
+                                for role in sorted(selected)
+                            },
+                        },
+                        state=state,
+                    )
                 )
+                state_fd = os.dup(state_lock.fileno())
+                runtime = generation_root / "server"
                 executable = runtime / "atrinik-server"
                 command = [
                     str(executable),
@@ -8604,23 +9530,49 @@ class Workspace:
                     "--port_mapping=off",
                     "--stun_server=off",
                     *arguments,
-                    f"--assetspath={runtime / 'assets'}",
+                    "--assetspath="
+                    f"{_runtime_record['mutable_state_outputs'][0]}",
                 ]
                 print(f"state: {state}")
                 print(f"cwd: {runtime}")
+                print(f"runtime generation: {generation}")
                 print(f"command: {display_arguments(command)}")
-                if not dry_run:
-                    run(
-                        command,
-                        cwd=runtime,
-                        diagnostics_to_stderr=False,
-                        pass_fds=tuple(
-                            lease.fileno()
-                            for lease in (layout_lock, state_lock, build_lock)
-                            if lease is not None
-                        ),
-                    )
-                return executable
+                return {
+                    "command": command,
+                    "cwd": runtime,
+                    "executable": executable,
+                    "generation_root": generation_root,
+                    "runtime_fd": runtime_fd,
+                    "state_fd": state_fd,
+                    "state_output": (
+                        Path(_runtime_record["mutable_state_outputs"][0])
+                        if _runtime_record["mutable_state_outputs"]
+                        else None
+                    ),
+                }
+
+    def _foreground_runtime_owner(self) -> Path:
+        root = self.paths.workspace / "foreground-runs"
+        metadata = {
+            "schema_version": SCHEMA_VERSION,
+            "purpose": "foreground-runtime-generations",
+        }
+        marker = root / MANAGED_MARKER
+        if root.exists() or root.is_symlink():
+            if (
+                not root.is_dir()
+                or root.is_symlink()
+                or not marker.is_file()
+                or marker.is_symlink()
+                or load_json(marker) != metadata
+            ):
+                raise WorkspaceError(
+                    f"foreground runtime container is invalid: {root}"
+                )
+        else:
+            root.mkdir()
+            atomic_json(marker, metadata)
+        return root
 
     @staticmethod
     def _validate_run_port(port: int) -> None:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -222,34 +222,42 @@ interrupt the holder. The diagnostic is emitted at most once per acquisition.
 If the platform cannot provide a working advisory shared lock, the consuming
 operation fails closed.
 
-A supervised topology transfers its shared layout, exact build-root, state,
-process-tree, and generation-reservation descriptors through the daemon
-supervisor. The supervisor and its same-generation guardian retain the
-workspace/state/reservation leases; services inherit only the process-tree
-identity needed for exact descendant recovery. Client runtimes
-retain links to selected client and sound checkouts, while server runtimes link
-selected server configuration and tool inputs. Inherited descriptors preserve
-the leases if the supervisor dies; topology shutdown terminates orphaned
-services before the guardian releases the last descriptors. A topology-unique inherited
-process-tree lease is also held as an advisory generation lock, so a topology
-name cannot restart until its prior process tree releases the lease. Shutdown
-uses the same lease identity to find and pidfd-signal surviving descendants
-without trusting recycled process or process-group numbers. Foreground client
-and server processes inherit the same applicable leases from the wrapper. The
-common command runner also inherits every active advisory-lock descriptor into
-build and scenario subprocesses, preserving layout, build-root, state,
-registry, and cache protection if their wrapper exits unexpectedly.
+A supervised topology stages its complete executable closure below a random
+topology-owned generation directory before publishing schema-2 spec/status.
+The sealed generation contains copied executables, plugins, client data,
+sound, server configuration and tools, content, resources, and generated maps;
+descriptor-relative no-follow copying rejects links, special files, and source
+identity changes. Its manifest binds topology/profile/provider identity,
+source commits and trees, build metadata, per-file digests, external state, and
+generation. The server state link is the only mutable external runtime input.
+The server's generated asset listing and compressed transport cache occupy a
+generation-named directory below that same exclusively leased state; a sealed
+client-map subtree is copied beside its writable `data` sibling and bound into
+the manifest, while all other asset inputs remain copied into the immutable
+runtime generation. The server receives that exact state-owned asset root.
+After publication, services retain no repository-layout or mutable build-root
+lease. The supervisor and guardian retain exact state, runtime-generation,
+process-tree, and generation-specific port-reservation leases; shutdown uses
+those identities without trusting recycled process or process-group numbers.
+Services inherit only the process-tree identity needed for exact descendant
+recovery. Foreground runs use an equivalent temporary sealed generation and
+retain only its lease plus server state when applicable.
+The common command runner still inherits active advisory-lock descriptors into
+build and scenario subprocesses so an interrupted wrapper cannot strand an
+unprotected mutation.
 
 The writer-pending announcement precedes the writer-intent gate and layout lock,
 which remain
 outermost relative to all operational locks; private helpers never reacquire
 either boundary. A direct build or foreground client then takes its build-root
 lock and subordinate cache locks; the foreground process retains that root
-lease. Topology startup takes the topology-operation/process-tree lock, the
+lease only through publication; the long-lived process retains the immutable
+generation lease instead. Topology startup takes the topology-operation/process-tree lock, the
 automatic allocator when applicable, the per-port transaction and immutable
 generation lease, the server-state lock when needed, and finally the build-root
-lock. It transfers workspace leases into the supervisor/guardian rather than
-services.
+lock. It releases the layout/build boundaries after atomic runtime publication
+and transfers only the exact state, runtime, process-tree, and port leases into
+the supervisor/guardian rather than services.
 Independent CMake roots briefly serialize first-use compiler-cache marker and
 metadata publication, then release that cache lock before compilation.
 Scenario create takes the scenario-operation lock, then build-root and
@@ -656,10 +664,10 @@ endpoint; it never signals a namespace-local, recycled, or unrelated PID.
 Legacy records retain the PID/start-tick fallback. A same-namespace guardian
 holds the process-tree generation until every inherited descendant is gone. If
 the supervisor dies, pipe closure makes the guardian terminate exact lease
-holders and retain the generation until their absence is proven. Layout,
-build, and state leases remain held by the supervisor and guardian rather than
-service-inherited, so a descendant that closes its process-tree identity cannot
-retain those workspace leases. The guardian releases them only after exact
+holders and retain the generation until their absence is proven.
+Runtime-generation and state leases remain held by the supervisor and guardian
+rather than service-inherited, so a descendant that closes its process-tree
+identity cannot retain those resources. The guardian releases them only after exact
 process-tree recovery completes. Another namespace
 waits or fails closed with the owning topology and recovery action. Normal
 shutdown asks the supervisor to gracefully stop children before releasing
@@ -694,23 +702,15 @@ its topology and profile; a foreground client receives its profile and direct
 run mode. The client uses this label only for its native window title. It is
 not part of persisted settings, package or protocol identity, or network
 metadata, and unmanaged launches receive no label.
-A server topology copies the collected-content and staged-resource caches after
-the shared incremental build. The profile build retains its source caches, and
-each topology owns independent immutable-at-startup copies, so later builds and
-other topology removal or mutation cannot change the filesystem seen by a
-running process. Content, resources, and generated client maps are staged and
-installed as one runtime-input transaction, so a copy or validation failure
-before installation retains the complete previous snapshot set and status.
-Snapshot traversal opens every directory and regular file descriptor-relative
-with no-follow semantics and rejects identity changes, links, and special files;
-retained descriptors bind a complete source/destination comparison through
-installation.
-Atomic replacement keeps at most one marker-owned prior-output backup; failed
-reclamation is retried before another replacement may change the output, and
-an interrupted move is restored before a later replacement attempt.
-Because the caches remain below the marker-owned profile build, existing build
-retention and marker-safe cleanup own their lifecycle; topology copies follow
-topology retention.
+Each successful startup atomically renames a new sealed directory into
+`generations/<generation>` and publishes status only afterward. Failure removes
+only its exact staging directory and leaves every previously complete stopped
+generation and status intact. Distinct topology names and generations remain
+independent while the shared build root is rebuilt or selected worktrees
+advance. Generation directories stay with the marker-owned topology record so
+the preview-first topology reclamation contract in #397 can remove only an
+inactive, released, fully validated record; malformed, linked, unreachable, or
+retained generations fail closed.
 A topology may select one service, and distinct runtime names permit concurrent
 combinations as long as their server ports and mutable state directories do not
 conflict. When replacement runtime support lands, a concurrent `classic` and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -251,11 +251,12 @@ which remain
 outermost relative to all operational locks; private helpers never reacquire
 either boundary. A direct build or foreground client then takes its build-root
 lock and subordinate cache locks; the foreground process retains that root
-lease only through publication; the long-lived process retains the immutable
-generation lease instead. Topology startup takes the topology-operation/process-tree lock, the
-automatic allocator when applicable, the per-port transaction and immutable
-generation lease, the server-state lock when needed, and finally the build-root
-lock. It releases the layout/build boundaries after atomic runtime publication
+lease only through publication, while the long-lived process retains the
+immutable generation lease instead. Topology startup takes the
+topology-operation/process-tree lock, the automatic allocator when applicable,
+the per-port transaction and immutable generation lease, the server-state lock
+when needed, and finally the build-root lock. It releases the layout/build
+boundaries after atomic runtime publication
 and transfers only the exact state, runtime, process-tree, and port leases into
 the supervisor/guardian rather than services.
 Independent CMake roots briefly serialize first-use compiler-cache marker and

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -768,6 +768,48 @@ class ParserTests(unittest.TestCase):
         workspace_type.return_value.topology_statuses.assert_called_once_with()
         self.assertEqual(json.loads(output.call_args.args[0]), statuses)
 
+    def test_ps_reports_current_and_historical_retained_leases(self) -> None:
+        common = {
+            "profile": "review",
+            "endpoint": None,
+            "services": {},
+            "supervisor": {"running": True, "pid": 1234},
+        }
+        statuses = [
+            {
+                **common,
+                "name": "current",
+                "observation": {
+                    "process_tree_lease": "retained",
+                    "runtime_bundle_lease": "retained",
+                    "runtime_generation": "a" * 64,
+                    "safe_action": "run ./atrinik down current",
+                },
+            },
+            {
+                **common,
+                "name": "historical",
+                "observation": {
+                    "process_tree_lease": "retained",
+                    "repository_layout_lease_owner": "supervisor 1234",
+                    "safe_action": "run ./atrinik down historical",
+                },
+            },
+        ]
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.topology_statuses.return_value = statuses
+            with mock.patch("builtins.print") as output:
+                result = main(["ps"])
+
+        self.assertEqual(result, 0)
+        rendered = "\n".join(
+            str(call.args[0]) if call.args else "" for call in output.call_args_list
+        )
+        self.assertIn(f"runtime-generation\tretained\t{'a' * 64}", rendered)
+        self.assertIn(
+            "repository-layout-lease\tretained\tsupervisor 1234", rendered
+        )
+
     def test_relative_external_profile_path_is_not_silently_absolutized(self) -> None:
         with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
             workspace_type.return_value.set_profile.side_effect = WorkspaceError(

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -486,6 +486,85 @@ class ServerReadinessCaptureTests(unittest.TestCase):
         )
         close.assert_called_once_with(9)
 
+    def test_current_supervisor_orderly_stop_closes_exact_leases(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            spec_path = root / "spec.json"
+            spec_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "name": "orderly",
+                        "profile": "default",
+                        "dependencies": [],
+                        "state": None,
+                        "build_root": "/tmp/build",
+                        "resolved": {},
+                        "endpoint": None,
+                        "runtime": {"generation": "a" * 64},
+                        "services": {},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with (
+                mock.patch.object(
+                    supervisor_module, "process_start_time", return_value="1"
+                ),
+                mock.patch.object(
+                    supervisor_module, "_validate_port_reservation"
+                ),
+                mock.patch.object(
+                    supervisor_module, "_serve_control", return_value=True
+                ),
+                mock.patch.object(supervisor_module, "terminate"),
+                mock.patch.object(supervisor_module.os, "close") as close,
+            ):
+                self.assertEqual(
+                    supervise(spec_path, None, None, None, None, 8, 9), 0
+                )
+
+        self.assertEqual(
+            {call.args[0] for call in close.call_args_list}, {8, 9}
+        )
+
+    def test_main_daemon_parent_returns_without_supervising(self) -> None:
+        with (
+            mock.patch.object(
+                sys,
+                "argv",
+                ["atrinik-supervisor", "--spec", "/tmp/spec.json", "--daemonize"],
+            ),
+            mock.patch.object(supervisor_module.os, "fork", return_value=1234),
+            mock.patch.object(supervisor_module, "supervise") as supervise_call,
+        ):
+            self.assertEqual(supervisor_module.main(), 0)
+        supervise_call.assert_not_called()
+
+    def test_main_tolerates_runtime_lease_already_closed_on_failure(self) -> None:
+        with (
+            mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "atrinik-supervisor",
+                    "--spec",
+                    "/tmp/spec.json",
+                    "--runtime-lock-fd",
+                    "9",
+                ],
+            ),
+            mock.patch.object(
+                supervisor_module,
+                "supervise",
+                side_effect=RuntimeError("invalid runtime"),
+            ),
+            mock.patch.object(supervisor_module, "atomic_status"),
+            mock.patch.object(supervisor_module.os, "close", side_effect=OSError),
+            mock.patch.object(sys, "stderr"),
+        ):
+            self.assertEqual(supervisor_module.main(), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -231,16 +231,22 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                 mock.patch.object(
                     supervisor_module.subprocess, "Popen", return_value=process
                 ),
+                mock.patch.object(
+                    supervisor_module,
+                    "_start_guardian",
+                    wraps=supervisor_module._start_guardian,
+                ) as start_guardian,
                 mock.patch.object(supervisor_module, "terminate") as terminate,
                 mock.patch.object(supervisor_module.os, "close") as close,
             ):
                 self.assertEqual(
-                    supervise(spec_path, None, 7, 8, None, None, 9), 1
+                    supervise(spec_path, 6, 7, 8, None, None, 9), 1
                 )
 
+            start_guardian.assert_called_once_with(None, None, 6, 9)
             terminate.assert_called_once()
             self.assertEqual(
-                {call.args[0] for call in close.call_args_list}, {7, 8, 9}
+                {call.args[0] for call in close.call_args_list}, {6, 7, 8, 9}
             )
             status = json.loads(
                 (root / "status.json").read_text(encoding="utf-8")
@@ -258,8 +264,10 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                     "-c",
                     "import os, pathlib, signal, sys, time; "
                     "child = os.fork(); "
+                    "path = pathlib.Path(sys.argv[1]); "
                     "child == 0 and signal.signal(signal.SIGTERM, signal.SIG_IGN); "
-                    "child == 0 and pathlib.Path(sys.argv[1]).write_text(str(os.getpid())); "
+                    "child == 0 and path.with_suffix('.tmp').write_text(str(os.getpid())); "
+                    "child == 0 and path.with_suffix('.tmp').replace(path); "
                     "child == 0 and time.sleep(60); "
                     "os._exit(0)",
                     str(descendant_path),
@@ -310,9 +318,11 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                     "-c",
                     "import os, pathlib, signal, sys, time; "
                     "child = os.fork(); "
+                    "path = pathlib.Path(sys.argv[1]); "
                     "child == 0 and os.close(int(sys.argv[2])); "
                     "child == 0 and signal.signal(signal.SIGTERM, signal.SIG_IGN); "
-                    "child == 0 and pathlib.Path(sys.argv[1]).write_text(str(os.getpid())); "
+                    "child == 0 and path.with_suffix('.tmp').write_text(str(os.getpid())); "
+                    "child == 0 and path.with_suffix('.tmp').replace(path); "
                     "child == 0 and time.sleep(60); "
                     "os._exit(0)",
                     str(descendant_path),

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -451,6 +451,41 @@ class ServerReadinessCaptureTests(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "identity is incomplete"):
             _initial_status({**spec, "stack": "classic"}, "123")
 
+    def test_main_closes_runtime_lease_after_startup_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            spec_path = Path(directory) / "spec.json"
+            with (
+                mock.patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "atrinik-supervisor",
+                        "--spec",
+                        str(spec_path),
+                        "--runtime-lock-fd",
+                        "9",
+                    ],
+                ),
+                mock.patch.object(
+                    supervisor_module,
+                    "supervise",
+                    side_effect=RuntimeError("invalid runtime"),
+                ) as supervise_call,
+                mock.patch.object(supervisor_module, "atomic_status") as status,
+                mock.patch.object(supervisor_module.os, "close") as close,
+                mock.patch.object(sys, "stderr"),
+            ):
+                self.assertEqual(supervisor_module.main(), 1)
+
+        supervise_call.assert_called_once_with(
+            spec_path, None, None, None, None, None, 9
+        )
+        status.assert_called_once_with(
+            spec_path.parent / "startup-error.json",
+            {"error": "RuntimeError: invalid runtime"},
+        )
+        close.assert_called_once_with(9)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -191,6 +191,62 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                 {call.args[0] for call in close.call_args_list}, {7, 8}
             )
 
+    def test_current_supervisor_releases_broad_leases_and_retains_runtime(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            runtime = {
+                "schema_version": 1,
+                "generation": "a" * 64,
+                "root": str(root / "runtime"),
+                "lease": {"device": 1, "inode": 2},
+            }
+            spec = {
+                "schema_version": 2,
+                "name": "cleanup",
+                "profile": "default",
+                "dependencies": ["client"],
+                "state": None,
+                "build_root": "/tmp/build",
+                "resolved": {},
+                "endpoint": None,
+                "runtime": runtime,
+                "services": {
+                    "client": {
+                        "command": ["client"],
+                        "cwd": str(root),
+                        "log": str(root / "client.log"),
+                    }
+                },
+            }
+            spec_path = root / "spec.json"
+            spec_path.write_text(json.dumps(spec), encoding="utf-8")
+            process = mock.MagicMock(pid=1234)
+
+            with (
+                mock.patch.object(
+                    supervisor_module,
+                    "process_start_time",
+                    side_effect=["1", None],
+                ),
+                mock.patch.object(
+                    supervisor_module.subprocess, "Popen", return_value=process
+                ),
+                mock.patch.object(supervisor_module, "terminate") as terminate,
+                mock.patch.object(supervisor_module.os, "close") as close,
+            ):
+                self.assertEqual(
+                    supervise(spec_path, None, 7, 8, None, None, 9), 1
+                )
+
+            terminate.assert_called_once()
+            self.assertEqual(
+                {call.args[0] for call in close.call_args_list}, {7, 8, 9}
+            )
+            status = json.loads(
+                (root / "status.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(status["runtime"], runtime)
+
     def test_terminate_cleans_group_after_service_leader_exits(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             descendant_path = Path(directory) / "descendant.pid"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -4543,6 +4543,19 @@ class WorkspaceTests(unittest.TestCase):
                 self.root / "missing-runtime-source", destination
             )
 
+        source = self.root / "runtime-source"
+        source.mkdir()
+        with (
+            mock.patch("atrinik_workspace.workspace.os.close") as close,
+            self.assertRaisesRegex(
+                WorkspaceError, "cannot open runtime publication directory"
+            ),
+        ):
+            self.workspace._copy_runtime_directory_contents(
+                source, self.root / "missing-runtime-destination"
+            )
+        close.assert_called_once()
+
     def test_topology_runtime_set_rejects_file_changed_to_link_during_copy(
         self,
     ) -> None:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -455,12 +455,7 @@ def synthetic_server_start_process(
                 ):
                     reserved_port.close()
 
-            runtime_inputs = {
-                key: root / key
-                for key in ("content", "resources", "client-maps")
-            }
-            for path in runtime_inputs.values():
-                path.mkdir(parents=True, exist_ok=True)
+            state.mkdir(parents=True, exist_ok=True)
 
             reservation_received.set()
             if not release_reservation.wait(10):
@@ -481,14 +476,6 @@ def synthetic_server_start_process(
                 mock.patch.object(workspace, "state_path", return_value=state),
                 mock.patch.object(
                     workspace, "_build_resolved", return_value=root
-                ),
-                mock.patch.object(
-                    workspace,
-                    "_copy_topology_runtime_inputs",
-                    return_value=runtime_inputs,
-                ),
-                mock.patch.object(
-                    workspace, "_prepare_server_runtime", return_value=root
                 ),
             ):
                 try:
@@ -6159,7 +6146,7 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual([process.exitcode for process in processes], [0] * 10)
         self.assertEqual([results.get(timeout=2) for _ in processes], [None] * 10)
 
-    def test_p0_harness_reproduces_current_lifecycle_layout_convoy(self) -> None:
+    def test_p0_harness_allows_lifecycle_progress_while_topology_runs(self) -> None:
         context = multiprocessing.get_context("spawn")
         for label in ("source-a", "source-b", "source-c"):
             self.workspace.create_worktree(
@@ -6257,30 +6244,23 @@ class WorkspaceTests(unittest.TestCase):
             wait_for_process_event(
                 writer_pending, "profile B mutation queue", results
             )
-            self.assertFalse(writer_entered.is_set())
+            wait_for_process_event(
+                writer_entered, "profile B mutation entry", results
+            )
 
             for reader in readers:
                 reader.start()
                 started.append(reader)
-            for index, blocked in enumerate(readers_blocked):
-                wait_for_process_event(
-                    blocked, f"C reader {index} confirmed lock block", results
-                )
-            self.assertFalse(writer_entered.is_set())
-            self.assertTrue(all(not entered.is_set() for entered in readers_entered))
-
-            # This records the current global A-topology/B-writer/C-reader
-            # convoy through positive lock-contention rendezvous. The #399
-            # cutover will replace this lock-specific expectation with scoped
-            # admission assertions for the same public operations.
-            self.workspace.topology_down("topology-a", timeout=5)
-            wait_for_process_event(
-                writer_entered, "profile B mutation entry", results
-            )
             for index, entered in enumerate(readers_entered):
                 wait_for_process_event(
                     entered, f"C reader {index} completion", results
                 )
+            self.assertTrue(self.workspace.topology_status("topology-a")["ready"])
+
+            # The topology retains only its immutable runtime generation and
+            # exact process/state leases after publication. Unrelated layout
+            # mutation and readers therefore progress while it remains live.
+            self.workspace.topology_down("topology-a", timeout=5)
         finally:
             status_path = (
                 self.workspace.paths.topologies / "topology-a" / "status.json"
@@ -6318,12 +6298,18 @@ class WorkspaceTests(unittest.TestCase):
             ("server-b", "state-b", "build-b", reservations[1].getsockname()[1]),
         )
         self.assertNotEqual(coordinates[0][3], coordinates[1][3])
+        source = self.workspace.paths.repositories / "server"
+        (source / "tools").mkdir()
+        for name in ("ca-bundle.crt", "permissions.cfg", "server.cfg"):
+            (source / name).write_text("test\n", encoding="utf-8")
         for index, (name, _state, build, _port) in enumerate(coordinates):
             self.workspace.create_profile(name)
             root = self.workspace.paths.builds / "profiles" / build
             root.mkdir(parents=True)
             atomic_json(root / workspace_module.BUILD_METADATA, {})
-            executable = root / "atrinik-server"
+            binary = root / "build" / "server"
+            binary.mkdir(parents=True)
+            executable = binary / "atrinik-server"
             executable.write_text(
                 "#!/usr/bin/env python3\n"
                 "from pathlib import Path\n"
@@ -6343,6 +6329,15 @@ class WorkspaceTests(unittest.TestCase):
                 encoding="utf-8",
             )
             executable.chmod(0o755)
+            for library in ("libplugin_arena.so", "libplugin_python.so"):
+                (binary / library).write_text("test\n", encoding="utf-8")
+            for path in (
+                root / "runtime" / "content" / "lib",
+                root / "runtime" / "content" / "maps",
+                root / "runtime" / "resources",
+            ):
+                path.mkdir(parents=True, exist_ok=True)
+            self.make_region_map_cache(root)
         processes = [
             context.Process(
                 target=synthetic_server_start_process,

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -4423,6 +4423,47 @@ class WorkspaceTests(unittest.TestCase):
                 (second / "payload").read_text(encoding="utf-8"), "shared\n"
             )
 
+    def test_runtime_generation_staging_change_publishes_nothing(self) -> None:
+        owner = self.root / "runtime-owner"
+        owner.mkdir()
+        client = self.root / "runtime-client"
+        sound = self.root / "runtime-sound"
+        binary = self.root / "runtime-client-binary"
+        for path in (client, sound, binary):
+            path.mkdir()
+        (client / "data").write_text("client\n", encoding="utf-8")
+        (sound / "sound").write_text("sound\n", encoding="utf-8")
+        executable = binary / "atrinik"
+        executable.write_text("client\n", encoding="utf-8")
+        executable.chmod(0o755)
+
+        with (
+            mock.patch.object(
+                self.workspace, "_classic_binary_directory", return_value=binary
+            ),
+            mock.patch.object(
+                self.workspace,
+                "_runtime_publication_input_digests",
+                side_effect=({"client": "before"}, {"client": "after"}),
+            ),
+            self.assertRaisesRegex(
+                WorkspaceError, "inputs changed during staging"
+            ),
+        ):
+            self.workspace._publish_runtime_generation(
+                owner,
+                "a" * 64,
+                "default",
+                self.root / "build",
+                {"client": client, "sound": sound},
+                {},
+                ["client"],
+                identity={"kind": "test"},
+                sound_root=sound,
+            )
+
+        self.assertEqual(list((owner / "generations").iterdir()), [])
+
     def test_topology_runtime_set_copy_failure_preserves_all_snapshots(self) -> None:
         topology = self.root / "topology"
         runtime = topology / "runtime"
@@ -7141,7 +7182,7 @@ class WorkspaceTests(unittest.TestCase):
             )
             self.assertEqual(
                 Path(status["services"]["client"]["cwd"]),
-                self.workspace.paths.topologies / "review" / "client-runtime",
+                Path(status["runtime"]["path"]) / "client",
             )
             with (
                 mock.patch.object(
@@ -7218,7 +7259,11 @@ class WorkspaceTests(unittest.TestCase):
                 cross_namespace["observation"][
                     "repository_layout_lease_owner"
                 ],
-                "review",
+                None,
+            )
+            self.assertEqual(
+                cross_namespace["observation"]["runtime_bundle_lease"],
+                "retained",
             )
             status_path = (
                 self.workspace.paths.topologies / "review" / "status.json"
@@ -7280,6 +7325,26 @@ class WorkspaceTests(unittest.TestCase):
             reused_local_pid = self.workspace.topology_status("review")
         self.assertEqual(reused_local_pid["supervisor"]["liveness"], "exited")
         self.assertFalse(reused_local_pid["services"]["client"]["running"])
+
+        invalid_root = self.workspace._topology_directory(
+            "invalid-config", create=True
+        )
+        (invalid_root / "client-config").write_text(
+            "not a directory\n", encoding="utf-8"
+        )
+        with (
+            mock.patch.object(
+                self.workspace, "_build_resolved", return_value=build_root
+            ),
+            mock.patch.object(self.workspace, "_require_client_display"),
+            self.assertRaisesRegex(
+                WorkspaceError, "client configuration path is invalid"
+            ),
+        ):
+            self.workspace.topology_up(
+                "invalid-config", "default", "default", ["client"]
+            )
+        self.assertEqual(list((invalid_root / "generations").iterdir()), [])
 
     def test_topology_status_inventory_probes_with_bounded_concurrency(self) -> None:
         for index in range(24):
@@ -7400,6 +7465,9 @@ class WorkspaceTests(unittest.TestCase):
                 "atrinik_workspace.workspace.verify_playtest_tree",
                 return_value=sound_record,
             ),
+            mock.patch(
+                "atrinik_workspace.workspace.git", return_value="c" * 40
+            ),
         ):
             status = self.workspace.topology_up(
                 "playtest-client", "classic-audio", "default", ["client"]
@@ -7408,7 +7476,8 @@ class WorkspaceTests(unittest.TestCase):
             self.assertTrue(status["services"]["client"]["running"])
             self.assertEqual(status["sound"], sound_record)
             runtime = Path(status["services"]["client"]["cwd"])
-            self.assertEqual((runtime / "sound").resolve(), sound_root.resolve())
+            self.assertFalse((runtime / "sound").is_symlink())
+            self.assertNotEqual((runtime / "sound").resolve(), sound_root.resolve())
             log = self.workspace.paths.topologies / "playtest-client" / "client.log"
             deadline = time.monotonic() + 5
             while time.monotonic() < deadline and (
@@ -7652,7 +7721,7 @@ class WorkspaceTests(unittest.TestCase):
         executable = binary / "atrinik-server"
         executable.write_text(
             "#!/usr/bin/env python3\n"
-            "import os, sys, time\n"
+            "import os, pathlib, sys, time\n"
             "for descriptor in os.listdir('/proc/self/fd'):\n"
             "    try:\n"
             "        target = os.readlink('/proc/self/fd/' + descriptor)\n"
@@ -7660,6 +7729,14 @@ class WorkspaceTests(unittest.TestCase):
             "        continue\n"
             "    assert not target.endswith('/ports.lock'), target\n"
             "    assert '/port-reservations/' not in target, target\n"
+            "assetspath = next(\n"
+            "    value.split('=', 1)[1]\n"
+            "    for value in sys.argv[1:]\n"
+            "    if value.startswith('--assetspath=')\n"
+            ")\n"
+            "data = pathlib.Path(assetspath) / 'data'\n"
+            "data.mkdir(exist_ok=True)\n"
+            "(data / 'listing.txt').write_text('generated\\n')\n"
             f"print('QUIC certificate SHA-256: {'a' * 64}', flush=True)\n"
             "print('Server ready. Waiting for connections...', flush=True)\n"
             "print(repr(sys.argv[1:]), flush=True)\n"
@@ -7741,22 +7818,65 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertEqual(status["endpoint"]["fingerprint"], "a" * 64)
         server_runtime = Path(status["services"]["server"]["cwd"])
+        generation_root = Path(status["runtime"]["path"])
+        mutable_asset_output = Path(
+            status["runtime"]["mutable_state_outputs"][0]
+        )
+        self.assertFalse((server_runtime / "assets").exists())
+        self.assertTrue((mutable_asset_output / "data").is_dir())
+        self.assertFalse((mutable_asset_output / "data").is_symlink())
         self.assertEqual(
-            (server_runtime / "maps").resolve(),
-            self.workspace.paths.topologies
-            / "server-review"
-            / "runtime"
-            / "content"
-            / "maps",
+            (mutable_asset_output / "data" / "listing.txt").read_text(),
+            "generated\n",
         )
-        topology_maps = (
-            self.workspace.paths.topologies
-            / "server-review"
-            / "runtime"
-            / "client-maps"
+        self.assertTrue(
+            (mutable_asset_output / "client-maps" / "incuna_-1.png").is_file()
         )
-        self.assertTrue((topology_maps / "incuna_-1.png").is_file())
-        staged_maps = server_runtime / "assets" / "client-maps"
+        self.assertTrue(
+            mutable_asset_output.is_relative_to(
+                self.workspace._state_location("default")
+            )
+        )
+        manifest_path = generation_root / workspace_module.RUNTIME_GENERATION_MANIFEST
+        status_path = (
+            self.workspace.paths.topologies / "server-review" / "status.json"
+        )
+        manifest_record = load_json(manifest_path)
+        status_record = load_json(status_path)
+        generation_mode = stat.S_IMODE(generation_root.stat().st_mode)
+        manifest_mode = stat.S_IMODE(manifest_path.stat().st_mode)
+        try:
+            generation_root.chmod(0o700)
+            manifest_path.chmod(0o600)
+            invalid_manifest = dict(manifest_record)
+            invalid_manifest["identity"] = {
+                **invalid_manifest["identity"],
+                "name": "different-topology",
+            }
+            atomic_json(manifest_path, invalid_manifest)
+            invalid_status = dict(status_record)
+            invalid_status["runtime"] = dict(invalid_status["runtime"])
+            invalid_status["runtime"]["manifest_sha256"] = (
+                workspace_module._file_digest(
+                    manifest_path, "runtime generation manifest"
+                )
+            )
+            atomic_json(status_path, invalid_status)
+            with self.assertRaisesRegex(
+                WorkspaceError, "runtime manifest identity is invalid"
+            ):
+                self.workspace.topology_status("server-review")
+        finally:
+            atomic_json(manifest_path, manifest_record)
+            manifest_path.chmod(manifest_mode)
+            generation_root.chmod(generation_mode)
+            atomic_json(status_path, status_record)
+        self.assertEqual(server_runtime, generation_root / "server")
+        self.assertFalse((server_runtime / "maps").is_symlink())
+        self.assertEqual(
+            (server_runtime / "maps" / "map").read_text(), "shared content\n"
+        )
+        staged_maps = mutable_asset_output / "client-maps"
         self.assertTrue((staged_maps / "incuna_-1.png").is_file())
         self.assertFalse(staged_maps.is_symlink())
         self.assertTrue(
@@ -7770,9 +7890,7 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertEqual(
             Path(status["services"]["client"]["cwd"]),
-            self.workspace.paths.topologies
-            / "server-review"
-            / "client-runtime",
+            generation_root / "client",
         )
         client_log = self.workspace.paths.topologies / "server-review" / "client.log"
         server_log = self.workspace.paths.topologies / "server-review" / "server.log"
@@ -7785,7 +7903,7 @@ class WorkspaceTests(unittest.TestCase):
         self.assertIn("'--port_mapping=off'", server_log.read_text())
         self.assertIn("'--stun_server=off'", server_log.read_text())
         self.assertIn(
-            f"'--assetspath={server_runtime / 'assets'}'", server_log.read_text()
+            f"'--assetspath={mutable_asset_output}'", server_log.read_text()
         )
         self.assertIn(
             f"'--server=127.0.0.1 17300 {'a' * 64}'", client_log.read_text()
@@ -7830,10 +7948,10 @@ class WorkspaceTests(unittest.TestCase):
             self.assertIn("client", second["dependencies"])
             self.assertNotIn("client", second["services"])
             self.assertNotIn("sound", second)
-            for topology in ("server-review", "server-review-two"):
-                snapshot = self.workspace.paths.topologies / topology / "runtime"
+            for topology_status in (status, second):
+                snapshot = Path(topology_status["runtime"]["path"]) / "server"
                 self.assertEqual(
-                    (snapshot / "content" / "maps" / "map").read_text(),
+                    (snapshot / "maps" / "map").read_text(),
                     "shared content\n",
                 )
                 self.assertEqual(
@@ -7841,43 +7959,42 @@ class WorkspaceTests(unittest.TestCase):
                     "shared resource\n",
                 )
             self.workspace.topology_down("server-review-two", timeout=5)
-            second_content = (
-                self.workspace.paths.topologies
-                / "server-review-two"
-                / "runtime"
-                / "content"
+            (build_root / "runtime" / "content" / "maps" / "map").write_text(
+                "rebuilt content\n", encoding="utf-8"
             )
-            shutil.rmtree(second_content)
             self.assertEqual(
-                (
-                    self.workspace.paths.topologies
-                    / "server-review"
-                    / "runtime"
-                    / "content"
-                    / "maps"
-                    / "map"
-                ).read_text(),
+                (generation_root / "server" / "maps" / "map").read_text(),
                 "shared content\n",
             )
             self.assertEqual(
                 (build_root / "runtime" / "content" / "maps" / "map").read_text(),
-                "shared content\n",
+                "rebuilt content\n",
             )
             with self.assertRaisesRegex(WorkspaceError, "already in use"):
                 with exclusive_lock(
                     Path(f"{state}.lock"), "server state", nonblocking=True
                 ):
                     self.fail("supervised state lock unexpectedly became available")
+            with exclusive_lock(
+                layout_lock, "repository layout", nonblocking=True
+            ):
+                pass
+            with exclusive_lock(
+                profile_lock, "profile build default", nonblocking=True
+            ):
+                pass
             with self.assertRaisesRegex(WorkspaceError, "already in use"):
                 with exclusive_lock(
-                    layout_lock, "repository layout", nonblocking=True
+                    generation_root / workspace_module.RUNTIME_GENERATION_LEASE,
+                    "runtime generation",
+                    nonblocking=True,
                 ):
-                    self.fail("supervised client released its layout lock")
-            with self.assertRaisesRegex(WorkspaceError, "already in use"):
-                with exclusive_lock(
-                    profile_lock, "profile build default", nonblocking=True
-                ):
-                    self.fail("supervised services released their build-root lock")
+                    self.fail("live topology released its runtime generation lease")
+            self.assertIsNone(
+                self.workspace.topology_status("server-review")["observation"][
+                    "repository_layout_lease_owner"
+                ]
+            )
 
             supervisor = status["supervisor"]
             pidfd = os.pidfd_open(supervisor["pid"])
@@ -7957,7 +8074,7 @@ class WorkspaceTests(unittest.TestCase):
                 "    signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
                 "    while True:\n"
                 "        time.sleep(0.1)\n"
-                "open('descendant.pid', 'w', encoding='utf-8').write(str(child))\n"
+                "open('data/tmp/descendant.pid', 'w', encoding='utf-8').write(str(child))\n"
                 f"print('QUIC certificate SHA-256: {'a' * 64}', flush=True)\n"
                 "print('Server ready. Waiting for connections...', flush=True)\n"
                 "while True:\n"
@@ -7973,12 +8090,11 @@ class WorkspaceTests(unittest.TestCase):
                 (layout_lock, "repository layout"),
                 (profile_lock, "profile build default"),
             ):
-                with self.assertRaisesRegex(WorkspaceError, "already in use"):
-                    with exclusive_lock(path, description, nonblocking=True):
-                        self.fail(f"server-only topology released {description}")
+                with exclusive_lock(path, description, nonblocking=True):
+                    pass
             descendant_path = Path(
                 server_only["services"]["server"]["cwd"]
-            ) / "descendant.pid"
+            ) / "data" / "tmp" / "descendant.pid"
             deadline = time.monotonic() + 5
             while time.monotonic() < deadline and not descendant_path.is_file():
                 time.sleep(0.05)
@@ -8839,10 +8955,14 @@ class WorkspaceTests(unittest.TestCase):
         executable.parent.mkdir(parents=True)
         executable.write_text("client\n", encoding="utf-8")
         (build_root / "sources" / "client").mkdir(parents=True)
+        atomic_json(
+            build_root / workspace_module.BUILD_METADATA,
+            {"sound": workspace_module.sound_source_record(self.wrapper / "sound")},
+        )
         expected = "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81"
 
         def execute_client(*_arguments: object, **_keywords: object) -> None:
-            self.assertEqual(len(_keywords["pass_fds"]), 2)
+            self.assertEqual(len(_keywords["pass_fds"]), 1)
             for path, description in (
                 (
                     self.workspace.paths.workspace / "repository-layout.lock",
@@ -8855,12 +8975,32 @@ class WorkspaceTests(unittest.TestCase):
                     "profile build default",
                 ),
             ):
-                with self.assertRaisesRegex(WorkspaceError, "already in use"):
-                    with exclusive_lock(path, description, nonblocking=True):
-                        self.fail(f"foreground client released {description}")
+                with exclusive_lock(path, description, nonblocking=True):
+                    pass
+            with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                with exclusive_lock(
+                    Path(_keywords["cwd"]).parent
+                    / workspace_module.RUNTIME_GENERATION_LEASE,
+                    "foreground runtime generation",
+                    nonblocking=True,
+                ):
+                    self.fail("foreground client released its runtime generation")
 
         with (
-            mock.patch.object(self.workspace, "_build", return_value=build_root),
+            mock.patch.object(
+                self.workspace,
+                "_resolve_build_profile",
+                return_value={
+                    "client": self.wrapper / "client",
+                    "sound": self.wrapper / "sound",
+                },
+            ),
+            mock.patch.object(
+                self.workspace, "_build_resolved", return_value=build_root
+            ),
+            mock.patch.object(
+                self.workspace, "_topology_resolved_status", return_value={}
+            ),
             mock.patch("builtins.print") as output,
             mock.patch(
                 "atrinik_workspace.workspace.run", side_effect=execute_client
@@ -8871,7 +9011,8 @@ class WorkspaceTests(unittest.TestCase):
                 "default", "default", 1731, ["--fullscreen"], False
             )
 
-        self.assertEqual(result, executable)
+        self.assertEqual(result.name, "atrinik")
+        self.assertFalse(result.exists())
         rendered = "\n".join(str(call.args[0]) for call in output.call_args_list)
         self.assertIn(f"--server=127.0.0.1 1731 {expected}", rendered)
         self.assertIn("--stun_server=off", rendered)
@@ -8916,8 +9057,32 @@ class WorkspaceTests(unittest.TestCase):
         executable.write_text("server\n", encoding="utf-8")
         selected = {"server": server}
 
+        def publish_server(*_arguments: object, **_keywords: object) -> tuple[Path, int, dict[str, object]]:
+            generation_root = self.root / "foreground-server-generation"
+            server_runtime = generation_root / "server"
+            server_runtime.mkdir(parents=True)
+            generated_executable = server_runtime / "atrinik-server"
+            generated_executable.write_text("server\n", encoding="utf-8")
+            (server_runtime / "assets").mkdir()
+            lease = generation_root / workspace_module.RUNTIME_GENERATION_LEASE
+            descriptor = os.open(lease, os.O_RDWR | os.O_CREAT, 0o600)
+            workspace_module.initialize_lease(descriptor, "a" * 64)
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            state_output = self.root / "foreground-server-state-output"
+            state_output.mkdir()
+            atomic_json(
+                state_output / MANAGED_MARKER,
+                {
+                    "schema_version": 1,
+                    "purpose": "runtime-state-output:foreground-server-generation",
+                },
+            )
+            return generation_root, descriptor, {
+                "mutable_state_outputs": [str(state_output)],
+            }
+
         def execute_server(*_arguments: object, **_keywords: object) -> None:
-            self.assertEqual(len(_keywords["pass_fds"]), 3)
+            self.assertEqual(len(_keywords["pass_fds"]), 2)
             for path, description in (
                 (
                     self.workspace.paths.workspace / "repository-layout.lock",
@@ -8929,14 +9094,24 @@ class WorkspaceTests(unittest.TestCase):
                     / "server-build.lock",
                     "profile build default",
                 ),
-                (
+            ):
+                with exclusive_lock(path, description, nonblocking=True):
+                    pass
+            with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                with exclusive_lock(
                     Path(f"{self.workspace._state_location('default')}.lock"),
                     "server state",
-                ),
-            ):
-                with self.assertRaisesRegex(WorkspaceError, "already in use"):
-                    with exclusive_lock(path, description, nonblocking=True):
-                        self.fail(f"foreground server released {description}")
+                    nonblocking=True,
+                ):
+                    self.fail("foreground server released its state")
+            with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                with exclusive_lock(
+                    Path(_keywords["cwd"]).parent
+                    / workspace_module.RUNTIME_GENERATION_LEASE,
+                    "foreground runtime generation",
+                    nonblocking=True,
+                ):
+                    self.fail("foreground server released its runtime generation")
 
         with (
             mock.patch.object(
@@ -8946,7 +9121,12 @@ class WorkspaceTests(unittest.TestCase):
                 self.workspace, "_build_resolved", return_value=build_root
             ),
             mock.patch.object(
-                self.workspace, "_prepare_server_runtime", return_value=runtime
+                self.workspace, "_topology_resolved_status", return_value={}
+            ),
+            mock.patch.object(
+                self.workspace,
+                "_publish_runtime_generation",
+                side_effect=publish_server,
             ),
             mock.patch(
                 "atrinik_workspace.workspace.run", side_effect=execute_server
@@ -8961,7 +9141,8 @@ class WorkspaceTests(unittest.TestCase):
                 False,
             )
 
-        self.assertEqual(result, executable)
+        self.assertEqual(result.name, "atrinik-server")
+        self.assertFalse(result.exists())
         rendered = "\n".join(str(call.args[0]) for call in output.call_args_list)
         self.assertIn("--port_quic=1731", rendered)
         self.assertIn("--port_mapping=off", rendered)
@@ -8969,7 +9150,9 @@ class WorkspaceTests(unittest.TestCase):
         self.assertIn("--no_console", rendered)
         self.assertLess(
             rendered.index("--assetspath=/tmp/untrusted"),
-            rendered.index(f"--assetspath={runtime / 'assets'}"),
+            rendered.index(
+                f"--assetspath={self.root / 'foreground-server-state-output'}"
+            ),
         )
 
     def test_foreground_launch_rejects_invalid_port(self) -> None:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -4532,6 +4532,17 @@ class WorkspaceTests(unittest.TestCase):
 
         self.assertEqual(list(topology.iterdir()), [])
 
+    def test_runtime_directory_copy_reports_unopenable_source(self) -> None:
+        destination = self.root / "runtime-destination"
+        destination.mkdir()
+
+        with self.assertRaisesRegex(
+            WorkspaceError, "cannot open runtime publication directory"
+        ):
+            self.workspace._copy_runtime_directory_contents(
+                self.root / "missing-runtime-source", destination
+            )
+
     def test_topology_runtime_set_rejects_file_changed_to_link_during_copy(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- publish complete, immutable, generation-addressed Classic client/server runtime closures before execution;
- retain only the exact runtime, process-tree, server-state, and port ownership needed after publication, releasing repository-layout and build leases;
- expose authenticated runtime-generation identity through topology status and `ps`, with schema-1 historical records kept distinct;
- place server-generated transport assets in a generation-named output under the exact leased state while keeping copied client maps immutable;
- integrate the immutable-runtime lifecycle with the exact per-port reservation behavior now on `main`.

Closes #400

## Coordinates

- Base: `main` at `8dace2935cdfc7c24202f34c861e416f6e28b043`
- Head branch: `refactor/immutable-runtime-generations`
- Head: `e058d1d4243d815e93c504a6523852ff14c80634`
- Commits:
  - `64badda99 refactor(runtime): publish immutable runtime generations`
  - `e4e2aa8af test(runtime): update lifecycle lease expectations`
  - `3d6006c6b test(runtime): cover rebased lease integration`
  - `cabc61a59 fix(runtime): order exact guardian lease release`
  - `725b2e989 test(runtime): cover supervisor startup lease cleanup`
  - `ad34d2129 test(runtime): cover exact supervisor teardown`
  - `8f311ad78 test(runtime): cover publication open failure`
  - `e058d1d42 test(runtime): cover partial publication cleanup`
- Worktree: `/workspaces/atrinik/workspace/worktrees/atrinik/issue-400-immutable-runtime-generations`

## Validation

- Latest-head integration suite: 670 tests passed.
- Focused supervisor and CLI regression suite: 48 tests passed.
- `python3 -m compileall -q atrinik atrinik_workspace tests`: passed.
- Guidance inventory, manifest validation, supply-chain validation, and `git diff --check`: passed.
- Codecov patch coverage: 78.25%, passing the 76.69% target.
- Focused lifecycle integration covers immutable-runtime topology progress, exact port reservations, concurrent server startup, and paired supervision.
- Real Classic server-only topology `issue-400-runtime-e` started from profile `classic` with state `issue-400-runtime`, reached ready, and reported the runtime/process/state leases retained with no repository-layout lease owner.
- A same-profile Classic rebuild completed while that server stayed live: integrated C build had no work; metaserver checks passed (424 Vitest, 68 admin, 2 service-binding tests, plus deploy dry-runs).
- After the rebuild, all 4,546 published files still matched their manifest and manifest SHA-256 `9ee17a043690ba4d246404e2b391b520b23850c8b47fad5286234f6592fba2bd`; zero mismatches.
- The exact topology was stopped successfully afterward.

The broader Classic `--test` run compiled successfully and passed its normal and discrete suites; the large smooth movement benchmark exceeded the local 900-second resource bound. This change does not modify Classic component source, and the wrapper/runtime validations above passed.

## Verification

No account or scenario is required. A display is needed only for client/paired follow-up; the verified recipe is server-only.

```sh
./atrinik profile show classic --json
./atrinik build all --profile classic
./atrinik up --name issue-400-runtime-e --profile classic --state issue-400-runtime --service server
./atrinik ps issue-400-runtime-e --json
./atrinik build all --profile classic
./atrinik ps issue-400-runtime-e --json
./atrinik down issue-400-runtime-e
```

Expected: both `ps` observations name the same runtime generation and manifest digest, report retained runtime/process/state/port leases, and report no repository-layout lease owner; the live service remains ready through the rebuild. Use a new unique topology/state name to repeat independently. Cleanup is intentionally not applied here and remains a separate preview-first request.

## Review

The branch is rebased onto `main` at `8dace2935`, preserving both immutable runtime generations and exact per-port reservation leases. Earlier complete review cycles found and resolved five issues covering manifest identity validation, pre-spawn rollback, writable generated asset placement, publication descriptor lifetime, and lifecycle harness integration. Post-rebase review added coverage for conflict-only schema/CLI branches. The first latest-head CI run then exposed two timing windows: PID-test publication is now atomic, and guardian teardown releases the exact runtime lease last. A fresh whole-diff review found zero remaining actionable findings.
