### PR TITLE
fix(workspace): preserve stale backfill references

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,8 +963,16 @@ coordination. Every operation also retains its own wrapper-worktree source
 coordinate, preventing cleanup from removing the code and ignored component
 checkouts beneath an active wrapper view. Saved non-primary profile references
 are also registered in this physical namespace, so cleanup from a relocated
-state root observes references published by another root. Profile names, topology
-names, scenarios, states, build roots, and cache keys remain workspace-local.
+state root observes references published by another root. First-use registry
+backfill retains exact paths from missing profile and scenario sources as
+conservative historical references without changing the authored records.
+Those unbound records do not prevent `status`, `sync`, or unrelated commands
+from constructing the workspace, but they protect a source that later reappears
+at the same path. Genuine source-lease contention reports the exact coordinate,
+owning operation and supported recovery action; an authored record that changes
+during confirmation fails with a distinct retry diagnostic. Profile names,
+topology names, scenarios, states, build roots, and cache keys remain
+workspace-local.
 Requests acquire that deterministic order. A writer queued for one coordinate
 precedes later readers of that coordinate, while unrelated resources continue:
 two builds on different worktrees of one repository overlap, and init/sync for

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -524,6 +524,12 @@ class Cleanup:
                         requests.extend(
                             [
                                 self.workspace._lease_request(
+                                    "registry",
+                                    "physical-references",
+                                    "exclusive",
+                                    f"cleanup worktree {target['path']}",
+                                ),
+                                self.workspace._lease_request(
                                     "source",
                                     self.workspace._source_coordinate(
                                         owner, Path(target["path"])

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -521,15 +521,25 @@ class Cleanup:
                         )
                     ]
                     if target["kind"] == "worktree":
-                        requests.append(
-                            self.workspace._lease_request(
-                                "source",
-                                self.workspace._source_coordinate(
-                                    owner, Path(target["path"])
+                        requests.extend(
+                            [
+                                self.workspace._lease_request(
+                                    "source",
+                                    self.workspace._source_coordinate(
+                                        owner, Path(target["path"])
+                                    ),
+                                    "exclusive",
+                                    f"cleanup worktree {target['path']}",
                                 ),
-                                "exclusive",
-                                f"cleanup worktree {target['path']}",
-                            )
+                                self.workspace._lease_request(
+                                    "source",
+                                    self.workspace._physical_source_coordinate(
+                                        Path(target["path"])
+                                    ),
+                                    "exclusive",
+                                    f"cleanup worktree {target['path']}",
+                                ),
+                            ]
                         )
                     try:
                         target_stack.enter_context(

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -3307,15 +3307,25 @@ class Workspace:
                         f"scenario resolved references are invalid: {root.name}"
                     )
                 sources = {
-                    (
-                        value["checkout"],
-                        Path(value["checkout_path"]).resolve(strict=False),
-                    )
+                    Path(value["checkout_path"]).resolve(strict=False)
                     for value in resolved.values()
                     if isinstance(value, dict)
                     and isinstance(value.get("checkout"), str)
                     and isinstance(value.get("checkout_path"), str)
                 }
+                # Historical scenario checkout identities are not authoritative:
+                # a repository split or manifest migration can give cleanup a
+                # different current owner for the same exact path. Cover every
+                # manifest owner coordinate during this one-time backfill so no
+                # current worktree remover can race publication under a stale
+                # scenario-provided name.
+                checkout_names = set(self.manifest.by_checkout)
+                checkout_names.update(
+                    value["checkout"]
+                    for value in resolved.values()
+                    if isinstance(value, dict)
+                    and isinstance(value.get("checkout"), str)
+                )
                 requests = [
                     self._lease_request(
                         "scenario", root.name, "shared", "backfill scenario reference"
@@ -3327,7 +3337,8 @@ class Workspace:
                             "shared",
                             "backfill scenario reference",
                         )
-                        for checkout, source in sorted(sources, key=lambda item: (item[0], str(item[1])))
+                        for checkout in sorted(checkout_names)
+                        for source in sorted(sources, key=str)
                     ],
                 ]
                 with resource_locks(self._lease_root, requests, nonblocking=True):

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -1511,7 +1511,7 @@ class Workspace:
     def _lease_root(self, request: LeaseRequest) -> Path:
         """Route physical and workspace-local coordinates to stable namespaces."""
 
-        if request.kind in {"git-admin", "source"}:
+        if request.kind in {"registry", "git-admin", "source"}:
             return self._lease_namespace
         return self.paths.workspace
 
@@ -2974,6 +2974,37 @@ class Workspace:
             str(self.paths.workspace.resolve()).encode()
         ).hexdigest()
         marker_reference = f"__backfill__:{state_identity}"
+        if self._physical_backfill_complete(state_identity, marker_reference):
+            return
+        registry_request = self._lease_request(
+            "registry",
+            f"physical-reference-backfill:{state_identity}",
+            "exclusive",
+            "backfill physical references",
+        )
+        with shared_maintenance_lock(
+            self._lease_namespace / "repository-layout.lock"
+        ):
+            with self._resource_locks([registry_request]):
+                if self._physical_backfill_complete(
+                    state_identity, marker_reference
+                ):
+                    return
+                self._backfill_profile_references()
+                self._backfill_scenario_references()
+                self._atomic_physical_reference(
+                    f"{state_identity}.json",
+                    {
+                        "schema_version": 1,
+                        "kind": "profiles",
+                        "reference": marker_reference,
+                        "sources": [],
+                    },
+                )
+
+    def _physical_backfill_complete(
+        self, state_identity: str, marker_reference: str
+    ) -> bool:
         for marker in self._physical_reference_records(
             only=f"{state_identity}.json"
         ):
@@ -2987,22 +3018,9 @@ class Workspace:
                 and marker.get("reference") == marker_reference
                 and marker.get("sources") == []
             ):
-                return
+                return True
             raise WorkspaceError("physical reference backfill marker is invalid")
-        with shared_maintenance_lock(
-            self._lease_namespace / "repository-layout.lock"
-        ):
-            self._backfill_profile_references()
-            self._backfill_scenario_references()
-            self._atomic_physical_reference(
-                f"{state_identity}.json",
-                {
-                    "schema_version": 1,
-                    "kind": "profiles",
-                    "reference": marker_reference,
-                    "sources": [],
-                },
-            )
+        return False
 
     def _atomic_physical_reference(
         self, name: str, value: dict[str, Any]

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -3306,26 +3306,28 @@ class Workspace:
                     raise WorkspaceError(
                         f"scenario resolved references are invalid: {root.name}"
                     )
-                sources = {
-                    Path(value["checkout_path"]).resolve(strict=False)
+                historical_sources = {
+                    (
+                        value["checkout"],
+                        Path(value["checkout_path"]).resolve(strict=False),
+                    )
                     for value in resolved.values()
                     if isinstance(value, dict)
                     and isinstance(value.get("checkout"), str)
                     and isinstance(value.get("checkout_path"), str)
                 }
+                sources = {source for _checkout, source in historical_sources}
                 # Historical scenario checkout identities are not authoritative:
                 # a repository split or manifest migration can give cleanup a
                 # different current owner for the same exact path. Cover every
                 # manifest owner coordinate during this one-time backfill so no
                 # current worktree remover can race publication under a stale
                 # scenario-provided name.
-                checkout_names = set(self.manifest.by_checkout)
-                checkout_names.update(
-                    value["checkout"]
-                    for value in resolved.values()
-                    if isinstance(value, dict)
-                    and isinstance(value.get("checkout"), str)
-                )
+                source_coordinates = historical_sources | {
+                    (checkout, source)
+                    for checkout in self.manifest.by_checkout
+                    for source in sources
+                }
                 requests = [
                     self._lease_request(
                         "scenario", root.name, "shared", "backfill scenario reference"
@@ -3337,8 +3339,10 @@ class Workspace:
                             "shared",
                             "backfill scenario reference",
                         )
-                        for checkout in sorted(checkout_names)
-                        for source in sorted(sources, key=str)
+                        for checkout, source in sorted(
+                            source_coordinates,
+                            key=lambda item: (item[0], str(item[1])),
+                        )
                     ],
                 ]
                 with resource_locks(self._lease_root, requests, nonblocking=True):

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -3356,13 +3356,6 @@ class Workspace:
                     raise WorkspaceError(
                         f"scenario resolved references are invalid: {root.name}"
                     )
-                sources = {
-                    Path(value["checkout_path"]).resolve(strict=False)
-                    for value in resolved.values()
-                    if isinstance(value, dict)
-                    and isinstance(value.get("checkout"), str)
-                    and isinstance(value.get("checkout_path"), str)
-                }
                 scenario_request = self._lease_request(
                     "scenario", root.name, "shared", "backfill scenario reference"
                 )
@@ -3378,9 +3371,7 @@ class Workspace:
                     # The caller holds the common physical-reference registry
                     # barrier against removal, so the complete source set can be
                     # published once without retaining one descriptor per path.
-                    self._publish_scenario_reference_sources(
-                        root.name, {str(source) for source in sources}
-                    )
+                    self._publish_scenario_references(root.name, confirmed)
 
     def _set_profile(
         self, name: str, component_name: str, kind: str, value: str = ""

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -2432,6 +2432,12 @@ class Workspace:
             "exclusive",
             f"remove worktree {checkout.name}/{label}",
         )
+        registry_request = self._lease_request(
+            "registry",
+            "physical-references",
+            "exclusive",
+            f"remove worktree {checkout.name}/{label}",
+        )
         with self._open_managed_worktree(destination) as (
             stable_destination,
             physical_destination,
@@ -2449,7 +2455,9 @@ class Workspace:
                 f"remove worktree {checkout.name}/{label}",
             )
             while True:
-                with self._resource_locks([source_request, physical_request]):
+                with self._resource_locks(
+                    [registry_request, source_request, physical_request]
+                ):
                     try:
                         with self._resource_locks(
                             [admin_request], nonblocking=True
@@ -2982,10 +2990,19 @@ class Workspace:
             "exclusive",
             "backfill physical references",
         )
+        publication_request = self._lease_request(
+            "registry",
+            "physical-references",
+            "shared",
+            "backfill physical references",
+        )
         with shared_maintenance_lock(
             self._lease_namespace / "repository-layout.lock"
         ):
-            with self._resource_locks([registry_request]):
+            with resource_locks(
+                self._lease_root,
+                [publication_request, registry_request],
+            ):
                 if self._physical_backfill_complete(
                     state_identity, marker_reference
                 ):
@@ -3358,54 +3375,12 @@ class Workspace:
                             "scenario changed during physical reference backfill: "
                             f"{root.name}; stop editing that scenario and retry"
                         )
-                    identity = hashlib.sha256(
-                        str(record.resolve()).encode()
-                    ).hexdigest()
-                    existing = self._physical_reference_records(
-                        only=f"{identity}.json"
+                    # The caller holds the common physical-reference registry
+                    # barrier against removal, so the complete source set can be
+                    # published once without retaining one descriptor per path.
+                    self._publish_scenario_reference_sources(
+                        root.name, {str(source) for source in sources}
                     )
-                    retained: set[str] = set()
-                    if existing:
-                        previous = existing[0]
-                        if (
-                            not isinstance(previous, dict)
-                            or set(previous)
-                            != {"schema_version", "kind", "reference", "sources"}
-                            or previous.get("schema_version") != 1
-                            or previous.get("kind") != "scenarios"
-                            or previous.get("reference") != root.name
-                            or not isinstance(previous.get("sources"), list)
-                            or any(
-                                not isinstance(source, str)
-                                or not Path(source).is_absolute()
-                                for source in previous["sources"]
-                            )
-                        ):
-                            raise WorkspaceError(
-                                "cannot prove physical reference record"
-                            )
-                        retained.update(previous["sources"])
-                    if not sources:
-                        self._publish_scenario_reference_sources(root.name, retained)
-                for source in sorted(sources, key=str):
-                    physical_request = self._lease_request(
-                        "source",
-                        self._physical_source_coordinate(source),
-                        "shared",
-                        "backfill scenario reference",
-                    )
-                    with resource_locks(
-                        self._lease_root,
-                        [physical_request, scenario_request],
-                        nonblocking=True,
-                    ):
-                        if load_regular_json(record, "scenario metadata") != metadata:
-                            raise WorkspaceError(
-                                "scenario changed during physical reference backfill: "
-                                f"{root.name}; stop editing that scenario and retry"
-                            )
-                        retained.add(str(source))
-                        self._publish_scenario_reference_sources(root.name, retained)
 
     def _set_profile(
         self, name: str, component_name: str, kind: str, value: str = ""

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -2819,10 +2819,9 @@ class Workspace:
             with self._resource_locks([source_request]):
                 self._set_profile(name, component_name, kind, value)
 
-    def _backfill_profile_references(self, *, already_locked: bool = False) -> bool:
+    def _backfill_profile_references(self, *, already_locked: bool = False) -> None:
         if not self.paths.profiles.is_dir() or self.paths.profiles.is_symlink():
-            return True
-        complete = True
+            return
         for path in sorted(self.paths.profiles.glob("*.json")):
             if already_locked:
                 profile = self._load_profile_file(path.stem, require_file=True)
@@ -2844,20 +2843,19 @@ class Workspace:
                     for checkout, source in sources
                 ],
             ]
-            try:
-                with resource_locks(self._lease_root, requests, nonblocking=True):
-                    confirmed = load_regular_json(path, f"profile {path.stem}")
-                    if confirmed != profile or any(
-                        not source.is_dir() for _checkout, source in sources
-                    ):
-                        complete = False
-                        continue
-                    self._publish_raw_profile_references(
-                        path.stem, path, profile=confirmed
+            with resource_locks(self._lease_root, requests, nonblocking=True):
+                confirmed = load_regular_json(path, f"profile {path.stem}")
+                if confirmed != profile:
+                    raise WorkspaceError(
+                        "profile changed during physical reference backfill: "
+                        f"{path.stem}; stop editing that profile and retry"
                     )
-            except LockBusyError:
-                complete = False
-        return complete
+                # Missing selectors are historical authored coordinates. Publish
+                # them conservatively so construction can finish without making
+                # a source at that exact path eligible for later reclamation.
+                self._publish_raw_profile_references(
+                    path.stem, path, profile=confirmed
+                )
 
     def _raw_profile_reference_sources(
         self, name: str, profile: Any
@@ -2984,13 +2982,8 @@ class Workspace:
         with shared_maintenance_lock(
             self._lease_namespace / "repository-layout.lock"
         ):
-            complete = self._backfill_profile_references()
-            complete = self._backfill_scenario_references() and complete
-            if not complete:
-                raise WorkspaceError(
-                    "physical reference backfill is busy; wait for the named exact "
-                    "resource operation to finish and retry"
-                )
+            self._backfill_profile_references()
+            self._backfill_scenario_references()
             self._atomic_physical_reference(
                 f"{state_identity}.json",
                 {
@@ -3301,10 +3294,9 @@ class Workspace:
             },
         )
 
-    def _backfill_scenario_references(self) -> bool:
+    def _backfill_scenario_references(self) -> None:
         if not self.paths.scenarios.is_dir() or self.paths.scenarios.is_symlink():
-            return True
-        complete = True
+            return
         for root in sorted(self.paths.scenarios.iterdir()):
             record = root / "scenario.json"
             if root.is_dir() and not root.is_symlink() and record.is_file():
@@ -3338,18 +3330,17 @@ class Workspace:
                         for checkout, source in sorted(sources, key=lambda item: (item[0], str(item[1])))
                     ],
                 ]
-                try:
-                    with resource_locks(self._lease_root, requests, nonblocking=True):
-                        confirmed = load_regular_json(record, "scenario metadata")
-                        if confirmed != metadata or any(
-                            not source.is_dir() for _checkout, source in sources
-                        ):
-                            complete = False
-                            continue
-                        self._publish_scenario_references(root.name, confirmed)
-                except LockBusyError:
-                    complete = False
-        return complete
+                with resource_locks(self._lease_root, requests, nonblocking=True):
+                    confirmed = load_regular_json(record, "scenario metadata")
+                    if confirmed != metadata:
+                        raise WorkspaceError(
+                            "scenario changed during physical reference backfill: "
+                            f"{root.name}; stop editing that scenario and retry"
+                        )
+                    # As with profiles, retain missing historical source paths in
+                    # the common registry so another workspace root cannot later
+                    # reclaim a source that the authored scenario still names.
+                    self._publish_scenario_references(root.name, confirmed)
 
     def _set_profile(
         self, name: str, component_name: str, kind: str, value: str = ""

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -1403,6 +1403,10 @@ class Workspace:
     def _source_coordinate(checkout_name: str, root: Path) -> str:
         return f"{checkout_name}:{Path(os.path.abspath(root))}"
 
+    @staticmethod
+    def _physical_source_coordinate(root: Path) -> str:
+        return f"physical-path:{Path(os.path.abspath(root))}"
+
     @property
     def _lease_namespace(self) -> Path:
         """Return the common-Git namespace shared by physical wrapper views."""
@@ -2438,8 +2442,14 @@ class Workspace:
                 "exclusive",
                 f"remove worktree {checkout.name}/{label}",
             )
+            physical_request = self._lease_request(
+                "source",
+                self._physical_source_coordinate(physical_destination),
+                "exclusive",
+                f"remove worktree {checkout.name}/{label}",
+            )
             while True:
-                with self._resource_locks([source_request]):
+                with self._resource_locks([source_request, physical_request]):
                     try:
                         with self._resource_locks(
                             [admin_request], nonblocking=True
@@ -3282,6 +3292,11 @@ class Workspace:
             }
             | (retained_sources or set())
         )
