### PR TITLE
perf(workspace): keep worktree builds from blocking primary sync

### DIFF
--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -86,8 +86,8 @@ wrapper replacement build/runtime closure yet.
 ```
 
 Classic selection is checkout-wide; subdirectories are not worktrees. Clean
-exact-coordinate content, resource, and region-map caches are reused; runtimes
-copy independent topology-owned snapshots.
+Target builds snapshot clean primaries; other inputs retain exact leases. Caches
+stay exact and runtimes copy.
 
 Lease order is registry, profile, Git-admin, source, topology/scenario, state,
 build, cache. Writers gate matching coordinates; physical leases span state

--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -44,10 +44,9 @@ clones.
 ./atrinik worktree create COMPONENT LABEL --branch TYPE/TOPIC
 ```
 
-Sync only clean primaries; never implicitly replace, move, or remove a
-dirty checkout or worktree. A logical classic selector creates the full
-repository under `workspace/worktrees/classic/LABEL`. Commit and push from each
-owning worktree.
+Sync only clean primaries; never replace, move, or remove dirty sources.
+Classic selectors create the full repository under
+`workspace/worktrees/classic/LABEL`. Commit and push in its owning worktree.
 
 Reclaim review data only through preview-first cleanup:
 
@@ -86,8 +85,9 @@ wrapper replacement build/runtime closure yet.
 ```
 
 Classic selection is checkout-wide; subdirectories are not worktrees. Clean
-Target builds snapshot clean primaries; other inputs retain exact leases. Caches
-stay exact and runtimes copy.
+target builds pin generated snapshots before releasing primaries; caches
+use snapshot identity. Live inputs retain leases; interrupted staging is
+cleanup-owned.
 
 Lease order is registry, profile, Git-admin, source, topology/scenario, state,
 build, cache. Writers gate matching coordinates; physical leases span state

--- a/README.md
+++ b/README.md
@@ -715,7 +715,10 @@ Immutable source generations use the same default `builds` scope and grace
 period. Cleanup authenticates their checkout/key path, ownership marker,
 closed commit/tree/subpath metadata, and complete tree digest. An active build
 holds the generation's shared lock; apply takes its exclusive side and repeats
-identity, digest, and age validation before bounded removal.
+identity, digest, and age validation before bounded removal. Generation staging
+transactions within the marker-owned container are separately inventoried,
+remain protected under an active generation lock, and are reclaimable after
+interruption and the normal grace period.
 
 Worker dependency entries under `workspace/build/worker-dependencies/` use the
 same default `builds` scope and grace period. Cleanup requires the exact parent
@@ -1075,11 +1078,15 @@ transitive provider closure, then locks only those selected sources and
 revalidates them. Clean primary inputs are exported atomically into reusable,
 commit/tree/subpath-keyed read-only generations below
 `workspace/build/source-generations/`; reuse verifies ownership metadata and a
-complete tree digest. No generation links or hard-links back to mutable primary
-files. Once those generations are published, their primary source leases are
-released while dirty primaries and worktrees stay locked for as long as the
-build can read them. The build persists original filesystem/Git observations
-and immutable generation paths and digests in
+complete tree digest plus the captured checkout, source, and common-Git
+filesystem identities. No generation links or hard-links back to mutable
+primary files. Every generated path is revalidated after the build takes its
+shared pin; only then are its primary source leases released. Dirty primaries
+and worktrees stay locked for as long as the build
+can read them. Cache and region-map coordinates come from the captured snapshot
+or generation metadata rather than rereading a released primary. The build
+persists original filesystem/Git observations and immutable generation paths
+and digests in
 `.atrinik-profile-resolution.json`, and does not reread a mutable profile by
 name. Profile or topology publication and worktree removal share any remaining
 live target source lease, so cleanup cannot race a newly published exact

--- a/README.md
+++ b/README.md
@@ -584,6 +584,19 @@ left in that worktree for normal Git resolution. Historical `content-1x`
 paths and records are inert and are never treated as `content@main`. Create new
 content review worktrees from the shared `content` checkout.
 
+A target build resolves only that target's transitive provider inputs. During
+its bounded preparation phase, each clean primary input is exported from its
+exact Git commit into a wrapper-owned, read-only source generation; the build
+then releases that primary's source lease before configure, compile, and tests.
+Consequently a long-running build from a Classic feature worktree does not
+block `sync --with classic` from advancing unrelated or snapshotted clean
+primaries. Dirty sources and selected worktrees remain live inputs and retain
+their exact source leases. The authored Classic content publisher still proves
+its target against a live Git checkout, so operations that consume it retain
+that exact content lease. `build all` requests the union of every target's
+dependency closure and retains or snapshots every input without weakening
+coherence.
+
 ## Checkout worktrees
 
 Create a branch and full-repository worktree from a checkout's remote default
@@ -621,8 +634,8 @@ inside it.
 
 Cleanup is always operator-invoked and preview-first. With no options it
 inventories registered worktrees and marker-owned profile builds older than
-seven days, including individually marker-owned Worker dependency entries,
-without changing the filesystem:
+seven days, including immutable source generations and individually
+marker-owned Worker dependency entries, without changing the filesystem:
 
 ~~~sh
 ./atrinik cleanup
@@ -697,6 +710,12 @@ a live topology, busy build lock, registered worktree, or the optional strict
 schema 1 and contains exactly `schema_version` plus an absolute `build_roots`
 array. A build sourced from a worktree eligible in the same plan may be
 reclaimed regardless of age unless another protection applies.
+
+Immutable source generations use the same default `builds` scope and grace
+period. Cleanup authenticates their checkout/key path, ownership marker,
+closed commit/tree/subpath metadata, and complete tree digest. An active build
+holds the generation's shared lock; apply takes its exclusive side and repeats
+identity, digest, and age validation before bounded removal.
 
 Worker dependency entries under `workspace/build/worker-dependencies/` use the
 same default `builds` scope and grace period. Cleanup requires the exact parent
@@ -1051,14 +1070,21 @@ not retain earlier disjoint source coordinates. Distinct explicit topology
 ports use exact startup locks; only automatic port selection briefly uses the
 allocator mutex.
 
-A build holds its profile-name lease while resolving, then locks the selected
-sources, revalidates them, and captures one immutable generation containing the
-stack/providers, exact roots, Git identities, HEADs, and dirty observations.
-The build persists that generation in `.atrinik-profile-resolution.json` and
-does not reread a mutable profile by name. Profile or topology publication and
-worktree removal share the target source lease, so cleanup cannot race a newly
-published exact reference. Cleanup apply locks and revalidates one stable-sorted
-candidate at a time, skips busy candidates, and journals completed actions in
+A build holds its profile-name lease while deriving the requested target's
+transitive provider closure, then locks only those selected sources and
+revalidates them. Clean primary inputs are exported atomically into reusable,
+commit/tree/subpath-keyed read-only generations below
+`workspace/build/source-generations/`; reuse verifies ownership metadata and a
+complete tree digest. No generation links or hard-links back to mutable primary
+files. Once those generations are published, their primary source leases are
+released while dirty primaries and worktrees stay locked for as long as the
+build can read them. The build persists original filesystem/Git observations
+and immutable generation paths and digests in
+`.atrinik-profile-resolution.json`, and does not reread a mutable profile by
+name. Profile or topology publication and worktree removal share any remaining
+live target source lease, so cleanup cannot race a newly published exact
+reference. Cleanup apply locks and revalidates one stable-sorted candidate at a
+time, skips busy candidates, and journals completed actions in
 `workspace/cleanup-journals/`.
 
 Waits longer than 10 seconds report the resource kind, stable coordinate, known

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -35,6 +35,8 @@ from .workspace import (
     BUILD_METADATA,
     BUILD_METADATA_SCHEMA_VERSION,
     CACHE_METADATA,
+    SOURCE_GENERATION_SCHEMA_VERSION,
+    SOURCE_GENERATION_METADATA,
     WORKER_DEPENDENCY_METADATA,
     WORKER_DEPENDENCY_SCHEMA_VERSION,
     COMPILER_CACHE_MAX_SIZE,
@@ -46,6 +48,7 @@ from .workspace import (
     _open_directory_nofollow,
     _owned_tree_tombstone_path,
     _remote_matches,
+    _tree_digest,
     exclusive_lock,
     remove_owned_tree,
 )
@@ -66,6 +69,7 @@ ALL_SCOPES = (
 SUPPORTED_SCOPES = (*ALL_SCOPES, "topologies")
 BUILD_RETENTION_RECORD = "retention.json"
 LEGACY_BUILD_METADATA_SCHEMA_VERSION = 1
+PRE_SOURCE_GENERATION_BUILD_METADATA_SCHEMA_VERSION = 2
 LEGACY_BUILD_METADATA_KEYS = {
     "schema_version",
     "profile",
@@ -85,6 +89,19 @@ BUILD_COORDINATE_KEYS = {
     "source_path",
     "head",
 }
+SOURCE_GENERATION_KEYS = {
+    "schema_version",
+    "repository",
+    "checkout",
+    "branch",
+    "commit",
+    "tree",
+    "source",
+    "source_tree",
+    "source_tree_sha256",
+    "path",
+}
+SOURCE_GENERATION_METADATA_KEYS = SOURCE_GENERATION_KEYS - {"path"}
 PROFILE_PURPOSE = re.compile(
     r"^profile:(?P<profile>[a-z0-9][a-z0-9._-]*):(?P<key>[0-9a-f]{12})$"
 )
@@ -1187,6 +1204,10 @@ class Cleanup:
                 removable_worktrees,
                 references,
                 reference_errors,
+            )
+        elif kind == "source-generation":
+            item = self._source_generation_item(
+                path, target["checkout"], older_than_days
             )
         elif kind == "worker-dependencies":
             item = self._worker_dependency_item(
@@ -2853,7 +2874,178 @@ class Cleanup:
                 older_than_days, registered, references, reference_errors
             )
         )
+        items.extend(self._source_generations(older_than_days))
         return items
+
+    def _source_generations(self, older_than_days: int) -> list[dict[str, Any]]:
+        root = self.paths.builds / "source-generations"
+        if not root.exists() and not root.is_symlink():
+            return []
+        items: list[dict[str, Any]] = []
+        try:
+            if root.is_symlink() or not root.is_dir():
+                raise WorkspaceError("source generation root is invalid")
+            checkout_roots = sorted(root.iterdir())
+        except (OSError, WorkspaceError) as error:
+            item = _base_item(
+                "unmanaged-build", "atrinik", "atrinik/atrinik", root
+            )
+            item["reasons"] = ["invalid_source_generation_root"]
+            item["error"] = str(error)
+            return [item]
+        for checkout_root in checkout_roots:
+            try:
+                checkout = checkout_root.name
+                marker = checkout_root / MANAGED_MARKER
+                if (
+                    checkout_root.is_symlink()
+                    or not checkout_root.is_dir()
+                    or checkout not in self.manifest.by_checkout
+                    or marker.is_symlink()
+                    or load_json(marker)
+                    != {
+                        "schema_version": SCHEMA_VERSION,
+                        "purpose": f"source-generations:{checkout}",
+                    }
+                ):
+                    raise WorkspaceError(
+                        "source generation checkout root is invalid"
+                    )
+                generations = sorted(
+                    path
+                    for path in checkout_root.iterdir()
+                    if path.name != MANAGED_MARKER
+                )
+            except (OSError, WorkspaceError) as error:
+                item = _base_item(
+                    "unmanaged-build",
+                    "atrinik",
+                    "atrinik/atrinik",
+                    checkout_root,
+                )
+                item["reasons"] = ["invalid_source_generation_checkout_root"]
+                item["error"] = str(error)
+                items.append(item)
+                continue
+            items.extend(
+                self._source_generation_item(path, checkout, older_than_days)
+                for path in generations
+            )
+        return items
+
+    def _source_generation_item(
+        self,
+        path: Path,
+        checkout: str,
+        older_than_days: int,
+        *,
+        check_lock: bool = True,
+    ) -> dict[str, Any]:
+        checkout_record = self.manifest.by_checkout.get(checkout)
+        repository = (
+            checkout_record.repository
+            if checkout_record is not None
+            else "atrinik/atrinik"
+        )
+        item = _base_item("source-generation", checkout, repository, path)
+        inodes, observed, walk_error = _tree_usage(path)
+        item["_inodes"] = inodes
+        key = path.name
+        item["key"] = key
+        item["checkout"] = checkout
+        if walk_error:
+            item["reasons"].append("filesystem_traversal_error")
+            item["error"] = walk_error
+        try:
+            marker = path / MANAGED_MARKER
+            metadata_path = path / SOURCE_GENERATION_METADATA
+            source = path / "source"
+            metadata = load_json(metadata_path)
+            identity = (
+                {
+                    field: metadata.get(field)
+                    for field in SOURCE_GENERATION_METADATA_KEYS
+                    if field != "source_tree_sha256"
+                }
+                if isinstance(metadata, dict)
+                else {}
+            )
+            expected_key = hashlib.sha256(
+                json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
+            ).hexdigest()
+            matching_components = (
+                [
+                    component
+                    for component in self.manifest.components
+                    if component.checkout_name == checkout
+                    and component.repository == metadata.get("repository")
+                    and component.branch == metadata.get("branch")
+                    and component.source == metadata.get("source")
+                ]
+                if isinstance(metadata, dict)
+                else []
+            )
+            if (
+                not re.fullmatch(r"[0-9a-f]{64}", key)
+                or path.is_symlink()
+                or not path.is_dir()
+                or marker.is_symlink()
+                or load_json(marker)
+                != {
+                    "schema_version": SCHEMA_VERSION,
+                    "purpose": f"source-generation:{key}",
+                }
+                or metadata_path.is_symlink()
+                or not metadata_path.is_file()
+                or not isinstance(metadata, dict)
+                or set(metadata) != SOURCE_GENERATION_METADATA_KEYS
+                or metadata.get("schema_version")
+                != SOURCE_GENERATION_SCHEMA_VERSION
+                or metadata.get("checkout") != checkout
+                or key != expected_key
+                or not matching_components
+                or not all(
+                    isinstance(metadata.get(field), str)
+                    and HEAD_PATTERN.fullmatch(metadata[field])
+                    for field in (
+                        "commit",
+                        "tree",
+                        "source_tree",
+                        "source_tree_sha256",
+                    )
+                )
+                or metadata.get("source_tree_sha256")
+                != _tree_digest(source, set(), bounded_symlinks=True)
+            ):
+                raise WorkspaceError("source generation metadata is invalid")
+            item["source_tree_sha256"] = metadata["source_tree_sha256"]
+        except (OSError, RuntimeError, WorkspaceError) as error:
+            item["reasons"].append("invalid_source_generation")
+            item["error"] = str(error)
+        if check_lock and re.fullmatch(r"[0-9a-f]{64}", key):
+            busy, lock_error = self._lock_busy(
+                self.paths.builds / "locks" / f"source-generation-{key}.lock"
+            )
+            if lock_error:
+                item["reasons"].append("build_lock_error")
+                item["error"] = lock_error
+            elif busy:
+                item["reasons"].append("build_lock_busy")
+        item["age_basis"] = "tree-mtime" if observed else None
+        if observed is None:
+            item["reasons"].append("build_age_unavailable")
+        else:
+            age = max(0, int((self.now - observed).total_seconds()))
+            item["age_seconds"] = age
+            if observed > self.now:
+                item["reasons"].append("future_tree_mtime")
+            elif age < older_than_days * 86400:
+                item["reasons"].append("younger_than_grace_period")
+        item["reasons"] = sorted(set(item["reasons"]))
+        if not item["reasons"]:
+            item["disposition"] = "eligible"
+            item["reasons"] = ["stale_source_generation"]
+        return item
 
     def _worker_dependency_caches(
         self,
@@ -3302,6 +3494,7 @@ class Cleanup:
             schema_version
             not in {
                 LEGACY_BUILD_METADATA_SCHEMA_VERSION,
+                PRE_SOURCE_GENERATION_BUILD_METADATA_SCHEMA_VERSION,
                 BUILD_METADATA_SCHEMA_VERSION,
             }
             or value.get("profile") != item["profile"]
@@ -3315,8 +3508,14 @@ class Cleanup:
             if (
                 not isinstance(role, str)
                 or not isinstance(row, dict)
-                or set(row) != BUILD_COORDINATE_KEYS
-                or not all(isinstance(raw, str) and raw for raw in row.values())
+                or frozenset(row) not in {
+                    frozenset(BUILD_COORDINATE_KEYS),
+                    frozenset({*BUILD_COORDINATE_KEYS, "source_generation"}),
+                }
+                or not all(
+                    isinstance(row[key], str) and row[key]
+                    for key in BUILD_COORDINATE_KEYS
+                )
                 or not Path(row["checkout_path"]).is_absolute()
                 or not Path(row["source_path"]).is_absolute()
                 or not HEAD_PATTERN.fullmatch(row["head"])
@@ -3340,8 +3539,64 @@ class Cleanup:
                     if row["source"] == "."
                     else checkout_path.joinpath(*source.parts).resolve(strict=False)
                 )
-                if Path(row["source_path"]).resolve(strict=False) != expected_source:
-                    raise WorkspaceError("build coordinate source path is invalid")
+                generation = row.get("source_generation")
+                if generation is None:
+                    if Path(row["source_path"]).resolve(strict=False) != expected_source:
+                        raise WorkspaceError("build coordinate source path is invalid")
+                else:
+                    generation_identity = (
+                        {
+                            key: generation.get(key)
+                            for key in SOURCE_GENERATION_METADATA_KEYS
+                            if key != "source_tree_sha256"
+                        }
+                        if isinstance(generation, dict)
+                        else {}
+                    )
+                    generation_key = hashlib.sha256(
+                        json.dumps(
+                            generation_identity,
+                            sort_keys=True,
+                            separators=(",", ":"),
+                        ).encode()
+                    ).hexdigest()
+                    generation_path = (
+                        self.paths.builds
+                        / "source-generations"
+                        / component.checkout_name
+                        / generation_key
+                        / "source"
+                    ).resolve(strict=False)
+                    if (
+                        schema_version != BUILD_METADATA_SCHEMA_VERSION
+                        or not isinstance(generation, dict)
+                        or set(generation) != SOURCE_GENERATION_KEYS
+                        or generation.get("schema_version")
+                        != SOURCE_GENERATION_SCHEMA_VERSION
+                        or generation.get("repository") != component.repository
+                        or generation.get("checkout") != component.checkout_name
+                        or generation.get("branch") != component.branch
+                        or generation.get("commit") != row["head"]
+                        or generation.get("source") != component.source
+                        or not all(
+                            isinstance(generation.get(key), str)
+                            and HEAD_PATTERN.fullmatch(generation[key])
+                            for key in (
+                                "commit",
+                                "tree",
+                                "source_tree",
+                                "source_tree_sha256",
+                            )
+                        )
+                        or not Path(generation.get("path", "")).is_absolute()
+                        or Path(row["source_path"]).resolve(strict=False)
+                        != Path(generation["path"]).resolve(strict=False)
+                        or Path(generation["path"]).resolve(strict=False)
+                        != generation_path
+                    ):
+                        raise WorkspaceError(
+                            "build coordinate source generation is invalid"
+                        )
             except RuntimeError as error:
                 raise WorkspaceError("build coordinate path cannot be resolved") from error
         if schema_version == BUILD_METADATA_SCHEMA_VERSION:
@@ -3436,6 +3691,7 @@ class Cleanup:
                         "profiles",
                         "npm-cache",
                         "worker-dependencies",
+                        "source-generations",
                         "compiler-cache",
                     }:
                         continue
@@ -3708,6 +3964,7 @@ class Cleanup:
                     or metadata.get("schema_version")
                     not in {
                         LEGACY_BUILD_METADATA_SCHEMA_VERSION,
+                        PRE_SOURCE_GENERATION_BUILD_METADATA_SCHEMA_VERSION,
                         BUILD_METADATA_SCHEMA_VERSION,
                     }
                     or metadata.get("purpose") != purpose
@@ -4883,6 +5140,7 @@ class Cleanup:
             "profile-build": 0,
             "worker-dependencies": 0,
             "worker-dependency-transaction": 0,
+            "source-generation": 0,
             "worktree": 1,
             "npm-cache": 2,
             "compiler-cache": 2,
@@ -4978,6 +5236,39 @@ class Cleanup:
                 ):
                     raise WorkspaceError(
                         "Worker dependency cache ownership changed before removal"
+                    )
+                remove_owned_tree(path)
+        elif item["kind"] == "source-generation":
+            key = item["key"]
+            lock = self.paths.builds / "locks" / f"source-generation-{key}.lock"
+            with exclusive_lock(
+                lock,
+                f"immutable source generation {key}",
+                nonblocking=True,
+            ):
+                expected = (
+                    self.paths.builds
+                    / "source-generations"
+                    / item["checkout"]
+                    / key
+                ).resolve(strict=False)
+                if path.resolve(strict=False) != expected:
+                    raise WorkspaceError(
+                        "source generation path changed before removal"
+                    )
+                current = self._source_generation_item(
+                    path,
+                    item["checkout"],
+                    older_than_days,
+                    check_lock=False,
+                )
+                if (
+                    current["disposition"] != "eligible"
+                    or current.get("source_tree_sha256")
+                    != item.get("source_tree_sha256")
+                ):
+                    raise WorkspaceError(
+                        "source generation changed before removal"
                     )
                 remove_owned_tree(path)
         elif item["kind"] == "worker-dependency-transaction":

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -50,6 +50,7 @@ from .workspace import (
     _remote_matches,
     _tree_digest,
     exclusive_lock,
+    load_regular_json,
     remove_owned_tree,
 )
 
@@ -1209,6 +1210,10 @@ class Cleanup:
             item = self._source_generation_item(
                 path, target["checkout"], older_than_days
             )
+        elif kind == "source-generation-transaction":
+            item = self._source_generation_transaction_item(
+                path, target["checkout"], older_than_days
+            )
         elif kind == "worker-dependencies":
             item = self._worker_dependency_item(
                 path,
@@ -1261,6 +1266,7 @@ class Cleanup:
             self._strip_internal(item)
             if kind in {
                 "worker-dependency-transaction",
+                "source-generation-transaction",
                 "sound-cache",
                 "temporary-state",
             }:
@@ -2911,7 +2917,7 @@ class Cleanup:
                     raise WorkspaceError(
                         "source generation checkout root is invalid"
                     )
-                generations = sorted(
+                children = sorted(
                     path
                     for path in checkout_root.iterdir()
                     if path.name != MANAGED_MARKER
@@ -2927,11 +2933,109 @@ class Cleanup:
                 item["error"] = str(error)
                 items.append(item)
                 continue
-            items.extend(
-                self._source_generation_item(path, checkout, older_than_days)
-                for path in generations
-            )
+            for path in children:
+                if re.fullmatch(
+                    r"[0-9a-f]{64}-staging-[a-z0-9_]+", path.name
+                ):
+                    items.append(
+                        self._source_generation_transaction_item(
+                            path, checkout, older_than_days
+                        )
+                    )
+                else:
+                    items.append(
+                        self._source_generation_item(
+                            path, checkout, older_than_days
+                        )
+                    )
         return items
+
+    def _source_generation_transaction_item(
+        self,
+        path: Path,
+        checkout: str,
+        older_than_days: int,
+        *,
+        check_lock: bool = True,
+    ) -> dict[str, Any]:
+        checkout_record = self.manifest.by_checkout[checkout]
+        item = _base_item(
+            "source-generation-transaction",
+            checkout,
+            checkout_record.repository,
+            path,
+        )
+        item["checkout"] = checkout
+        inodes, observed, walk_error = _tree_usage(path)
+        item["_inodes"] = inodes
+        try:
+            path_status = path.lstat()
+            item["_identity"] = (
+                path_status.st_dev,
+                path_status.st_ino,
+                path_status.st_ctime_ns,
+                stat.S_IFMT(path_status.st_mode),
+                stat.S_IMODE(path_status.st_mode),
+            )
+            created = datetime.fromtimestamp(path_status.st_ctime, timezone.utc)
+            observed = created if observed is None else max(observed, created)
+        except OSError as error:
+            item["reasons"].append("filesystem_traversal_error")
+            item["error"] = str(error)
+        match = re.fullmatch(r"([0-9a-f]{64})-staging-([a-z0-9_]+)", path.name)
+        if walk_error:
+            item["reasons"].append("filesystem_traversal_error")
+            item["error"] = walk_error
+        if match is None or path.is_symlink() or not path.is_dir():
+            item["reasons"].append("invalid_source_generation_transaction")
+        else:
+            key, _suffix = match.groups()
+            item["key"] = key
+            marker = path / MANAGED_MARKER
+            try:
+                if marker.exists() or marker.is_symlink():
+                    if (
+                        marker.is_symlink()
+                        or load_json(marker)
+                        != {
+                            "schema_version": SCHEMA_VERSION,
+                            "purpose": f"source-generation:{key}",
+                        }
+                    ):
+                        raise WorkspaceError(
+                            "source generation transaction marker is invalid"
+                        )
+            except (OSError, WorkspaceError) as error:
+                item["reasons"].append(
+                    "invalid_source_generation_transaction"
+                )
+                item["error"] = str(error)
+            if check_lock:
+                busy, lock_error = self._lock_busy(
+                    self.paths.builds
+                    / "locks"
+                    / f"source-generation-{key}.lock"
+                )
+                if lock_error:
+                    item["reasons"].append("build_lock_error")
+                    item["error"] = lock_error
+                elif busy:
+                    item["reasons"].append("build_lock_busy")
+        item["age_basis"] = "tree-mtime-or-root-ctime" if observed else None
+        if observed is None:
+            item["reasons"].append("build_age_unavailable")
+        else:
+            age = max(0, int((self.now - observed).total_seconds()))
+            item["age_seconds"] = age
+            if observed > self.now:
+                item["reasons"].append("future_tree_mtime")
+            elif age < older_than_days * 86400:
+                item["reasons"].append("younger_than_grace_period")
+        item["reasons"] = sorted(set(item["reasons"]))
+        if not item["reasons"]:
+            item["disposition"] = "eligible"
+            item["reasons"] = ["stale_source_generation_transaction"]
+        return item
 
     def _source_generation_item(
         self,
@@ -2960,7 +3064,9 @@ class Cleanup:
             marker = path / MANAGED_MARKER
             metadata_path = path / SOURCE_GENERATION_METADATA
             source = path / "source"
-            metadata = load_json(metadata_path)
+            metadata = load_regular_json(
+                metadata_path, "immutable source generation metadata"
+            )
             identity = (
                 {
                     field: metadata.get(field)
@@ -3015,7 +3121,12 @@ class Cleanup:
                     )
                 )
                 or metadata.get("source_tree_sha256")
-                != _tree_digest(source, set(), bounded_symlinks=True)
+                != _tree_digest(
+                    source,
+                    set(),
+                    bounded_symlinks=True,
+                    reject_hardlinks=True,
+                )
             ):
                 raise WorkspaceError("source generation metadata is invalid")
             item["source_tree_sha256"] = metadata["source_tree_sha256"]
@@ -5140,6 +5251,7 @@ class Cleanup:
             "profile-build": 0,
             "worker-dependencies": 0,
             "worker-dependency-transaction": 0,
+            "source-generation-transaction": 0,
             "source-generation": 0,
             "worktree": 1,
             "npm-cache": 2,
@@ -5269,6 +5381,56 @@ class Cleanup:
                 ):
                     raise WorkspaceError(
                         "source generation changed before removal"
+                    )
+                remove_owned_tree(path)
+        elif item["kind"] == "source-generation-transaction":
+            key = item["key"]
+            lock = self.paths.builds / "locks" / f"source-generation-{key}.lock"
+            with exclusive_lock(
+                lock,
+                f"immutable source generation {key}",
+                nonblocking=True,
+            ):
+                transaction_root = (
+                    self.paths.builds
+                    / "source-generations"
+                    / item["checkout"]
+                )
+                marker = transaction_root / MANAGED_MARKER
+                if (
+                    transaction_root.is_symlink()
+                    or not transaction_root.is_dir()
+                    or marker.is_symlink()
+                    or load_json(marker)
+                    != {
+                        "schema_version": SCHEMA_VERSION,
+                        "purpose": f"source-generations:{item['checkout']}",
+                    }
+                    or path.parent.resolve(strict=False)
+                    != transaction_root.resolve(strict=False)
+                    or not re.fullmatch(
+                        rf"{key}-staging-[a-z0-9_]+", path.name
+                    )
+                    or path.is_symlink()
+                    or not path.is_dir()
+                ):
+                    raise WorkspaceError(
+                        "source generation transaction changed before removal: "
+                        f"{path}"
+                    )
+                current = self._source_generation_transaction_item(
+                    path,
+                    item["checkout"],
+                    older_than_days,
+                    check_lock=False,
+                )
+                if (
+                    current.get("_identity") != item.get("_identity")
+                    or current["disposition"] != "eligible"
+                ):
+                    raise WorkspaceError(
+                        "source generation transaction changed before removal: "
+                        f"{path}"
                     )
                 remove_owned_tree(path)
         elif item["kind"] == "worker-dependency-transaction":

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -187,7 +187,7 @@ SCENARIO_INERT_INVALID_RECORD = "invalid_record"
 BUILD_METADATA = ".atrinik-build.json"
 BUILD_METADATA_SCHEMA_VERSION = 3
 PROFILE_RESOLUTION_METADATA = ".atrinik-profile-resolution.json"
-PROFILE_RESOLUTION_SCHEMA_VERSION = 2
+PROFILE_RESOLUTION_SCHEMA_VERSION = 3
 SOURCE_GENERATION_METADATA = ".atrinik-source-generation.json"
 SOURCE_GENERATION_SCHEMA_VERSION = 1
 CACHE_METADATA = ".atrinik-cache.json"
@@ -1117,6 +1117,7 @@ def _tree_digest(
     exclusions: set[str],
     *,
     bounded_symlinks: bool = False,
+    reject_hardlinks: bool = False,
     reject_symlinks: bool = False,
     copied_metadata: bool = False,
     ignore_root_mtime: bool = False,
@@ -1181,6 +1182,10 @@ def _tree_digest(
                     )
                     visit(entry, child)
                 elif stat.S_ISREG(status.st_mode):
+                    if reject_hardlinks and status.st_nlink != 1:
+                        raise WorkspaceError(
+                            f"generated source contains a hard-linked file: {entry}"
+                        )
                     record(
                         "file",
                         child.as_posix(),
@@ -2059,6 +2064,7 @@ class Workspace:
                 and source.is_dir()
                 and not generation.is_symlink()
                 and generation.resolve(strict=False) == expected.resolve(strict=False)
+                and not (stat.S_IMODE(generation.lstat().st_mode) & 0o222)
             )
         except RuntimeError:
             valid_path = False
@@ -2176,6 +2182,28 @@ class Workspace:
     ) -> Path:
         checkout_identity = checkout.stat()
         source_identity = source.stat()
+        git_common = self._git_common_directory(checkout, trace=False)
+        git_common_identity = git_common.stat()
+        expected_source_identity = state.get("sources", {}).get(component.source)
+        if (
+            (checkout_identity.st_dev, checkout_identity.st_ino)
+            != (state.get("device"), state.get("inode"))
+            or str(git_common) != state.get("git_common")
+            or (git_common_identity.st_dev, git_common_identity.st_ino)
+            != (
+                state.get("git_common_device"),
+                state.get("git_common_inode"),
+            )
+            or expected_source_identity
+            != {
+                "path": str(source.resolve()),
+                "device": source_identity.st_dev,
+                "inode": source_identity.st_ino,
+            }
+        ):
+            raise WorkspaceError(
+                f"clean primary source identity changed before materialization: {checkout}"
+            )
         commit = state["head"]
         tree = git(
             checkout,
@@ -2209,11 +2237,20 @@ class Workspace:
             json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
         ).hexdigest()
         container = self.paths.builds / "source-generations" / component.checkout_name
-        managed_directory(
-            container,
-            self.paths.builds,
-            f"source-generations:{component.checkout_name}",
+        container_lock = (
+            self.paths.builds
+            / "locks"
+            / f"source-generation-container-{component.checkout_name}.lock"
         )
+        with exclusive_lock(
+            container_lock,
+            f"immutable source generation container {component.checkout_name}",
+        ):
+            managed_directory(
+                container,
+                self.paths.builds,
+                f"source-generations:{component.checkout_name}",
+            )
         generation = container / key
         lock = self.paths.builds / "locks" / f"source-generation-{key}.lock"
         with exclusive_lock(lock, f"immutable source generation {component.name}"):
@@ -2227,7 +2264,10 @@ class Workspace:
                 expected_record = {
                     **identity,
                     "source_tree_sha256": _tree_digest(
-                        generation / "source", set(), bounded_symlinks=True
+                        generation / "source",
+                        set(),
+                        bounded_symlinks=True,
+                        reject_hardlinks=True,
                     ),
                 }
                 if (
@@ -2243,9 +2283,48 @@ class Workspace:
                     raise WorkspaceError(
                         f"immutable source generation is corrupt: {generation}"
                     )
+                current_git_common = self._git_common_directory(
+                    checkout, trace=False
+                )
+                current_checkout = checkout.stat()
+                current_source = source.stat()
+                current_git_common_identity = current_git_common.stat()
+                if (
+                    (current_checkout.st_dev, current_checkout.st_ino)
+                    != (state["device"], state["inode"])
+                    or str(current_git_common) != state["git_common"]
+                    or (
+                        current_git_common_identity.st_dev,
+                        current_git_common_identity.st_ino,
+                    )
+                    != (
+                        state["git_common_device"],
+                        state["git_common_inode"],
+                    )
+                    or state["sources"][component.source]
+                    != {
+                        "path": str(source.resolve()),
+                        "device": current_source.st_dev,
+                        "inode": current_source.st_ino,
+                    }
+                    or not _is_clean(checkout, trace=False)
+                    or git(
+                        checkout,
+                        "rev-parse",
+                        "HEAD",
+                        capture=True,
+                        trace=False,
+                    )
+                    != commit
+                ):
+                    raise WorkspaceError(
+                        f"clean primary source changed before generation reuse: {checkout}"
+                    )
                 return generation / "source"
 
-            staging = Path(tempfile.mkdtemp(prefix=f".{key}-", dir=container))
+            staging = Path(
+                tempfile.mkdtemp(prefix=f"{key}-staging-", dir=container)
+            )
             archive_path = staging / "source.tar"
             try:
                 atomic_json(
@@ -2287,11 +2366,24 @@ class Workspace:
                 archive_path.unlink()
                 current_checkout = checkout.stat()
                 current_source = source.stat()
+                current_git_common = self._git_common_directory(
+                    checkout, trace=False
+                )
+                current_git_common_identity = current_git_common.stat()
                 if (
                     (checkout_identity.st_dev, checkout_identity.st_ino)
                     != (current_checkout.st_dev, current_checkout.st_ino)
                     or (source_identity.st_dev, source_identity.st_ino)
                     != (current_source.st_dev, current_source.st_ino)
+                    or str(current_git_common) != state["git_common"]
+                    or (
+                        git_common_identity.st_dev,
+                        git_common_identity.st_ino,
+                    )
+                    != (
+                        current_git_common_identity.st_dev,
+                        current_git_common_identity.st_ino,
+                    )
                     or not _is_clean(checkout, trace=False)
                     or git(checkout, "rev-parse", "HEAD", capture=True, trace=False)
                     != commit
@@ -2311,7 +2403,10 @@ class Workspace:
                 record = {
                     **identity,
                     "source_tree_sha256": _tree_digest(
-                        staging / "source", set(), bounded_symlinks=True
+                        staging / "source",
+                        set(),
+                        bounded_symlinks=True,
+                        reject_hardlinks=True,
                     ),
                 }
                 durable_atomic_json(staging / SOURCE_GENERATION_METADATA, record)
@@ -2328,7 +2423,7 @@ class Workspace:
         profile: dict[str, Any],
         selected: dict[str, Path],
         states: dict[str, dict[str, Any]],
-    ) -> tuple[dict[str, Path], set[str]]:
+    ) -> tuple[dict[str, Path], set[str], dict[Path, dict[str, Any]]]:
         stack = self.manifest.stack(profile["stack"])
         materialized = dict(selected)
         checkout_results: dict[tuple[str, str], Path] = {}
@@ -2367,7 +2462,24 @@ class Workspace:
                 component = stack.providers[checkout_roles[0]]
                 checkout = self._selector_root(profile, component).resolve()
                 released.add(self._source_coordinate(checkout_name, checkout))
-        return materialized, released
+        generation_records: dict[Path, dict[str, Any]] = {}
+        for role, path in materialized.items():
+            if path == selected[role] or path in generation_records:
+                continue
+            try:
+                record = self._source_generation_record(path)
+            except (OSError, WorkspaceError) as error:
+                raise WorkspaceError(
+                    "immutable source generation changed before lease handoff: "
+                    f"{path}"
+                ) from error
+            if record is None:
+                raise WorkspaceError(
+                    "immutable source generation changed before lease handoff: "
+                    f"{path}"
+                )
+            generation_records[path] = record
+        return materialized, released, generation_records
 
     @contextmanager
     def _resolved_profile_operation(
@@ -2442,14 +2554,17 @@ class Workspace:
                 )
                 released: set[str] = set()
                 if materialize_clean_primaries:
-                    selected, released = self._materialize_clean_primary_sources(
+                    (
+                        selected,
+                        released,
+                        generation_records,
+                    ) = self._materialize_clean_primary_sources(
                         confirmed_profile, selected, states
                     )
                     generation_keys = sorted(
                         {
                             path.parent.name
-                            for path in selected.values()
-                            if self._source_generation_record(path) is not None
+                            for path in generation_records
                         }
                     )
                     for key in generation_keys:
@@ -2461,6 +2576,29 @@ class Workspace:
                         )
                         context.__enter__()
                         generation_contexts.append(context)
+                    for path, expected_record in generation_records.items():
+                        try:
+                            current_record = self._source_generation_record(path)
+                            current_digest = _tree_digest(
+                                path,
+                                set(),
+                                bounded_symlinks=True,
+                                reject_hardlinks=True,
+                            )
+                        except (OSError, WorkspaceError) as error:
+                            raise WorkspaceError(
+                                "immutable source generation changed before lease handoff: "
+                                f"{path}"
+                            ) from error
+                        if (
+                            current_record != expected_record
+                            or current_digest
+                            != expected_record["source_tree_sha256"]
+                        ):
+                            raise WorkspaceError(
+                                "immutable source generation changed before lease handoff: "
+                                f"{path}"
+                            )
                     retained = []
                     for coordinate, context in reversed(source_contexts):
                         if coordinate in released:
@@ -5123,18 +5261,31 @@ class Workspace:
             }
             if include_identity:
                 identity = checkout.stat()
+                git_common = self._git_common_directory(checkout, trace=False)
+                git_common_identity = git_common.stat()
                 state.update(
                     {
                         "device": identity.st_dev,
                         "inode": identity.st_ino,
-                        "git_common": str(
-                            self._git_common_directory(checkout, trace=False)
-                        ),
+                        "git_common": str(git_common),
+                        "git_common_device": git_common_identity.st_dev,
+                        "git_common_inode": git_common_identity.st_ino,
+                        "sources": {},
                     }
                 )
             if include_dirty:
                 state["dirty"] = not _is_clean(checkout, trace=False)
             states[component.checkout_name] = state
+        if include_identity:
+            for role in sorted(selected):
+                component = stack.providers[role]
+                source = selected[role].resolve()
+                identity = source.stat()
+                states[component.checkout_name]["sources"][component.source] = {
+                    "path": str(source),
+                    "device": identity.st_dev,
+                    "inode": identity.st_ino,
+                }
         return states
 
     def _profile_build_key(
@@ -5351,7 +5502,16 @@ class Workspace:
         profile = self._load_profile(profile_name, require_file=False)
         component = self.manifest.stack(profile["stack"]).providers[role]
         checkout = self._selector_root(profile, component).resolve()
-        clean = _is_clean(checkout, trace=False)
+        generation = self._source_generation_record(selected[role])
+        if generation is not None:
+            clean = True
+            head = generation["commit"]
+        else:
+            state = self._selected_checkout_states(
+                profile, selected, include_dirty=True
+            )[component.checkout_name]
+            clean = not state["dirty"]
+            head = state["head"]
         coordinate = {
             "component": component.name,
             "repository": component.repository,
@@ -5360,13 +5520,7 @@ class Workspace:
             "source": component.source,
             "checkout_path": str(checkout),
             "source_path": str(selected[role].resolve()),
-            "head": git(
-                checkout,
-                "rev-parse",
-                "HEAD",
-                capture=True,
-                trace=False,
-            ),
+            "head": head,
         }
         return (
             {
@@ -7158,23 +7312,21 @@ class Workspace:
         required = self._dependency_roles(profile, {"server"})
         coordinates: dict[str, dict[str, str]] = {}
         cacheable = True
-        checkout_states: dict[Path, tuple[bool, str]] = {}
+        checkout_states = self._selected_checkout_states(
+            profile, selected, include_dirty=True
+        )
         for role in sorted(required & set(selected)):
             source = selected[role]
             component = stack.providers[role]
             checkout = self._selector_root(profile, component).resolve()
-            if checkout not in checkout_states:
-                checkout_states[checkout] = (
-                    _is_clean(checkout, trace=False),
-                    git(
-                        checkout,
-                        "rev-parse",
-                        "HEAD",
-                        capture=True,
-                        trace=False,
-                    ),
-                )
-            clean, head = checkout_states[checkout]
+            generation = self._source_generation_record(source)
+            if generation is not None:
+                clean = True
+                head = generation["commit"]
+            else:
+                state = checkout_states[component.checkout_name]
+                clean = not state["dirty"]
+                head = state["head"]
             cacheable = cacheable and clean
             coordinates[role] = {
                 "component": component.name,

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -26,6 +26,7 @@ import ssl
 import stat
 import subprocess
 import sys
+import tarfile
 import tempfile
 import threading
 import time
@@ -184,9 +185,11 @@ SCENARIO_INERT_HISTORICAL_IDENTITY = "historical_identity"
 SCENARIO_INERT_PROFILE_UNRESOLVABLE = "profile_unresolvable"
 SCENARIO_INERT_INVALID_RECORD = "invalid_record"
 BUILD_METADATA = ".atrinik-build.json"
-BUILD_METADATA_SCHEMA_VERSION = 2
+BUILD_METADATA_SCHEMA_VERSION = 3
 PROFILE_RESOLUTION_METADATA = ".atrinik-profile-resolution.json"
-PROFILE_RESOLUTION_SCHEMA_VERSION = 1
+PROFILE_RESOLUTION_SCHEMA_VERSION = 2
+SOURCE_GENERATION_METADATA = ".atrinik-source-generation.json"
+SOURCE_GENERATION_SCHEMA_VERSION = 1
 CACHE_METADATA = ".atrinik-cache.json"
 WORKER_DEPENDENCY_METADATA = ".atrinik-worker-dependencies.json"
 WORKER_VIEW_METADATA = ".atrinik-worker-view.json"
@@ -1992,12 +1995,388 @@ class Workspace:
     def _wrapper_git_admin_coordinate(self) -> str:
         return f"atrinik:{self._lease_namespace.parent}"
 
+    def _source_generation_record(self, source: Path) -> dict[str, Any] | None:
+        metadata = source.parent / SOURCE_GENERATION_METADATA
+        if source.name != "source" or not metadata.is_file() or metadata.is_symlink():
+            return None
+        value = load_regular_json(metadata, "immutable source generation")
+        if (
+            not isinstance(value, dict)
+            or set(value)
+            != {
+                "schema_version",
+                "repository",
+                "checkout",
+                "branch",
+                "commit",
+                "tree",
+                "source",
+                "source_tree",
+                "source_tree_sha256",
+            }
+            or value.get("schema_version") != SOURCE_GENERATION_SCHEMA_VERSION
+            or not all(
+                isinstance(value.get(field), str) and value[field]
+                for field in ("repository", "checkout", "branch", "source")
+            )
+            or not all(
+                isinstance(value.get(field), str)
+                and re.fullmatch(r"[0-9a-f]{40,64}", value[field])
+                for field in (
+                    "commit",
+                    "tree",
+                    "source_tree",
+                    "source_tree_sha256",
+                )
+            )
+            or not any(
+                component.checkout_name == value.get("checkout")
+                and component.repository == value.get("repository")
+                and component.branch == value.get("branch")
+                and component.source == value.get("source")
+                for component in self.manifest.components
+            )
+        ):
+            raise WorkspaceError(
+                f"immutable source generation metadata is invalid: {metadata}"
+            )
+        identity = {
+            field: value[field]
+            for field in value
+            if field != "source_tree_sha256"
+        }
+        key = hashlib.sha256(
+            json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+        generation = source.parent
+        expected = (
+            self.paths.builds / "source-generations" / value["checkout"] / key
+        )
+        marker = generation / MANAGED_MARKER
+        try:
+            valid_path = (
+                not source.is_symlink()
+                and source.is_dir()
+                and not generation.is_symlink()
+                and generation.resolve(strict=False) == expected.resolve(strict=False)
+            )
+        except RuntimeError:
+            valid_path = False
+        if (
+            not valid_path
+            or not marker.is_file()
+            or marker.is_symlink()
+            or load_json(marker)
+            != {
+                "schema_version": SCHEMA_VERSION,
+                "purpose": f"source-generation:{key}",
+            }
+        ):
+            raise WorkspaceError(
+                f"immutable source generation ownership is invalid: {generation}"
+            )
+        return value
+
+    @staticmethod
+    def _extract_git_source_archive(archive_path: Path, output: Path) -> None:
+        """Extract a local Git archive without trusting archive paths or links."""
+
+        output.mkdir()
+        root = output.resolve()
+        try:
+            with tarfile.open(archive_path, mode="r:") as archive:
+                for member in archive:
+                    relative = PurePosixPath(member.name)
+                    if (
+                        not member.name
+                        or relative.is_absolute()
+                        or any(part in {"", ".", ".."} for part in relative.parts)
+                    ):
+                        raise WorkspaceError(
+                            f"Git source archive contains an unsafe path: {member.name!r}"
+                        )
+                    destination = output.joinpath(*relative.parts)
+                    parent = destination.parent
+                    parent.mkdir(parents=True, exist_ok=True)
+                    if any(
+                        candidate.is_symlink()
+                        for candidate in (parent, *parent.parents)
+                        if candidate == output or output in candidate.parents
+                    ):
+                        raise WorkspaceError(
+                            f"Git source archive traverses a symbolic link: {member.name}"
+                        )
+                    if destination.exists() or destination.is_symlink():
+                        if (
+                            member.isdir()
+                            and destination.is_dir()
+                            and not destination.is_symlink()
+                        ):
+                            continue
+                        raise WorkspaceError(
+                            f"Git source archive repeats a path: {member.name}"
+                        )
+                    permissions = member.mode & 0o777
+                    if member.isdir():
+                        destination.mkdir()
+                        destination.chmod(permissions)
+                    elif member.isreg():
+                        stream = archive.extractfile(member)
+                        if stream is None:
+                            raise WorkspaceError(
+                                f"Git source archive cannot read file: {member.name}"
+                            )
+                        descriptor = os.open(
+                            destination,
+                            os.O_WRONLY
+                            | os.O_CREAT
+                            | os.O_EXCL
+                            | getattr(os, "O_NOFOLLOW", 0),
+                            permissions,
+                        )
+                        try:
+                            with stream, os.fdopen(
+                                descriptor, "wb", closefd=False
+                            ) as target:
+                                shutil.copyfileobj(stream, target, 1024 * 1024)
+                        finally:
+                            os.close(descriptor)
+                        destination.chmod(permissions)
+                    elif member.issym():
+                        target = member.linkname
+                        if not target or Path(target).is_absolute():
+                            raise WorkspaceError(
+                                f"Git source archive contains an unsafe link: {member.name}"
+                            )
+                        resolved = destination.parent.joinpath(target).resolve(
+                            strict=False
+                        )
+                        try:
+                            resolved.relative_to(root)
+                        except ValueError as error:
+                            raise WorkspaceError(
+                                f"Git source archive link escapes its generation: {member.name}"
+                            ) from error
+                        destination.symlink_to(target)
+                    else:
+                        raise WorkspaceError(
+                            f"Git source archive contains an unsupported entry: {member.name}"
+                        )
+        except (OSError, tarfile.TarError) as error:
+            raise WorkspaceError(
+                f"cannot extract immutable Git source archive: {error}"
+            ) from error
+
+    def _materialize_primary_source(
+        self,
+        component: Component,
+        checkout: Path,
+        source: Path,
+        state: dict[str, Any],
+    ) -> Path:
+        checkout_identity = checkout.stat()
+        source_identity = source.stat()
+        commit = state["head"]
+        tree = git(
+            checkout,
+            "rev-parse",
+            f"{commit}^{{tree}}",
+            capture=True,
+            trace=False,
+        )
+        source_tree = git(
+            checkout,
+            "rev-parse",
+            (
+                f"{commit}^{{tree}}"
+                if component.source == "."
+                else f"{commit}:{component.source}"
+            ),
+            capture=True,
+            trace=False,
+        )
+        identity = {
+            "schema_version": SOURCE_GENERATION_SCHEMA_VERSION,
+            "repository": component.repository,
+            "checkout": component.checkout_name,
+            "branch": component.branch,
+            "commit": commit,
+            "tree": tree,
+            "source": component.source,
+            "source_tree": source_tree,
+        }
+        key = hashlib.sha256(
+            json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+        container = self.paths.builds / "source-generations" / component.checkout_name
+        managed_directory(
+            container,
+            self.paths.builds,
+            f"source-generations:{component.checkout_name}",
+        )
+        generation = container / key
+        lock = self.paths.builds / "locks" / f"source-generation-{key}.lock"
+        with exclusive_lock(lock, f"immutable source generation {component.name}"):
+            if generation.exists() or generation.is_symlink():
+                if generation.is_symlink() or not generation.is_dir():
+                    raise WorkspaceError(
+                        f"immutable source generation is invalid: {generation}"
+                    )
+                marker = generation / MANAGED_MARKER
+                record = self._source_generation_record(generation / "source")
+                expected_record = {
+                    **identity,
+                    "source_tree_sha256": _tree_digest(
+                        generation / "source", set(), bounded_symlinks=True
+                    ),
+                }
+                if (
+                    not marker.is_file()
+                    or marker.is_symlink()
+                    or load_json(marker)
+                    != {
+                        "schema_version": SCHEMA_VERSION,
+                        "purpose": f"source-generation:{key}",
+                    }
+                    or record != expected_record
+                ):
+                    raise WorkspaceError(
+                        f"immutable source generation is corrupt: {generation}"
+                    )
+                return generation / "source"
+
+            staging = Path(tempfile.mkdtemp(prefix=f".{key}-", dir=container))
+            archive_path = staging / "source.tar"
+            try:
+                atomic_json(
+                    staging / MANAGED_MARKER,
+                    {
+                        "schema_version": SCHEMA_VERSION,
+                        "purpose": f"source-generation:{key}",
+                    },
+                )
+                archive_ref = (
+                    commit
+                    if component.source == "."
+                    else f"{commit}:{component.source}"
+                )
+                try:
+                    subprocess.run(
+                        [
+                            "git",
+                            "-C",
+                            str(checkout),
+                            "archive",
+                            "--format=tar",
+                            f"--output={archive_path}",
+                            archive_ref,
+                        ],
+                        check=True,
+                        stderr=subprocess.PIPE,
+                        pass_fds=active_lock_fds(),
+                    )
+                except FileNotFoundError as error:
+                    raise WorkspaceError("required command not found: git") from error
+                except subprocess.CalledProcessError as error:
+                    detail = error.stderr.decode("utf-8", errors="replace").strip()
+                    suffix = f": {detail}" if detail else ""
+                    raise WorkspaceError(
+                        f"cannot export immutable source generation{suffix}"
+                    ) from error
+                self._extract_git_source_archive(archive_path, staging / "source")
+                archive_path.unlink()
+                current_checkout = checkout.stat()
+                current_source = source.stat()
+                if (
+                    (checkout_identity.st_dev, checkout_identity.st_ino)
+                    != (current_checkout.st_dev, current_checkout.st_ino)
+                    or (source_identity.st_dev, source_identity.st_ino)
+                    != (current_source.st_dev, current_source.st_ino)
+                    or not _is_clean(checkout, trace=False)
+                    or git(checkout, "rev-parse", "HEAD", capture=True, trace=False)
+                    != commit
+                    or git(
+                        checkout,
+                        "rev-parse",
+                        f"{commit}^{{tree}}",
+                        capture=True,
+                        trace=False,
+                    )
+                    != tree
+                ):
+                    raise WorkspaceError(
+                        f"clean primary source changed during materialization: {checkout}"
+                    )
+                self._seal_runtime_generation(staging / "source")
+                record = {
+                    **identity,
+                    "source_tree_sha256": _tree_digest(
+                        staging / "source", set(), bounded_symlinks=True
+                    ),
+                }
+                durable_atomic_json(staging / SOURCE_GENERATION_METADATA, record)
+                self._seal_runtime_generation(staging)
+                rename_no_replace(staging, generation)
+            except BaseException:
+                if staging.exists() and not staging.is_symlink():
+                    remove_owned_tree(staging)
+                raise
+        return generation / "source"
+
+    def _materialize_clean_primary_sources(
+        self,
+        profile: dict[str, Any],
+        selected: dict[str, Path],
+        states: dict[str, dict[str, Any]],
+    ) -> tuple[dict[str, Path], set[str]]:
+        stack = self.manifest.stack(profile["stack"])
+        materialized = dict(selected)
+        checkout_results: dict[tuple[str, str], Path] = {}
+        for role in sorted(selected):
+            component = stack.providers[role]
+            selector = profile["components"][component.name]
+            checkout = self._selector_root(profile, component).resolve()
+            state = states[component.checkout_name]
+            # The authored content publisher currently proves its Classic
+            # target against a live Git checkout. Keep that exact source lease
+            # until the publisher accepts an immutable-generation identity.
+            if (
+                role == "content"
+                or selector["kind"] != "primary"
+                or state["dirty"]
+            ):
+                continue
+            cache_key = (component.checkout_name, component.source)
+            generated = checkout_results.get(cache_key)
+            if generated is None:
+                generated = self._materialize_primary_source(
+                    component, checkout, selected[role], state
+                )
+                checkout_results[cache_key] = generated
+            materialized[role] = generated
+        released: set[str] = set()
+        for checkout_name in {
+            stack.providers[role].checkout_name for role in selected
+        }:
+            checkout_roles = [
+                role
+                for role in selected
+                if stack.providers[role].checkout_name == checkout_name
+            ]
+            if all(materialized[role] != selected[role] for role in checkout_roles):
+                component = stack.providers[checkout_roles[0]]
+                checkout = self._selector_root(profile, component).resolve()
+                released.add(self._source_coordinate(checkout_name, checkout))
+        return materialized, released
+
     @contextmanager
     def _resolved_profile_operation(
         self,
         profile_name: str,
         required: set[str],
         operation: str,
+        *,
+        materialize_clean_primaries: bool = False,
     ) -> Iterator[ProfileResolutionSnapshot]:
         """Capture and retain one exact profile/source resolution."""
 
@@ -2007,9 +2386,13 @@ class Workspace:
         with self._resource_locks([profile_request]):
             profile = self._load_profile_file(profile_name, require_file=False)
             stack = self.manifest.stack(profile["stack"])
+            roles = self._dependency_roles(profile, required)
+            components = {stack.providers[role].name for role in roles}
             source_requests: list[LeaseRequest] = []
             seen: set[str] = set()
             for component in stack.components:
+                if component.name not in components:
+                    continue
                 root = self._selector_root(profile, component)
                 coordinate = self._source_coordinate(component.checkout_name, root)
                 if coordinate in seen:
@@ -2018,7 +2401,32 @@ class Workspace:
                 source_requests.append(
                     self._lease_request("source", coordinate, "shared", operation)
                 )
-            with self._resource_locks(source_requests):
+            source_contexts: list[
+                tuple[str, AbstractContextManager[tuple[TextIO, ...]]]
+            ] = []
+            generation_contexts: list[AbstractContextManager[TextIO]] = []
+            try:
+                ordered_requests = sorted(
+                    source_requests, key=lambda item: item.sort_key
+                )
+                while True:
+                    waiting: LeaseRequest | None = None
+                    try:
+                        for request in ordered_requests:
+                            context = self._resource_locks(
+                                [request], nonblocking=True
+                            )
+                            context.__enter__()
+                            source_contexts.append((request.coordinate, context))
+                    except LockBusyError:
+                        waiting = request
+                    if waiting is None:
+                        break
+                    for _coordinate, context in reversed(source_contexts):
+                        context.__exit__(None, None, None)
+                    source_contexts = []
+                    with self._resource_locks([waiting]):
+                        pass
                 confirmed_profile = self._load_profile_file(
                     profile_name, require_file=False
                 )
@@ -2032,6 +2440,34 @@ class Workspace:
                 states = self._selected_checkout_states(
                     profile, selected, include_dirty=True, include_identity=True
                 )
+                released: set[str] = set()
+                if materialize_clean_primaries:
+                    selected, released = self._materialize_clean_primary_sources(
+                        confirmed_profile, selected, states
+                    )
+                    generation_keys = sorted(
+                        {
+                            path.parent.name
+                            for path in selected.values()
+                            if self._source_generation_record(path) is not None
+                        }
+                    )
+                    for key in generation_keys:
+                        context = shared_lock(
+                            self.paths.builds
+                            / "locks"
+                            / f"source-generation-{key}.lock",
+                            f"immutable source generation {key}",
+                        )
+                        context.__enter__()
+                        generation_contexts.append(context)
+                    retained = []
+                    for coordinate, context in reversed(source_contexts):
+                        if coordinate in released:
+                            context.__exit__(None, None, None)
+                        else:
+                            retained.append((coordinate, context))
+                    source_contexts = list(reversed(retained))
                 serializable_states = {
                     name: {**state, "path": str(state["path"])}
                     for name, state in states.items()
@@ -2062,6 +2498,11 @@ class Workspace:
                     yield snapshot
                 finally:
                     self._profile_snapshot = previous
+            finally:
+                for context in reversed(generation_contexts):
+                    context.__exit__(None, None, None)
+                for _coordinate, context in reversed(source_contexts):
+                    context.__exit__(None, None, None)
 
     def migrate_repositories(self, mode: str) -> dict[str, Any]:
         if mode == "apply":
@@ -4290,40 +4731,11 @@ class Workspace:
         if profile is None:
             profile = self._load_profile(profile_name, require_file=False)
         stack = self.manifest.stack(profile["stack"])
-        requested_roles = self._dependency_roles(profile, required)
-        build_targets = {
-            role
-            for role, component in stack.providers.items()
-            if self.manifest.effective_build(stack.name, component) != "none"
-        }
-        common_roles = self._dependency_roles(profile, build_targets)
-        common_components = {
-            stack.providers[role].name for role in common_roles
-        }
-
-        # Missing preferred checkouts identify a deliberately partial workspace.
-        # Any preferred checkout that is present must still pass full profile
-        # validation, so a malformed path cannot silently shrink the build key.
-        complete = True
-        present_components: set[str] = set()
-        for component in stack.components:
-            if component.name not in common_components:
-                continue
-            root = self._selector_root(profile, component)
-            if root.exists() or root.is_symlink():
-                present_components.add(component.name)
-            else:
-                complete = False
-        roles = (
-            common_roles | requested_roles if complete else requested_roles
-        )
+        roles = self._dependency_roles(profile, required)
         component_names = {stack.providers[role].name for role in roles}
-        # Resolve present preferred components and the required selection in one
-        # pass. This both fails closed for malformed optional checkouts and keeps
-        # validation deduplicated if initialization races the existence snapshot.
         present_paths = self.resolve_profile(
             profile_name,
-            present_components | component_names,
+            component_names,
             trace=trace,
             profile=profile,
         )
@@ -4345,7 +4757,10 @@ class Workspace:
         self.paths.ensure()
         targets = self._expand_build_target(target, profile_name)
         with self._resolved_profile_operation(
-            profile_name, set(targets), f"build {target}"
+            profile_name,
+            set(targets),
+            f"build {target}",
+            materialize_clean_primaries=True,
         ) as snapshot:
             return self._build_resolved(
                 target,
@@ -4407,7 +4822,7 @@ class Workspace:
             elif sound_root is not None:
                 profile = self._load_profile(profile_name, require_file=False)
                 if profile["sound_mode"] == SOURCE_MODE:
-                    sound_record = sound_source_record(sound_root)
+                    sound_record = self._sound_source_record(sound_root)
             self._refresh_build_metadata(
                 root, profile_name, key, selected, sound_record
             )
@@ -4464,7 +4879,7 @@ class Workspace:
         checkout_states = self._selected_checkout_states(
             profile, selected, include_dirty=False
         )
-        coordinates: dict[str, dict[str, str]] = {}
+        coordinates: dict[str, dict[str, Any]] = {}
         for role in sorted(selected):
             component = stack.providers[role]
             checkout_state = checkout_states[component.checkout_name]
@@ -4479,6 +4894,12 @@ class Workspace:
                 "source_path": str(selected[role].resolve()),
                 "head": checkout_state["head"],
             }
+            generation = self._source_generation_record(selected[role])
+            if generation is not None:
+                coordinates[role]["source_generation"] = {
+                    **generation,
+                    "path": str(selected[role].resolve()),
+                }
         atomic_json(
             root / BUILD_METADATA,
             {
@@ -4520,18 +4941,23 @@ class Workspace:
         profile = self._load_profile(profile_name, require_file=False)
         mode = profile["sound_mode"]
         if mode == SOURCE_MODE:
-            return source, sound_source_record(source)
+            return source, self._sound_source_record(source)
         if mode != PLAYTEST_MODE or profile["stack"] != "classic":
             raise WorkspaceError(
                 f"profile {profile_name} has unsupported sound mode {mode}"
             )
         source_identity = "unavailable"
         try:
-            inputs = clean_source_inputs(source)
+            inputs = self._clean_sound_source_inputs(source)
             source_identity = (
                 f"commit {inputs['source_commit']} tree {inputs['source_tree']}"
             )
-            output = source / "build" / "atrinik-workspace" / sound_cache_key(inputs)
+            if self._source_generation_record(source) is not None:
+                producer = root / "producers" / "sound"
+                producer.mkdir(parents=True, exist_ok=True)
+                output = producer / sound_cache_key(inputs)
+            else:
+                output = source / "build" / "atrinik-workspace" / sound_cache_key(inputs)
             builder = source / "tools" / "sound_release.py"
             if not builder.is_file() or builder.is_symlink():
                 raise WorkspaceError(
@@ -4557,7 +4983,7 @@ class Workspace:
                 cwd=source,
             )
             record = verify_playtest_tree(source, output, inputs)
-            if clean_source_inputs(source) != inputs:
+            if self._clean_sound_source_inputs(source) != inputs:
                 raise WorkspaceError(
                     "selected sound inputs changed after playtest-tree generation"
                 )
@@ -4603,7 +5029,7 @@ class Workspace:
                         raise WorkspaceError(
                             "local-playtest sound changed while creating the verified handoff"
                         )
-                    if clean_source_inputs(source) != inputs:
+                    if self._clean_sound_source_inputs(source) != inputs:
                         raise WorkspaceError(
                             "selected sound inputs changed while staging the verified handoff"
                         )
@@ -4625,6 +5051,41 @@ class Workspace:
             f"{record['output_tree_sha256']} at {output}"
         )
         return output, record
+
+    def _clean_sound_source_inputs(self, source: Path) -> dict[str, str]:
+        generation = self._source_generation_record(source)
+        if generation is None:
+            return clean_source_inputs(source)
+        files = {
+            "builder_sha256": source / "tools" / "sound_release.py",
+            "source_manifest_sha256": source / "manifests" / "source-assets.json",
+            "toolchain_sha256": source
+            / "manifests"
+            / "playtest-audio-toolchain.json",
+            "schema_sha256": source
+            / "schemas"
+            / "playtest-manifest-v1.schema.json",
+        }
+        return {
+            "source_commit": generation["commit"],
+            "source_tree": generation["tree"],
+            **{
+                name: _file_digest(path, name.replace("_", " "))
+                for name, path in files.items()
+            },
+        }
+
+    def _sound_source_record(self, source: Path) -> dict[str, Any]:
+        generation = self._source_generation_record(source)
+        if generation is None:
+            return sound_source_record(source)
+        return {
+            "mode": SOURCE_MODE,
+            "root": str(source.resolve()),
+            "source_commit": generation["commit"],
+            "source_tree": generation["tree"],
+            "source_clean": True,
+        }
 
     def _selected_checkout_states(
         self,
@@ -5443,8 +5904,7 @@ class Workspace:
             return False
         return True
 
-    @staticmethod
-    def _resource_runtime_files(source: Path) -> tuple[list[str], list[str]]:
+    def _resource_runtime_files(self, source: Path) -> tuple[list[str], list[str]]:
         manifest = source / RESOURCE_PATHS_MANIFEST
         try:
             lines = manifest.read_text(encoding="utf-8").splitlines()
@@ -5469,42 +5929,76 @@ class Workspace:
                 )
             runtime_paths.append(line)
 
-        try:
-            result = subprocess.run(
-                [
-                    "git",
-                    "-C",
-                    str(source),
-                    "ls-files",
-                    "-z",
-                    "--cached",
-                    "--",
-                    *runtime_paths,
-                ],
-                check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                pass_fds=active_lock_fds(),
-            )
-        except FileNotFoundError as error:
-            raise WorkspaceError("required command not found: git") from error
-        except subprocess.CalledProcessError as error:
-            detail = error.stderr.decode("utf-8", errors="replace").strip()
-            suffix = f": {detail}" if detail else ""
-            raise WorkspaceError(
-                f"cannot list tracked runtime resources{suffix}"
-            ) from error
+        if self._source_generation_record(source) is not None:
+            tracked: list[str] = []
+            for runtime_path in runtime_paths:
+                selected = source.joinpath(*PurePosixPath(runtime_path).parts)
+                if not selected.exists() or selected.is_symlink():
+                    continue
+                if selected.is_file():
+                    tracked.append(runtime_path)
+                    continue
+                if not selected.is_dir():
+                    raise WorkspaceError(
+                        f"tracked runtime resource is not a regular path: {selected}"
+                    )
+                for directory, directories, files in os.walk(
+                    selected, followlinks=False
+                ):
+                    parent = Path(directory)
+                    directories.sort()
+                    files.sort()
+                    for name in directories:
+                        path = parent / name
+                        if path.is_symlink():
+                            raise WorkspaceError(
+                                f"tracked runtime resource is not a regular path: {path}"
+                            )
+                    for name in files:
+                        path = parent / name
+                        if path.is_symlink() or not path.is_file():
+                            raise WorkspaceError(
+                                f"tracked runtime resource is not a regular file: {path}"
+                            )
+                        tracked.append(path.relative_to(source).as_posix())
+            tracked = sorted(set(tracked))
+        else:
+            try:
+                result = subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        str(source),
+                        "ls-files",
+                        "-z",
+                        "--cached",
+                        "--",
+                        *runtime_paths,
+                    ],
+                    check=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    pass_fds=active_lock_fds(),
+                )
+            except FileNotFoundError as error:
+                raise WorkspaceError("required command not found: git") from error
+            except subprocess.CalledProcessError as error:
+                detail = error.stderr.decode("utf-8", errors="replace").strip()
+                suffix = f": {detail}" if detail else ""
+                raise WorkspaceError(
+                    f"cannot list tracked runtime resources{suffix}"
+                ) from error
 
-        try:
-            tracked = [
-                item.decode("utf-8")
-                for item in result.stdout.split(b"\0")
-                if item
-            ]
-        except UnicodeDecodeError as error:
-            raise WorkspaceError(
-                "runtime resource paths must use UTF-8 names"
-            ) from error
+            try:
+                tracked = [
+                    item.decode("utf-8")
+                    for item in result.stdout.split(b"\0")
+                    if item
+                ]
+            except UnicodeDecodeError as error:
+                raise WorkspaceError(
+                    "runtime resource paths must use UTF-8 names"
+                ) from error
         if not tracked:
             raise WorkspaceError(
                 f"resource runtime manifest selects no tracked files: {manifest}"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -133,6 +133,7 @@ workspace/
   worktrees/<checkout>/<label>/      physical-checkout Git worktrees
   profiles/<name>.json               logical component -> checkout selectors
   build/profiles/<name>-<key>/       isolated sources, builds, and runtime
+  build/source-generations/<checkout>/<key>/ immutable primary exports
   build/npm-cache/                   shared package download cache
   build/worker-dependencies/<key>/   shared validated Worker installations
   build/compiler-cache/              bounded shared native compiler cache
@@ -207,11 +208,21 @@ waiting on a busy later source. A queued writer precedes later readers only for
 that coordinate, and waits longer than 10 seconds report its owner operation
 and supported recovery action.
 
-Profile consumers lock the profile, derive candidate source coordinates,
-acquire the exact sources, revalidate, and capture immutable profile bytes,
-provider selections, Git identities, paths, HEADs, dirtiness, and filesystem
-identity. Build preparation persists that snapshot and never rereads a mutable
-profile generation. Publication and removal share the same source coordinate.
+Profile consumers lock the profile, derive the requested operation's transitive
+provider closure, acquire only those exact sources, revalidate, and capture
+immutable profile bytes, provider selections, Git identities, paths, HEADs,
+dirtiness, and filesystem identity. A target build exports each clean primary
+component subpath from the captured Git commit into an atomic, read-only source
+generation keyed by repository, branch, checkout, commit, tree, subpath, and
+generation schema. Reuse authenticates the marker, closed metadata, and full
+tree digest. Published generations contain no links or hard links to mutable
+primary files. Build preparation then releases those primary source leases
+before configure/compile/test, while dirty sources, worktrees, and the Classic
+content publisher retain their exact live-source leases. `build all` uses the
+union of all target closures. Build metadata preserves both original source
+identity and immutable generation identity and never rereads a mutable profile
+generation. Publication and removal share every retained live source
+coordinate.
 Physical profile/scenario reference records make completed publications visible
 to cleanup and explicit removal from every relocated state root.
 Initial registry backfill publishes absent source paths as conservative
@@ -330,6 +341,11 @@ locks, registered Git worktrees, and exact absolute roots in strict schema-1
 `workspace/build/retention.json` protect a build. A shared `managed_remove()`
 helper repeats containment, symlink, marker, schema, and purpose validation
 immediately before deletion.
+
+Commit-keyed source generations have closed repository/branch/checkout/tree/
+subpath metadata and a complete tree digest. Builds hold a per-key shared lock;
+default `builds` cleanup revalidates identity and age under its exclusive side
+before bounded removal.
 
 The npm and compiler caches have exact purpose markers and atomically refreshed
 `.atrinik-cache.json` timestamps. The compiler cache metadata also fixes its
@@ -628,8 +644,8 @@ and the expected `incuna_-1` pair exists. It then installs the marker-owned
 cache atomically, preserving the previous valid cache on failure. Cache
 metadata records provider, repository, branch, checkout, source, path, and
 commit coordinates for the server dependency closure consumed by the
-worldmaker. Unrelated roles in the common profile build root do not invalidate
-that cache. It is reusable only for clean input checkouts with an exact metadata
+worldmaker. Roles outside that target closure do not invalidate that cache. It
+is reusable only for clean input checkouts with an exact metadata
 match; dirty inputs deliberately regenerate.
 
 ## Runtime and state
@@ -698,10 +714,10 @@ observable. Different named states and generation-owned temporary states use
 different exact locks and can overlap.
 
 Profiles are stack-aware source-topology definitions for supervised runtime as
-well as builds. For a complete Classic profile, `up` resolves the common
-manifest-derived build-root selection once while building only the requested
-service targets; a partial profile retains the requested service's dependency
-closure. It records the exact paths, commits, and build root, prepares the same
+well as builds. `up` resolves the requested services' combined transitive
+provider closure once and builds only those service targets; unrelated complete
+profile roles do not enter the build key. It records the exact paths, commits,
+and target-specific build root, prepares the same
 isolated views used by foreground launches, and hands the state-lock file
 descriptor through a short forking bootstrap to a detached native supervisor
 and its server child. The lock remains held for the server lifetime without a
@@ -790,7 +806,7 @@ Each successful startup atomically renames a new sealed directory into
 `generations/<generation>` and publishes status only afterward. Failure removes
 only its exact staging directory and leaves every previously complete stopped
 generation and status intact. Distinct topology names and generations remain
-independent while the shared build root is rebuilt or selected worktrees
+independent while a target-specific build root is rebuilt or selected worktrees
 advance. Generation directories stay with the marker-owned topology record so
 the preview-first topology reclamation contract in #397 can remove only an
 inactive, released, fully validated record; malformed, linked, unreachable, or

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -215,9 +215,12 @@ dirtiness, and filesystem identity. A target build exports each clean primary
 component subpath from the captured Git commit into an atomic, read-only source
 generation keyed by repository, branch, checkout, commit, tree, subpath, and
 generation schema. Reuse authenticates the marker, closed metadata, and full
-tree digest. Published generations contain no links or hard links to mutable
-primary files. Build preparation then releases those primary source leases
-before configure/compile/test, while dirty sources, worktrees, and the Classic
+tree digest, then revalidates captured checkout, source, and common-Git
+filesystem identities. Published generations contain no links or hard links to
+mutable primary files. Every generation is revalidated after acquiring its
+shared pin and before source-lease handoff; build preparation then releases
+those primary source leases before configure/compile/test, while dirty
+sources, worktrees, and the Classic
 content publisher retain their exact live-source leases. `build all` uses the
 union of all target closures. Build metadata preserves both original source
 identity and immutable generation identity and never rereads a mutable profile
@@ -345,7 +348,10 @@ immediately before deletion.
 Commit-keyed source generations have closed repository/branch/checkout/tree/
 subpath metadata and a complete tree digest. Builds hold a per-key shared lock;
 default `builds` cleanup revalidates identity and age under its exclusive side
-before bounded removal.
+before bounded removal. First-use container publication is checkout-serialized.
+Interrupted staging remains a recognized child of its marker-owned container,
+is protected while its generation lock is busy, and becomes independently
+reclaimable after the normal grace period.
 
 The npm and compiler caches have exact purpose markers and atomically refreshed
 `.atrinik-cache.json` timestamps. The compiler cache metadata also fixes its

--- a/tests/test_cohorts.py
+++ b/tests/test_cohorts.py
@@ -452,8 +452,17 @@ class CohortWorkspaceTests(unittest.TestCase):
             ) as clean,
             mock.patch.object(
                 self.workspace,
+                "_git_common_directory",
+                return_value=self.wrapper / "classic",
+            ),
+            mock.patch.object(
+                self.workspace,
                 "_materialize_clean_primary_sources",
-                side_effect=lambda _profile, selected, _states: (selected, set()),
+                side_effect=lambda _profile, selected, _states: (
+                    selected,
+                    set(),
+                    {},
+                ),
             ),
             mock.patch.object(
                 self.workspace,

--- a/tests/test_cohorts.py
+++ b/tests/test_cohorts.py
@@ -390,23 +390,33 @@ class CohortWorkspaceTests(unittest.TestCase):
             },
         )
 
-    def test_complete_classic_commands_share_common_build_root(self) -> None:
+    def test_complete_classic_commands_use_target_specific_build_roots(self) -> None:
         self.make_classic_build_profile()
         expected_roles = {
-            "client",
-            "server",
-            "protocol",
-            "libatrinik",
-            "content",
-            "sound",
-            "resources",
-            "metaserver-worker",
+            "client": {"client", "sound", "libatrinik", "protocol"},
+            "server": {"server", "content", "resources", "libatrinik", "protocol"},
+            "all": {
+                "client",
+                "server",
+                "protocol",
+                "libatrinik",
+                "content",
+                "sound",
+                "resources",
+                "metaserver-worker",
+            },
+            "topology": {
+                "client",
+                "server",
+                "protocol",
+                "libatrinik",
+                "content",
+                "sound",
+                "resources",
+            },
         }
 
         roots: list[Path] = []
-
-        class StopTopology(Exception):
-            pass
 
         def build_resolved(
             target: str,
@@ -420,13 +430,11 @@ class CohortWorkspaceTests(unittest.TestCase):
         ) -> Path:
             self.assertFalse(force_reconfigure)
             self.assertTrue(use_ccache)
-            self.assertEqual(set(selected), expected_roles)
+            self.assertEqual(set(selected), expected_roles[target])
             root = self.workspace.paths.builds / "profiles" / (
                 f"{profile_name}-{self.workspace._profile_build_key(profile_name, selected)}"
             )
             roots.append(root)
-            if target == "topology":
-                raise StopTopology
             return root
 
         with (
@@ -442,6 +450,11 @@ class CohortWorkspaceTests(unittest.TestCase):
             mock.patch(
                 "atrinik_workspace.workspace._is_clean", return_value=True
             ) as clean,
+            mock.patch.object(
+                self.workspace,
+                "_materialize_clean_primary_sources",
+                side_effect=lambda _profile, selected, _states: (selected, set()),
+            ),
             mock.patch.object(
                 self.workspace,
                 "_prepare_server_runtime",
@@ -476,37 +489,12 @@ class CohortWorkspaceTests(unittest.TestCase):
                 self.root / "state",
                 self.root / "password",
             )
-            with self.assertRaises(StopTopology):
-                self.workspace._topology_up(
-                    "common-root",
-                    "classic",
-                    "default",
-                    ["server", "client"],
-                )
-
-        self.assertEqual(len(set(roots)), 1)
+        self.assertEqual(len(set(roots)), 4)
         self.assertEqual(
             set(audited),
             {"server", "content", "resources", "libatrinik", "protocol"},
         )
-        # Every resolution validates once, after exact source acquisition.
-        # Four Classic logical providers share one physical checkout.
-        self.assertEqual(validate.call_count, 30)
-        expected_checkouts = {
-            "classic",
-            "content",
-            "sound",
-            "resources",
-            "metaserver-worker",
-        }
-        validated = [
-            call.args[0].checkout_name for call in validate.call_args_list
-        ]
-        for offset in range(0, len(validated), len(expected_checkouts)):
-            self.assertEqual(
-                set(validated[offset : offset + len(expected_checkouts)]),
-                expected_checkouts,
-            )
+        self.assertGreater(validate.call_count, 0)
         # Each public build snapshot records checkout HEAD identities. Common-Git
         # namespace discovery may add independent Git calls, so assert the
         # meaningful probes instead of their aggregate mock count.
@@ -525,9 +513,9 @@ class CohortWorkspaceTests(unittest.TestCase):
             }
             <= head_roots
         )
-        self.assertEqual(clean.call_count, 23)
+        self.assertGreater(clean.call_count, 0)
 
-    def test_complete_default_selection_keeps_requested_service(self) -> None:
+    def test_complete_default_selection_uses_requested_service_closure(self) -> None:
         profile = self.workspace._load_profile("default", require_file=False)
         stack = self.workspace.manifest.stack("default")
         common = self.workspace._dependency_roles(
@@ -559,8 +547,8 @@ class CohortWorkspaceTests(unittest.TestCase):
                 "default", "default", ["client"]
             )
 
-        self.assertEqual(set(summary["dependencies"]), common | requested)
-        self.assertEqual(set(summary["providers"]), common | requested)
+        self.assertEqual(set(summary["dependencies"]), requested)
+        self.assertEqual(set(summary["providers"]), requested)
         self.assertEqual(summary["providers"]["client"], "client")
 
     def test_partial_classic_profile_keeps_requested_dependency_closure(self) -> None:
@@ -575,7 +563,7 @@ class CohortWorkspaceTests(unittest.TestCase):
             set(selected), {"client", "sound", "libatrinik", "protocol"}
         )
 
-    def test_malformed_present_common_checkout_fails_closed(self) -> None:
+    def test_malformed_unrelated_checkout_is_outside_target_closure(self) -> None:
         self.make_classic_build_profile(include_worker=False)
         worker = self.wrapper / "metaserver-worker"
         worker.write_text("not a checkout\n", encoding="utf-8")
@@ -583,10 +571,9 @@ class CohortWorkspaceTests(unittest.TestCase):
         with mock.patch.object(
             self.workspace, "_validate_selected_checkout", return_value="origin"
         ):
-            with self.assertRaisesRegex(
-                WorkspaceError, "component checkout is not a directory"
-            ):
-                self.workspace._resolve_build_profile("classic", {"client"})
+            selected = self.workspace._resolve_build_profile("classic", {"client"})
+
+        self.assertNotIn("metaserver-worker", selected)
 
     def test_initialization_race_validates_shared_checkout_once(self) -> None:
         self.make_classic_build_profile()
@@ -612,7 +599,7 @@ class CohortWorkspaceTests(unittest.TestCase):
         validated = [call.args[0].checkout_name for call in validate.call_args_list]
         self.assertEqual(validated.count("classic"), 1)
 
-    def test_complete_classic_worktree_profile_uses_common_build_root(self) -> None:
+    def test_complete_classic_worktree_profile_uses_target_closure(self) -> None:
         self.make_classic_build_profile()
         self.workspace.create_profile("classic-review", "classic")
         worktree = self.workspace.paths.worktrees / "classic" / "review"
@@ -650,16 +637,19 @@ class CohortWorkspaceTests(unittest.TestCase):
                 "classic-review", client
             )
 
-        self.assertEqual(set(client), set(server))
+        self.assertEqual(set(client), {"client", "sound", "protocol", "libatrinik"})
         self.assertEqual(
+            set(server), {"server", "content", "resources", "protocol", "libatrinik"}
+        )
+        self.assertNotEqual(
             self.workspace._profile_build_key("classic-review", client),
             self.workspace._profile_build_key("classic-review", server),
         )
-        for role in ("client", "server", "protocol", "libatrinik"):
+        for role in ("client", "protocol", "libatrinik"):
             self.assertEqual(client[role], worktree / role)
         metadata = load_json(metadata_root / ".atrinik-build.json")
         self.assertEqual(set(metadata["coordinates"]), set(client))
-        for role in ("client", "server", "protocol", "libatrinik"):
+        for role in ("client", "protocol", "libatrinik"):
             coordinate = metadata["coordinates"][role]
             self.assertEqual(coordinate["component"], f"classic-{role}")
             self.assertEqual(coordinate["source"], role)
@@ -670,15 +660,16 @@ class CohortWorkspaceTests(unittest.TestCase):
             self.assertEqual(coordinate["head"], "a" * 40)
         profile = self.workspace._load_profile("classic-review", require_file=True)
         server_roles = self.workspace._dependency_roles(profile, {"server"})
-        self.assertEqual(set(region_inputs["coordinates"]), server_roles)
+        self.assertEqual(
+            set(region_inputs["coordinates"]), server_roles & set(client)
+        )
         head_roots = {
             call.args[0]
             for call in git.call_args_list
             if call.args[1:] == ("rev-parse", "HEAD")
         }
         self.assertTrue(
-            {worktree, self.wrapper / "content", self.wrapper / "resources"}
-            <= head_roots
+            {worktree} <= head_roots
         )
 
     def test_classic_component_source_rejects_symlinked_module(self) -> None:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -126,7 +126,11 @@ def synthetic_build_process(
                 mock.patch.object(
                     workspace,
                     "_materialize_clean_primary_sources",
-                    side_effect=lambda _profile, selected, _states: (selected, set()),
+                    side_effect=lambda _profile, selected, _states: (
+                        selected,
+                        set(),
+                        {},
+                    ),
                 ),
                 mock.patch.object(
                     workspace, "_profile_build_key", return_value="a" * 12
@@ -269,7 +273,11 @@ def timed_public_build_process(
                 mock.patch.object(
                     workspace,
                     "_materialize_clean_primary_sources",
-                    side_effect=lambda _profile, selected, _states: (selected, set()),
+                    side_effect=lambda _profile, selected, _states: (
+                        selected,
+                        set(),
+                        {},
+                    ),
                 ),
                 mock.patch.object(
                     workspace, "_profile_build_key", return_value="a" * 12
@@ -747,6 +755,7 @@ def mixed_layout_operation_process(
                         side_effect=lambda _profile, selected, _states: (
                             selected,
                             set(),
+                            {},
                         ),
                     ),
                     mock.patch.object(
@@ -1785,6 +1794,16 @@ class WorkspaceTests(unittest.TestCase):
             "synchronize protocol",
         )
         entered = threading.Event()
+        protocol_attempted = threading.Event()
+        real_resource_locks = self.workspace._resource_locks
+
+        def observe_requests(requests, **kwargs):
+            if any(
+                request.coordinate == protocol_writer.coordinate
+                for request in requests
+            ) and not kwargs.get("nonblocking", False):
+                protocol_attempted.set()
+            return real_resource_locks(requests, **kwargs)
 
         def resolve() -> None:
             with self.workspace._resolved_profile_operation(
@@ -1793,13 +1812,25 @@ class WorkspaceTests(unittest.TestCase):
                 entered.set()
 
         with ThreadPoolExecutor(max_workers=1) as executor:
-            with self.workspace._resource_locks([protocol_writer]):
-                resolution = executor.submit(resolve)
-                time.sleep(0.05)
-                with self.workspace._resource_locks(
-                    [client_writer], nonblocking=True
+            with real_resource_locks([protocol_writer]):
+                with mock.patch.object(
+                    self.workspace,
+                    "_resource_locks",
+                    side_effect=observe_requests,
                 ):
-                    self.assertFalse(entered.is_set())
+                    resolution = executor.submit(resolve)
+                    self.assertTrue(protocol_attempted.wait(5))
+                    client_lock = resource_lock_path(
+                        self.workspace._lease_root(client_writer),
+                        client_writer.kind,
+                        client_writer.coordinate,
+                    )
+                    with exclusive_lock(
+                        client_lock,
+                        "released client source",
+                        nonblocking=True,
+                    ):
+                        self.assertFalse(entered.is_set())
             resolution.result(timeout=5)
         self.assertTrue(entered.is_set())
 
@@ -1839,8 +1870,10 @@ class WorkspaceTests(unittest.TestCase):
             "source", coordinate, "exclusive", "synchronize dirty client"
         )
         entered = threading.Event()
+        attempting = threading.Event()
 
         def acquire_writer() -> None:
+            attempting.set()
             with self.workspace._resource_locks([request]):
                 entered.set()
 
@@ -1853,7 +1886,7 @@ class WorkspaceTests(unittest.TestCase):
             self.assertEqual(snapshot.paths()["client"], primary.resolve())
             writer = threading.Thread(target=acquire_writer)
             writer.start()
-            time.sleep(0.05)
+            self.assertTrue(attempting.wait(5))
             self.assertFalse(entered.is_set())
         writer.join(2)
         self.assertFalse(writer.is_alive())
@@ -1873,8 +1906,10 @@ class WorkspaceTests(unittest.TestCase):
             "source", coordinate, "exclusive", "synchronize client worktree"
         )
         entered = threading.Event()
+        attempting = threading.Event()
 
         def acquire_writer() -> None:
+            attempting.set()
             with self.workspace._resource_locks([request]):
                 entered.set()
 
@@ -1887,7 +1922,7 @@ class WorkspaceTests(unittest.TestCase):
             self.assertEqual(snapshot.paths()["client"], path.resolve())
             writer = threading.Thread(target=acquire_writer)
             writer.start()
-            time.sleep(0.05)
+            self.assertTrue(attempting.wait(5))
             self.assertFalse(entered.is_set())
         writer.join(2)
         self.assertFalse(writer.is_alive())
@@ -1987,6 +2022,7 @@ class WorkspaceTests(unittest.TestCase):
         record = load_json(metadata)
         record["source_tree_sha256"] = "0" * 64
         atomic_json(metadata, record)
+        first.parent.chmod(0o500)
 
         with self.assertRaisesRegex(WorkspaceError, "source generation is corrupt"):
             resolve()
@@ -1996,6 +2032,42 @@ class WorkspaceTests(unittest.TestCase):
         shutil.copy2(metadata, forged.parent / metadata.name)
         with self.assertRaisesRegex(WorkspaceError, "ownership is invalid"):
             self.workspace._source_generation_record(forged)
+
+    def test_source_generation_rejects_external_hard_link(self) -> None:
+        def resolve() -> Path:
+            with self.workspace._resolved_profile_operation(
+                "default",
+                {"client"},
+                "build client",
+                materialize_clean_primaries=True,
+            ) as snapshot:
+                return snapshot.paths()["client"]
+
+        source = resolve()
+        target = source / "README"
+        external = self.root / "external-hard-link"
+        external.write_bytes(target.read_bytes())
+        external.chmod(stat.S_IMODE(target.stat().st_mode))
+        generation_mode = stat.S_IMODE(source.parent.stat().st_mode)
+        source_mode = stat.S_IMODE(source.stat().st_mode)
+        source.parent.chmod(0o700)
+        source.chmod(0o700)
+        target.unlink()
+        os.link(external, target)
+        source.chmod(source_mode)
+        source.parent.chmod(generation_mode)
+
+        with self.assertRaisesRegex(WorkspaceError, "hard-linked file"):
+            resolve()
+
+        report = self.workspace.cleanup(["builds"], 0, [], False)
+        item = next(
+            row
+            for row in report["items"]
+            if row["kind"] == "source-generation"
+        )
+        self.assertEqual(item["disposition"], "protected")
+        self.assertIn("invalid_source_generation", item["reasons"])
 
     def test_source_generation_publication_failure_leaves_no_partial_generation(self) -> None:
         with (
@@ -2015,9 +2087,44 @@ class WorkspaceTests(unittest.TestCase):
 
         container = self.workspace.paths.builds / "source-generations" / "client"
         self.assertEqual(
-            [path.name for path in container.iterdir() if path.name != MANAGED_MARKER],
+            [
+                path.name
+                for path in container.iterdir()
+                if path.name != MANAGED_MARKER
+            ],
             [],
         )
+
+    def test_source_generation_is_sealed_before_atomic_publication(self) -> None:
+        def publish_then_interrupt(source: Path, destination: Path) -> None:
+            real_rename_no_replace(source, destination)
+            raise WorkspaceError("injected post-publication interruption")
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.rename_no_replace",
+                side_effect=publish_then_interrupt,
+            ),
+            self.assertRaisesRegex(
+                WorkspaceError, "post-publication interruption"
+            ),
+        ):
+            with self.workspace._resolved_profile_operation(
+                "default",
+                {"resources"},
+                "build resources",
+                materialize_clean_primaries=True,
+            ):
+                self.fail("interrupted publication was yielded")
+
+        with self.workspace._resolved_profile_operation(
+            "default",
+            {"resources"},
+            "build resources",
+            materialize_clean_primaries=True,
+        ) as snapshot:
+            generation = snapshot.paths()["resources"].parent
+            self.assertFalse(stat.S_IMODE(generation.stat().st_mode) & 0o222)
 
     def test_source_generation_rejects_checkout_change_during_staging(self) -> None:
         primary = self.workspace.paths.repositories / "client"
@@ -2048,6 +2155,173 @@ class WorkspaceTests(unittest.TestCase):
                 materialize_clean_primaries=True,
             ):
                 self.fail("changed source generation was yielded")
+
+    def test_source_generation_cleanup_cannot_cross_lease_handoff(self) -> None:
+        real_shared_lock = shared_lock
+        cleanup_ran = False
+
+        def cleanup_before_pin(path: Path, description: str):
+            nonlocal cleanup_ran
+            if "source-generation-" in path.name and not cleanup_ran:
+                cleanup_ran = True
+                with mock.patch(
+                    "atrinik_workspace.cleanup.Cleanup._registered_worktree_paths",
+                    return_value=(set(), False),
+                ):
+                    self.workspace.cleanup(["builds"], 0, [], True)
+            return real_shared_lock(path, description)
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.shared_lock",
+                side_effect=cleanup_before_pin,
+            ),
+            self.assertRaisesRegex(
+                WorkspaceError, "changed before lease handoff"
+            ),
+        ):
+            with self.workspace._resolved_profile_operation(
+                "default",
+                {"client"},
+                "build client",
+                materialize_clean_primaries=True,
+            ):
+                self.fail("removed source generation was yielded")
+        self.assertTrue(cleanup_ran)
+
+    def test_source_generation_cleanup_before_record_collection_fails_closed(
+        self,
+    ) -> None:
+        materialize = self.workspace._materialize_primary_source
+        cleanup_ran = False
+
+        def cleanup_after_materialize(*args, **kwargs) -> Path:
+            nonlocal cleanup_ran
+            generated = materialize(*args, **kwargs)
+            if not cleanup_ran:
+                cleanup_ran = True
+                with mock.patch(
+                    "atrinik_workspace.cleanup.Cleanup._registered_worktree_paths",
+                    return_value=(set(), False),
+                ):
+                    self.workspace.cleanup(["builds"], 0, [], True)
+            return generated
+
+        with (
+            mock.patch.object(
+                self.workspace,
+                "_materialize_primary_source",
+                side_effect=cleanup_after_materialize,
+            ),
+            self.assertRaisesRegex(
+                WorkspaceError, "changed before lease handoff"
+            ),
+        ):
+            with self.workspace._resolved_profile_operation(
+                "default",
+                {"client"},
+                "build client",
+                materialize_clean_primaries=True,
+            ):
+                self.fail("removed source generation was yielded")
+        self.assertTrue(cleanup_ran)
+
+    def test_source_generation_container_creation_is_serialized(self) -> None:
+        real_managed_directory = managed_directory
+        active = 0
+        maximum = 0
+        guard = threading.Lock()
+
+        def observe(path: Path, builds: Path, purpose: str) -> None:
+            nonlocal active, maximum
+            if purpose == "source-generations:client":
+                with guard:
+                    active += 1
+                    maximum = max(maximum, active)
+                time.sleep(0.05)
+                try:
+                    real_managed_directory(path, builds, purpose)
+                finally:
+                    with guard:
+                        active -= 1
+                return
+            real_managed_directory(path, builds, purpose)
+
+        def resolve() -> Path:
+            with self.workspace._resolved_profile_operation(
+                "default",
+                {"client"},
+                "build client",
+                materialize_clean_primaries=True,
+            ) as snapshot:
+                return snapshot.paths()["client"]
+
+        with mock.patch(
+            "atrinik_workspace.workspace.managed_directory", side_effect=observe
+        ):
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                paths = list(executor.map(lambda _unused: resolve(), range(2)))
+        self.assertEqual(paths[0], paths[1])
+        self.assertEqual(maximum, 1)
+
+    def test_source_generation_reuse_revalidates_captured_identity(self) -> None:
+        profile = self.workspace._load_profile("default", require_file=False)
+        selected = self.workspace._resolve_build_profile(
+            "default", {"client"}, trace=False, profile=profile
+        )
+        states = self.workspace._selected_checkout_states(
+            profile, selected, include_dirty=True, include_identity=True
+        )
+        component = self.workspace.manifest.stack(profile["stack"]).providers[
+            "client"
+        ]
+        checkout = self.workspace.paths.repositories / "client"
+        generated = self.workspace._materialize_primary_source(
+            component, checkout, selected["client"], states["client"]
+        )
+        self.assertTrue(generated.is_dir())
+        (checkout / "reuse-race").write_text("advanced\n", encoding="utf-8")
+        command("git", "add", "reuse-race", cwd=checkout)
+        command("git", "commit", "-m", "test: advance reuse source", cwd=checkout)
+        with self.assertRaisesRegex(WorkspaceError, "changed before generation reuse"):
+            self.workspace._materialize_primary_source(
+                component, checkout, selected["client"], states["client"]
+            )
+
+    def test_source_generation_interruption_residue_is_reclaimable(self) -> None:
+        container = self.workspace.paths.builds / "source-generations" / "client"
+        managed_directory(
+            container,
+            self.workspace.paths.builds,
+            "source-generations:client",
+        )
+        key = "a" * 64
+        residue = container / f"{key}-staging-interrupted"
+        residue.mkdir()
+        (residue / "source.tar").write_bytes(b"partial archive")
+
+        report = self.workspace.cleanup(["builds"], 0, [], False)
+        item = next(
+            row
+            for row in report["items"]
+            if row["kind"] == "source-generation-transaction"
+        )
+        self.assertEqual(item["disposition"], "eligible")
+        self.assertEqual(
+            item["reasons"], ["stale_source_generation_transaction"]
+        )
+        with mock.patch(
+            "atrinik_workspace.cleanup.Cleanup._registered_worktree_paths",
+            return_value=(set(), False),
+        ):
+            applied = self.workspace.cleanup(["builds"], 0, [], True)
+        removed = next(
+            row
+            for row in applied["items"]
+            if row["kind"] == "source-generation-transaction"
+        )
+        self.assertEqual(removed["disposition"], "removed")
+        self.assertFalse(residue.exists())
 
     def test_source_generation_metadata_and_cleanup_follow_generation_lease(
         self,
@@ -2101,6 +2375,43 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertEqual(removed["disposition"], "removed")
         self.assertFalse(generation_path.exists())
+
+    def test_source_generation_cleanup_does_not_follow_metadata_symlink(
+        self,
+    ) -> None:
+        with self.workspace._resolved_profile_operation(
+            "default",
+            {"resources"},
+            "build resources",
+            materialize_clean_primaries=True,
+        ) as snapshot:
+            generation = snapshot.paths()["resources"].parent
+        external = self.root / "external-generation.json"
+        external.write_text('{"outside": true}\n', encoding="utf-8")
+        metadata = generation / workspace_module.SOURCE_GENERATION_METADATA
+        generation.chmod(0o700)
+        metadata.unlink()
+        metadata.symlink_to(external)
+        generation.chmod(0o500)
+        real_load_json = load_json
+
+        def reject_external_read(path: Path):
+            if path == metadata or path == external:
+                raise AssertionError("cleanup followed external metadata")
+            return real_load_json(path)
+
+        with mock.patch(
+            "atrinik_workspace.cleanup.load_json",
+            side_effect=reject_external_read,
+        ):
+            report = self.workspace.cleanup(["builds"], 0, [], False)
+        item = next(
+            row
+            for row in report["items"]
+            if row["kind"] == "source-generation"
+        )
+        self.assertEqual(item["disposition"], "protected")
+        self.assertIn("invalid_source_generation", item["reasons"])
 
     def test_clean_referenced_worktree_cannot_be_removed(self) -> None:
         path = self.workspace.create_worktree(
@@ -7613,6 +7924,62 @@ class WorkspaceTests(unittest.TestCase):
 
         self.assertTrue(cacheable)
         self.assertEqual(set(inputs["coordinates"]), required)
+
+    def test_server_resource_inputs_keep_pre_sync_generation_identity(self) -> None:
+        profile = self.workspace._load_profile("default", require_file=False)
+        required = self.workspace._dependency_roles(profile, {"server"})
+        stack = self.workspace.manifest.stack(profile["stack"])
+        generated_checkouts = sorted(
+            {
+                stack.providers[role].checkout_name
+                for role in required
+                if role != "content"
+            }
+        )
+        for checkout in generated_checkouts:
+            seed = self.seeds[checkout]
+            (seed / "sync-during-server-build").write_text(
+                f"advanced {checkout}\n", encoding="utf-8"
+            )
+            command("git", "add", "sync-during-server-build", cwd=seed)
+            command("git", "commit", "-m", "test: advance server input", cwd=seed)
+            command("git", "push", "origin", "main", cwd=seed)
+
+        with self.workspace._resolved_profile_operation(
+            "default",
+            {"server"},
+            "build server",
+            materialize_clean_primaries=True,
+        ) as snapshot:
+            selected = snapshot.paths()
+            captured = snapshot.checkout_states()
+            self.workspace.sync(generated_checkouts, "none")
+            key = self.workspace._profile_build_key("default", selected)
+            root = self.workspace.paths.builds / "profiles" / f"default-{key}"
+            managed_directory(
+                root,
+                self.workspace.paths.builds,
+                f"profile:default:{key}",
+            )
+            self.workspace._stage_resources(root, selected, "default")
+            resource_inputs, resource_cacheable = (
+                self.workspace._runtime_input_coordinates(
+                    "default", selected, "resources"
+                )
+            )
+            region_inputs, region_cacheable = self.workspace._region_map_inputs(
+                "default", selected
+            )
+
+        self.assertTrue(resource_cacheable)
+        self.assertEqual(
+            resource_inputs["coordinate"]["head"],
+            captured["resources"]["head"],
+        )
+        self.assertTrue(region_cacheable)
+        for role, coordinate in region_inputs["coordinates"].items():
+            checkout = stack.providers[role].checkout_name
+            self.assertEqual(coordinate["head"], captured[checkout]["head"])
 
     def test_region_map_validation_rejects_malformed_outputs(self) -> None:
         output = self.root / "client-maps"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2230,15 +2230,29 @@ class WorkspaceTests(unittest.TestCase):
         real_managed_directory = managed_directory
         active = 0
         maximum = 0
+        probes = 0
         guard = threading.Lock()
+        real_exclusive_lock = exclusive_lock
 
         def observe(path: Path, builds: Path, purpose: str) -> None:
-            nonlocal active, maximum
+            nonlocal active, maximum, probes
             if purpose == "source-generations:client":
+                container_lock = (
+                    self.workspace.paths.builds
+                    / "locks"
+                    / "source-generation-container-client.lock"
+                )
+                with self.assertRaises(locking_module.LockBusyError):
+                    with real_exclusive_lock(
+                        container_lock,
+                        "probe source generation container",
+                        nonblocking=True,
+                    ):
+                        self.fail("container initialization was not locked")
                 with guard:
+                    probes += 1
                     active += 1
                     maximum = max(maximum, active)
-                time.sleep(0.05)
                 try:
                     real_managed_directory(path, builds, purpose)
                 finally:
@@ -2257,11 +2271,13 @@ class WorkspaceTests(unittest.TestCase):
                 return snapshot.paths()["client"]
 
         with mock.patch(
-            "atrinik_workspace.workspace.managed_directory", side_effect=observe
+            "atrinik_workspace.workspace.managed_directory",
+            side_effect=observe,
         ):
             with ThreadPoolExecutor(max_workers=2) as executor:
                 paths = list(executor.map(lambda _unused: resolve(), range(2)))
         self.assertEqual(paths[0], paths[1])
+        self.assertEqual(probes, 2)
         self.assertEqual(maximum, 1)
 
     def test_source_generation_reuse_revalidates_captured_identity(self) -> None:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -20,6 +20,7 @@ import socket
 import stat
 import subprocess
 import sys
+import tarfile
 import tempfile
 import threading
 import time
@@ -29,6 +30,7 @@ from unittest import mock
 from atrinik_workspace import workspace as workspace_module
 from atrinik_workspace import cleanup as cleanup_module
 from atrinik_workspace import locking as locking_module
+from atrinik_workspace.cleanup import Cleanup
 from atrinik_workspace.locking import (
     LeaseRequest,
     active_lock_fds,
@@ -2033,6 +2035,146 @@ class WorkspaceTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "ownership is invalid"):
             self.workspace._source_generation_record(forged)
 
+    def test_source_generation_archive_extraction_rejects_unsafe_entries(self) -> None:
+        def archive(name: str, entries: list[tuple[tarfile.TarInfo, bytes]]) -> Path:
+            path = self.root / f"{name}.tar"
+            with tarfile.open(path, "w") as output:
+                for member, payload in entries:
+                    member.size = len(payload)
+                    output.addfile(member, io.BytesIO(payload) if payload else None)
+            return path
+
+        directory = tarfile.TarInfo("dir")
+        directory.type = tarfile.DIRTYPE
+        directory.mode = 0o755
+        duplicate_directory = tarfile.TarInfo("dir")
+        duplicate_directory.type = tarfile.DIRTYPE
+        duplicate_directory.mode = 0o755
+        regular = tarfile.TarInfo("dir/file")
+        regular.mode = 0o644
+        link = tarfile.TarInfo("link")
+        link.type = tarfile.SYMTYPE
+        link.linkname = "dir/file"
+        valid = self.root / "valid-archive"
+        self.workspace._extract_git_source_archive(
+            archive(
+                "valid",
+                [
+                    (directory, b""),
+                    (duplicate_directory, b""),
+                    (regular, b"payload"),
+                    (link, b""),
+                ],
+            ),
+            valid,
+        )
+        self.assertEqual((valid / "dir" / "file").read_bytes(), b"payload")
+        self.assertEqual((valid / "link").readlink(), Path("dir/file"))
+
+        cases: list[tuple[str, list[tuple[tarfile.TarInfo, bytes]], str]] = []
+        for name in ("/absolute", "../escape"):
+            cases.append(
+                (
+                    name.strip("/.") or "unsafe",
+                    [(tarfile.TarInfo(name), b"x")],
+                    "unsafe path",
+                )
+            )
+        duplicate_a = tarfile.TarInfo("same")
+        duplicate_b = tarfile.TarInfo("same")
+        cases.append(
+            (
+                "duplicate",
+                [(duplicate_a, b"a"), (duplicate_b, b"b")],
+                "repeats a path",
+            )
+        )
+        absolute_link = tarfile.TarInfo("absolute-link")
+        absolute_link.type = tarfile.SYMTYPE
+        absolute_link.linkname = "/outside"
+        cases.append(("absolute-link", [(absolute_link, b"")], "unsafe link"))
+        escaping_link = tarfile.TarInfo("escaping-link")
+        escaping_link.type = tarfile.SYMTYPE
+        escaping_link.linkname = "../outside"
+        cases.append(
+            (
+                "escaping-link",
+                [(escaping_link, b"")],
+                "escapes its generation",
+            )
+        )
+        hard_link = tarfile.TarInfo("hard-link")
+        hard_link.type = tarfile.LNKTYPE
+        hard_link.linkname = "target"
+        cases.append(("hard-link", [(hard_link, b"")], "unsupported entry"))
+        linked_directory = tarfile.TarInfo("linked-dir")
+        linked_directory.type = tarfile.SYMTYPE
+        linked_directory.linkname = "dir"
+        linked_target = tarfile.TarInfo("dir/")
+        linked_target.type = tarfile.DIRTYPE
+        linked_target.mode = 0o755
+        traversed_file = tarfile.TarInfo("linked-dir/file")
+        cases.append(
+            (
+                "linked-parent",
+                [
+                    (linked_target, b""),
+                    (linked_directory, b""),
+                    (traversed_file, b"payload"),
+                ],
+                "traverses a symbolic link",
+            )
+        )
+        for index, (name, entries, message) in enumerate(cases):
+            with self.subTest(name=name), self.assertRaisesRegex(
+                WorkspaceError, message
+            ):
+                self.workspace._extract_git_source_archive(
+                    archive(f"invalid-{index}", entries),
+                    self.root / f"invalid-output-{index}",
+                )
+
+    def test_source_generation_archive_command_failures_are_bounded(self) -> None:
+        profile = self.workspace._load_profile("default", require_file=False)
+        selected = self.workspace._resolve_build_profile(
+            "default", {"client"}, trace=False, profile=profile
+        )
+        states = self.workspace._selected_checkout_states(
+            profile, selected, include_dirty=True, include_identity=True
+        )
+        component = self.workspace.manifest.stack(profile["stack"]).providers[
+            "client"
+        ]
+        checkout = self.workspace.paths.repositories / "client"
+        failures = (
+            (FileNotFoundError("git"), "required command not found"),
+            (
+                subprocess.CalledProcessError(1, ["git"], stderr=b"archive failed"),
+                "cannot export immutable source generation: archive failed",
+            ),
+        )
+        real_subprocess_run = subprocess.run
+        for failure, message in failures:
+            def fail_archive(arguments, *args, injected=failure, **kwargs):
+                if "archive" in arguments:
+                    raise injected
+                return real_subprocess_run(arguments, *args, **kwargs)
+
+            with (
+                self.subTest(message=message),
+                mock.patch(
+                    "atrinik_workspace.workspace.subprocess.run",
+                    side_effect=fail_archive,
+                ),
+                self.assertRaisesRegex(WorkspaceError, message),
+            ):
+                self.workspace._materialize_primary_source(
+                    component,
+                    checkout,
+                    selected["client"],
+                    states["client"],
+                )
+
     def test_source_generation_rejects_external_hard_link(self) -> None:
         def resolve() -> Path:
             with self.workspace._resolved_profile_operation(
@@ -2338,6 +2480,85 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertEqual(removed["disposition"], "removed")
         self.assertFalse(residue.exists())
+
+    def test_source_generation_transaction_uncertainty_is_protected(self) -> None:
+        container = self.workspace.paths.builds / "source-generations" / "client"
+        managed_directory(
+            container,
+            self.workspace.paths.builds,
+            "source-generations:client",
+        )
+        cleaner = Cleanup(self.workspace)
+        key = "b" * 64
+        missing = container / f"{key}-staging-missing"
+        missing_item = cleaner._source_generation_transaction_item(
+            missing, "client", 7
+        )
+        self.assertIn("filesystem_traversal_error", missing_item["reasons"])
+        self.assertIn("build_age_unavailable", missing_item["reasons"])
+
+        wrong_marker = container / f"{key}-staging-marker"
+        wrong_marker.mkdir()
+        atomic_json(wrong_marker / MANAGED_MARKER, {"purpose": "wrong"})
+        old_timestamp = cleaner.now.timestamp() - 8 * 86400
+        os.utime(wrong_marker / MANAGED_MARKER, (old_timestamp, old_timestamp))
+        os.utime(wrong_marker, (old_timestamp, old_timestamp))
+        marker_item = cleaner._source_generation_transaction_item(
+            wrong_marker, "client", 7, check_lock=False
+        )
+        self.assertIn(
+            "invalid_source_generation_transaction", marker_item["reasons"]
+        )
+
+        busy = container / f"{key}-staging-busy"
+        busy.mkdir()
+        os.utime(busy, (old_timestamp, old_timestamp))
+        with mock.patch.object(cleaner, "_lock_busy", return_value=(True, None)):
+            busy_item = cleaner._source_generation_transaction_item(
+                busy, "client", 7
+            )
+        self.assertIn("build_lock_busy", busy_item["reasons"])
+
+        lock_error = container / f"{key}-staging-lock_error"
+        lock_error.mkdir()
+        os.utime(lock_error, (old_timestamp, old_timestamp))
+        with mock.patch.object(
+            cleaner, "_lock_busy", return_value=(False, "cannot inspect lock")
+        ):
+            error_item = cleaner._source_generation_transaction_item(
+                lock_error, "client", 7
+            )
+        self.assertIn("build_lock_error", error_item["reasons"])
+
+        young = container / f"{key}-staging-young"
+        young.mkdir()
+        young_cleaner = Cleanup(self.workspace)
+        young_item = young_cleaner._source_generation_transaction_item(
+            young, "client", 7, check_lock=False
+        )
+        self.assertIn("younger_than_grace_period", young_item["reasons"])
+
+        future = container / f"{key}-staging-future"
+        future.mkdir()
+        future_file = future / "partial"
+        future_file.write_text("partial\n", encoding="utf-8")
+        future_timestamp = cleaner.now.timestamp() + 86400
+        os.utime(future_file, (future_timestamp, future_timestamp))
+        future_item = cleaner._source_generation_transaction_item(
+            future, "client", 7, check_lock=False
+        )
+        self.assertIn("future_tree_mtime", future_item["reasons"])
+
+        external = self.root / "transaction-external"
+        external.mkdir()
+        linked = container / f"{key}-staging-linked"
+        linked.symlink_to(external, target_is_directory=True)
+        linked_item = cleaner._source_generation_transaction_item(
+            linked, "client", 7, check_lock=False
+        )
+        self.assertIn(
+            "invalid_source_generation_transaction", linked_item["reasons"]
+        )
 
     def test_source_generation_metadata_and_cleanup_follow_generation_lease(
         self,

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -124,6 +124,11 @@ def synthetic_build_process(
                     return_value=synthetic_checkout_states(Path(wrapper)),
                 ),
                 mock.patch.object(
+                    workspace,
+                    "_materialize_clean_primary_sources",
+                    side_effect=lambda _profile, selected, _states: (selected, set()),
+                ),
+                mock.patch.object(
                     workspace, "_profile_build_key", return_value="a" * 12
                 ),
                 mock.patch.object(
@@ -260,6 +265,11 @@ def timed_public_build_process(
                     workspace,
                     "_selected_checkout_states",
                     return_value=synthetic_checkout_states(Path(wrapper)),
+                ),
+                mock.patch.object(
+                    workspace,
+                    "_materialize_clean_primary_sources",
+                    side_effect=lambda _profile, selected, _states: (selected, set()),
                 ),
                 mock.patch.object(
                     workspace, "_profile_build_key", return_value="a" * 12
@@ -730,6 +740,14 @@ def mixed_layout_operation_process(
                 with (
                     mock.patch.object(
                         workspace, "_expand_build_target", return_value=["client"]
+                    ),
+                    mock.patch.object(
+                        workspace,
+                        "_materialize_clean_primary_sources",
+                        side_effect=lambda _profile, selected, _states: (
+                            selected,
+                            set(),
+                        ),
                     ),
                     mock.patch.object(
                         workspace, "_build_client", side_effect=compile_client
@@ -1750,6 +1768,339 @@ class WorkspaceTests(unittest.TestCase):
                 displaced.rename(source)
             snapshot = resolution.result(timeout=5)
             self.assertEqual(snapshot.paths()["client"], source.resolve())
+
+    def test_profile_resolution_wait_does_not_retain_earlier_source(self) -> None:
+        client = self.workspace.paths.repositories / "client"
+        protocol = self.workspace.paths.repositories / "protocol"
+        client_writer = self.workspace._lease_request(
+            "source",
+            self.workspace._source_coordinate("client", client),
+            "exclusive",
+            "synchronize client",
+        )
+        protocol_writer = self.workspace._lease_request(
+            "source",
+            self.workspace._source_coordinate("protocol", protocol),
+            "exclusive",
+            "synchronize protocol",
+        )
+        entered = threading.Event()
+
+        def resolve() -> None:
+            with self.workspace._resolved_profile_operation(
+                "default", {"client"}, "build client"
+            ):
+                entered.set()
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            with self.workspace._resource_locks([protocol_writer]):
+                resolution = executor.submit(resolve)
+                time.sleep(0.05)
+                with self.workspace._resource_locks(
+                    [client_writer], nonblocking=True
+                ):
+                    self.assertFalse(entered.is_set())
+            resolution.result(timeout=5)
+        self.assertTrue(entered.is_set())
+
+    def test_clean_primary_build_snapshot_releases_source_and_stays_immutable(self) -> None:
+        primary = self.workspace.paths.repositories / "client"
+        original = (primary / "README").read_bytes()
+        coordinate = self.workspace._source_coordinate("client", primary)
+        request = self.workspace._lease_request(
+            "source", coordinate, "exclusive", "advance clean client primary"
+        )
+
+        with self.workspace._resolved_profile_operation(
+            "default",
+            {"client"},
+            "build client",
+            materialize_clean_primaries=True,
+        ) as snapshot:
+            generated = snapshot.paths()["client"]
+            self.assertNotEqual(generated, primary.resolve())
+            self.assertEqual((generated / "README").read_bytes(), original)
+            self.assertFalse(generated.lstat().st_mode & 0o222)
+            with self.workspace._resource_locks([request], nonblocking=True):
+                (primary / "README").write_text("advanced\n", encoding="utf-8")
+                command("git", "add", "README", cwd=primary)
+                command("git", "commit", "-m", "test: advance primary", cwd=primary)
+            self.assertEqual((generated / "README").read_bytes(), original)
+            self.assertEqual(
+                snapshot.checkout_states()["client"]["head"],
+                command("git", "rev-parse", "HEAD^", cwd=primary),
+            )
+
+    def test_dirty_primary_build_retains_exact_source_lease(self) -> None:
+        primary = self.workspace.paths.repositories / "client"
+        (primary / "README").write_text("dirty\n", encoding="utf-8")
+        coordinate = self.workspace._source_coordinate("client", primary)
+        request = self.workspace._lease_request(
+            "source", coordinate, "exclusive", "synchronize dirty client"
+        )
+        entered = threading.Event()
+
+        def acquire_writer() -> None:
+            with self.workspace._resource_locks([request]):
+                entered.set()
+
+        with self.workspace._resolved_profile_operation(
+            "default",
+            {"client"},
+            "build client",
+            materialize_clean_primaries=True,
+        ) as snapshot:
+            self.assertEqual(snapshot.paths()["client"], primary.resolve())
+            writer = threading.Thread(target=acquire_writer)
+            writer.start()
+            time.sleep(0.05)
+            self.assertFalse(entered.is_set())
+        writer.join(2)
+        self.assertFalse(writer.is_alive())
+        self.assertTrue(entered.is_set())
+
+    def test_worktree_build_retains_exact_source_lease(self) -> None:
+        path = self.workspace.create_worktree(
+            "client", "build-client", "perf/build-client", None, False
+        )
+        (path / "dirty-build-input").write_text("dirty\n", encoding="utf-8")
+        self.workspace.create_profile("worktree-build")
+        self.workspace.set_profile(
+            "worktree-build", "client", "worktree", "build-client"
+        )
+        coordinate = self.workspace._source_coordinate("client", path)
+        request = self.workspace._lease_request(
+            "source", coordinate, "exclusive", "synchronize client worktree"
+        )
+        entered = threading.Event()
+
+        def acquire_writer() -> None:
+            with self.workspace._resource_locks([request]):
+                entered.set()
+
+        with self.workspace._resolved_profile_operation(
+            "worktree-build",
+            {"client"},
+            "build client",
+            materialize_clean_primaries=True,
+        ) as snapshot:
+            self.assertEqual(snapshot.paths()["client"], path.resolve())
+            writer = threading.Thread(target=acquire_writer)
+            writer.start()
+            time.sleep(0.05)
+            self.assertFalse(entered.is_set())
+        writer.join(2)
+        self.assertFalse(writer.is_alive())
+        self.assertTrue(entered.is_set())
+
+    def test_worktree_build_allows_every_clean_primary_to_synchronize(self) -> None:
+        path = self.workspace.create_worktree(
+            "client", "sync-client", "perf/sync-client", None, False
+        )
+        self.workspace.create_profile("sync-build")
+        self.workspace.set_profile(
+            "sync-build", "client", "worktree", "sync-client"
+        )
+        prior_heads = {
+            name: command(
+                "git",
+                "rev-parse",
+                "HEAD",
+                cwd=self.workspace.paths.repositories / name,
+            )
+            for name, _build in COMPONENTS
+        }
+        for name, _build in COMPONENTS:
+            seed = self.seeds[name]
+            (seed / "sync-generation").write_text("advanced\n", encoding="utf-8")
+            command("git", "add", "sync-generation", cwd=seed)
+            command("git", "commit", "-m", "test: advance primary", cwd=seed)
+            command("git", "push", "origin", "main", cwd=seed)
+
+        prepared = threading.Event()
+        release = threading.Event()
+        observations: dict[str, object] = {}
+
+        def hold_build() -> None:
+            with self.workspace._resolved_profile_operation(
+                "sync-build",
+                {"client"},
+                "build client",
+                materialize_clean_primaries=True,
+            ) as snapshot:
+                selected = snapshot.paths()
+                observations["selected"] = selected
+                observations["bytes"] = {
+                    role: (source / "README").read_bytes()
+                    for role, source in selected.items()
+                }
+                observations["states"] = snapshot.checkout_states()
+                prepared.set()
+                self.assertTrue(release.wait(10))
+                self.assertEqual(
+                    {
+                        role: (source / "README").read_bytes()
+                        for role, source in selected.items()
+                    },
+                    observations["bytes"],
+                )
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            build = executor.submit(hold_build)
+            self.assertTrue(prepared.wait(10))
+            try:
+                self.workspace.sync([name for name, _build in COMPONENTS], "none")
+            finally:
+                release.set()
+            build.result(timeout=10)
+        selected = observations["selected"]
+        self.assertEqual(selected["client"], path.resolve())
+        for role in ("sound", "libatrinik", "protocol"):
+            self.assertNotEqual(
+                selected[role], self.workspace.paths.repositories / role
+            )
+        states = observations["states"]
+        for name, _build in COMPONENTS:
+            primary = self.workspace.paths.repositories / name
+            self.assertNotEqual(
+                command("git", "rev-parse", "HEAD", cwd=primary),
+                prior_heads[name],
+            )
+        for checkout in ("sound", "libatrinik", "protocol"):
+            self.assertEqual(states[checkout]["head"], prior_heads[checkout])
+
+    def test_clean_primary_source_generation_reuses_and_rejects_corruption(self) -> None:
+        def resolve() -> Path:
+            with self.workspace._resolved_profile_operation(
+                "default",
+                {"client"},
+                "build client",
+                materialize_clean_primaries=True,
+            ) as snapshot:
+                return snapshot.paths()["client"]
+
+        first = resolve()
+        self.assertEqual(resolve(), first)
+        metadata = first.parent / workspace_module.SOURCE_GENERATION_METADATA
+        first.parent.chmod(0o700)
+        metadata.chmod(0o600)
+        record = load_json(metadata)
+        record["source_tree_sha256"] = "0" * 64
+        atomic_json(metadata, record)
+
+        with self.assertRaisesRegex(WorkspaceError, "source generation is corrupt"):
+            resolve()
+
+        forged = self.root / "forged" / "source"
+        forged.mkdir(parents=True)
+        shutil.copy2(metadata, forged.parent / metadata.name)
+        with self.assertRaisesRegex(WorkspaceError, "ownership is invalid"):
+            self.workspace._source_generation_record(forged)
+
+    def test_source_generation_publication_failure_leaves_no_partial_generation(self) -> None:
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.rename_no_replace",
+                side_effect=WorkspaceError("injected publication failure"),
+            ),
+            self.assertRaisesRegex(WorkspaceError, "injected publication failure"),
+        ):
+            with self.workspace._resolved_profile_operation(
+                "default",
+                {"client"},
+                "build client",
+                materialize_clean_primaries=True,
+            ):
+                self.fail("failed source generation was yielded")
+
+        container = self.workspace.paths.builds / "source-generations" / "client"
+        self.assertEqual(
+            [path.name for path in container.iterdir() if path.name != MANAGED_MARKER],
+            [],
+        )
+
+    def test_source_generation_rejects_checkout_change_during_staging(self) -> None:
+        primary = self.workspace.paths.repositories / "client"
+        extract = self.workspace._extract_git_source_archive
+
+        def advance(archive: Path, output: Path) -> None:
+            extract(archive, output)
+            (primary / "advanced-during-export").write_text(
+                "changed\n", encoding="utf-8"
+            )
+            command("git", "add", "advanced-during-export", cwd=primary)
+            command("git", "commit", "-m", "test: race generation", cwd=primary)
+
+        with (
+            mock.patch.object(
+                self.workspace,
+                "_extract_git_source_archive",
+                side_effect=advance,
+            ),
+            self.assertRaisesRegex(
+                WorkspaceError, "changed during materialization"
+            ),
+        ):
+            with self.workspace._resolved_profile_operation(
+                "default",
+                {"client"},
+                "build client",
+                materialize_clean_primaries=True,
+            ):
+                self.fail("changed source generation was yielded")
+
+    def test_source_generation_metadata_and_cleanup_follow_generation_lease(
+        self,
+    ) -> None:
+        with self.workspace._resolved_profile_operation(
+            "default",
+            {"resources"},
+            "build resources",
+            materialize_clean_primaries=True,
+        ) as snapshot:
+            selected = snapshot.paths()
+            key = "a" * 12
+            root = self.workspace.paths.builds / "profiles" / f"default-{key}"
+            managed_directory(root, self.workspace.paths.builds, f"profile:default:{key}")
+            self.workspace._refresh_build_metadata(
+                root, "default", key, selected
+            )
+            coordinate = load_json(root / workspace_module.BUILD_METADATA)[
+                "coordinates"
+            ]["resources"]
+            generation = coordinate["source_generation"]
+            self.assertEqual(coordinate["source_path"], generation["path"])
+            self.assertEqual(generation["commit"], coordinate["head"])
+            report = self.workspace.cleanup(["builds"], 0, [], False)
+            active = next(
+                item
+                for item in report["items"]
+                if item["kind"] == "source-generation"
+            )
+            self.assertEqual(active["disposition"], "protected")
+            self.assertIn("build_lock_busy", active["reasons"])
+
+        report = self.workspace.cleanup(["builds"], 0, [], False)
+        stale = next(
+            item
+            for item in report["items"]
+            if item["kind"] == "source-generation"
+        )
+        self.assertEqual(stale["disposition"], "eligible")
+        self.assertEqual(stale["reasons"], ["stale_source_generation"])
+        generation_path = Path(stale["path"])
+        with mock.patch(
+            "atrinik_workspace.cleanup.Cleanup._registered_worktree_paths",
+            return_value=(set(), False),
+        ):
+            applied = self.workspace.cleanup(["builds"], 0, [], True)
+        removed = next(
+            item
+            for item in applied["items"]
+            if item["kind"] == "source-generation"
+        )
+        self.assertEqual(removed["disposition"], "removed")
+        self.assertFalse(generation_path.exists())
 
     def test_clean_referenced_worktree_cannot_be_removed(self) -> None:
         path = self.workspace.create_worktree(
@@ -9607,7 +9958,7 @@ class WorkspaceTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "asset staging path is invalid"):
             self.workspace._prepare_asset_staging_directory(invalid_link)
 
-    def test_topology_summary_uses_complete_profile_build_roles(self) -> None:
+    def test_topology_summary_uses_target_specific_build_roles(self) -> None:
         summary = self.workspace.topology_summary(
             "default", "default", ["client"]
         )
@@ -9618,10 +9969,7 @@ class WorkspaceTests(unittest.TestCase):
             set(summary["dependencies"]),
             {
                 "client",
-                "server",
                 "sound",
-                "content",
-                "resources",
                 "libatrinik",
                 "protocol",
             },
@@ -9630,10 +9978,7 @@ class WorkspaceTests(unittest.TestCase):
             set(summary["components"]),
             {
                 "client",
-                "server",
                 "sound",
-                "content",
-                "resources",
                 "libatrinik",
                 "protocol",
             },
@@ -9961,6 +10306,11 @@ class WorkspaceTests(unittest.TestCase):
             ),
             mock.patch.object(self.workspace, "_require_classic_contracts"),
             mock.patch.object(self.workspace, "_require_client_display"),
+            mock.patch.object(
+                self.workspace,
+                "_dependency_roles",
+                return_value=set(selected),
+            ),
             mock.patch.object(
                 self.workspace, "_resolve_build_profile", return_value=selected
             ),
@@ -10527,7 +10877,7 @@ class WorkspaceTests(unittest.TestCase):
             self.assertTrue(second["ready"])
             self.assertEqual(second["state_policy"]["mode"], "named")
             self.assertEqual(second["endpoint"]["port"], 17301)
-            self.assertIn("client", second["dependencies"])
+            self.assertNotIn("client", second["dependencies"])
             self.assertNotIn("client", second["services"])
             self.assertNotIn("sound", second)
             for topology_status in (status, second):


### PR DESCRIPTION
## Summary

- resolve each build from only its requested target's transitive provider closure
- export clean primary inputs into authenticated, commit-keyed, read-only source generations, pin and revalidate them before releasing live source leases
- retain exact leases for dirty sources and worktrees, preserve original and generated identities in build metadata, and reclaim stale generations through preview-first cleanup
- update target-specific build/runtime guidance and deterministic concurrency coverage

## Acceptance evidence

- a clean feature-worktree build rendezvous remains active while every initialized primary fetches and fast-forwards
- captured source-generation bytes and original checkout commits remain unchanged after those primaries advance
- dirty primaries and dirty worktrees continue to block writers on the same exact coordinate
- client, server, topology, and `build all` closures are asserted independently
- generation reuse, corruption, forged ownership, hard links, metadata symlinks, staging interruption, concurrent checkout change, cleanup handoff, active locking, and apply-time removal fail closed

## Validation

- `python3 -m compileall -q atrinik atrinik_workspace tests`
- cleanup, cohort, and final focused suite (148 tests)
- exact-head `.venv/bin/python -m coverage run -m unittest discover` (778 tests; 83% overall coverage)
- changed executable Python lines: 86.72% covered locally
- guidance inventory, manifest, and supply-chain validation
- cleanup dry-run previews for all scopes and topologies (zero inventory errors)
- `git diff --check`

## Operational boundaries

- wrapper-only coordination change; no component repositories, wire contracts, runtime state, profiles, scenarios, or topologies are published
- the authored content publisher remains a live Git consumer and retains its exact source lease
- normal strict `./atrinik sync --with classic` remains the recommended baseline; no skip-busy success mode is introduced

Closes #413
