### PR TITLE
feat(cleanup)!: reclaim inactive topology records

### DIFF
--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -56,18 +56,18 @@ Reclaim review data only through preview-first cleanup:
 ```sh
 ./atrinik cleanup --dry-run --json
 ./atrinik cleanup --scope sound-cache sound --older-than 7 --dry-run --json
-./atrinik cleanup --scope sound-cache sound --older-than 7 --apply
 ./atrinik cleanup --scope worktrees sound --older-than 7 --dry-run --json
-./atrinik cleanup --scope worktrees sound --older-than 7 --apply
+./atrinik cleanup --scope topologies --older-than 7 --dry-run --json
 ```
 
-Default cleanup covers worktrees/builds; npm, compiler, and sound caches are
-opt-in. Apply sound-cache before a fresh worktree preview/apply because every
-remaining cache protects its worktree. Sound build/verify shares the exact
-versioned Git-admin lease; removal locks its same inode exclusively. Missing,
-replaced, invalid, or busy leases fail closed. References, ambiguous Git,
-unsafe paths/markers, populated submodules, replace refs, and grafts protect
-targets. The sole historical-base exception is the frozen
+Repeat a scoped command with `--apply` after review. Defaults cover
+worktrees/builds; npm, compiler, sound, and topology history are opt-in, with
+topologies also excluded from `all`. Reclaim only stopped, released,
+marker-owned topology records. Apply sound-cache before worktrees because each
+remaining cache protects its worktree. Producer and removal share the exact
+versioned Git-admin lease; missing, replaced, invalid, or busy leases fail
+closed. References, ambiguous Git, unsafe paths/markers, populated submodules,
+replace refs, and grafts protect targets. The historical-base exception is the frozen
 `atrinik/atrinik@main` `build/worktrees/` contract at
 `ee5ba2096c94bce0161629423d4962a966bc61d8`. Apply re-inventories under the
 layout lock and removes only exact proven targets through non-force Git while

--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -54,13 +54,14 @@ Reclaim review data only through preview-first cleanup:
 ```sh
 ./atrinik cleanup --dry-run --json
 ./atrinik cleanup --scope sound-cache sound --older-than 7 --dry-run --json
-./atrinik cleanup --scope sound-cache sound --older-than 7 --apply
 ./atrinik cleanup --scope worktrees sound --older-than 7 --dry-run --json
+./atrinik cleanup --scope topologies --older-than 7 --dry-run --json
 ```
 
-Default cleanup covers worktrees/builds; caches are opt-in. Apply sound-cache
-before a fresh worktree preview because each cache protects its worktree. Sound
-build/verify shares the versioned Git-admin lease; removal locks its inode.
+Repeat a scoped command with `--apply` after review. Defaults cover
+worktrees/builds; caches and topology history are opt-in, and topologies are
+excluded from `all`. Reclaim only stopped, released, marker-owned records.
+Apply sound-cache before worktrees because each cache protects its worktree.
 Missing, replaced, invalid, busy, referenced, or unsafe targets fail closed.
 The sole historical-base exception is the frozen
 `atrinik/atrinik@main` `build/worktrees/` contract at

--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -21,9 +21,8 @@ Run from the `atrinik/atrinik` wrapper root.
    keep only orchestration, composition, manifest, and wrapper docs here.
 
 Checkouts are independent ignored repositories. A `classic` worktree contains
-all five `classic-*` components. Both stacks share `content@main`; Classic
-selects its publisher adapter, and retained `content-1x` paths are historical.
-Keep wrapper composition in `.devcontainer/` and reusable images in its owner.
+all five `classic-*` components. Both stacks share `content@main`; retained
+`content-1x` paths are historical. Keep composition in `.devcontainer/`.
 
 ## Prepare safe worktrees
 
@@ -42,7 +41,6 @@ clones.
 ./atrinik init [COMPONENT...]
 ./atrinik init --with classic
 ./atrinik sync [COMPONENT...]
-./atrinik sync --with classic
 ./atrinik worktree create COMPONENT LABEL --branch TYPE/TOPIC
 ```
 
@@ -58,20 +56,18 @@ Reclaim review data only through preview-first cleanup:
 ./atrinik cleanup --scope sound-cache sound --older-than 7 --dry-run --json
 ./atrinik cleanup --scope sound-cache sound --older-than 7 --apply
 ./atrinik cleanup --scope worktrees sound --older-than 7 --dry-run --json
-./atrinik cleanup --scope worktrees sound --older-than 7 --apply
 ```
 
-Default cleanup covers worktrees/builds; npm, compiler, and sound caches are
-opt-in. Apply sound-cache before a fresh worktree preview/apply because every
-remaining cache protects its worktree. Sound build/verify shares the exact
-versioned Git-admin lease; removal locks its same inode exclusively. Missing,
-replaced, invalid, or busy leases fail closed. References, ambiguous Git,
-unsafe paths/markers, populated submodules, replace refs, and grafts protect
-targets. The sole historical-base exception is the frozen
+Default cleanup covers worktrees/builds; caches are opt-in. Apply sound-cache
+before a fresh worktree preview because each cache protects its worktree. Sound
+build/verify shares the versioned Git-admin lease; removal locks its inode.
+Missing, replaced, invalid, busy, referenced, or unsafe targets fail closed.
+The sole historical-base exception is the frozen
 `atrinik/atrinik@main` `build/worktrees/` contract at
-`ee5ba2096c94bce0161629423d4962a966bc61d8`. Apply re-inventories under the
-layout lock and removes only exact proven targets through non-force Git while
-preserving refs, state, records, Git objects, reports, and unmarked paths.
+`ee5ba2096c94bce0161629423d4962a966bc61d8`. Apply locks and revalidates each
+exact target with its reference-publication coordinates, journals completed
+actions, skips busy targets, and uses non-force Git while preserving refs,
+state, records, objects, reports, and unmarked paths.
 
 ## Compose coherent sources
 
@@ -92,8 +88,11 @@ Classic selection is checkout-wide; subdirectories are not worktrees. Clean
 exact-coordinate content, resource, and region-map caches are reused; runtimes
 copy independent topology-owned snapshots.
 
-Readers share the layout lock. Writers announce, gate, then lock; all leases
-precede finer locks and diagnose 10-second waits. Fail closed without sharing.
+Lease order is registry, profile, Git-admin, source, topology/scenario, state,
+build, cache. Writers gate matching coordinates; physical leases span state
+roots and multi-source writers retry all-or-none. Only migration takes the
+barrier exclusively. Published runtimes retain sealed generation, process-tree,
+state, and port leases, not preparation leases. Fail closed without sharing.
 Incomplete coordinates are inert; wrapper owns paths, locks, state, PIDs, logs,
 content/resources and cleanup. Completion is bounded, local, read-only,
 secret-free and parser-driven before `Workspace`; stops at `--` or a `run`

--- a/.agents/skills/atrinik-server-runtime/SKILL.md
+++ b/.agents/skills/atrinik-server-runtime/SKILL.md
@@ -38,6 +38,18 @@ follow the reported safe action: wait for bounded guardian recovery and retry
 `ps` and `down`; preserve an exact retained lease for operator diagnosis.
 Never inspect `/proc`, signal the recorded PIDs, unlink control or lease files,
 or reuse the name as recovery.
+After `down`, retain the record for diagnosis or reclaim it only through the
+separate preview-first lifecycle:
+
+```sh
+./atrinik cleanup --scope topologies --older-than 7 --dry-run --json
+./atrinik cleanup --scope topologies --older-than 7 --apply
+```
+
+This scope is excluded from defaults and `all`. It accepts only old `exited` or
+legacy `stale` marker-owned records with unreachable controls and released
+leases; it never acts as `down` or touches persistent state, scenarios, builds,
+profiles, or source.
 The wrapper uses a short generation-derived endpoint in the shared workspace
 and binds both process-tree and immutable runtime-bundle leases to the exact
 generation and file identities. Missing, replaced, linked, or malformed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,12 +49,11 @@
 - Worktrees belong to physical checkouts. Selecting `classic`, a `classic-*`
   component, or one of its roles selects one root for all five; profiles append
   manifest source directories.
-- Use wrapper path/topology commands; never reconstruct managed paths. Give concurrent
-  topologies distinct names, states, ports, and client config.
-- Keep shell completion parser-driven, bounded, local-only, secret-free, and
-  ahead of `Workspace` construction.
-- Lease resources in order. Writers gate same-coordinate readers. Operations
-  share the migration barrier.
+- Use wrapper commands; never reconstruct paths. Isolate concurrent topology
+  names, states, ports, and config.
+- Keep completion bounded, local, parser-driven, secret-free, and before
+  `Workspace` construction.
+- Lease in order; gate same-coordinate readers; share the migration barrier.
 - Unbound persisted records are historical and inert.
 - On touch, refresh existing Atrinik-owned copyright terminal years and blanket
   holders per `CONTRIBUTING.md`; preserve precise attribution.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,12 +50,12 @@
 - Worktrees belong to physical checkouts. Selecting `classic`, a `classic-*`
   component, or one of its roles selects one root for all five; profiles append
   manifest source directories.
-- Use wrapper path/topology commands; never reconstruct managed paths. Give
-  concurrent topologies distinct names, states, ports, and client config.
+- Use wrapper paths; never reconstruct managed paths. Give concurrent
+  topologies distinct names, states, ports, and client config.
 - Keep shell completion parser-driven, bounded, local-only, secret-free, and
   ahead of `Workspace` construction.
-- Layout writers announce, gate, lock; they precede finer locks and diagnose
-  10-second waits.
+- Lease resources in order. Writers gate same-coordinate readers. Operations
+  share the migration barrier.
 - Unbound persisted records are historical and inert.
 - On touch, refresh existing Atrinik-owned copyright terminal years and blanket
   holders per `CONTRIBUTING.md`; preserve precise attribution.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,7 @@
 
 ## Overview
 
-- This MIT Python 3.11+ repository coordinates Atrinik repositories, not
-  component source.
+- This MIT Python 3.11+ repository coordinates Atrinik repositories, not source.
   `./atrinik` and `components.json` manage profiles, worktrees, builds, runtimes,
   cleanup, migration, and supply-chain reports.
 - `default` selects the MIT replacement stack (Rust, Go, Protobuf, and Astro).
@@ -50,7 +49,7 @@
 - Worktrees belong to physical checkouts. Selecting `classic`, a `classic-*`
   component, or one of its roles selects one root for all five; profiles append
   manifest source directories.
-- Use wrapper paths; never reconstruct managed paths. Give concurrent
+- Use wrapper path/topology commands; never reconstruct managed paths. Give concurrent
   topologies distinct names, states, ports, and client config.
 - Keep shell completion parser-driven, bounded, local-only, secret-free, and
   ahead of `Workspace` construction.
@@ -113,6 +112,7 @@ For cleanup changes also run:
 
 ```sh
 ./atrinik cleanup --scope all --older-than 7 --dry-run --json
+./atrinik cleanup --scope topologies --older-than 7 --dry-run --json
 ```
 
 Run ShellCheck for shell changes, actionlint for workflows, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,7 @@
 
 ## Overview
 
-- This MIT Python 3.11+ repository coordinates Atrinik repositories, not
-  component source.
+- This MIT Python 3.11+ repository coordinates Atrinik repositories, not source.
   `./atrinik` and `components.json` manage profiles, worktrees, builds, runtimes,
   cleanup, migration, and supply-chain reports.
 - `default` selects the MIT replacement stack (Rust, Go, Protobuf, and Astro).
@@ -50,13 +49,12 @@
 - Worktrees belong to physical checkouts. Selecting `classic`, a `classic-*`
   component, or one of its roles selects one root for all five; profiles append
   manifest source directories.
-- Use wrapper path/topology commands; never reconstruct managed paths. Give
-  concurrent topologies distinct names, states, ports, and client config.
-- Keep shell completion parser-driven, bounded, local-only, secret-free, and
-  ahead of `Workspace` construction.
+- Use wrapper path/topology commands; never reconstruct paths. Isolate
+  concurrent topology names, states, ports, and client config.
+- Keep completion parser-driven, bounded, local, secret-free, and ahead of
+  `Workspace` construction.
 - Layout writers announce, gate, lock; they precede finer locks and diagnose
   10-second waits.
-- Unbound persisted records are historical and inert.
 - On touch, refresh existing Atrinik-owned copyright terminal years and blanket
   holders per `CONTRIBUTING.md`; preserve precise attribution.
 - MIT reuse follows `docs/PROVENANCE.md` and its canonical identity registry;
@@ -113,6 +111,7 @@ For cleanup changes also run:
 
 ```sh
 ./atrinik cleanup --scope all --older-than 7 --dry-run --json
+./atrinik cleanup --scope topologies --older-than 7 --dry-run --json
 ```
 
 Run ShellCheck for shell changes, actionlint for workflows, and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,13 @@ components use their repository-owned aggregate validation today and remain
 inspectable through wrapper manifest/profile contracts until wrapper build
 adapters are implemented.
 
+For lease-graph, profile publication, Git administration, or cleanup changes,
+add process-rendezvous coverage for same-coordinate exclusion and fairness,
+disjoint-coordinate overlap, immutable profile generations, descriptor
+inheritance, reference-publication/removal races, and fail-closed diagnostics.
+Run the cleanup dry-run required by `AGENTS.md`; never use cleanup apply as
+validation.
+
 For CMake/cache changes, also repeat an unchanged build, exercise
 `--force-reconfigure` and `--no-ccache`, inspect `ccache --show-stats` when the
 command is installed, and preview shared-cache retention with

--- a/README.md
+++ b/README.md
@@ -630,12 +630,17 @@ without changing the filesystem:
 ./atrinik cleanup --scope worktrees classic-server --older-than 14
 ./atrinik cleanup --scope builds --scope npm-cache --scope compiler-cache --older-than 0
 ./atrinik cleanup --scope sound-cache --older-than 7 --dry-run --json
+./atrinik cleanup --scope topologies --older-than 7 --dry-run --json
+./atrinik cleanup --scope topologies --older-than 7 --apply
 ./atrinik cleanup --scope all --older-than 7 --apply
 ~~~
 
 `--dry-run` is the explicit spelling of the default mode; only `--apply`
 mutates. Repeated `--scope` options combine `worktrees`, `builds`, and the
 opt-in `npm-cache`, `compiler-cache`, and `sound-cache`; `all` selects all five.
+Topology history is a separate opt-in `topologies` scope and is deliberately
+excluded from both the default and `all`, so a broad cache/worktree cleanup
+cannot silently expand to runtime history.
 Positional checkout or logical component names narrow worktree and sound-cache
 inventory and still deduplicate
 aliases to one physical checkout. The special `atrinik` filter selects wrapper
@@ -728,11 +733,26 @@ worktree removal holds its exclusive side from final proof through Git removal,
 so a producer cannot start in the removal window. A sound worktree without the
 versioned producer lease marker is not reclaimable by wrapper cleanup.
 
+The explicit `topologies` scope inventories direct marker-owned directories
+below `workspace/topologies/`. It reports liveness, control generation,
+process-tree and repository-layout lease state, conservative age, and every
+path inside the directory that apply would remove. Only `exited` or legacy
+`stale` records with unreachable controls and proven-released leases are
+eligible. Orderly records age from `stopped_at`; a legacy stale record without
+that timestamp ages from the newest no-follow tree mtime, so missing history
+never bypasses the grace period. Live, unreachable, young, active-operation,
+linked, malformed, unowned, or unverifiable records remain protected. Apply
+holds the repository-layout writer lock, takes the exact topology operation
+lock, repeats identity/generation/lease/age/tree validation, and removes only
+that topology directory. It never invokes `down`, signals processes, reuses a
+name, removes build roots, or changes profiles, scenarios, source, or
+persistent server state.
+
 Apply holds the repository-layout lock and performs one complete inventory and
 size recomputation. Immediately before each removal it freshly revalidates the
 target's safety dependencies without rescanning unrelated report-only payloads.
-Any new uncertainty fails closed. It removes eligible profile builds and
-explicit sound-cache entries first, exact Git worktrees second, other explicit
+Any new uncertainty fails closed. It removes eligible topology records first,
+then profile builds and explicit sound-cache entries, exact Git worktrees second, other explicit
 caches next, and safely shared prunable Git metadata last. A pre-mutation race
 aborts without deletion; after the first
 successful mutation, the deterministic policy stops on the first error and
@@ -1220,6 +1240,8 @@ worktrees, so commit, stash, or otherwise preserve intentional edits first:
 
 ~~~sh
 ./atrinik down combined-review
+./atrinik cleanup --scope topologies --older-than 7 --dry-run --json
+./atrinik cleanup --scope topologies --older-than 7 --apply
 ./atrinik profile set combined-review classic --primary
 ./atrinik profile set combined-review content --primary
 ./atrinik cleanup --scope worktrees --scope builds \
@@ -1230,9 +1252,10 @@ worktrees, so commit, stash, or otherwise preserve intentional edits first:
 
 The saved `combined-review` profile protects both selected worktrees until the
 explicit `profile set` commands repoint it. Do that only when the retained
-review selection is no longer useful, then preview cleanup. Cleanup never removes profiles,
-scenarios, topology records/logs, state, migration evidence, commits, or
-branches.
+review selection and stopped topology history are no longer useful, then
+preview each cleanup scope. Only the explicit `topologies` scope removes
+eligible topology records and logs. Cleanup never removes profiles, scenarios,
+state, migration evidence, commits, or branches.
 
 ## Persistent server state
 

--- a/README.md
+++ b/README.md
@@ -630,12 +630,17 @@ without changing the filesystem:
 ./atrinik cleanup --scope worktrees classic-server --older-than 14
 ./atrinik cleanup --scope builds --scope npm-cache --scope compiler-cache --older-than 0
 ./atrinik cleanup --scope sound-cache --older-than 7 --dry-run --json
+./atrinik cleanup --scope topologies --older-than 7 --dry-run --json
+./atrinik cleanup --scope topologies --older-than 7 --apply
 ./atrinik cleanup --scope all --older-than 7 --apply
 ~~~
 
 `--dry-run` is the explicit spelling of the default mode; only `--apply`
 mutates. Repeated `--scope` options combine `worktrees`, `builds`, and the
 opt-in `npm-cache`, `compiler-cache`, and `sound-cache`; `all` selects all five.
+Topology history is a separate opt-in `topologies` scope and is deliberately
+excluded from both the default and `all`, so a broad cache/worktree cleanup
+cannot silently expand to runtime history.
 Positional checkout or logical component names narrow worktree and sound-cache
 inventory and still deduplicate
 aliases to one physical checkout. The special `atrinik` filter selects wrapper
@@ -728,14 +733,27 @@ worktree removal holds its exclusive side from final proof through Git removal,
 so a producer cannot start in the removal window. A sound worktree without the
 versioned producer lease marker is not reclaimable by wrapper cleanup.
 
+The explicit `topologies` scope inventories direct marker-owned directories
+below `workspace/topologies/`. It reports liveness, control generation,
+process-tree, runtime, port, and legacy repository-layout lease state,
+conservative age, and every path apply would remove. Only old `exited` or
+legacy `stale` records with unreachable controls and released leases are
+eligible. Orderly records age from `stopped_at`; legacy stale records without
+it use the newest no-follow tree mtime. Live, unreachable, young, locked,
+linked, malformed, unowned, or unverifiable records remain protected. Apply
+takes the exact topology coordinate lease and operation lock, repeats
+identity/generation/lease/age/tree validation, and removes only that topology
+directory. It never invokes `down`, signals processes, reuses a name, removes
+build roots, or changes profiles, scenarios, source, or persistent state.
+
 Apply performs one complete inventory and size recomputation, then acquires the
 exact target/reference leases and freshly revalidates each stable-sorted
 candidate without rescanning unrelated report-only payloads. Any new uncertainty
 fails closed. Busy targets are skipped so they do not convoy unrelated cleanup.
-Eligible profile builds and explicit sound-cache entries come first, exact Git
-worktrees second, other explicit caches next, and safely shared prunable Git
-metadata last. `workspace/cleanup-journals/` records the ordered targets and is
-atomically refreshed after every completed action; an unexpected interruption
+Eligible topology records come first, then profile builds and explicit
+sound-cache entries, exact Git worktrees, other explicit caches, and safely
+shared prunable Git metadata. `workspace/cleanup-journals/` records the ordered
+targets and is atomically refreshed after every completed action; interruption
 therefore preserves exact progress without claiming rollback.
 
 ## Composing coherent component sources
@@ -1239,6 +1257,8 @@ worktrees, so commit, stash, or otherwise preserve intentional edits first:
 
 ~~~sh
 ./atrinik down combined-review
+./atrinik cleanup --scope topologies --older-than 7 --dry-run --json
+./atrinik cleanup --scope topologies --older-than 7 --apply
 ./atrinik profile set combined-review classic --primary
 ./atrinik profile set combined-review content --primary
 ./atrinik cleanup --scope worktrees --scope builds \
@@ -1249,9 +1269,10 @@ worktrees, so commit, stash, or otherwise preserve intentional edits first:
 
 The saved `combined-review` profile protects both selected worktrees until the
 explicit `profile set` commands repoint it. Do that only when the retained
-review selection is no longer useful, then preview cleanup. Cleanup never removes profiles,
-scenarios, topology records/logs, state, migration evidence, commits, or
-branches.
+review selection and stopped topology history are no longer useful, then
+preview each cleanup scope. Only the explicit `topologies` scope removes
+eligible topology records and logs. Cleanup never removes profiles, scenarios,
+state, migration evidence, commits, or branches.
 
 ## Persistent server state
 

--- a/README.md
+++ b/README.md
@@ -728,15 +728,15 @@ worktree removal holds its exclusive side from final proof through Git removal,
 so a producer cannot start in the removal window. A sound worktree without the
 versioned producer lease marker is not reclaimable by wrapper cleanup.
 
-Apply holds the repository-layout lock and performs one complete inventory and
-size recomputation. Immediately before each removal it freshly revalidates the
-target's safety dependencies without rescanning unrelated report-only payloads.
-Any new uncertainty fails closed. It removes eligible profile builds and
-explicit sound-cache entries first, exact Git worktrees second, other explicit
-caches next, and safely shared prunable Git metadata last. A pre-mutation race
-aborts without deletion; after the first
-successful mutation, the deterministic policy stops on the first error and
-reports exactly what was reclaimed without claiming rollback.
+Apply performs one complete inventory and size recomputation, then acquires the
+exact target/reference leases and freshly revalidates each stable-sorted
+candidate without rescanning unrelated report-only payloads. Any new uncertainty
+fails closed. Busy targets are skipped so they do not convoy unrelated cleanup.
+Eligible profile builds and explicit sound-cache entries come first, exact Git
+worktrees second, other explicit caches next, and safely shared prunable Git
+metadata last. `workspace/cleanup-journals/` records the ordered targets and is
+atomically refreshed after every completed action; an unexpected interruption
+therefore preserves exact progress without claiming rollback.
 
 ## Composing coherent component sources
 
@@ -954,33 +954,52 @@ declaring the topology ready. Use
 `--service server` or `--service client` for a single service. Client startup
 requires a live forwarded display socket.
 
-Build and runtime-publication preparation hold a shared repository-layout lock.
-Different profile build roots may compile concurrently; an exclusive per-root
-lock still serializes the same root. Initialization, synchronization, worktree
-or profile changes, and cleanup apply take the layout lock exclusively, so they
-wait until every build or runtime reader finishes. A mutation first announces
-itself with a shared `repository-layout.writer-pending.lock`, then holds the
-exclusive `repository-layout.writer-intent.lock` admission gate. New readers
-briefly take the admission gate and proceed only when they can exclusively
-probe the pending lock; otherwise they release admission, wait for the announced
-writers, and retry. Readers admitted before a mutation finish normally while
-later arrivals cannot bypass it, and admitted readers continue to overlap.
-Repository migration uses the same
-exclusive layout mode but reports a busy result instead of waiting. The wrapper
-fails closed when advisory shared locking is unavailable. A wait longer than 10
-seconds emits one diagnostic naming safe `ps` and worktree inventories; it does
-not interrupt a reader, topology, build, or mutation. The pending announcement,
-writer-intent gate, and layout lock are always acquired before topology,
-scenario, port allocator/per-port reservation, state, build-root, registry, or
-cache locks. The allocator is released before state/build/runtime preparation;
-the exact generation reservation remains held. Foreground processes run from
-temporary immutable generations after releasing layout/build leases.
-Supervised services likewise run from topology-owned generations and retain
-only exact runtime-generation/process-tree resources plus server state and the
-selected port reservation when applicable. Mutation
-subprocesses inherit all three writer leases. Build and scenario
-subprocesses inherit every active layout, build-root, state, registry, and cache
-lease so an orphan cannot outlive its protection.
+Ordinary wrapper operations coordinate through fair, exact-resource leases,
+not the workspace-global layout lock. Workspace-local coordinates live under
+`workspace/leases/`; physical-checkout Git administration and source
+coordinates live under the wrapper's common-Git `atrinik-resource-leases/`
+namespace so wrapper worktrees or relocated state roots cannot split
+coordination. Every operation also retains its own wrapper-worktree source
+coordinate, preventing cleanup from removing the code and ignored component
+checkouts beneath an active wrapper view. Saved non-primary profile references
+are also registered in this physical namespace, so cleanup from a relocated
+state root observes references published by another root. Profile names, topology
+names, scenarios, states, build roots, and cache keys remain workspace-local.
+Requests acquire that deterministic order. A writer queued for one coordinate
+precedes later readers of that coordinate, while unrelated resources continue:
+two builds on different worktrees of one repository overlap, and init/sync for
+distinct checkouts do not convoy.
+Multi-source writers use all-or-none retry, so waiting for one busy source does
+not retain earlier disjoint source coordinates. Distinct explicit topology
+ports use exact startup locks; only automatic port selection briefly uses the
+allocator mutex.
+
+A build holds its profile-name lease while resolving, then locks the selected
+sources, revalidates them, and captures one immutable generation containing the
+stack/providers, exact roots, Git identities, HEADs, and dirty observations.
+The build persists that generation in `.atrinik-profile-resolution.json` and
+does not reread a mutable profile by name. Profile or topology publication and
+worktree removal share the target source lease, so cleanup cannot race a newly
+published exact reference. Cleanup apply locks and revalidates one stable-sorted
+candidate at a time, skips busy candidates, and journals completed actions in
+`workspace/cleanup-journals/`.
+
+Waits longer than 10 seconds report the resource kind, stable coordinate, known
+owner operation, and supported recovery command without relying on a
+namespace-local PID. The wrapper fails closed when advisory shared locking or
+resource identity is unavailable. Active preparation leases are inherited by
+subprocesses. Build and startup hold profile, source, and build-root leases only
+until a sealed runtime generation is published. Foreground processes then
+retain the runtime-generation lease plus server state when applicable;
+supervisors and guardians retain only runtime-generation, process-tree,
+server-state, and generation-specific port-reservation leases.
+
+The common-Git `repository-layout.lock` is the bounded maintenance barrier for
+schema/layout migration apply or restore. Ordinary exact-lease operations share
+the barrier, so they overlap one another but cannot race an exclusive migration;
+subprocesses inherit it only while they retain their exact operation leases.
+Migration entry points require or derive this physical barrier rather than
+falling back to the state-root-local legacy lock.
 
 The supervisor records exact source commits/trees, build metadata, runtime
 digests, state paths, and process start identities. `ps` without a name lists every recorded topology; a name

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -1111,6 +1111,25 @@ class Cleanup:
             reasons.append("topology_status_unverifiable")
             item["error"] = str(error)
 
+        if tree_error is None:
+            (
+                rechecked_identity,
+                rechecked_paths,
+                _rechecked_time,
+                _rechecked_inodes,
+                rechecked_error,
+            ) = _topology_tree_snapshot(path)
+            if (
+                rechecked_error is not None
+                or rechecked_identity != identity
+                or rechecked_paths != deletion_paths
+            ):
+                reasons.append("topology_changed_during_inventory")
+                item["error"] = rechecked_error or (
+                    f"topology tree changed during inventory: {path.name}"
+                )
+                item["tree_identity"] = None
+
         item["reasons"] = sorted(set(reasons)) or ["inactive_topology"]
         item["disposition"] = "eligible" if not reasons else "protected"
         return item

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from contextvars import copy_context
 from datetime import datetime, timezone
 import fcntl
@@ -9,11 +9,12 @@ import json
 import os
 from pathlib import Path, PurePosixPath
 import re
+import secrets
 import stat
 import subprocess
 from typing import Any, Iterable, Iterator
 
-from .locking import active_lock_fds
+from .locking import LockBusyError, active_lock_fds
 from .content_migration import CONTENT_MIGRATION_PENDING, CONTENT_MIGRATION_RECORD
 from .migration import MIGRATION_PENDING, MIGRATION_RECORD, OPERATION_PATHS
 from .model import (
@@ -21,6 +22,7 @@ from .model import (
     SCHEMA_VERSION,
     WorkspaceError,
     atomic_json,
+    durable_atomic_json,
     load_json,
     managed_remove,
 )
@@ -37,7 +39,6 @@ from .workspace import (
     COMPILER_CACHE_PURPOSE,
     _remote_matches,
     exclusive_lock,
-    exclusive_layout_lock,
     remove_owned_tree,
 )
 
@@ -460,21 +461,88 @@ class Cleanup:
             raise WorkspaceError(
                 f"workspace ownership marker is invalid: {self.paths.marker}"
             )
-        with exclusive_layout_lock(
-            self.paths.workspace / "repository-layout.lock",
-            "repository layout",
-        ):
-            report = self._plan(selected_scopes, older_than_days, selected_names, "apply")
-            if report["summary"]["error_count"]:
-                report["aborted"] = True
-                return report
-            targets = [
-                item for item in report["items"] if item["disposition"] == "eligible"
-            ]
-            targets.sort(key=self._apply_order)
-            mutated = False
-            completed: set[tuple[str, str]] = set()
-            for target in targets:
+        report = self._plan(selected_scopes, older_than_days, selected_names, "apply")
+        if report["summary"]["error_count"]:
+            report["aborted"] = True
+            return report
+        targets = [
+            item for item in report["items"] if item["disposition"] == "eligible"
+        ]
+        targets.sort(key=self._apply_order)
+        mutated = False
+        completed: set[tuple[str, str]] = set()
+        report["completed_actions"] = []
+        journal_path = (
+            self.paths.workspace
+            / "cleanup-journals"
+            / f"{self.now.strftime('%Y%m%dT%H%M%S%fZ')}-{secrets.token_hex(6)}.json"
+        )
+        journal: dict[str, Any] = {
+            "schema_version": 1,
+            "started_at": self.now.isoformat(),
+            "status": "in-progress",
+            "targets": [
+                {"kind": target["kind"], "path": target["path"]}
+                for target in targets
+            ],
+            "completed": [],
+        }
+        durable_atomic_json(journal_path, journal)
+        report["journal"] = str(journal_path)
+        for target in targets:
+            with ExitStack() as target_stack:
+                if target["kind"] in {"worktree", "prunable-metadata"}:
+                    owner = target["owner"]
+                    checkout = self.manifest.by_checkout.get(owner)
+                    primary = (
+                        self.paths.repository
+                        if owner == "atrinik"
+                        else self.paths.repositories / checkout.path
+                        if checkout is not None
+                        else None
+                    )
+                    if primary is None:
+                        target["disposition"] = "error"
+                        target["reasons"] = ["unknown_worktree_owner"]
+                        report["aborted"] = True
+                        break
+                    requests = [
+                        self.workspace._lease_request(
+                            "git-admin",
+                            (
+                                self.workspace._git_admin_coordinate(
+                                    checkout, primary
+                                )
+                                if checkout is not None
+                                else self.workspace._wrapper_git_admin_coordinate()
+                            ),
+                            "exclusive",
+                            f"cleanup {target['kind']} {target['path']}",
+                        )
+                    ]
+                    if target["kind"] == "worktree":
+                        requests.append(
+                            self.workspace._lease_request(
+                                "source",
+                                self.workspace._source_coordinate(
+                                    owner, Path(target["path"])
+                                ),
+                                "exclusive",
+                                f"cleanup worktree {target['path']}",
+                            )
+                        )
+                    try:
+                        target_stack.enter_context(
+                            self.workspace._resource_locks(
+                                requests,
+                                nonblocking=True,
+                            )
+                        )
+                    except LockBusyError as error:
+                        target["disposition"] = "skipped"
+                        target["reasons"] = ["resource_busy"]
+                        target["error"] = str(error)
+                        continue
                 identity = (target["kind"], target["path"])
                 if identity in completed:
                     continue
@@ -513,6 +581,11 @@ class Cleanup:
                 report["mutation_attempted"] = True
                 try:
                     self._remove(match, older_than_days)
+                except LockBusyError as error:
+                    target["disposition"] = "skipped"
+                    target["reasons"] = ["resource_busy"]
+                    target["error"] = str(error)
+                    continue
                 except (OSError, RuntimeError, WorkspaceError) as error:
                     target["disposition"] = "error"
                     target["reasons"] = ["removal_failed"]
@@ -523,6 +596,19 @@ class Cleanup:
                 target["reasons"] = ["removed"]
                 mutated = True
                 completed.add(identity)
+                report["completed_actions"].append(
+                    {"kind": target["kind"], "path": target["path"]}
+                )
+                journal["completed"] = list(report["completed_actions"])
+                try:
+                    durable_atomic_json(journal_path, journal)
+                except (OSError, RuntimeError, WorkspaceError) as error:
+                    report["aborted"] = True
+                    report["journal_error"] = (
+                        "cleanup removed the reported target but could not durably "
+                        f"refresh its progress journal: {error}"
+                    )
+                    break
                 if target["kind"] == "prunable-metadata":
                     for related in targets:
                         if (
@@ -532,10 +618,21 @@ class Cleanup:
                             related["disposition"] = "removed"
                             related["reasons"] = ["removed"]
                             completed.add((related["kind"], related["path"]))
-            report["mutated"] = mutated
-            report.setdefault("mutation_attempted", False)
-            report["summary"] = self._summary(report["items"])
-            return report
+        report["mutated"] = mutated
+        report.setdefault("mutation_attempted", False)
+        report["summary"] = self._summary(report["items"])
+        journal["status"] = "aborted" if report.get("aborted") else "complete"
+        journal["finished_at"] = datetime.now(timezone.utc).isoformat()
+        try:
+            durable_atomic_json(journal_path, journal)
+        except (OSError, RuntimeError, WorkspaceError) as error:
+            report["aborted"] = True
+            report.setdefault(
+                "journal_error",
+                "cleanup completed the reported actions but could not durably "
+                f"finalize its journal: {error}",
+            )
+        return report
 
     @staticmethod
     def _normalize_scopes(scopes: list[str]) -> list[str]:
@@ -964,6 +1061,30 @@ class Cleanup:
             return False
 
     def _profile_references(self, references: dict[str, Any], errors: set[str]) -> None:
+        try:
+            for record in self.workspace._physical_reference_records():
+                if (
+                    not isinstance(record, dict)
+                    or set(record)
+                    != {"schema_version", "kind", "reference", "sources"}
+                    or record["schema_version"] != 1
+                    or record["kind"] not in {"profiles", "scenarios"}
+                    or not isinstance(record["reference"], str)
+                    or not isinstance(record["sources"], list)
+                    or not all(
+                        isinstance(source, str) and Path(source).is_absolute()
+                        for source in record["sources"]
+                    )
+                ):
+                    raise WorkspaceError("physical profile reference is invalid")
+                for source in record["sources"]:
+                    self._add_reference(
+                        references[record["kind"]],
+                        Path(source),
+                        record["reference"],
+                    )
+        except (OSError, WorkspaceError):
+            errors.add("profile_inventory_error")
         if not self.paths.profiles.is_dir() or self.paths.profiles.is_symlink():
             if self.paths.profiles.exists() or self.paths.profiles.is_symlink():
                 errors.add("profile_inventory_error")
@@ -1460,6 +1581,8 @@ class Cleanup:
         primary_item = normalized == primary.resolve()
         if primary_item:
             item["reasons"].append("primary_checkout")
+        if owner == "atrinik" and normalized == self.paths.repository.resolve():
+            item["reasons"].append("active_wrapper_view")
         reference_reasons = {
             "profiles": "profile_reference",
             "scenarios": "scenario_reference",

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -1130,12 +1130,16 @@ class Cleanup:
             item["error"] = tree_error
 
         if check_operation:
-            busy, lock_error = self._lock_busy(path / "operation.lock")
-            if busy:
-                reasons.append("active_topology_operation")
-            if lock_error:
-                reasons.append("invalid_topology_operation_lock")
-                item["error"] = lock_error
+            operation_lock = path / "operation.lock"
+            if not operation_lock.exists() and not operation_lock.is_symlink():
+                reasons.append("topology_operation_lock_unavailable")
+            else:
+                busy, lock_error = self._lock_busy(operation_lock)
+                if busy:
+                    reasons.append("active_topology_operation")
+                if lock_error:
+                    reasons.append("invalid_topology_operation_lock")
+                    item["error"] = lock_error
 
         try:
             status = self.workspace.topology_status(path.name)

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -5,6 +5,7 @@ from contextlib import ExitStack, contextmanager
 from contextvars import copy_context
 from datetime import datetime, timezone
 import fcntl
+import hashlib
 import json
 import os
 from pathlib import Path, PurePosixPath
@@ -49,6 +50,7 @@ WORKER_DEPENDENCY_CLEANUP_SCHEMA_VERSIONS = frozenset(
 )
 DEFAULT_SCOPES = ("worktrees", "builds")
 ALL_SCOPES = (*DEFAULT_SCOPES, "npm-cache", "compiler-cache", "sound-cache")
+SUPPORTED_SCOPES = (*ALL_SCOPES, "topologies")
 BUILD_RETENTION_RECORD = "retention.json"
 LEGACY_BUILD_METADATA_SCHEMA_VERSION = 1
 LEGACY_BUILD_METADATA_KEYS = {
@@ -377,6 +379,153 @@ def _tree_usage(
     return sizes, observed, None
 
 
+def _topology_tree_snapshot(
+    root: Path,
+) -> tuple[
+    str | None,
+    list[str],
+    datetime | None,
+    dict[tuple[int, int], int],
+    str | None,
+]:
+    """Snapshot one topology tree without following links or special files."""
+
+    rows: list[tuple[Any, ...]] = []
+    paths: list[str] = []
+    sizes: dict[tuple[int, int], int] = {}
+    maximum: float | None = None
+    parent_descriptor: int | None = None
+    root_descriptor: int | None = None
+
+    def record(metadata: os.stat_result, relative: str, display: Path) -> None:
+        nonlocal maximum
+        if metadata.st_dev != root_device:
+            raise WorkspaceError(f"topology tree contains a mount: {display}")
+        if not (
+            stat.S_ISDIR(metadata.st_mode) or stat.S_ISREG(metadata.st_mode)
+        ):
+            raise WorkspaceError(f"topology tree contains a special file: {display}")
+        if stat.S_ISREG(metadata.st_mode) and metadata.st_nlink != 1:
+            raise WorkspaceError(f"topology tree contains a linked file: {display}")
+        rows.append(
+            (
+                relative,
+                metadata.st_dev,
+                metadata.st_ino,
+                stat.S_IFMT(metadata.st_mode),
+                stat.S_IMODE(metadata.st_mode),
+                metadata.st_nlink,
+                metadata.st_size,
+                metadata.st_blocks,
+                metadata.st_mtime_ns,
+                metadata.st_ctime_ns,
+            )
+        )
+        paths.append(str(display))
+        sizes.setdefault(
+            (metadata.st_dev, metadata.st_ino), metadata.st_blocks * 512
+        )
+        maximum = (
+            metadata.st_mtime
+            if maximum is None
+            else max(maximum, metadata.st_mtime)
+        )
+
+    def walk(descriptor: int, relative: str, display: Path) -> None:
+        record(os.fstat(descriptor), relative, display)
+        for name in sorted(os.listdir(descriptor)):
+            child_display = display / name
+            child_relative = name if relative == "." else f"{relative}/{name}"
+            metadata = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
+            if stat.S_ISLNK(metadata.st_mode):
+                raise WorkspaceError(
+                    f"topology tree contains a symbolic link: {child_display}"
+                )
+            if stat.S_ISDIR(metadata.st_mode):
+                child_descriptor = os.open(
+                    name,
+                    os.O_RDONLY
+                    | os.O_DIRECTORY
+                    | os.O_CLOEXEC
+                    | getattr(os, "O_NOFOLLOW", 0),
+                    dir_fd=descriptor,
+                )
+                try:
+                    opened = os.fstat(child_descriptor)
+                    if (opened.st_dev, opened.st_ino) != (
+                        metadata.st_dev,
+                        metadata.st_ino,
+                    ):
+                        raise WorkspaceError(
+                            f"topology tree changed during inventory: {child_display}"
+                        )
+                    walk(child_descriptor, child_relative, child_display)
+                finally:
+                    os.close(child_descriptor)
+            else:
+                record(metadata, child_relative, child_display)
+
+    try:
+        parent_descriptor = os.open(
+            root.parent,
+            os.O_RDONLY
+            | os.O_DIRECTORY
+            | os.O_CLOEXEC
+            | getattr(os, "O_NOFOLLOW", 0),
+        )
+        root_metadata = os.stat(
+            root.name, dir_fd=parent_descriptor, follow_symlinks=False
+        )
+        if not stat.S_ISDIR(root_metadata.st_mode) or stat.S_ISLNK(
+            root_metadata.st_mode
+        ):
+            raise WorkspaceError("topology root is not a regular directory")
+        root_device = root_metadata.st_dev
+        root_descriptor = os.open(
+            root.name,
+            os.O_RDONLY
+            | os.O_DIRECTORY
+            | os.O_CLOEXEC
+            | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=parent_descriptor,
+        )
+        opened = os.fstat(root_descriptor)
+        if (opened.st_dev, opened.st_ino) != (
+            root_metadata.st_dev,
+            root_metadata.st_ino,
+        ):
+            raise WorkspaceError(f"topology root changed during inventory: {root}")
+        walk(root_descriptor, ".", root)
+        retained = os.stat(
+            root.name, dir_fd=parent_descriptor, follow_symlinks=False
+        )
+        if (retained.st_dev, retained.st_ino) != (
+            opened.st_dev,
+            opened.st_ino,
+        ):
+            raise WorkspaceError(f"topology root changed during inventory: {root}")
+        payload = json.dumps(rows, separators=(",", ":"), ensure_ascii=True)
+        observed = (
+            datetime.fromtimestamp(maximum, timezone.utc)
+            if maximum is not None
+            else None
+        )
+        return (
+            hashlib.sha256(payload.encode()).hexdigest(),
+            sorted(paths),
+            observed,
+            sizes,
+            None,
+        )
+    except (OSError, RuntimeError, WorkspaceError) as error:
+        return None, sorted(paths), None, {}, str(error)
+    finally:
+        if root_descriptor is not None:
+            os.close(root_descriptor)
+        if parent_descriptor is not None:
+            os.close(parent_descriptor)
+
+
 def _listed_usage(root: Path, relative_paths: Iterable[str]) -> dict[tuple[int, int], int]:
     """Account for Git-listed paths without resolving and rewalking every file."""
 
@@ -543,6 +692,26 @@ class Cleanup:
                         target["reasons"] = ["resource_busy"]
                         target["error"] = str(error)
                         continue
+                elif target["kind"] == "topology":
+                    try:
+                        target_stack.enter_context(
+                            self.workspace._resource_locks(
+                                [
+                                    self.workspace._lease_request(
+                                        "topology",
+                                        target["name"],
+                                        "exclusive",
+                                        f"cleanup topology {target['name']}",
+                                    )
+                                ],
+                                nonblocking=True,
+                            )
+                        )
+                    except LockBusyError as error:
+                        target["disposition"] = "skipped"
+                        target["reasons"] = ["resource_busy"]
+                        target["error"] = str(error)
+                        continue
                 identity = (target["kind"], target["path"])
                 if identity in completed:
                     continue
@@ -638,8 +807,8 @@ class Cleanup:
     def _normalize_scopes(scopes: list[str]) -> list[str]:
         requested = scopes or list(DEFAULT_SCOPES)
         if "all" in requested:
-            requested = list(ALL_SCOPES)
-        return [scope for scope in ALL_SCOPES if scope in set(requested)]
+            requested = [*requested, *ALL_SCOPES]
+        return [scope for scope in SUPPORTED_SCOPES if scope in set(requested)]
 
     def _normalize_names(self, names: list[str]) -> set[str] | None:
         if not names:
@@ -669,11 +838,25 @@ class Cleanup:
         mode: str,
     ) -> dict[str, Any]:
         self._reset_inventory()
-        references, reference_errors = self._references()
+        topology_only = set(scopes) == {"topologies"}
+        if topology_only:
+            references = {
+                "profiles": {},
+                "scenarios": {},
+                "topologies": {},
+                "live_builds": {},
+                "migration": {},
+                "retention": {},
+            }
+            reference_errors: set[str] = set()
+        else:
+            references, reference_errors = self._references()
         items: list[dict[str, Any]] = []
-        registered, registered_error = self._registered_worktree_paths()
-        if registered_error:
-            reference_errors.add("worktree_inventory_error")
+        registered: set[Path] = set()
+        if not topology_only:
+            registered, registered_error = self._registered_worktree_paths()
+            if registered_error:
+                reference_errors.add("worktree_inventory_error")
         if "worktrees" in scopes:
             worktrees, _ = self._worktrees(names, references, reference_errors)
             items.extend(worktrees)
@@ -712,6 +895,13 @@ class Cleanup:
         if "sound-cache" in scopes and (names is None or "sound" in names):
             items.extend(
                 self._sound_caches(older_than_days, reference_errors)
+            )
+        if "topologies" in scopes:
+            items.extend(
+                self._topologies(
+                    older_than_days,
+                    check_layout=mode == "dry-run",
+                )
             )
         items.sort(key=lambda item: (item["kind"], item["owner"], item["path"]))
         self._credit_sizes(items)
@@ -758,12 +948,23 @@ class Cleanup:
         """Refresh one target's safety predicates without rebuilding report payloads."""
 
         self._reset_inventory()
+        path = Path(target["path"])
+        kind = target["kind"]
+        if kind == "topology":
+            item = self._topology_item(
+                path,
+                older_than_days,
+                check_layout=False,
+            )
+            if not self._same_topology_snapshot(target, item):
+                raise WorkspaceError(
+                    f"topology changed during apply revalidation: {target['name']}"
+                )
+            return item
         references, reference_errors = self._references()
         registered, registered_error = self._registered_worktree_paths()
         if registered_error:
             reference_errors.add("worktree_inventory_error")
-        path = Path(target["path"])
-        kind = target["kind"]
         if kind == "profile-build":
             removable_worktrees = (
                 self._revalidate_build_sources(
@@ -845,6 +1046,193 @@ class Cleanup:
                 item["_sound_worktree_identity"] = sound_worktree_identity
                 item["_sound_producer_identity"] = sound_producer_identity
         return item
+
+    def _topologies(
+        self, older_than_days: int, *, check_layout: bool
+    ) -> list[dict[str, Any]]:
+        root = self.paths.topologies
+        if not root.exists() and not root.is_symlink():
+            return []
+        if root.is_symlink() or not root.is_dir():
+            item = _base_item("topology", "atrinik", "atrinik/atrinik", root)
+            item["reasons"] = ["invalid_topology_container"]
+            return [item]
+        infrastructure = {"port-reservations", "ports.lock"}
+        return [
+            self._topology_item(path, older_than_days, check_layout=check_layout)
+            for path in sorted(root.iterdir())
+            if path.name not in infrastructure
+        ]
+
+    def _topology_item(
+        self,
+        path: Path,
+        older_than_days: int,
+        *,
+        check_layout: bool,
+        check_operation: bool = True,
+    ) -> dict[str, Any]:
+        item = _base_item("topology", "atrinik", "atrinik/atrinik", path)
+        item.update(
+            {
+                "name": path.name,
+                "liveness": "unverifiable",
+                "control_observation": "unverifiable",
+                "generation": None,
+                "process_tree_lease": "unverifiable",
+                "runtime_bundle_lease": "unverifiable",
+                "port_reservation_lease": "unverifiable",
+                "repository_layout_lease": "unverifiable",
+                "age_observed_at": None,
+                "deletion_paths": [],
+                "tree_identity": None,
+            }
+        )
+        reasons: list[str] = []
+        try:
+            if not self._owned_direct_child(path, self.paths.topologies):
+                raise WorkspaceError("topology is not a direct managed child")
+            marker = path / MANAGED_MARKER
+            if (
+                path.is_symlink()
+                or not path.is_dir()
+                or marker.is_symlink()
+                or not marker.is_file()
+                or load_json(marker)
+                != {
+                    "schema_version": SCHEMA_VERSION,
+                    "purpose": f"topology:{path.name}",
+                }
+            ):
+                raise WorkspaceError("topology ownership marker is invalid")
+        except (OSError, RuntimeError, WorkspaceError) as error:
+            item["reasons"] = ["invalid_topology_ownership"]
+            item["error"] = str(error)
+            return item
+
+        (
+            identity,
+            deletion_paths,
+            tree_time,
+            inodes,
+            tree_error,
+        ) = _topology_tree_snapshot(path)
+        item["tree_identity"] = identity
+        item["deletion_paths"] = deletion_paths
+        item["_inodes"] = inodes
+        if tree_error is not None:
+            reasons.append("invalid_topology_tree")
+            item["error"] = tree_error
+
+        if check_operation:
+            busy, lock_error = self._lock_busy(path / "operation.lock")
+            if busy:
+                reasons.append("active_topology_operation")
+            if lock_error:
+                reasons.append("invalid_topology_operation_lock")
+                item["error"] = lock_error
+
+        try:
+            status = self.workspace.topology_status(path.name)
+            supervisor = status["supervisor"]
+            services = status["services"].values()
+            observed = [supervisor["liveness"], *(row["liveness"] for row in services)]
+            if "live" in observed:
+                liveness = "live"
+            elif "unreachable" in observed:
+                liveness = "unreachable"
+            elif "stale" in observed:
+                liveness = "stale"
+            else:
+                liveness = "exited"
+            observation = status["observation"]
+            item["liveness"] = liveness
+            item["control_observation"] = observation["control"]
+            item["generation"] = observation["generation"]
+            item["process_tree_lease"] = observation["process_tree_lease"]
+            item["runtime_bundle_lease"] = observation.get(
+                "runtime_bundle_lease", "unverifiable"
+            )
+            if liveness == "live":
+                reasons.append("live_topology")
+            elif liveness == "unreachable":
+                reasons.append("unreachable_topology")
+            if observation["control"] == "reachable":
+                reasons.append("reachable_topology_control")
+            if observation["process_tree_lease"] == "retained":
+                reasons.append("process_tree_lease_retained")
+            elif observation["process_tree_lease"] != "released":
+                reasons.append("process_tree_lease_unverifiable")
+            if item["runtime_bundle_lease"] == "retained":
+                reasons.append("runtime_bundle_lease_retained")
+            elif item["runtime_bundle_lease"] not in {"released", "historical"}:
+                reasons.append("runtime_bundle_lease_unverifiable")
+            port = observation.get("port_reservation")
+            if port is None:
+                item["port_reservation_lease"] = "released"
+            elif isinstance(port, dict) and port.get("lease") in {
+                "released",
+                "retained",
+            }:
+                item["port_reservation_lease"] = port["lease"]
+            if item["port_reservation_lease"] == "retained":
+                reasons.append("port_reservation_lease_retained")
+            elif item["port_reservation_lease"] != "released":
+                reasons.append("port_reservation_lease_unverifiable")
+            if observation.get("repository_layout_lease_owner") is not None:
+                reasons.append("repository_layout_lease_retained")
+                item["repository_layout_lease"] = "retained"
+            else:
+                item["repository_layout_lease"] = "released"
+
+            stopped_at = status.get("stopped_at")
+            if stopped_at is not None:
+                age_time = _parse_time(stopped_at, "topology stopped_at")
+                item["age_basis"] = "stopped-at"
+            elif liveness == "stale":
+                age_time = tree_time
+                item["age_basis"] = "legacy-tree-mtime" if tree_time else None
+            else:
+                age_time = None
+                item["age_basis"] = None
+                reasons.append("topology_stopped_at_unavailable")
+            if age_time is None:
+                reasons.append("topology_age_unavailable")
+            else:
+                item["age_observed_at"] = age_time.isoformat()
+                age_seconds = int((self.now - age_time).total_seconds())
+                item["age_seconds"] = max(0, age_seconds)
+                if age_time > self.now:
+                    reasons.append("future_topology_timestamp")
+                elif age_seconds < older_than_days * 86400:
+                    reasons.append("topology_younger_than_grace_period")
+        except (OSError, RuntimeError, KeyError, WorkspaceError) as error:
+            reasons.append("topology_status_unverifiable")
+            item["error"] = str(error)
+
+        item["reasons"] = sorted(set(reasons)) or ["inactive_topology"]
+        item["disposition"] = "eligible" if not reasons else "protected"
+        return item
+
+    @staticmethod
+    def _same_topology_snapshot(
+        expected: dict[str, Any], current: dict[str, Any]
+    ) -> bool:
+        keys = (
+            "disposition",
+            "liveness",
+            "control_observation",
+            "generation",
+            "process_tree_lease",
+            "runtime_bundle_lease",
+            "port_reservation_lease",
+            "repository_layout_lease",
+            "age_basis",
+            "age_observed_at",
+            "tree_identity",
+            "deletion_paths",
+        )
+        return all(current.get(key) == expected.get(key) for key in keys)
 
     def _revalidate_build_sources(
         self,
@@ -3088,6 +3476,7 @@ class Cleanup:
     @staticmethod
     def _apply_order(item: dict[str, Any]) -> tuple[int, str]:
         order = {
+            "topology": -1,
             "profile-build": 0,
             "worker-dependencies": 0,
             "worker-dependency-transaction": 0,
@@ -3113,6 +3502,31 @@ class Cleanup:
                     self.paths.builds,
                     f"profile:{item['profile']}:{item['key']}",
                 )
+        elif item["kind"] == "topology":
+            with exclusive_lock(
+                path / "operation.lock",
+                f"topology {item['name']} operation",
+                nonblocking=True,
+            ):
+                current = self._topology_item(
+                    path,
+                    older_than_days,
+                    check_layout=False,
+                    check_operation=False,
+                )
+                if not self._same_topology_snapshot(item, current):
+                    raise WorkspaceError(
+                        f"topology changed before removal: {item['name']}"
+                    )
+                marker = path / MANAGED_MARKER
+                if load_json(marker) != {
+                    "schema_version": SCHEMA_VERSION,
+                    "purpose": f"topology:{item['name']}",
+                }:
+                    raise WorkspaceError(
+                        f"topology ownership changed before removal: {item['name']}"
+                    )
+                remove_owned_tree(path)
         elif item["kind"] == "worker-dependencies":
             lock = (
                 self.paths.builds

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -1054,7 +1054,7 @@ class Cleanup:
         if not root.exists() and not root.is_symlink():
             return []
         if root.is_symlink() or not root.is_dir():
-            item = _base_item("topology", "atrinik", "atrinik/atrinik", root)
+            item = self._base_topology_item(root)
             item["reasons"] = ["invalid_topology_container"]
             return [item]
         infrastructure = {"port-reservations", "ports.lock"}
@@ -1064,14 +1064,8 @@ class Cleanup:
             if path.name not in infrastructure
         ]
 
-    def _topology_item(
-        self,
-        path: Path,
-        older_than_days: int,
-        *,
-        check_layout: bool,
-        check_operation: bool = True,
-    ) -> dict[str, Any]:
+    @staticmethod
+    def _base_topology_item(path: Path) -> dict[str, Any]:
         item = _base_item("topology", "atrinik", "atrinik/atrinik", path)
         item.update(
             {
@@ -1088,6 +1082,17 @@ class Cleanup:
                 "tree_identity": None,
             }
         )
+        return item
+
+    def _topology_item(
+        self,
+        path: Path,
+        older_than_days: int,
+        *,
+        check_layout: bool,
+        check_operation: bool = True,
+    ) -> dict[str, Any]:
+        item = self._base_topology_item(path)
         reasons: list[str] = []
         try:
             if not self._owned_direct_child(path, self.paths.topologies):

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -1013,12 +1013,16 @@ class Cleanup:
             item["error"] = tree_error
 
         if check_operation:
-            busy, lock_error = self._lock_busy(path / "operation.lock")
-            if busy:
-                reasons.append("active_topology_operation")
-            if lock_error:
-                reasons.append("invalid_topology_operation_lock")
-                item["error"] = lock_error
+            operation_lock = path / "operation.lock"
+            if not operation_lock.exists() and not operation_lock.is_symlink():
+                reasons.append("topology_operation_lock_unavailable")
+            else:
+                busy, lock_error = self._lock_busy(operation_lock)
+                if busy:
+                    reasons.append("active_topology_operation")
+                if lock_error:
+                    reasons.append("invalid_topology_operation_lock")
+                    item["error"] = lock_error
 
         if check_layout:
             busy, lock_error = self._lock_busy(

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from contextvars import copy_context
 from datetime import datetime, timezone
 import fcntl
+import hashlib
 import json
 import os
 from pathlib import Path, PurePosixPath
@@ -48,6 +49,7 @@ WORKER_DEPENDENCY_CLEANUP_SCHEMA_VERSIONS = frozenset(
 )
 DEFAULT_SCOPES = ("worktrees", "builds")
 ALL_SCOPES = (*DEFAULT_SCOPES, "npm-cache", "compiler-cache", "sound-cache")
+SUPPORTED_SCOPES = (*ALL_SCOPES, "topologies")
 BUILD_RETENTION_RECORD = "retention.json"
 LEGACY_BUILD_METADATA_SCHEMA_VERSION = 1
 LEGACY_BUILD_METADATA_KEYS = {
@@ -376,6 +378,153 @@ def _tree_usage(
     return sizes, observed, None
 
 
+def _topology_tree_snapshot(
+    root: Path,
+) -> tuple[
+    str | None,
+    list[str],
+    datetime | None,
+    dict[tuple[int, int], int],
+    str | None,
+]:
+    """Snapshot one topology tree without following links or special files."""
+
+    rows: list[tuple[Any, ...]] = []
+    paths: list[str] = []
+    sizes: dict[tuple[int, int], int] = {}
+    maximum: float | None = None
+    parent_descriptor: int | None = None
+    root_descriptor: int | None = None
+
+    def record(metadata: os.stat_result, relative: str, display: Path) -> None:
+        nonlocal maximum
+        if metadata.st_dev != root_device:
+            raise WorkspaceError(f"topology tree contains a mount: {display}")
+        if not (
+            stat.S_ISDIR(metadata.st_mode) or stat.S_ISREG(metadata.st_mode)
+        ):
+            raise WorkspaceError(f"topology tree contains a special file: {display}")
+        if stat.S_ISREG(metadata.st_mode) and metadata.st_nlink != 1:
+            raise WorkspaceError(f"topology tree contains a linked file: {display}")
+        rows.append(
+            (
+                relative,
+                metadata.st_dev,
+                metadata.st_ino,
+                stat.S_IFMT(metadata.st_mode),
+                stat.S_IMODE(metadata.st_mode),
+                metadata.st_nlink,
+                metadata.st_size,
+                metadata.st_blocks,
+                metadata.st_mtime_ns,
+                metadata.st_ctime_ns,
+            )
+        )
+        paths.append(str(display))
+        sizes.setdefault(
+            (metadata.st_dev, metadata.st_ino), metadata.st_blocks * 512
+        )
+        maximum = (
+            metadata.st_mtime
+            if maximum is None
+            else max(maximum, metadata.st_mtime)
+        )
+
+    def walk(descriptor: int, relative: str, display: Path) -> None:
+        record(os.fstat(descriptor), relative, display)
+        for name in sorted(os.listdir(descriptor)):
+            child_display = display / name
+            child_relative = name if relative == "." else f"{relative}/{name}"
+            metadata = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
+            if stat.S_ISLNK(metadata.st_mode):
+                raise WorkspaceError(
+                    f"topology tree contains a symbolic link: {child_display}"
+                )
+            if stat.S_ISDIR(metadata.st_mode):
+                child_descriptor = os.open(
+                    name,
+                    os.O_RDONLY
+                    | os.O_DIRECTORY
+                    | os.O_CLOEXEC
+                    | getattr(os, "O_NOFOLLOW", 0),
+                    dir_fd=descriptor,
+                )
+                try:
+                    opened = os.fstat(child_descriptor)
+                    if (opened.st_dev, opened.st_ino) != (
+                        metadata.st_dev,
+                        metadata.st_ino,
+                    ):
+                        raise WorkspaceError(
+                            f"topology tree changed during inventory: {child_display}"
+                        )
+                    walk(child_descriptor, child_relative, child_display)
+                finally:
+                    os.close(child_descriptor)
+            else:
+                record(metadata, child_relative, child_display)
+
+    try:
+        parent_descriptor = os.open(
+            root.parent,
+            os.O_RDONLY
+            | os.O_DIRECTORY
+            | os.O_CLOEXEC
+            | getattr(os, "O_NOFOLLOW", 0),
+        )
+        root_metadata = os.stat(
+            root.name, dir_fd=parent_descriptor, follow_symlinks=False
+        )
+        if not stat.S_ISDIR(root_metadata.st_mode) or stat.S_ISLNK(
+            root_metadata.st_mode
+        ):
+            raise WorkspaceError("topology root is not a regular directory")
+        root_device = root_metadata.st_dev
+        root_descriptor = os.open(
+            root.name,
+            os.O_RDONLY
+            | os.O_DIRECTORY
+            | os.O_CLOEXEC
+            | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=parent_descriptor,
+        )
+        opened = os.fstat(root_descriptor)
+        if (opened.st_dev, opened.st_ino) != (
+            root_metadata.st_dev,
+            root_metadata.st_ino,
+        ):
+            raise WorkspaceError(f"topology root changed during inventory: {root}")
+        walk(root_descriptor, ".", root)
+        retained = os.stat(
+            root.name, dir_fd=parent_descriptor, follow_symlinks=False
+        )
+        if (retained.st_dev, retained.st_ino) != (
+            opened.st_dev,
+            opened.st_ino,
+        ):
+            raise WorkspaceError(f"topology root changed during inventory: {root}")
+        payload = json.dumps(rows, separators=(",", ":"), ensure_ascii=True)
+        observed = (
+            datetime.fromtimestamp(maximum, timezone.utc)
+            if maximum is not None
+            else None
+        )
+        return (
+            hashlib.sha256(payload.encode()).hexdigest(),
+            sorted(paths),
+            observed,
+            sizes,
+            None,
+        )
+    except (OSError, RuntimeError, WorkspaceError) as error:
+        return None, sorted(paths), None, {}, str(error)
+    finally:
+        if root_descriptor is not None:
+            os.close(root_descriptor)
+        if parent_descriptor is not None:
+            os.close(parent_descriptor)
+
+
 def _listed_usage(root: Path, relative_paths: Iterable[str]) -> dict[tuple[int, int], int]:
     """Account for Git-listed paths without resolving and rewalking every file."""
 
@@ -541,8 +690,8 @@ class Cleanup:
     def _normalize_scopes(scopes: list[str]) -> list[str]:
         requested = scopes or list(DEFAULT_SCOPES)
         if "all" in requested:
-            requested = list(ALL_SCOPES)
-        return [scope for scope in ALL_SCOPES if scope in set(requested)]
+            requested = [*requested, *ALL_SCOPES]
+        return [scope for scope in SUPPORTED_SCOPES if scope in set(requested)]
 
     def _normalize_names(self, names: list[str]) -> set[str] | None:
         if not names:
@@ -572,11 +721,25 @@ class Cleanup:
         mode: str,
     ) -> dict[str, Any]:
         self._reset_inventory()
-        references, reference_errors = self._references()
+        topology_only = set(scopes) == {"topologies"}
+        if topology_only:
+            references = {
+                "profiles": {},
+                "scenarios": {},
+                "topologies": {},
+                "live_builds": {},
+                "migration": {},
+                "retention": {},
+            }
+            reference_errors: set[str] = set()
+        else:
+            references, reference_errors = self._references()
         items: list[dict[str, Any]] = []
-        registered, registered_error = self._registered_worktree_paths()
-        if registered_error:
-            reference_errors.add("worktree_inventory_error")
+        registered: set[Path] = set()
+        if not topology_only:
+            registered, registered_error = self._registered_worktree_paths()
+            if registered_error:
+                reference_errors.add("worktree_inventory_error")
         if "worktrees" in scopes:
             worktrees, _ = self._worktrees(names, references, reference_errors)
             items.extend(worktrees)
@@ -615,6 +778,13 @@ class Cleanup:
         if "sound-cache" in scopes and (names is None or "sound" in names):
             items.extend(
                 self._sound_caches(older_than_days, reference_errors)
+            )
+        if "topologies" in scopes:
+            items.extend(
+                self._topologies(
+                    older_than_days,
+                    check_layout=mode == "dry-run",
+                )
             )
         items.sort(key=lambda item: (item["kind"], item["owner"], item["path"]))
         self._credit_sizes(items)
@@ -661,12 +831,23 @@ class Cleanup:
         """Refresh one target's safety predicates without rebuilding report payloads."""
 
         self._reset_inventory()
+        path = Path(target["path"])
+        kind = target["kind"]
+        if kind == "topology":
+            item = self._topology_item(
+                path,
+                older_than_days,
+                check_layout=False,
+            )
+            if not self._same_topology_snapshot(target, item):
+                raise WorkspaceError(
+                    f"topology changed during apply revalidation: {target['name']}"
+                )
+            return item
         references, reference_errors = self._references()
         registered, registered_error = self._registered_worktree_paths()
         if registered_error:
             reference_errors.add("worktree_inventory_error")
-        path = Path(target["path"])
-        kind = target["kind"]
         if kind == "profile-build":
             removable_worktrees = (
                 self._revalidate_build_sources(
@@ -748,6 +929,206 @@ class Cleanup:
                 item["_sound_worktree_identity"] = sound_worktree_identity
                 item["_sound_producer_identity"] = sound_producer_identity
         return item
+
+    def _topologies(
+        self, older_than_days: int, *, check_layout: bool
+    ) -> list[dict[str, Any]]:
+        root = self.paths.topologies
+        if not root.exists() and not root.is_symlink():
+            return []
+        if root.is_symlink() or not root.is_dir():
+            item = _base_item("topology", "atrinik", "atrinik/atrinik", root)
+            item["reasons"] = ["invalid_topology_container"]
+            return [item]
+        infrastructure = {"port-reservations", "ports.lock"}
+        return [
+            self._topology_item(path, older_than_days, check_layout=check_layout)
+            for path in sorted(root.iterdir())
+            if path.name not in infrastructure
+        ]
+
+    def _topology_item(
+        self,
+        path: Path,
+        older_than_days: int,
+        *,
+        check_layout: bool,
+        check_operation: bool = True,
+    ) -> dict[str, Any]:
+        item = _base_item("topology", "atrinik", "atrinik/atrinik", path)
+        item.update(
+            {
+                "name": path.name,
+                "liveness": "unverifiable",
+                "control_observation": "unverifiable",
+                "generation": None,
+                "process_tree_lease": "unverifiable",
+                "runtime_bundle_lease": "unverifiable",
+                "port_reservation_lease": "unverifiable",
+                "repository_layout_lease": "unverifiable",
+                "age_observed_at": None,
+                "deletion_paths": [],
+                "tree_identity": None,
+            }
+        )
+        reasons: list[str] = []
+        try:
+            if not self._owned_direct_child(path, self.paths.topologies):
+                raise WorkspaceError("topology is not a direct managed child")
+            marker = path / MANAGED_MARKER
+            if (
+                path.is_symlink()
+                or not path.is_dir()
+                or marker.is_symlink()
+                or not marker.is_file()
+                or load_json(marker)
+                != {
+                    "schema_version": SCHEMA_VERSION,
+                    "purpose": f"topology:{path.name}",
+                }
+            ):
+                raise WorkspaceError("topology ownership marker is invalid")
+        except (OSError, RuntimeError, WorkspaceError) as error:
+            item["reasons"] = ["invalid_topology_ownership"]
+            item["error"] = str(error)
+            return item
+
+        (
+            identity,
+            deletion_paths,
+            tree_time,
+            inodes,
+            tree_error,
+        ) = _topology_tree_snapshot(path)
+        item["tree_identity"] = identity
+        item["deletion_paths"] = deletion_paths
+        item["_inodes"] = inodes
+        if tree_error is not None:
+            reasons.append("invalid_topology_tree")
+            item["error"] = tree_error
+
+        if check_operation:
+            busy, lock_error = self._lock_busy(path / "operation.lock")
+            if busy:
+                reasons.append("active_topology_operation")
+            if lock_error:
+                reasons.append("invalid_topology_operation_lock")
+                item["error"] = lock_error
+
+        if check_layout:
+            busy, lock_error = self._lock_busy(
+                self.paths.workspace / "repository-layout.lock"
+            )
+            if busy:
+                reasons.append("repository_layout_lease_retained")
+                item["repository_layout_lease"] = "retained"
+            elif lock_error:
+                reasons.append("repository_layout_lease_unverifiable")
+                item["error"] = lock_error
+            else:
+                item["repository_layout_lease"] = "released"
+        else:
+            item["repository_layout_lease"] = "released"
+
+        try:
+            status = self.workspace.topology_status(path.name)
+            supervisor = status["supervisor"]
+            services = status["services"].values()
+            observed = [supervisor["liveness"], *(row["liveness"] for row in services)]
+            if "live" in observed:
+                liveness = "live"
+            elif "unreachable" in observed:
+                liveness = "unreachable"
+            elif "stale" in observed:
+                liveness = "stale"
+            else:
+                liveness = "exited"
+            observation = status["observation"]
+            item["liveness"] = liveness
+            item["control_observation"] = observation["control"]
+            item["generation"] = observation["generation"]
+            item["process_tree_lease"] = observation["process_tree_lease"]
+            item["runtime_bundle_lease"] = observation.get(
+                "runtime_bundle_lease", "unverifiable"
+            )
+            if liveness == "live":
+                reasons.append("live_topology")
+            elif liveness == "unreachable":
+                reasons.append("unreachable_topology")
+            if observation["control"] == "reachable":
+                reasons.append("reachable_topology_control")
+            if observation["process_tree_lease"] == "retained":
+                reasons.append("process_tree_lease_retained")
+            elif observation["process_tree_lease"] != "released":
+                reasons.append("process_tree_lease_unverifiable")
+            if item["runtime_bundle_lease"] == "retained":
+                reasons.append("runtime_bundle_lease_retained")
+            elif item["runtime_bundle_lease"] not in {"released", "historical"}:
+                reasons.append("runtime_bundle_lease_unverifiable")
+            port = observation.get("port_reservation")
+            if port is None:
+                item["port_reservation_lease"] = "released"
+            elif isinstance(port, dict) and port.get("lease") in {
+                "released",
+                "retained",
+            }:
+                item["port_reservation_lease"] = port["lease"]
+            if item["port_reservation_lease"] == "retained":
+                reasons.append("port_reservation_lease_retained")
+            elif item["port_reservation_lease"] != "released":
+                reasons.append("port_reservation_lease_unverifiable")
+            if observation.get("repository_layout_lease_owner") is not None:
+                reasons.append("repository_layout_lease_retained")
+                item["repository_layout_lease"] = "retained"
+
+            stopped_at = status.get("stopped_at")
+            if stopped_at is not None:
+                age_time = _parse_time(stopped_at, "topology stopped_at")
+                item["age_basis"] = "stopped-at"
+            elif liveness == "stale":
+                age_time = tree_time
+                item["age_basis"] = "legacy-tree-mtime" if tree_time else None
+            else:
+                age_time = None
+                item["age_basis"] = None
+                reasons.append("topology_stopped_at_unavailable")
+            if age_time is None:
+                reasons.append("topology_age_unavailable")
+            else:
+                item["age_observed_at"] = age_time.isoformat()
+                age_seconds = int((self.now - age_time).total_seconds())
+                item["age_seconds"] = max(0, age_seconds)
+                if age_time > self.now:
+                    reasons.append("future_topology_timestamp")
+                elif age_seconds < older_than_days * 86400:
+                    reasons.append("topology_younger_than_grace_period")
+        except (OSError, RuntimeError, KeyError, WorkspaceError) as error:
+            reasons.append("topology_status_unverifiable")
+            item["error"] = str(error)
+
+        item["reasons"] = sorted(set(reasons)) or ["inactive_topology"]
+        item["disposition"] = "eligible" if not reasons else "protected"
+        return item
+
+    @staticmethod
+    def _same_topology_snapshot(
+        expected: dict[str, Any], current: dict[str, Any]
+    ) -> bool:
+        keys = (
+            "disposition",
+            "liveness",
+            "control_observation",
+            "generation",
+            "process_tree_lease",
+            "runtime_bundle_lease",
+            "port_reservation_lease",
+            "repository_layout_lease",
+            "age_basis",
+            "age_observed_at",
+            "tree_identity",
+            "deletion_paths",
+        )
+        return all(current.get(key) == expected.get(key) for key in keys)
 
     def _revalidate_build_sources(
         self,
@@ -2965,6 +3346,7 @@ class Cleanup:
     @staticmethod
     def _apply_order(item: dict[str, Any]) -> tuple[int, str]:
         order = {
+            "topology": -1,
             "profile-build": 0,
             "worker-dependencies": 0,
             "worker-dependency-transaction": 0,
@@ -2990,6 +3372,31 @@ class Cleanup:
                     self.paths.builds,
                     f"profile:{item['profile']}:{item['key']}",
                 )
+        elif item["kind"] == "topology":
+            with exclusive_lock(
+                path / "operation.lock",
+                f"topology {item['name']} operation",
+                nonblocking=True,
+            ):
+                current = self._topology_item(
+                    path,
+                    older_than_days,
+                    check_layout=False,
+                    check_operation=False,
+                )
+                if not self._same_topology_snapshot(item, current):
+                    raise WorkspaceError(
+                        f"topology changed before removal: {item['name']}"
+                    )
+                marker = path / MANAGED_MARKER
+                if load_json(marker) != {
+                    "schema_version": SCHEMA_VERSION,
+                    "purpose": f"topology:{item['name']}",
+                }:
+                    raise WorkspaceError(
+                        f"topology ownership changed before removal: {item['name']}"
+                    )
+                remove_owned_tree(path)
         elif item["kind"] == "worker-dependencies":
             lock = (
                 self.paths.builds

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -937,7 +937,7 @@ class Cleanup:
         if not root.exists() and not root.is_symlink():
             return []
         if root.is_symlink() or not root.is_dir():
-            item = _base_item("topology", "atrinik", "atrinik/atrinik", root)
+            item = self._base_topology_item(root)
             item["reasons"] = ["invalid_topology_container"]
             return [item]
         infrastructure = {"port-reservations", "ports.lock"}
@@ -947,14 +947,8 @@ class Cleanup:
             if path.name not in infrastructure
         ]
 
-    def _topology_item(
-        self,
-        path: Path,
-        older_than_days: int,
-        *,
-        check_layout: bool,
-        check_operation: bool = True,
-    ) -> dict[str, Any]:
+    @staticmethod
+    def _base_topology_item(path: Path) -> dict[str, Any]:
         item = _base_item("topology", "atrinik", "atrinik/atrinik", path)
         item.update(
             {
@@ -971,6 +965,17 @@ class Cleanup:
                 "tree_identity": None,
             }
         )
+        return item
+
+    def _topology_item(
+        self,
+        path: Path,
+        older_than_days: int,
+        *,
+        check_layout: bool,
+        check_operation: bool = True,
+    ) -> dict[str, Any]:
+        item = self._base_topology_item(path)
         reasons: list[str] = []
         try:
             if not self._owned_direct_child(path, self.paths.topologies):

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -1215,6 +1215,25 @@ class Cleanup:
             reasons.append("topology_status_unverifiable")
             item["error"] = str(error)
 
+        if tree_error is None:
+            (
+                rechecked_identity,
+                rechecked_paths,
+                _rechecked_time,
+                _rechecked_inodes,
+                rechecked_error,
+            ) = _topology_tree_snapshot(path)
+            if (
+                rechecked_error is not None
+                or rechecked_identity != identity
+                or rechecked_paths != deletion_paths
+            ):
+                reasons.append("topology_changed_during_inventory")
+                item["error"] = rechecked_error or (
+                    f"topology tree changed during inventory: {path.name}"
+                )
+                item["tree_identity"] = None
+
         item["reasons"] = sorted(set(reasons)) or ["inactive_topology"]
         item["disposition"] = "eligible" if not reasons else "protected"
         return item

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -897,12 +897,7 @@ class Cleanup:
                 self._sound_caches(older_than_days, reference_errors)
             )
         if "topologies" in scopes:
-            items.extend(
-                self._topologies(
-                    older_than_days,
-                    check_layout=mode == "dry-run",
-                )
-            )
+            items.extend(self._topologies(older_than_days))
         items.sort(key=lambda item: (item["kind"], item["owner"], item["path"]))
         self._credit_sizes(items)
         for item in items:
@@ -954,7 +949,6 @@ class Cleanup:
             item = self._topology_item(
                 path,
                 older_than_days,
-                check_layout=False,
             )
             if not self._same_topology_snapshot(target, item):
                 raise WorkspaceError(
@@ -1047,9 +1041,7 @@ class Cleanup:
                 item["_sound_producer_identity"] = sound_producer_identity
         return item
 
-    def _topologies(
-        self, older_than_days: int, *, check_layout: bool
-    ) -> list[dict[str, Any]]:
+    def _topologies(self, older_than_days: int) -> list[dict[str, Any]]:
         root = self.paths.topologies
         if not root.exists() and not root.is_symlink():
             return []
@@ -1059,7 +1051,7 @@ class Cleanup:
             return [item]
         infrastructure = {"port-reservations", "ports.lock"}
         return [
-            self._topology_item(path, older_than_days, check_layout=check_layout)
+            self._topology_item(path, older_than_days)
             for path in sorted(root.iterdir())
             if path.name not in infrastructure
         ]
@@ -1089,7 +1081,6 @@ class Cleanup:
         path: Path,
         older_than_days: int,
         *,
-        check_layout: bool,
         check_operation: bool = True,
     ) -> dict[str, Any]:
         item = self._base_topology_item(path)
@@ -3539,7 +3530,6 @@ class Cleanup:
                 current = self._topology_item(
                     path,
                     older_than_days,
-                    check_layout=False,
                     check_operation=False,
                 )
                 if not self._same_topology_snapshot(item, current):

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -184,7 +184,7 @@ def parser() -> argparse.ArgumentParser:
         action="append",
         choices=[
             "worktrees", "builds", "npm-cache", "compiler-cache",
-            "sound-cache", "all",
+            "sound-cache", "topologies", "all",
         ],
         default=[],
     )
@@ -691,6 +691,22 @@ def main(arguments: list[str] | None = None) -> int:
                         f"{size_fields}\t{age}\t{item['path']}\t"
                         f"{reasons}"
                     )
+                    if item["kind"] == "topology":
+                        generation = item["generation"] or "-"
+                        print(
+                            f"topology-observation\t{item['name']}\t"
+                            f"liveness={item['liveness']}\t"
+                            f"control={item['control_observation']}\t"
+                            f"generation={generation}\t"
+                            f"process-tree={item['process_tree_lease']}\t"
+                            f"runtime-bundle={item['runtime_bundle_lease']}\t"
+                            f"port-reservation={item['port_reservation_lease']}\t"
+                            f"repository-layout={item['repository_layout_lease']}\t"
+                            f"age-basis={item['age_basis'] or '-'}\t"
+                            f"age-observed-at={item['age_observed_at'] or '-'}"
+                        )
+                        for deletion_path in item["deletion_paths"]:
+                            print(f"delete\t{item['name']}\t{deletion_path}")
                 summary = report["summary"]
                 print(
                     "summary\t"

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -438,6 +438,8 @@ def main(arguments: list[str] | None = None) -> int:
     if raw_arguments and raw_arguments[0] == protocol_command():
         return protocol(root_parser, ROOT, raw_arguments[1:])
     options = root_parser.parse_args(raw_arguments)
+    workspace: Any = None
+    command_maintenance: Any = None
     try:
         if options.command == "completion":
             print(shell_script(options.shell), end="")
@@ -470,7 +472,23 @@ def main(arguments: list[str] | None = None) -> int:
         workspace_type = Workspace
         if workspace_type is None:
             from .workspace import Workspace as workspace_type
-        workspace = workspace_type(ROOT)
+        read_only_dry_run = (
+            options.command == "cleanup" and not options.apply
+        ) or (
+            options.command == "migrate"
+            and options.migrate_command in {"repositories", "content"}
+            and (options.dry_run or options.audit)
+        )
+        workspace = workspace_type(
+            ROOT, backfill_references=not read_only_dry_run
+        )
+        # Foreground runs acquire the maintenance barrier only while resolving,
+        # building, and publishing their sealed runtime generation. Keeping the
+        # CLI-wide reader after publication would needlessly block migration for
+        # the lifetime of an immutable client/server process.
+        if options.command not in {"migrate", "run"}:
+            command_maintenance = workspace.command_maintenance()
+            command_maintenance.__enter__()
         if options.command == "supply-chain":
             inventory = Inventory.load(
                 ROOT / "supply-chain" / "inventory.json", ROOT / "components.json"
@@ -926,6 +944,11 @@ def main(arguments: list[str] | None = None) -> int:
     except KeyboardInterrupt:
         print("interrupted", file=sys.stderr)
         return 130
+    finally:
+        if command_maintenance is not None:
+            command_maintenance.__exit__(None, None, None)
+        if workspace is not None:
+            workspace.close()
 
 
 if __name__ == "__main__":

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -184,7 +184,7 @@ def parser() -> argparse.ArgumentParser:
         action="append",
         choices=[
             "worktrees", "builds", "npm-cache", "compiler-cache",
-            "sound-cache", "all",
+            "sound-cache", "topologies", "all",
         ],
         default=[],
     )
@@ -673,6 +673,22 @@ def main(arguments: list[str] | None = None) -> int:
                         f"{size_fields}\t{age}\t{item['path']}\t"
                         f"{reasons}"
                     )
+                    if item["kind"] == "topology":
+                        generation = item["generation"] or "-"
+                        print(
+                            f"topology-observation\t{item['name']}\t"
+                            f"liveness={item['liveness']}\t"
+                            f"control={item['control_observation']}\t"
+                            f"generation={generation}\t"
+                            f"process-tree={item['process_tree_lease']}\t"
+                            f"runtime-bundle={item['runtime_bundle_lease']}\t"
+                            f"port-reservation={item['port_reservation_lease']}\t"
+                            f"repository-layout={item['repository_layout_lease']}\t"
+                            f"age-basis={item['age_basis'] or '-'}\t"
+                            f"age-observed-at={item['age_observed_at'] or '-'}"
+                        )
+                        for deletion_path in item["deletion_paths"]:
+                            print(f"delete\t{item['name']}\t{deletion_path}")
                 summary = report["summary"]
                 print(
                     "summary\t"

--- a/atrinik_workspace/content_migration.py
+++ b/atrinik_workspace/content_migration.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import re
 import subprocess
 import tempfile
-from typing import Any
+from typing import Any, Callable
 
 from .locking import (
     LockBusyError,
@@ -20,7 +20,14 @@ from .locking import (
     layout_writer_intent_path,
     layout_writer_pending_path,
 )
-from .model import WorkspaceError, atomic_json, load_json
+from .model import (
+    AtomicJsonCommitUncertain,
+    JsonUnlinkCommitUncertain,
+    WorkspaceError,
+    durable_atomic_json,
+    load_json,
+    unlink_validated_json,
+)
 from .process_tree import (
     bound_lease_locked,
     control_socket_path,
@@ -66,6 +73,12 @@ def _certified_parity() -> dict[str, str]:
         "final_1x_release": "v1.8.19",
         "status": "certified",
     }
+
+
+def _durable_unlink(path: Path, *, missing_ok: bool = False) -> None:
+    if missing_ok and not path.exists() and not path.is_symlink():
+        return
+    unlink_validated_json(path, lambda _value: None)
 
 
 def _git(path: Path, *arguments: str, check: bool = True) -> str:
@@ -154,7 +167,14 @@ def _atomic_bytes(path: Path, value: bytes) -> None:
 class ContentMigration:
     """Retire active ``content-1x`` selectors without rewriting history."""
 
-    def __init__(self, repository_root: Path, workspace_paths: Any, manifest: Any):
+    def __init__(
+        self,
+        repository_root: Path,
+        workspace_paths: Any,
+        manifest: Any,
+        physical_lock_path: Path,
+        reference_publisher: Callable[[dict[str, tuple[bytes, bytes]] | None], None],
+    ):
         self.repository_root = Path(repository_root).resolve()
         self.paths = workspace_paths
         self.manifest = manifest
@@ -163,6 +183,8 @@ class ContentMigration:
         self.pending_path = self.workspace / CONTENT_MIGRATION_PENDING
         self.canonical = self.repository_root / "content"
         self.legacy = self.repository_root / "content-1x"
+        self.physical_lock_path = Path(physical_lock_path)
+        self.reference_publisher = reference_publisher
 
     def execute(self, mode: str) -> dict[str, Any]:
         if mode not in {"dry-run", "apply", "audit", "restore"}:
@@ -179,6 +201,13 @@ class ContentMigration:
         lock_path = self.workspace / "repository-layout.lock"
         lock_stack = ExitStack()
         try:
+            lock_stack.enter_context(
+                exclusive_layout_lock(
+                    self.physical_lock_path,
+                    "physical repository layout",
+                    nonblocking=True,
+                )
+            )
             lock_stack.enter_context(
                 exclusive_layout_lock(
                     lock_path, "repository layout", nonblocking=True
@@ -200,8 +229,39 @@ class ContentMigration:
             if self.record_path.is_file() and not self.record_path.is_symlink():
                 result = self._audit()
                 if result["status"] == "complete":
+                    self.reference_publisher(None)
+                    if self.pending_path.exists() or self.pending_path.is_symlink():
+                        def validate_committed_pending(value: Any) -> None:
+                            if not isinstance(value, dict):
+                                raise WorkspaceError("pending migration journal is invalid")
+                            expected_keys = (
+                                set(result) - {"applied_at", "restore"}
+                            ) | {"started_at"}
+                            if set(value) != expected_keys:
+                                raise WorkspaceError(
+                                    "pending migration journal has unexpected fields"
+                                )
+                            if value["status"] != "pending" or not isinstance(
+                                value["started_at"], str
+                            ):
+                                raise WorkspaceError(
+                                    "pending migration journal state is invalid"
+                                )
+                            ignored = {"status", "started_at"}
+                            for key, pending_value in value.items():
+                                if key in ignored:
+                                    continue
+                                if key not in result or result[key] != pending_value:
+                                    raise WorkspaceError(
+                                        "pending journal does not match the committed migration"
+                                    )
+
+                        unlink_validated_json(
+                            self.pending_path, validate_committed_pending
+                        )
                     result["status"] = "already-applied"
                 elif result["status"] == "restored":
+                    self.reference_publisher(None)
                     result["status"] = "refused"
                     result["refusals"] = [
                         _refusal(
@@ -248,6 +308,13 @@ class ContentMigration:
         lock_path = self.workspace / "repository-layout.lock"
         lock_stack = ExitStack()
         try:
+            lock_stack.enter_context(
+                exclusive_layout_lock(
+                    self.physical_lock_path,
+                    "physical repository layout",
+                    nonblocking=True,
+                )
+            )
             lock_stack.enter_context(
                 exclusive_layout_lock(
                     lock_path, "repository layout", nonblocking=True
@@ -936,11 +1003,21 @@ class ContentMigration:
             "status": "pending",
             "started_at": datetime.now(timezone.utc).isoformat(),
         }
-        atomic_json(self.pending_path, journal)
+        durable_atomic_json(self.pending_path, journal)
         applied_profiles: list[dict[str, Any]] = []
         applied_moves: list[dict[str, Any]] = []
         published = False
         try:
+            self.reference_publisher(
+                {
+                    Path(row["path"]).stem: (
+                        base64.b64decode(row["original_base64"], validate=True),
+                        base64.b64decode(row["replacement_base64"], validate=True),
+                    )
+                    for row in inspection["profiles"]
+                    if row["status"] == "rewrite"
+                }
+            )
             for move in inspection["worktree_moves"]:
                 source, destination = self._managed_worktree_paths(
                     Path(move["source"]).name
@@ -978,26 +1055,48 @@ class ContentMigration:
                     ),
                 },
             }
-            atomic_json(self.record_path, record)
-            published = True
             try:
-                self.pending_path.unlink()
-            except OSError:
+                durable_atomic_json(self.record_path, record)
+            except AtomicJsonCommitUncertain:
+                published = True
+                raise
+            else:
+                published = True
+            self.reference_publisher(None)
+            try:
+                _durable_unlink(self.pending_path)
+            except JsonUnlinkCommitUncertain as error:
                 return {
                     **record,
-                    "pending_journal_retained": str(self.pending_path),
+                    "pending_journal_removed_durability_uncertain": str(error),
                 }
+            except WorkspaceError as error:
+                field = (
+                    "pending_journal_retained"
+                    if self.pending_path.exists() or self.pending_path.is_symlink()
+                    else "pending_journal_removed_durability_uncertain"
+                )
+                value = (
+                    str(self.pending_path)
+                    if field == "pending_journal_retained"
+                    else str(error)
+                )
+                return {**record, field: value}
             return record
         except BaseException as error:
             if published:
                 raise WorkspaceError(
                     "content migration completed and its durable record was published, "
                     f"but final journal cleanup failed: {error}; preserve {self.record_path} "
-                    f"and {self.pending_path} and run --audit"
+                    f"and {self.pending_path} and rerun --apply"
                 ) from error
             rollback_errors = self._rollback(applied_profiles, applied_moves)
+            try:
+                self.reference_publisher(None)
+            except WorkspaceError as publish_error:
+                rollback_errors.append(str(publish_error))
             if not rollback_errors:
-                self.pending_path.unlink(missing_ok=True)
+                _durable_unlink(self.pending_path, missing_ok=True)
             detail = f"content migration failed: {error}"
             if rollback_errors:
                 detail += "; rollback failed: " + "; ".join(rollback_errors)
@@ -1298,7 +1397,21 @@ class ContentMigration:
             return {**audit, "status": "refused", "resources": resources, "refusals": refusals}
         restored_profiles: list[dict[str, Any]] = []
         restored_moves: list[dict[str, Any]] = []
+        record_visible = False
         try:
+            # Retain both durable generations before changing either profiles
+            # or worktree paths. A crash at any later instruction therefore
+            # leaves cleanup conservatively protecting both sides.
+            self.reference_publisher(
+                {
+                    Path(row["path"]).stem: (
+                        base64.b64decode(row["original_base64"], validate=True),
+                        base64.b64decode(row["replacement_base64"], validate=True),
+                    )
+                    for row in audit["profiles"]
+                    if row.get("status") == "rewrite"
+                }
+            )
             for row in audit["profiles"]:
                 if row.get("status") != "rewrite":
                     continue
@@ -1327,12 +1440,29 @@ class ContentMigration:
                 "restored_at": datetime.now(timezone.utc).isoformat(),
                 "refusals": [],
             }
-            atomic_json(self.record_path, restored)
+            try:
+                durable_atomic_json(self.record_path, restored)
+            except AtomicJsonCommitUncertain:
+                record_visible = True
+                raise
+            record_visible = True
+            self.reference_publisher(None)
             return restored
         except BaseException as error:
+            if record_visible:
+                raise WorkspaceError(
+                    "content migration restore completed and its restored record is "
+                    f"visible, but directory durability is uncertain: {error}; "
+                    "preserve the record, repair the reported registry problem, "
+                    "then rerun --apply to finish reference reconciliation"
+                ) from error
             rollback_errors = self._rollback_restore(
                 restored_profiles, restored_moves, audit["canonical"]
             )
+            try:
+                self.reference_publisher(None)
+            except WorkspaceError as publish_error:
+                rollback_errors.append(str(publish_error))
             detail = (
                 "content migration restore stopped after a changed precondition: "
                 f"{error}; preserve the journal and all paths"

--- a/atrinik_workspace/locking.py
+++ b/atrinik_workspace/locking.py
@@ -2,13 +2,20 @@ from __future__ import annotations
 
 from contextlib import ExitStack, contextmanager
 from contextvars import ContextVar
+from dataclasses import dataclass
 import fcntl
+import hashlib
+import json
 import os
 from pathlib import Path
+import re
+import secrets
+import socket
 import stat
 import sys
 import threading
-from typing import BinaryIO, Iterator, TextIO
+from datetime import datetime, timezone
+from typing import BinaryIO, Callable, Iterator, TextIO
 
 from .model import WorkspaceError
 
@@ -16,6 +23,47 @@ from .model import WorkspaceError
 LAYOUT_WRITER_INTENT_SUFFIX = ".writer-intent"
 LAYOUT_WRITER_PENDING_SUFFIX = ".writer-pending"
 LOCK_WAIT_DIAGNOSTIC_SECONDS = 10.0
+RESOURCE_LEASE_SCHEMA_VERSION = 1
+RESOURCE_KIND_ORDER = {
+    "maintenance": 0,
+    "registry": 10,
+    "profile": 20,
+    "git-admin": 30,
+    "source": 40,
+    "topology": 50,
+    "scenario": 55,
+    "state": 60,
+    "build-root": 70,
+    "cache": 80,
+}
+
+
+@dataclass(frozen=True)
+class LeaseRequest:
+    """One exact resource in the workspace lease graph."""
+
+    kind: str
+    coordinate: str
+    mode: str
+    operation: str
+    recovery: str
+
+    def __post_init__(self) -> None:
+        if self.kind not in RESOURCE_KIND_ORDER:
+            raise ValueError(f"unknown resource lease kind: {self.kind}")
+        if self.mode not in {"shared", "exclusive"}:
+            raise ValueError(f"unknown resource lease mode: {self.mode}")
+        for label, value in (
+            ("coordinate", self.coordinate),
+            ("operation", self.operation),
+            ("recovery", self.recovery),
+        ):
+            if not value or "\n" in value or "\r" in value:
+                raise ValueError(f"resource lease {label} must be one non-empty line")
+
+    @property
+    def sort_key(self) -> tuple[int, str]:
+        return RESOURCE_KIND_ORDER[self.kind], self.coordinate
 
 
 class LockBusyError(WorkspaceError):
@@ -25,6 +73,9 @@ class LockBusyError(WorkspaceError):
 _ACTIVE_LOCK_FDS: ContextVar[tuple[int, ...]] = ContextVar(
     "atrinik_active_lock_fds", default=()
 )
+_ACTIVE_MAINTENANCE_PATHS: ContextVar[tuple[str, ...]] = ContextVar(
+    "atrinik_active_maintenance_paths", default=()
+)
 
 
 def active_lock_fds() -> tuple[int, ...]:
@@ -32,8 +83,10 @@ def active_lock_fds() -> tuple[int, ...]:
 
 
 @contextmanager
-def inherit_lock_fds(*leases: BinaryIO) -> Iterator[None]:
-    descriptors = tuple(lease.fileno() for lease in leases)
+def inherit_lock_fds(*leases: BinaryIO | int) -> Iterator[None]:
+    descriptors = tuple(
+        lease if isinstance(lease, int) else lease.fileno() for lease in leases
+    )
     current = active_lock_fds()
     token = _ACTIVE_LOCK_FDS.set(tuple(dict.fromkeys((*current, *descriptors))))
     try:
@@ -42,16 +95,76 @@ def inherit_lock_fds(*leases: BinaryIO) -> Iterator[None]:
         _ACTIVE_LOCK_FDS.reset(token)
 
 
-def _open_lock(path: Path, description: str) -> TextIO:
+@contextmanager
+def shared_maintenance_lock(
+    path: Path, *, inherit: bool = True
+) -> Iterator[None]:
+    """Retain the migration barrier once across nested exact-lease scopes."""
+
+    coordinate = str(path.resolve(strict=False))
+    active = _ACTIVE_MAINTENANCE_PATHS.get()
+    if coordinate in active:
+        yield
+        return
+    with shared_layout_lock(path, "repository maintenance", inherit=inherit):
+        token = _ACTIVE_MAINTENANCE_PATHS.set((*active, coordinate))
+        try:
+            yield
+        finally:
+            _ACTIVE_MAINTENANCE_PATHS.reset(token)
+
+
+def _open_lock(
+    path: Path,
+    description: str,
+    *,
+    directory_fd: int | None = None,
+) -> TextIO:
     flags = os.O_RDWR | os.O_CREAT | os.O_CLOEXEC
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
+    directory_flags = os.O_RDONLY | os.O_CLOEXEC
+    if hasattr(os, "O_DIRECTORY"):
+        directory_flags |= os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+        directory_flags |= os.O_NOFOLLOW
+    parent_descriptor: int | None = None
+    descriptor: int | None = None
     try:
-        descriptor = os.open(path, flags, 0o600)
+        if directory_fd is None:
+            parent_descriptor = os.open(path.parent, directory_flags)
+            parent_status = os.fstat(parent_descriptor)
+            visible_status = path.parent.stat(follow_symlinks=False)
+            if (
+                not stat.S_ISDIR(visible_status.st_mode)
+                or (parent_status.st_dev, parent_status.st_ino)
+                != (visible_status.st_dev, visible_status.st_ino)
+            ):
+                raise OSError("lock parent directory changed during open")
+        else:
+            parent_descriptor = directory_fd
+        descriptor = os.open(path.name, flags, 0o600, dir_fd=parent_descriptor)
+        opened_status = os.fstat(descriptor)
+        visible_lock = os.stat(
+            path.name, dir_fd=parent_descriptor, follow_symlinks=False
+        )
+        if (
+            not stat.S_ISREG(visible_lock.st_mode)
+            or (opened_status.st_dev, opened_status.st_ino)
+            != (visible_lock.st_dev, visible_lock.st_ino)
+        ):
+            os.close(descriptor)
+            descriptor = None
+            raise OSError("lock file changed during open")
     except OSError as error:
+        if descriptor is not None:
+            os.close(descriptor)
         raise WorkspaceError(
             f"cannot open {description} lock {path}: {error}"
         ) from error
+    finally:
+        if directory_fd is None and parent_descriptor is not None:
+            os.close(parent_descriptor)
     if not stat.S_ISREG(os.fstat(descriptor).st_mode):
         os.close(descriptor)
         raise WorkspaceError(f"{description} lock is not a regular file: {path}")
@@ -65,9 +178,11 @@ def _advisory_lock(
     operation: int,
     *,
     nonblocking: bool = False,
+    directory_fd: int | None = None,
 ) -> Iterator[TextIO]:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with _open_lock(path, description) as lock:
+    if directory_fd is None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    with _open_lock(path, description, directory_fd=directory_fd) as lock:
         try:
             fcntl.flock(lock, operation | fcntl.LOCK_NB)
         except BlockingIOError as error:
@@ -86,19 +201,101 @@ def _advisory_lock(
         yield lock
 
 
+def _lease_owner_summary(path: Path) -> str:
+    owners = path.with_name(f"{path.name}.owners")
+    parent_descriptor: int | None = None
+    owners_descriptor: int | None = None
+    try:
+        parent_descriptor = _open_directory(
+            path.parent, "resource lease parent"
+        )
+        flags = os.O_RDONLY | os.O_CLOEXEC
+        if hasattr(os, "O_DIRECTORY"):
+            flags |= os.O_DIRECTORY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        owners_descriptor = os.open(
+            owners.name, flags, dir_fd=parent_descriptor
+        )
+        paths = sorted(os.listdir(owners_descriptor))
+    except (FileNotFoundError, NotADirectoryError, PermissionError, OSError, WorkspaceError):
+        if owners_descriptor is not None:
+            os.close(owners_descriptor)
+        if parent_descriptor is not None:
+            os.close(parent_descriptor)
+        return "owner metadata unavailable"
+    descriptions: list[str] = []
+    for metadata_name in paths:
+        descriptor: int | None = None
+        try:
+            flags = os.O_RDWR | os.O_CLOEXEC
+            if hasattr(os, "O_NOFOLLOW"):
+                flags |= os.O_NOFOLLOW
+            descriptor = os.open(
+                metadata_name, flags, dir_fd=owners_descriptor
+            )
+            opened = os.fstat(descriptor)
+            visible = os.stat(
+                metadata_name,
+                dir_fd=owners_descriptor,
+                follow_symlinks=False,
+            )
+            if (
+                not stat.S_ISREG(visible.st_mode)
+                or (opened.st_dev, opened.st_ino)
+                != (visible.st_dev, visible.st_ino)
+            ):
+                continue
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                pass
+            else:
+                os.close(descriptor)
+                descriptor = None
+                os.unlink(metadata_name, dir_fd=owners_descriptor)
+                continue
+            with os.fdopen(descriptor, encoding="utf-8") as stream:
+                descriptor = None
+                value = json.load(stream)
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            continue
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+        if not isinstance(value, dict):
+            continue
+        operation = value.get("operation")
+        owner = value.get("owner")
+        mode = value.get("mode")
+        if all(isinstance(item, str) and item for item in (operation, owner, mode)):
+            if len(descriptions) < 8:
+                descriptions.append(f"{mode} {operation} by {owner}")
+    os.close(owners_descriptor)
+    os.close(parent_descriptor)
+    return "; ".join(descriptions) if descriptions else "owner metadata unavailable"
+
+
 @contextmanager
-def _diagnose_layout_wait(path: Path, description: str) -> Iterator[None]:
+def _diagnose_layout_wait(
+    path: Path,
+    description: str,
+    recovery_action: str | None = None,
+) -> Iterator[None]:
     acquired = threading.Event()
 
     def warn_about_wait() -> None:
         if acquired.wait(LOCK_WAIT_DIAGNOSTIC_SECONDS):
             return
+        owner = _lease_owner_summary(path)
+        recovery = recovery_action or (
+            "inspect `./atrinik ps --json` and "
+            "`./atrinik worktree list --json`; do not bypass the wrapper "
+            "or stop unrelated processes"
+        )
         print(
             f"waiting more than {LOCK_WAIT_DIAGNOSTIC_SECONDS:g}s "
-            f"for {description} lock at {path}; inspect "
-            "`./atrinik ps --json` and "
-            "`./atrinik worktree list --json`; do not bypass the "
-            "wrapper or stop unrelated processes",
+            f"for {description} lock at {path}; known owner: {owner}; {recovery}",
             file=sys.stderr,
         )
 
@@ -116,14 +313,21 @@ def exclusive_lock(
     path: Path,
     description: str,
     nonblocking: bool = False,
+    *,
+    directory_fd: int | None = None,
+    inherit: bool = True,
 ) -> Iterator[TextIO]:
     with _advisory_lock(
         path,
         description,
         fcntl.LOCK_EX,
         nonblocking=nonblocking,
+        directory_fd=directory_fd,
     ) as lock:
-        with inherit_lock_fds(lock):
+        if inherit:
+            with inherit_lock_fds(lock):
+                yield lock
+        else:
             yield lock
 
 
@@ -132,6 +336,8 @@ def shared_lock(
     path: Path,
     description: str,
     nonblocking: bool = False,
+    *,
+    directory_fd: int | None = None,
 ) -> Iterator[TextIO]:
     operation = getattr(fcntl, "LOCK_SH", None)
     if not isinstance(operation, int):
@@ -143,6 +349,7 @@ def shared_lock(
         description,
         operation,
         nonblocking=nonblocking,
+        directory_fd=directory_fd,
     ) as lock:
         with inherit_lock_fds(lock):
             yield lock
@@ -162,15 +369,21 @@ def layout_writer_pending_path(path: Path) -> Path:
 
 @contextmanager
 def exclusive_layout_lock(
-    path: Path, description: str, nonblocking: bool = False
+    path: Path,
+    description: str,
+    nonblocking: bool = False,
+    *,
+    recovery_action: str | None = None,
+    directory_fd: int | None = None,
 ) -> Iterator[TextIO]:
     with ExitStack() as locks:
-        with _diagnose_layout_wait(path, description):
+        with _diagnose_layout_wait(path, description, recovery_action):
             locks.enter_context(
                 shared_lock(
                     layout_writer_pending_path(path),
                     f"{description} writer pending",
                     nonblocking,
+                    directory_fd=directory_fd,
                 )
             )
             locks.enter_context(
@@ -178,6 +391,7 @@ def exclusive_layout_lock(
                     layout_writer_intent_path(path),
                     f"{description} writer intent",
                     nonblocking,
+                    directory_fd=directory_fd,
                 )
             )
             lock = locks.enter_context(
@@ -185,13 +399,22 @@ def exclusive_layout_lock(
                     path,
                     description,
                     nonblocking,
+                    directory_fd=directory_fd,
                 )
             )
         yield lock
 
 
 @contextmanager
-def shared_layout_lock(path: Path, description: str) -> Iterator[TextIO]:
+def shared_layout_lock(
+    path: Path,
+    description: str,
+    nonblocking: bool = False,
+    *,
+    recovery_action: str | None = None,
+    directory_fd: int | None = None,
+    inherit: bool = True,
+) -> Iterator[TextIO]:
     operation = getattr(fcntl, "LOCK_EX", None)
     if not isinstance(operation, int):
         raise WorkspaceError(
@@ -204,12 +427,14 @@ def shared_layout_lock(path: Path, description: str) -> Iterator[TextIO]:
             f"shared locking is unavailable for {description}; refusing to continue"
         )
     with ExitStack() as layout_stack:
-        with _diagnose_layout_wait(path, description):
+        with _diagnose_layout_wait(path, description, recovery_action):
             pending_busy = False
             with _advisory_lock(
                 layout_writer_intent_path(path),
                 f"{description} reader admission",
                 operation,
+                nonblocking=nonblocking,
+                directory_fd=directory_fd,
             ):
                 pending_stack = ExitStack()
                 try:
@@ -219,6 +444,7 @@ def shared_layout_lock(path: Path, description: str) -> Iterator[TextIO]:
                             f"{description} writer pending",
                             operation,
                             nonblocking=True,
+                            directory_fd=directory_fd,
                         )
                     )
                 except LockBusyError:
@@ -231,6 +457,8 @@ def shared_layout_lock(path: Path, description: str) -> Iterator[TextIO]:
                                 path,
                                 description,
                                 shared_operation,
+                                nonblocking=nonblocking,
+                                directory_fd=directory_fd,
                             )
                         )
             if pending_busy:
@@ -238,18 +466,352 @@ def shared_layout_lock(path: Path, description: str) -> Iterator[TextIO]:
                     layout_writer_pending_path(path),
                     f"{description} writer pending",
                     operation,
+                    nonblocking=nonblocking,
+                    directory_fd=directory_fd,
                 ):
                     with _advisory_lock(
                         layout_writer_intent_path(path),
                         f"{description} reader admission",
                         operation,
+                        nonblocking=nonblocking,
+                        directory_fd=directory_fd,
                     ):
                         lock = layout_stack.enter_context(
                             _advisory_lock(
                                 path,
                                 description,
-                                shared_operation,
+                            shared_operation,
+                            nonblocking=nonblocking,
+                            directory_fd=directory_fd,
                             )
                         )
-        with inherit_lock_fds(lock):
+        if inherit:
+            with inherit_lock_fds(lock):
+                yield lock
+        else:
             yield lock
+
+
+def resource_lock_path(root: Path, kind: str, coordinate: str) -> Path:
+    """Return a bounded, stable path for an exact resource coordinate."""
+
+    if kind not in RESOURCE_KIND_ORDER:
+        raise WorkspaceError(f"unknown resource lease kind: {kind}")
+    digest = hashlib.sha256(f"{kind}\0{coordinate}".encode()).hexdigest()
+    slug = re.sub(r"[^a-z0-9]+", "-", coordinate.lower()).strip("-")[:48]
+    return root / "leases" / kind / f"{slug or 'resource'}-{digest[:20]}.lock"
+
+
+def _ensure_resource_lock_directory(root: Path, kind: str) -> int:
+    """Create and retain the exact no-follow lease-kind directory."""
+
+    if not root.exists() and not root.is_symlink():
+        try:
+            root.mkdir(mode=0o700, parents=True)
+        except FileExistsError:
+            pass
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot create resource lease directory {root}: {error}"
+            ) from error
+    root_descriptor = _open_directory(root, "resource lease")
+    leases_descriptor: int | None = None
+    try:
+        leases_descriptor = _open_or_create_directory_at(
+            root_descriptor, "leases", root / "leases"
+        )
+        return _open_or_create_directory_at(
+            leases_descriptor, kind, root / "leases" / kind
+        )
+    finally:
+        if leases_descriptor is not None:
+            os.close(leases_descriptor)
+        os.close(root_descriptor)
+
+
+def _open_directory(path: Path, description: str) -> int:
+    flags = os.O_RDONLY | os.O_CLOEXEC
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+        opened = os.fstat(descriptor)
+        visible = path.stat(follow_symlinks=False)
+    except OSError as error:
+        if "descriptor" in locals():
+            os.close(descriptor)
+        raise WorkspaceError(
+            f"cannot open {description} directory {path}: {error}"
+        ) from error
+    if (
+        not stat.S_ISDIR(visible.st_mode)
+        or (opened.st_dev, opened.st_ino) != (visible.st_dev, visible.st_ino)
+    ):
+        os.close(descriptor)
+        raise WorkspaceError(f"{description} directory is unsafe: {path}")
+    return descriptor
+
+
+def _open_or_create_directory_at(
+    parent_descriptor: int, name: str, display_path: Path
+) -> int:
+    try:
+        os.mkdir(name, mode=0o700, dir_fd=parent_descriptor)
+    except FileExistsError:
+        pass
+    except OSError as error:
+        raise WorkspaceError(
+            f"cannot create resource lease directory {display_path}: {error}"
+        ) from error
+    flags = os.O_RDONLY | os.O_CLOEXEC
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(name, flags, dir_fd=parent_descriptor)
+        opened = os.fstat(descriptor)
+        visible = os.stat(
+            name, dir_fd=parent_descriptor, follow_symlinks=False
+        )
+    except OSError as error:
+        if descriptor is not None:
+            os.close(descriptor)
+        raise WorkspaceError(
+            f"cannot open resource lease directory {display_path}: {error}"
+        ) from error
+    if (
+        not stat.S_ISDIR(visible.st_mode)
+        or (opened.st_dev, opened.st_ino) != (visible.st_dev, visible.st_ino)
+    ):
+        os.close(descriptor)
+        raise WorkspaceError(
+            f"resource lease directory is unsafe: {display_path}"
+        )
+    return descriptor
+
+
+@contextmanager
+def _resource_owner(
+    path: Path,
+    request: LeaseRequest,
+    *,
+    directory_fd: int | None = None,
+    inherit: bool = True,
+) -> Iterator[None]:
+    owners = path.with_name(f"{path.name}.owners")
+    parent_descriptor = (
+        os.dup(directory_fd)
+        if directory_fd is not None
+        else _open_directory(path.parent, "resource lease parent")
+    )
+    owner_descriptor: int | None = None
+    try:
+        try:
+            os.mkdir(owners.name, mode=0o700, dir_fd=parent_descriptor)
+        except FileExistsError:
+            pass
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot create resource lease owner directory {owners}: {error}"
+            ) from error
+        owner_flags = os.O_RDONLY | os.O_CLOEXEC
+        if hasattr(os, "O_DIRECTORY"):
+            owner_flags |= os.O_DIRECTORY
+        if hasattr(os, "O_NOFOLLOW"):
+            owner_flags |= os.O_NOFOLLOW
+        owner_descriptor = os.open(
+            owners.name, owner_flags, dir_fd=parent_descriptor
+        )
+        opened = os.fstat(owner_descriptor)
+        visible = os.stat(
+            owners.name, dir_fd=parent_descriptor, follow_symlinks=False
+        )
+        if (
+            not stat.S_ISDIR(visible.st_mode)
+            or (opened.st_dev, opened.st_ino)
+            != (visible.st_dev, visible.st_ino)
+        ):
+            os.close(owner_descriptor)
+            owner_descriptor = None
+            raise WorkspaceError(
+                f"resource lease owner directory is unsafe: {owners}"
+            )
+    except (OSError, WorkspaceError) as error:
+        if owner_descriptor is not None:
+            os.close(owner_descriptor)
+        os.close(parent_descriptor)
+        if isinstance(error, WorkspaceError):
+            raise
+        raise WorkspaceError(
+            f"cannot open resource lease owner directory {owners}: {error}"
+        ) from error
+    token = secrets.token_hex(16)
+    metadata_path = owners / f"{token}.json"
+    owner = f"{socket.gethostname()} uid={os.geteuid()} token={token}"
+    value = {
+        "schema_version": RESOURCE_LEASE_SCHEMA_VERSION,
+        "kind": request.kind,
+        "coordinate": request.coordinate,
+        "mode": request.mode,
+        "operation": request.operation,
+        "owner": owner,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "recovery": request.recovery,
+    }
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(
+            metadata_path.name, flags, 0o600, dir_fd=owner_descriptor
+        )
+    except OSError:
+        os.close(owner_descriptor)
+        os.close(parent_descriptor)
+        raise WorkspaceError(
+            f"cannot create resource lease owner metadata {metadata_path}"
+        ) from None
+    try:
+        with os.fdopen(descriptor, "w+", encoding="utf-8", closefd=False) as stream:
+            json.dump(value, stream, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        with os.fdopen(os.dup(descriptor), "a+") as owner_lease:
+            if inherit:
+                with inherit_lock_fds(owner_lease):
+                    yield
+            else:
+                yield
+    finally:
+        os.close(descriptor)
+        cleanup_descriptor: int | None = None
+        try:
+            cleanup_flags = os.O_RDWR | os.O_CLOEXEC
+            if hasattr(os, "O_NOFOLLOW"):
+                cleanup_flags |= os.O_NOFOLLOW
+            cleanup_descriptor = os.open(
+                metadata_path.name,
+                cleanup_flags,
+                dir_fd=owner_descriptor,
+            )
+            fcntl.flock(
+                cleanup_descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB
+            )
+            os.unlink(metadata_path.name, dir_fd=owner_descriptor)
+        except (FileNotFoundError, BlockingIOError, OSError):
+            # An inherited descriptor deliberately keeps the owner record live;
+            # a later diagnostic scan reaps it after the child exits.
+            pass
+        finally:
+            if cleanup_descriptor is not None:
+                os.close(cleanup_descriptor)
+            os.close(owner_descriptor)
+            os.close(parent_descriptor)
+
+
+@contextmanager
+def resource_locks(
+    root: Path | Callable[[LeaseRequest], Path],
+    requests: list[LeaseRequest] | tuple[LeaseRequest, ...],
+    *,
+    nonblocking: bool = False,
+) -> Iterator[tuple[TextIO, ...]]:
+    """Acquire de-duplicated exact resources in deterministic graph order."""
+
+    combined: dict[tuple[str, str], LeaseRequest] = {}
+    for request in requests:
+        identity = (request.kind, request.coordinate)
+        previous = combined.get(identity)
+        if previous is None:
+            combined[identity] = request
+            continue
+        mode = (
+            "exclusive"
+            if "exclusive" in {previous.mode, request.mode}
+            else "shared"
+        )
+        combined[identity] = LeaseRequest(
+            request.kind,
+            request.coordinate,
+            mode,
+            ", ".join(dict.fromkeys((previous.operation, request.operation))),
+            request.recovery,
+        )
+    ordered = sorted(combined.values(), key=lambda request: request.sort_key)
+    with ExitStack() as stack:
+        leases: list[TextIO] = []
+        for request in ordered:
+            request_root = root(request) if callable(root) else root
+            directory_descriptor = _ensure_resource_lock_directory(
+                request_root, request.kind
+            )
+            stack.callback(os.close, directory_descriptor)
+            path = resource_lock_path(
+                request_root, request.kind, request.coordinate
+            )
+            description = (
+                f"resource {request.kind} coordinate {request.coordinate}"
+            )
+            try:
+                if request.mode == "exclusive":
+                    lease = stack.enter_context(
+                        exclusive_layout_lock(
+                            path,
+                            description,
+                            nonblocking,
+                            recovery_action=request.recovery,
+                            directory_fd=directory_descriptor,
+                        )
+                    )
+                else:
+                    lease = stack.enter_context(
+                        shared_layout_lock(
+                            path,
+                            description,
+                            nonblocking,
+                            recovery_action=request.recovery,
+                            directory_fd=directory_descriptor,
+                        )
+                    )
+            except LockBusyError as error:
+                raise LockBusyError(
+                    f"{request.kind} {request.coordinate} is already in use by "
+                    f"{_lease_owner_summary(path)}; {request.recovery}"
+                ) from error
+            stack.enter_context(
+                _resource_owner(
+                    path, request, directory_fd=directory_descriptor
+                )
+            )
+            leases.append(lease)
+        yield tuple(leases)
+
+
+@contextmanager
+def resource_lifetime_reader(
+    root: Path,
+    request: LeaseRequest,
+) -> Iterator[TextIO]:
+    """Hold a fair diagnosed resource reader without subprocess registration."""
+
+    directory_fd = _ensure_resource_lock_directory(root, request.kind)
+    path = resource_lock_path(root, request.kind, request.coordinate)
+    try:
+        with shared_layout_lock(
+            path,
+            f"resource {request.kind} coordinate {request.coordinate}",
+            recovery_action=request.recovery,
+            directory_fd=directory_fd,
+            inherit=False,
+        ) as lease:
+            with _resource_owner(
+                path, request, directory_fd=directory_fd, inherit=False
+            ):
+                yield lease
+    finally:
+        os.close(directory_fd)

--- a/atrinik_workspace/migration.py
+++ b/atrinik_workspace/migration.py
@@ -15,10 +15,17 @@ import shutil
 import stat
 import subprocess
 import tempfile
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable
 
 from .locking import LockBusyError, active_lock_fds, exclusive_layout_lock
-from .model import WorkspaceError, atomic_json, load_json
+from .model import (
+    AtomicJsonCommitUncertain,
+    JsonUnlinkCommitUncertain,
+    WorkspaceError,
+    durable_atomic_json,
+    load_json,
+    unlink_validated_json,
+)
 from .process_tree import bound_lease_locked, control_socket_path, lease_locked
 from .supervisor import process_matches
 
@@ -29,6 +36,28 @@ LEGACY_PROFILE_SCHEMA_VERSION = 3
 MIGRATION_NAME = "repositories"
 MIGRATION_RECORD = "migrations/repositories.json"
 MIGRATION_PENDING = "migrations/repositories.pending.json"
+
+
+def physical_repository_lock_path(repository_root: Path) -> Path:
+    """Derive the mandatory maintenance barrier shared by wrapper worktrees."""
+
+    repository = Path(repository_root).resolve()
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repository), "rev-parse", "--git-common-dir"],
+            check=True,
+            capture_output=True,
+            text=True,
+            pass_fds=active_lock_fds(),
+        )
+    except (OSError, subprocess.CalledProcessError) as error:
+        raise WorkspaceError(
+            f"cannot derive physical repository maintenance lock: {repository}"
+        ) from error
+    common = Path(result.stdout.strip())
+    if not common.is_absolute():
+        common = repository / common
+    return common.resolve() / "atrinik-resource-leases" / "repository-layout.lock"
 
 # The two source names are deliberately retained.  A workspace may still use
 # the pre-rename canonical paths or may already have completed the earlier
@@ -381,7 +410,14 @@ class RepositoryMigration:
     state differs from the imported classic primary.
     """
 
-    def __init__(self, repository_root: Path, workspace_paths: Any, manifest: Any):
+    def __init__(
+        self,
+        repository_root: Path,
+        workspace_paths: Any,
+        manifest: Any,
+        physical_lock_path: Path,
+        reference_publisher: Callable[[dict[str, tuple[bytes, bytes]] | None], None],
+    ):
         self.repository_root = Path(repository_root).resolve()
         self.paths = workspace_paths
         self.manifest = manifest
@@ -389,6 +425,8 @@ class RepositoryMigration:
         self.record_path = self.workspace / MIGRATION_RECORD
         self.pending_path = self.workspace / MIGRATION_PENDING
         self.archive_root = self.workspace / "archive" / "classic-migration"
+        self.physical_lock_path = Path(physical_lock_path)
+        self.reference_publisher = reference_publisher
 
     def execute(self, mode: str) -> dict[str, Any]:
         if mode not in {"dry-run", "apply", "audit"}:
@@ -411,6 +449,13 @@ class RepositoryMigration:
         try:
             lock_stack.enter_context(
                 exclusive_layout_lock(
+                    self.physical_lock_path,
+                    "physical repository layout",
+                    nonblocking=True,
+                )
+            )
+            lock_stack.enter_context(
+                exclusive_layout_lock(
                     lock_path, "repository layout", nonblocking=True
                 )
             )
@@ -426,10 +471,53 @@ class RepositoryMigration:
             if self.record_path.is_file() and not self.record_path.is_symlink():
                 audited = self._audit()
                 if audited["status"] == "complete":
+                    self.reference_publisher(None)
+                    if self.pending_path.exists() or self.pending_path.is_symlink():
+                        committed = load_json(self.record_path)
+                        committed_journal = (
+                            committed.get("journal", {})
+                            if isinstance(committed, dict)
+                            else {}
+                        )
+                        pending_sha256 = committed_journal.get("pending_sha256")
+                        if not isinstance(pending_sha256, str):
+                            raise WorkspaceError(
+                                "committed migration lacks pending-journal identity"
+                            )
+
+                        def validate_committed_pending(value: Any) -> None:
+                            if not isinstance(value, dict):
+                                raise WorkspaceError("pending journal is invalid")
+                            self._validate_pending_journal(value)
+                            encoded = json.dumps(
+                                value,
+                                sort_keys=True,
+                                separators=(",", ":"),
+                            ).encode()
+                            if hashlib.sha256(encoded).hexdigest() != pending_sha256:
+                                raise WorkspaceError(
+                                    "pending journal does not match the committed migration"
+                                )
+
+                        unlink_validated_json(
+                            self.pending_path, validate_committed_pending
+                        )
                     audited["status"] = "already-applied"
                     return audited
                 return audited
             if self.pending_path.exists() or self.pending_path.is_symlink():
+                try:
+                    self.reference_publisher(
+                        self._pending_reference_transitions()
+                    )
+                except WorkspaceError as error:
+                    return self._with_refusal(
+                        inspection.plan,
+                        "pending_migration",
+                        "an interrupted repository migration could not retain "
+                        f"both profile generations: {error}",
+                        "preserve the pending journal and repair only its exact recorded paths",
+                    )
                 recovery_errors = self._rollback_pending()
                 if recovery_errors:
                     return self._with_refusal(
@@ -439,6 +527,7 @@ class RepositoryMigration:
                         + "; ".join(recovery_errors),
                         "preserve the pending journal and repair only its exact recorded paths",
                     )
+                self.reference_publisher(None)
             inspection = self._inspect()
             if inspection.plan["refusals"]:
                 return inspection.plan
@@ -1443,7 +1532,6 @@ class RepositoryMigration:
         if inspection.classic is None:
             raise WorkspaceError("classic checkout disappeared before apply")
         journal = self._pending_value(inspection)
-        self.pending_path.parent.mkdir(parents=True, exist_ok=True)
         self._durable_atomic_json(self.pending_path, journal)
         created_worktrees: list[_Worktree] = []
         created_composites: list[_CompositeWorktree] = []
@@ -1452,6 +1540,12 @@ class RepositoryMigration:
         temporary_profiles: list[Path] = []
         record_installed = False
         try:
+            self.reference_publisher(
+                {
+                    action.name: (action.before, action.after)
+                    for action in inspection.profiles
+                }
+            )
             for source in inspection.sources:
                 for worktree in source.worktrees:
                     if worktree.destination is None:
@@ -1467,7 +1561,6 @@ class RepositoryMigration:
                 backup, mode = self._exchange_profile(action)
                 temporary_profiles.append(backup)
                 exchanged_profiles.append((action, backup, mode))
-
             for source in inspection.sources:
                 archived.append(source)
                 self._archive_source(source)
@@ -1495,6 +1588,13 @@ class RepositoryMigration:
                 row["status"] = "preserved"
             record = copy.deepcopy(result)
             record["journal"] = {
+                "pending_sha256": hashlib.sha256(
+                    json.dumps(
+                        journal,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ).encode()
+                ).hexdigest(),
                 "profiles": [
                     {
                         "after": self._encode_bytes(action.after),
@@ -1504,22 +1604,40 @@ class RepositoryMigration:
                     for action in inspection.profiles
                 ]
             }
-            self._durable_atomic_json(self.record_path, record)
-            record_installed = True
+            try:
+                self._durable_atomic_json(self.record_path, record)
+            except AtomicJsonCommitUncertain:
+                record_installed = True
+                raise
+            else:
+                record_installed = True
+            self.reference_publisher(None)
             # Once the durable record exists, cleanup failures must not trigger
             # rollback of a migration that has already committed successfully.
-            try:
-                self.pending_path.unlink(missing_ok=True)
-                self._fsync_directory(self.pending_path.parent)
-            except (OSError, WorkspaceError):
-                pass
+            pending_outcome: dict[str, str] = {}
+            if self.pending_path.exists() or self.pending_path.is_symlink():
+                try:
+                    unlink_validated_json(
+                        self.pending_path,
+                        self._validate_pending_journal,
+                    )
+                except JsonUnlinkCommitUncertain as error:
+                    pending_outcome["pending_journal_removed_durability_uncertain"] = str(error)
+                except WorkspaceError:
+                    pending_outcome["pending_journal_retained"] = str(self.pending_path)
             for path in temporary_profiles:
                 try:
                     path.unlink(missing_ok=True)
                 except OSError:
                     pass
-            return result
+            return {**result, **pending_outcome}
         except BaseException as error:
+            if record_installed:
+                raise WorkspaceError(
+                    "repository migration committed, but conservative physical "
+                    f"references could not be narrowed: {error}; preserve "
+                    f"{self.record_path} and rerun --apply"
+                ) from error
             rollback_errors: list[str] = []
             if not record_installed and (
                 self.record_path.exists() or self.record_path.is_symlink()
@@ -1541,6 +1659,12 @@ class RepositoryMigration:
                     self._rollback_profile(action, backup, mode)
                 except (OSError, WorkspaceError) as rollback_error:
                     rollback_errors.append(f"profile {action.path}: {rollback_error}")
+            try:
+                self.reference_publisher(None)
+            except WorkspaceError as rollback_error:
+                rollback_errors.append(
+                    f"physical profile references: {rollback_error}"
+                )
             for composite in reversed(created_composites):
                 try:
                     self._remove_composite_worktree(inspection.classic, composite)
@@ -2292,6 +2416,28 @@ class RepositoryMigration:
             except (OSError, WorkspaceError) as error:
                 errors.append(f"cannot remove recovered pending journal: {error}")
         return errors
+
+    def _pending_reference_transitions(
+        self,
+    ) -> dict[str, tuple[bytes, bytes]]:
+        if self.pending_path.is_symlink():
+            raise WorkspaceError(f"pending journal is a symlink: {self.pending_path}")
+        pending = load_json(self.pending_path)
+        if (
+            not isinstance(pending, dict)
+            or pending.get("migration") != MIGRATION_NAME
+            or pending.get("schema_version") != PLAN_SCHEMA_VERSION
+        ):
+            raise WorkspaceError("pending journal has an unsupported shape")
+        self._validate_pending_journal(pending)
+        transitions: dict[str, tuple[bytes, bytes]] = {}
+        for raw in pending.get("profiles", []):
+            path = Path(str(raw["path"]))
+            transitions[path.stem] = (
+                self._decode_bytes(raw["before"]),
+                self._decode_bytes(raw["after"]),
+            )
+        return transitions
 
     def _validate_pending_journal(self, pending: dict[str, Any]) -> None:
         if set(pending) != {
@@ -3605,8 +3751,7 @@ class RepositoryMigration:
             raise
 
     def _durable_atomic_json(self, path: Path, value: Any) -> None:
-        atomic_json(path, value)
-        self._fsync_directory(path.parent)
+        durable_atomic_json(path, value)
 
     @staticmethod
     def _fsync_directory(path: Path) -> None:
@@ -3765,4 +3910,6 @@ def migrate_repositories(
 ) -> dict[str, Any]:
     """Convenience entry point for the workspace coordinator."""
 
-    return RepositoryMigration(repository_root, workspace_paths, manifest).execute(mode)
+    raise WorkspaceError(
+        "repository migration requires the Workspace coordinator to publish physical references"
+    )

--- a/atrinik_workspace/model.py
+++ b/atrinik_workspace/model.py
@@ -7,10 +7,10 @@ import json
 import os
 from pathlib import Path, PurePosixPath
 import re
+import secrets
 import stat
-import tempfile
 import time
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable
 
 
 SCHEMA_VERSION = 1
@@ -151,6 +151,14 @@ class WorkspaceError(RuntimeError):
     """A workspace operation cannot be completed safely."""
 
 
+class AtomicJsonCommitUncertain(WorkspaceError):
+    """The JSON replacement is visible but directory durability was not proven."""
+
+
+class JsonUnlinkCommitUncertain(WorkspaceError):
+    """The JSON record is absent but directory durability was not proven."""
+
+
 def _reject_duplicate_keys(pairs: Iterable[tuple[str, Any]]) -> dict[str, Any]:
     result: dict[str, Any] = {}
     for key, value in pairs:
@@ -168,21 +176,170 @@ def load_json(path: Path) -> Any:
         raise WorkspaceError(f"cannot read {path}: {error}") from error
 
 
-def atomic_json(path: Path, value: Any) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    descriptor, temporary_name = tempfile.mkstemp(
-        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
-    )
-    temporary = Path(temporary_name)
+def unlink_validated_json(path: Path, validate: Callable[[Any], None]) -> None:
+    """Validate and unlink the same no-follow JSON inode through a parent dirfd."""
+
+    directory_flags = os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_DIRECTORY", 0)
+    directory_flags |= getattr(os, "O_NOFOLLOW", 0)
+    file_flags = os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_NOFOLLOW", 0)
+    directory: int | None = None
+    descriptor: int | None = None
     try:
+        directory = _open_directory_nofollow(path.parent, directory_flags)
+        parent_opened = os.fstat(directory)
+        parent_visible = path.parent.stat(follow_symlinks=False)
+        if (
+            not stat.S_ISDIR(parent_opened.st_mode)
+            or (parent_opened.st_dev, parent_opened.st_ino)
+            != (parent_visible.st_dev, parent_visible.st_ino)
+        ):
+            raise WorkspaceError(f"JSON parent directory was replaced: {path.parent}")
+        descriptor = os.open(path.name, file_flags, dir_fd=directory)
+        opened = os.fstat(descriptor)
+        visible = os.stat(path.name, dir_fd=directory, follow_symlinks=False)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or (opened.st_dev, opened.st_ino) != (visible.st_dev, visible.st_ino)
+        ):
+            raise WorkspaceError(f"JSON record identity is unsafe: {path}")
+        with os.fdopen(descriptor, encoding="utf-8", closefd=False) as stream:
+            value = json.load(stream, object_pairs_hook=_reject_duplicate_keys)
+        validate(value)
+        parent_visible = path.parent.stat(follow_symlinks=False)
+        if (parent_opened.st_dev, parent_opened.st_ino) != (
+            parent_visible.st_dev,
+            parent_visible.st_ino,
+        ):
+            raise WorkspaceError(f"JSON parent directory was replaced: {path.parent}")
+        visible = os.stat(path.name, dir_fd=directory, follow_symlinks=False)
+        if (opened.st_dev, opened.st_ino) != (visible.st_dev, visible.st_ino):
+            raise WorkspaceError(f"JSON record was replaced: {path}")
+        os.unlink(path.name, dir_fd=directory)
+        try:
+            os.fsync(directory)
+        except OSError as error:
+            raise JsonUnlinkCommitUncertain(
+                "JSON record is absent but its directory durability is uncertain: "
+                f"{path}: {error}"
+            ) from error
+    except (OSError, UnicodeError, ValueError, RecursionError) as error:
+        raise WorkspaceError(f"cannot consume {path}: {error}") from error
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        if directory is not None:
+            os.close(directory)
+
+
+def atomic_json(path: Path, value: Any) -> None:
+    _atomic_json(path, value, durable=False)
+
+
+def durable_atomic_json(path: Path, value: Any) -> None:
+    """Replace JSON and prove the containing directory persisted the rename."""
+
+    _atomic_json(path, value, durable=True)
+
+
+def _atomic_json(path: Path, value: Any, *, durable: bool) -> None:
+    directory_flags = os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_DIRECTORY", 0)
+    directory_flags |= getattr(os, "O_NOFOLLOW", 0)
+    directory = _open_directory_nofollow(
+        path.parent, directory_flags, create=True
+    )
+    temporary = f".{path.name}.{secrets.token_hex(12)}.tmp"
+    descriptor: int | None = None
+    try:
+        opened_parent = os.fstat(directory)
+        visible_parent = path.parent.stat(follow_symlinks=False)
+        if (
+            not stat.S_ISDIR(opened_parent.st_mode)
+            or (opened_parent.st_dev, opened_parent.st_ino)
+            != (visible_parent.st_dev, visible_parent.st_ino)
+        ):
+            raise WorkspaceError(f"JSON parent directory was replaced: {path.parent}")
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | os.O_CLOEXEC
+            | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+            dir_fd=directory,
+        )
         with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            descriptor = None
             json.dump(value, stream, indent=2, sort_keys=True)
             stream.write("\n")
             stream.flush()
             os.fsync(stream.fileno())
-        temporary.replace(path)
+        visible_parent = path.parent.stat(follow_symlinks=False)
+        if (opened_parent.st_dev, opened_parent.st_ino) != (
+            visible_parent.st_dev,
+            visible_parent.st_ino,
+        ):
+            raise WorkspaceError(f"JSON parent directory was replaced: {path.parent}")
+        os.rename(
+            temporary,
+            path.name,
+            src_dir_fd=directory,
+            dst_dir_fd=directory,
+        )
+        if durable:
+            try:
+                os.fsync(directory)
+            except OSError as error:
+                raise AtomicJsonCommitUncertain(
+                    "JSON replacement is visible but its directory durability is "
+                    f"uncertain: {path}: {error}"
+                ) from error
     except BaseException:
-        temporary.unlink(missing_ok=True)
+        try:
+            os.unlink(temporary, dir_fd=directory)
+        except FileNotFoundError:
+            pass
+        raise
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(directory)
+
+
+def _open_directory_nofollow(
+    path: Path, flags: int, *, create: bool = False
+) -> int:
+    """Open every component of a directory path without following symlinks."""
+
+    absolute = Path(os.path.abspath(path))
+    descriptor = os.open("/", flags)
+    try:
+        for part in absolute.parts[1:]:
+            try:
+                next_descriptor = os.open(part, flags, dir_fd=descriptor)
+            except FileNotFoundError:
+                if not create:
+                    raise
+                try:
+                    os.mkdir(part, 0o777, dir_fd=descriptor)
+                except FileExistsError:
+                    # Another publisher may have created the same safe
+                    # directory after our failed open. Reopen it no-follow
+                    # below and prove its parent directory entry durable.
+                    pass
+                try:
+                    os.fsync(descriptor)
+                except OSError as error:
+                    raise AtomicJsonCommitUncertain(
+                        "JSON ancestor directory is visible but its parent "
+                        f"durability is uncertain: {absolute}: {error}"
+                    ) from error
+                next_descriptor = os.open(part, flags, dir_fd=descriptor)
+            os.close(descriptor)
+            descriptor = next_descriptor
+        return descriptor
+    except BaseException:
+        os.close(descriptor)
         raise
 
 

--- a/atrinik_workspace/port_reservation.py
+++ b/atrinik_workspace/port_reservation.py
@@ -95,9 +95,12 @@ def _directory_identity(metadata: os.stat_result) -> dict[str, int]:
 
 
 def _validate_directory_path(directory: Path, identity: dict[str, int]) -> None:
+    descriptor: int | None = None
     try:
         metadata = directory.lstat()
     except OSError as error:
+        if descriptor is not None:
+            os.close(descriptor)
         raise PortReservationError(
             f"cannot inspect topology port reservation directory {directory}: {error}"
         ) from error
@@ -110,31 +113,57 @@ def _validate_directory_path(directory: Path, identity: dict[str, int]) -> None:
         )
 
 
-def open_directory(topologies: Path) -> tuple[int, Path, dict[str, int]]:
+def open_directory(
+    topologies: Path, *, root_identity: tuple[int, int] | None = None
+) -> tuple[int, Path, dict[str, int]]:
     directory = topologies / PORT_RESERVATION_DIRECTORY
-    try:
-        directory.mkdir(mode=0o700)
-    except FileExistsError:
-        pass
     flags = os.O_RDONLY | os.O_CLOEXEC
     if hasattr(os, "O_DIRECTORY"):
         flags |= os.O_DIRECTORY
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
     try:
-        descriptor = os.open(directory, flags)
+        root_descriptor = os.open(topologies, flags)
     except OSError as error:
         raise PortReservationError(
-            f"cannot open topology port reservation directory {directory}: {error}"
+            f"cannot open topology port reservation root {topologies}: {error}"
         ) from error
+    descriptor: int | None = None
     try:
+        root_metadata = os.fstat(root_descriptor)
+        visible_root = topologies.lstat()
+        if (
+            not stat.S_ISDIR(root_metadata.st_mode)
+            or not stat.S_ISDIR(visible_root.st_mode)
+            or (root_metadata.st_dev, root_metadata.st_ino)
+            != (visible_root.st_dev, visible_root.st_ino)
+            or (
+                root_identity is not None
+                and (root_metadata.st_dev, root_metadata.st_ino) != root_identity
+            )
+        ):
+            raise PortReservationError(
+                f"topology port reservation root was replaced: {topologies}"
+            )
+        try:
+            os.mkdir(PORT_RESERVATION_DIRECTORY, mode=0o700, dir_fd=root_descriptor)
+        except FileExistsError:
+            pass
+        descriptor = os.open(
+            PORT_RESERVATION_DIRECTORY, flags, dir_fd=root_descriptor
+        )
         metadata = os.fstat(descriptor)
         path_metadata = directory.lstat()
+        visible_root = topologies.lstat()
     except OSError as error:
-        os.close(descriptor)
+        if descriptor is not None:
+            os.close(descriptor)
         raise PortReservationError(
             f"cannot open topology port reservation directory {directory}: {error}"
         ) from error
+    finally:
+        os.close(root_descriptor)
+    assert descriptor is not None
     if (
         not stat.S_ISDIR(metadata.st_mode)
         or stat.S_IMODE(metadata.st_mode) != 0o700
@@ -142,6 +171,8 @@ def open_directory(topologies: Path) -> tuple[int, Path, dict[str, int]]:
         or not stat.S_ISDIR(path_metadata.st_mode)
         or (path_metadata.st_dev, path_metadata.st_ino)
         != (metadata.st_dev, metadata.st_ino)
+        or (visible_root.st_dev, visible_root.st_ino)
+        != (root_metadata.st_dev, root_metadata.st_ino)
     ):
         os.close(descriptor)
         raise PortReservationError(
@@ -245,10 +276,15 @@ def _rename_no_replace(
 
 
 def open_transaction(
-    topologies: Path, port: int
+    topologies: Path,
+    port: int,
+    *,
+    root_identity: tuple[int, int] | None = None,
 ) -> tuple[int, int, Path, dict[str, int]]:
     port = _validate_port(port)
-    directory_fd, directory, identity = open_directory(topologies)
+    directory_fd, directory, identity = open_directory(
+        topologies, root_identity=root_identity
+    )
     try:
         descriptor = _open_child(
             directory_fd, f"{port}.lock", os.O_RDWR | os.O_CREAT

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -18,11 +18,7 @@ from typing import Any, BinaryIO
 
 from .launch_identity import CLIENT_LAUNCH_LABEL_ENV, client_launch_label
 from .process_tree import control_socket_path, holders_exist, signal_holders
-from .port_reservation import (
-    PORT_RESERVATION_DIRECTORY,
-    PortReservationError,
-    validate_held,
-)
+from .port_reservation import PortReservationError, validate_held
 
 
 LOG_LIMIT = 10 * 1024 * 1024
@@ -297,7 +293,7 @@ def _initial_status(spec: dict[str, Any], supervisor_start_time: str) -> dict[st
 
 
 def _validate_port_reservation(
-    spec: dict[str, Any], descriptor: int | None, topology_root: Path
+    spec: dict[str, Any], descriptor: int | None, _topology_root: Path
 ) -> None:
     reservation = spec.get("port_reservation")
     if reservation is None and descriptor is None:
@@ -316,10 +312,6 @@ def _validate_port_reservation(
         or validated["generation"] != control.get("generation")
         or not isinstance(endpoint, dict)
         or validated["port"] != endpoint.get("port")
-        or Path(validated["path"])
-        != topology_root.parent
-        / PORT_RESERVATION_DIRECTORY
-        / f"{validated['port']}-{validated['generation']}.lease"
     ):
         raise RuntimeError("topology port reservation does not match the topology")
 
@@ -601,7 +593,8 @@ def supervise(
             )
         )
         guardian_pid, guardian_write_fd = _start_guardian(
-            process_tree_fd, *retained_fds
+            process_tree_fd,
+            *retained_fds,
         )
         control_socket = _open_control(spec, spec_path.parent)
         if "server" in spec["services"]:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import binascii
+import copy
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from contextlib import ExitStack, contextmanager
+from contextlib import AbstractContextManager, ExitStack, contextmanager
 from contextvars import copy_context
 import ctypes
+from dataclasses import dataclass
 from datetime import datetime, timezone
 import errno
 import fcntl
@@ -32,11 +34,17 @@ from typing import Any, Callable, Iterator, TextIO
 from .launch_identity import CLIENT_LAUNCH_LABEL_ENV, client_launch_label
 from .content_migration import ContentMigration
 from .locking import (
+    LeaseRequest,
+    LockBusyError,
     active_lock_fds,
     exclusive_layout_lock,
     exclusive_lock,
     inherit_lock_fds,
     layout_writer_intent_path as _layout_writer_intent_path,
+    resource_lock_path,
+    resource_lifetime_reader,
+    resource_locks,
+    shared_maintenance_lock,
     shared_layout_lock,
     shared_lock,
 )
@@ -67,8 +75,11 @@ from .model import (
     Component,
     Manifest,
     Paths,
+    AtomicJsonCommitUncertain,
     WorkspaceError,
+    _reject_duplicate_keys,
     atomic_json,
+    durable_atomic_json,
     load_json,
     _managed_path_no_symlinks,
     managed_directory,
@@ -79,6 +90,7 @@ from .model import (
 )
 from .migration import (
     MIGRATED_CONTENT_WORKTREE_KIND,
+    PROFILE_IDENTITIES,
     RepositoryMigration,
     classic_lineage,
     rename_no_replace,
@@ -165,6 +177,8 @@ SCENARIO_INERT_PROFILE_UNRESOLVABLE = "profile_unresolvable"
 SCENARIO_INERT_INVALID_RECORD = "invalid_record"
 BUILD_METADATA = ".atrinik-build.json"
 BUILD_METADATA_SCHEMA_VERSION = 2
+PROFILE_RESOLUTION_METADATA = ".atrinik-profile-resolution.json"
+PROFILE_RESOLUTION_SCHEMA_VERSION = 1
 CACHE_METADATA = ".atrinik-cache.json"
 WORKER_DEPENDENCY_METADATA = ".atrinik-worker-dependencies.json"
 WORKER_VIEW_METADATA = ".atrinik-worker-view.json"
@@ -194,6 +208,32 @@ WORKER_NPM_FILE_CONFIG_KEYS = {
 }
 RUNTIME_INPUT_METADATA = ".atrinik-dependency.json"
 RUNTIME_INPUT_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class ProfileResolutionSnapshot:
+    """Immutable profile bytes and exact source observations for one operation."""
+
+    name: str
+    generation: str
+    profile_json: str
+    selected: tuple[tuple[str, str], ...]
+    checkout_states_json: str
+
+    def profile(self) -> dict[str, Any]:
+        value = json.loads(self.profile_json)
+        assert isinstance(value, dict)
+        return value
+
+    def paths(self) -> dict[str, Path]:
+        return {role: Path(path) for role, path in self.selected}
+
+    def checkout_states(self) -> dict[str, dict[str, Any]]:
+        value = json.loads(self.checkout_states_json)
+        assert isinstance(value, dict)
+        for state in value.values():
+            state["path"] = Path(state["path"])
+        return value
 REGION_MAP_METADATA = ".atrinik-region-maps.json"
 REGION_MAP_SCHEMA_VERSION = 1
 EXPECTED_REGION_MAP = "incuna_-1"
@@ -331,6 +371,20 @@ def _descriptor_mount_id(descriptor: int) -> int | tuple[int, int]:
         raise WorkspaceError(
             f"filesystem mount identity is unavailable on {sys.platform}"
         )
+
+
+def _descriptor_path(descriptor: int) -> Path:
+    """Return the host's stable pathname for an open directory descriptor."""
+
+    root = Path("/proc/self/fd") if sys.platform == "linux" else Path("/dev/fd")
+    path = root / str(descriptor)
+    try:
+        path.resolve(strict=True)
+    except OSError as error:
+        raise WorkspaceError(
+            f"open-descriptor paths are unavailable on {sys.platform}: {path}"
+        ) from error
+    return path
 
 
 def _linux_fchmod_path_descriptor(descriptor: int, mode: int) -> None:
@@ -1198,15 +1252,83 @@ def open_regular_file(
         raise WorkspaceError(f"cannot open {description} {path}: {error}") from error
 
 
+def load_regular_json(path: Path, description: str, *, limit: int = 4 * 1024 * 1024) -> Any:
+    """Read one identity-bound regular JSON file without following links."""
+
+    descriptor = open_regular_file(path, os.O_RDONLY, description)
+    try:
+        opened = os.fstat(descriptor)
+        visible = path.stat(follow_symlinks=False)
+        if (
+            (opened.st_dev, opened.st_ino) != (visible.st_dev, visible.st_ino)
+            or opened.st_size > limit
+        ):
+            raise WorkspaceError(f"{description} identity is unsafe: {path}")
+        with os.fdopen(descriptor, encoding="utf-8", closefd=False) as stream:
+            return json.load(stream, object_pairs_hook=_reject_duplicate_keys)
+    except (OSError, UnicodeError, ValueError, RecursionError) as error:
+        raise WorkspaceError(f"cannot read {description} {path}: {error}") from error
+    finally:
+        os.close(descriptor)
+
+
 class Workspace:
-    def __init__(self, repository: Path):
+    def __init__(self, repository: Path, *, backfill_references: bool = True):
         self.paths = Paths.discover(repository)
         self.manifest = Manifest.load(self.paths.repository / "components.json")
+        self._wrapper_lease: Any = None
         self._build_state = threading.local()
         self._prefix_map_support: dict[
             tuple[str, str, str | None, str | None], bool
         ] = {}
         self._prefix_map_support_lock = threading.Lock()
+        repository_identity = self.paths.repository.stat()
+        common_identity = self._lease_namespace.parent.stat()
+        namespace_identity = self._establish_lease_namespace_identity()
+        wrapper_request = self._lease_request(
+            "source",
+            self._source_coordinate("atrinik", self.paths.repository),
+            "shared",
+            "use wrapper worktree",
+        )
+        self._wrapper_lease = resource_lifetime_reader(
+            self._lease_namespace, wrapper_request
+        )
+        self._wrapper_lease.__enter__()
+        if not self.paths.repository.is_dir():
+            raise WorkspaceError(
+                f"wrapper worktree disappeared while acquiring its lease: {self.paths.repository}"
+            )
+        current_repository = self.paths.repository.stat()
+        current_common = self._lease_namespace.parent.stat()
+        current_namespace = self._lease_namespace.stat(follow_symlinks=False)
+        if (
+            (repository_identity.st_dev, repository_identity.st_ino)
+            != (current_repository.st_dev, current_repository.st_ino)
+            or (common_identity.st_dev, common_identity.st_ino)
+            != (current_common.st_dev, current_common.st_ino)
+            or namespace_identity
+            != (current_namespace.st_dev, current_namespace.st_ino)
+        ):
+            raise WorkspaceError("wrapper worktree identity changed while acquiring its lease")
+        self.manifest = Manifest.load(self.paths.repository / "components.json")
+        self._physical_lease_namespace_identity = namespace_identity
+        if backfill_references:
+            self._backfill_physical_references()
+
+    def close(self) -> None:
+        """Release the command-lifetime wrapper and maintenance leases."""
+
+        wrapper_lease = self._wrapper_lease
+        if wrapper_lease is not None:
+            self._wrapper_lease = None
+            wrapper_lease.__exit__(None, None, None)
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except BaseException:
+            pass
 
     @property
     def _force_reconfigure(self) -> bool:
@@ -1244,19 +1366,315 @@ class Workspace:
     def _source_view_unchanged(self, value: dict[str, bool]) -> None:
         self._build_state.source_view_unchanged = value
 
+    @property
+    def _profile_snapshot(self) -> ProfileResolutionSnapshot | None:
+        return getattr(self._build_state, "profile_snapshot", None)
+
+    @_profile_snapshot.setter
+    def _profile_snapshot(self, value: ProfileResolutionSnapshot | None) -> None:
+        self._build_state.profile_snapshot = value
+
+    @staticmethod
+    def _lease_recovery(kind: str, coordinate: str) -> str:
+        if kind == "profile":
+            return f"inspect `./atrinik profile show {coordinate} --json` and retry"
+        if kind in {"source", "git-admin"}:
+            return "inspect `./atrinik worktree list --json` and retry after the exact operation finishes"
+        if kind == "topology":
+            return f"inspect `./atrinik ps {coordinate} --json` and stop only that topology when appropriate"
+        return "inspect the exact resource owner and retry after its operation finishes"
+
+    def _lease_request(
+        self,
+        kind: str,
+        coordinate: str,
+        mode: str,
+        operation: str,
+    ) -> LeaseRequest:
+        return LeaseRequest(
+            kind,
+            coordinate,
+            mode,
+            operation,
+            self._lease_recovery(kind, coordinate),
+        )
+
+    @staticmethod
+    def _source_coordinate(checkout_name: str, root: Path) -> str:
+        return f"{checkout_name}:{Path(os.path.abspath(root))}"
+
+    @property
+    def _lease_namespace(self) -> Path:
+        """Return the common-Git namespace shared by physical wrapper views."""
+
+        cached = getattr(self, "_physical_lease_namespace", None)
+        if isinstance(cached, Path):
+            self._assert_lease_namespace_identity(cached)
+            return cached
+        fallback = getattr(self, "_fallback_lease_namespace", None)
+        if isinstance(fallback, Path) and not (
+            self.paths.repository / ".git"
+        ).exists():
+            self._assert_lease_namespace_identity(fallback)
+            return fallback
+        try:
+            anchor = self._git_common_directory(
+                self.paths.repository, trace=False
+            )
+        except WorkspaceError:
+            # Unit fixtures and a not-yet-materialized wrapper still need a
+            # stable pre-Git anchor. A production wrapper is itself a checkout.
+            git_marker = self.paths.repository / ".git"
+            if git_marker.exists() or git_marker.is_symlink():
+                raise
+            anchor = self.paths.repository.resolve(strict=False)
+        namespace = anchor / "atrinik-resource-leases"
+        if (self.paths.repository / ".git").exists():
+            if isinstance(fallback, Path) and fallback != namespace:
+                raise WorkspaceError(
+                    "wrapper Git identity materialized after workspace construction; "
+                    "recreate the Workspace before continuing"
+                )
+            self._physical_lease_namespace = namespace
+        else:
+            self._fallback_lease_namespace = namespace
+        return namespace
+
+    def _establish_lease_namespace_identity(self) -> tuple[int, int]:
+        namespace = self._lease_namespace
+        namespace.mkdir(mode=0o700, exist_ok=True)
+        visible = namespace.stat(follow_symlinks=False)
+        if not stat.S_ISDIR(visible.st_mode) or stat.S_IMODE(visible.st_mode) != 0o700:
+            raise WorkspaceError(f"physical lease namespace is unsafe: {namespace}")
+        identity = (visible.st_dev, visible.st_ino)
+        if not (self.paths.repository / ".git").exists():
+            return identity
+        record_path = namespace.parent / "atrinik-resource-leases.identity.json"
+        lock_path = namespace.parent / "atrinik-resource-leases.identity.lock"
+        with exclusive_lock(lock_path, "physical lease namespace identity"):
+            if record_path.exists() or record_path.is_symlink():
+                record = load_regular_json(
+                    record_path, "physical lease namespace identity"
+                )
+                if (
+                    not isinstance(record, dict)
+                    or set(record) != {"schema_version", "device", "inode"}
+                    or record.get("schema_version") != 1
+                    or record.get("device") != identity[0]
+                    or record.get("inode") != identity[1]
+                ):
+                    raise WorkspaceError(
+                        "physical lease namespace identity changed; restore the "
+                        f"original namespace: {namespace}"
+                    )
+            else:
+                durable_atomic_json(
+                    record_path,
+                    {
+                        "schema_version": 1,
+                        "device": identity[0],
+                        "inode": identity[1],
+                    },
+                )
+        return identity
+
+    def _assert_lease_namespace_identity(self, namespace: Path) -> None:
+        expected = getattr(self, "_physical_lease_namespace_identity", None)
+        if expected is None:
+            return
+        try:
+            visible = namespace.stat(follow_symlinks=False)
+        except OSError as error:
+            raise WorkspaceError(
+                f"physical lease namespace is unavailable: {namespace}: {error}"
+            ) from error
+        if (
+            not stat.S_ISDIR(visible.st_mode)
+            or (visible.st_dev, visible.st_ino) != expected
+        ):
+            raise WorkspaceError(
+                "physical lease namespace identity changed; restore the original "
+                f"namespace: {namespace}"
+            )
+
+    def command_maintenance(self) -> AbstractContextManager[None]:
+        """Protect one non-migration CLI command from physical layout writers."""
+
+        return shared_maintenance_lock(
+            self._lease_namespace / "repository-layout.lock"
+        )
+
+    def _lease_root(self, request: LeaseRequest) -> Path:
+        """Route physical and workspace-local coordinates to stable namespaces."""
+
+        if request.kind in {"git-admin", "source"}:
+            return self._lease_namespace
+        return self.paths.workspace
+
+    def _assert_physical_namespace_fd(self, descriptor: int) -> None:
+        expected = getattr(self, "_physical_lease_namespace_identity", None)
+        if expected is None:
+            return
+        opened = os.fstat(descriptor)
+        if (opened.st_dev, opened.st_ino) != expected:
+            raise WorkspaceError(
+                "physical lease namespace identity changed; restore the original "
+                f"namespace: {self._lease_namespace}"
+            )
+
+    @contextmanager
+    def _resource_locks(
+        self,
+        requests: list[LeaseRequest] | tuple[LeaseRequest, ...],
+        *,
+        nonblocking: bool = False,
+    ) -> Iterator[tuple[TextIO, ...]]:
+        """Acquire exact leases beneath the shared migration barrier."""
+
+        wrapper_request = self._lease_request(
+            "source",
+            self._source_coordinate("atrinik", self.paths.repository),
+            "shared",
+            "use wrapper worktree",
+        )
+        protected_requests = (*requests, wrapper_request)
+        with shared_maintenance_lock(
+            self._lease_namespace / "repository-layout.lock"
+        ):
+            with resource_locks(
+                self._lease_root, protected_requests, nonblocking=nonblocking
+            ) as leases:
+                self._assert_lease_namespace_identity(self._lease_namespace)
+                yield leases
+                self._assert_lease_namespace_identity(self._lease_namespace)
+
+    @contextmanager
+    def _resource_locks_all_or_none(
+        self, requests: list[LeaseRequest] | tuple[LeaseRequest, ...]
+    ) -> Iterator[tuple[TextIO, ...]]:
+        """Acquire a set without retaining earlier coordinates while waiting."""
+
+        ordered = tuple(sorted(requests, key=lambda request: request.sort_key))
+        while True:
+            try:
+                with self._resource_locks(ordered, nonblocking=True) as leases:
+                    yield leases
+                    return
+            except LockBusyError:
+                pass
+            for request in ordered:
+                try:
+                    with self._resource_locks([request], nonblocking=True):
+                        continue
+                except LockBusyError:
+                    with self._resource_locks([request]):
+                        pass
+                    break
+
+    def _git_admin_coordinate(self, checkout: Checkout, primary: Path) -> str:
+        # Every wrapper-managed worktree for a physical checkout is anchored to
+        # its canonical primary. The stable primary coordinate remains usable
+        # before clone and avoids reading mutable Git administration state just
+        # to discover the lease that protects that state.
+        return f"{checkout.name}:{primary.resolve(strict=False)}"
+
+    def _wrapper_git_admin_coordinate(self) -> str:
+        return f"atrinik:{self._lease_namespace.parent}"
+
+    @contextmanager
+    def _resolved_profile_operation(
+        self,
+        profile_name: str,
+        required: set[str],
+        operation: str,
+    ) -> Iterator[ProfileResolutionSnapshot]:
+        """Capture and retain one exact profile/source resolution."""
+
+        profile_request = self._lease_request(
+            "profile", profile_name, "shared", operation
+        )
+        with self._resource_locks([profile_request]):
+            profile = self._load_profile_file(profile_name, require_file=False)
+            stack = self.manifest.stack(profile["stack"])
+            source_requests: list[LeaseRequest] = []
+            seen: set[str] = set()
+            for component in stack.components:
+                root = self._selector_root(profile, component)
+                coordinate = self._source_coordinate(component.checkout_name, root)
+                if coordinate in seen:
+                    continue
+                seen.add(coordinate)
+                source_requests.append(
+                    self._lease_request("source", coordinate, "shared", operation)
+                )
+            with self._resource_locks(source_requests):
+                confirmed_profile = self._load_profile_file(
+                    profile_name, require_file=False
+                )
+                if confirmed_profile != profile:
+                    raise WorkspaceError(
+                        f"profile {profile_name} changed while its exact sources were being locked; retry"
+                    )
+                selected = self._resolve_build_profile(
+                    profile_name, required, trace=False, profile=confirmed_profile
+                )
+                states = self._selected_checkout_states(
+                    profile, selected, include_dirty=True, include_identity=True
+                )
+                serializable_states = {
+                    name: {**state, "path": str(state["path"])}
+                    for name, state in states.items()
+                }
+                profile_json = json.dumps(
+                    profile, sort_keys=True, separators=(",", ":")
+                )
+                selected_rows = tuple(
+                    (role, str(path.resolve()))
+                    for role, path in sorted(selected.items())
+                )
+                state_json = json.dumps(
+                    serializable_states, sort_keys=True, separators=(",", ":")
+                )
+                generation = hashlib.sha256(
+                    f"{profile_json}\0{selected_rows!r}\0{state_json}".encode()
+                ).hexdigest()
+                snapshot = ProfileResolutionSnapshot(
+                    profile_name,
+                    generation,
+                    profile_json,
+                    selected_rows,
+                    state_json,
+                )
+                previous = self._profile_snapshot
+                self._profile_snapshot = snapshot
+                try:
+                    yield snapshot
+                finally:
+                    self._profile_snapshot = previous
+
     def migrate_repositories(self, mode: str) -> dict[str, Any]:
         if mode == "apply":
             self.paths.ensure()
-        return RepositoryMigration(
-            self.paths.repository, self.paths, self.manifest
+        result = RepositoryMigration(
+            self.paths.repository,
+            self.paths,
+            self.manifest,
+            self._lease_namespace / "repository-layout.lock",
+            self._publish_migration_profile_references,
         ).execute(mode)
+        return result
 
     def migrate_content(self, mode: str) -> dict[str, Any]:
         if mode in {"apply", "restore"}:
             self.paths.ensure()
-        return ContentMigration(
-            self.paths.repository, self.paths, self.manifest
+        result = ContentMigration(
+            self.paths.repository,
+            self.paths,
+            self.manifest,
+            self._lease_namespace / "repository-layout.lock",
+            self._publish_migration_profile_references,
         ).execute(mode)
+        return result
 
     def cleanup(
         self,
@@ -1269,7 +1687,12 @@ class Workspace:
         # helpers without creating a module import cycle.
         from .cleanup import Cleanup
 
-        return Cleanup(self).execute(scopes, older_than_days, names, apply)
+        if not apply:
+            return Cleanup(self).execute(scopes, older_than_days, names, False)
+        with shared_maintenance_lock(
+            self._lease_namespace / "repository-layout.lock"
+        ):
+            return Cleanup(self).execute(scopes, older_than_days, names, True)
 
     def _checkout_identity(self, value: Checkout | Component) -> Checkout:
         if isinstance(value, Checkout):
@@ -1320,34 +1743,47 @@ class Workspace:
         self.paths.ensure()
         checkouts = self._operation_checkouts(names, include_classic)
         failures: list[str] = []
-        with exclusive_layout_lock(
-            self.paths.workspace / "repository-layout.lock",
-            "repository layout",
-        ):
-            # Validate every occupied destination before starting any clone.
-            # A pre-split classic checkout at a canonical replacement path
-            # must stop the entire operation without leaving a partially
-            # initialized replacement cohort behind.
-            for checkout in checkouts:
-                destination = self._primary_path(checkout)
-                if destination.exists() or destination.is_symlink():
-                    self._validate_primary_checkout(checkout, destination)
-            with ThreadPoolExecutor(
-                max_workers=max(1, min(jobs, len(checkouts)))
-            ) as executor:
-                futures = {
-                    executor.submit(
-                        copy_context().run, self._ensure_repository, checkout
-                    ): checkout
-                    for checkout in checkouts
-                }
-                for future in as_completed(futures):
-                    checkout = futures[future]
-                    try:
-                        future.result()
-                        print(f"{checkout.name}: ready")
-                    except Exception as error:
-                        failures.append(f"{checkout.name}: {error}")
+        # Validate every occupied destination before starting any clone. This
+        # preserves all-or-nothing preflight while the actual operations use
+        # disjoint checkout leases and may overlap.
+        for checkout in checkouts:
+            destination = self._primary_path(checkout)
+            if destination.exists() or destination.is_symlink():
+                self._validate_primary_checkout(checkout, destination)
+
+        def initialize_checkout(checkout: Checkout) -> Path:
+            destination = self._primary_path(checkout)
+            requests = [
+                self._lease_request(
+                    "git-admin",
+                    self._git_admin_coordinate(checkout, destination),
+                    "exclusive",
+                    f"initialize {checkout.name}",
+                ),
+                self._lease_request(
+                    "source",
+                    self._source_coordinate(checkout.name, destination),
+                    "exclusive",
+                    f"initialize {checkout.name}",
+                ),
+            ]
+            with self._resource_locks(requests):
+                return self._ensure_repository(checkout)
+
+        with ThreadPoolExecutor(
+            max_workers=max(1, min(jobs, len(checkouts)))
+        ) as executor:
+            futures = {
+                executor.submit(copy_context().run, initialize_checkout, checkout): checkout
+                for checkout in checkouts
+            }
+            for future in as_completed(futures):
+                checkout = futures[future]
+                try:
+                    future.result()
+                    print(f"{checkout.name}: ready")
+                except Exception as error:
+                    failures.append(f"{checkout.name}: {error}")
         if failures:
             raise WorkspaceError(
                 "repository initialization failed:\n" + "\n".join(sorted(failures))
@@ -1614,11 +2050,111 @@ class Workspace:
         if worktree_strategy not in {"none", "merge", "rebase"}:
             raise WorkspaceError(f"unknown worktree strategy: {worktree_strategy}")
         checkouts = self._operation_checkouts(names, include_classic)
-        with exclusive_layout_lock(
-            self.paths.workspace / "repository-layout.lock",
-            "repository layout",
-        ):
-            self._sync_components(checkouts, names, worktree_strategy)
+        failures: list[str] = []
+
+        # Preserve the command's all-checkout preflight guarantee before any
+        # parallel worker can fetch or advance a checkout. Workers repeat this
+        # validation under their exact Git-admin/source leases to close races.
+        explicitly_requested = {
+            checkout.name
+            for checkout in self._operation_checkouts(names, False)
+        } if names else set()
+        migrated_content = (
+            self._migrated_content_worktree_paths()
+            if worktree_strategy != "none"
+            and any(checkout.name == "content" for checkout in checkouts)
+            else set()
+        )
+        for checkout in checkouts:
+            repository = self._primary_path(checkout)
+            if not repository.exists() and not repository.is_symlink():
+                if checkout.name in explicitly_requested:
+                    raise WorkspaceError(
+                        "component is not initialized; run ./atrinik init "
+                        f"{checkout.name}: {repository}"
+                    )
+                continue
+            self._validate_primary_checkout(checkout, repository)
+            if not _is_clean(repository):
+                raise WorkspaceError(
+                    f"refusing to update dirty primary checkout: {repository}"
+                )
+            self._canonical_remote(checkout, repository)
+            if worktree_strategy != "none":
+                self._component_worktrees(
+                    repository,
+                    migrated_content if checkout.name == "content" else set(),
+                )
+
+        def sync_checkout(checkout: Checkout) -> None:
+            repository = self._primary_path(checkout)
+            admin_request = self._lease_request(
+                "git-admin",
+                self._git_admin_coordinate(checkout, repository),
+                "exclusive",
+                f"synchronize {checkout.name}",
+            )
+            def source_roots() -> tuple[Path, ...]:
+                roots = [repository]
+                if repository.is_dir() and worktree_strategy != "none":
+                    roots.extend(
+                        Path(record["worktree"])
+                        for record in _worktree_records(repository, trace=False)
+                        if "branch" in record
+                    )
+                return tuple(
+                    sorted(
+                        {root.resolve(strict=False) for root in roots},
+                        key=str,
+                    )
+                )
+
+            while True:
+                with self._resource_locks([admin_request]):
+                    roots = source_roots()
+                requests = [
+                    self._lease_request(
+                        "source",
+                        self._source_coordinate(checkout.name, root),
+                        "exclusive",
+                        f"synchronize {checkout.name}",
+                    )
+                    for root in roots
+                ]
+                with self._resource_locks_all_or_none(requests):
+                    try:
+                        with self._resource_locks(
+                            [admin_request],
+                            nonblocking=True,
+                        ):
+                            if source_roots() != roots:
+                                continue
+                            self._sync_components(
+                                [checkout], names, worktree_strategy
+                            )
+                            return
+                    except LockBusyError:
+                        pass
+                # Never wait for Git administration while retaining a source
+                # lease: let the conflicting bounded mutation complete, then
+                # resnapshot and retry the ordered exact set.
+                with self._resource_locks([admin_request]):
+                    pass
+
+        with ThreadPoolExecutor(max_workers=max(1, len(checkouts))) as executor:
+            futures = {
+                executor.submit(copy_context().run, sync_checkout, checkout): checkout
+                for checkout in checkouts
+            }
+            for future in as_completed(futures):
+                try:
+                    future.result()
+                except Exception as error:
+                    failures.append(f"{futures[future].name}: {error}")
+        if failures:
+            raise WorkspaceError(
+                "repository synchronization failed:\n" + "\n".join(sorted(failures))
+            )
 
     def _sync_components(
         self,
@@ -1760,13 +2296,49 @@ class Workspace:
         existing: bool,
     ) -> Path:
         self.paths.ensure()
-        with exclusive_layout_lock(
-            self.paths.workspace / "repository-layout.lock",
-            "repository layout",
+        validate_name(label, "worktree label")
+        checkout = self._resolve_checkout(component_name)
+        repository = self._primary_path(checkout)
+        destination = self.paths.worktrees / checkout.name / label
+        with shared_maintenance_lock(
+            self._lease_namespace / "repository-layout.lock"
         ):
-            return self._create_worktree(
-                component_name, label, branch, start_point, existing
-            )
+            with self._open_managed_worktree_parent(destination) as (
+                stable_destination,
+                physical_destination,
+            ):
+                requests = [
+                    self._lease_request(
+                        "git-admin",
+                        self._git_admin_coordinate(checkout, repository),
+                        "exclusive",
+                        f"create worktree {checkout.name}/{label}",
+                    ),
+                    self._lease_request(
+                        "source",
+                        self._source_coordinate(checkout.name, physical_destination),
+                        "exclusive",
+                        f"create worktree {checkout.name}/{label}",
+                    ),
+                ]
+                if not repository.exists() and not repository.is_symlink():
+                    requests.append(
+                        self._lease_request(
+                            "source",
+                            self._source_coordinate(checkout.name, repository),
+                            "exclusive",
+                            f"initialize {checkout.name} for worktree creation",
+                        )
+                    )
+                with self._resource_locks(requests):
+                    return self._create_worktree(
+                        component_name,
+                        label,
+                        branch,
+                        start_point,
+                        existing,
+                        stable_destination,
+                    )
 
     def _create_worktree(
         self,
@@ -1775,6 +2347,7 @@ class Workspace:
         branch: str,
         start_point: str | None,
         existing: bool,
+        stable_destination: Path | None = None,
     ) -> Path:
         self.paths.ensure()
         validate_name(label, "worktree label")
@@ -1782,66 +2355,331 @@ class Workspace:
         repository = self._ensure_repository(checkout)
         remote = self._canonical_remote(checkout, repository)
         run(["git", "check-ref-format", "--branch", branch], capture=True)
-        destination = self.paths.worktrees / checkout.name / label
+        reported_destination = self.paths.worktrees / checkout.name / label
+        destination = stable_destination or reported_destination
         if destination.exists():
-            raise WorkspaceError(f"worktree destination already exists: {destination}")
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        if existing:
-            git(repository, "worktree", "add", "--", str(destination), branch)
-        else:
-            if start_point is not None and start_point.startswith("-"):
-                raise WorkspaceError("worktree start point must not begin with '-'")
-            point = start_point or f"{remote}/{checkout.branch}"
-            git(repository, "fetch", "--prune", remote)
-            commit = git(
-                repository,
-                "rev-parse",
-                "--verify",
-                "--end-of-options",
-                f"{point}^{{commit}}",
-                capture=True,
+            raise WorkspaceError(
+                f"worktree destination already exists: {reported_destination}"
             )
-            git(
-                repository,
-                "worktree",
-                "add",
-                "-b",
-                branch,
-                "--",
-                str(destination),
-                commit,
-            )
-        self._validate_checkout(checkout, destination)
-        print(destination)
-        return destination
+        if stable_destination is None:
+            destination.parent.mkdir(parents=True, exist_ok=True)
+        installed = False
+        try:
+            if existing:
+                git(repository, "worktree", "add", "--", str(destination), branch)
+            else:
+                if start_point is not None and start_point.startswith("-"):
+                    raise WorkspaceError("worktree start point must not begin with '-'")
+                point = start_point or f"{remote}/{checkout.branch}"
+                git(repository, "fetch", "--prune", remote)
+                commit = git(
+                    repository,
+                    "rev-parse",
+                    "--verify",
+                    "--end-of-options",
+                    f"{point}^{{commit}}",
+                    capture=True,
+                )
+                git(
+                    repository,
+                    "worktree",
+                    "add",
+                    "-b",
+                    branch,
+                    "--",
+                    str(destination),
+                    commit,
+                )
+            installed = True
+            self._validate_checkout(checkout, destination)
+            if stable_destination is not None:
+                self._require_visible_worktree_identity(
+                    reported_destination, destination
+                )
+        except BaseException as error:
+            if installed:
+                try:
+                    git(repository, "worktree", "remove", "--force", str(destination))
+                    if not existing:
+                        git(repository, "branch", "-D", branch)
+                except BaseException as rollback_error:
+                    raise WorkspaceError(
+                        "worktree creation failed and its Git registration could not "
+                        f"be rolled back: {rollback_error}"
+                    ) from error
+            raise
+        print(reported_destination)
+        return reported_destination
 
     def remove_worktree(self, component_name: str, label: str) -> None:
         self.paths.ensure()
-        with exclusive_layout_lock(
-            self.paths.workspace / "repository-layout.lock",
-            "repository layout",
+        validate_name(label, "worktree label")
+        checkout = self._resolve_checkout(component_name)
+        destination = self.paths.worktrees / checkout.name / label
+        repository = self._primary_path(checkout)
+        if not repository.is_dir() or repository.is_symlink():
+            raise WorkspaceError(
+                "component is not initialized; run ./atrinik init "
+                f"{checkout.name}: {repository}"
+            )
+        admin_request = self._lease_request(
+            "git-admin",
+            self._git_admin_coordinate(checkout, repository),
+            "exclusive",
+            f"remove worktree {checkout.name}/{label}",
+        )
+        with self._open_managed_worktree(destination) as (
+            stable_destination,
+            physical_destination,
         ):
-            self._remove_worktree(component_name, label)
+            source_request = self._lease_request(
+                "source",
+                self._source_coordinate(checkout.name, physical_destination),
+                "exclusive",
+                f"remove worktree {checkout.name}/{label}",
+            )
+            while True:
+                with self._resource_locks([source_request]):
+                    try:
+                        with self._resource_locks(
+                            [admin_request], nonblocking=True
+                        ):
+                            self._remove_worktree(
+                                component_name, label, stable_destination
+                            )
+                            return
+                    except LockBusyError:
+                        pass
+                with self._resource_locks([admin_request]):
+                    pass
 
-    def _remove_worktree(self, component_name: str, label: str) -> None:
+    def _remove_worktree(
+        self, component_name: str, label: str, stable_destination: Path
+    ) -> None:
         self.paths.ensure()
         validate_name(label, "worktree label")
         checkout = self._resolve_checkout(component_name)
-        repository = self._ensure_repository(checkout)
+        repository = self._primary_path(checkout)
+        self._validate_primary_checkout(checkout, repository)
         candidates = [self.paths.worktrees / checkout.name / label]
-        existing = [candidate.resolve() for candidate in candidates if candidate.is_dir()]
-        if len(existing) != 1:
-            rendered = ", ".join(str(candidate) for candidate in candidates)
-            raise WorkspaceError(f"worktree does not exist unambiguously: {rendered}")
-        destination = existing[0]
-        expected_parents = {
-            (self.paths.worktrees / checkout.name).resolve(),
-        }
-        if destination.parent not in expected_parents:
-            raise WorkspaceError(f"invalid managed worktree path: {destination}")
+        destination = stable_destination
+        if any(candidate.is_symlink() for candidate in candidates):
+            raise WorkspaceError(
+                "worktree does not exist unambiguously: "
+                + ", ".join(str(candidate) for candidate in candidates)
+            )
+        self._require_visible_worktree_identity(candidates[0], destination)
         if not _is_clean(destination):
             raise WorkspaceError(f"refusing to remove dirty worktree: {destination}")
+        references = self._source_references(destination)
+        if references:
+            raise WorkspaceError(
+                f"refusing to remove referenced worktree {destination}: "
+                + ", ".join(references)
+            )
+        self._require_visible_worktree_identity(candidates[0], destination)
         git(repository, "worktree", "remove", str(destination))
+
+    @staticmethod
+    def _require_visible_worktree_identity(visible: Path, stable: Path) -> None:
+        try:
+            visible_identity = visible.stat(follow_symlinks=False)
+            stable_identity = stable.stat()
+        except OSError as error:
+            raise WorkspaceError(
+                f"managed worktree path was replaced: {visible}"
+            ) from error
+        if (
+            not stat.S_ISDIR(visible_identity.st_mode)
+            or (visible_identity.st_dev, visible_identity.st_ino)
+            != (stable_identity.st_dev, stable_identity.st_ino)
+        ):
+            raise WorkspaceError(f"managed worktree path was replaced: {visible}")
+
+    @contextmanager
+    def _open_managed_worktree(
+        self, destination: Path
+    ) -> Iterator[tuple[Path, Path]]:
+        """Retain a no-follow target descriptor through destructive Git use."""
+
+        root = Path(os.path.abspath(self.paths.worktrees))
+        candidate = Path(os.path.abspath(destination))
+        try:
+            relative = candidate.relative_to(root)
+        except ValueError as error:
+            raise WorkspaceError(f"invalid managed worktree path: {candidate}") from error
+        if len(relative.parts) != 2:
+            raise WorkspaceError(f"invalid managed worktree path: {candidate}")
+        flags = os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_DIRECTORY", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        descriptors: list[int] = []
+        try:
+            current_fd = os.open(root, flags)
+            descriptors.append(current_fd)
+            current_path = root
+            for part in relative.parts:
+                next_fd = os.open(part, flags, dir_fd=current_fd)
+                descriptors.append(next_fd)
+                current_fd = next_fd
+                current_path /= part
+                opened = os.fstat(current_fd)
+                visible = current_path.stat(follow_symlinks=False)
+                if (
+                    not stat.S_ISDIR(opened.st_mode)
+                    or (opened.st_dev, opened.st_ino)
+                    != (visible.st_dev, visible.st_ino)
+                ):
+                    raise WorkspaceError(
+                        f"managed worktree path was replaced: {current_path}"
+                    )
+            retained = os.dup(current_fd)
+            try:
+                stable = _descriptor_path(retained)
+                physical = stable.resolve(strict=True)
+                with inherit_lock_fds(retained):
+                    yield stable, physical
+            finally:
+                os.close(retained)
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot open managed worktree path {candidate}: {error}"
+            ) from error
+        finally:
+            for descriptor in reversed(descriptors):
+                os.close(descriptor)
+
+    @contextmanager
+    def _open_managed_worktree_parent(
+        self, destination: Path
+    ) -> Iterator[tuple[Path, Path]]:
+        """Retain the destination parent without following managed-path links."""
+
+        root = Path(os.path.abspath(self.paths.worktrees))
+        candidate = Path(os.path.abspath(destination))
+        try:
+            relative = candidate.relative_to(root)
+        except ValueError as error:
+            raise WorkspaceError(f"invalid managed worktree path: {candidate}") from error
+        if len(relative.parts) != 2:
+            raise WorkspaceError(f"invalid managed worktree path: {candidate}")
+        checkout_name, label = relative.parts
+        flags = os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_DIRECTORY", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        descriptors: list[int] = []
+        try:
+            root_fd = os.open(root, flags)
+            descriptors.append(root_fd)
+            try:
+                os.mkdir(checkout_name, dir_fd=root_fd)
+            except FileExistsError:
+                pass
+            parent_fd = os.open(checkout_name, flags, dir_fd=root_fd)
+            descriptors.append(parent_fd)
+            opened = os.fstat(parent_fd)
+            visible_path = root / checkout_name
+            visible = visible_path.stat(follow_symlinks=False)
+            if (
+                not stat.S_ISDIR(opened.st_mode)
+                or (opened.st_dev, opened.st_ino) != (visible.st_dev, visible.st_ino)
+            ):
+                raise WorkspaceError(
+                    f"managed worktree path was replaced: {visible_path}"
+                )
+            try:
+                os.stat(label, dir_fd=parent_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                pass
+            else:
+                raise WorkspaceError(f"worktree destination already exists: {candidate}")
+            retained = os.dup(parent_fd)
+            try:
+                stable_parent = _descriptor_path(retained)
+                physical_parent = stable_parent.resolve(strict=True)
+                with inherit_lock_fds(retained):
+                    yield stable_parent / label, physical_parent / label
+            finally:
+                os.close(retained)
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot open managed worktree parent {candidate.parent}: {error}"
+            ) from error
+        finally:
+            for descriptor in reversed(descriptors):
+                os.close(descriptor)
+
+    def _source_references(self, source_root: Path) -> list[str]:
+        """Return exact persisted references while the caller holds source exclusive."""
+
+        target = source_root.resolve()
+        references: list[str] = []
+        for record in self._physical_reference_records():
+            if (
+                not isinstance(record, dict)
+                or set(record) != {"schema_version", "kind", "reference", "sources"}
+                or record["schema_version"] != 1
+                or record["kind"] not in {"profiles", "scenarios"}
+                or not isinstance(record["reference"], str)
+                or not isinstance(record["sources"], list)
+            ):
+                raise WorkspaceError("cannot prove physical reference record")
+            if any(
+                not isinstance(source, str) or not Path(source).is_absolute()
+                for source in record["sources"]
+            ):
+                raise WorkspaceError("cannot prove physical reference record")
+            if target in {
+                Path(source).resolve(strict=False) for source in record["sources"]
+            }:
+                references.append(f"{record['kind'][:-1]}:{record['reference']}")
+        if self.paths.profiles.exists():
+            for path in sorted(self.paths.profiles.glob("*.json")):
+                profile = self._load_profile_file(path.stem, require_file=True)
+                stack = self.manifest.stack(profile["stack"])
+                roots = {
+                    self._selector_root(profile, component).resolve(strict=False)
+                    for component in stack.components
+                }
+                if target in roots:
+                    references.append(f"profile:{profile['name']}")
+        for container, record_name in (
+            (self.paths.topologies, "topology"),
+            (self.paths.scenarios, "scenario"),
+        ):
+            if not container.exists():
+                continue
+            for directory in sorted(container.iterdir()):
+                if (
+                    directory.name.startswith(".")
+                    or not directory.is_dir()
+                    or directory.is_symlink()
+                ):
+                    continue
+                candidates = (
+                    (directory / "spec.json", directory / "status.json")
+                    if record_name == "topology"
+                    else (directory / "scenario.json",)
+                )
+                for record_path in candidates:
+                    if not record_path.exists():
+                        continue
+                    value = load_json(record_path)
+                    resolved = value.get("resolved") if isinstance(value, dict) else None
+                    if not isinstance(resolved, dict):
+                        raise WorkspaceError(
+                            f"cannot prove {record_name} references: {record_path}"
+                        )
+                    for coordinate in resolved.values():
+                        if not isinstance(coordinate, dict):
+                            continue
+                        raw_path = coordinate.get("checkout_path") or coordinate.get("path")
+                        if isinstance(raw_path, str) and Path(raw_path).resolve(
+                            strict=False
+                        ) == target:
+                            references.append(f"{record_name}:{directory.name}")
+                            break
+                    if references and references[-1] == f"{record_name}:{directory.name}":
+                        break
+        return sorted(set(references))
 
     def list_worktrees(self, names: list[str] | None = None) -> list[tuple[str, dict[str, str]]]:
         self.paths.ensure()
@@ -1864,13 +2702,49 @@ class Workspace:
 
     def create_profile(self, name: str, source: str = "default") -> Path:
         self.paths.ensure()
-        with exclusive_layout_lock(
-            self.paths.workspace / "repository-layout.lock",
-            "repository layout",
-        ):
-            return self._create_profile(name, source)
+        validate_name(name, "profile name")
+        validate_name(source, "profile name")
+        requests = [
+            self._lease_request(
+                "profile", name, "exclusive", f"create profile {name}"
+            ),
+            self._lease_request(
+                "profile", source, "shared", f"copy profile {source} to {name}"
+            ),
+        ]
+        with self._resource_locks(requests):
+            source_profile = self._load_profile_file(source, require_file=False)
+            stack = self.manifest.stack(source_profile["stack"])
+            source_requests: list[LeaseRequest] = []
+            seen: set[str] = set()
+            for component in stack.components:
+                root = self._selector_root(source_profile, component)
+                coordinate = self._source_coordinate(
+                    component.checkout_name, root
+                )
+                if coordinate in seen:
+                    continue
+                seen.add(coordinate)
+                source_requests.append(
+                    self._lease_request(
+                        "source", coordinate, "shared", f"create profile {name}"
+                    )
+                )
+            with self._resource_locks(source_requests):
+                confirmed_profile = self._load_profile_file(
+                    source, require_file=False
+                )
+                if confirmed_profile != source_profile:
+                    raise WorkspaceError(
+                        f"profile {source} changed while its exact sources were being locked; retry"
+                    )
+                return self._create_profile(name, confirmed_profile)
 
-    def _create_profile(self, name: str, source: str = "default") -> Path:
+    def _create_profile(
+        self,
+        name: str,
+        source_profile: dict[str, Any],
+    ) -> Path:
         self.paths.ensure()
         validate_name(name, "profile name")
         if name in self.manifest.stacks:
@@ -1878,7 +2752,6 @@ class Workspace:
         path = self.paths.profiles / f"{name}.json"
         if path.exists():
             raise WorkspaceError(f"profile already exists: {name}")
-        source_profile = self._load_profile(source, require_file=False)
         value = {
             "schema_version": PROFILE_SCHEMA_VERSION,
             "name": name,
@@ -1889,7 +2762,16 @@ class Workspace:
                 for component_name, selector in source_profile["components"].items()
             },
         }
-        atomic_json(path, value)
+        self._publish_profile_references(name, value)
+        try:
+            durable_atomic_json(path, value)
+        except AtomicJsonCommitUncertain:
+            # The authored profile is visible. Keep its conservative physical
+            # references rather than pretending publication did not occur.
+            raise
+        except BaseException:
+            self._remove_physical_reference(path)
+            raise
         print(path)
         return path
 
@@ -1897,17 +2779,584 @@ class Workspace:
         self, name: str, component_name: str, kind: str, value: str = ""
     ) -> None:
         self.paths.ensure()
-        with exclusive_layout_lock(
-            self.paths.workspace / "repository-layout.lock",
-            "repository layout",
+        validate_name(name, "profile name")
+        profile_request = self._lease_request(
+            "profile", name, "exclusive", f"update profile {name}"
+        )
+        with self._resource_locks([profile_request]):
+            profile = self._load_profile_file(name, require_file=True)
+            components = self._profile_components(profile, component_name)
+            checkout_names = {component.checkout_name for component in components}
+            if len(checkout_names) != 1:
+                raise WorkspaceError(
+                    f"profile selection spans multiple checkouts: {component_name}"
+                )
+            checkout_name = checkout_names.pop()
+            checkout = self.manifest.by_checkout[checkout_name]
+            if kind == "primary":
+                selected_root = self._primary_path(checkout)
+            elif kind == "worktree":
+                validate_name(value, "worktree label")
+                selected_root = self.paths.worktrees / checkout_name / value
+            elif kind == "path":
+                selected_root = Path(value).expanduser()
+                if not selected_root.is_absolute():
+                    raise WorkspaceError("profile checkout path must be absolute")
+                if selected_root.is_symlink():
+                    raise WorkspaceError(
+                        f"component checkout is not a directory: {selected_root}"
+                    )
+                selected_root = selected_root.resolve(strict=False)
+                value = str(selected_root)
+            else:
+                raise WorkspaceError(f"invalid profile selector kind: {kind}")
+            source_request = self._lease_request(
+                "source",
+                self._source_coordinate(checkout_name, selected_root),
+                "shared",
+                f"publish profile {name}",
+            )
+            with self._resource_locks([source_request]):
+                self._set_profile(name, component_name, kind, value)
+
+    def _backfill_profile_references(self, *, already_locked: bool = False) -> bool:
+        if not self.paths.profiles.is_dir() or self.paths.profiles.is_symlink():
+            return True
+        complete = True
+        for path in sorted(self.paths.profiles.glob("*.json")):
+            if already_locked:
+                profile = self._load_profile_file(path.stem, require_file=True)
+                self._publish_profile_references(path.stem, profile)
+                continue
+            profile = load_regular_json(path, f"profile {path.stem}")
+            sources = self._raw_profile_reference_sources(path.stem, profile)
+            requests = [
+                self._lease_request(
+                    "profile", path.stem, "shared", "backfill profile reference"
+                ),
+                *[
+                    self._lease_request(
+                        "source",
+                        self._source_coordinate(checkout, source),
+                        "shared",
+                        "backfill profile reference",
+                    )
+                    for checkout, source in sources
+                ],
+            ]
+            try:
+                with resource_locks(self._lease_root, requests, nonblocking=True):
+                    confirmed = load_regular_json(path, f"profile {path.stem}")
+                    if confirmed != profile or any(
+                        not source.is_dir() for _checkout, source in sources
+                    ):
+                        complete = False
+                        continue
+                    self._publish_raw_profile_references(
+                        path.stem, path, profile=confirmed
+                    )
+            except LockBusyError:
+                complete = False
+        return complete
+
+    def _raw_profile_reference_sources(
+        self, name: str, profile: Any
+    ) -> list[tuple[str, Path]]:
+        if not isinstance(profile, dict) or not isinstance(profile.get("components"), dict):
+            raise WorkspaceError(f"profile must be an object with components: {name}")
+        sources: dict[tuple[str, str], tuple[str, Path]] = {}
+        for component_name, selector in profile["components"].items():
+            if not isinstance(selector, dict) or selector.get("kind") == "primary":
+                continue
+            component = self.manifest.by_name.get(component_name)
+            kind, value = selector.get("kind"), selector.get("value")
+            legacy_component = component is None and (
+                component_name == "content-1x" or component_name in PROFILE_IDENTITIES
+            )
+            if (component is None and not legacy_component) or not isinstance(value, str):
+                raise WorkspaceError(f"profile selector is invalid: {name}/{component_name}")
+            legacy_checkout = (
+                "content-1x"
+                if component_name in {"content", "content-1x"}
+                else component_name.removeprefix("legacy-")
+            )
+            root = (
+                self.paths.worktrees
+                / (component.checkout_name if component is not None else legacy_checkout)
+                / value
+                if kind == "worktree"
+                else Path(value)
+            )
+            if not root.is_absolute():
+                raise WorkspaceError(f"profile selector is invalid: {name}/{component_name}")
+            resolved = root.resolve(strict=False)
+            checkout_name = (
+                component.checkout_name if component is not None else legacy_checkout
+            )
+            sources[(checkout_name, str(resolved))] = (
+                checkout_name,
+                resolved,
+            )
+        return [sources[key] for key in sorted(sources)]
+
+    def _publish_raw_profile_references(
+        self, name: str, path: Path, *, profile: Any | None = None
+    ) -> None:
+        if profile is None:
+            profile = load_regular_json(path, f"profile {name}")
+        sources = self._raw_profile_reference_sources(name, profile)
+        identity = hashlib.sha256(str(path.resolve()).encode()).hexdigest()
+        self._atomic_physical_reference(
+            f"{identity}.json",
+            {
+                "schema_version": 1,
+                "kind": "profiles",
+                "reference": name,
+                "sources": sorted(str(source) for _checkout, source in sources),
+            },
+        )
+
+    def _publish_migration_profile_references(
+        self, transitions: dict[str, tuple[bytes, bytes]] | None = None
+    ) -> None:
+        """Publish conservative profile refs while a migration owns the barrier."""
+
+        retained: dict[str, set[str]] = {}
+        for name, generations in (transitions or {}).items():
+            sources: set[str] = set()
+            for raw in generations:
+                try:
+                    profile = json.loads(
+                        raw, object_pairs_hook=_reject_duplicate_keys
+                    )
+                    sources.update(
+                        str(source)
+                        for _checkout, source in self._raw_profile_reference_sources(
+                            name, profile
+                        )
+                    )
+                except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+                    raise WorkspaceError(
+                        f"cannot publish migration references for profile {name}: {error}"
+                    ) from error
+            retained[name] = sources
+        if not self.paths.profiles.is_dir():
+            return
+        for path in sorted(self.paths.profiles.glob("*.json")):
+            profile = load_regular_json(path, f"profile {path.stem}")
+            current = {
+                str(source)
+                for _checkout, source in self._raw_profile_reference_sources(
+                    path.stem, profile
+                )
+            }
+            identity = hashlib.sha256(str(path.resolve()).encode()).hexdigest()
+            self._atomic_physical_reference(
+                f"{identity}.json",
+                {
+                    "schema_version": 1,
+                    "kind": "profiles",
+                    "reference": path.stem,
+                    "sources": sorted(current | retained.get(path.stem, set())),
+                },
+            )
+
+    def _backfill_physical_references(self) -> None:
+        state_identity = hashlib.sha256(
+            str(self.paths.workspace.resolve()).encode()
+        ).hexdigest()
+        marker_reference = f"__backfill__:{state_identity}"
+        for marker in self._physical_reference_records(
+            only=f"{state_identity}.json"
         ):
-            self._set_profile(name, component_name, kind, value)
+            if not isinstance(marker, dict):
+                raise WorkspaceError("physical reference backfill marker is invalid")
+            if (
+                set(marker)
+                == {"schema_version", "kind", "reference", "sources"}
+                and marker.get("schema_version") == 1
+                and marker.get("kind") == "profiles"
+                and marker.get("reference") == marker_reference
+                and marker.get("sources") == []
+            ):
+                return
+            raise WorkspaceError("physical reference backfill marker is invalid")
+        with shared_maintenance_lock(
+            self._lease_namespace / "repository-layout.lock"
+        ):
+            complete = self._backfill_profile_references()
+            complete = self._backfill_scenario_references() and complete
+            if not complete:
+                raise WorkspaceError(
+                    "physical reference backfill is busy; wait for the named exact "
+                    "resource operation to finish and retry"
+                )
+            self._atomic_physical_reference(
+                f"{state_identity}.json",
+                {
+                    "schema_version": 1,
+                    "kind": "profiles",
+                    "reference": marker_reference,
+                    "sources": [],
+                },
+            )
+
+    def _atomic_physical_reference(
+        self, name: str, value: dict[str, Any]
+    ) -> None:
+        namespace = self._lease_namespace
+        flags = os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_DIRECTORY", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        parent_fd = os.open(namespace, flags)
+        directory_fd: int | None = None
+        temporary = f".{name}.{secrets.token_hex(12)}.tmp"
+        try:
+            self._assert_physical_namespace_fd(parent_fd)
+            self._validate_physical_reference_directory(
+                parent_fd, namespace, "physical lease namespace"
+            )
+            try:
+                os.mkdir("profile-references", mode=0o700, dir_fd=parent_fd)
+            except FileExistsError:
+                pass
+            directory_fd = os.open("profile-references", flags, dir_fd=parent_fd)
+            registry = namespace / "profile-references"
+            self._validate_physical_reference_directory(
+                directory_fd,
+                registry,
+                "physical reference registry",
+                expected_mode=0o700,
+            )
+            # Persist (or re-prove) the registry directory entry before any
+            # reference is accepted as durable within it. This is required on
+            # EEXIST too: a prior creator may have failed before its parent
+            # fsync completed.
+            os.fsync(parent_fd)
+            descriptor = os.open(
+                temporary,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC,
+                0o600,
+                dir_fd=directory_fd,
+            )
+            try:
+                with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+                    json.dump(value, stream, indent=2, sort_keys=True)
+                    stream.write("\n")
+                    stream.flush()
+                    os.fsync(stream.fileno())
+                os.rename(temporary, name, src_dir_fd=directory_fd, dst_dir_fd=directory_fd)
+                os.fsync(directory_fd)
+                self._validate_physical_reference_directory(
+                    directory_fd,
+                    registry,
+                    "physical reference registry",
+                    expected_mode=0o700,
+                )
+                self._validate_physical_reference_directory(
+                    parent_fd, namespace, "physical lease namespace"
+                )
+            except BaseException:
+                try:
+                    os.unlink(temporary, dir_fd=directory_fd)
+                except FileNotFoundError:
+                    pass
+                raise
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot publish physical reference {name}: {error}"
+            ) from error
+        finally:
+            if directory_fd is not None:
+                os.close(directory_fd)
+            os.close(parent_fd)
+
+    @staticmethod
+    def _validate_physical_reference_directory(
+        descriptor: int,
+        path: Path,
+        description: str,
+        *,
+        expected_mode: int | None = None,
+    ) -> None:
+        opened = os.fstat(descriptor)
+        visible = path.stat(follow_symlinks=False)
+        if (
+            not stat.S_ISDIR(opened.st_mode)
+            or not stat.S_ISDIR(visible.st_mode)
+            or (opened.st_dev, opened.st_ino) != (visible.st_dev, visible.st_ino)
+            or opened.st_uid != os.geteuid()
+            or (
+                expected_mode is not None
+                and stat.S_IMODE(opened.st_mode) != expected_mode
+            )
+        ):
+            raise WorkspaceError(f"{description} was replaced or is unsafe: {path}")
+
+    def _physical_reference_records(
+        self, *, only: str | None = None
+    ) -> list[dict[str, Any]]:
+        registry = self._lease_namespace / "profile-references"
+        flags = os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_DIRECTORY", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        namespace_fd: int | None = None
+        try:
+            namespace_fd = os.open(self._lease_namespace, flags)
+            self._assert_physical_namespace_fd(namespace_fd)
+            self._validate_physical_reference_directory(
+                namespace_fd, self._lease_namespace, "physical lease namespace"
+            )
+            try:
+                directory_fd = os.open(
+                    "profile-references", flags, dir_fd=namespace_fd
+                )
+            except FileNotFoundError:
+                self._validate_physical_reference_directory(
+                    namespace_fd,
+                    self._lease_namespace,
+                    "physical lease namespace",
+                )
+                os.close(namespace_fd)
+                return []
+            self._validate_physical_reference_directory(
+                directory_fd,
+                registry,
+                "physical reference registry",
+                expected_mode=0o700,
+            )
+        except (OSError, WorkspaceError) as error:
+            if namespace_fd is not None:
+                os.close(namespace_fd)
+            if isinstance(error, WorkspaceError):
+                raise
+            raise WorkspaceError(
+                f"cannot open physical reference registry {registry}: {error}"
+            ) from error
+        records: list[dict[str, Any]] = []
+        try:
+            names = [only] if only is not None else sorted(os.listdir(directory_fd))
+            for name in names:
+                if re.fullmatch(r"\.[0-9a-f]{64}\.json\.[0-9a-f]{24}\.tmp", name):
+                    continue
+                if not re.fullmatch(r"[0-9a-f]{64}\.json", name):
+                    raise WorkspaceError(
+                        f"cannot prove physical reference registry entry: {name}"
+                    )
+                try:
+                    descriptor = os.open(
+                        name,
+                        os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_NOFOLLOW", 0),
+                        dir_fd=directory_fd,
+                    )
+                except FileNotFoundError:
+                    if only is not None:
+                        continue
+                    raise
+                try:
+                    metadata = os.fstat(descriptor)
+                    visible = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+                    if (
+                        not stat.S_ISREG(metadata.st_mode)
+                        or (metadata.st_dev, metadata.st_ino)
+                        != (visible.st_dev, visible.st_ino)
+                        or metadata.st_size > 4 * 1024 * 1024
+                    ):
+                        raise WorkspaceError(
+                            f"cannot prove physical reference registry entry: {name}"
+                        )
+                    with os.fdopen(descriptor, encoding="utf-8", closefd=False) as stream:
+                        records.append(
+                            json.load(
+                                stream, object_pairs_hook=_reject_duplicate_keys
+                            )
+                        )
+                finally:
+                    os.close(descriptor)
+            self._validate_physical_reference_directory(
+                directory_fd,
+                registry,
+                "physical reference registry",
+                expected_mode=0o700,
+            )
+            self._validate_physical_reference_directory(
+                namespace_fd,
+                self._lease_namespace,
+                "physical lease namespace",
+            )
+        except (OSError, UnicodeError, ValueError, RecursionError) as error:
+            raise WorkspaceError(
+                f"cannot read physical reference registry {registry}: {error}"
+            ) from error
+        finally:
+            os.close(directory_fd)
+            os.close(namespace_fd)
+        return records
+
+    def _remove_physical_reference(self, authored_path: Path) -> None:
+        """Roll back a prepublished reference when authored creation fails."""
+
+        name = hashlib.sha256(str(authored_path.resolve()).encode()).hexdigest() + ".json"
+        namespace = self._lease_namespace
+        registry = namespace / "profile-references"
+        flags = os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_DIRECTORY", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        namespace_fd: int | None = None
+        try:
+            namespace_fd = os.open(namespace, flags)
+            self._assert_physical_namespace_fd(namespace_fd)
+            self._validate_physical_reference_directory(
+                namespace_fd, namespace, "physical lease namespace"
+            )
+            directory_fd = os.open("profile-references", flags, dir_fd=namespace_fd)
+            try:
+                self._validate_physical_reference_directory(
+                    directory_fd,
+                    registry,
+                    "physical reference registry",
+                    expected_mode=0o700,
+                )
+                try:
+                    os.unlink(name, dir_fd=directory_fd)
+                except FileNotFoundError:
+                    return
+                os.fsync(directory_fd)
+                self._validate_physical_reference_directory(
+                    directory_fd,
+                    registry,
+                    "physical reference registry",
+                    expected_mode=0o700,
+                )
+                self._assert_physical_namespace_fd(namespace_fd)
+                self._validate_physical_reference_directory(
+                    namespace_fd, namespace, "physical lease namespace"
+                )
+            finally:
+                os.close(directory_fd)
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot roll back physical reference {name}: {error}"
+            ) from error
+        finally:
+            if namespace_fd is not None:
+                os.close(namespace_fd)
+
+    def _publish_profile_references(
+        self,
+        name: str,
+        profile: dict[str, Any],
+        retained_sources: set[str] | None = None,
+    ) -> None:
+        stack = self.manifest.stack(profile["stack"])
+        sources = sorted(
+            ({
+                str(self._selector_root(profile, component).resolve(strict=False))
+                for component in stack.components
+                if profile["components"][component.name]["kind"] != "primary"
+            } | (retained_sources or set()))
+        )
+        identity = hashlib.sha256(
+            str((self.paths.profiles / f"{name}.json").resolve()).encode()
+        ).hexdigest()
+        self._atomic_physical_reference(
+            f"{identity}.json",
+            {
+                "schema_version": 1,
+                "kind": "profiles",
+                "reference": name,
+                "sources": sources,
+            },
+        )
+
+    def _publish_scenario_references(
+        self,
+        name: str,
+        metadata: dict[str, Any],
+        retained_sources: set[str] | None = None,
+    ) -> None:
+        resolved = metadata.get("resolved")
+        if not isinstance(resolved, dict):
+            raise WorkspaceError(f"scenario resolved references are invalid: {name}")
+        if any(
+            not isinstance(value, dict)
+            or not isinstance(value.get("checkout"), str)
+            or not isinstance(value.get("checkout_path"), str)
+            for value in resolved.values()
+        ):
+            raise WorkspaceError(f"scenario resolved references are invalid: {name}")
+        sources = sorted(
+            {
+                str(Path(value["checkout_path"]).resolve(strict=False))
+                for value in resolved.values()
+            }
+            | (retained_sources or set())
+        )
+        record = (self.paths.scenarios / name / "scenario.json").resolve()
+        identity = hashlib.sha256(str(record).encode()).hexdigest()
+        self._atomic_physical_reference(
+            f"{identity}.json",
+            {
+                "schema_version": 1,
+                "kind": "scenarios",
+                "reference": name,
+                "sources": sources,
+            },
+        )
+
+    def _backfill_scenario_references(self) -> bool:
+        if not self.paths.scenarios.is_dir() or self.paths.scenarios.is_symlink():
+            return True
+        complete = True
+        for root in sorted(self.paths.scenarios.iterdir()):
+            record = root / "scenario.json"
+            if root.is_dir() and not root.is_symlink() and record.is_file():
+                metadata = load_regular_json(record, "scenario metadata")
+                resolved = metadata.get("resolved") if isinstance(metadata, dict) else None
+                if not isinstance(resolved, dict):
+                    raise WorkspaceError(
+                        f"scenario resolved references are invalid: {root.name}"
+                    )
+                sources = {
+                    (
+                        value["checkout"],
+                        Path(value["checkout_path"]).resolve(strict=False),
+                    )
+                    for value in resolved.values()
+                    if isinstance(value, dict)
+                    and isinstance(value.get("checkout"), str)
+                    and isinstance(value.get("checkout_path"), str)
+                }
+                requests = [
+                    self._lease_request(
+                        "scenario", root.name, "shared", "backfill scenario reference"
+                    ),
+                    *[
+                        self._lease_request(
+                            "source",
+                            self._source_coordinate(checkout, source),
+                            "shared",
+                            "backfill scenario reference",
+                        )
+                        for checkout, source in sorted(sources, key=lambda item: (item[0], str(item[1])))
+                    ],
+                ]
+                try:
+                    with resource_locks(self._lease_root, requests, nonblocking=True):
+                        confirmed = load_regular_json(record, "scenario metadata")
+                        if confirmed != metadata or any(
+                            not source.is_dir() for _checkout, source in sources
+                        ):
+                            complete = False
+                            continue
+                        self._publish_scenario_references(root.name, confirmed)
+                except LockBusyError:
+                    complete = False
+        return complete
 
     def _set_profile(
         self, name: str, component_name: str, kind: str, value: str = ""
     ) -> None:
         self.paths.ensure()
         profile = self._load_profile(name, require_file=True)
+        old_profile = copy.deepcopy(profile)
         components = self._profile_components(profile, component_name)
         checkout_names = {component.checkout_name for component in components}
         if len(checkout_names) != 1:
@@ -1931,13 +3380,23 @@ class Workspace:
             raise WorkspaceError(f"invalid profile selector kind: {kind}")
         for component in components:
             profile["components"][component.name] = {"kind": kind, "value": value}
-        atomic_json(self.paths.profiles / f"{name}.json", profile)
+        old_sources = {
+            str(self._selector_root(old_profile, component).resolve(strict=False))
+            for component in self.manifest.stack(old_profile["stack"]).components
+            if old_profile["components"][component.name]["kind"] != "primary"
+        }
+        self._publish_profile_references(name, profile, old_sources)
+        durable_atomic_json(self.paths.profiles / f"{name}.json", profile)
+        self._publish_profile_references(name, profile)
 
     def set_profile_sound_mode(self, name: str, mode: str) -> None:
         self.paths.ensure()
-        with exclusive_layout_lock(
-            self.paths.workspace / "repository-layout.lock",
-            "repository layout",
+        with self._resource_locks(
+            [
+                self._lease_request(
+                    "profile", name, "exclusive", f"update profile {name} sound mode"
+                )
+            ],
         ):
             if name in self.manifest.stacks:
                 raise WorkspaceError(
@@ -2034,9 +3493,11 @@ class Workspace:
         component_names: set[str] | None = None,
         *,
         trace: bool = True,
+        profile: dict[str, Any] | None = None,
     ) -> dict[str, Path]:
         self.paths.ensure()
-        profile = self._load_profile(name, require_file=False)
+        if profile is None:
+            profile = self._load_profile(name, require_file=False)
         result: dict[str, Path] = {}
         stack = self.manifest.stack(profile["stack"])
         stack_components = {component.name: component for component in stack.components}
@@ -2154,6 +3615,12 @@ class Workspace:
         return value.resolve() if value.is_absolute() else (path / value).resolve()
 
     def _load_profile(self, name: str, require_file: bool) -> dict[str, Any]:
+        snapshot = self._profile_snapshot
+        if snapshot is not None and snapshot.name == name and not require_file:
+            return snapshot.profile()
+        return self._load_profile_file(name, require_file)
+
+    def _load_profile_file(self, name: str, require_file: bool) -> dict[str, Any]:
         validate_name(name, "profile name")
         if name in self.manifest.stacks and not require_file:
             stack = self.manifest.stack(name)
@@ -2168,9 +3635,9 @@ class Workspace:
                 },
             }
         path = self.paths.profiles / f"{name}.json"
-        if not path.is_file():
+        if path.is_symlink() or not path.is_file():
             raise WorkspaceError(f"profile does not exist: {name}")
-        profile = load_json(path)
+        profile = load_regular_json(path, f"profile {name}")
         if not isinstance(profile, dict):
             raise WorkspaceError(f"profile must be an object: {name}")
         schema_version = profile.get("schema_version")
@@ -2234,6 +3701,9 @@ class Workspace:
                     raise WorkspaceError(
                         f"invalid profile selector: {component_name}"
                     ) from error
+                if kind == "path":
+                    selector = {"kind": kind, "value": str(selected_path)}
+                    profile["components"][component_name] = selector
             if kind == MIGRATED_CONTENT_WORKTREE_KIND:
                 expected_parent = (self.paths.worktrees / "content").resolve()
                 if (
@@ -2381,9 +3851,15 @@ class Workspace:
                 )
 
     def _resolve_build_profile(
-        self, profile_name: str, required: set[str]
+        self,
+        profile_name: str,
+        required: set[str],
+        *,
+        trace: bool = True,
+        profile: dict[str, Any] | None = None,
     ) -> dict[str, Path]:
-        profile = self._load_profile(profile_name, require_file=False)
+        if profile is None:
+            profile = self._load_profile(profile_name, require_file=False)
         stack = self.manifest.stack(profile["stack"])
         requested_roles = self._dependency_roles(profile, required)
         build_targets = {
@@ -2417,7 +3893,10 @@ class Workspace:
         # pass. This both fails closed for malformed optional checkouts and keeps
         # validation deduplicated if initialization races the existence snapshot.
         present_paths = self.resolve_profile(
-            profile_name, present_components | component_names
+            profile_name,
+            present_components | component_names,
+            trace=trace,
+            profile=profile,
         )
         paths = {
             component_name: present_paths[component_name]
@@ -2435,14 +3914,16 @@ class Workspace:
         use_ccache: bool = True,
     ) -> Path:
         self.paths.ensure()
-        with shared_layout_lock(
-            self.paths.workspace / "repository-layout.lock",
-            "repository layout",
-        ):
-            return self._build(
+        targets = self._expand_build_target(target, profile_name)
+        with self._resolved_profile_operation(
+            profile_name, set(targets), f"build {target}"
+        ) as snapshot:
+            return self._build_resolved(
                 target,
                 profile_name,
                 tests,
+                targets,
+                snapshot.paths(),
                 force_reconfigure=force_reconfigure,
                 use_ccache=use_ccache,
             )
@@ -2581,6 +4062,24 @@ class Workspace:
                 "last_used_at": datetime.now(timezone.utc).isoformat(),
             },
         )
+        snapshot = self._profile_snapshot
+        if snapshot is not None and snapshot.name == profile_name:
+            atomic_json(
+                root / PROFILE_RESOLUTION_METADATA,
+                {
+                    "schema_version": PROFILE_RESOLUTION_SCHEMA_VERSION,
+                    "profile": profile_name,
+                    "generation": snapshot.generation,
+                    "stack": stack.name,
+                    "stack_generation": stack.generation,
+                    "sound_mode": profile["sound_mode"],
+                    "selected": coordinates,
+                    "checkouts": {
+                        name: {**state, "path": str(state["path"])}
+                        for name, state in snapshot.checkout_states().items()
+                    },
+                },
+            )
 
     def _prepare_sound(
         self,
@@ -2704,7 +4203,17 @@ class Workspace:
         selected: dict[str, Path],
         *,
         include_dirty: bool,
+        include_identity: bool = False,
     ) -> dict[str, dict[str, Any]]:
+        snapshot = self._profile_snapshot
+        if snapshot is not None and snapshot.paths() == {
+            role: path.resolve() for role, path in selected.items()
+        }:
+            states = snapshot.checkout_states()
+            if not include_dirty:
+                for state in states.values():
+                    state.pop("dirty", None)
+            return states
         stack = self.manifest.stack(profile["stack"])
         states: dict[str, dict[str, Any]] = {}
         for role in sorted(selected):
@@ -2722,6 +4231,17 @@ class Workspace:
                     trace=False,
                 ),
             }
+            if include_identity:
+                identity = checkout.stat()
+                state.update(
+                    {
+                        "device": identity.st_dev,
+                        "inode": identity.st_ino,
+                        "git_common": str(
+                            self._git_common_directory(checkout, trace=False)
+                        ),
+                    }
+                )
             if include_dirty:
                 state["dirty"] = not _is_clean(checkout, trace=False)
             states[component.checkout_name] = state
@@ -5929,6 +7449,12 @@ class Workspace:
 
     def state_add(self, name: str, path: Path | None) -> Path:
         self.paths.ensure()
+        with shared_maintenance_lock(
+            self._lease_namespace / "repository-layout.lock"
+        ):
+            return self._state_add(name, path)
+
+    def _state_add(self, name: str, path: Path | None) -> Path:
         validate_name(name, "state name")
         if path is None:
             resolved = (self.paths.state / "server" / name).resolve(strict=False)
@@ -6030,7 +7556,7 @@ class Workspace:
         if not root.is_dir() or root.is_symlink():
             raise WorkspaceError(f"scenario does not exist: {name}")
         marker = root / MANAGED_MARKER
-        if marker.is_symlink() or load_json(marker) != {
+        if marker.is_symlink() or load_regular_json(marker, "scenario ownership marker") != {
             "schema_version": SCHEMA_VERSION,
             "purpose": "test-scenario",
         }:
@@ -6038,7 +7564,7 @@ class Workspace:
         metadata_path = root / "scenario.json"
         if metadata_path.is_symlink():
             raise WorkspaceError(f"scenario metadata is invalid: {name}")
-        metadata = load_json(metadata_path)
+        metadata = load_regular_json(metadata_path, "scenario metadata")
         if not isinstance(metadata, dict):
             raise WorkspaceError(f"scenario metadata must be an object: {name}")
         actual_keys = set(metadata)
@@ -6226,11 +7752,18 @@ class Workspace:
         self, name: str, profile: str, preset: str = "basic-player"
     ) -> dict[str, Any]:
         self.paths.ensure()
-        with shared_layout_lock(
-            self.paths.workspace / "repository-layout.lock",
-            "repository layout",
+        validate_name(name, "scenario name")
+        with self._resolved_profile_operation(
+            profile, {"server"}, f"create scenario {name}"
         ):
-            return self._scenario_create(name, profile, preset)
+            with self._resource_locks(
+                [
+                    self._lease_request(
+                        "scenario", name, "exclusive", f"create scenario {name}"
+                    )
+                ],
+            ):
+                return self._scenario_create(name, profile, preset)
 
     def _scenario_create(
         self, name: str, profile: str, preset: str = "basic-player"
@@ -6262,7 +7795,7 @@ class Workspace:
         metadata["providers"] = {
             role: selected_stack.providers[role].name for role in sorted(required)
         }
-        operation_lock = self.paths.scenarios / "operation.lock"
+        operation_lock = self.paths.scenarios / ".locks" / f"{name}.lock"
         with exclusive_lock(operation_lock, "scenario operation"):
             if root.exists() or root.is_symlink():
                 raise WorkspaceError(f"scenario already exists: {name}")
@@ -6287,12 +7820,17 @@ class Workspace:
                     metadata, state, password_file
                 )
                 metadata["provisioned_at"] = datetime.now(timezone.utc).isoformat()
-                atomic_json(staging / "scenario.json", metadata)
-                staging.replace(root)
+                self._publish_scenario_references(name, metadata)
                 try:
-                    self._register_state(state_name, (root / "state").resolve())
+                    durable_atomic_json(staging / "scenario.json", metadata)
+                    staging.replace(root)
+                    try:
+                        self._register_state(state_name, (root / "state").resolve())
+                    except BaseException:
+                        shutil.rmtree(root)
+                        raise
                 except BaseException:
-                    shutil.rmtree(root)
+                    self._remove_physical_reference(root / "scenario.json")
                     raise
             except BaseException:
                 if staging.exists():
@@ -6347,18 +7885,32 @@ class Workspace:
 
     def scenario_reset(self, name: str) -> dict[str, Any]:
         self.paths.ensure()
-        with shared_layout_lock(
-            self.paths.workspace / "repository-layout.lock",
-            "repository layout",
+        validate_name(name, "scenario name")
+        metadata = self._load_scenario(name)
+        with self._resolved_profile_operation(
+            metadata["profile"], {"server"}, f"reset scenario {name}"
         ):
-            return self._scenario_reset(name)
+            with self._resource_locks(
+                [
+                    self._lease_request(
+                        "scenario", name, "exclusive", f"reset scenario {name}"
+                    )
+                ],
+            ):
+                return self._scenario_reset(name)
 
     def _scenario_reset(self, name: str) -> dict[str, Any]:
         self.paths.ensure()
         root = self._scenario_directory(name)
-        operation_lock = self.paths.scenarios / "operation.lock"
+        operation_lock = self.paths.scenarios / ".locks" / f"{name}.lock"
         with exclusive_lock(operation_lock, "scenario operation"):
             metadata = self._load_scenario(name)
+            old_sources = {
+                str(Path(value["checkout_path"]).resolve(strict=False))
+                for value in metadata["resolved"].values()
+                if isinstance(value, dict)
+                and isinstance(value.get("checkout_path"), str)
+            }
             state = root / "state"
             with exclusive_lock(
                 Path(f"{state}.lock"),
@@ -6379,8 +7931,12 @@ class Workspace:
                         metadata, staging_state, root / "password"
                     )
                     metadata["provisioned_at"] = datetime.now(timezone.utc).isoformat()
+                    self._publish_scenario_references(
+                        name, metadata, old_sources
+                    )
                     replace_directory(state, staging_state, f".{name}-state-previous-")
-                    atomic_json(root / "scenario.json", metadata)
+                    durable_atomic_json(root / "scenario.json", metadata)
+                    self._publish_scenario_references(name, metadata)
                 finally:
                     if staging_root.exists():
                         shutil.rmtree(staging_root)
@@ -8256,7 +9812,7 @@ class Workspace:
                 validate_port_reservation(
                     port_reservation,
                     expected_path=(
-                        self.paths.topologies
+                        self._lease_namespace
                         / PORT_RESERVATION_DIRECTORY
                         / f"{reservation_port}-{port_reservation.get('generation')}.lease"
                     ),
@@ -8451,13 +10007,14 @@ class Workspace:
             raise WorkspaceError("topology port must be between 0 and 65535")
 
         automatic = requested in (None, 0)
+        reservation_root = self._lease_namespace
 
         def conflict(owner: dict[str, Any]) -> None:
             raise WorkspaceError(
                 f"topology UDP port {owner['port']} is reserved by topology "
                 f"{owner['topology']} generation {owner['generation']}; "
                 "retry after its startup transaction completes; if contention "
-                f"persists inspect ./atrinik ps {owner['topology']} --json"
+                f"persists inspect the shared reservation {owner['path']}"
             )
 
         def validate_known_evidence(port: int) -> None:
@@ -8477,7 +10034,7 @@ class Workspace:
                     if owner["port"] != port:
                         continue
                     expected_path = (
-                        self.paths.topologies
+                        reservation_root
                         / PORT_RESERVATION_DIRECTORY
                         / f"{port}-{owner['generation']}.lease"
                     )
@@ -8499,7 +10056,9 @@ class Workspace:
                 validate_known_evidence(port)
                 transaction, directory_fd, directory, directory_identity = (
                     open_port_transaction(
-                        self.paths.topologies, port
+                        reservation_root,
+                        port,
+                        root_identity=self._physical_lease_namespace_identity,
                     )
                 )
                 try:
@@ -8547,7 +10106,7 @@ class Workspace:
             return reserved
 
         with exclusive_lock(
-            self.paths.topologies / "ports.lock",
+            reservation_root / "ports.lock",
             "topology automatic port allocation",
         ):
             for _attempt in range(64):
@@ -8584,18 +10143,26 @@ class Workspace:
         port: int | None = None,
     ) -> dict[str, Any]:
         self.paths.ensure()
-        with shared_layout_lock(
-            self.paths.workspace / "repository-layout.lock",
-            "repository layout",
-        ) as layout_lock:
-            return self._topology_up(
-                name,
-                profile_name,
-                state_name,
-                services,
-                port,
-                layout_lock=layout_lock,
-            )
+        selected_services = self._topology_services(services)
+        with self._resolved_profile_operation(
+            profile_name,
+            set(selected_services),
+            f"prepare topology {name}",
+        ):
+            with self._resource_locks(
+                [
+                    self._lease_request(
+                        "topology", name, "exclusive", f"prepare topology {name}"
+                    )
+                ],
+            ):
+                return self._topology_up(
+                    name,
+                    profile_name,
+                    state_name,
+                    services,
+                    port,
+                )
 
     def _topology_resolved_status(
         self, profile_name: str, selected: dict[str, Path]
@@ -8628,8 +10195,6 @@ class Workspace:
         state_name: str,
         services: list[str] | None = None,
         port: int | None = None,
-        *,
-        layout_lock: TextIO | None = None,
     ) -> dict[str, Any]:
         selected_services = self._topology_services(services)
         if "client" in selected_services:
@@ -9300,9 +10865,8 @@ class Workspace:
         dry_run: bool,
     ) -> Path:
         self.paths.ensure()
-        with shared_layout_lock(
-            self.paths.workspace / "repository-layout.lock",
-            "repository layout",
+        with self._resolved_profile_operation(
+            profile_name, {"client"}, "publish foreground client runtime"
         ):
             prepared = self._run_client(
                 profile_name,
@@ -9436,9 +11000,8 @@ class Workspace:
         dry_run: bool,
     ) -> Path:
         self.paths.ensure()
-        with shared_layout_lock(
-            self.paths.workspace / "repository-layout.lock",
-            "repository layout",
+        with self._resolved_profile_operation(
+            profile_name, {"server"}, "publish foreground server runtime"
         ):
             prepared = self._run_server(
                 profile_name,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -323,8 +323,25 @@ adopts the marker before calling the common removal helper. No other unmarked
 path receives that exception. Unmarked profile roots, unknown
 `workspace/build` children, and the mixed top-level `build/` tree remain
 visible report-only `unmanaged-build` records. Cleanup never targets profiles,
-scenarios, state, topology records/logs, migration archives/evidence, branches,
-Git objects, or arbitrary unmarked paths.
+scenarios, state, migration archives/evidence, branches, Git objects, or
+arbitrary unmarked paths. Topology records and logs belong only to the separate
+opt-in `topologies` scope, which is excluded from the default and `all`
+expansion.
+
+Topology cleanup inventories only direct marker-owned children of
+`workspace/topologies/` and uses the runtime status validator as the authority
+for control generation, liveness, process-tree/runtime/port leases, and legacy
+identity. It reports a no-follow metadata identity and the complete set of
+paths in the topology directory. Orderly records use `stopped_at`; legacy stale
+records without it use the newest tree mtime. Only old `exited` or `stale`
+records with unreachable controls and every applicable lease released are
+eligible. Apply takes the exact topology coordinate lease and then the topology
+operation lock, and repeats ownership, generation, lease, timestamp, and
+tree-identity validation before descriptor-bounded removal. This makes a
+concurrent `up`, `down`, `ps`, replacement, link, or file change fail closed.
+The removal boundary is exactly the topology directory, including its transient
+runtime snapshots. External persistent state, profiles, scenarios, source, and
+build roots are not cleanup targets.
 
 Worker dependency entries are direct key children of the marker-owned
 `worker-dependencies` container; its reserved `.transactions` child owns

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -190,37 +190,35 @@ side effect.
 
 `cleanup` is an explicit garbage-collection boundary, never an implicit step
 of initialization, synchronization, build, or startup. Default and explicit
-`--dry-run` modes are read-only. `--apply` first takes the exclusive mode of the
-repository-layout lock, then performs one complete inventory and size
-recomputation. Immediately before each removal it freshly revalidates that
-target's safety dependencies without rescanning unrelated report-only
-payloads; any new ambiguity fails closed. Build roots are removed before Git
-worktrees; the explicitly selected npm cache and safe prunable Git metadata
-come last. A race before the first mutation aborts the plan. A later failure
-stops the ordered sequence and reports completed reclamation without attempting
-to reconstruct generated data.
+`--dry-run` modes are read-only. `--apply` inventories once, then takes only the
+exact candidate leases and freshly revalidates that target immediately before
+removal. Busy or newly ambiguous candidates are preserved; completed removals
+are journaled before the ordered sequence continues.
 
-The repository-layout lock is a workspace-wide interprocess read/write boundary.
-Initialization, synchronization, worktree and profile mutation, cleanup apply,
-and repository migration take it exclusively. Builds, topology startup,
-foreground client and server runs, and scenario create/reset take it in shared
-mode while they consume selected checkout and profile coordinates. Independent
-build roots can therefore compile concurrently, while each root's existing
-exclusive build lock still serializes identical profile/key work. An exclusive
-writer cannot advance or remove a selected checkout until all readers exit.
-Waiting mutations first announce themselves with a shared
-`repository-layout.writer-pending.lock`, then hold the exclusive
-`repository-layout.writer-intent.lock` admission gate. A new reader briefly
-takes the admission gate and proceeds only if its exclusive pending-lock probe
-finds no announced writer; otherwise it releases admission, waits, and retries.
-Existing readers complete normally but later readers cannot repeatedly bypass
-a writer that has announced itself. The writer holds the pending, intent, and
-layout locks through the mutation, and its subprocesses inherit all three
-descriptors. A wait longer than 10 seconds emits one diagnostic
-with the supported process and worktree inventories, but does not time out or
-interrupt the holder. The diagnostic is emitted at most once per acquisition.
-If the platform cannot provide a working advisory shared lock, the consuming
-operation fails closed.
+Ordinary operations use fair exact-coordinate leases. Workspace-local
+coordinates live below `workspace/leases/`; physical Git-administration,
+source, port, and persistent-reference coordination lives below the wrapper's
+common-Git `atrinik-resource-leases/`, so linked wrapper worktrees and relocated
+state roots cannot split exclusion. Profile, Git-admin, source, topology,
+scenario, state, build-root, and cache requests are deduplicated and sorted.
+Multi-source writers retry all-or-none, releasing earlier coordinates before
+waiting on a busy later source. A queued writer precedes later readers only for
+that coordinate, and waits longer than 10 seconds report its owner operation
+and supported recovery action.
+
+Profile consumers lock the profile, derive candidate source coordinates,
+acquire the exact sources, revalidate, and capture immutable profile bytes,
+provider selections, Git identities, paths, HEADs, dirtiness, and filesystem
+identity. Build preparation persists that snapshot and never rereads a mutable
+profile generation. Publication and removal share the same source coordinate.
+Physical profile/scenario reference records make completed publications visible
+to cleanup and explicit removal from every relocated state root.
+
+The common-Git `repository-layout.lock` is only the maintenance barrier for
+schema/layout migration apply or restore. Ordinary operations share it while
+active; an exclusive migration waits for them to drain. Migration publication
+keeps old and new profile sources conservatively referenced until the durable
+transition commits or rolls back.
 
 A supervised topology stages its complete executable closure below a random
 topology-owned generation directory before publishing schema-2 spec/status.
@@ -246,27 +244,18 @@ The common command runner still inherits active advisory-lock descriptors into
 build and scenario subprocesses so an interrupted wrapper cannot strand an
 unprotected mutation.
 
-The writer-pending announcement precedes the writer-intent gate and layout lock,
-which remain
-outermost relative to all operational locks; private helpers never reacquire
-either boundary. A direct build or foreground client then takes its build-root
-lock and subordinate cache locks; the foreground process retains that root
-lease only through publication, while the long-lived process retains the
-immutable generation lease instead. Topology startup takes the
-topology-operation/process-tree lock, the automatic allocator when applicable,
-the per-port transaction and immutable generation lease, the server-state lock
-when needed, and finally the build-root lock. It releases the layout/build
-boundaries after atomic runtime publication
-and transfers only the exact state, runtime, process-tree, and port leases into
-the supervisor/guardian rather than services.
+Lease order is maintenance (migration only), registry, profile, Git admin,
+source, topology, scenario, state, build root, then cache. Runtime publication
+releases profile/source/build preparation leases after sealing the generation.
+Topology startup transfers only exact state, runtime-generation, process-tree,
+and generation-specific port leases into the supervisor/guardian; foreground
+processes retain only their runtime generation and server state when applicable.
 Independent CMake roots briefly serialize first-use compiler-cache marker and
 metadata publication, then release that cache lock before compilation.
-Scenario create takes the scenario-operation lock, then build-root and
-state-registry locks; reset takes scenario-operation, state, and build-root locks.
-Foreground server launch takes state before build-root. Layout writers take the
-exclusive layout lock before any cleanup build-lock probes or mutation-specific
-work. Operations use only the applicable suffix of these orders and never acquire
-the layout lock from inside a finer-grained lock.
+Scenario create/reset use a per-scenario operation coordinate rather than one
+global scenario lock. Foreground server launch takes state before build-root.
+Operations use only the applicable ordered suffix and never acquire a broader
+resource from inside a finer one.
 
 Inventory records are stable-sorted and carry a kind, physical owner and
 repository, exact path, no-follow allocated size, age and age basis,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -334,8 +334,25 @@ adopts the marker before calling the common removal helper. No other unmarked
 path receives that exception. Unmarked profile roots, unknown
 `workspace/build` children, and the mixed top-level `build/` tree remain
 visible report-only `unmanaged-build` records. Cleanup never targets profiles,
-scenarios, state, topology records/logs, migration archives/evidence, branches,
-Git objects, or arbitrary unmarked paths.
+scenarios, state, migration archives/evidence, branches, Git objects, or
+arbitrary unmarked paths. Topology records and logs belong only to the separate
+opt-in `topologies` scope, which is excluded from the default and `all`
+expansion.
+
+Topology cleanup inventories only direct marker-owned children of
+`workspace/topologies/` and uses the runtime status validator as the authority
+for control generation, liveness, process-tree/runtime/port leases, and legacy
+identity. It reports a no-follow metadata identity and the complete set of
+paths in the topology directory. Orderly records use `stopped_at`; legacy stale
+records without it use the newest tree mtime. Only old `exited` or `stale`
+records with unreachable controls and every applicable lease released are
+eligible. Apply first holds the repository-layout writer boundary, then the
+topology operation lock, and repeats ownership, generation, lease, timestamp,
+and tree-identity validation before descriptor-bounded removal. This makes a
+concurrent `up`, `down`, `ps`, replacement, link, or file change fail closed.
+The removal boundary is exactly the topology directory, including its transient
+runtime snapshots. External persistent state, profiles, scenarios, source, and
+build roots are not cleanup targets.
 
 Worker dependency entries are direct key children of the marker-owned
 `worker-dependencies` container; its reserved `.transactions` child owns

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -475,6 +475,23 @@ class CleanupTests(unittest.TestCase):
         self.assertIn("changed during apply revalidation", item["error"])
         self.assertTrue(root.is_dir())
 
+    def test_topology_preview_protects_a_change_during_inventory(self) -> None:
+        root = self.make_topology_record("inventory-race")
+
+        def change_during_status(_name: str) -> dict[str, object]:
+            (root / "late-log").write_text("changed\n", encoding="utf-8")
+            return self.topology_observation("exited")
+
+        with mock.patch.object(
+            self.workspace, "topology_status", side_effect=change_during_status
+        ):
+            report = self.workspace.cleanup(["topologies"], 7, [], False)
+
+        item = next(row for row in report["items"] if row["path"] == str(root))
+        self.assertEqual(item["disposition"], "protected")
+        self.assertIn("topology_changed_during_inventory", item["reasons"])
+        self.assertIsNone(item["tree_identity"])
+
     def test_topology_cleanup_preserves_an_interrupted_record_for_retry(self) -> None:
         root = self.make_topology_record("interrupted-removal")
 

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -250,6 +250,19 @@ class CleanupTests(unittest.TestCase):
         self.assertEqual(report["items"], [])
         self.assertEqual(report["summary"]["error_count"], 0)
 
+    def test_invalid_topology_container_has_a_complete_protected_record(self) -> None:
+        self.workspace.paths.topologies.rmdir()
+        self.workspace.paths.topologies.symlink_to(self.root)
+
+        report = self.workspace.cleanup(["topologies"], 7, [], False)
+
+        self.assertEqual(len(report["items"]), 1)
+        item = report["items"][0]
+        self.assertEqual(item["disposition"], "protected")
+        self.assertEqual(item["reasons"], ["invalid_topology_container"])
+        self.assertEqual(item["liveness"], "unverifiable")
+        self.assertEqual(item["deletion_paths"], [])
+
     def test_topology_only_scope_does_not_inventory_unrelated_resources(self) -> None:
         root = self.make_topology_record("isolated-history")
 

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -482,6 +482,23 @@ class CleanupTests(unittest.TestCase):
         self.assertIn("changed during apply revalidation", item["error"])
         self.assertTrue(root.is_dir())
 
+    def test_topology_preview_protects_a_change_during_inventory(self) -> None:
+        root = self.make_topology_record("inventory-race")
+
+        def change_during_status(_name: str) -> dict[str, object]:
+            (root / "late-log").write_text("changed\n", encoding="utf-8")
+            return self.topology_observation("exited")
+
+        with mock.patch.object(
+            self.workspace, "topology_status", side_effect=change_during_status
+        ):
+            report = self.workspace.cleanup(["topologies"], 7, [], False)
+
+        item = next(row for row in report["items"] if row["path"] == str(root))
+        self.assertEqual(item["disposition"], "protected")
+        self.assertIn("topology_changed_during_inventory", item["reasons"])
+        self.assertIsNone(item["tree_identity"])
+
     def test_topology_cleanup_preserves_an_interrupted_record_for_retry(self) -> None:
         root = self.make_topology_record("interrupted-removal")
 

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -243,6 +243,19 @@ class CleanupTests(unittest.TestCase):
         self.assertEqual(report["items"], [])
         self.assertEqual(report["summary"]["error_count"], 0)
 
+    def test_invalid_topology_container_has_a_complete_protected_record(self) -> None:
+        self.workspace.paths.topologies.rmdir()
+        self.workspace.paths.topologies.symlink_to(self.root)
+
+        report = self.workspace.cleanup(["topologies"], 7, [], False)
+
+        self.assertEqual(len(report["items"]), 1)
+        item = report["items"][0]
+        self.assertEqual(item["disposition"], "protected")
+        self.assertEqual(item["reasons"], ["invalid_topology_container"])
+        self.assertEqual(item["liveness"], "unverifiable")
+        self.assertEqual(item["deletion_paths"], [])
+
     def test_topology_only_scope_does_not_inventory_unrelated_resources(self) -> None:
         root = self.make_topology_record("isolated-history")
 

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -206,6 +206,7 @@ class CleanupTests(unittest.TestCase):
         process_tree_lease: str = "released",
         control: str = "unreachable",
         stopped_at: str | None = "2026-07-01T00:00:00+00:00",
+        repository_layout_lease_owner: str | None = None,
     ) -> dict[str, object]:
         return {
             "supervisor": {"liveness": liveness},
@@ -217,7 +218,7 @@ class CleanupTests(unittest.TestCase):
                 "process_tree_lease": process_tree_lease,
                 "runtime_bundle_lease": "released",
                 "port_reservation": None,
-                "repository_layout_lease_owner": None,
+                "repository_layout_lease_owner": repository_layout_lease_owner,
             },
         }
 
@@ -431,20 +432,38 @@ class CleanupTests(unittest.TestCase):
         self.assertEqual(items["invalid-lease"]["disposition"], "protected")
         self.assertEqual(items["unowned"]["disposition"], "protected")
 
-    def test_topology_preview_reports_a_retained_repository_layout_lease(self) -> None:
+    def test_topology_preview_reports_a_retained_legacy_layout_lease(self) -> None:
         root = self.make_topology_record("layout-reader")
-        layout = self.workspace.paths.workspace / "repository-layout.lock"
-        descriptor = os.open(layout, os.O_RDWR | os.O_CREAT, 0o600)
-        try:
-            fcntl.flock(descriptor, fcntl.LOCK_SH | fcntl.LOCK_NB)
+        with mock.patch.object(
+            self.workspace,
+            "topology_status",
+            return_value=self.topology_observation(
+                "exited", repository_layout_lease_owner="layout-reader"
+            ),
+        ):
             report = self.workspace.cleanup(["topologies"], 7, [], False)
-        finally:
-            os.close(descriptor)
 
         item = next(row for row in report["items"] if row["path"] == str(root))
         self.assertEqual(item["repository_layout_lease"], "retained")
         self.assertIn("repository_layout_lease_retained", item["reasons"])
         self.assertEqual(item["disposition"], "protected")
+
+    def test_topology_apply_skips_a_busy_exact_topology_lease(self) -> None:
+        root = self.make_topology_record("busy-coordinate")
+        request = self.workspace._lease_request(
+            "topology",
+            "busy-coordinate",
+            "shared",
+            "inspect topology busy-coordinate",
+        )
+
+        with self.workspace._resource_locks([request]):
+            report = self.workspace.cleanup(["topologies"], 7, [], True)
+
+        item = next(row for row in report["items"] if row["path"] == str(root))
+        self.assertEqual(item["disposition"], "skipped")
+        self.assertEqual(item["reasons"], ["resource_busy"])
+        self.assertTrue(root.is_dir())
 
     def test_topology_apply_rejects_a_post_revalidation_restart_race(self) -> None:
         root = self.make_topology_record("restart-race")

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -12,6 +12,7 @@ import unittest
 from unittest import mock
 
 from atrinik_workspace.cleanup import (
+    ALL_SCOPES,
     Cleanup,
     _base_item,
     _command,
@@ -149,6 +150,336 @@ class CleanupTests(unittest.TestCase):
         )
         (cache / "playtest-manifest.json").write_text("{}\n", encoding="utf-8")
         return sound, cache
+
+    def make_topology_record(
+        self,
+        name: str,
+        *,
+        stopped_at: str | None = "2026-07-01T00:00:00+00:00",
+        old: bool = True,
+    ) -> Path:
+        root = self.workspace._topology_directory(name, create=True)
+        (root / "operation.lock").touch(mode=0o600)
+        (root / "process-tree.lease").touch(mode=0o600)
+        (root / "server.log").write_text("stopped\n", encoding="utf-8")
+        runtime = root / "runtime"
+        runtime.mkdir()
+        (runtime / "snapshot").write_text("transient\n", encoding="utf-8")
+        atomic_json(
+            root / "status.json",
+            {
+                "schema_version": SCHEMA_VERSION,
+                "name": name,
+                "profile": "default",
+                "dependencies": [],
+                "state": None,
+                "build_root": str(self.workspace.paths.builds / "profiles" / "fixture"),
+                "resolved": {},
+                "endpoint": None,
+                "ready": False,
+                "started_at": "2026-06-01T00:00:00+00:00",
+                "stopped_at": stopped_at,
+                "supervisor": {"pid": 999999, "start_time": "1"},
+                "services": {},
+                "error": "fixture",
+            },
+        )
+        if old:
+            timestamp = self.old.timestamp()
+            for path in sorted(root.rglob("*"), reverse=True):
+                os.utime(path, (timestamp, timestamp), follow_symlinks=False)
+            os.utime(root, (timestamp, timestamp))
+        return root
+
+    def topology_observation(
+        self,
+        liveness: str,
+        *,
+        generation: str | None = None,
+        process_tree_lease: str = "released",
+        control: str = "unreachable",
+        stopped_at: str | None = "2026-07-01T00:00:00+00:00",
+    ) -> dict[str, object]:
+        return {
+            "supervisor": {"liveness": liveness},
+            "services": {},
+            "stopped_at": stopped_at,
+            "observation": {
+                "control": control,
+                "generation": generation,
+                "process_tree_lease": process_tree_lease,
+                "runtime_bundle_lease": "released",
+                "port_reservation": None,
+                "repository_layout_lease_owner": None,
+            },
+        }
+
+    def test_topology_cleanup_is_explicit_and_excluded_from_all(self) -> None:
+        root = self.make_topology_record("retained-history")
+
+        self.assertFalse(
+            any(item["kind"] == "topology" for item in self.plan([])["items"])
+        )
+        self.assertFalse(
+            any(item["kind"] == "topology" for item in self.plan(["all"])["items"])
+        )
+        combined = self.plan(["all", "topologies"])
+        self.assertTrue(any(item["kind"] == "topology" for item in combined["items"]))
+        self.assertEqual(combined["scopes"], [*ALL_SCOPES, "topologies"])
+        report = self.workspace.cleanup(["topologies"], 7, [], False)
+
+        self.assertEqual(report["scopes"], ["topologies"])
+        item = next(row for row in report["items"] if row["path"] == str(root))
+        self.assertEqual(item["disposition"], "eligible")
+        self.assertEqual(item["reasons"], ["inactive_topology"])
+        self.assertEqual(item["liveness"], "exited")
+        self.assertEqual(item["age_basis"], "stopped-at")
+
+    def test_missing_topology_container_is_an_empty_inventory(self) -> None:
+        self.workspace.paths.topologies.rmdir()
+
+        report = self.workspace.cleanup(["topologies"], 7, [], False)
+
+        self.assertEqual(report["items"], [])
+        self.assertEqual(report["summary"]["error_count"], 0)
+
+    def test_topology_only_scope_does_not_inventory_unrelated_resources(self) -> None:
+        root = self.make_topology_record("isolated-history")
+
+        with (
+            mock.patch.object(
+                Cleanup, "_references", side_effect=AssertionError("unrelated inventory")
+            ),
+            mock.patch.object(
+                Cleanup,
+                "_registered_worktree_paths",
+                side_effect=AssertionError("unrelated Git inventory"),
+            ),
+        ):
+            report = self.workspace.cleanup(["topologies"], 7, [], False)
+            applied = self.workspace.cleanup(["topologies"], 7, [], True)
+
+        item = next(row for row in report["items"] if row["path"] == str(root))
+        self.assertEqual(item["disposition"], "eligible")
+        self.assertEqual(report["inventory_errors"], [])
+        removed = next(row for row in applied["items"] if row["path"] == str(root))
+        self.assertEqual(removed["disposition"], "removed")
+
+    def test_topology_cleanup_removes_only_the_record_and_is_idempotent(self) -> None:
+        root = self.make_topology_record("old-exit")
+        state = self.workspace.paths.state / "preserved"
+        build = self.workspace.paths.builds / "preserved"
+        profile = self.workspace.paths.profiles / "preserved.txt"
+        for path in (state, build):
+            path.mkdir()
+            (path / "sentinel").write_text("preserve\n", encoding="utf-8")
+        profile.write_text("{}\n", encoding="utf-8")
+
+        earlier_builds = self.workspace.cleanup(["builds"], 7, [], False)
+        self.assertNotIn("topology_inventory_error", earlier_builds["inventory_errors"])
+
+        preview = self.workspace.cleanup(["topologies"], 7, [], False)
+        item = next(row for row in preview["items"] if row["path"] == str(root))
+        self.assertIn(str(root / "status.json"), item["deletion_paths"])
+        self.assertIn(str(root / "server.log"), item["deletion_paths"])
+        self.assertIn(str(root / "runtime" / "snapshot"), item["deletion_paths"])
+        self.assertTrue(root.is_dir())
+
+        applied = self.workspace.cleanup(["topologies"], 7, [], True)
+        removed = next(row for row in applied["items"] if row["path"] == str(root))
+        self.assertEqual(removed["disposition"], "removed")
+        self.assertFalse(root.exists())
+        self.assertEqual(self.workspace.topology_statuses(), [])
+        self.assertEqual((state / "sentinel").read_text(), "preserve\n")
+        self.assertEqual((build / "sentinel").read_text(), "preserve\n")
+        self.assertEqual(profile.read_text(), "{}\n")
+
+        later_builds = self.workspace.cleanup(["builds"], 7, [], False)
+        self.assertNotIn("topology_inventory_error", later_builds["inventory_errors"])
+
+        repeated = self.workspace.cleanup(["topologies"], 7, [], True)
+        self.assertEqual(repeated["summary"]["removed_count"], 0)
+        self.assertFalse(repeated["mutated"])
+
+    def test_legacy_stale_topology_uses_conservative_tree_age(self) -> None:
+        old = self.make_topology_record("old-stale", stopped_at=None)
+        young = self.make_topology_record("young-stale", stopped_at=None, old=False)
+        orderly_young = self.make_topology_record(
+            "young-exit", stopped_at=datetime.now(timezone.utc).isoformat()
+        )
+
+        report = self.workspace.cleanup(["topologies"], 7, [], False)
+        old_item = next(row for row in report["items"] if row["path"] == str(old))
+        young_item = next(row for row in report["items"] if row["path"] == str(young))
+        self.assertEqual(old_item["liveness"], "stale")
+        self.assertEqual(old_item["age_basis"], "legacy-tree-mtime")
+        self.assertEqual(old_item["disposition"], "eligible")
+        self.assertEqual(young_item["disposition"], "protected")
+        self.assertIn("topology_younger_than_grace_period", young_item["reasons"])
+        orderly_item = next(
+            row for row in report["items"] if row["path"] == str(orderly_young)
+        )
+        self.assertEqual(orderly_item["age_basis"], "stopped-at")
+        self.assertIn(
+            "topology_younger_than_grace_period", orderly_item["reasons"]
+        )
+
+    def test_exited_topology_without_stopped_at_does_not_use_legacy_age(self) -> None:
+        root = self.make_topology_record("invalid-orderly-exit", stopped_at=None)
+
+        with mock.patch.object(
+            self.workspace,
+            "topology_status",
+            return_value=self.topology_observation("exited", stopped_at=None),
+        ):
+            report = self.workspace.cleanup(["topologies"], 7, [], False)
+
+        item = next(row for row in report["items"] if row["path"] == str(root))
+        self.assertIsNone(item["age_basis"])
+        self.assertIn("topology_stopped_at_unavailable", item["reasons"])
+        self.assertEqual(item["disposition"], "protected")
+
+    def test_topology_cleanup_protects_liveness_leases_links_and_operations(self) -> None:
+        live = self.make_topology_record("live")
+        unreachable = self.make_topology_record("unreachable")
+        retained = self.make_topology_record("retained")
+        linked = self.make_topology_record("linked")
+        (linked / "unsafe-link").symlink_to(self.root)
+        active = self.make_topology_record("active-operation")
+        descriptor = os.open(active / "operation.lock", os.O_RDWR)
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+        def status(name: str) -> dict[str, object]:
+            if name == "live":
+                return self.topology_observation("live", control="reachable")
+            if name == "unreachable":
+                return self.topology_observation("unreachable")
+            if name == "retained":
+                return self.topology_observation(
+                    "stale", process_tree_lease="retained"
+                )
+            return self.topology_observation("exited")
+
+        try:
+            with mock.patch.object(self.workspace, "topology_status", side_effect=status):
+                report = self.workspace.cleanup(["topologies"], 7, [], False)
+        finally:
+            os.close(descriptor)
+        items = {row["name"]: row for row in report["items"]}
+        self.assertIn("live_topology", items["live"]["reasons"])
+        self.assertIn("reachable_topology_control", items["live"]["reasons"])
+        self.assertIn("unreachable_topology", items["unreachable"]["reasons"])
+        self.assertIn("process_tree_lease_retained", items["retained"]["reasons"])
+        self.assertIn("invalid_topology_tree", items["linked"]["reasons"])
+        self.assertIn("active_topology_operation", items["active-operation"]["reasons"])
+        self.assertTrue(all(row["disposition"] == "protected" for row in items.values()))
+
+    def test_current_generation_and_invalid_records_are_reported_fail_closed(self) -> None:
+        self.make_topology_record("current-generation")
+        malformed = self.make_topology_record("invalid-lease")
+        status = json.loads((malformed / "status.json").read_text(encoding="utf-8"))
+        status["control"] = {
+            "socket": "/wrong/control",
+            "generation": "b" * 64,
+            "lease": {"device": 1, "inode": 2},
+        }
+        atomic_json(malformed / "status.json", status)
+        unowned = self.workspace.paths.topologies / "unowned"
+        unowned.mkdir()
+        (unowned / "status.json").write_text("{}\n", encoding="utf-8")
+
+        actual_status = self.workspace.topology_status
+
+        def observe(name: str) -> dict[str, object]:
+            if name == "current-generation":
+                return self.topology_observation("exited", generation="a" * 64)
+            return actual_status(name)
+
+        with mock.patch.object(self.workspace, "topology_status", side_effect=observe):
+            report = self.workspace.cleanup(["topologies"], 7, [], False)
+        items = {row["name"]: row for row in report["items"]}
+        self.assertEqual(items["current-generation"]["generation"], "a" * 64)
+        self.assertEqual(items["current-generation"]["disposition"], "eligible")
+        self.assertIn("topology_status_unverifiable", items["invalid-lease"]["reasons"])
+        self.assertIn("invalid_topology_ownership", items["unowned"]["reasons"])
+        self.assertEqual(items["invalid-lease"]["disposition"], "protected")
+        self.assertEqual(items["unowned"]["disposition"], "protected")
+
+    def test_topology_preview_reports_a_retained_repository_layout_lease(self) -> None:
+        root = self.make_topology_record("layout-reader")
+        layout = self.workspace.paths.workspace / "repository-layout.lock"
+        descriptor = os.open(layout, os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_SH | fcntl.LOCK_NB)
+            report = self.workspace.cleanup(["topologies"], 7, [], False)
+        finally:
+            os.close(descriptor)
+
+        item = next(row for row in report["items"] if row["path"] == str(root))
+        self.assertEqual(item["repository_layout_lease"], "retained")
+        self.assertIn("repository_layout_lease_retained", item["reasons"])
+        self.assertEqual(item["disposition"], "protected")
+
+    def test_topology_apply_rejects_a_post_revalidation_restart_race(self) -> None:
+        root = self.make_topology_record("restart-race")
+        original = Cleanup._revalidate_target
+
+        def restart_after_revalidation(
+            cleanup: Cleanup, *arguments: object
+        ) -> dict[str, object] | None:
+            item = original(cleanup, *arguments)
+            if item is not None and item["kind"] == "topology":
+                (root / "restart-evidence").write_text("changed\n", encoding="utf-8")
+            return item
+
+        with mock.patch.object(
+            Cleanup, "_revalidate_target", new=restart_after_revalidation
+        ):
+            report = self.workspace.cleanup(["topologies"], 7, [], True)
+
+        item = next(row for row in report["items"] if row["path"] == str(root))
+        self.assertEqual(item["disposition"], "error")
+        self.assertEqual(item["reasons"], ["removal_failed"])
+        self.assertIn("changed before removal", item["error"])
+        self.assertTrue(root.is_dir())
+
+    def test_topology_apply_rejects_a_change_during_revalidation(self) -> None:
+        root = self.make_topology_record("revalidation-race")
+
+        with mock.patch.object(
+            self.workspace,
+            "topology_status",
+            side_effect=(
+                self.topology_observation("exited"),
+                self.topology_observation("stale"),
+            ),
+        ):
+            report = self.workspace.cleanup(["topologies"], 7, [], True)
+
+        item = next(row for row in report["items"] if row["path"] == str(root))
+        self.assertEqual(item["disposition"], "error")
+        self.assertEqual(item["reasons"], ["revalidation_error"])
+        self.assertIn("changed during apply revalidation", item["error"])
+        self.assertTrue(root.is_dir())
+
+    def test_topology_cleanup_preserves_an_interrupted_record_for_retry(self) -> None:
+        root = self.make_topology_record("interrupted-removal")
+
+        with mock.patch(
+            "atrinik_workspace.cleanup.remove_owned_tree",
+            side_effect=WorkspaceError("simulated interruption"),
+        ):
+            interrupted = self.workspace.cleanup(["topologies"], 7, [], True)
+
+        item = next(row for row in interrupted["items"] if row["path"] == str(root))
+        self.assertEqual(item["disposition"], "error")
+        self.assertEqual(item["reasons"], ["removal_failed"])
+        self.assertTrue(root.is_dir())
+
+        retried = self.workspace.cleanup(["topologies"], 7, [], True)
+        item = next(row for row in retried["items"] if row["path"] == str(root))
+        self.assertEqual(item["disposition"], "removed")
+        self.assertFalse(root.exists())
 
     @staticmethod
     def write_sound_producer_lease(worktree: Path) -> Path:

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 import json
 import fcntl
@@ -8,6 +9,7 @@ from pathlib import Path
 import shutil
 import subprocess
 import tempfile
+import threading
 import unittest
 from unittest import mock
 
@@ -24,7 +26,12 @@ from atrinik_workspace.cleanup import (
     _worktree_records,
     _workspace_owned,
 )
-from atrinik_workspace.locking import active_lock_fds, inherit_lock_fds
+from atrinik_workspace.locking import (
+    LeaseRequest,
+    active_lock_fds,
+    inherit_lock_fds,
+    resource_locks,
+)
 from atrinik_workspace.model import (
     MANAGED_MARKER,
     SCHEMA_VERSION,
@@ -1393,9 +1400,154 @@ class CleanupTests(unittest.TestCase):
         item = next(row for row in report["items"] if row["path"] == str(worktree))
         self.assertEqual(item["disposition"], "removed")
         self.assertFalse(worktree.exists())
+        journal = json.loads(Path(report["journal"]).read_text(encoding="utf-8"))
+        self.assertEqual(journal["status"], "complete")
+        self.assertEqual(
+            journal["completed"],
+            [{"kind": "worktree", "path": str(worktree)}],
+        )
         self.assertEqual(
             command("git", "branch", "--list", branch, cwd=self.wrapper).strip(),
             f"{branch}",
+        )
+
+    def test_apply_skips_busy_target_and_continues_with_disjoint_target(self) -> None:
+        busy = self.make_wrapper_worktree("busy")
+        removable = self.make_wrapper_worktree("removable")
+        request = LeaseRequest(
+            "source",
+            self.workspace._source_coordinate("atrinik", busy),
+            "shared",
+            "build busy worktree",
+            "wait for the build to finish",
+        )
+
+        with resource_locks(
+            self.workspace._lease_root, [request]
+        ), mock.patch.object(
+            Cleanup,
+            "_github_pulls",
+            side_effect=lambda _repository, head: self.merged_pull(head),
+        ):
+            report = self.workspace.cleanup(["worktrees"], 7, [], True)
+
+        by_path = {row["path"]: row for row in report["items"]}
+        self.assertEqual(by_path[str(busy)]["reasons"], ["resource_busy"])
+        self.assertTrue(busy.is_dir())
+        self.assertEqual(by_path[str(removable)]["disposition"], "removed")
+        self.assertFalse(removable.exists())
+        journal = json.loads(Path(report["journal"]).read_text(encoding="utf-8"))
+        self.assertEqual(journal["status"], "complete")
+        self.assertEqual(
+            journal["completed"],
+            [{"kind": "worktree", "path": str(removable)}],
+        )
+
+    def test_apply_skips_wrapper_worktree_running_public_operation(self) -> None:
+        busy = self.make_wrapper_worktree("active-wrapper")
+        with mock.patch.dict(
+            os.environ,
+            {"ATRINIK_WORKSPACE_DIR": str(self.root / "active-workspace")},
+        ):
+            active_workspace = Workspace(busy)
+            active_workspace.paths.ensure()
+        entered = threading.Event()
+        release = threading.Event()
+
+        def hold_create(*_arguments: object) -> Path:
+            entered.set()
+            self.assertTrue(release.wait(5))
+            return active_workspace.paths.profiles / "active.json"
+
+        with (
+            mock.patch.object(
+                active_workspace, "_create_profile", side_effect=hold_create
+            ),
+            mock.patch.object(
+                Cleanup,
+                "_github_pulls",
+                side_effect=lambda _repository, head: self.merged_pull(head),
+            ),
+            ThreadPoolExecutor(max_workers=1) as executor,
+        ):
+            operation = executor.submit(active_workspace.create_profile, "active")
+            if not entered.wait(2):
+                operation.result(timeout=1)
+                self.fail("wrapper operation did not acquire its source lease")
+            report = self.workspace.cleanup(["worktrees"], 7, [], True)
+            item = next(row for row in report["items"] if row["path"] == str(busy))
+            self.assertEqual(item["reasons"], ["resource_busy"])
+            self.assertTrue(busy.is_dir())
+            release.set()
+            operation.result(timeout=5)
+
+    def test_apply_from_wrapper_worktree_preserves_invoking_view(self) -> None:
+        current = self.make_wrapper_worktree("invoking-wrapper")
+        with mock.patch.dict(
+            os.environ,
+            {"ATRINIK_WORKSPACE_DIR": str(self.root / "invoking-workspace")},
+        ):
+            workspace = Workspace(current)
+            workspace.paths.ensure()
+            with mock.patch.object(
+                Cleanup,
+                "_github_pulls",
+                side_effect=lambda _repository, head: self.merged_pull(head),
+            ):
+                report = workspace.cleanup(["worktrees"], 7, [], True)
+
+        item = next(row for row in report["items"] if row["path"] == str(current))
+        self.assertEqual(item["disposition"], "protected")
+        self.assertIn("active_wrapper_view", item["reasons"])
+        self.assertTrue(current.is_dir())
+
+    def test_profile_reference_in_other_state_root_protects_worktree(self) -> None:
+        target = self.make_component_worktree("cross-state", component="client")
+        with mock.patch.dict(
+            os.environ,
+            {"ATRINIK_WORKSPACE_DIR": str(self.root / "other-workspace")},
+        ):
+            other = Workspace(self.wrapper)
+            other.paths.ensure()
+            other.create_profile("cross-state")
+            other.set_profile("cross-state", "client", "path", str(target))
+
+        with mock.patch.object(
+            Cleanup,
+            "_github_pulls",
+            side_effect=lambda _repository, head: self.merged_pull(head),
+        ):
+            report = self.workspace.cleanup(["worktrees"], 7, [], True)
+
+        item = next(row for row in report["items"] if row["path"] == str(target))
+        self.assertEqual(item["disposition"], "protected")
+        self.assertIn("profile_reference", item["reasons"])
+        self.assertTrue(target.is_dir())
+
+    def test_apply_removes_worktrees_from_two_physical_owners(self) -> None:
+        client = self.make_component_worktree("client-review", component="client")
+        server = self.make_component_worktree("server-review", component="server")
+
+        with mock.patch.object(
+            Cleanup,
+            "_github_pulls",
+            side_effect=lambda _repository, head: self.merged_pull(head),
+        ):
+            report = self.workspace.cleanup(["worktrees"], 7, [], True)
+
+        by_path = {row["path"]: row for row in report["items"]}
+        self.assertEqual(by_path[str(client)]["disposition"], "removed")
+        self.assertEqual(by_path[str(server)]["disposition"], "removed")
+        self.assertFalse(client.exists())
+        self.assertFalse(server.exists())
+        journal = json.loads(Path(report["journal"]).read_text(encoding="utf-8"))
+        self.assertEqual(journal["status"], "complete")
+        self.assertEqual(
+            journal["completed"],
+            [
+                {"kind": "worktree", "path": str(client)},
+                {"kind": "worktree", "path": str(server)},
+            ],
         )
 
     def test_populated_submodule_worktree_is_protected_in_preview_and_apply(
@@ -1888,6 +2040,35 @@ class CleanupTests(unittest.TestCase):
         self.assertFalse(first.exists())
         self.assertTrue(second.exists())
         self.assertTrue(report["aborted"])
+
+    def test_apply_reports_progress_journal_failure_after_removal(self) -> None:
+        first = self.make_build("first", "a" * 12)
+        second = self.make_build("second", "b" * 12)
+        real_atomic_json = atomic_json
+        publications = 0
+
+        def publish(path: Path, value: object) -> None:
+            nonlocal publications
+            publications += 1
+            if publications > 1:
+                raise WorkspaceError("injected journal failure")
+            real_atomic_json(path, value)
+
+        with mock.patch(
+            "atrinik_workspace.cleanup.durable_atomic_json", side_effect=publish
+        ):
+            report = self.workspace.cleanup(["builds"], 7, [], True)
+
+        by_path = {row["path"]: row for row in report["items"]}
+        self.assertEqual(by_path[str(first)]["disposition"], "removed")
+        self.assertFalse(first.exists())
+        self.assertTrue(second.exists())
+        self.assertEqual(
+            report["completed_actions"],
+            [{"kind": "profile-build", "path": str(first)}],
+        )
+        self.assertTrue(report["aborted"])
+        self.assertIn("journal failure", report["journal_error"])
 
     def test_apply_reports_revalidation_error_after_a_completed_mutation(self) -> None:
         first = self.make_build("first", "a" * 12)
@@ -2803,50 +2984,56 @@ class CleanupTests(unittest.TestCase):
     def test_physical_aliases_deduplicate_and_content_branches_stay_distinct(
         self,
     ) -> None:
-        repository = Path(__file__).resolve().parents[1]
+        repository = self.root / "full-wrapper"
+        repository.mkdir()
+        shutil.copy2(Path(__file__).resolve().parents[1] / "components.json", repository)
+        command("git", "init", "-b", "main", cwd=repository)
         actual_workspace = Workspace(repository)
-        cleanup = Cleanup(actual_workspace)
-        self.assertEqual(
-            cleanup._normalize_scopes(["all"]),
-            [
-                "worktrees", "builds", "npm-cache", "compiler-cache",
-                "sound-cache",
-            ],
-        )
-        self.assertEqual(cleanup._normalize_names(["atrinik"]), {"atrinik"})
-        with self.assertRaisesRegex(WorkspaceError, "unknown components"):
-            cleanup._normalize_names(["not-a-component"])
-        self.assertEqual(
-            cleanup._normalize_names(
-                ["classic", "classic-client", "classic-server", "classic-protocol"]
-            ),
-            {"classic"},
-        )
-        self.assertEqual(cleanup._normalize_names(["content"]), {"content"})
-        with self.assertRaisesRegex(WorkspaceError, "unknown components"):
-            cleanup._normalize_names(["content-1x"])
+        try:
+            cleanup = Cleanup(actual_workspace)
+            self.assertEqual(
+                cleanup._normalize_scopes(["all"]),
+                [
+                    "worktrees", "builds", "npm-cache", "compiler-cache",
+                    "sound-cache",
+                ],
+            )
+            self.assertEqual(cleanup._normalize_names(["atrinik"]), {"atrinik"})
+            with self.assertRaisesRegex(WorkspaceError, "unknown components"):
+                cleanup._normalize_names(["not-a-component"])
+            self.assertEqual(
+                cleanup._normalize_names(
+                    ["classic", "classic-client", "classic-server", "classic-protocol"]
+                ),
+                {"classic"},
+            )
+            self.assertEqual(cleanup._normalize_names(["content"]), {"content"})
+            with self.assertRaisesRegex(WorkspaceError, "unknown components"):
+                cleanup._normalize_names(["content-1x"])
 
-        head = "a" * 40
-        pulls = self.merged_pull(head, base="main")
-        reason, _, _ = Cleanup._pull_evidence(pulls, head, "main")
-        self.assertIsNone(reason)
-        reason, _, _ = Cleanup._pull_evidence(pulls, head, "1.x")
-        self.assertEqual(reason, "wrong_base_branch")
+            head = "a" * 40
+            pulls = self.merged_pull(head, base="main")
+            reason, _, _ = Cleanup._pull_evidence(pulls, head, "main")
+            self.assertIsNone(reason)
+            reason, _, _ = Cleanup._pull_evidence(pulls, head, "1.x")
+            self.assertEqual(reason, "wrong_base_branch")
 
-        profile = actual_workspace._load_profile("classic", require_file=False)
-        migrated = actual_workspace.paths.worktrees / "content" / "classic-maps"
-        profile["name"] = "migrated"
-        profile["components"]["content-1x"] = {
-            "kind": "migrated-worktree",
-            "value": str(migrated),
-        }
-        profile["components"].pop("content")
-        atomic_json(actual_workspace.paths.profiles / "migrated.json", profile)
-        references: dict[str, object] = {"profiles": {}}
-        errors: set[str] = set()
-        cleanup._profile_references(references, errors)
-        self.assertEqual(errors, set())
-        self.assertEqual(references["profiles"], {migrated: ["migrated"]})
+            profile = actual_workspace._load_profile("classic", require_file=False)
+            migrated = actual_workspace.paths.worktrees / "content" / "classic-maps"
+            profile["name"] = "migrated"
+            profile["components"]["content-1x"] = {
+                "kind": "migrated-worktree",
+                "value": str(migrated),
+            }
+            profile["components"].pop("content")
+            atomic_json(actual_workspace.paths.profiles / "migrated.json", profile)
+            references: dict[str, object] = {"profiles": {}}
+            errors: set[str] = set()
+            cleanup._profile_references(references, errors)
+            self.assertEqual(errors, set())
+            self.assertEqual(references["profiles"], {migrated: ["migrated"]})
+        finally:
+            actual_workspace.close()
 
     def test_allocated_size_credit_deduplicates_shared_inodes(self) -> None:
         first = _base_item("worktree", "atrinik", "atrinik/atrinik", self.root / "a")

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -204,8 +204,10 @@ class CleanupTests(unittest.TestCase):
         *,
         generation: str | None = None,
         process_tree_lease: str = "released",
+        runtime_bundle_lease: str = "released",
         control: str = "unreachable",
         stopped_at: str | None = "2026-07-01T00:00:00+00:00",
+        port_reservation: object = None,
         repository_layout_lease_owner: str | None = None,
     ) -> dict[str, object]:
         return {
@@ -216,8 +218,8 @@ class CleanupTests(unittest.TestCase):
                 "control": control,
                 "generation": generation,
                 "process_tree_lease": process_tree_lease,
-                "runtime_bundle_lease": "released",
-                "port_reservation": None,
+                "runtime_bundle_lease": runtime_bundle_lease,
+                "port_reservation": port_reservation,
                 "repository_layout_lease_owner": repository_layout_lease_owner,
             },
         }
@@ -400,6 +402,42 @@ class CleanupTests(unittest.TestCase):
         )
         self.assertIn("active_topology_operation", items["active-operation"]["reasons"])
         self.assertTrue(all(row["disposition"] == "protected" for row in items.values()))
+
+    def test_topology_cleanup_rejects_special_and_hard_linked_files(self) -> None:
+        special = self.make_topology_record("special-file")
+        os.mkfifo(special / "unsafe-fifo")
+        linked = self.make_topology_record("hard-linked")
+        os.link(linked / "server.log", linked / "server-copy.log")
+
+        report = self.workspace.cleanup(["topologies"], 7, [], False)
+        items = {row["name"]: row for row in report["items"]}
+
+        self.assertIn("invalid_topology_tree", items["special-file"]["reasons"])
+        self.assertIn("special file", items["special-file"]["error"])
+        self.assertIn("invalid_topology_tree", items["hard-linked"]["reasons"])
+        self.assertIn("linked file", items["hard-linked"]["error"])
+
+    def test_topology_cleanup_protects_unverifiable_runtime_and_port_leases(self) -> None:
+        runtime = self.make_topology_record("runtime-unknown")
+        port = self.make_topology_record("port-unknown")
+
+        def status(name: str) -> dict[str, object]:
+            if name == runtime.name:
+                return self.topology_observation(
+                    "exited", runtime_bundle_lease="unverifiable"
+                )
+            return self.topology_observation("exited", port_reservation={})
+
+        with mock.patch.object(self.workspace, "topology_status", side_effect=status):
+            report = self.workspace.cleanup(["topologies"], 7, [], False)
+        items = {row["name"]: row for row in report["items"]}
+
+        self.assertIn(
+            "runtime_bundle_lease_unverifiable", items[runtime.name]["reasons"]
+        )
+        self.assertIn(
+            "port_reservation_lease_unverifiable", items[port.name]["reasons"]
+        )
 
     def test_current_generation_and_invalid_records_are_reported_fail_closed(self) -> None:
         self.make_topology_record("current-generation")

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -14,6 +14,7 @@ import unittest
 from unittest import mock
 
 from atrinik_workspace.cleanup import (
+    ALL_SCOPES,
     Cleanup,
     _base_item,
     _command,
@@ -156,6 +157,336 @@ class CleanupTests(unittest.TestCase):
         )
         (cache / "playtest-manifest.json").write_text("{}\n", encoding="utf-8")
         return sound, cache
+
+    def make_topology_record(
+        self,
+        name: str,
+        *,
+        stopped_at: str | None = "2026-07-01T00:00:00+00:00",
+        old: bool = True,
+    ) -> Path:
+        root = self.workspace._topology_directory(name, create=True)
+        (root / "operation.lock").touch(mode=0o600)
+        (root / "process-tree.lease").touch(mode=0o600)
+        (root / "server.log").write_text("stopped\n", encoding="utf-8")
+        runtime = root / "runtime"
+        runtime.mkdir()
+        (runtime / "snapshot").write_text("transient\n", encoding="utf-8")
+        atomic_json(
+            root / "status.json",
+            {
+                "schema_version": SCHEMA_VERSION,
+                "name": name,
+                "profile": "default",
+                "dependencies": [],
+                "state": None,
+                "build_root": str(self.workspace.paths.builds / "profiles" / "fixture"),
+                "resolved": {},
+                "endpoint": None,
+                "ready": False,
+                "started_at": "2026-06-01T00:00:00+00:00",
+                "stopped_at": stopped_at,
+                "supervisor": {"pid": 999999, "start_time": "1"},
+                "services": {},
+                "error": "fixture",
+            },
+        )
+        if old:
+            timestamp = self.old.timestamp()
+            for path in sorted(root.rglob("*"), reverse=True):
+                os.utime(path, (timestamp, timestamp), follow_symlinks=False)
+            os.utime(root, (timestamp, timestamp))
+        return root
+
+    def topology_observation(
+        self,
+        liveness: str,
+        *,
+        generation: str | None = None,
+        process_tree_lease: str = "released",
+        control: str = "unreachable",
+        stopped_at: str | None = "2026-07-01T00:00:00+00:00",
+    ) -> dict[str, object]:
+        return {
+            "supervisor": {"liveness": liveness},
+            "services": {},
+            "stopped_at": stopped_at,
+            "observation": {
+                "control": control,
+                "generation": generation,
+                "process_tree_lease": process_tree_lease,
+                "runtime_bundle_lease": "released",
+                "port_reservation": None,
+                "repository_layout_lease_owner": None,
+            },
+        }
+
+    def test_topology_cleanup_is_explicit_and_excluded_from_all(self) -> None:
+        root = self.make_topology_record("retained-history")
+
+        self.assertFalse(
+            any(item["kind"] == "topology" for item in self.plan([])["items"])
+        )
+        self.assertFalse(
+            any(item["kind"] == "topology" for item in self.plan(["all"])["items"])
+        )
+        combined = self.plan(["all", "topologies"])
+        self.assertTrue(any(item["kind"] == "topology" for item in combined["items"]))
+        self.assertEqual(combined["scopes"], [*ALL_SCOPES, "topologies"])
+        report = self.workspace.cleanup(["topologies"], 7, [], False)
+
+        self.assertEqual(report["scopes"], ["topologies"])
+        item = next(row for row in report["items"] if row["path"] == str(root))
+        self.assertEqual(item["disposition"], "eligible")
+        self.assertEqual(item["reasons"], ["inactive_topology"])
+        self.assertEqual(item["liveness"], "exited")
+        self.assertEqual(item["age_basis"], "stopped-at")
+
+    def test_missing_topology_container_is_an_empty_inventory(self) -> None:
+        self.workspace.paths.topologies.rmdir()
+
+        report = self.workspace.cleanup(["topologies"], 7, [], False)
+
+        self.assertEqual(report["items"], [])
+        self.assertEqual(report["summary"]["error_count"], 0)
+
+    def test_topology_only_scope_does_not_inventory_unrelated_resources(self) -> None:
+        root = self.make_topology_record("isolated-history")
+
+        with (
+            mock.patch.object(
+                Cleanup, "_references", side_effect=AssertionError("unrelated inventory")
+            ),
+            mock.patch.object(
+                Cleanup,
+                "_registered_worktree_paths",
+                side_effect=AssertionError("unrelated Git inventory"),
+            ),
+        ):
+            report = self.workspace.cleanup(["topologies"], 7, [], False)
+            applied = self.workspace.cleanup(["topologies"], 7, [], True)
+
+        item = next(row for row in report["items"] if row["path"] == str(root))
+        self.assertEqual(item["disposition"], "eligible")
+        self.assertEqual(report["inventory_errors"], [])
+        removed = next(row for row in applied["items"] if row["path"] == str(root))
+        self.assertEqual(removed["disposition"], "removed")
+
+    def test_topology_cleanup_removes_only_the_record_and_is_idempotent(self) -> None:
+        root = self.make_topology_record("old-exit")
+        state = self.workspace.paths.state / "preserved"
+        build = self.workspace.paths.builds / "preserved"
+        profile = self.workspace.paths.profiles / "preserved.txt"
+        for path in (state, build):
+            path.mkdir()
+            (path / "sentinel").write_text("preserve\n", encoding="utf-8")
+        profile.write_text("{}\n", encoding="utf-8")
+
+        earlier_builds = self.workspace.cleanup(["builds"], 7, [], False)
+        self.assertNotIn("topology_inventory_error", earlier_builds["inventory_errors"])
+
+        preview = self.workspace.cleanup(["topologies"], 7, [], False)
+        item = next(row for row in preview["items"] if row["path"] == str(root))
+        self.assertIn(str(root / "status.json"), item["deletion_paths"])
+        self.assertIn(str(root / "server.log"), item["deletion_paths"])
+        self.assertIn(str(root / "runtime" / "snapshot"), item["deletion_paths"])
+        self.assertTrue(root.is_dir())
+
+        applied = self.workspace.cleanup(["topologies"], 7, [], True)
+        removed = next(row for row in applied["items"] if row["path"] == str(root))
+        self.assertEqual(removed["disposition"], "removed")
+        self.assertFalse(root.exists())
+        self.assertEqual(self.workspace.topology_statuses(), [])
+        self.assertEqual((state / "sentinel").read_text(), "preserve\n")
+        self.assertEqual((build / "sentinel").read_text(), "preserve\n")
+        self.assertEqual(profile.read_text(), "{}\n")
+
+        later_builds = self.workspace.cleanup(["builds"], 7, [], False)
+        self.assertNotIn("topology_inventory_error", later_builds["inventory_errors"])
+
+        repeated = self.workspace.cleanup(["topologies"], 7, [], True)
+        self.assertEqual(repeated["summary"]["removed_count"], 0)
+        self.assertFalse(repeated["mutated"])
+
+    def test_legacy_stale_topology_uses_conservative_tree_age(self) -> None:
+        old = self.make_topology_record("old-stale", stopped_at=None)
+        young = self.make_topology_record("young-stale", stopped_at=None, old=False)
+        orderly_young = self.make_topology_record(
+            "young-exit", stopped_at=datetime.now(timezone.utc).isoformat()
+        )
+
+        report = self.workspace.cleanup(["topologies"], 7, [], False)
+        old_item = next(row for row in report["items"] if row["path"] == str(old))
+        young_item = next(row for row in report["items"] if row["path"] == str(young))
+        self.assertEqual(old_item["liveness"], "stale")
+        self.assertEqual(old_item["age_basis"], "legacy-tree-mtime")
+        self.assertEqual(old_item["disposition"], "eligible")
+        self.assertEqual(young_item["disposition"], "protected")
+        self.assertIn("topology_younger_than_grace_period", young_item["reasons"])
+        orderly_item = next(
+            row for row in report["items"] if row["path"] == str(orderly_young)
+        )
+        self.assertEqual(orderly_item["age_basis"], "stopped-at")
+        self.assertIn(
+            "topology_younger_than_grace_period", orderly_item["reasons"]
+        )
+
+    def test_exited_topology_without_stopped_at_does_not_use_legacy_age(self) -> None:
+        root = self.make_topology_record("invalid-orderly-exit", stopped_at=None)
+
+        with mock.patch.object(
+            self.workspace,
+            "topology_status",
+            return_value=self.topology_observation("exited", stopped_at=None),
+        ):
+            report = self.workspace.cleanup(["topologies"], 7, [], False)
+
+        item = next(row for row in report["items"] if row["path"] == str(root))
+        self.assertIsNone(item["age_basis"])
+        self.assertIn("topology_stopped_at_unavailable", item["reasons"])
+        self.assertEqual(item["disposition"], "protected")
+
+    def test_topology_cleanup_protects_liveness_leases_links_and_operations(self) -> None:
+        live = self.make_topology_record("live")
+        unreachable = self.make_topology_record("unreachable")
+        retained = self.make_topology_record("retained")
+        linked = self.make_topology_record("linked")
+        (linked / "unsafe-link").symlink_to(self.root)
+        active = self.make_topology_record("active-operation")
+        descriptor = os.open(active / "operation.lock", os.O_RDWR)
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+        def status(name: str) -> dict[str, object]:
+            if name == "live":
+                return self.topology_observation("live", control="reachable")
+            if name == "unreachable":
+                return self.topology_observation("unreachable")
+            if name == "retained":
+                return self.topology_observation(
+                    "stale", process_tree_lease="retained"
+                )
+            return self.topology_observation("exited")
+
+        try:
+            with mock.patch.object(self.workspace, "topology_status", side_effect=status):
+                report = self.workspace.cleanup(["topologies"], 7, [], False)
+        finally:
+            os.close(descriptor)
+        items = {row["name"]: row for row in report["items"]}
+        self.assertIn("live_topology", items["live"]["reasons"])
+        self.assertIn("reachable_topology_control", items["live"]["reasons"])
+        self.assertIn("unreachable_topology", items["unreachable"]["reasons"])
+        self.assertIn("process_tree_lease_retained", items["retained"]["reasons"])
+        self.assertIn("invalid_topology_tree", items["linked"]["reasons"])
+        self.assertIn("active_topology_operation", items["active-operation"]["reasons"])
+        self.assertTrue(all(row["disposition"] == "protected" for row in items.values()))
+
+    def test_current_generation_and_invalid_records_are_reported_fail_closed(self) -> None:
+        self.make_topology_record("current-generation")
+        malformed = self.make_topology_record("invalid-lease")
+        status = json.loads((malformed / "status.json").read_text(encoding="utf-8"))
+        status["control"] = {
+            "socket": "/wrong/control",
+            "generation": "b" * 64,
+            "lease": {"device": 1, "inode": 2},
+        }
+        atomic_json(malformed / "status.json", status)
+        unowned = self.workspace.paths.topologies / "unowned"
+        unowned.mkdir()
+        (unowned / "status.json").write_text("{}\n", encoding="utf-8")
+
+        actual_status = self.workspace.topology_status
+
+        def observe(name: str) -> dict[str, object]:
+            if name == "current-generation":
+                return self.topology_observation("exited", generation="a" * 64)
+            return actual_status(name)
+
+        with mock.patch.object(self.workspace, "topology_status", side_effect=observe):
+            report = self.workspace.cleanup(["topologies"], 7, [], False)
+        items = {row["name"]: row for row in report["items"]}
+        self.assertEqual(items["current-generation"]["generation"], "a" * 64)
+        self.assertEqual(items["current-generation"]["disposition"], "eligible")
+        self.assertIn("topology_status_unverifiable", items["invalid-lease"]["reasons"])
+        self.assertIn("invalid_topology_ownership", items["unowned"]["reasons"])
+        self.assertEqual(items["invalid-lease"]["disposition"], "protected")
+        self.assertEqual(items["unowned"]["disposition"], "protected")
+
+    def test_topology_preview_reports_a_retained_repository_layout_lease(self) -> None:
+        root = self.make_topology_record("layout-reader")
+        layout = self.workspace.paths.workspace / "repository-layout.lock"
+        descriptor = os.open(layout, os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_SH | fcntl.LOCK_NB)
+            report = self.workspace.cleanup(["topologies"], 7, [], False)
+        finally:
+            os.close(descriptor)
+
+        item = next(row for row in report["items"] if row["path"] == str(root))
+        self.assertEqual(item["repository_layout_lease"], "retained")
+        self.assertIn("repository_layout_lease_retained", item["reasons"])
+        self.assertEqual(item["disposition"], "protected")
+
+    def test_topology_apply_rejects_a_post_revalidation_restart_race(self) -> None:
+        root = self.make_topology_record("restart-race")
+        original = Cleanup._revalidate_target
+
+        def restart_after_revalidation(
+            cleanup: Cleanup, *arguments: object
+        ) -> dict[str, object] | None:
+            item = original(cleanup, *arguments)
+            if item is not None and item["kind"] == "topology":
+                (root / "restart-evidence").write_text("changed\n", encoding="utf-8")
+            return item
+
+        with mock.patch.object(
+            Cleanup, "_revalidate_target", new=restart_after_revalidation
+        ):
+            report = self.workspace.cleanup(["topologies"], 7, [], True)
+
+        item = next(row for row in report["items"] if row["path"] == str(root))
+        self.assertEqual(item["disposition"], "error")
+        self.assertEqual(item["reasons"], ["removal_failed"])
+        self.assertIn("changed before removal", item["error"])
+        self.assertTrue(root.is_dir())
+
+    def test_topology_apply_rejects_a_change_during_revalidation(self) -> None:
+        root = self.make_topology_record("revalidation-race")
+
+        with mock.patch.object(
+            self.workspace,
+            "topology_status",
+            side_effect=(
+                self.topology_observation("exited"),
+                self.topology_observation("stale"),
+            ),
+        ):
+            report = self.workspace.cleanup(["topologies"], 7, [], True)
+
+        item = next(row for row in report["items"] if row["path"] == str(root))
+        self.assertEqual(item["disposition"], "error")
+        self.assertEqual(item["reasons"], ["revalidation_error"])
+        self.assertIn("changed during apply revalidation", item["error"])
+        self.assertTrue(root.is_dir())
+
+    def test_topology_cleanup_preserves_an_interrupted_record_for_retry(self) -> None:
+        root = self.make_topology_record("interrupted-removal")
+
+        with mock.patch(
+            "atrinik_workspace.cleanup.remove_owned_tree",
+            side_effect=WorkspaceError("simulated interruption"),
+        ):
+            interrupted = self.workspace.cleanup(["topologies"], 7, [], True)
+
+        item = next(row for row in interrupted["items"] if row["path"] == str(root))
+        self.assertEqual(item["disposition"], "error")
+        self.assertEqual(item["reasons"], ["removal_failed"])
+        self.assertTrue(root.is_dir())
+
+        retried = self.workspace.cleanup(["topologies"], 7, [], True)
+        item = next(row for row in retried["items"] if row["path"] == str(root))
+        self.assertEqual(item["disposition"], "removed")
+        self.assertFalse(root.exists())
 
     @staticmethod
     def write_sound_producer_lease(worktree: Path) -> Path:

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -358,6 +358,8 @@ class CleanupTests(unittest.TestCase):
         retained = self.make_topology_record("retained")
         linked = self.make_topology_record("linked")
         (linked / "unsafe-link").symlink_to(self.root)
+        missing_lock = self.make_topology_record("missing-operation-lock")
+        (missing_lock / "operation.lock").unlink()
         active = self.make_topology_record("active-operation")
         descriptor = os.open(active / "operation.lock", os.O_RDWR)
         fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -384,6 +386,10 @@ class CleanupTests(unittest.TestCase):
         self.assertIn("unreachable_topology", items["unreachable"]["reasons"])
         self.assertIn("process_tree_lease_retained", items["retained"]["reasons"])
         self.assertIn("invalid_topology_tree", items["linked"]["reasons"])
+        self.assertIn(
+            "topology_operation_lock_unavailable",
+            items["missing-operation-lock"]["reasons"],
+        )
         self.assertIn("active_topology_operation", items["active-operation"]["reasons"])
         self.assertTrue(all(row["disposition"] == "protected" for row in items.values()))
 

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -365,6 +365,8 @@ class CleanupTests(unittest.TestCase):
         retained = self.make_topology_record("retained")
         linked = self.make_topology_record("linked")
         (linked / "unsafe-link").symlink_to(self.root)
+        missing_lock = self.make_topology_record("missing-operation-lock")
+        (missing_lock / "operation.lock").unlink()
         active = self.make_topology_record("active-operation")
         descriptor = os.open(active / "operation.lock", os.O_RDWR)
         fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -391,6 +393,10 @@ class CleanupTests(unittest.TestCase):
         self.assertIn("unreachable_topology", items["unreachable"]["reasons"])
         self.assertIn("process_tree_lease_retained", items["retained"]["reasons"])
         self.assertIn("invalid_topology_tree", items["linked"]["reasons"])
+        self.assertIn(
+            "topology_operation_lock_unavailable",
+            items["missing-operation-lock"]["reasons"],
+        )
         self.assertIn("active_topology_operation", items["active-operation"]["reasons"])
         self.assertTrue(all(row["disposition"] == "protected" for row in items.values()))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,10 @@ from atrinik_workspace.model import WorkspaceError
 
 
 class ParserTests(unittest.TestCase):
+    def test_cleanup_accepts_the_explicit_topologies_scope(self) -> None:
+        options = parser().parse_args(["cleanup", "--scope", "topologies"])
+        self.assertEqual(options.scope, ["topologies"])
+
     def test_human_bytes_uses_compact_iec_units_and_promotes_rounding(self) -> None:
         self.assertEqual(
             [_human_bytes(value) for value in (0, 1023, 1024, 1536)],
@@ -172,6 +176,60 @@ class ParserTests(unittest.TestCase):
             "summary\tcandidates=1 candidate_bytes=4KiB protected=0 "
             "protected_bytes=0B removed=0 removed_bytes=0B errors=0",
             lines,
+        )
+
+    def test_cleanup_text_report_includes_topology_observation_and_paths(self) -> None:
+        report = {
+            "items": [
+                {
+                    "disposition": "eligible",
+                    "kind": "topology",
+                    "allocated_bytes": 512,
+                    "age_seconds": 8 * 86400,
+                    "path": "/workspace/topologies/old",
+                    "reasons": ["inactive_topology"],
+                    "name": "old",
+                    "liveness": "exited",
+                    "control_observation": "legacy",
+                    "generation": None,
+                    "process_tree_lease": "released",
+                    "runtime_bundle_lease": "historical",
+                    "port_reservation_lease": "released",
+                    "repository_layout_lease": "released",
+                    "age_basis": "stopped-at",
+                    "age_observed_at": "2026-08-01T00:00:00+00:00",
+                    "deletion_paths": [
+                        "/workspace/topologies/old",
+                        "/workspace/topologies/old/status.json",
+                    ],
+                }
+            ],
+            "summary": {
+                "candidate_count": 1,
+                "candidate_bytes": 512,
+                "protected_count": 0,
+                "protected_bytes": 0,
+                "removed_count": 0,
+                "removed_bytes": 0,
+                "error_count": 0,
+            },
+        }
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.cleanup.return_value = report
+            with mock.patch("builtins.print") as output:
+                result = main(["cleanup", "--scope", "topologies"])
+
+        lines = [call.args[0] for call in output.call_args_list]
+        self.assertEqual(result, 0)
+        self.assertIn(
+            "topology-observation\told\tliveness=exited\tcontrol=legacy\t"
+            "generation=-\tprocess-tree=released\truntime-bundle=historical\t"
+            "port-reservation=released\trepository-layout=released\t"
+            "age-basis=stopped-at\tage-observed-at=2026-08-01T00:00:00+00:00",
+            lines,
+        )
+        self.assertIn(
+            "delete\told\t/workspace/topologies/old/status.json", lines
         )
 
     def test_cleanup_text_report_uses_concise_iec_byte_units(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -702,6 +702,7 @@ class ParserTests(unittest.TestCase):
         workspace_type.return_value.run_client.assert_called_once_with(
             "review", "shared", 1731, [], True
         )
+        workspace_type.return_value.command_maintenance.assert_not_called()
 
     def test_up_defaults_runtime_name_to_profile(self) -> None:
         status = {

--- a/tests/test_cohorts.py
+++ b/tests/test_cohorts.py
@@ -202,8 +202,11 @@ class CohortWorkspaceTests(unittest.TestCase):
             component_names: set[str] | None = None,
             *,
             trace: bool = True,
+            profile: dict[str, object] | None = None,
         ) -> dict[str, Path]:
-            stack = self.workspace.manifest.stack(profile_name)
+            stack = self.workspace.manifest.stack(
+                profile["stack"] if profile is not None else profile_name
+            )
             selected = component_names or {
                 component.name for component in stack.components
             }
@@ -486,8 +489,8 @@ class CohortWorkspaceTests(unittest.TestCase):
             set(audited),
             {"server", "content", "resources", "libatrinik", "protocol"},
         )
-        # Each of six resolutions validates the five selected physical
-        # checkouts once; four Classic logical providers share one checkout.
+        # Every resolution validates once, after exact source acquisition.
+        # Four Classic logical providers share one physical checkout.
         self.assertEqual(validate.call_count, 30)
         expected_checkouts = {
             "classic",
@@ -504,10 +507,25 @@ class CohortWorkspaceTests(unittest.TestCase):
                 set(validated[offset : offset + len(expected_checkouts)]),
                 expected_checkouts,
             )
-        # Topology summary probes all five physical roots once. Scenario audit
-        # intentionally records only the three physical server-closure roots.
-        self.assertEqual(git.call_count, 8)
-        self.assertEqual(clean.call_count, 8)
+        # Each public build snapshot records checkout HEAD identities. Common-Git
+        # namespace discovery may add independent Git calls, so assert the
+        # meaningful probes instead of their aggregate mock count.
+        head_roots = {
+            call.args[0]
+            for call in git.call_args_list
+            if call.args[1:] == ("rev-parse", "HEAD")
+        }
+        self.assertTrue(
+            {
+                self.wrapper / "classic",
+                self.wrapper / "content",
+                self.wrapper / "sound",
+                self.wrapper / "resources",
+                self.wrapper / "metaserver-worker",
+            }
+            <= head_roots
+        )
+        self.assertEqual(clean.call_count, 23)
 
     def test_complete_default_selection_keeps_requested_service(self) -> None:
         profile = self.workspace._load_profile("default", require_file=False)
@@ -653,9 +671,15 @@ class CohortWorkspaceTests(unittest.TestCase):
         profile = self.workspace._load_profile("classic-review", require_file=True)
         server_roles = self.workspace._dependency_roles(profile, {"server"})
         self.assertEqual(set(region_inputs["coordinates"]), server_roles)
-        # Five metadata checkouts plus the three physical server/worldmaker
-        # inputs (Classic, content, and resources) are each probed once.
-        self.assertEqual(git.call_count, 8)
+        head_roots = {
+            call.args[0]
+            for call in git.call_args_list
+            if call.args[1:] == ("rev-parse", "HEAD")
+        }
+        self.assertTrue(
+            {worktree, self.wrapper / "content", self.wrapper / "resources"}
+            <= head_roots
+        )
 
     def test_classic_component_source_rejects_symlinked_module(self) -> None:
         checkout = self.wrapper / "classic"
@@ -702,7 +726,12 @@ class CohortWorkspaceTests(unittest.TestCase):
         ):
             self.workspace.sync(["client"], "none", include_classic=True)
 
-        self.assertEqual(git.call_count, 2)
+        git.assert_any_call(
+            self.wrapper / "client", "fetch", "--prune", "--tags", "origin"
+        )
+        git.assert_any_call(
+            self.wrapper / "client", "merge", "--ff-only", "origin/main"
+        )
 
     def test_external_content_profile_requires_canonical_repository(self) -> None:
         selected = self.wrapper / "external-content-review"
@@ -852,7 +881,13 @@ class CohortWorkspaceTests(unittest.TestCase):
         ):
             self.workspace.sync(["content"], "merge")
 
-        worktrees.assert_called_once_with(primary, {selected.resolve()})
+        self.assertEqual(
+            worktrees.call_args_list,
+            [
+                mock.call(primary, {selected.resolve()}),
+                mock.call(primary, {selected.resolve()}),
+            ],
+        )
 
     def test_explicit_sync_of_missing_component_fails_closed(self) -> None:
         with self.assertRaisesRegex(WorkspaceError, "run ./atrinik init classic"):

--- a/tests/test_content_migration.py
+++ b/tests/test_content_migration.py
@@ -122,6 +122,8 @@ class ContentMigrationTests(unittest.TestCase):
             self.workspace.paths.repository,
             self.workspace.paths,
             self.workspace.manifest,
+            self.workspace.paths.workspace / "physical-repository-layout.lock",
+            lambda _transitions=None: None,
         )
 
     def test_primary_profile_apply_audit_and_restore_preserve_legacy_checkout(self) -> None:
@@ -789,6 +791,9 @@ class ContentMigrationTests(unittest.TestCase):
                                 workspace.paths.repository,
                                 workspace.paths,
                                 workspace.manifest,
+                                workspace.paths.workspace
+                                / "physical-repository-layout.lock",
+                                lambda _transitions=None: None,
                             ).execute("dry-run")
                         self.assertEqual(result["status"], "refused")
                         self.assertIn(
@@ -1018,7 +1023,7 @@ class ContentMigrationTests(unittest.TestCase):
         profile, original = self._legacy_profile()
         migration = self.migration()
         plan = migration.execute("dry-run")
-        real_atomic_json = migration_module.atomic_json
+        real_atomic_json = migration_module.durable_atomic_json
         calls = 0
 
         def fail_record(path: Path, value: object) -> None:
@@ -1028,7 +1033,9 @@ class ContentMigrationTests(unittest.TestCase):
                 raise OSError("record publication failed")
             real_atomic_json(path, value)
 
-        with mock.patch.object(migration_module, "atomic_json", side_effect=fail_record):
+        with mock.patch.object(
+            migration_module, "durable_atomic_json", side_effect=fail_record
+        ):
             with self.assertRaisesRegex(
                 migration_module.WorkspaceError, "record publication failed"
             ):
@@ -1038,24 +1045,86 @@ class ContentMigrationTests(unittest.TestCase):
         self.assertFalse(migration.pending_path.exists())
         self.assertFalse(migration.record_path.exists())
 
+    def test_apply_does_not_rollback_visible_record_on_fsync_uncertainty(self) -> None:
+        profile, original = self._legacy_profile()
+        migration = self.migration()
+        plan = migration.execute("dry-run")
+        real_atomic_json = migration_module.durable_atomic_json
+
+        def uncertain_record(path: Path, value: object) -> None:
+            real_atomic_json(path, value)
+            if path == migration.record_path:
+                raise migration_module.AtomicJsonCommitUncertain(
+                    "simulated record durability uncertainty"
+                )
+
+        with (
+            mock.patch.object(
+                migration_module, "durable_atomic_json", side_effect=uncertain_record
+            ),
+            self.assertRaisesRegex(
+                migration_module.WorkspaceError, "durable record was published"
+            ),
+        ):
+            migration._apply(plan)
+
+        self.assertNotEqual(profile.read_bytes(), original)
+        self.assertTrue(migration.record_path.is_file())
+        self.assertTrue(migration.pending_path.is_file())
+
     def test_apply_reports_retained_pending_journal_after_commit(self) -> None:
         self._legacy_profile()
         migration = self.migration()
         plan = migration.execute("dry-run")
-        real_unlink = Path.unlink
-
-        def fail_pending(path: Path, *args: object, **kwargs: object) -> None:
-            if path == migration.pending_path:
-                raise OSError("retain journal")
-            real_unlink(path, *args, **kwargs)
-
-        with mock.patch.object(Path, "unlink", fail_pending):
+        with mock.patch.object(
+            migration_module,
+            "_durable_unlink",
+            side_effect=migration_module.WorkspaceError("retain journal"),
+        ):
             result = migration._apply(plan)
 
         self.assertEqual(result["status"], "complete")
         self.assertEqual(result["pending_journal_retained"], str(migration.pending_path))
         self.assertTrue(migration.record_path.is_file())
         self.assertTrue(migration.pending_path.is_file())
+
+        pending = json.loads(migration.pending_path.read_text(encoding="utf-8"))
+        truncated = dict(pending)
+        truncated.pop("resources")
+        migration_module.durable_atomic_json(migration.pending_path, truncated)
+        with self.assertRaisesRegex(
+            migration_module.WorkspaceError, "unexpected fields"
+        ):
+            migration.execute("apply")
+        migration_module.durable_atomic_json(migration.pending_path, pending)
+
+        retry = migration.execute("apply")
+
+        self.assertEqual(retry["status"], "already-applied")
+        self.assertFalse(migration.pending_path.exists())
+
+    def test_apply_reports_removed_pending_journal_durability_uncertainty(self) -> None:
+        self._legacy_profile()
+        migration = self.migration()
+        plan = migration.execute("dry-run")
+
+        def uncertain_unlink(path: Path, *, missing_ok: bool = False) -> None:
+            path.unlink(missing_ok=missing_ok)
+            raise migration_module.JsonUnlinkCommitUncertain(
+                "simulated unlink durability uncertainty"
+            )
+
+        with mock.patch.object(
+            migration_module, "_durable_unlink", side_effect=uncertain_unlink
+        ):
+            result = migration._apply(plan)
+
+        self.assertEqual(result["status"], "complete")
+        self.assertIn(
+            "simulated unlink durability uncertainty",
+            result["pending_journal_removed_durability_uncertain"],
+        )
+        self.assertFalse(migration.pending_path.exists())
 
     def test_journal_shape_and_digest_tampering_fail_closed(self) -> None:
         self._legacy_profile()

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -152,7 +152,13 @@ class RepositoryMigrationTests(unittest.TestCase):
         self.temporary.cleanup()
 
     def migration(self) -> RepositoryMigration:
-        return RepositoryMigration(self.wrapper, self.paths, self.manifest)
+        return RepositoryMigration(
+            self.wrapper,
+            self.paths,
+            self.manifest,
+            self.paths.workspace / "physical-repository-layout.lock",
+            lambda _transitions=None: None,
+        )
 
     def test_classic_profile_fallback_includes_playtester(self) -> None:
         migration = self.migration()
@@ -384,6 +390,69 @@ class RepositoryMigrationTests(unittest.TestCase):
         audit = self.migration().execute("audit")
         self.assertEqual(audit["status"], "complete", audit)
         self.assertEqual(self.migration().execute("apply")["status"], "already-applied")
+
+    def test_record_fsync_uncertainty_does_not_rollback_committed_layout(self) -> None:
+        source = self.make_repository("client", "client")
+        self.make_classic({"client": source})
+        profile = self.write_profile(
+            "review",
+            {
+                "client": {"kind": "primary", "value": ""},
+                "content": {"kind": "primary", "value": ""},
+            },
+        )
+        migration = self.migration()
+        real_publish = migration._durable_atomic_json
+
+        def uncertain(path: Path, value: object) -> None:
+            real_publish(path, value)
+            if path == migration.record_path:
+                raise migration_module.AtomicJsonCommitUncertain(
+                    "simulated record durability uncertainty"
+                )
+
+        with (
+            mock.patch.object(migration, "_durable_atomic_json", side_effect=uncertain),
+            self.assertRaisesRegex(WorkspaceError, "migration committed"),
+        ):
+            migration.execute("apply")
+
+        self.assertTrue(migration.record_path.is_file())
+        self.assertFalse(source.exists())
+        self.assertNotEqual(json.loads(profile.read_text())["schema_version"], 1)
+
+    def test_already_applied_retry_rejects_symlinked_pending_journal(self) -> None:
+        source = self.make_repository("client", "client")
+        self.make_classic({"client": source})
+        self.write_profile(
+            "review",
+            {
+                "client": {"kind": "primary", "value": ""},
+                "content": {"kind": "primary", "value": ""},
+            },
+        )
+        migration = self.migration()
+        real_unlink = migration_module.unlink_validated_json
+
+        def retain_pending(path: Path, validator: object) -> None:
+            if path == migration.pending_path:
+                raise WorkspaceError("retain journal")
+            real_unlink(path, validator)
+
+        with mock.patch.object(
+            migration_module,
+            "unlink_validated_json",
+            side_effect=retain_pending,
+        ):
+            self.assertEqual(migration.execute("apply")["status"], "applied")
+        external = self.root / "external-pending.json"
+        migration.pending_path.rename(external)
+        migration.pending_path.symlink_to(external)
+
+        with self.assertRaisesRegex(WorkspaceError, "cannot consume"):
+            migration.execute("apply")
+
+        self.assertTrue(external.is_file())
 
     def test_schema_v3_replacement_profile_is_valid_and_left_unchanged(self) -> None:
         profile = self.paths.profiles / "replacement.json"
@@ -1235,7 +1304,13 @@ class RepositoryMigrationTests(unittest.TestCase):
                                 / "client"
                             )
                             conflict.mkdir(parents=True)
-                        result = RepositoryMigration(wrapper, paths, self.manifest).execute("apply")
+                        result = RepositoryMigration(
+                            wrapper,
+                            paths,
+                            self.manifest,
+                            paths.workspace / "physical-repository-layout.lock",
+                            lambda _transitions=None: None,
+                        ).execute("apply")
                         self.assertEqual(result["status"], "refused")
                         self.assertTrue(result["refusals"])
                         self.assertTrue(source.is_dir())

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,6 +4,7 @@ import copy
 import json
 import os
 from pathlib import Path
+import stat
 import sys
 import tempfile
 import unittest
@@ -14,6 +15,7 @@ from atrinik_workspace.model import (
     Paths,
     WorkspaceError,
     atomic_json,
+    durable_atomic_json,
     load_json,
     managed_directory,
     managed_remove,
@@ -834,6 +836,70 @@ class PathSafetyTests(unittest.TestCase):
             with mock.patch.dict(os.environ, {"ATRINIK_WORKSPACE_DIR": str(workspace)}):
                 with self.assertRaisesRegex(WorkspaceError, "unmanaged non-empty"):
                     Paths.discover(root / "wrapper").ensure()
+
+    def test_atomic_json_rejects_symlinked_ancestor(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            external = root / "external"
+            (external / "records").mkdir(parents=True)
+            redirected = root / "redirected"
+            redirected.symlink_to(external, target_is_directory=True)
+
+            with self.assertRaises(OSError):
+                atomic_json(redirected / "records" / "value.json", {"safe": True})
+
+            self.assertFalse((external / "records" / "value.json").exists())
+
+    def test_durable_atomic_json_fsyncs_each_created_directory_parent(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            path = root / "first" / "second" / "value.json"
+            fsynced: set[tuple[int, int]] = set()
+            real_fsync = os.fsync
+
+            def observe(descriptor: int) -> None:
+                identity = os.fstat(descriptor)
+                if stat.S_ISDIR(identity.st_mode):
+                    fsynced.add((identity.st_dev, identity.st_ino))
+                real_fsync(descriptor)
+
+            with mock.patch("atrinik_workspace.model.os.fsync", side_effect=observe):
+                durable_atomic_json(path, {"safe": True})
+
+            self.assertIn(
+                (root.stat().st_dev, root.stat().st_ino),
+                fsynced,
+            )
+            self.assertIn(
+                ((root / "first").stat().st_dev, (root / "first").stat().st_ino),
+                fsynced,
+            )
+
+    def test_durable_atomic_json_accepts_safe_directory_creation_race(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            path = root / "records" / "value.json"
+            real_mkdir = os.mkdir
+            raced = False
+
+            def create_then_report_race(
+                name: str, mode: int = 0o777, *, dir_fd: int | None = None
+            ) -> None:
+                nonlocal raced
+                if name == "records" and not raced:
+                    raced = True
+                    real_mkdir(name, mode, dir_fd=dir_fd)
+                    raise FileExistsError(name)
+                real_mkdir(name, mode, dir_fd=dir_fd)
+
+            with mock.patch(
+                "atrinik_workspace.model.os.mkdir",
+                side_effect=create_then_report_race,
+            ):
+                durable_atomic_json(path, {"safe": True})
+
+            self.assertTrue(raced)
+            self.assertEqual(load_json(path), {"safe": True})
 
     def test_profile_key_is_unambiguous_for_paths_with_newlines(self) -> None:
         first = {"a": Path("/x\nb=/y"), "b": Path("/z")}

--- a/tests/test_port_reservation.py
+++ b/tests/test_port_reservation.py
@@ -44,6 +44,12 @@ class PortReservationTests(unittest.TestCase):
         self.topologies.mkdir()
         self.workspace = object.__new__(Workspace)
         self.workspace.paths = SimpleNamespace(topologies=self.topologies)
+        self.workspace._physical_lease_namespace = self.topologies
+        identity = self.topologies.stat()
+        self.workspace._physical_lease_namespace_identity = (
+            identity.st_dev,
+            identity.st_ino,
+        )
 
     @staticmethod
     def free_port() -> int:
@@ -158,9 +164,22 @@ class PortReservationTests(unittest.TestCase):
             open_directory(self.topologies)
 
         directory = self.topologies / PORT_RESERVATION_DIRECTORY
+        directory.mkdir(exist_ok=True)
         directory.chmod(0o755)
         with self.assertRaisesRegex(PortReservationError, "directory is invalid"):
             open_directory(self.topologies)
+
+    def test_directory_rejects_replaced_expected_root_identity(self) -> None:
+        identity = self.topologies.stat()
+        expected = (identity.st_dev, identity.st_ino)
+        detached = self.topologies.with_name("detached-topologies")
+        self.topologies.rename(detached)
+        self.topologies.mkdir()
+
+        with self.assertRaisesRegex(PortReservationError, "root was replaced"):
+            open_transaction(
+                self.topologies, 17300, root_identity=expected
+            )
 
     def test_lock_list_and_read_errors_fail_closed(self) -> None:
         with (

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import redirect_stderr
+from contextlib import ExitStack, redirect_stderr
 import ctypes
 import errno
 import fcntl
@@ -27,7 +27,12 @@ from unittest import mock
 
 from atrinik_workspace import workspace as workspace_module
 from atrinik_workspace import locking as locking_module
-from atrinik_workspace.locking import active_lock_fds
+from atrinik_workspace.locking import (
+    LeaseRequest,
+    active_lock_fds,
+    resource_lock_path,
+    resource_locks,
+)
 from atrinik_workspace.migration import rename_no_replace as real_rename_no_replace
 from atrinik_workspace.launch_identity import client_launch_label
 from atrinik_workspace.model import (
@@ -60,6 +65,20 @@ from atrinik_workspace.workspace import (
     replace_runtime_directory as workspace_replace_directory,
     run as workspace_run,
 )
+
+
+def synthetic_checkout_states(root: Path) -> dict[str, dict[str, object]]:
+    identity = root.stat()
+    return {
+        "client": {
+            "path": root,
+            "head": "a" * 40,
+            "dirty": False,
+            "device": identity.st_dev,
+            "inode": identity.st_ino,
+            "git_common": str(root / ".git"),
+        }
+    }
 
 
 def synthetic_build_process(
@@ -96,6 +115,11 @@ def synthetic_build_process(
                     workspace,
                     "_resolve_build_profile",
                     return_value={"client": Path(wrapper)},
+                ),
+                mock.patch.object(
+                    workspace,
+                    "_selected_checkout_states",
+                    return_value=synthetic_checkout_states(Path(wrapper)),
                 ),
                 mock.patch.object(
                     workspace, "_profile_build_key", return_value="a" * 12
@@ -231,6 +255,11 @@ def timed_public_build_process(
                     return_value={"client": Path(wrapper)},
                 ),
                 mock.patch.object(
+                    workspace,
+                    "_selected_checkout_states",
+                    return_value=synthetic_checkout_states(Path(wrapper)),
+                ),
+                mock.patch.object(
                     workspace, "_profile_build_key", return_value="a" * 12
                 ),
                 mock.patch.object(
@@ -295,6 +324,34 @@ def fair_layout_writer_process(
         raise
 
 
+def resource_lease_process(
+    workspace_directory: str,
+    kind: str,
+    coordinate: str,
+    mode: str,
+    name: str,
+    entered: object,
+    release: object | None,
+    results: object,
+) -> None:
+    try:
+        request = LeaseRequest(
+            kind,
+            coordinate,
+            mode,
+            name,
+            "wait for the exact test operation",
+        )
+        with resource_locks(Path(workspace_directory), [request]):
+            entered.put(name)
+            if release is not None and not release.wait(10):
+                raise TimeoutError(f"{name} was not released")
+        results.put(None)
+    except BaseException as error:
+        results.put(f"{type(error).__name__}: {error}")
+        raise
+
+
 def profile_mutation_process(
     wrapper: str,
     workspace_directory: str,
@@ -307,23 +364,8 @@ def profile_mutation_process(
             os.environ, {"ATRINIK_WORKSPACE_DIR": workspace_directory}
         ):
             workspace = Workspace(Path(wrapper))
-            pending_path = locking_module.layout_writer_pending_path(
-                workspace.paths.workspace / "repository-layout.lock"
-            ).resolve()
-            real_flock = locking_module.fcntl.flock
-
-            def observe_flock(lock: object, operation: int) -> None:
-                real_flock(lock, operation)
-                descriptor_path = Path(
-                    os.readlink(f"/proc/self/fd/{lock.fileno()}")
-                )
-                if operation & fcntl.LOCK_SH and descriptor_path == pending_path:
-                    pending_acquired.set()
-
-            with mock.patch.object(
-                locking_module.fcntl, "flock", side_effect=observe_flock
-            ):
-                workspace.set_profile("profile-b", "client", "primary")
+            pending_acquired.set()
+            workspace.set_profile("profile-b", "client", "primary")
             entered.set()
         results.put(None)
     except BaseException as error:
@@ -345,62 +387,33 @@ def public_lifecycle_reader_process(
             os.environ, {"ATRINIK_WORKSPACE_DIR": workspace_directory}
         ):
             workspace = Workspace(Path(wrapper))
-            pending_path = locking_module.layout_writer_pending_path(
-                workspace.paths.workspace / "repository-layout.lock"
-            ).resolve()
-            intent_path = locking_module.layout_writer_intent_path(
-                workspace.paths.workspace / "repository-layout.lock"
-            ).resolve()
-            real_flock = locking_module.fcntl.flock
-
-            def observe_flock(lock: object, operation: int) -> None:
-                descriptor = lock if isinstance(lock, int) else lock.fileno()
-                descriptor_path = Path(
-                    os.readlink(f"/proc/self/fd/{descriptor}")
-                )
-                if (
-                    operation & fcntl.LOCK_EX
-                    and not operation & fcntl.LOCK_NB
-                    and descriptor_path in {pending_path, intent_path}
+            blocked.set()
+            if operation == "build-c":
+                workspace.build("sound", "profile-c", False)
+            else:
+                with (
+                    mock.patch.object(workspace, "_require_client_display"),
+                    mock.patch.object(
+                        workspace,
+                        "_build_resolved",
+                        return_value=Path(build_root),
+                    ),
                 ):
-                    with descriptor_path.open("a+", encoding="utf-8") as probe:
-                        try:
-                            real_flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                        except BlockingIOError:
-                            blocked.set()
-                        else:
-                            real_flock(probe, fcntl.LOCK_UN)
-                real_flock(lock, operation)
-
-            with mock.patch.object(
-                locking_module.fcntl, "flock", side_effect=observe_flock
-            ):
-                if operation == "build-c":
-                    workspace.build("sound", "profile-c", False)
-                else:
-                    with (
-                        mock.patch.object(workspace, "_require_client_display"),
-                        mock.patch.object(
-                            workspace,
-                            "_build_resolved",
-                            return_value=Path(build_root),
-                        ),
-                    ):
-                        try:
-                            workspace.topology_up(
-                                "topology-c",
-                                "profile-c",
-                                "default",
-                                ["client"],
-                            )
-                        finally:
-                            status_path = (
-                                workspace.paths.topologies
-                                / "topology-c"
-                                / "status.json"
-                            )
-                            if status_path.is_file():
-                                workspace.topology_down("topology-c", timeout=5)
+                    try:
+                        workspace.topology_up(
+                            "topology-c",
+                            "profile-c",
+                            "default",
+                            ["client"],
+                        )
+                    finally:
+                        status_path = (
+                            workspace.paths.topologies
+                            / "topology-c"
+                            / "status.json"
+                        )
+                        if status_path.is_file():
+                            workspace.topology_down("topology-c", timeout=5)
             entered.set()
         results.put(None)
     except BaseException as error:
@@ -426,7 +439,9 @@ def synthetic_server_start_process(
             os.environ, {"ATRINIK_WORKSPACE_DIR": workspace_directory}
         ):
             workspace = Workspace(Path(wrapper))
-            ports_path = (workspace.paths.topologies / "ports.lock").resolve()
+            ports_path = (
+                workspace._lease_namespace / "ports" / f"{port}.lock"
+            ).resolve()
             state = Path(state_path)
             root = Path(build_root)
             real_flock = locking_module.fcntl.flock
@@ -493,7 +508,6 @@ def synthetic_server_start_process(
         reserved_port.close()
         results.put(f"{type(error).__name__}: {error}")
         raise
-
 
 def inherited_leases_wrapper_process(
     layout_path: str,
@@ -1031,20 +1045,15 @@ class WorkspaceTests(unittest.TestCase):
 
         self.assertTrue((self.workspace.paths.repositories / "client" / ".git").exists())
 
-    def test_initialize_workers_inherit_repository_layout_lease(self) -> None:
+    def test_initialize_workers_inherit_exact_checkout_leases(self) -> None:
         observed: list[tuple[int, ...]] = []
         observed_lock = threading.Lock()
-        layout = self.workspace.paths.workspace / "repository-layout.lock"
 
         def run_in_worker(*_arguments: object, **keywords: object) -> object:
             descriptors = keywords["pass_fds"]
-            with observed_lock:
-                observed.append(descriptors)
-            with self.assertRaisesRegex(WorkspaceError, "already in use"):
-                with exclusive_lock(
-                    layout, "repository layout", nonblocking=True
-                ):
-                    self.fail("initialize worker released its layout lease")
+            if _arguments and _arguments[0] == ["tool"] and descriptors:
+                with observed_lock:
+                    observed.append(descriptors)
             return mock.MagicMock(stdout="")
 
         def ensure(_checkout: object) -> None:
@@ -1062,8 +1071,185 @@ class WorkspaceTests(unittest.TestCase):
         ):
             self.workspace.initialize(["client", "server"], jobs=2)
 
-        self.assertEqual(len(observed), 2)
-        self.assertTrue(all(len(descriptors) == 3 for descriptors in observed))
+        workers = [descriptors for descriptors in observed if len(descriptors) > 1]
+        self.assertEqual(len(workers), 2)
+        self.assertTrue(
+            all(len(descriptors) == 11 for descriptors in workers), workers
+        )
+
+    def test_sync_distinct_checkouts_overlap(self) -> None:
+        barrier = threading.Barrier(2)
+        observed: set[str] = set()
+        observed_lock = threading.Lock()
+
+        def synchronize(checkouts: list[object], *_arguments: object) -> None:
+            with observed_lock:
+                observed.add(checkouts[0].name)
+            barrier.wait(timeout=5)
+
+        with mock.patch.object(
+            self.workspace, "_sync_components", side_effect=synchronize
+        ):
+            self.workspace.sync(["client", "server"], "none")
+        self.assertEqual(observed, {"client", "server"})
+
+    def test_same_checkout_sync_serializes(self) -> None:
+        entered = threading.Event()
+        release = threading.Event()
+        calls = 0
+        calls_lock = threading.Lock()
+
+        def synchronize(*_arguments: object) -> None:
+            nonlocal calls
+            with calls_lock:
+                calls += 1
+                current = calls
+            if current == 1:
+                entered.set()
+                self.assertTrue(release.wait(5))
+
+        other = Workspace(self.wrapper)
+        with (
+            mock.patch.object(
+                self.workspace, "_sync_components", side_effect=synchronize
+            ),
+            mock.patch.object(other, "_sync_components", side_effect=synchronize),
+            ThreadPoolExecutor(max_workers=2) as executor,
+        ):
+            first = executor.submit(self.workspace.sync, ["client"], "none")
+            self.assertTrue(entered.wait(2))
+            second = executor.submit(other.sync, ["client"], "none")
+            time.sleep(0.05)
+            self.assertEqual(calls, 1)
+            release.set()
+            first.result(timeout=5)
+            second.result(timeout=5)
+        self.assertEqual(calls, 2)
+
+    def test_sync_waiting_on_source_does_not_block_disjoint_worktree_create(
+        self,
+    ) -> None:
+        source_a = self.workspace.create_worktree(
+            "client", "source-a", "test/source-a", None, False
+        )
+        coordinate = self.workspace._source_coordinate("client", source_a)
+        pending = locking_module.layout_writer_pending_path(
+            resource_lock_path(
+                self.workspace._lease_namespace, "source", coordinate
+            )
+        )
+        reader = LeaseRequest(
+            "source",
+            coordinate,
+            "shared",
+            "build source A",
+            "wait for build A",
+        )
+        sync_workspace = Workspace(self.wrapper)
+        sync_entered = threading.Event()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            with mock.patch.object(
+                sync_workspace,
+                "_sync_components",
+                side_effect=lambda *_: sync_entered.set(),
+            ):
+                with resource_locks(
+                    self.workspace._lease_root, [reader]
+                ):
+                    syncing = executor.submit(
+                        sync_workspace.sync, ["client"], "merge"
+                    )
+                    deadline = time.monotonic() + 5
+                    while time.monotonic() < deadline:
+                        try:
+                            with exclusive_lock(
+                                pending,
+                                "source A writer pending",
+                                nonblocking=True,
+                            ):
+                                pass
+                        except WorkspaceError:
+                            break
+                        time.sleep(0.01)
+                    else:
+                        self.fail("sync did not queue for source A")
+
+                    created = executor.submit(
+                        self.workspace.create_worktree,
+                        "client",
+                        "source-b",
+                        "test/source-b",
+                        None,
+                        False,
+                    ).result(timeout=5)
+                    self.assertTrue(created.is_dir())
+                    self.assertFalse(sync_entered.is_set())
+
+                syncing.result(timeout=5)
+                self.assertTrue(sync_entered.is_set())
+
+    def test_remove_waiting_on_source_does_not_block_disjoint_worktree_create(
+        self,
+    ) -> None:
+        source_a = self.workspace.create_worktree(
+            "client", "remove-a", "test/remove-a", None, False
+        )
+        request = self.workspace._lease_request(
+            "source",
+            self.workspace._source_coordinate("client", source_a),
+            "shared",
+            "run source A",
+        )
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            with resource_locks(self.workspace._lease_root, [request]):
+                removing = executor.submit(
+                    self.workspace.remove_worktree, "client", "remove-a"
+                )
+                time.sleep(0.05)
+                self.assertFalse(removing.done())
+                created = executor.submit(
+                    self.workspace.create_worktree,
+                    "client",
+                    "remove-b",
+                    "test/remove-b",
+                    None,
+                    False,
+                ).result(timeout=5)
+                self.assertTrue(created.is_dir())
+            removing.result(timeout=5)
+        self.assertFalse(source_a.exists())
+
+    def test_worktree_creation_waits_for_missing_primary_source_reader(self) -> None:
+        primary = self.workspace.paths.repositories / "client"
+        shutil.rmtree(primary)
+        request = self.workspace._lease_request(
+            "source",
+            self.workspace._source_coordinate("client", primary),
+            "shared",
+            "inspect missing primary",
+        )
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            with mock.patch.object(
+                self.workspace,
+                "_component_clone_url",
+                return_value=str(self.origins["client"]),
+            ):
+                with resource_locks(self.workspace._lease_root, [request]):
+                    creating = executor.submit(
+                        self.workspace.create_worktree,
+                        "client",
+                        "initialized",
+                        "test/initialized",
+                        None,
+                        False,
+                    )
+                    time.sleep(0.05)
+                    self.assertFalse(creating.done())
+                    self.assertFalse(primary.exists())
+                created = creating.result(timeout=10)
+        self.assertTrue(primary.is_dir())
+        self.assertTrue(created.is_dir())
 
     def test_failed_clone_does_not_strand_destination(self) -> None:
         destination = self.workspace.paths.repositories / "client"
@@ -1282,6 +1468,118 @@ class WorkspaceTests(unittest.TestCase):
             self.workspace.remove_worktree("content", "map-review")
         self.assertTrue((path / "untracked").is_file())
 
+    def test_remove_worktree_rejects_symlinked_managed_parent(self) -> None:
+        external = self.root / "external-worktrees"
+        external.mkdir()
+        worktrees = self.workspace.paths.worktrees
+        shutil.rmtree(worktrees)
+        worktrees.symlink_to(external, target_is_directory=True)
+
+        with self.assertRaisesRegex(WorkspaceError, "cannot open managed worktree"):
+            self.workspace.remove_worktree("content", "redirected")
+
+    def test_create_worktree_rejects_symlinked_managed_parent(self) -> None:
+        external = self.root / "external-worktrees"
+        external.mkdir()
+        parent = self.workspace.paths.worktrees / "content"
+        parent.symlink_to(external, target_is_directory=True)
+
+        with self.assertRaisesRegex(WorkspaceError, "cannot open managed worktree"):
+            self.workspace.create_worktree(
+                "content", "redirected", "feat/redirected", None, False
+            )
+
+        self.assertEqual(list(external.iterdir()), [])
+
+    def test_create_worktree_rolls_back_after_visibility_race(self) -> None:
+        repository = self.workspace.paths.repositories / "content"
+        destination = self.workspace.paths.worktrees / "content" / "rolled-back"
+
+        with (
+            mock.patch.object(
+                self.workspace,
+                "_require_visible_worktree_identity",
+                side_effect=WorkspaceError("simulated parent replacement"),
+            ),
+            self.assertRaisesRegex(WorkspaceError, "parent replacement"),
+        ):
+            self.workspace.create_worktree(
+                "content", "rolled-back", "feat/rolled-back", None, False
+            )
+
+        records = command(
+            "git", "worktree", "list", "--porcelain", cwd=repository
+        )
+        self.assertNotIn(str(destination), records)
+        branch = subprocess.run(
+            ["git", "show-ref", "--verify", "--quiet", "refs/heads/feat/rolled-back"],
+            cwd=repository,
+            check=False,
+        )
+        self.assertNotEqual(branch.returncode, 0)
+        self.assertFalse(destination.exists())
+
+    def test_descriptor_path_uses_dev_fd_off_linux(self) -> None:
+        descriptor = os.open(self.workspace.paths.worktrees, os.O_RDONLY)
+        try:
+            with mock.patch.object(workspace_module.sys, "platform", "darwin"):
+                path = workspace_module._descriptor_path(descriptor)
+            self.assertEqual(path, Path("/dev/fd") / str(descriptor))
+            self.assertTrue(path.samefile(self.workspace.paths.worktrees))
+        finally:
+            os.close(descriptor)
+
+    def test_open_managed_worktree_pins_target_across_parent_replacement(self) -> None:
+        path = self.workspace.create_worktree(
+            "content", "pinned", "feat/pinned", None, False
+        )
+        parent = path.parent
+        detached = parent.with_name("detached-content-worktrees")
+        external = self.root / "external-worktrees"
+        external.mkdir()
+        (external / "pinned").mkdir()
+
+        with self.workspace._open_managed_worktree(path) as (stable, physical):
+            self.assertEqual(physical, path.resolve())
+            parent.rename(detached)
+            parent.symlink_to(external, target_is_directory=True)
+            try:
+                self.assertTrue(stable.samefile(detached / "pinned"))
+                self.assertFalse(stable.samefile(external / "pinned"))
+            finally:
+                parent.unlink()
+                detached.rename(parent)
+
+    def test_remove_worktree_refuses_parent_replacement_before_git(self) -> None:
+        path = self.workspace.create_worktree(
+            "content", "replace-race", "feat/replace-race", None, False
+        )
+        parent = path.parent
+        detached = parent.with_name("detached-content-worktrees")
+        external = self.root / "external-worktrees"
+        external.mkdir()
+        (external / "replace-race").mkdir()
+
+        def replace_parent(_path: Path) -> bool:
+            parent.rename(detached)
+            parent.symlink_to(external, target_is_directory=True)
+            return True
+
+        try:
+            with (
+                mock.patch(
+                    "atrinik_workspace.workspace._is_clean",
+                    side_effect=replace_parent,
+                ),
+                self.assertRaisesRegex(WorkspaceError, "path was replaced"),
+            ):
+                self.workspace.remove_worktree("content", "replace-race")
+            self.assertTrue((detached / "replace-race").is_dir())
+            self.assertTrue((external / "replace-race").is_dir())
+        finally:
+            parent.unlink(missing_ok=True)
+            detached.rename(parent)
+
     def test_profile_can_clone_an_existing_selection(self) -> None:
         path = self.workspace.create_worktree(
             "content", "map-review", "feat/map-review", None, False
@@ -1298,6 +1596,235 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual(
             self.workspace.component_path("content", "review"), path.resolve()
         )
+
+    def test_profile_resolution_snapshot_is_old_or_new_never_mixed(self) -> None:
+        path = self.workspace.create_worktree(
+            "client", "snapshot-review", "feat/snapshot-review", None, False
+        )
+        self.workspace.create_profile("snapshot")
+        updated = threading.Event()
+
+        def update_profile() -> None:
+            self.workspace.set_profile(
+                "snapshot", "client", "worktree", "snapshot-review"
+            )
+            updated.set()
+
+        with self.workspace._resolved_profile_operation(
+            "snapshot", {"client"}, "snapshot test"
+        ) as snapshot:
+            updater = threading.Thread(target=update_profile)
+            updater.start()
+            time.sleep(0.05)
+            self.assertFalse(updated.is_set())
+            self.assertNotIn(path.resolve(), snapshot.paths().values())
+            self.assertEqual(
+                self.workspace._load_profile("snapshot", require_file=False),
+                snapshot.profile(),
+            )
+        updater.join(2)
+        self.assertFalse(updater.is_alive())
+        self.assertTrue(updated.is_set())
+        self.assertEqual(
+            self.workspace.component_path("client", "snapshot"), path.resolve()
+        )
+
+    def test_profile_resolution_waits_before_inspecting_locked_source(self) -> None:
+        source = self.workspace.paths.repositories / "client"
+        displaced = self.root / "client-displaced"
+        request = self.workspace._lease_request(
+            "source",
+            self.workspace._source_coordinate("client", source),
+            "exclusive",
+            "replace client source",
+        )
+
+        def resolve() -> object:
+            with self.workspace._resolved_profile_operation(
+                "default", {"client"}, "build default"
+            ) as snapshot:
+                return snapshot
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            with resource_locks(self.workspace._lease_root, [request]):
+                source.rename(displaced)
+                resolution = executor.submit(resolve)
+                time.sleep(0.05)
+                self.assertFalse(resolution.done())
+                displaced.rename(source)
+            snapshot = resolution.result(timeout=5)
+            self.assertEqual(snapshot.paths()["client"], source.resolve())
+
+    def test_clean_referenced_worktree_cannot_be_removed(self) -> None:
+        path = self.workspace.create_worktree(
+            "content", "referenced", "feat/referenced", None, False
+        )
+        self.workspace.create_profile("referenced")
+        self.workspace.set_profile(
+            "referenced", "content", "worktree", "referenced"
+        )
+        with self.assertRaisesRegex(WorkspaceError, "profile:referenced"):
+            self.workspace.remove_worktree("content", "referenced")
+        self.assertTrue(path.is_dir())
+
+    def test_profile_publication_cannot_enter_target_removal_window(self) -> None:
+        path = self.workspace.create_worktree(
+            "content", "publication-race", "feat/publication-race", None, False
+        )
+        self.workspace.create_profile("publication-race")
+        replacement = path.with_name("publication-race.removed")
+        published = threading.Event()
+        errors: list[BaseException] = []
+
+        def publish_reference() -> None:
+            try:
+                self.workspace.set_profile(
+                    "publication-race",
+                    "content",
+                    "worktree",
+                    "publication-race",
+                )
+            except BaseException as error:
+                errors.append(error)
+            finally:
+                published.set()
+
+        request = LeaseRequest(
+            "source",
+            self.workspace._source_coordinate("content", path),
+            "exclusive",
+            "cleanup publication-race candidate",
+            "wait for candidate cleanup to finish and retry",
+        )
+        try:
+            with resource_locks(self.workspace._lease_root, [request]):
+                publisher = threading.Thread(target=publish_reference)
+                publisher.start()
+                time.sleep(0.05)
+                self.assertFalse(published.is_set())
+                path.rename(replacement)
+            publisher.join(2)
+            self.assertFalse(publisher.is_alive())
+            self.assertTrue(published.is_set())
+            self.assertEqual(len(errors), 1)
+            self.assertIsInstance(errors[0], WorkspaceError)
+            self.assertEqual(
+                self.workspace._load_profile_file(
+                    "publication-race", require_file=True
+                )["components"]["content"],
+                {"kind": "primary", "value": ""},
+            )
+        finally:
+            if replacement.exists() and not path.exists():
+                replacement.rename(path)
+
+    def test_path_profile_alias_uses_canonical_source_lease(self) -> None:
+        path = self.workspace.create_worktree(
+            "content", "path-alias", "feat/path-alias", None, False
+        )
+        self.workspace.create_profile("path-alias")
+        alias_parent = self.root / "worktree-alias"
+        alias_parent.symlink_to(path.parent, target_is_directory=True)
+        alias = alias_parent / path.name
+        request = self.workspace._lease_request(
+            "source",
+            self.workspace._source_coordinate("content", path),
+            "exclusive",
+            "remove canonical source",
+        )
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            with resource_locks(self.workspace._lease_root, [request]):
+                publishing = executor.submit(
+                    self.workspace.set_profile,
+                    "path-alias",
+                    "content",
+                    "path",
+                    str(alias),
+                )
+                time.sleep(0.05)
+                self.assertFalse(publishing.done())
+            publishing.result(timeout=5)
+        self.assertEqual(
+            self.workspace._load_profile_file("path-alias", True)["components"][
+                "content"
+            ]["value"],
+            str(path.resolve()),
+        )
+
+    def test_loaded_path_profile_alias_uses_canonical_source_lease(self) -> None:
+        path = self.workspace.create_worktree(
+            "content", "loaded-alias", "feat/loaded-alias", None, False
+        )
+        alias_parent = self.root / "loaded-worktree-alias"
+        alias_parent.symlink_to(path.parent, target_is_directory=True)
+        profile = self.workspace._load_profile_file("default", False)
+        profile["name"] = "loaded-alias"
+        profile["components"]["content"] = {
+            "kind": "path",
+            "value": str(alias_parent / path.name),
+        }
+        atomic_json(self.workspace.paths.profiles / "loaded-alias.json", profile)
+        request = self.workspace._lease_request(
+            "source",
+            self.workspace._source_coordinate("content", path),
+            "exclusive",
+            "remove canonical source",
+        )
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            with resource_locks(self.workspace._lease_root, [request]):
+                resolving = executor.submit(
+                    lambda: self._resolved_path("loaded-alias", "content")
+                )
+                time.sleep(0.05)
+                self.assertFalse(resolving.done())
+            self.assertEqual(resolving.result(timeout=5), path.resolve())
+
+    def test_resolved_profile_uses_confirmed_profile_without_rereading(self) -> None:
+        load_profile = self.workspace._load_profile_file
+        calls = 0
+
+        def load_once_confirmed(name: str, require_file: bool) -> dict[str, object]:
+            nonlocal calls
+            calls += 1
+            if calls > 2:
+                raise AssertionError("profile reread after exact source leases")
+            return load_profile(name, require_file)
+
+        with mock.patch.object(
+            self.workspace, "_load_profile_file", side_effect=load_once_confirmed
+        ):
+            self.assertEqual(
+                self._resolved_path("default", "content"),
+                (self.workspace.paths.repositories / "content").resolve(),
+            )
+        self.assertEqual(calls, 2)
+
+    def test_create_profile_copies_confirmed_profile_without_rereading(self) -> None:
+        load_profile = self.workspace._load_profile_file
+        calls = 0
+
+        def load_once_confirmed(name: str, require_file: bool) -> dict[str, object]:
+            nonlocal calls
+            calls += 1
+            if calls > 2:
+                raise AssertionError("source profile reread after exact source leases")
+            return load_profile(name, require_file)
+
+        with mock.patch.object(
+            self.workspace, "_load_profile_file", side_effect=load_once_confirmed
+        ):
+            self.workspace.create_profile("confirmed-copy")
+        self.assertEqual(calls, 2)
+        self.assertEqual(
+            self.workspace._load_profile_file("confirmed-copy", True)["stack"],
+            "default",
+        )
+
+    def _resolved_path(self, profile: str, role: str) -> Path:
+        with self.workspace._resolved_profile_operation(
+            profile, {role}, f"resolve {profile}"
+        ) as snapshot:
+            return snapshot.paths()[role]
 
     def test_component_path_only_requires_selected_component(self) -> None:
         for name, _ in COMPONENTS:
@@ -5755,7 +6282,6 @@ class WorkspaceTests(unittest.TestCase):
                 "head": commit,
             },
         }
-
         for stack_name, expected_target in (("default", False), ("classic", True)):
             with self.subTest(stack=stack_name):
                 root = workspace.paths.builds / "profiles" / f"target-{stack_name}"
@@ -6266,7 +6792,7 @@ class WorkspaceTests(unittest.TestCase):
             writer.start()
             started.append(writer)
             wait_for_process_event(
-                writer_pending, "profile B mutation queue", results
+                writer_pending, "profile B mutation attempt", results
             )
             wait_for_process_event(
                 writer_entered, "profile B mutation entry", results
@@ -6277,7 +6803,7 @@ class WorkspaceTests(unittest.TestCase):
                 started.append(reader)
             for index, entered in enumerate(readers_entered):
                 wait_for_process_event(
-                    entered, f"C reader {index} completion", results
+                    entered, f"disjoint C reader {index} completion", results, 10
                 )
             self.assertTrue(self.workspace.topology_status("topology-a")["ready"])
 
@@ -6300,7 +6826,7 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual([process.exitcode for process in processes], [0] * 3)
         self.assertEqual([results.get(timeout=2) for _ in processes], [None] * 3)
 
-    def test_p0_harness_reproduces_current_server_startup_port_convoy(
+    def test_distinct_server_ports_reach_pre_ready_concurrently(
         self,
     ) -> None:
         context = multiprocessing.get_context("spawn")
@@ -6431,6 +6957,359 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual([process.exitcode for process in processes], [0, 0])
         self.assertEqual([results.get(timeout=2) for _ in processes], [None, None])
 
+    def test_profile_reference_registry_rejects_symlink(self) -> None:
+        target = self.root / "redirected-references"
+        target.mkdir()
+        registry = self.workspace._lease_namespace / "profile-references"
+        shutil.rmtree(registry)
+        registry.symlink_to(target, target_is_directory=True)
+
+        with self.assertRaisesRegex(
+            WorkspaceError, "cannot publish physical reference"
+        ):
+            self.workspace.create_profile("unsafe-registry")
+
+        self.assertEqual(list(target.iterdir()), [])
+
+    def test_physical_lease_namespace_replacement_fails_closed(self) -> None:
+        namespace = self.workspace._lease_namespace
+        detached = namespace.with_name("detached-atrinik-resource-leases")
+        namespace.rename(detached)
+        namespace.mkdir(mode=0o700)
+        try:
+            with self.assertRaisesRegex(
+                WorkspaceError, "physical lease namespace identity changed"
+            ):
+                self.workspace.create_profile("split-brain")
+        finally:
+            shutil.rmtree(namespace)
+            detached.rename(namespace)
+
+    def test_physical_reference_rollback_rejects_namespace_replacement(self) -> None:
+        profile = self.workspace.create_profile("rollback-namespace")
+        namespace = self.workspace._lease_namespace
+        detached = namespace.with_name("detached-rollback-namespace")
+        real_open = os.open
+        replaced = False
+
+        def replace_before_open(path: object, *args: object, **kwargs: object) -> int:
+            nonlocal replaced
+            if Path(path) == namespace and not replaced:
+                replaced = True
+                namespace.rename(detached)
+                namespace.mkdir(mode=0o700)
+            return real_open(path, *args, **kwargs)
+
+        try:
+            with (
+                mock.patch(
+                    "atrinik_workspace.workspace.os.open",
+                    side_effect=replace_before_open,
+                ),
+                self.assertRaisesRegex(
+                    WorkspaceError, "physical lease namespace identity changed"
+                ),
+            ):
+                self.workspace._remove_physical_reference(profile)
+        finally:
+            shutil.rmtree(namespace)
+            detached.rename(namespace)
+
+    def test_profile_reference_publication_rejects_registry_replacement(self) -> None:
+        registry = self.workspace._lease_namespace / "profile-references"
+        detached = registry.with_name("detached-profile-references")
+        real_rename = os.rename
+
+        def replace_after_publish(*arguments: object, **keywords: object) -> None:
+            real_rename(*arguments, **keywords)
+            real_rename(registry, detached)
+            registry.mkdir(mode=0o700)
+
+        with (
+            mock.patch("atrinik_workspace.workspace.os.rename", side_effect=replace_after_publish),
+            self.assertRaisesRegex(WorkspaceError, "registry was replaced"),
+        ):
+            self.workspace.create_profile("replaced-registry")
+
+        self.assertFalse(
+            (self.workspace.paths.profiles / "replaced-registry.json").exists()
+        )
+
+    def test_first_physical_reference_persists_registry_before_record(self) -> None:
+        namespace = self.workspace._lease_namespace
+        registry = namespace / "profile-references"
+        shutil.rmtree(registry)
+        namespace_identity = namespace.stat()
+        namespace_key = (namespace_identity.st_dev, namespace_identity.st_ino)
+        fsynced: list[tuple[int, int]] = []
+        real_fsync = os.fsync
+
+        def observe(descriptor: int) -> None:
+            metadata = os.fstat(descriptor)
+            if stat.S_ISDIR(metadata.st_mode):
+                fsynced.append((metadata.st_dev, metadata.st_ino))
+            real_fsync(descriptor)
+
+        with mock.patch(
+            "atrinik_workspace.workspace.os.fsync", side_effect=observe
+        ):
+            self.workspace.create_profile("durable-registry")
+
+        registry_identity = registry.stat()
+        registry_key = (registry_identity.st_dev, registry_identity.st_ino)
+        self.assertIn(namespace_key, fsynced)
+        self.assertIn(registry_key, fsynced)
+        self.assertLess(fsynced.index(namespace_key), fsynced.index(registry_key))
+
+    def test_physical_reference_retry_repersists_existing_registry(self) -> None:
+        namespace = self.workspace._lease_namespace
+        registry = namespace / "profile-references"
+        shutil.rmtree(registry)
+        namespace_identity = namespace.stat()
+        namespace_key = (namespace_identity.st_dev, namespace_identity.st_ino)
+        real_fsync = os.fsync
+        namespace_fsyncs = 0
+
+        def fail_first_namespace_fsync(descriptor: int) -> None:
+            nonlocal namespace_fsyncs
+            metadata = os.fstat(descriptor)
+            if (metadata.st_dev, metadata.st_ino) == namespace_key:
+                namespace_fsyncs += 1
+                if namespace_fsyncs == 1:
+                    raise OSError("simulated namespace fsync failure")
+            real_fsync(descriptor)
+
+        with mock.patch(
+            "atrinik_workspace.workspace.os.fsync",
+            side_effect=fail_first_namespace_fsync,
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "cannot publish"):
+                self.workspace.create_profile("retry-registry")
+            self.workspace.create_profile("retry-registry")
+
+        self.assertGreaterEqual(namespace_fsyncs, 2)
+        self.assertTrue(
+            (self.workspace.paths.profiles / "retry-registry.json").is_file()
+        )
+
+    def test_profile_creation_failure_removes_prepublished_reference(self) -> None:
+        path = self.workspace.paths.profiles / "failed-create.json"
+        identity = hashlib.sha256(str(path.resolve()).encode()).hexdigest()
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.durable_atomic_json",
+                side_effect=WorkspaceError("simulated profile write failure"),
+            ),
+            self.assertRaisesRegex(WorkspaceError, "simulated"),
+        ):
+            self.workspace.create_profile("failed-create")
+        self.assertFalse(path.exists())
+        self.assertFalse(
+            (
+                self.workspace._lease_namespace
+                / "profile-references"
+                / f"{identity}.json"
+            ).exists()
+        )
+
+    def test_profile_creation_keeps_reference_when_directory_fsync_is_uncertain(self) -> None:
+        path = self.workspace.paths.profiles / "uncertain-create.json"
+        identity = hashlib.sha256(str(path.resolve()).encode()).hexdigest()
+        def uncertain_write(target: Path, value: object) -> None:
+            atomic_json(target, value)
+            raise workspace_module.AtomicJsonCommitUncertain(
+                "simulated durability is uncertain"
+            )
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.durable_atomic_json",
+                side_effect=uncertain_write,
+            ),
+            self.assertRaisesRegex(WorkspaceError, "durability is uncertain"),
+        ):
+            self.workspace.create_profile("uncertain-create")
+
+        self.assertTrue(path.is_file())
+        self.assertTrue(
+            (
+                self.workspace._lease_namespace
+                / "profile-references"
+                / f"{identity}.json"
+            ).is_file()
+        )
+
+    def test_backfill_retries_without_publishing_when_source_is_busy(self) -> None:
+        source = self.workspace.create_worktree(
+            "content", "backfill-busy", "feat/backfill-busy", None, False
+        )
+        profile = self.workspace.create_profile("backfill-busy")
+        self.workspace.set_profile("backfill-busy", "content", "path", str(source))
+        registry = self.workspace._lease_namespace / "profile-references"
+        profile_identity = hashlib.sha256(str(profile.resolve()).encode()).hexdigest()
+        state_identity = hashlib.sha256(
+            str(self.workspace.paths.workspace.resolve()).encode()
+        ).hexdigest()
+        (registry / f"{profile_identity}.json").unlink()
+        (registry / f"{state_identity}.json").unlink()
+        source_request = self.workspace._lease_request(
+            "source",
+            self.workspace._source_coordinate("content", source),
+            "exclusive",
+            "remove selected source",
+        )
+        with resource_locks(self.workspace._lease_root, [source_request]):
+            with self.assertRaisesRegex(WorkspaceError, "backfill is busy"):
+                self.workspace._backfill_physical_references()
+        self.assertFalse((registry / f"{profile_identity}.json").exists())
+        self.assertFalse((registry / f"{state_identity}.json").exists())
+
+        self.workspace._backfill_physical_references()
+        self.assertTrue((registry / f"{profile_identity}.json").is_file())
+        self.assertTrue((registry / f"{state_identity}.json").is_file())
+
+    def test_backfill_rejects_inexact_marker_schema(self) -> None:
+        state_identity = hashlib.sha256(
+            str(self.workspace.paths.workspace.resolve()).encode()
+        ).hexdigest()
+        marker = (
+            self.workspace._lease_namespace
+            / "profile-references"
+            / f"{state_identity}.json"
+        )
+        atomic_json(
+            marker,
+            {
+                "kind": "profiles",
+                "reference": f"__backfill__:{state_identity}",
+                "sources": [],
+                "unexpected": True,
+            },
+        )
+
+        with self.assertRaisesRegex(WorkspaceError, "backfill marker is invalid"):
+            self.workspace._backfill_physical_references()
+
+    def test_profile_json_rejects_duplicate_keys_without_following_links(self) -> None:
+        path = self.workspace.paths.profiles / "duplicate.json"
+        path.write_text(
+            '{"schema_version":4,"name":"duplicate","name":"other"}\n',
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(WorkspaceError, "duplicate JSON key"):
+            self.workspace._load_profile_file("duplicate", require_file=True)
+
+    def test_migration_reference_publisher_accepts_legacy_profile_shapes(self) -> None:
+        content_source = self.workspace.paths.worktrees / "content-1x" / "maps"
+        content_source.mkdir(parents=True)
+        current = self.workspace._load_profile("classic", require_file=False)
+        legacy_content = copy.deepcopy(current)
+        legacy_content["name"] = "legacy-content"
+        legacy_content["components"]["content-1x"] = {
+            "kind": "worktree",
+            "value": "maps",
+        }
+        legacy_content["components"].pop("content", None)
+        content_path = self.workspace.paths.profiles / "legacy-content.json"
+        atomic_json(content_path, legacy_content)
+
+        old_source = self.workspace.paths.worktrees / "client" / "review"
+        old_source.mkdir(parents=True)
+        legacy_repository = {
+            "schema_version": 1,
+            "name": "legacy-repository",
+            "components": {
+                "client": {"kind": "worktree", "value": "review"}
+            },
+        }
+        repository_path = self.workspace.paths.profiles / "legacy-repository.json"
+        atomic_json(repository_path, legacy_repository)
+
+        self.workspace._publish_migration_profile_references(
+            {
+                "legacy-content": (
+                    json.dumps(legacy_content).encode(),
+                    json.dumps(current | {"name": "legacy-content"}).encode(),
+                ),
+                "legacy-repository": (
+                    json.dumps(legacy_repository).encode(),
+                    json.dumps(legacy_repository).encode(),
+                ),
+            }
+        )
+
+        records = {
+            record["reference"]: record
+            for record in self.workspace._physical_reference_records()
+        }
+        self.assertIn(str(content_source.resolve()), records["legacy-content"]["sources"])
+        self.assertIn(str(old_source.resolve()), records["legacy-repository"]["sources"])
+
+    def test_profile_write_failure_retains_old_physical_reference(self) -> None:
+        path = self.workspace.create_worktree(
+            "content", "old-reference", "feat/old-reference", None, False
+        )
+        self.workspace.create_profile("write-failure")
+        self.workspace.set_profile(
+            "write-failure", "content", "path", str(path)
+        )
+        with mock.patch(
+            "atrinik_workspace.workspace.durable_atomic_json",
+            side_effect=WorkspaceError("simulated profile write failure"),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "simulated"):
+                self.workspace.set_profile(
+                    "write-failure", "content", "primary", ""
+                )
+        identity = hashlib.sha256(
+            str(
+                (self.workspace.paths.profiles / "write-failure.json").resolve()
+            ).encode()
+        ).hexdigest()
+        record = load_json(
+            self.workspace._lease_namespace
+            / "profile-references"
+            / f"{identity}.json"
+        )
+        self.assertIn(str(path.resolve()), record["sources"])
+
+    def test_profile_fsync_uncertainty_retains_conservative_references(self) -> None:
+        path = self.workspace.create_worktree(
+            "content", "uncertain-reference", "feat/uncertain-reference", None, False
+        )
+        self.workspace.create_profile("uncertain-update")
+        self.workspace.set_profile(
+            "uncertain-update", "content", "path", str(path)
+        )
+        profile_path = self.workspace.paths.profiles / "uncertain-update.json"
+        real_publish = workspace_module.durable_atomic_json
+
+        def uncertain_write(target: Path, value: object) -> None:
+            real_publish(target, value)
+            if target == profile_path:
+                raise workspace_module.AtomicJsonCommitUncertain(
+                    "simulated profile durability uncertainty"
+                )
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.durable_atomic_json",
+                side_effect=uncertain_write,
+            ),
+            self.assertRaisesRegex(WorkspaceError, "durability uncertainty"),
+        ):
+            self.workspace.set_profile(
+                "uncertain-update", "content", "primary", ""
+            )
+
+        identity = hashlib.sha256(str(profile_path.resolve()).encode()).hexdigest()
+        record = load_json(
+            self.workspace._lease_namespace
+            / "profile-references"
+            / f"{identity}.json"
+        )
+        self.assertIn(str(path.resolve()), record["sources"])
+
     def test_layout_lock_reports_one_actionable_prolonged_wait(self) -> None:
         layout = self.workspace.paths.workspace / "repository-layout.lock"
         intent = workspace_module._layout_writer_intent_path(layout)
@@ -6463,6 +7342,248 @@ class WorkspaceTests(unittest.TestCase):
         self.assertIn("./atrinik ps --json", diagnostic)
         self.assertIn("./atrinik worktree list --json", diagnostic)
         self.assertIn("do not bypass the wrapper", diagnostic)
+
+    def test_resource_wait_names_coordinate_owner_and_recovery(self) -> None:
+        coordinate = "client:/worktrees/review"
+        holder = LeaseRequest(
+            "source",
+            coordinate,
+            "exclusive",
+            "advance review worktree",
+            "wait for the exact advance to finish",
+        )
+        waiter_entered = threading.Event()
+
+        def wait_for_source() -> None:
+            request = LeaseRequest(
+                "source",
+                coordinate,
+                "shared",
+                "build review",
+                "inspect `./atrinik worktree list --json` and retry",
+            )
+            with resource_locks(self.workspace.paths.workspace, [request]):
+                waiter_entered.set()
+
+        output = io.StringIO()
+        with (
+            mock.patch.object(locking_module, "LOCK_WAIT_DIAGNOSTIC_SECONDS", 0.05),
+            redirect_stderr(output),
+            resource_locks(self.workspace.paths.workspace, [holder]),
+        ):
+            waiter = threading.Thread(target=wait_for_source)
+            waiter.start()
+            time.sleep(0.08)
+            self.assertFalse(waiter_entered.is_set())
+        waiter.join(2)
+        self.assertFalse(waiter.is_alive())
+        diagnostic = output.getvalue()
+        self.assertIn("resource source coordinate", diagnostic)
+        self.assertIn(coordinate, diagnostic)
+        self.assertIn("advance review worktree", diagnostic)
+        self.assertIn("worktree list --json", diagnostic)
+        self.assertNotIn(f"pid={os.getpid()}", diagnostic)
+
+    def test_resource_lease_rejects_symlinked_namespace(self) -> None:
+        external = self.root / "external-leases"
+        external.mkdir()
+        leases = self.workspace.paths.workspace / "leases"
+        leases.symlink_to(external, target_is_directory=True)
+        request = LeaseRequest(
+            "source",
+            "client:/worktrees/review",
+            "shared",
+            "inspect review",
+            "remove the unsafe lease namespace",
+        )
+
+        with self.assertRaisesRegex(
+            WorkspaceError, "directory is unsafe|cannot open.*directory"
+        ):
+            with resource_locks(self.workspace.paths.workspace, [request]):
+                self.fail("symlinked lease namespace unexpectedly acquired")
+
+        self.assertEqual(list(external.iterdir()), [])
+
+    def test_resource_lease_rejects_symlinked_kind_and_owner_directories(
+        self,
+    ) -> None:
+        request = LeaseRequest(
+            "source",
+            "client:/worktrees/review",
+            "shared",
+            "inspect review",
+            "remove the unsafe lease namespace",
+        )
+        for level in ("kind", "owners"):
+            with self.subTest(level=level):
+                root = self.root / f"lease-{level}"
+                kind = root / "leases" / "source"
+                kind.parent.mkdir(parents=True)
+                external = self.root / f"external-{level}"
+                external.mkdir()
+                if level == "kind":
+                    kind.symlink_to(external, target_is_directory=True)
+                else:
+                    kind.mkdir()
+                    lock = resource_lock_path(
+                        root, request.kind, request.coordinate
+                    )
+                    lock.with_name(f"{lock.name}.owners").symlink_to(
+                        external, target_is_directory=True
+                    )
+
+                with self.assertRaisesRegex(
+                    WorkspaceError, "directory is unsafe|cannot open.*directory"
+                ):
+                    with resource_locks(root, [request]):
+                        self.fail("symlinked lease directory unexpectedly acquired")
+                self.assertEqual(list(external.iterdir()), [])
+
+    def test_resource_owner_metadata_is_reclaimed_after_normal_release(self) -> None:
+        request = LeaseRequest(
+            "source",
+            "client:/worktrees/review",
+            "shared",
+            "inspect review",
+            "wait for review",
+        )
+        for _ in range(20):
+            with resource_locks(self.workspace.paths.workspace, [request]):
+                pass
+
+        lock = resource_lock_path(
+            self.workspace.paths.workspace, request.kind, request.coordinate
+        )
+        owners = lock.with_name(f"{lock.name}.owners")
+        self.assertEqual(list(owners.iterdir()), [])
+
+    def test_resource_owner_metadata_survives_inherited_child(self) -> None:
+        request = LeaseRequest(
+            "source",
+            "client:/worktrees/review",
+            "shared",
+            "inspect review",
+            "wait for review",
+        )
+        lock = resource_lock_path(
+            self.workspace.paths.workspace, request.kind, request.coordinate
+        )
+        child: subprocess.Popen[bytes]
+        with resource_locks(self.workspace.paths.workspace, [request]):
+            child = subprocess.Popen(
+                [sys.executable, "-c", "import time; time.sleep(30)"],
+                pass_fds=active_lock_fds(),
+            )
+        owners = lock.with_name(f"{lock.name}.owners")
+        self.assertEqual(len(list(owners.iterdir())), 1)
+        child.terminate()
+        child.wait(timeout=5)
+        locking_module._lease_owner_summary(lock)
+        self.assertEqual(list(owners.iterdir()), [])
+
+    def test_relocated_workspace_roots_share_physical_lease_namespace(self) -> None:
+        alternate_root = self.root / "alternate-workspace"
+        with mock.patch.dict(
+            os.environ, {"ATRINIK_WORKSPACE_DIR": str(alternate_root)}
+        ):
+            alternate = Workspace(self.wrapper)
+            alternate.paths.ensure()
+
+        self.assertEqual(
+            self.workspace._lease_namespace, alternate._lease_namespace
+        )
+        primary = self.workspace.paths.repositories / "client"
+        coordinate = self.workspace._source_coordinate("client", primary)
+        request = self.workspace._lease_request(
+            "source", coordinate, "exclusive", "replace client source"
+        )
+        competing = alternate._lease_request(
+            "source", coordinate, "exclusive", "sync client source"
+        )
+        with resource_locks(self.workspace._lease_root, [request]):
+            with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                with resource_locks(
+                    alternate._lease_root, [competing], nonblocking=True
+                ):
+                    self.fail("relocated workspace acquired duplicate source lease")
+
+    def test_wrapper_worktrees_share_common_git_lease_namespace(self) -> None:
+        self.workspace.close()
+        command("git", "init", "-b", "main", cwd=self.wrapper)
+        command("git", "config", "user.name", "Tests", cwd=self.wrapper)
+        command(
+            "git", "config", "user.email", "tests@example.invalid", cwd=self.wrapper
+        )
+        command("git", "add", "components.json", cwd=self.wrapper)
+        command("git", "commit", "-m", "feat: seed wrapper", cwd=self.wrapper)
+        self.workspace = Workspace(self.wrapper)
+        linked_root = self.root / "linked-wrapper"
+        command(
+            "git",
+            "worktree",
+            "add",
+            "-b",
+            "test/linked-wrapper",
+            str(linked_root),
+            cwd=self.wrapper,
+        )
+        linked = Workspace(linked_root)
+        primary_status = command("git", "status", "--porcelain", cwd=self.wrapper)
+        linked_status = command("git", "status", "--porcelain", cwd=linked_root)
+
+        self.assertEqual(self.workspace._lease_namespace, linked._lease_namespace)
+        request = LeaseRequest(
+            "git-admin",
+            self.workspace._wrapper_git_admin_coordinate(),
+            "exclusive",
+            "clean wrapper worktree",
+            "wait for wrapper administration",
+        )
+        with resource_locks(self.workspace._lease_root, [request]):
+            competing = LeaseRequest(
+                "git-admin",
+                linked._wrapper_git_admin_coordinate(),
+                "exclusive",
+                "clean linked wrapper",
+                "wait for wrapper administration",
+            )
+            with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                with resource_locks(
+                    linked._lease_root, [competing], nonblocking=True
+                ):
+                    self.fail("linked wrapper acquired duplicate Git-admin lease")
+        self.assertEqual(
+            command("git", "status", "--porcelain", cwd=self.wrapper),
+            primary_status,
+        )
+        self.assertEqual(
+            command("git", "status", "--porcelain", cwd=linked_root),
+            linked_status,
+        )
+        linked.close()
+        namespace = self.workspace._lease_namespace
+        detached = namespace.with_name("detached-atrinik-resource-leases")
+        namespace.rename(detached)
+        namespace.mkdir(mode=0o700)
+        try:
+            with self.assertRaisesRegex(
+                WorkspaceError, "physical lease namespace identity changed"
+            ):
+                Workspace(linked_root)
+        finally:
+            shutil.rmtree(namespace)
+            detached.rename(namespace)
+
+    def test_git_checkout_common_namespace_resolution_fails_closed(self) -> None:
+        (self.wrapper / ".git").mkdir()
+        with mock.patch.object(
+            Workspace,
+            "_git_common_directory",
+            side_effect=WorkspaceError("untrusted Git administration"),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "untrusted"):
+                Workspace(self.wrapper)
 
     def test_shared_layout_lock_registers_only_live_layout_lease(self) -> None:
         layout = self.workspace.paths.workspace / "repository-layout.lock"
@@ -6548,6 +7669,8 @@ class WorkspaceTests(unittest.TestCase):
 
     def test_independent_build_roots_overlap_across_processes(self) -> None:
         context = multiprocessing.get_context("spawn")
+        self.workspace.create_profile("independent-a")
+        self.workspace.create_profile("independent-b")
         entered = context.Queue()
         release = context.Event()
         results = context.Queue()
@@ -6655,6 +7778,8 @@ class WorkspaceTests(unittest.TestCase):
                 )
                 for index in range(2)
             ]
+            for index in range(2):
+                self.workspace.create_profile(f"timed-{mode}-{index}")
             try:
                 for process in processes:
                     process.start()
@@ -6679,6 +7804,7 @@ class WorkspaceTests(unittest.TestCase):
 
     def test_same_build_root_serializes_across_processes(self) -> None:
         context = multiprocessing.get_context("spawn")
+        self.workspace.create_profile("same-root")
         entered = context.Queue()
         release = context.Event()
         results = context.Queue()
@@ -6726,64 +7852,103 @@ class WorkspaceTests(unittest.TestCase):
             [results.get(timeout=2), results.get(timeout=2)], [None, None]
         )
 
-    def test_layout_writers_wait_for_build_readers_across_processes(self) -> None:
+    def test_source_reader_blocks_only_same_coordinate_writer(self) -> None:
         context = multiprocessing.get_context("spawn")
-        for operation in ("sync", "remove-worktree"):
-            with self.subTest(operation=operation):
-                entered = context.Queue()
-                release = context.Event()
-                reader_results = context.Queue()
-                reader_attempting = context.Event()
-                writer_attempting = context.Event()
-                writer_entered = context.Event()
-                writer_results = context.Queue()
-                reader = context.Process(
-                    target=synthetic_build_process,
-                    args=(
-                        str(self.wrapper),
-                        str(self.workspace_directory),
-                        f"reader-{operation}",
-                        reader_attempting,
-                        entered,
-                        release,
-                        reader_results,
-                    ),
-                )
-                writer = context.Process(
-                    target=layout_writer_process,
-                    args=(
-                        str(self.wrapper),
-                        str(self.workspace_directory),
-                        operation,
-                        writer_attempting,
-                        writer_entered,
-                        writer_results,
-                    ),
-                )
-                try:
-                    reader.start()
-                    self.assertEqual(
-                        entered.get(timeout=5), f"reader-{operation}"
-                    )
-                    writer.start()
-                    self.assertTrue(writer_attempting.wait(timeout=5))
-                    with self.assertRaisesRegex(WorkspaceError, "already in use"):
-                        with exclusive_lock(
-                            self.workspace.paths.workspace
-                            / "repository-layout.lock",
-                            "repository layout",
-                            nonblocking=True,
-                        ):
-                            self.fail("held layout lock unexpectedly available")
-                    self.assertFalse(writer_entered.wait(timeout=0.25))
-                finally:
-                    release.set()
-                    join_or_stop_processes([reader, writer], 10)
-                self.assertTrue(writer_entered.is_set())
-                self.assertEqual(reader.exitcode, 0)
-                self.assertEqual(writer.exitcode, 0)
-                self.assertIsNone(reader_results.get(timeout=2))
-                self.assertIsNone(writer_results.get(timeout=2))
+        entered = context.Queue()
+        results = context.Queue()
+        release_reader = context.Event()
+        release_writers = context.Event()
+        coordinate_a = "client:/worktrees/a"
+        coordinate_b = "client:/worktrees/b"
+        reader = context.Process(
+            target=resource_lease_process,
+            args=(
+                str(self.workspace_directory),
+                "source",
+                coordinate_a,
+                "shared",
+                "reader-a",
+                entered,
+                release_reader,
+                results,
+            ),
+        )
+        writer_a = context.Process(
+            target=resource_lease_process,
+            args=(
+                str(self.workspace_directory),
+                "source",
+                coordinate_a,
+                "exclusive",
+                "writer-a",
+                entered,
+                release_writers,
+                results,
+            ),
+        )
+        writer_b = context.Process(
+            target=resource_lease_process,
+            args=(
+                str(self.workspace_directory),
+                "source",
+                coordinate_b,
+                "exclusive",
+                "writer-b",
+                entered,
+                release_writers,
+                results,
+            ),
+        )
+        processes = [reader, writer_a, writer_b]
+        try:
+            reader.start()
+            self.assertEqual(entered.get(timeout=5), "reader-a")
+            writer_a.start()
+            writer_b.start()
+            self.assertEqual(entered.get(timeout=5), "writer-b")
+            with self.assertRaises(queue.Empty):
+                entered.get(timeout=0.25)
+            release_reader.set()
+            self.assertEqual(entered.get(timeout=5), "writer-a")
+        finally:
+            release_reader.set()
+            release_writers.set()
+            join_or_stop_processes(processes, 10)
+        self.assertEqual([process.exitcode for process in processes], [0, 0, 0])
+        self.assertEqual([results.get(timeout=2) for _ in processes], [None] * 3)
+
+    def test_multi_source_wait_does_not_retain_earlier_coordinate(self) -> None:
+        earlier = self.workspace._lease_request(
+            "source", "client:/a", "exclusive", "synchronize client"
+        )
+        later = self.workspace._lease_request(
+            "source", "client:/z", "exclusive", "synchronize client"
+        )
+        later_reader = self.workspace._lease_request(
+            "source", "client:/z", "shared", "build later"
+        )
+        earlier_reader = self.workspace._lease_request(
+            "source", "client:/a", "shared", "build earlier"
+        )
+        entered = threading.Event()
+        release = threading.Event()
+
+        def acquire_both() -> None:
+            with self.workspace._resource_locks_all_or_none([earlier, later]):
+                entered.set()
+                self.assertTrue(release.wait(5))
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            with self.workspace._resource_locks([later_reader]):
+                writer = executor.submit(acquire_both)
+                time.sleep(0.05)
+                with self.workspace._resource_locks(
+                    [earlier_reader], nonblocking=True
+                ):
+                    self.assertFalse(entered.is_set())
+            self.assertTrue(entered.wait(2))
+            release.set()
+            writer.result(timeout=5)
 
     def test_exclusive_lock_refuses_symlink(self) -> None:
         target = self.root / "valuable"
@@ -6798,107 +7963,72 @@ class WorkspaceTests(unittest.TestCase):
 
         self.assertEqual(target.read_text(encoding="utf-8"), "preserve\n")
 
-    def test_layout_sensitive_operations_wait_for_repository_lock(self) -> None:
-        operations = (
-            (
-                "_create_worktree",
-                lambda: self.workspace.create_worktree(
-                    "client", "review", "feat/review", None, False
-                ),
-            ),
-            (
-                "_remove_worktree",
-                lambda: self.workspace.remove_worktree("client", "review"),
-            ),
-            (
-                "_create_profile",
-                lambda: self.workspace.create_profile("review"),
-            ),
-            (
-                "_set_profile",
-                lambda: self.workspace.set_profile(
-                    "review", "client", "primary"
-                ),
-            ),
-            ("_build", lambda: self.workspace.build("client", "default", False)),
-            (
-                "_scenario_create",
-                lambda: self.workspace.scenario_create("review", "default"),
-            ),
-            (
-                "_scenario_reset",
-                lambda: self.workspace.scenario_reset("review"),
-            ),
-            (
-                "_topology_up",
-                lambda: self.workspace.topology_up(
-                    "review", "default", "review", ["server"], None
-                ),
-            ),
-            (
-                "_run_server",
-                lambda: self.workspace.run_server(
-                    "default", "review", 13327, [], True
-                ),
-            ),
-            (
-                "_run_client",
-                lambda: self.workspace.run_client(
-                    "default", "review", 13327, [], True
-                ),
-            ),
-            (
-                "_run_client",
-                lambda: self.workspace.run_client(
-                    "default", "review", 13327, [], True
-                ),
-            ),
-        )
-        lock = self.workspace.paths.workspace / "repository-layout.lock"
-        for private_name, invoke in operations:
-            with self.subTest(operation=private_name):
-                with mock.patch.object(self.workspace, private_name) as operation:
-                    with ThreadPoolExecutor(max_workers=1) as executor:
-                        with exclusive_lock(lock, "repository layout"):
-                            future = executor.submit(invoke)
-                            time.sleep(0.05)
-                            self.assertFalse(future.done())
-                            operation.assert_not_called()
-                        future.result(timeout=2)
-                    operation.assert_called_once()
+    def test_operational_profile_mutation_waits_for_maintenance_barrier(self) -> None:
+        lock = self.workspace._lease_namespace / "repository-layout.lock"
+        completed = threading.Event()
 
-    def test_layout_readers_share_repository_lock(self) -> None:
-        operations = (
-            ("_build", lambda: self.workspace.build("client", "default", False)),
-            (
-                "_scenario_create",
-                lambda: self.workspace.scenario_create("review", "default"),
-            ),
-            (
-                "_scenario_reset",
-                lambda: self.workspace.scenario_reset("review"),
-            ),
-            (
-                "_topology_up",
-                lambda: self.workspace.topology_up(
-                    "review", "default", "review", ["server"], None
+        def create() -> None:
+            self.workspace.create_profile("review")
+            completed.set()
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            with exclusive_layout_lock(lock, "repository maintenance"):
+                future = executor.submit(create)
+                time.sleep(0.05)
+                self.assertFalse(completed.is_set())
+            future.result(timeout=5)
+        self.assertEqual(self.workspace.profile_summary("review")["name"], "review")
+
+    def test_state_and_cleanup_mutations_wait_for_maintenance_barrier(self) -> None:
+        lock = self.workspace._lease_namespace / "repository-layout.lock"
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            with exclusive_layout_lock(lock, "repository maintenance"):
+                state = executor.submit(self.workspace.state_add, "held", None)
+                cleanup = executor.submit(
+                    self.workspace.cleanup, ["builds"], 7, [], True
+                )
+                time.sleep(0.05)
+                self.assertFalse(state.done())
+                self.assertFalse(cleanup.done())
+            self.assertEqual(
+                state.result(timeout=5),
+                (self.workspace.paths.state / "server" / "held").resolve(),
+            )
+            self.assertIsInstance(cleanup.result(timeout=5), dict)
+
+    def test_distinct_profile_writers_overlap(self) -> None:
+        context = multiprocessing.get_context("spawn")
+        entered = context.Queue()
+        results = context.Queue()
+        release = context.Event()
+        processes = [
+            context.Process(
+                target=resource_lease_process,
+                args=(
+                    str(self.workspace_directory),
+                    "profile",
+                    name,
+                    "exclusive",
+                    name,
+                    entered,
+                    release,
+                    results,
                 ),
-            ),
-            (
-                "_run_server",
-                lambda: self.workspace.run_server(
-                    "default", "review", 13327, [], True
-                ),
-            ),
-        )
-        lock = self.workspace.paths.workspace / "repository-layout.lock"
-        for private_name, invoke in operations:
-            with self.subTest(operation=private_name):
-                with mock.patch.object(self.workspace, private_name) as operation:
-                    with shared_lock(lock, "repository layout"):
-                        with ThreadPoolExecutor(max_workers=1) as executor:
-                            executor.submit(invoke).result(timeout=2)
-                    operation.assert_called_once()
+            )
+            for name in ("profile-a", "profile-b")
+        ]
+        try:
+            for process in processes:
+                process.start()
+            self.assertEqual(
+                {entered.get(timeout=5), entered.get(timeout=5)},
+                {"profile-a", "profile-b"},
+            )
+        finally:
+            release.set()
+            join_or_stop_processes(processes, 10)
+        self.assertEqual([process.exitcode for process in processes], [0, 0])
+        self.assertEqual([results.get(timeout=2) for _ in processes], [None, None])
 
     def test_mixed_layout_readers_preserve_markers_and_coordinates(self) -> None:
         self.workspace.create_profile("stress")
@@ -7002,59 +8132,26 @@ class WorkspaceTests(unittest.TestCase):
         expected_status["error"] = "stress generation 19"
         self.assertEqual(load_json(topology_root / "status.json"), expected_status)
 
-    def test_layout_writer_waits_for_foreground_client_process(self) -> None:
-        context = multiprocessing.get_context("spawn")
-        client_attempting = context.Event()
-        client_entered = context.Event()
-        release = context.Event()
-        client_results = context.Queue()
-        writer_attempting = context.Event()
-        writer_entered = context.Event()
-        writer_results = context.Queue()
-        client = context.Process(
-            target=synthetic_client_process,
-            args=(
-                str(self.wrapper),
-                str(self.workspace_directory),
-                client_attempting,
-                client_entered,
-                release,
-                client_results,
-            ),
-        )
-        writer = context.Process(
-            target=layout_writer_process,
-            args=(
-                str(self.wrapper),
-                str(self.workspace_directory),
-                "remove-worktree",
-                writer_attempting,
-                writer_entered,
-                writer_results,
-            ),
-        )
-        try:
-            client.start()
-            self.assertTrue(client_entered.wait(timeout=5))
-            writer.start()
-            self.assertTrue(writer_attempting.wait(timeout=5))
-            with self.assertRaisesRegex(WorkspaceError, "already in use"):
-                with exclusive_lock(
-                    self.workspace.paths.workspace / "repository-layout.lock",
-                    "repository layout",
-                    nonblocking=True,
-                ):
-                    self.fail("held layout lock unexpectedly available")
-            self.assertFalse(writer_entered.wait(timeout=0.25))
-        finally:
-            release.set()
-            client.join(timeout=10)
-            writer.join(timeout=10)
-        self.assertTrue(writer_entered.is_set())
-        self.assertEqual(client.exitcode, 0)
-        self.assertEqual(writer.exitcode, 0)
-        self.assertIsNone(client_results.get(timeout=2))
-        self.assertIsNone(writer_results.get(timeout=2))
+    def test_topology_releases_profile_and_source_leases_after_publication(self) -> None:
+        observed: tuple[int, ...] = ()
+
+        def inspect(*_arguments: object, **keywords: object) -> dict[str, object]:
+            nonlocal observed
+            self.assertNotIn("resource_lock_fds", keywords)
+            observed = active_lock_fds()
+            self.assertGreaterEqual(len(observed), 2)
+            self.assertTrue(all(os.fstat(descriptor) for descriptor in observed))
+            return {"name": "review"}
+
+        with mock.patch.object(self.workspace, "_topology_up", side_effect=inspect):
+            result = self.workspace.topology_up(
+                "review", "default", "default", ["server"]
+            )
+        self.assertEqual(result, {"name": "review"})
+        self.assertTrue(observed)
+        for descriptor in observed:
+            with self.assertRaises(OSError):
+                os.fstat(descriptor)
 
     def test_server_runtime_paths_are_isolated_by_state(self) -> None:
         source = self.workspace.paths.repositories / "server"
@@ -7274,11 +8371,8 @@ class WorkspaceTests(unittest.TestCase):
             self.assertEqual(
                 cross_namespace["observation"]["control"], "reachable"
             )
-            self.assertEqual(
-                cross_namespace["observation"][
-                    "repository_layout_lease_owner"
-                ],
-                None,
+            self.assertNotIn(
+                "source_lease_owner", cross_namespace["observation"]
             )
             self.assertEqual(
                 cross_namespace["observation"]["runtime_bundle_lease"],
@@ -7454,6 +8548,17 @@ class WorkspaceTests(unittest.TestCase):
             "source_commit": sound_record["source_commit"],
             "source_tree": sound_record["source_tree"],
         }
+        snapshot_states = {
+            role: {
+                "path": Path(record["checkout_path"]),
+                "head": record["head"],
+                "dirty": record["dirty"],
+                "device": Path(record["checkout_path"]).stat().st_dev,
+                "inode": Path(record["checkout_path"]).stat().st_ino,
+                "git_common": str(Path(record["checkout_path"]) / ".git"),
+            }
+            for role, record in resolved.items()
+        }
         classic_stack = mock.Mock()
         classic_stack.name = "classic"
         classic_stack.components = ()
@@ -7469,6 +8574,16 @@ class WorkspaceTests(unittest.TestCase):
             mock.patch.object(self.workspace, "_require_client_display"),
             mock.patch.object(
                 self.workspace, "_resolve_build_profile", return_value=selected
+            ),
+            mock.patch.object(
+                self.workspace,
+                "_selector_root",
+                side_effect=lambda _profile, component: selected[component.name],
+            ),
+            mock.patch.object(
+                self.workspace,
+                "_selected_checkout_states",
+                return_value=snapshot_states,
             ),
             mock.patch.object(
                 self.workspace, "_build_resolved", return_value=build_root
@@ -7944,7 +9059,20 @@ class WorkspaceTests(unittest.TestCase):
         )
         state = self.workspace._state_location("default")
         second_state = self.workspace.state_add("second", None)
-        layout_lock = self.workspace.paths.workspace / "repository-layout.lock"
+        source_lock = resource_lock_path(
+            self.workspace._lease_namespace,
+            "source",
+            self.workspace._source_coordinate(
+                "client", self.workspace.paths.repositories / "client"
+            ),
+        )
+        server_source_lock = resource_lock_path(
+            self.workspace._lease_namespace,
+            "source",
+            self.workspace._source_coordinate(
+                "server", self.workspace.paths.repositories / "server"
+            ),
+        )
         profile_lock = (
             self.workspace.paths.builds / "locks" / f"{build_root.name}.lock"
         )
@@ -7994,10 +9122,6 @@ class WorkspaceTests(unittest.TestCase):
                     Path(f"{state}.lock"), "server state", nonblocking=True
                 ):
                     self.fail("supervised state lock unexpectedly became available")
-            with exclusive_lock(
-                layout_lock, "repository layout", nonblocking=True
-            ):
-                pass
             with exclusive_lock(
                 profile_lock, "profile build default", nonblocking=True
             ):
@@ -8106,7 +9230,7 @@ class WorkspaceTests(unittest.TestCase):
         try:
             self.assertTrue(server_only["ready"])
             for path, description in (
-                (layout_lock, "repository layout"),
+                (server_source_lock, "server source"),
                 (profile_lock, "profile build default"),
             ):
                 with exclusive_lock(path, description, nonblocking=True):
@@ -8159,7 +9283,7 @@ class WorkspaceTests(unittest.TestCase):
                 orphaned["observation"]["process_tree_lease"], "released"
             )
             for path, description in (
-                (layout_lock, "repository layout"),
+                (server_source_lock, "server source"),
                 (profile_lock, "profile build default"),
             ):
                 with exclusive_lock(path, description, nonblocking=True):
@@ -8181,7 +9305,9 @@ class WorkspaceTests(unittest.TestCase):
             Path(f"{second_state}.lock"), "server state", nonblocking=True
         ):
             pass
-        with exclusive_lock(layout_lock, "repository layout", nonblocking=True):
+        with exclusive_lock(
+            server_source_lock, "server source", nonblocking=True
+        ):
             pass
         with exclusive_lock(
             profile_lock, "profile build default", nonblocking=True
@@ -8434,6 +9560,56 @@ class WorkspaceTests(unittest.TestCase):
             self.assertGreater(reset["provisioned_at"], created["provisioned_at"])
 
         self.assertEqual(provision.call_count, 2)
+
+    def test_scenario_reset_fsync_uncertainty_retains_old_references(self) -> None:
+        resolved = self.scenario_resolved_fixture()
+        with mock.patch.object(
+            self.workspace, "_scenario_provision_state", return_value=resolved
+        ):
+            self.workspace.scenario_create("uncertain-reset", "default")
+
+        scenario_path = (
+            self.workspace.paths.scenarios / "uncertain-reset" / "scenario.json"
+        )
+        identity = hashlib.sha256(str(scenario_path.resolve()).encode()).hexdigest()
+        old_sources = {
+            str(Path(row["checkout_path"]).resolve()) for row in resolved.values()
+        }
+        replacement = copy.deepcopy(resolved)
+        new_content = self.root / "replacement-content"
+        new_content.mkdir()
+        replacement["content"]["checkout_path"] = str(new_content)
+        replacement["content"]["path"] = str(new_content)
+        real_publish = workspace_module.durable_atomic_json
+
+        def uncertain_write(target: Path, value: object) -> None:
+            real_publish(target, value)
+            if target == scenario_path:
+                raise workspace_module.AtomicJsonCommitUncertain(
+                    "simulated scenario durability uncertainty"
+                )
+
+        with (
+            mock.patch.object(
+                self.workspace,
+                "_scenario_provision_state",
+                return_value=replacement,
+            ),
+            mock.patch(
+                "atrinik_workspace.workspace.durable_atomic_json",
+                side_effect=uncertain_write,
+            ),
+            self.assertRaisesRegex(WorkspaceError, "durability uncertainty"),
+        ):
+            self.workspace.scenario_reset("uncertain-reset")
+
+        record = load_json(
+            self.workspace._lease_namespace
+            / "profile-references"
+            / f"{identity}.json"
+        )
+        self.assertTrue(old_sources.issubset(set(record["sources"])))
+        self.assertIn(str(new_content.resolve()), record["sources"])
 
     def test_scenario_lifecycle_prepares_fresh_asset_staging(self) -> None:
         selected = {
@@ -8979,13 +10155,26 @@ class WorkspaceTests(unittest.TestCase):
             {"sound": workspace_module.sound_source_record(self.wrapper / "sound")},
         )
         expected = "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81"
+        self.workspace._physical_lease_namespace = self.workspace._lease_namespace
 
         def execute_client(*_arguments: object, **_keywords: object) -> None:
             self.assertEqual(len(_keywords["pass_fds"]), 1)
             for path, description in (
                 (
-                    self.workspace.paths.workspace / "repository-layout.lock",
-                    "repository layout",
+                    resource_lock_path(
+                        self.workspace.paths.workspace, "profile", "default"
+                    ),
+                    "profile default",
+                ),
+                (
+                    resource_lock_path(
+                        self.workspace._lease_namespace,
+                        "source",
+                        self.workspace._source_coordinate(
+                            "client", self.workspace.paths.repositories / "client"
+                        ),
+                    ),
+                    "client source",
                 ),
                 (
                     self.workspace.paths.builds
@@ -9019,6 +10208,11 @@ class WorkspaceTests(unittest.TestCase):
             ),
             mock.patch.object(
                 self.workspace, "_topology_resolved_status", return_value={}
+            ),
+            mock.patch.object(
+                self.workspace,
+                "_selected_checkout_states",
+                return_value=synthetic_checkout_states(self.wrapper / "client"),
             ),
             mock.patch("builtins.print") as output,
             mock.patch(
@@ -9075,6 +10269,7 @@ class WorkspaceTests(unittest.TestCase):
         executable = runtime / "atrinik-server"
         executable.write_text("server\n", encoding="utf-8")
         selected = {"server": server}
+        self.workspace._physical_lease_namespace = self.workspace._lease_namespace
 
         def publish_server(*_arguments: object, **_keywords: object) -> tuple[Path, int, dict[str, object]]:
             generation_root = self.root / "foreground-server-generation"
@@ -9104,8 +10299,18 @@ class WorkspaceTests(unittest.TestCase):
             self.assertEqual(len(_keywords["pass_fds"]), 2)
             for path, description in (
                 (
-                    self.workspace.paths.workspace / "repository-layout.lock",
-                    "repository layout",
+                    resource_lock_path(
+                        self.workspace.paths.workspace, "profile", "default"
+                    ),
+                    "profile default",
+                ),
+                (
+                    resource_lock_path(
+                        self.workspace._lease_namespace,
+                        "source",
+                        self.workspace._source_coordinate("server", server),
+                    ),
+                    "server source",
                 ),
                 (
                     self.workspace.paths.builds
@@ -9141,6 +10346,11 @@ class WorkspaceTests(unittest.TestCase):
             ),
             mock.patch.object(
                 self.workspace, "_topology_resolved_status", return_value={}
+            ),
+            mock.patch.object(
+                self.workspace,
+                "_selected_checkout_states",
+                return_value=synthetic_checkout_states(server),
             ),
             mock.patch.object(
                 self.workspace,


### PR DESCRIPTION
## Summary

- add an explicit, preview-first `topologies` cleanup scope while keeping defaults and plain `all` unchanged
- inventory marker-owned inactive topology records with deterministic liveness, control, lease, age, identity, and exact-path evidence
- revalidate stable no-follow snapshots under exact topology-coordinate and operation locks before descriptor-bounded removal
- preserve persistent state, scenarios, profiles, builds, source, and existing cleanup reference behavior
- document the supported lifecycle and cover current/legacy records, hazards, races, interruption, idempotency, references, CLI output, and completion

Closes #397

## Safety and compatibility

- topology cleanup remains opt-in and never acts as `down`, signals a process, or reuses a topology name
- live, unreachable, reachable-control, retained/unverifiable-lease, young, malformed, linked, replaced, unowned, locked, busy, or concurrently changed records are protected or skipped
- legacy stale records without `stopped_at` use the newest no-follow tree mtime; orderly exits without `stopped_at` remain protected
- integrates with the exact-coordinate lease and cleanup-journal architecture released in `v4.0.0`
- no dependency, protocol, component-runtime, persistent-state-format, or supply-chain inventory changes

## Validation

- `/workspaces/atrinik/.venv/bin/python -m coverage run -m unittest discover -q` — 745 tests passed
- `/workspaces/atrinik/.venv/bin/python -m coverage report --format=total` — 82%
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `./atrinik cleanup --scope topologies --older-than 7 --dry-run --json`
- `./atrinik cleanup --scope all --older-than 7 --dry-run --json`
- `git diff --check`

## Review coordinates

- base: `main` at `0ab823aa26acb1e79c613194e1615b4270d313ac`
- head: `feat/topology-record-cleanup` at `df024b4d8dadb6e93079aea95c6922f3e474ff41`
- worktree: `/workspaces/atrinik/workspace/worktrees/atrinik/issue-397-topology-cleanup`

## Verification

```sh
./atrinik cleanup --scope topologies --older-than 7 --dry-run --json
# Inspect every candidate, reason, observation, and deletion_paths entry.
./atrinik cleanup --scope topologies --older-than 7 --apply
./atrinik ps --json
```

Dry run is non-mutating. Apply removes only an unchanged eligible topology directory, skips a busy exact topology coordinate, and journals progress. A repeated apply removes nothing; persistent state/build/profile/source data remains unchanged. No runtime is required for review; do not apply cleanup to shared records unless their removal is intentional.