+        self._publish_scenario_reference_sources(name, sources)
+
+    def _publish_scenario_reference_sources(
+        self, name: str, sources: list[str] | set[str]
+    ) -> None:
         record = (self.paths.scenarios / name / "scenario.json").resolve()
         identity = hashlib.sha256(str(record).encode()).hexdigest()
         self._atomic_physical_reference(
@@ -3290,7 +3305,7 @@ class Workspace:
                 "schema_version": 1,
                 "kind": "scenarios",
                 "reference": name,
-                "sources": sources,
+                "sources": sorted(sources),
             },
         )
 
@@ -3306,56 +3321,73 @@ class Workspace:
                     raise WorkspaceError(
                         f"scenario resolved references are invalid: {root.name}"
                     )
-                historical_sources = {
-                    (
-                        value["checkout"],
-                        Path(value["checkout_path"]).resolve(strict=False),
-                    )
+                sources = {
+                    Path(value["checkout_path"]).resolve(strict=False)
                     for value in resolved.values()
                     if isinstance(value, dict)
                     and isinstance(value.get("checkout"), str)
                     and isinstance(value.get("checkout_path"), str)
                 }
-                sources = {source for _checkout, source in historical_sources}
-                # Historical scenario checkout identities are not authoritative:
-                # a repository split or manifest migration can give cleanup a
-                # different current owner for the same exact path. Cover every
-                # manifest owner coordinate during this one-time backfill so no
-                # current worktree remover can race publication under a stale
-                # scenario-provided name.
-                source_coordinates = historical_sources | {
-                    (checkout, source)
-                    for checkout in self.manifest.by_checkout
-                    for source in sources
-                }
-                requests = [
-                    self._lease_request(
-                        "scenario", root.name, "shared", "backfill scenario reference"
-                    ),
-                    *[
-                        self._lease_request(
-                            "source",
-                            self._source_coordinate(checkout, source),
-                            "shared",
-                            "backfill scenario reference",
-                        )
-                        for checkout, source in sorted(
-                            source_coordinates,
-                            key=lambda item: (item[0], str(item[1])),
-                        )
-                    ],
-                ]
-                with resource_locks(self._lease_root, requests, nonblocking=True):
+                scenario_request = self._lease_request(
+                    "scenario", root.name, "shared", "backfill scenario reference"
+                )
+                with resource_locks(
+                    self._lease_root, [scenario_request], nonblocking=True
+                ):
                     confirmed = load_regular_json(record, "scenario metadata")
                     if confirmed != metadata:
                         raise WorkspaceError(
                             "scenario changed during physical reference backfill: "
                             f"{root.name}; stop editing that scenario and retry"
                         )
-                    # As with profiles, retain missing historical source paths in
-                    # the common registry so another workspace root cannot later
-                    # reclaim a source that the authored scenario still names.
-                    self._publish_scenario_references(root.name, confirmed)
+                    identity = hashlib.sha256(
+                        str(record.resolve()).encode()
+                    ).hexdigest()
+                    existing = self._physical_reference_records(
+                        only=f"{identity}.json"
+                    )
+                    retained: set[str] = set()
+                    if existing:
+                        previous = existing[0]
+                        if (
+                            not isinstance(previous, dict)
+                            or set(previous)
+                            != {"schema_version", "kind", "reference", "sources"}
+                            or previous.get("schema_version") != 1
+                            or previous.get("kind") != "scenarios"
+                            or previous.get("reference") != root.name
+                            or not isinstance(previous.get("sources"), list)
+                            or any(
+                                not isinstance(source, str)
+                                or not Path(source).is_absolute()
+                                for source in previous["sources"]
+                            )
+                        ):
+                            raise WorkspaceError(
+                                "cannot prove physical reference record"
+                            )
+                        retained.update(previous["sources"])
+                    if not sources:
+                        self._publish_scenario_reference_sources(root.name, retained)
+                for source in sorted(sources, key=str):
+                    physical_request = self._lease_request(
+                        "source",
+                        self._physical_source_coordinate(source),
+                        "shared",
+                        "backfill scenario reference",
+                    )
+                    with resource_locks(
+                        self._lease_root,
+                        [physical_request, scenario_request],
+                        nonblocking=True,
+                    ):
+                        if load_regular_json(record, "scenario metadata") != metadata:
+                            raise WorkspaceError(
+                                "scenario changed during physical reference backfill: "
+                                f"{root.name}; stop editing that scenario and retry"
+                            )
+                        retained.add(str(source))
+                        self._publish_scenario_reference_sources(root.name, retained)
 
     def _set_profile(
         self, name: str, component_name: str, kind: str, value: str = ""

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -220,6 +220,10 @@ the profile or scenario. A later source at the same path remains protected
 across relocated roots. Exact lease contention propagates its coordinate,
 operation, owner metadata and recovery action; a record that changes between
 read and confirmation fails separately and leaves the backfill marker absent.
+Because an inert scenario can retain a pre-migration checkout name, its
+one-time backfill covers every current manifest checkout owner coordinate for
+each exact path; current-owner cleanup therefore cannot race publication under
+the stale name.
 
 The common-Git `repository-layout.lock` is only the maintenance barrier for
 schema/layout migration apply or restore. Ordinary operations share it while

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -213,6 +213,13 @@ identity. Build preparation persists that snapshot and never rereads a mutable
 profile generation. Publication and removal share the same source coordinate.
 Physical profile/scenario reference records make completed publications visible
 to cleanup and explicit removal from every relocated state root.
+Initial registry backfill publishes absent source paths as conservative
+historical references while holding the authored-record and exact source
+leases. It then marks that state root classified without rewriting or removing
+the profile or scenario. A later source at the same path remains protected
+across relocated roots. Exact lease contention propagates its coordinate,
+operation, owner metadata and recovery action; a record that changes between
+read and confirmation fails separately and leaves the backfill marker absent.
 
 The common-Git `repository-layout.lock` is only the maintenance barrier for
 schema/layout migration apply or restore. Ordinary operations share it while

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -225,7 +225,9 @@ backfill and removal also share an owner-independent exact-path coordinate.
 Backfill processes one path at a time and durably accumulates its conservative
 record, so descriptor use stays bounded and interruption can only leave a safe
 partial record plus an absent marker. Current-owner cleanup therefore cannot
-race publication under a stale name.
+race publication under a stale name. An exclusive per-state-root registry lease
+serializes first-use backfills, and every waiter rechecks the completion marker
+before publishing, so a lagging constructor cannot regress a completed record.
 
 The common-Git `repository-layout.lock` is only the maintenance barrier for
 schema/layout migration apply or restore. Ordinary operations share it while

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -220,10 +220,12 @@ the profile or scenario. A later source at the same path remains protected
 across relocated roots. Exact lease contention propagates its coordinate,
 operation, owner metadata and recovery action; a record that changes between
 read and confirmation fails separately and leaves the backfill marker absent.
-Because an inert scenario can retain a pre-migration checkout name, its
-one-time backfill covers every current manifest checkout owner coordinate for
-each exact path; current-owner cleanup therefore cannot race publication under
-the stale name.
+Because an inert scenario can retain a pre-migration checkout name, scenario
+backfill and removal also share an owner-independent exact-path coordinate.
+Backfill processes one path at a time and durably accumulates its conservative
+record, so descriptor use stays bounded and interruption can only leave a safe
+partial record plus an absent marker. Current-owner cleanup therefore cannot
+race publication under a stale name.
 
 The common-Git `repository-layout.lock` is only the maintenance barrier for
 schema/layout migration apply or restore. Ordinary operations share it while

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -220,14 +220,15 @@ the profile or scenario. A later source at the same path remains protected
 across relocated roots. Exact lease contention propagates its coordinate,
 operation, owner metadata and recovery action; a record that changes between
 read and confirmation fails separately and leaves the backfill marker absent.
-Because an inert scenario can retain a pre-migration checkout name, scenario
-backfill and removal also share an owner-independent exact-path coordinate.
-Backfill processes one path at a time and durably accumulates its conservative
-record, so descriptor use stays bounded and interruption can only leave a safe
-partial record plus an absent marker. Current-owner cleanup therefore cannot
-race publication under a stale name. An exclusive per-state-root registry lease
-serializes first-use backfills, and every waiter rechecks the completion marker
-before publishing, so a lagging constructor cannot regress a completed record.
+Because an inert scenario can retain a pre-migration checkout name, a common-Git
+physical-reference registry lease spans the complete one-time classification;
+worktree removal and cleanup take it exclusively, so they cannot reach an
+unprocessed path under any current owner between publications. Backfill
+publishes each scenario's complete conservative path set once, keeping
+descriptor use and durable I/O bounded. An exclusive per-state-root registry
+lease serializes first-use backfills, and every waiter rechecks the completion
+marker before publishing, so a lagging constructor cannot regress a completed
+record.
 
 The common-Git `repository-layout.lock` is only the maintenance barrier for
 schema/layout migration apply or restore. Ordinary operations share it while

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1867,6 +1867,69 @@ class CleanupTests(unittest.TestCase):
             [{"kind": "worktree", "path": str(removable)}],
         )
 
+    def test_apply_skips_worktree_during_relocated_reference_backfill(self) -> None:
+        target = self.make_component_worktree("backfill-race", component="client")
+        alternate_root = self.root / "alternate-backfill-workspace"
+        scenario = alternate_root / "scenarios" / "cleanup-race"
+        scenario.mkdir(parents=True)
+        atomic_json(
+            scenario / "scenario.json",
+            {
+                "resolved": {
+                    "client": {
+                        "checkout": "retired-client-owner",
+                        "checkout_path": str(target),
+                    }
+                }
+            },
+        )
+        with mock.patch.dict(
+            os.environ, {"ATRINIK_WORKSPACE_DIR": str(alternate_root)}
+        ):
+            alternate = Workspace(self.wrapper, backfill_references=False)
+        entered = threading.Event()
+        release = threading.Event()
+        publish = alternate._publish_scenario_references
+
+        def pause_publication(name: str, metadata: dict[str, object]) -> None:
+            entered.set()
+            self.assertTrue(release.wait(5))
+            publish(name, metadata)
+
+        try:
+            with (
+                mock.patch.object(
+                    alternate,
+                    "_publish_scenario_references",
+                    side_effect=pause_publication,
+                ),
+                mock.patch.object(
+                    Cleanup,
+                    "_github_pulls",
+                    side_effect=lambda _repository, head: self.merged_pull(head),
+                ),
+                ThreadPoolExecutor(max_workers=1) as executor,
+            ):
+                backfill = executor.submit(alternate._backfill_physical_references)
+                self.assertTrue(entered.wait(5))
+                report = self.workspace.cleanup(["worktrees"], 7, ["client"], True)
+                item = next(
+                    row for row in report["items"] if row["path"] == str(target)
+                )
+                self.assertEqual(item["disposition"], "skipped")
+                self.assertEqual(item["reasons"], ["resource_busy"])
+                self.assertIn(
+                    "registry physical-references is already in use by shared "
+                    "backfill physical references",
+                    item["error"],
+                )
+                self.assertTrue(target.is_dir())
+                release.set()
+                backfill.result(timeout=5)
+        finally:
+            release.set()
+            alternate.close()
+
     def test_apply_skips_wrapper_worktree_running_public_operation(self) -> None:
         busy = self.make_wrapper_worktree("active-wrapper")
         with mock.patch.dict(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7289,18 +7289,18 @@ class WorkspaceTests(unittest.TestCase):
             fresh = Workspace(self.wrapper, backfill_references=False)
         entered = threading.Event()
         release = threading.Event()
-        publish = fresh._publish_scenario_reference_sources
+        publish = fresh._publish_scenario_references
 
-        def pause_publication(name: str, values: list[str] | set[str]) -> None:
+        def pause_publication(name: str, metadata: dict[str, object]) -> None:
             entered.set()
             self.assertTrue(release.wait(5))
-            publish(name, values)
+            publish(name, metadata)
 
         try:
             with (
                 mock.patch.object(
                     fresh,
-                    "_publish_scenario_reference_sources",
+                    "_publish_scenario_references",
                     side_effect=pause_publication,
                 ),
                 ThreadPoolExecutor(max_workers=2) as executor,
@@ -7406,6 +7406,35 @@ class WorkspaceTests(unittest.TestCase):
             self.assertTrue((registry / f"{state_identity}.json").is_file())
         finally:
             fresh.close()
+
+    def test_backfill_rejects_malformed_scenario_without_marker(self) -> None:
+        root = self.workspace.paths.scenarios / "malformed-backfill"
+        root.mkdir()
+        atomic_json(
+            root / "scenario.json",
+            {
+                "resolved": {
+                    "server": {
+                        "checkout": "server",
+                        "checkout_path": str(self.root / "retained-server"),
+                    },
+                    "invalid": {"checkout": "retired-owner"},
+                }
+            },
+        )
+        state_identity = hashlib.sha256(
+            str(self.workspace.paths.workspace.resolve()).encode()
+        ).hexdigest()
+        registry = self.workspace._lease_namespace / "profile-references"
+        (registry / f"{state_identity}.json").unlink()
+
+        with self.assertRaisesRegex(
+            WorkspaceError,
+            "scenario resolved references are invalid: malformed-backfill",
+        ):
+            self.workspace._backfill_physical_references()
+
+        self.assertFalse((registry / f"{state_identity}.json").exists())
 
     def test_backfill_reports_authored_record_change_separately(self) -> None:
         profile = self.workspace.create_profile("changing-backfill")

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7256,6 +7256,57 @@ class WorkspaceTests(unittest.TestCase):
                 self.workspace._source_references(source),
             )
 
+    def test_relocated_scenario_backfill_covers_current_checkout_owner(self) -> None:
+        source = self.workspace.paths.worktrees / "server" / "retired-scenario"
+        source.mkdir(parents=True)
+        alternate_root = self.root / "alternate-scenario-workspace"
+        scenario = alternate_root / "scenarios" / "retired-scenario"
+        scenario.mkdir(parents=True)
+        record = scenario / "scenario.json"
+        atomic_json(
+            record,
+            {
+                "resolved": {
+                    "server": {
+                        "checkout": "retired-server-owner",
+                        "checkout_path": str(source),
+                    }
+                }
+            },
+        )
+        source.rmdir()
+        removal = self.workspace._lease_request(
+            "source",
+            self.workspace._source_coordinate("server", source),
+            "exclusive",
+            "remove selected source",
+        )
+
+        with resource_locks(self.workspace._lease_root, [removal]):
+            with (
+                mock.patch.dict(
+                    os.environ, {"ATRINIK_WORKSPACE_DIR": str(alternate_root)}
+                ),
+                self.assertRaisesRegex(
+                    WorkspaceError,
+                    rf"source server:{re.escape(str(source))} is already in use by "
+                    r"exclusive remove selected source by",
+                ),
+            ):
+                Workspace(self.wrapper)
+
+        with mock.patch.dict(
+            os.environ, {"ATRINIK_WORKSPACE_DIR": str(alternate_root)}
+        ):
+            fresh = Workspace(self.wrapper)
+            fresh.close()
+        source.mkdir(parents=True)
+        with resource_locks(self.workspace._lease_root, [removal]):
+            self.assertIn(
+                "scenario:retired-scenario",
+                self.workspace._source_references(source),
+            )
+
     def test_backfill_preserves_missing_scenario_as_historical_reference(self) -> None:
         root = self.workspace.paths.scenarios / "missing-scenario"
         root.mkdir()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7258,7 +7258,13 @@ class WorkspaceTests(unittest.TestCase):
 
     def test_relocated_scenario_backfill_blocks_removal_until_complete(self) -> None:
         sources = [
-            self.workspace.paths.worktrees / "server" / f"retired-scenario-{index}"
+            self.workspace.create_worktree(
+                "content",
+                f"retired-scenario-{index}",
+                f"feat/retired-scenario-{index}",
+                None,
+                False,
+            )
             for index in range(2)
         ]
         alternate_root = self.root / "alternate-scenario-workspace"
@@ -7277,29 +7283,18 @@ class WorkspaceTests(unittest.TestCase):
                 }
             },
         )
