### PR TITLE
test(workspace)!: prove scoped lifecycle isolation

### DIFF
--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -335,7 +335,6 @@ def resource_lease_process(
     results: object,
     attempting: object | None = None,
     entered_event: object | None = None,
-    admission_attempting: object | None = None,
 ) -> None:
     try:
         request = LeaseRequest(
@@ -347,30 +346,12 @@ def resource_lease_process(
         )
         if attempting is not None:
             attempting.set()
-        original_advisory_lock = locking_module._advisory_lock
-
-        @contextmanager
-        def observed_advisory_lock(*args: object, **kwargs: object):
-            if (
-                admission_attempting is not None
-                and Path(args[0])
-                == locking_module.layout_writer_intent_path(
-                    resource_lock_path(Path(workspace_directory), kind, coordinate)
-                )
-            ):
-                admission_attempting.set()
-            with original_advisory_lock(*args, **kwargs) as lock:
-                yield lock
-
-        with mock.patch.object(
-            locking_module, "_advisory_lock", observed_advisory_lock
-        ):
-            with resource_locks(Path(workspace_directory), [request]):
-                if entered_event is not None:
-                    entered_event.set()
-                entered.put(name)
-                if release is not None and not release.wait(60):
-                    raise TimeoutError(f"{name} was not released")
+        with resource_locks(Path(workspace_directory), [request]):
+            if entered_event is not None:
+                entered_event.set()
+            entered.put(name)
+            if release is not None and not release.wait(60):
+                raise TimeoutError(f"{name} was not released")
         results.put(None)
     except BaseException as error:
         results.put(f"{type(error).__name__}: {error}")
@@ -407,6 +388,61 @@ def public_profile_mutation_process(
                 workspace.set_profile(
                     "profile-a", "client", "worktree", "source-a"
                 )
+        results.put(None)
+    except BaseException as error:
+        results.put(f"{type(error).__name__}: {error}")
+        raise
+
+
+def public_profile_reader_process(
+    wrapper: str,
+    workspace_directory: str,
+    build_root: str,
+    admission_attempting: object,
+    entered: object,
+    release: object,
+    results: object,
+) -> None:
+    try:
+        with mock.patch.dict(
+            os.environ, {"ATRINIK_WORKSPACE_DIR": workspace_directory}
+        ):
+            workspace = Workspace(Path(wrapper))
+            profile_intent = locking_module.layout_writer_intent_path(
+                resource_lock_path(
+                    workspace._lease_root(
+                        LeaseRequest(
+                            "profile", "profile-a", "shared", "build", "wait"
+                        )
+                    ),
+                    "profile",
+                    "profile-a",
+                )
+            )
+            original_advisory_lock = locking_module._advisory_lock
+
+            @contextmanager
+            def observed_advisory_lock(*args: object, **kwargs: object):
+                if Path(args[0]) == profile_intent:
+                    admission_attempting.set()
+                with original_advisory_lock(*args, **kwargs) as lock:
+                    yield lock
+
+            def paused_build(*args: object, **kwargs: object) -> Path:
+                entered.set()
+                if not release.wait(60):
+                    raise TimeoutError("profile reader was not released")
+                return Path(build_root)
+
+            with (
+                mock.patch.object(
+                    locking_module, "_advisory_lock", observed_advisory_lock
+                ),
+                mock.patch.object(
+                    workspace, "_build_resolved", side_effect=paused_build
+                ),
+            ):
+                workspace.build("client", "profile-a", False)
         results.put(None)
     except BaseException as error:
         results.put(f"{type(error).__name__}: {error}")
@@ -823,6 +859,9 @@ class WorkspaceTests(unittest.TestCase):
         self.remote_matcher.start()
 
     def tearDown(self) -> None:
+        # Test-owned process cleanup must run before its temporary lease paths
+        # are removed; unittest's default ordering runs cleanups after tearDown.
+        self.doCleanups()
         self.remote_matcher.stop()
         self.environment.stop()
         self.temporary.cleanup()
@@ -7019,19 +7058,15 @@ class WorkspaceTests(unittest.TestCase):
             ),
         )
         late_reader = context.Process(
-            target=resource_lease_process,
+            target=public_profile_reader_process,
             args=(
-                str(lease_root),
-                "profile",
-                coordinate_a,
-                "shared",
-                "late-reader-a",
-                exact_entered,
+                str(self.wrapper),
+                str(self.workspace_directory),
+                str(topology_a_root),
+                late_reader_attempting,
+                late_reader_entered,
                 release_late_reader,
                 results,
-                None,
-                late_reader_entered,
-                late_reader_attempting,
             ),
         )
         readers = [

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -6879,6 +6879,18 @@ class WorkspaceTests(unittest.TestCase):
 
         topology_a_root = client_build_root("profile-a")
         topology_c_root = client_build_root("profile-c")
+
+        def stop_topology_a() -> None:
+            status_path = (
+                self.workspace.paths.topologies / "topology-a" / "status.json"
+            )
+            if status_path.is_file():
+                try:
+                    self.workspace.topology_down("topology-a", timeout=5)
+                except WorkspaceError:
+                    pass
+
+        self.addCleanup(stop_topology_a)
         with (
             mock.patch.object(
                 self.workspace, "_build_resolved", return_value=topology_a_root
@@ -6888,19 +6900,6 @@ class WorkspaceTests(unittest.TestCase):
             topology_a = self.workspace.topology_up(
                 "topology-a", "profile-a", "default", ["client"]
             )
-
-        def stop_topology_a() -> None:
-            status_path = (
-                self.workspace.paths.topologies / "topology-a" / "status.json"
-            )
-            if status_path.is_file():
-                try:
-                    if self.workspace.topology_status("topology-a")["ready"]:
-                        self.workspace.topology_down("topology-a", timeout=5)
-                except WorkspaceError:
-                    pass
-
-        self.addCleanup(stop_topology_a)
         self.assertTrue(topology_a["ready"])
         generation_root = Path(topology_a["runtime"]["path"])
         generation_digest = _tree_digest(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import ExitStack, redirect_stderr
+from contextlib import contextmanager, ExitStack, redirect_stderr
 import ctypes
 import errno
 import fcntl
@@ -335,6 +335,7 @@ def resource_lease_process(
     results: object,
     attempting: object | None = None,
     entered_event: object | None = None,
+    admission_attempting: object | None = None,
 ) -> None:
     try:
         request = LeaseRequest(
@@ -346,12 +347,30 @@ def resource_lease_process(
         )
         if attempting is not None:
             attempting.set()
-        with resource_locks(Path(workspace_directory), [request]):
-            if entered_event is not None:
-                entered_event.set()
-            entered.put(name)
-            if release is not None and not release.wait(60):
-                raise TimeoutError(f"{name} was not released")
+        original_advisory_lock = locking_module._advisory_lock
+
+        @contextmanager
+        def observed_advisory_lock(*args: object, **kwargs: object):
+            if (
+                admission_attempting is not None
+                and Path(args[0])
+                == locking_module.layout_writer_intent_path(
+                    resource_lock_path(Path(workspace_directory), kind, coordinate)
+                )
+            ):
+                admission_attempting.set()
+            with original_advisory_lock(*args, **kwargs) as lock:
+                yield lock
+
+        with mock.patch.object(
+            locking_module, "_advisory_lock", observed_advisory_lock
+        ):
+            with resource_locks(Path(workspace_directory), [request]):
+                if entered_event is not None:
+                    entered_event.set()
+                entered.put(name)
+                if release is not None and not release.wait(60):
+                    raise TimeoutError(f"{name} was not released")
         results.put(None)
     except BaseException as error:
         results.put(f"{type(error).__name__}: {error}")
@@ -6876,15 +6895,60 @@ class WorkspaceTests(unittest.TestCase):
         def stop_test_topologies() -> None:
             failures = []
             for name in ("topology-a", "topology-c"):
-                status_path = (
-                    self.workspace.paths.topologies / name / "status.json"
+                root = self.workspace.paths.topologies / name
+                status_path = root / "status.json"
+                process_tree_path = (
+                    root / workspace_module.TOPOLOGY_PROCESS_TREE_LEASE
                 )
-                if not status_path.is_file():
-                    continue
-                try:
-                    self.workspace.topology_down(name, timeout=5)
-                except WorkspaceError as error:
-                    failures.append(f"{name}: {error}")
+                down_error = None
+                if status_path.is_file():
+                    try:
+                        self.workspace.topology_down(name, timeout=5)
+                    except WorkspaceError as error:
+                        down_error = error
+                if process_tree_path.is_file() and not process_tree_path.is_symlink():
+                    descriptor = workspace_module.open_regular_file(
+                        process_tree_path,
+                        os.O_PATH,
+                        "test topology process-tree lease",
+                    )
+                    try:
+                        if workspace_module.holders_exist(
+                            descriptor, exclude=(os.getpid(),)
+                        ):
+                            workspace_module.signal_holders(
+                                descriptor, signal.SIGTERM, exclude=(os.getpid(),)
+                            )
+                            deadline = time.monotonic() + 5
+                            while (
+                                time.monotonic() < deadline
+                                and workspace_module.holders_exist(
+                                    descriptor, exclude=(os.getpid(),)
+                                )
+                            ):
+                                time.sleep(0.05)
+                        if workspace_module.holders_exist(
+                            descriptor, exclude=(os.getpid(),)
+                        ):
+                            workspace_module.signal_holders(
+                                descriptor, signal.SIGKILL, exclude=(os.getpid(),)
+                            )
+                            deadline = time.monotonic() + 2
+                            while (
+                                time.monotonic() < deadline
+                                and workspace_module.holders_exist(
+                                    descriptor, exclude=(os.getpid(),)
+                                )
+                            ):
+                                time.sleep(0.05)
+                        if workspace_module.holders_exist(
+                            descriptor, exclude=(os.getpid(),)
+                        ):
+                            failures.append(f"{name}: process tree remains active")
+                    finally:
+                        os.close(descriptor)
+                elif down_error is not None:
+                    failures.append(f"{name}: {down_error}")
             if failures:
                 self.fail("cannot stop test topologies: " + "; ".join(failures))
 
@@ -6965,8 +7029,9 @@ class WorkspaceTests(unittest.TestCase):
                 exact_entered,
                 release_late_reader,
                 results,
-                late_reader_attempting,
+                None,
                 late_reader_entered,
+                late_reader_attempting,
             ),
         )
         readers = [

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -333,6 +333,7 @@ def resource_lease_process(
     entered: object,
     release: object | None,
     results: object,
+    attempting: object | None = None,
 ) -> None:
     try:
         request = LeaseRequest(
@@ -342,31 +343,12 @@ def resource_lease_process(
             name,
             "wait for the exact test operation",
         )
+        if attempting is not None:
+            attempting.set()
         with resource_locks(Path(workspace_directory), [request]):
             entered.put(name)
             if release is not None and not release.wait(10):
                 raise TimeoutError(f"{name} was not released")
-        results.put(None)
-    except BaseException as error:
-        results.put(f"{type(error).__name__}: {error}")
-        raise
-
-
-def profile_mutation_process(
-    wrapper: str,
-    workspace_directory: str,
-    pending_acquired: object,
-    entered: object,
-    results: object,
-) -> None:
-    try:
-        with mock.patch.dict(
-            os.environ, {"ATRINIK_WORKSPACE_DIR": workspace_directory}
-        ):
-            workspace = Workspace(Path(wrapper))
-            pending_acquired.set()
-            workspace.set_profile("profile-b", "client", "primary")
-            entered.set()
         results.put(None)
     except BaseException as error:
         results.put(f"{type(error).__name__}: {error}")
@@ -6696,22 +6678,126 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual([process.exitcode for process in processes], [0] * 10)
         self.assertEqual([results.get(timeout=2) for _ in processes], [None] * 10)
 
-    def test_p0_harness_allows_lifecycle_progress_while_topology_runs(self) -> None:
+    def test_exact_resource_matrix_scopes_conflicts_to_coordinates(self) -> None:
         context = multiprocessing.get_context("spawn")
-        for label in ("source-a", "source-b", "source-c"):
+        for kind in (
+            "registry",
+            "profile",
+            "git-admin",
+            "source",
+            "topology",
+            "scenario",
+            "state",
+            "build-root",
+            "cache",
+        ):
+            with self.subTest(kind=kind):
+                entered = context.Queue()
+                results = context.Queue()
+                release_reader = context.Event()
+                release_writers = context.Event()
+                writer_attempting = context.Event()
+                coordinate_a = f"{kind}:a"
+                coordinate_b = f"{kind}:b"
+                reader = context.Process(
+                    target=resource_lease_process,
+                    args=(
+                        str(self.workspace_directory),
+                        kind,
+                        coordinate_a,
+                        "shared",
+                        "reader-a",
+                        entered,
+                        release_reader,
+                        results,
+                    ),
+                )
+                writer_a = context.Process(
+                    target=resource_lease_process,
+                    args=(
+                        str(self.workspace_directory),
+                        kind,
+                        coordinate_a,
+                        "exclusive",
+                        "writer-a",
+                        entered,
+                        release_writers,
+                        results,
+                        writer_attempting,
+                    ),
+                )
+                writer_b = context.Process(
+                    target=resource_lease_process,
+                    args=(
+                        str(self.workspace_directory),
+                        kind,
+                        coordinate_b,
+                        "exclusive",
+                        "writer-b",
+                        entered,
+                        release_writers,
+                        results,
+                    ),
+                )
+                processes = [reader, writer_a, writer_b]
+                started: list[multiprocessing.Process] = []
+                try:
+                    reader.start()
+                    started.append(reader)
+                    self.assertEqual(entered.get(timeout=5), "reader-a")
+                    writer_a.start()
+                    started.append(writer_a)
+                    self.assertTrue(writer_attempting.wait(5))
+                    pending = locking_module.layout_writer_pending_path(
+                        resource_lock_path(
+                            self.workspace_directory, kind, coordinate_a
+                        )
+                    )
+                    deadline = time.monotonic() + 5
+                    while time.monotonic() < deadline:
+                        try:
+                            with exclusive_lock(
+                                pending,
+                                f"{kind} writer pending observation",
+                                nonblocking=True,
+                            ):
+                                pass
+                        except locking_module.LockBusyError:
+                            break
+                        time.sleep(0.005)
+                    else:
+                        self.fail(f"{kind} writer did not publish pending state")
+
+                    writer_b.start()
+                    started.append(writer_b)
+                    self.assertEqual(entered.get(timeout=5), "writer-b")
+                    release_reader.set()
+                    self.assertEqual(entered.get(timeout=5), "writer-a")
+                finally:
+                    release_reader.set()
+                    release_writers.set()
+                    join_or_stop_processes(started, 10)
+                self.assertEqual(started, processes)
+                self.assertEqual(
+                    [process.exitcode for process in processes], [0, 0, 0]
+                )
+                self.assertEqual(
+                    [results.get(timeout=2) for _ in processes], [None] * 3
+                )
+
+    def test_incremental_harness_isolates_live_topology_conflicts(self) -> None:
+        context = multiprocessing.get_context("spawn")
+        for label in ("source-a", "source-c"):
             self.workspace.create_worktree(
                 "client", label, f"test/{label}", None, False
             )
         self.workspace.create_worktree(
             "sound", "source-c", "test/sound-source-c", None, False
         )
-        for profile in ("profile-a", "profile-b", "profile-c"):
+        for profile in ("profile-a", "profile-c"):
             self.workspace.create_profile(profile)
         self.workspace.set_profile(
             "profile-a", "client", "worktree", "source-a"
-        )
-        self.workspace.set_profile(
-            "profile-b", "client", "worktree", "source-b"
         )
         self.workspace.set_profile(
             "profile-c", "client", "worktree", "source-c"
@@ -6755,20 +6841,72 @@ class WorkspaceTests(unittest.TestCase):
                 "topology-a", "profile-a", "default", ["client"]
             )
         self.assertTrue(topology_a["ready"])
+        generation_root = Path(topology_a["runtime"]["path"])
+        generation_digest = _tree_digest(
+            generation_root, frozenset(), reject_symlinks=True
+        )
+        source_a = self.workspace.paths.worktrees / "client" / "source-a"
+        (source_a / "post-publication.txt").write_text(
+            "changed source\n", encoding="utf-8"
+        )
+        (topology_a_root / "build" / "client" / "atrinik").write_text(
+            "#!/bin/sh\nexit 1\n", encoding="utf-8"
+        )
+        self.assertEqual(
+            _tree_digest(generation_root, frozenset(), reject_symlinks=True),
+            generation_digest,
+        )
+        self.assertTrue(self.workspace.topology_status("topology-a")["ready"])
 
-        writer_pending = context.Event()
-        writer_entered = context.Event()
+        coordinate_a = self.workspace._source_coordinate("client", source_a)
+        exact_entered = context.Queue()
+        release_initial = context.Event()
+        release_writer = context.Event()
+        release_late_reader = context.Event()
+        writer_attempting = context.Event()
+        late_reader_attempting = context.Event()
         readers_blocked = [context.Event(), context.Event()]
         readers_entered = [context.Event(), context.Event()]
         results = context.Queue()
-        writer = context.Process(
-            target=profile_mutation_process,
+        initial_reader = context.Process(
+            target=resource_lease_process,
             args=(
-                str(self.wrapper),
-                str(self.workspace_directory),
-                writer_pending,
-                writer_entered,
+                str(self.workspace._lease_namespace),
+                "source",
+                coordinate_a,
+                "shared",
+                "initial-reader-a",
+                exact_entered,
+                release_initial,
                 results,
+            ),
+        )
+        writer = context.Process(
+            target=resource_lease_process,
+            args=(
+                str(self.workspace._lease_namespace),
+                "source",
+                coordinate_a,
+                "exclusive",
+                "writer-a",
+                exact_entered,
+                release_writer,
+                results,
+                writer_attempting,
+            ),
+        )
+        late_reader = context.Process(
+            target=resource_lease_process,
+            args=(
+                str(self.workspace._lease_namespace),
+                "source",
+                coordinate_a,
+                "shared",
+                "late-reader-a",
+                exact_entered,
+                release_late_reader,
+                results,
+                late_reader_attempting,
             ),
         )
         readers = [
@@ -6786,17 +6924,38 @@ class WorkspaceTests(unittest.TestCase):
             )
             for index, operation in enumerate(("build-c", "topology-c"))
         ]
-        processes = [writer, *readers]
+        processes = [initial_reader, writer, late_reader, *readers]
         started: list[multiprocessing.Process] = []
         try:
+            initial_reader.start()
+            started.append(initial_reader)
+            self.assertEqual(exact_entered.get(timeout=5), "initial-reader-a")
             writer.start()
             started.append(writer)
-            wait_for_process_event(
-                writer_pending, "profile B mutation attempt", results
+            self.assertTrue(writer_attempting.wait(5))
+            pending = locking_module.layout_writer_pending_path(
+                resource_lock_path(
+                    self.workspace._lease_namespace, "source", coordinate_a
+                )
             )
-            wait_for_process_event(
-                writer_entered, "profile B mutation entry", results
-            )
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline:
+                try:
+                    with exclusive_lock(
+                        pending,
+                        "source A writer pending observation",
+                        nonblocking=True,
+                    ):
+                        pass
+                except locking_module.LockBusyError:
+                    break
+                time.sleep(0.005)
+            else:
+                self.fail("source A writer did not publish pending state")
+
+            late_reader.start()
+            started.append(late_reader)
+            self.assertTrue(late_reader_attempting.wait(5))
 
             for reader in readers:
                 reader.start()
@@ -6806,12 +6965,19 @@ class WorkspaceTests(unittest.TestCase):
                     entered, f"disjoint C reader {index} completion", results, 10
                 )
             self.assertTrue(self.workspace.topology_status("topology-a")["ready"])
+            release_initial.set()
+            self.assertEqual(exact_entered.get(timeout=5), "writer-a")
+            release_writer.set()
+            self.assertEqual(exact_entered.get(timeout=5), "late-reader-a")
+            release_late_reader.set()
 
-            # The topology retains only its immutable runtime generation and
-            # exact process/state leases after publication. Unrelated layout
-            # mutation and readers therefore progress while it remains live.
+            # The immutable topology remains live while fairness gates only
+            # source A and disjoint build/topology C operations complete.
             self.workspace.topology_down("topology-a", timeout=5)
         finally:
+            release_initial.set()
+            release_writer.set()
+            release_late_reader.set()
             status_path = (
                 self.workspace.paths.topologies / "topology-a" / "status.json"
             )
@@ -6823,8 +6989,8 @@ class WorkspaceTests(unittest.TestCase):
                     pass
             join_or_stop_processes(started, 10)
         self.assertEqual(started, processes)
-        self.assertEqual([process.exitcode for process in processes], [0] * 3)
-        self.assertEqual([results.get(timeout=2) for _ in processes], [None] * 3)
+        self.assertEqual([process.exitcode for process in processes], [0] * 5)
+        self.assertEqual([results.get(timeout=2) for _ in processes], [None] * 5)
 
     def test_distinct_server_ports_reach_pre_ready_concurrently(
         self,

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -334,6 +334,7 @@ def resource_lease_process(
     release: object | None,
     results: object,
     attempting: object | None = None,
+    entered_event: object | None = None,
 ) -> None:
     try:
         request = LeaseRequest(
@@ -346,9 +347,47 @@ def resource_lease_process(
         if attempting is not None:
             attempting.set()
         with resource_locks(Path(workspace_directory), [request]):
+            if entered_event is not None:
+                entered_event.set()
             entered.put(name)
-            if release is not None and not release.wait(10):
+            if release is not None and not release.wait(60):
                 raise TimeoutError(f"{name} was not released")
+        results.put(None)
+    except BaseException as error:
+        results.put(f"{type(error).__name__}: {error}")
+        raise
+
+
+def public_profile_mutation_process(
+    wrapper: str,
+    workspace_directory: str,
+    attempting: object,
+    entered: object,
+    release: object,
+    results: object,
+) -> None:
+    try:
+        with mock.patch.dict(
+            os.environ, {"ATRINIK_WORKSPACE_DIR": workspace_directory}
+        ):
+            workspace = Workspace(Path(wrapper))
+            original = workspace._set_profile
+
+            def paused_mutation(
+                name: str, component_name: str, kind: str, value: str = ""
+            ) -> None:
+                entered.set()
+                if not release.wait(60):
+                    raise TimeoutError("profile mutation was not released")
+                original(name, component_name, kind, value)
+
+            with mock.patch.object(
+                workspace, "_set_profile", side_effect=paused_mutation
+            ):
+                attempting.set()
+                workspace.set_profile(
+                    "profile-a", "client", "worktree", "source-a"
+                )
         results.put(None)
     except BaseException as error:
         results.put(f"{type(error).__name__}: {error}")
@@ -6697,12 +6736,17 @@ class WorkspaceTests(unittest.TestCase):
                 release_reader = context.Event()
                 release_writers = context.Event()
                 writer_attempting = context.Event()
+                writer_a_entered = context.Event()
+                writer_b_entered = context.Event()
                 coordinate_a = f"{kind}:a"
                 coordinate_b = f"{kind}:b"
+                lease_root = self.workspace._lease_root(
+                    LeaseRequest(kind, coordinate_a, "shared", "matrix", "wait")
+                )
                 reader = context.Process(
                     target=resource_lease_process,
                     args=(
-                        str(self.workspace_directory),
+                        str(lease_root),
                         kind,
                         coordinate_a,
                         "shared",
@@ -6715,7 +6759,7 @@ class WorkspaceTests(unittest.TestCase):
                 writer_a = context.Process(
                     target=resource_lease_process,
                     args=(
-                        str(self.workspace_directory),
+                        str(lease_root),
                         kind,
                         coordinate_a,
                         "exclusive",
@@ -6724,12 +6768,13 @@ class WorkspaceTests(unittest.TestCase):
                         release_writers,
                         results,
                         writer_attempting,
+                        writer_a_entered,
                     ),
                 )
                 writer_b = context.Process(
                     target=resource_lease_process,
                     args=(
-                        str(self.workspace_directory),
+                        str(lease_root),
                         kind,
                         coordinate_b,
                         "exclusive",
@@ -6737,6 +6782,8 @@ class WorkspaceTests(unittest.TestCase):
                         entered,
                         release_writers,
                         results,
+                        None,
+                        writer_b_entered,
                     ),
                 )
                 processes = [reader, writer_a, writer_b]
@@ -6749,9 +6796,7 @@ class WorkspaceTests(unittest.TestCase):
                     started.append(writer_a)
                     self.assertTrue(writer_attempting.wait(5))
                     pending = locking_module.layout_writer_pending_path(
-                        resource_lock_path(
-                            self.workspace_directory, kind, coordinate_a
-                        )
+                        resource_lock_path(lease_root, kind, coordinate_a)
                     )
                     deadline = time.monotonic() + 5
                     while time.monotonic() < deadline:
@@ -6770,9 +6815,10 @@ class WorkspaceTests(unittest.TestCase):
 
                     writer_b.start()
                     started.append(writer_b)
-                    self.assertEqual(entered.get(timeout=5), "writer-b")
+                    self.assertTrue(writer_b_entered.wait(5))
+                    self.assertFalse(writer_a_entered.is_set())
                     release_reader.set()
-                    self.assertEqual(entered.get(timeout=5), "writer-a")
+                    self.assertTrue(writer_a_entered.wait(5))
                 finally:
                     release_reader.set()
                     release_writers.set()
@@ -6787,10 +6833,12 @@ class WorkspaceTests(unittest.TestCase):
 
     def test_incremental_harness_isolates_live_topology_conflicts(self) -> None:
         context = multiprocessing.get_context("spawn")
-        for label in ("source-a", "source-c"):
-            self.workspace.create_worktree(
-                "client", label, f"test/{label}", None, False
-            )
+        source_a = self.workspace.create_worktree(
+            "client", "source-a", "test/source-a", None, False
+        )
+        self.workspace.create_worktree(
+            "client", "source-c", "test/source-c", None, False
+        )
         self.workspace.create_worktree(
             "sound", "source-c", "test/sound-source-c", None, False
         )
@@ -6840,12 +6888,24 @@ class WorkspaceTests(unittest.TestCase):
             topology_a = self.workspace.topology_up(
                 "topology-a", "profile-a", "default", ["client"]
             )
+
+        def stop_topology_a() -> None:
+            status_path = (
+                self.workspace.paths.topologies / "topology-a" / "status.json"
+            )
+            if status_path.is_file():
+                try:
+                    if self.workspace.topology_status("topology-a")["ready"]:
+                        self.workspace.topology_down("topology-a", timeout=5)
+                except WorkspaceError:
+                    pass
+
+        self.addCleanup(stop_topology_a)
         self.assertTrue(topology_a["ready"])
         generation_root = Path(topology_a["runtime"]["path"])
         generation_digest = _tree_digest(
             generation_root, frozenset(), reject_symlinks=True
         )
-        source_a = self.workspace.paths.worktrees / "client" / "source-a"
         (source_a / "post-publication.txt").write_text(
             "changed source\n", encoding="utf-8"
         )
@@ -6858,21 +6918,26 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertTrue(self.workspace.topology_status("topology-a")["ready"])
 
-        coordinate_a = self.workspace._source_coordinate("client", source_a)
+        coordinate_a = "profile-a"
+        lease_root = self.workspace._lease_root(
+            LeaseRequest("profile", coordinate_a, "shared", "matrix", "wait")
+        )
         exact_entered = context.Queue()
         release_initial = context.Event()
         release_writer = context.Event()
         release_late_reader = context.Event()
         writer_attempting = context.Event()
         late_reader_attempting = context.Event()
+        writer_entered = context.Event()
+        late_reader_entered = context.Event()
         readers_blocked = [context.Event(), context.Event()]
         readers_entered = [context.Event(), context.Event()]
         results = context.Queue()
         initial_reader = context.Process(
             target=resource_lease_process,
             args=(
-                str(self.workspace._lease_namespace),
-                "source",
+                str(lease_root),
+                "profile",
                 coordinate_a,
                 "shared",
                 "initial-reader-a",
@@ -6882,24 +6947,21 @@ class WorkspaceTests(unittest.TestCase):
             ),
         )
         writer = context.Process(
-            target=resource_lease_process,
+            target=public_profile_mutation_process,
             args=(
-                str(self.workspace._lease_namespace),
-                "source",
-                coordinate_a,
-                "exclusive",
-                "writer-a",
-                exact_entered,
+                str(self.wrapper),
+                str(self.workspace_directory),
+                writer_attempting,
+                writer_entered,
                 release_writer,
                 results,
-                writer_attempting,
             ),
         )
         late_reader = context.Process(
             target=resource_lease_process,
             args=(
-                str(self.workspace._lease_namespace),
-                "source",
+                str(lease_root),
+                "profile",
                 coordinate_a,
                 "shared",
                 "late-reader-a",
@@ -6907,6 +6969,7 @@ class WorkspaceTests(unittest.TestCase):
                 release_late_reader,
                 results,
                 late_reader_attempting,
+                late_reader_entered,
             ),
         )
         readers = [
@@ -6934,16 +6997,14 @@ class WorkspaceTests(unittest.TestCase):
             started.append(writer)
             self.assertTrue(writer_attempting.wait(5))
             pending = locking_module.layout_writer_pending_path(
-                resource_lock_path(
-                    self.workspace._lease_namespace, "source", coordinate_a
-                )
+                resource_lock_path(lease_root, "profile", coordinate_a)
             )
             deadline = time.monotonic() + 5
             while time.monotonic() < deadline:
                 try:
                     with exclusive_lock(
                         pending,
-                        "source A writer pending observation",
+                        "profile A writer pending observation",
                         nonblocking=True,
                     ):
                         pass
@@ -6951,11 +7012,13 @@ class WorkspaceTests(unittest.TestCase):
                     break
                 time.sleep(0.005)
             else:
-                self.fail("source A writer did not publish pending state")
+                self.fail("profile A writer did not publish pending state")
 
             late_reader.start()
             started.append(late_reader)
             self.assertTrue(late_reader_attempting.wait(5))
+            self.assertFalse(writer_entered.is_set())
+            self.assertFalse(late_reader_entered.is_set())
 
             for reader in readers:
                 reader.start()
@@ -6966,27 +7029,20 @@ class WorkspaceTests(unittest.TestCase):
                 )
             self.assertTrue(self.workspace.topology_status("topology-a")["ready"])
             release_initial.set()
-            self.assertEqual(exact_entered.get(timeout=5), "writer-a")
+            self.assertTrue(writer_entered.wait(5))
+            self.assertFalse(late_reader_entered.is_set())
             release_writer.set()
-            self.assertEqual(exact_entered.get(timeout=5), "late-reader-a")
+            self.assertTrue(late_reader_entered.wait(5))
             release_late_reader.set()
 
-            # The immutable topology remains live while fairness gates only
-            # source A and disjoint build/topology C operations complete.
+            # The immutable topology remains live while a real profile A
+            # mutation gates only A and disjoint build/topology C completes.
             self.workspace.topology_down("topology-a", timeout=5)
         finally:
             release_initial.set()
             release_writer.set()
             release_late_reader.set()
-            status_path = (
-                self.workspace.paths.topologies / "topology-a" / "status.json"
-            )
-            if status_path.is_file():
-                try:
-                    if self.workspace.topology_status("topology-a")["ready"]:
-                        self.workspace.topology_down("topology-a", timeout=5)
-                except WorkspaceError:
-                    pass
+            stop_topology_a()
             join_or_stop_processes(started, 10)
         self.assertEqual(started, processes)
         self.assertEqual([process.exitcode for process in processes], [0] * 5)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -6719,16 +6719,9 @@ class WorkspaceTests(unittest.TestCase):
 
     def test_exact_resource_matrix_scopes_conflicts_to_coordinates(self) -> None:
         context = multiprocessing.get_context("spawn")
-        for kind in (
-            "registry",
-            "profile",
-            "git-admin",
-            "source",
-            "topology",
-            "scenario",
-            "state",
-            "build-root",
-            "cache",
+        for kind in sorted(
+            locking_module.RESOURCE_KIND_ORDER,
+            key=locking_module.RESOURCE_KIND_ORDER.__getitem__,
         ):
             with self.subTest(kind=kind):
                 entered = context.Queue()
@@ -6880,17 +6873,22 @@ class WorkspaceTests(unittest.TestCase):
         topology_a_root = client_build_root("profile-a")
         topology_c_root = client_build_root("profile-c")
 
-        def stop_topology_a() -> None:
-            status_path = (
-                self.workspace.paths.topologies / "topology-a" / "status.json"
-            )
-            if status_path.is_file():
+        def stop_test_topologies() -> None:
+            failures = []
+            for name in ("topology-a", "topology-c"):
+                status_path = (
+                    self.workspace.paths.topologies / name / "status.json"
+                )
+                if not status_path.is_file():
+                    continue
                 try:
-                    self.workspace.topology_down("topology-a", timeout=5)
-                except WorkspaceError:
-                    pass
+                    self.workspace.topology_down(name, timeout=5)
+                except WorkspaceError as error:
+                    failures.append(f"{name}: {error}")
+            if failures:
+                self.fail("cannot stop test topologies: " + "; ".join(failures))
 
-        self.addCleanup(stop_topology_a)
+        self.addCleanup(stop_test_topologies)
         with (
             mock.patch.object(
                 self.workspace, "_build_resolved", return_value=topology_a_root
@@ -7041,8 +7039,8 @@ class WorkspaceTests(unittest.TestCase):
             release_initial.set()
             release_writer.set()
             release_late_reader.set()
-            stop_topology_a()
             join_or_stop_processes(started, 10)
+            stop_test_topologies()
         self.assertEqual(started, processes)
         self.assertEqual([process.exitcode for process in processes], [0] * 5)
         self.assertEqual([results.get(timeout=2) for _ in processes], [None] * 5)


### PR DESCRIPTION
## Summary

- add an exact-coordinate conflict/isolation matrix derived from every production lease kind, including maintenance
- extend the concurrent lifecycle harness to prove queued-writer fairness without convoying disjoint build/topology work
- verify a published topology stays live and byte-stable after its selected source and mutable build output change

## Scope

This is the incremental post-P0 portion of #404 described by #398. The P0 regression harness landed in #405, and the resource behaviors from #399, #400, and #401 are now on `main`.

This PR is incremental, and #404 must remain open. Final P2 coverage remains dependent on the unfinished state-policy and lifecycle work in #402 and #403.

## Coordinates

- base: `main@c8e37307344a0ad0e1711f60961119413e9cccec`
- head: `test/concurrent-lifecycle-isolation-404@5b8f19872c58fcaabe020d6c2243aaf3e78deac7`
- worktree: `/workspaces/atrinik/workspace/worktrees/atrinik/issue-404-lifecycle-isolation`

## Verification

- `/workspaces/atrinik/.venv/bin/python -m coverage run -m unittest discover -q` — 757 tests passed in 235.461s
- `/workspaces/atrinik/.venv/bin/python -m coverage report --format=total` — 83% total coverage
- both new concurrency tests repeated five times successfully
- focused lifecycle, lease-matrix, source-removal, topology, and port-isolation tests passed outside the socket-restricted sandbox
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `./atrinik cleanup --scope all --older-than 7 --dry-run --json` — 302 protected, zero candidates or errors; no apply
- `git diff --check`

The runtime checks use deterministic temporary supervisor fixtures. They require no Classic account, shared state, or gameplay scenario, and teardown stops all child processes and removes the temporary resources.

Relates to #404 and #398.