-        removal = self.workspace._lease_request(
-            "registry",
-            "physical-references",
-            "exclusive",
-            "remove selected source",
-        )
         with mock.patch.dict(
             os.environ, {"ATRINIK_WORKSPACE_DIR": str(alternate_root)}
         ):
             fresh = Workspace(self.wrapper, backfill_references=False)
         entered = threading.Event()
         release = threading.Event()
-        removal_entered = threading.Event()
         publish = fresh._publish_scenario_reference_sources
 
         def pause_publication(name: str, values: list[str] | set[str]) -> None:
             entered.set()
             self.assertTrue(release.wait(5))
             publish(name, values)
-
-        def attempt_removal() -> None:
-            with resource_locks(fresh._lease_root, [removal]):
-                removal_entered.set()
 
         try:
             with (
@@ -7312,13 +7307,22 @@ class WorkspaceTests(unittest.TestCase):
             ):
                 backfill = executor.submit(fresh._backfill_physical_references)
                 self.assertTrue(entered.wait(5))
-                removing = executor.submit(attempt_removal)
+                removing = executor.submit(
+                    self.workspace.remove_worktree,
+                    "content",
+                    "retired-scenario-1",
+                )
                 time.sleep(0.05)
-                self.assertFalse(removal_entered.is_set())
+                self.assertFalse(removing.done())
                 release.set()
                 backfill.result(timeout=5)
-                removing.result(timeout=5)
-            self.assertTrue(removal_entered.is_set())
+                with self.assertRaisesRegex(
+                    WorkspaceError,
+                    r"refusing to remove referenced worktree .*: "
+                    r"scenario:retired-scenario$",
+                ):
+                    removing.result(timeout=5)
+            self.assertTrue(sources[1].is_dir())
             reference = load_json(
                 fresh._lease_namespace
                 / "profile-references"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -13,6 +13,7 @@ import multiprocessing
 import os
 from pathlib import Path
 import queue
+import re
 import shutil
 import signal
 import socket
@@ -7159,7 +7160,12 @@ class WorkspaceTests(unittest.TestCase):
             "remove selected source",
         )
         with resource_locks(self.workspace._lease_root, [source_request]):
-            with self.assertRaisesRegex(WorkspaceError, "backfill is busy"):
+            with self.assertRaisesRegex(
+                WorkspaceError,
+                rf"source content:{re.escape(str(source))} is already in use by "
+                r"exclusive remove selected source by .*; "
+                r"inspect `\./atrinik worktree list --json` and retry",
+            ):
                 self.workspace._backfill_physical_references()
         self.assertFalse((registry / f"{profile_identity}.json").exists())
         self.assertFalse((registry / f"{state_identity}.json").exists())
@@ -7167,6 +7173,157 @@ class WorkspaceTests(unittest.TestCase):
         self.workspace._backfill_physical_references()
         self.assertTrue((registry / f"{profile_identity}.json").is_file())
         self.assertTrue((registry / f"{state_identity}.json").is_file())
+
+    def test_backfill_preserves_missing_profile_as_historical_reference(self) -> None:
+        source = self.workspace.create_worktree(
+            "content", "missing-profile", "feat/missing-profile", None, False
+        )
+        profile = self.workspace.create_profile("missing-profile")
+        self.workspace.set_profile("missing-profile", "content", "path", str(source))
+        authored = profile.read_bytes()
+        registry = self.workspace._lease_namespace / "profile-references"
+        profile_identity = hashlib.sha256(str(profile.resolve()).encode()).hexdigest()
+        state_identity = hashlib.sha256(
+            str(self.workspace.paths.workspace.resolve()).encode()
+        ).hexdigest()
+        (registry / f"{profile_identity}.json").unlink()
+        (registry / f"{state_identity}.json").unlink()
+        shutil.rmtree(source)
+
+        fresh = Workspace(self.wrapper)
+        try:
+            self.assertTrue(fresh.repository_status(["content"]))
+            fresh.sync(["content"], "none")
+            self.assertEqual(profile.read_bytes(), authored)
+            record = load_json(registry / f"{profile_identity}.json")
+            self.assertEqual(record["sources"], [str(source.resolve())])
+            self.assertTrue((registry / f"{state_identity}.json").is_file())
+        finally:
+            fresh.close()
+
+    def test_relocated_backfill_and_removal_share_missing_source_coordinate(
+        self,
+    ) -> None:
+        source = self.workspace.create_worktree(
+            "content", "relocated-missing", "feat/relocated-missing", None, False
+        )
+        alternate_root = self.root / "alternate-workspace"
+        with mock.patch.dict(
+            os.environ, {"ATRINIK_WORKSPACE_DIR": str(alternate_root)}
+        ):
+            alternate = Workspace(self.wrapper)
+            alternate.paths.ensure()
+            profile = alternate.create_profile("relocated-missing")
+            alternate.set_profile(
+                "relocated-missing", "content", "path", str(source)
+            )
+            alternate.close()
+
+        registry = self.workspace._lease_namespace / "profile-references"
+        profile_identity = hashlib.sha256(str(profile.resolve()).encode()).hexdigest()
+        state_identity = hashlib.sha256(str(alternate_root.resolve()).encode()).hexdigest()
+        (registry / f"{profile_identity}.json").unlink()
+        (registry / f"{state_identity}.json").unlink()
+        shutil.rmtree(source)
+        removal = self.workspace._lease_request(
+            "source",
+            self.workspace._source_coordinate("content", source),
+            "exclusive",
+            "remove selected source",
+        )
+        with resource_locks(self.workspace._lease_root, [removal]):
+            with (
+                mock.patch.dict(
+                    os.environ, {"ATRINIK_WORKSPACE_DIR": str(alternate_root)}
+                ),
+                self.assertRaisesRegex(
+                    WorkspaceError,
+                    rf"source content:{re.escape(str(source))} is already in use by "
+                    r"exclusive remove selected source by",
+                ),
+            ):
+                Workspace(self.wrapper)
+
+        with mock.patch.dict(
+            os.environ, {"ATRINIK_WORKSPACE_DIR": str(alternate_root)}
+        ):
+            fresh = Workspace(self.wrapper)
+            fresh.close()
+        source.mkdir(parents=True)
+        with resource_locks(self.workspace._lease_root, [removal]):
+            self.assertIn(
+                "profile:relocated-missing",
+                self.workspace._source_references(source),
+            )
+
+    def test_backfill_preserves_missing_scenario_as_historical_reference(self) -> None:
+        root = self.workspace.paths.scenarios / "missing-scenario"
+        root.mkdir()
+        missing = self.workspace.paths.worktrees / "server" / "missing-scenario"
+        record = root / "scenario.json"
+        atomic_json(
+            record,
+            {
+                "resolved": {
+                    "server": {
+                        "checkout": "server",
+                        "checkout_path": str(missing),
+                    }
+                }
+            },
+        )
+        authored = record.read_bytes()
+        registry = self.workspace._lease_namespace / "profile-references"
+        scenario_identity = hashlib.sha256(str(record.resolve()).encode()).hexdigest()
+        state_identity = hashlib.sha256(
+            str(self.workspace.paths.workspace.resolve()).encode()
+        ).hexdigest()
+        (registry / f"{state_identity}.json").unlink()
+
+        fresh = Workspace(self.wrapper)
+        try:
+            self.assertEqual(record.read_bytes(), authored)
+            reference = load_json(registry / f"{scenario_identity}.json")
+            self.assertEqual(reference["sources"], [str(missing.resolve())])
+            self.assertTrue((registry / f"{state_identity}.json").is_file())
+        finally:
+            fresh.close()
+
+    def test_backfill_reports_authored_record_change_separately(self) -> None:
+        profile = self.workspace.create_profile("changing-backfill")
+        registry = self.workspace._lease_namespace / "profile-references"
+        profile_identity = hashlib.sha256(str(profile.resolve()).encode()).hexdigest()
+        state_identity = hashlib.sha256(
+            str(self.workspace.paths.workspace.resolve()).encode()
+        ).hexdigest()
+        (registry / f"{profile_identity}.json").unlink()
+        (registry / f"{state_identity}.json").unlink()
+        real_load = workspace_module.load_regular_json
+        reads = 0
+
+        def changed_on_confirmation(path: Path, description: str) -> object:
+            nonlocal reads
+            value = real_load(path, description)
+            if path == profile:
+                reads += 1
+                if reads == 2:
+                    return {**value, "name": "changed-directly"}
+            return value
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.load_regular_json",
+                side_effect=changed_on_confirmation,
+            ),
+            self.assertRaisesRegex(
+                WorkspaceError,
+                "profile changed during physical reference backfill: "
+                "changing-backfill; stop editing that profile and retry",
+            ),
+        ):
+            self.workspace._backfill_physical_references()
+        self.assertFalse((registry / f"{profile_identity}.json").exists())
+        self.assertFalse((registry / f"{state_identity}.json").exists())
 
     def test_backfill_rejects_inexact_marker_schema(self) -> None:
         state_identity = hashlib.sha256(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7277,7 +7277,7 @@ class WorkspaceTests(unittest.TestCase):
         source.rmdir()
         removal = self.workspace._lease_request(
             "source",
-            self.workspace._source_coordinate("server", source),
+            self.workspace._physical_source_coordinate(source),
             "exclusive",
             "remove selected source",
         )
@@ -7289,7 +7289,8 @@ class WorkspaceTests(unittest.TestCase):
                 ),
                 self.assertRaisesRegex(
                     WorkspaceError,
-                    rf"source server:{re.escape(str(source))} is already in use by "
+                    rf"source physical\-path:{re.escape(str(source))} "
+                    r"is already in use by "
                     r"exclusive remove selected source by",
                 ),
             ):
@@ -7310,7 +7311,7 @@ class WorkspaceTests(unittest.TestCase):
     def test_scenario_backfill_does_not_cross_product_historical_owners(self) -> None:
         root = self.workspace.paths.scenarios / "bounded-historical"
         root.mkdir()
-        historical_count = 20
+        historical_count = 341
         atomic_json(
             root / "scenario.json",
             {
@@ -7345,7 +7346,7 @@ class WorkspaceTests(unittest.TestCase):
 
         self.assertEqual(
             observed,
-            [1 + historical_count * (1 + len(self.workspace.manifest.by_checkout))],
+            [1] + [2] * historical_count,
         )
 
     def test_backfill_preserves_missing_scenario_as_historical_reference(self) -> None:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7289,12 +7289,26 @@ class WorkspaceTests(unittest.TestCase):
             fresh = Workspace(self.wrapper, backfill_references=False)
         entered = threading.Event()
         release = threading.Event()
+        removal_reached_fence = threading.Event()
         publish = fresh._publish_scenario_references
+        lock_resources = self.workspace._resource_locks
 
         def pause_publication(name: str, metadata: dict[str, object]) -> None:
             entered.set()
             self.assertTrue(release.wait(5))
             publish(name, metadata)
+
+        def observe_removal_fence(
+            requests: list[LeaseRequest], *args: object, **kwargs: object
+        ) -> object:
+            if any(
+                request.kind == "registry"
+                and request.coordinate == "physical-references"
+                and request.mode == "exclusive"
+                for request in requests
+            ):
+                removal_reached_fence.set()
+            return lock_resources(requests, *args, **kwargs)
 
         try:
             with (
@@ -7302,6 +7316,11 @@ class WorkspaceTests(unittest.TestCase):
                     fresh,
                     "_publish_scenario_references",
                     side_effect=pause_publication,
+                ),
+                mock.patch.object(
+                    self.workspace,
+                    "_resource_locks",
+                    side_effect=observe_removal_fence,
                 ),
                 ThreadPoolExecutor(max_workers=2) as executor,
             ):
@@ -7312,7 +7331,7 @@ class WorkspaceTests(unittest.TestCase):
                     "content",
                     "retired-scenario-1",
                 )
-                time.sleep(0.05)
+                self.assertTrue(removal_reached_fence.wait(5))
                 self.assertFalse(removing.done())
                 release.set()
                 backfill.result(timeout=5)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7440,6 +7440,57 @@ class WorkspaceTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "backfill marker is invalid"):
             self.workspace._backfill_physical_references()
 
+    def test_concurrent_backfill_rechecks_marker_after_serialization(self) -> None:
+        registry = self.workspace._lease_namespace / "profile-references"
+        state_identity = hashlib.sha256(
+            str(self.workspace.paths.workspace.resolve()).encode()
+        ).hexdigest()
+        (registry / f"{state_identity}.json").unlink()
+        first = Workspace(self.wrapper, backfill_references=False)
+        second = Workspace(self.wrapper, backfill_references=False)
+        entered = threading.Event()
+        release = threading.Event()
+        second_started_work = threading.Event()
+        first_backfill = first._backfill_scenario_references
+
+        def pause_first_backfill() -> None:
+            entered.set()
+            self.assertTrue(release.wait(5))
+            first_backfill()
+
+        def observe_second_work() -> None:
+            second_started_work.set()
+
+        try:
+            with (
+                mock.patch.object(
+                    first,
+                    "_backfill_scenario_references",
+                    side_effect=pause_first_backfill,
+                ),
+                mock.patch.object(
+                    second,
+                    "_backfill_profile_references",
+                    side_effect=observe_second_work,
+                ),
+                ThreadPoolExecutor(max_workers=2) as executor,
+            ):
+                first_result = executor.submit(first._backfill_physical_references)
+                self.assertTrue(entered.wait(5))
+                second_result = executor.submit(second._backfill_physical_references)
+                time.sleep(0.05)
+                self.assertFalse(second_result.done())
+                self.assertFalse(second_started_work.is_set())
+                release.set()
+                first_result.result(timeout=5)
+                second_result.result(timeout=5)
+            self.assertFalse(second_started_work.is_set())
+            self.assertTrue((registry / f"{state_identity}.json").is_file())
+        finally:
+            release.set()
+            first.close()
+            second.close()
+
     def test_profile_json_rejects_duplicate_keys_without_following_links(self) -> None:
         path = self.workspace.paths.profiles / "duplicate.json"
         path.write_text(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7307,6 +7307,47 @@ class WorkspaceTests(unittest.TestCase):
                 self.workspace._source_references(source),
             )
 
+    def test_scenario_backfill_does_not_cross_product_historical_owners(self) -> None:
+        root = self.workspace.paths.scenarios / "bounded-historical"
+        root.mkdir()
+        historical_count = 20
+        atomic_json(
+            root / "scenario.json",
+            {
+                "resolved": {
+                    f"role-{index}": {
+                        "checkout": f"retired-owner-{index}",
+                        "checkout_path": str(self.root / f"missing-{index}"),
+                    }
+                    for index in range(historical_count)
+                }
+            },
+        )
+        state_identity = hashlib.sha256(
+            str(self.workspace.paths.workspace.resolve()).encode()
+        ).hexdigest()
+        registry = self.workspace._lease_namespace / "profile-references"
+        (registry / f"{state_identity}.json").unlink()
+        observed: list[int] = []
+        real_locks = workspace_module.resource_locks
+
+        def record_requests(*args: object, **kwargs: object) -> object:
+            requests = args[1]
+            if any(request.kind == "scenario" for request in requests):
+                observed.append(len(requests))
+            return real_locks(*args, **kwargs)
+
+        with mock.patch(
+            "atrinik_workspace.workspace.resource_locks",
+            side_effect=record_requests,
+        ):
+            self.workspace._backfill_physical_references()
+
+        self.assertEqual(
+            observed,
+            [1 + historical_count * (1 + len(self.workspace.manifest.by_checkout))],
+        )
+
     def test_backfill_preserves_missing_scenario_as_historical_reference(self) -> None:
         root = self.workspace.paths.scenarios / "missing-scenario"
         root.mkdir()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7256,9 +7256,11 @@ class WorkspaceTests(unittest.TestCase):
                 self.workspace._source_references(source),
             )
 
-    def test_relocated_scenario_backfill_covers_current_checkout_owner(self) -> None:
-        source = self.workspace.paths.worktrees / "server" / "retired-scenario"
-        source.mkdir(parents=True)
+    def test_relocated_scenario_backfill_blocks_removal_until_complete(self) -> None:
+        sources = [
+            self.workspace.paths.worktrees / "server" / f"retired-scenario-{index}"
+            for index in range(2)
+        ]
         alternate_root = self.root / "alternate-scenario-workspace"
         scenario = alternate_root / "scenarios" / "retired-scenario"
         scenario.mkdir(parents=True)
@@ -7267,46 +7269,65 @@ class WorkspaceTests(unittest.TestCase):
             record,
             {
                 "resolved": {
-                    "server": {
+                    f"server-{index}": {
                         "checkout": "retired-server-owner",
                         "checkout_path": str(source),
                     }
+                    for index, source in enumerate(sources)
                 }
             },
         )
-        source.rmdir()
         removal = self.workspace._lease_request(
-            "source",
-            self.workspace._physical_source_coordinate(source),
+            "registry",
+            "physical-references",
             "exclusive",
             "remove selected source",
         )
-
-        with resource_locks(self.workspace._lease_root, [removal]):
-            with (
-                mock.patch.dict(
-                    os.environ, {"ATRINIK_WORKSPACE_DIR": str(alternate_root)}
-                ),
-                self.assertRaisesRegex(
-                    WorkspaceError,
-                    rf"source physical\-path:{re.escape(str(source))} "
-                    r"is already in use by "
-                    r"exclusive remove selected source by",
-                ),
-            ):
-                Workspace(self.wrapper)
-
         with mock.patch.dict(
             os.environ, {"ATRINIK_WORKSPACE_DIR": str(alternate_root)}
         ):
-            fresh = Workspace(self.wrapper)
-            fresh.close()
-        source.mkdir(parents=True)
-        with resource_locks(self.workspace._lease_root, [removal]):
-            self.assertIn(
-                "scenario:retired-scenario",
-                self.workspace._source_references(source),
+            fresh = Workspace(self.wrapper, backfill_references=False)
+        entered = threading.Event()
+        release = threading.Event()
+        removal_entered = threading.Event()
+        publish = fresh._publish_scenario_reference_sources
+
+        def pause_publication(name: str, values: list[str] | set[str]) -> None:
+            entered.set()
+            self.assertTrue(release.wait(5))
+            publish(name, values)
+
+        def attempt_removal() -> None:
+            with resource_locks(fresh._lease_root, [removal]):
+                removal_entered.set()
+
+        try:
+            with (
+                mock.patch.object(
+                    fresh,
+                    "_publish_scenario_reference_sources",
+                    side_effect=pause_publication,
+                ),
+                ThreadPoolExecutor(max_workers=2) as executor,
+            ):
+                backfill = executor.submit(fresh._backfill_physical_references)
+                self.assertTrue(entered.wait(5))
+                removing = executor.submit(attempt_removal)
+                time.sleep(0.05)
+                self.assertFalse(removal_entered.is_set())
+                release.set()
+                backfill.result(timeout=5)
+                removing.result(timeout=5)
+            self.assertTrue(removal_entered.is_set())
+            reference = load_json(
+                fresh._lease_namespace
+                / "profile-references"
+                / f"{hashlib.sha256(str(record.resolve()).encode()).hexdigest()}.json"
             )
+            self.assertEqual(reference["sources"], sorted(map(str, sources)))
+        finally:
+            release.set()
+            fresh.close()
 
     def test_scenario_backfill_does_not_cross_product_historical_owners(self) -> None:
         root = self.workspace.paths.scenarios / "bounded-historical"
@@ -7346,7 +7367,7 @@ class WorkspaceTests(unittest.TestCase):
 
         self.assertEqual(
             observed,
-            [1] + [2] * historical_count,
+            [1],
         )
 
     def test_backfill_preserves_missing_scenario_as_historical_reference(self) -> None:


### PR DESCRIPTION
Closes #410.

## Summary

- preserve missing profile and scenario paths as conservative historical references without changing authored records
- propagate exact lease diagnostics for real contention and distinguish changed or malformed authored records
- serialize first-use classification and fence cross-root removal/cleanup until each complete scenario reference set is durably published
- keep descriptor use and durable I/O bounded without historical-owner/path cross products or cumulative rewrites

## Isolation

- base branch: `main`
- exact base SHA: `c18e9e57947a3529e290ddeabe7df7f7c6765c13`
- head branch: `fix/stale-reference-backfill-410`
- head SHA: `9308f7673e0e69550ef1e3378c50a13747632800`
- worktree: `/workspaces/atrinik/workspace/worktrees/atrinik/issue-410-stale-reference-backfill`

## Validation

- `/workspaces/atrinik/.venv/bin/python -m unittest discover -v` — 756 tests passed at the exact head
- issue regressions cover missing profile/scenario paths, exact busy diagnostics, changed and malformed records, concurrent same-state construction, relocated roots, stale owners, bounded locking/publication, and a deterministic two-source real-removal race
- cleanup apply also has a deterministic relocated-root interleaving that proves reclamation skips a target while publication is incomplete
- `/workspaces/atrinik/.venv/bin/python -m compileall -q atrinik atrinik_workspace tests`
- `/workspaces/atrinik/.venv/bin/python -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `./atrinik status --json`
- `./atrinik cleanup --scope all --older-than 7 --dry-run --json` — 0 candidates, 0 errors, no changes
- `git diff --check`
- latest-head GitHub integration, CodeQL, conventional-title, and Codecov patch checks passed

## Verification

Runtime provisioning is not applicable: this changes pre-command workspace construction and persistent physical-reference classification, not a game service or adapter. The focused checks can be repeated with:

```sh
/workspaces/atrinik/.venv/bin/python -m unittest -v \
  tests.test_workspace.WorkspaceTests.test_backfill_retries_without_publishing_when_source_is_busy \
  tests.test_workspace.WorkspaceTests.test_backfill_preserves_missing_profile_as_historical_reference \
  tests.test_workspace.WorkspaceTests.test_backfill_preserves_missing_scenario_as_historical_reference \
  tests.test_workspace.WorkspaceTests.test_backfill_rejects_malformed_scenario_without_marker \
  tests.test_workspace.WorkspaceTests.test_concurrent_backfill_rechecks_marker_after_serialization \
  tests.test_workspace.WorkspaceTests.test_relocated_scenario_backfill_blocks_removal_until_complete \
  tests.test_workspace.WorkspaceTests.test_scenario_backfill_does_not_cross_product_historical_owners
```

The real-removal race pauses an alternate-root backfill before publication, proves removal of the later of two referenced worktrees cannot proceed, then confirms removal fails closed after the complete record is published.

## Cleanup

No runtime topology, persistent scenario, mutable server state, or service was created. Keep the issue worktree and ignored deep-review report while this pull request remains open; later cleanup remains preview-first and separately authorized.
