### PR TITLE
feat(runtime): support explicit topology state policies

### DIFF
--- a/.agents/skills/atrinik-issue-delivery/SKILL.md
+++ b/.agents/skills/atrinik-issue-delivery/SKILL.md
@@ -101,11 +101,13 @@ Before provisioning, run the supported inventories as applicable:
 ./atrinik state list --json
 ./atrinik ps --json
 ./atrinik profile show PROFILE --json
-./atrinik topology show PROFILE --state STATE --json
+./atrinik topology show PROFILE --temporary-state --json
 ```
 
 Reuse rather than recreate a compatible issue profile, stopped issue topology,
-wrapper-owned state and server/client data, or issue-owned scenario. Reuse only
+wrapper-owned state and server/client data, or issue-owned scenario. Prefer a
+fresh generation-owned temporary state for automation; select named/default
+state only when persistence or an existing account is required. Reuse only
 resources
 whose immutable repository, branch, checkout, source, provider, commit, profile,
 generation, and state-owner coordinates match final HEAD; incomplete historical
@@ -123,7 +125,8 @@ is impractical.
 
 For Classic, compose the runtime/scenario skills and provide concrete
 copy-pasteable profile, build, scenario, credentials-local-only, topology,
-bounded-log, action/result, repeat, shutdown, and cleanup commands. Initial
+bounded-log, action/result, repeat, shutdown, and cleanup commands. State the
+temporary, named, default, or scenario policy explicitly. Initial
 `down` applies only to that exact running topology; reset only issue-owned data.
 State display/login prerequisites.
 

--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -102,7 +102,8 @@ remainder.
 For classic server execution or diagnosis, load `atrinik-server-runtime`. For
 a ready account and character, also load `atrinik-test-scenario`; never
 handcraft saves or expose credentials. Keep every concurrent topology on a
-distinct name and server state.
+distinct name and state policy; prefer generation-owned temporary state for
+isolated automation.
 
 ## Validate and hand off
 
@@ -112,8 +113,8 @@ names and follows this lifecycle:
 ```sh
 ./atrinik profile show PROFILE
 ./atrinik build COMPONENT --profile PROFILE --test
-./atrinik topology show PROFILE --json
-./atrinik up --name TOPOLOGY --profile PROFILE --state STATE
+./atrinik topology show PROFILE --temporary-state --json
+./atrinik up --name TOPOLOGY --profile PROFILE --temporary-state
 ./atrinik ps TOPOLOGY --json
 ./atrinik logs TOPOLOGY [server|client] --follow
 ./atrinik down TOPOLOGY

--- a/.agents/skills/atrinik-server-runtime/SKILL.md
+++ b/.agents/skills/atrinik-server-runtime/SKILL.md
@@ -33,7 +33,9 @@ HTTP(S) origin; never restore a bundled HTTP listener.
 `--state NAME` selects a registered persistent state; `--default-state`
 explicitly selects the legacy managed default. The three selectors are
 mutually exclusive. A confirmed clean `down` removes temporary state only
-after exact process/state lease release. Use `down NAME --retain-state` and
+after expected service exit and exact process/state lease release; persisted
+clean proof makes interrupted finalization retryable. Use `down NAME
+--retain-state` and
 `state promote NAME SAVED_NAME` to preserve it without overwrite. Crash,
 unreachable, malformed, linked, busy, or uncertain state remains for diagnosis;
 inventory it with `cleanup --scope temporary-states --dry-run --json` and never

--- a/.agents/skills/atrinik-server-runtime/SKILL.md
+++ b/.agents/skills/atrinik-server-runtime/SKILL.md
@@ -37,7 +37,9 @@ after exact process/state lease release. Use `down NAME --retain-state` and
 `state promote NAME SAVED_NAME` to preserve it without overwrite. Crash,
 unreachable, malformed, linked, busy, or uncertain state remains for diagnosis;
 inventory it with `cleanup --scope temporary-states --dry-run --json` and never
-apply cleanup without the matching preview.
+apply cleanup without the matching preview. Do not reuse a topology name while
+its temporary state is retained or has an unfinished lifecycle; promote or
+explicitly reclaim that state first.
 
 `ps --json` reports generation-bound `live`, `exited`, `stale`, or
 `unreachable` liveness and exact runtime-generation, process-tree, state-policy
@@ -48,6 +50,8 @@ follow the reported safe action: wait for bounded guardian recovery and retry
 `ps` and `down`; preserve an exact retained lease for operator diagnosis.
 Never inspect `/proc`, signal the recorded PIDs, unlink control or lease files,
 or reuse the name as recovery.
+`logs` prefixes service output with the same state-policy context. Preserve that
+header with bounded diagnostic excerpts and handoffs.
 After `down`, retain the record for diagnosis or reclaim it only through the
 separate preview-first lifecycle:
 

--- a/.agents/skills/atrinik-server-runtime/SKILL.md
+++ b/.agents/skills/atrinik-server-runtime/SKILL.md
@@ -17,21 +17,31 @@ HTTP(S) origin; never restore a bundled HTTP listener.
 
 1. Read the workspace and selected server/content/resource guides.
 2. Inspect a coherent classic-derived profile and topology.
-3. Give concurrent topologies distinct registered states. Never replace source,
-   share live state, or edit managed runtime files.
+3. Give isolated automation generation-owned temporary state. Use a distinct
+   named state or explicit default state only when persistence is required.
+   Never replace source, share live state, or edit managed runtime files.
 
 ```sh
 ./atrinik build server --profile PROFILE --test
-./atrinik topology show PROFILE --state STATE --json
-./atrinik up --name NAME --profile PROFILE --state STATE
+./atrinik topology show PROFILE --temporary-state --json
+./atrinik up --name NAME --profile PROFILE --temporary-state
 ./atrinik ps NAME --json
 ./atrinik logs NAME server --follow
 ./atrinik down NAME
 ```
 
+`--state NAME` selects a registered persistent state; `--default-state`
+explicitly selects the legacy managed default. The three selectors are
+mutually exclusive. A confirmed clean `down` removes temporary state only
+after exact process/state lease release. Use `down NAME --retain-state` and
+`state promote NAME SAVED_NAME` to preserve it without overwrite. Crash,
+unreachable, malformed, linked, busy, or uncertain state remains for diagnosis;
+inventory it with `cleanup --scope temporary-states --dry-run --json` and never
+apply cleanup without the matching preview.
+
 `ps --json` reports generation-bound `live`, `exited`, `stale`, or
-`unreachable` liveness and exact runtime-generation, process-tree, state, and
-port observations. A ready topology retains no repository-layout or mutable
+`unreachable` liveness and exact runtime-generation, process-tree, state-policy
+owner/path/lifecycle, and port observations. A ready topology retains no repository-layout or mutable
 build-root lease. Cross-session `down` uses the matching filesystem
 control endpoint, never a PID from the caller's namespace. For `unreachable`,
 follow the reported safe action: wait for bounded guardian recovery and retry

--- a/.agents/skills/atrinik-test-scenario/SKILL.md
+++ b/.agents/skills/atrinik-test-scenario/SKILL.md
@@ -9,7 +9,9 @@ Use scenarios for repeatable reproductions. Keep account creation in the server
 API and orchestration in the wrapper; never edit account/player files.
 
 Fresh state comes from Classic `install_data`; the wrapper creates disposable
-asset staging. Never add generated assets to scenario state.
+asset staging. Scenario state is registered, persistent, and scenario-owned;
+it is not generic temporary topology state and must still be selected with
+`--state scenario-NAME`. Never add generated assets to scenario state.
 
 1. Select the exact coherent classic-derived profile.
 2. Choose a lowercase issue/feature name and use `basic-player` unless a tested

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,8 @@
   guidance in `docs/`, `README.md`, and `CONTRIBUTING.md`.
 - Workflows live in `.agents/skills/`, composition in `.devcontainer/`,
   CI/release in `.github/`, and helpers in `scripts/`.
-- Manifest destinations (`client/`, `server/`, `classic/`) are independent
-  ignored repositories; `workspace/` and `build/` are ignored generated state,
-  so root `git status` omits them.
+- Manifest destinations are independent ignored repositories; `workspace/`
+  and `build/` are ignored generated state, so root status omits them.
 - Resolve ownership through `components.json` and the checkout's nearest
   `AGENTS.md`; keep implementation, tests, packages, and releases there.
 - `classic/` provides five `classic-*` components. Both stacks share
@@ -49,11 +48,12 @@
 - Worktrees belong to physical checkouts. Selecting `classic`, a `classic-*`
   component, or one of its roles selects one root for all five; profiles append
   manifest source directories.
-- Use wrapper commands; never reconstruct paths. Isolate concurrent topology
-  names, states, ports, and config.
-- Keep completion bounded, local, parser-driven, secret-free, and before
-  `Workspace` construction.
-- Lease in order; gate same-coordinate readers; share the migration barrier.
+- Use wrapper commands; never reconstruct paths. Give concurrent topologies distinct names, ports, client
+  config, and preferably generation-owned temporary state.
+- Keep shell completion parser-driven, bounded, local-only, secret-free, and
+  ahead of `Workspace` construction.
+- Lease resources in order. Writers gate same-coordinate readers. Operations
+  share the migration barrier.
 - Unbound persisted records are historical and inert.
 - On touch, refresh existing Atrinik-owned copyright terminal years and blanket
   holders per `CONTRIBUTING.md`; preserve precise attribution.
@@ -88,7 +88,7 @@ interactive log session):
 ```sh
 ./atrinik profile show classic --json
 ./atrinik build all --profile classic --test
-./atrinik up --name classic-local --profile classic --state default
+./atrinik up --name classic-local --profile classic --temporary-state
 ./atrinik ps classic-local --json
 ./atrinik logs classic-local server --tail 100
 ./atrinik down classic-local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,12 +48,10 @@
 - Worktrees belong to physical checkouts. Selecting `classic`, a `classic-*`
   component, or one of its roles selects one root for all five; profiles append
   manifest source directories.
-- Use wrapper commands; never reconstruct paths. Give concurrent topologies distinct names, ports, client
-  config, and preferably generation-owned temporary state.
-- Keep shell completion parser-driven, bounded, local-only, secret-free, and
-  ahead of `Workspace` construction.
-- Lease resources in order. Writers gate same-coordinate readers. Operations
-  share the migration barrier.
+- Use wrapper paths. Concurrent topologies need names, ports, and client
+  config; prefer temporary state.
+- Keep completion bounded, local, parser-driven and secret-free.
+- Lease in order; gate same-coordinate readers; share the migration barrier.
 - Unbound persisted records are historical and inert.
 - On touch, refresh existing Atrinik-owned copyright terminal years and blanket
   holders per `CONTRIBUTING.md`; preserve precise attribution.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,15 +30,14 @@
 
 ## Core behaviors and patterns
 
-- Use `atrinik-multi-repo-workspace` for ownership, profiles, worktrees,
-  migration, cleanup, releases, or wrapper CLI/layout work. Add only the narrow
-  C, content, protocol, runtime, scenario, or GitHub skill needed. Use
-  `atrinik-guidance-maintenance` for periodic guidance audits or drift updates.
+- Use `atrinik-multi-repo-workspace` for wrapper ownership, profiles, worktrees,
+  migration, cleanup, releases, CLI, or layout. Add only applicable specialist
+  skills; use `atrinik-guidance-maintenance` for guidance audits.
 - Use `atrinik-issue-delivery` only when explicitly invoked for
   issue-to-ready-PR delivery; it stops before merge.
 - Use `atrinik-program-delivery` only when explicitly invoked for an ordered
-  master issue; it composes leaf delivery across human merge gates and stops
-  before merge or issue closure.
+  master issue; it composes leaves across merge gates and stops before merge or
+  issue closure.
 - Never replace or move a dirty primary checkout, remove a dirty worktree, or
   overwrite mutable server data. Preserve recoverable migration inputs.
 - Cleanup is explicit and preview-first: run
@@ -48,9 +47,11 @@
 - Worktrees belong to physical checkouts. Selecting `classic`, a `classic-*`
   component, or one of its roles selects one root for all five; profiles append
   manifest source directories.
-- Use wrapper paths. Concurrent topologies need names, ports, and client
-  config; prefer temporary state.
-- Keep completion bounded, local, parser-driven and secret-free.
+- Use wrapper commands and paths; never reconstruct managed paths. Give
+  concurrent topologies distinct names, states, ports, and client config;
+  prefer temporary state.
+- Keep completion bounded, local, parser-driven, secret-free, and ahead of
+  `Workspace` construction.
 - Lease in order; gate same-coordinate readers; share the migration barrier.
 - Unbound persisted records are historical and inert.
 - On touch, refresh existing Atrinik-owned copyright terminal years and blanket
@@ -65,8 +66,7 @@
   never visible literal `\n` separators. Feed multi-section bodies by file or
   stdin; after create/edit, verify remote rendering. Use
   `atrinik-github-governance` for publication, policy, or native PR stacks.
-  Semantic-release owns
-  tags/assets; keep confidential or unreleased work off public surfaces.
+  Semantic-release owns tags/assets; keep unreleased work off public surfaces.
 
 ## Working agreements and commands
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Add the complete currently playable classic stack explicitly:
 ./atrinik status --json
 ./atrinik profile show classic
 ./atrinik build all --profile classic --test
-./atrinik up --name classic-local --profile classic --state default
+./atrinik up --name classic-local --profile classic --temporary-state
 ./atrinik ps classic-local --json
 ./atrinik logs classic-local server --follow
 # Press Ctrl-C to stop following logs; the services keep running.
@@ -495,15 +495,15 @@ process.
 
 Change handoffs should end with a copy-pasteable verification recipe that uses
 the thin wrapper instead of internal build paths or direct component binaries.
-Use the actual profile, topology, and state names for the change. A runtime
+Use the actual profile, topology, and state policy for the change. A runtime
 client/server review normally follows this shape; until replacement runtime
 contracts land, `PROFILE` must be `classic` or derived from it:
 
 ~~~sh
 ./atrinik profile show PROFILE
 ./atrinik build COMPONENT --profile PROFILE --test
-./atrinik topology show PROFILE --json
-./atrinik up --name TOPOLOGY --profile PROFILE --state STATE
+./atrinik topology show PROFILE --temporary-state --json
+./atrinik up --name TOPOLOGY --profile PROFILE --temporary-state
 ./atrinik ps TOPOLOGY --json
 ./atrinik logs TOPOLOGY client --follow
 # Perform the feature-specific checks described in the handoff.
@@ -515,9 +515,9 @@ filesystem control endpoint. `ps` and `down` therefore work from another
 supported devcontainer or sandbox that shares the workspace even when its PID
 namespace cannot see the namespace-local process numbers. JSON status reports
 `live`, `exited`, `stale`, or fail-closed `unreachable` liveness plus exact
-runtime-generation, process-tree, server-state, and port observations and the
-safe next action. Text status prints the retained generation identity and
-action. A control response must match both the topology name and generation;
+runtime-generation, process-tree, state-policy owner/path/lifecycle, and port
+observations and the safe next action. Text status prints the retained
+generation identity and action. A control response must match both the topology name and generation;
 `down` never falls back to signaling a mismatched or recycled PID.
 The runtime places the socket under a short generation-derived name in the
 shared workspace, avoiding ordinary managed-worktree and topology-name path
@@ -632,17 +632,19 @@ without changing the filesystem:
 ./atrinik cleanup --scope sound-cache --older-than 7 --dry-run --json
 ./atrinik cleanup --scope topologies --older-than 7 --dry-run --json
 ./atrinik cleanup --scope topologies --older-than 7 --apply
+./atrinik cleanup --scope temporary-states --older-than 7 --dry-run --json
 ./atrinik cleanup --scope all --older-than 7 --apply
 ~~~
 
 `--dry-run` is the explicit spelling of the default mode; only `--apply`
 mutates. Repeated `--scope` options combine `worktrees`, `builds`, and the
-opt-in `npm-cache`, `compiler-cache`, and `sound-cache`; `all` selects all five.
+opt-in `temporary-states`, `npm-cache`, `compiler-cache`, and `sound-cache`;
+`all` selects all six.
 Topology history is a separate opt-in `topologies` scope and is deliberately
 excluded from both the default and `all`, so a broad cache/worktree cleanup
 cannot silently expand to runtime history.
 Positional checkout or logical component names narrow worktree and sound-cache
-inventory and still deduplicate
+inventory, exclude topology-owned temporary state, and still deduplicate
 aliases to one physical checkout. The special `atrinik` filter selects wrapper
 worktrees. JSON output is stable schema-versioned data and keeps Git/GitHub
 diagnostics off stdout; its byte fields remain exact integers. Text output uses
@@ -744,7 +746,17 @@ linked, malformed, unowned, or unverifiable records remain protected. Apply
 takes the exact topology coordinate lease and operation lock, repeats
 identity/generation/lease/age/tree validation, and removes only that topology
 directory. It never invokes `down`, signals processes, reuses a name, removes
-build roots, or changes profiles, scenarios, source, or persistent state.
+build roots, or changes profiles, scenarios, source, or persistent state. A
+topology containing any generation-owned temporary state remains protected;
+reclaim eligible disposable state with the separate scope first.
+
+The explicit `temporary-states` scope inventories generation-named states
+below marker-owned topology records. An old disposable state becomes eligible
+only when its topology/generation metadata, directory identity, registry
+absence, and released exact lease all validate. Retained, promoted, live,
+unreachable, busy, linked, malformed, registered, or uncertain state remains
+protected. Apply holds the topology operation and state locks while repeating
+the proof and never stops a topology.
 
 Apply performs one complete inventory and size recomputation, then acquires the
 exact target/reference leases and freshly revalidates each stable-sorted
@@ -933,11 +945,42 @@ commands turn that selection into a Compose-like native development stack:
 
 ~~~sh
 ./atrinik topology show PROFILE
-./atrinik up --name TOPOLOGY --profile PROFILE --state STATE [--port UDP_PORT]
+./atrinik up --name TOPOLOGY --profile PROFILE --temporary-state [--port UDP_PORT]
 ./atrinik ps [TOPOLOGY]
 ./atrinik logs TOPOLOGY [server|client] [--follow]
 ./atrinik down TOPOLOGY
 ~~~
+
+Server topologies choose exactly one state policy: `--temporary-state` creates
+a fresh generation-owned state for isolated automation, `--state NAME` selects
+an existing registered persistent state, and `--default-state` explicitly
+selects the legacy managed persistent default. Omitting all three remains
+backward compatible with `--state default`. `topology show`, `up`, and
+`ps --json` report the policy, exact owner, path identity, and lifecycle.
+Temporary state is never entered in `state list`; a confirmed clean `down`
+removes it after its process and state leases are released. A crash,
+unreachable supervisor, malformed record, or uncertain lease retains it for
+diagnosis.
+
+Retain a clean temporary state deliberately, then promote it without replacing
+an existing name:
+
+~~~sh
+./atrinik down TOPOLOGY --retain-state
+./atrinik state promote TOPOLOGY SAVED_NAME --json
+~~~
+
+Promotion registers the exact stopped directory in place. Retained and
+promoted states are protected. Abandoned disposable states participate only in
+the explicit preview-first cleanup scope:
+
+~~~sh
+./atrinik cleanup --scope temporary-states --older-than 7 --dry-run --json
+./atrinik cleanup --scope temporary-states --older-than 7 --apply --json
+~~~
+
+Cleanup never stops a topology and never removes a live, busy, linked,
+malformed, registered, retained, promoted, or otherwise uncertain state.
 
 For a complete Classic profile, `up`, scenarios, and individual builds resolve
 one manifest-derived build-root selection across the `client`, `server`,
@@ -1061,7 +1104,7 @@ cd ~/atrinik
 ./atrinik init --with classic
 ./atrinik sync --with classic
 ./atrinik topology show classic
-./atrinik up --name classic-main --profile classic --state default
+./atrinik up --name classic-main --profile classic --default-state
 ./atrinik ps classic-main
 ./atrinik logs classic-main server --follow
 # Press Ctrl-C to stop following logs; the services keep running.
@@ -1280,9 +1323,11 @@ explicit `profile set` commands repoint it. Do that only when the retained
 review selection and stopped topology history are no longer useful, then
 preview each cleanup scope. Only the explicit `topologies` scope removes
 eligible topology records and logs. Cleanup never removes profiles, scenarios,
-state, migration evidence, commits, or branches.
+registered or scenario state, migration evidence, commits, or branches. Only the explicit
+`temporary-states` scope can reclaim an abandoned, unregistered, disposable
+generation state after exact revalidation.
 
-## Persistent server state
+## Server state policies
 
 The built-in state named `default` is initialized once at
 `workspace/state/server/default` and then reused by every profile. Register a
@@ -1301,6 +1346,12 @@ useful:
 State contains player, key, unique-item, and other mutable runtime data. It is
 never regenerated over an existing directory. A nonblocking lock prevents two
 coordinator-launched servers from using the same state simultaneously.
+Managed default, named, scenario, and temporary state records preserve their
+distinct policy and owner identities; an optional implementation marker causes
+future Classic/replacement mismatches to fail closed instead of sharing an
+incompatible directory. Registered external paths remain outside wrapper
+deletion ownership. Scenario state remains registered, scenario-owned, and
+resettable only through `scenario reset`; it is not temporary topology state.
 Repository migration never moves, rewrites, or retags an existing state; state
 ownership evolution is a separate migration contract.
 

--- a/README.md
+++ b/README.md
@@ -975,8 +975,9 @@ an existing name:
 ~~~
 
 Promotion registers the exact stopped directory in place and persistent policy
-surfaces retain its topology-generation provenance. Retained and promoted
-states are protected, and a topology name with unfinished temporary
+surfaces retain its topology-generation provenance in independent durable
+metadata, including across a promotion retry or unavailable origin record.
+Retained and promoted states are protected, and a topology name with unfinished temporary
 state cannot be restarted until that state is promoted or explicitly reclaimed.
 Abandoned disposable states participate only in
 the explicit preview-first cleanup scope:

--- a/README.md
+++ b/README.md
@@ -956,7 +956,9 @@ a fresh generation-owned state for isolated automation, `--state NAME` selects
 an existing registered persistent state, and `--default-state` explicitly
 selects the legacy managed persistent default. Omitting all three remains
 backward compatible with `--state default`. `topology show`, `up`, and
-`ps --json` report the policy, exact owner, path identity, and lifecycle.
+`ps --json` report the policy, exact owner, path identity, and lifecycle. Bounded
+and followed service logs begin with the same policy context so captured output
+retains the state ownership boundary.
 Temporary state is never entered in `state list`; a confirmed clean `down`
 removes it after its process and state leases are released. A crash,
 unreachable supervisor, malformed record, or uncertain lease retains it for
@@ -971,7 +973,9 @@ an existing name:
 ~~~
 
 Promotion registers the exact stopped directory in place. Retained and
-promoted states are protected. Abandoned disposable states participate only in
+promoted states are protected, and a topology name with unfinished temporary
+state cannot be restarted until that state is promoted or explicitly reclaimed.
+Abandoned disposable states participate only in
 the explicit preview-first cleanup scope:
 
 ~~~sh

--- a/README.md
+++ b/README.md
@@ -960,7 +960,9 @@ backward compatible with `--state default`. `topology show`, `up`, and
 and followed service logs begin with the same policy context so captured output
 retains the state ownership boundary.
 Temporary state is never entered in `state list`; a confirmed clean `down`
-removes it after its process and state leases are released. A crash,
+removes it after its process and state leases are released. Clean proof
+requires expected service exit status as well as released leases and remains
+durable so an interrupted `down` can safely retry finalization. A crash,
 unreachable supervisor, malformed record, or uncertain lease retains it for
 diagnosis.
 
@@ -972,8 +974,9 @@ an existing name:
 ./atrinik state promote TOPOLOGY SAVED_NAME --json
 ~~~
 
-Promotion registers the exact stopped directory in place. Retained and
-promoted states are protected, and a topology name with unfinished temporary
+Promotion registers the exact stopped directory in place and persistent policy
+surfaces retain its topology-generation provenance. Retained and promoted
+states are protected, and a topology name with unfinished temporary
 state cannot be restarted until that state is promoted or explicitly reclaimed.
 Abandoned disposable states participate only in
 the explicit preview-first cleanup scope:

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -3154,6 +3154,31 @@ class Cleanup:
         except OSError as error:
             return False, str(error)
 
+    @staticmethod
+    def _state_lock_observation(
+        path: Path,
+    ) -> tuple[bool, str | None, dict[str, int] | None]:
+        flags = os.O_RDWR | os.O_CLOEXEC
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        try:
+            descriptor = os.open(path, flags)
+            metadata = os.fstat(descriptor)
+            if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+                os.close(descriptor)
+                return False, f"state lock identity is invalid: {path}", None
+            identity = {"device": metadata.st_dev, "inode": metadata.st_ino}
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                os.close(descriptor)
+                return True, None, identity
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+            os.close(descriptor)
+            return False, None, identity
+        except OSError as error:
+            return False, str(error), None
+
     def _unmanaged_builds(self, registered: set[Path]) -> list[dict[str, Any]]:
         items: list[dict[str, Any]] = []
         roots: list[tuple[Path, list[Path]]] = []
@@ -3539,6 +3564,7 @@ class Cleanup:
         older_than_days: int,
         *,
         check_lock: bool = True,
+        held_lease_identity: dict[str, int] | None = None,
     ) -> dict[str, Any]:
         item = _base_item(
             "temporary-state", "atrinik", "atrinik/atrinik", path
@@ -3587,31 +3613,31 @@ class Cleanup:
             }:
                 raise WorkspaceError("temporary state ownership marker is invalid")
             record = load_json(path / TEMPORARY_STATE_METADATA)
-            policy = record.get("state_policy") if isinstance(record, dict) else None
+            creation_policy = (
+                record.get("state_policy") if isinstance(record, dict) else None
+            )
             if (
                 not isinstance(record, dict)
                 or record.get("schema_version") != TEMPORARY_STATE_SCHEMA_VERSION
-                or not isinstance(policy, dict)
-                or policy.get("mode") != "temporary"
-                or policy.get("path") != str(path)
-                or policy.get("owner")
+                or not isinstance(creation_policy, dict)
+                or creation_policy.get("mode") != "temporary"
+                or creation_policy.get("name") is not None
+                or creation_policy.get("lifecycle") != "disposable"
+                or creation_policy.get("path") != str(path)
+                or creation_policy.get("owner")
                 != {
                     "kind": "topology-generation",
                     "topology": topology_name,
                     "generation": generation,
                 }
-                or policy.get("identity")
+                or creation_policy.get("identity")
                 != {"device": metadata.st_dev, "inode": metadata.st_ino}
             ):
                 raise WorkspaceError("temporary state metadata is invalid")
             item["topology"] = topology_name
             item["generation"] = generation
-            item["state_policy"] = policy
-            lifecycle = policy.get("lifecycle")
-            if lifecycle in {"retained", "promotion-pending", "promoted"}:
-                item["reasons"].append(f"temporary_state_{lifecycle.replace('-', '_')}")
-            elif lifecycle != "disposable":
-                item["reasons"].append("invalid_temporary_state_lifecycle")
+            policy = creation_policy
+            observed_lease_identity = held_lease_identity
             registered = {
                 self.workspace._canonical_state_path(Path(value))
                 for value in self.workspace._load_states().values()
@@ -3619,33 +3645,101 @@ class Cleanup:
             if path in registered:
                 item["reasons"].append("registered_state")
             if check_lock:
-                busy, lock_error = self._lock_busy(Path(f"{path}.lock"))
-                if lock_error:
-                    item["reasons"].append("state_lease_error")
-                    item["error"] = lock_error
-                elif busy:
-                    item["reasons"].append("active_state_lease")
+                state_lock = Path(f"{path}.lock")
+                if not state_lock.exists() and not state_lock.is_symlink():
+                    item["reasons"].append("state_lease_unverifiable")
+                else:
+                    busy, lock_error, observed_lease_identity = (
+                        self._state_lock_observation(state_lock)
+                    )
+                    if lock_error:
+                        item["reasons"].append("state_lease_error")
+                        item["error"] = lock_error
+                    elif busy:
+                        item["reasons"].append("active_state_lease")
             status_path = topology / "status.json"
-            if status_path.exists() or status_path.is_symlink():
+            if not status_path.exists() and not status_path.is_symlink():
+                item["reasons"].append("topology_status_uncertain")
+            else:
                 try:
-                    if status_path.is_symlink() or not status_path.is_file():
-                        raise WorkspaceError("topology status is invalid")
-                    status = load_json(status_path)
-                    control = status.get("control") if isinstance(status, dict) else None
+                    status = self.workspace.topology_status(topology_name)
+                    control = status.get("control")
+                    observation = status.get("observation")
                     current_generation = (
                         control.get("generation")
                         if isinstance(control, dict)
                         else None
                     )
-                    if (
-                        isinstance(status, dict)
-                        and current_generation == generation
-                        and status.get("state_policy") != policy
-                    ):
-                        item["reasons"].append("topology_state_record_mismatch")
-                except (OSError, WorkspaceError) as error:
+                    if current_generation != generation:
+                        item["reasons"].append("topology_generation_mismatch")
+                    else:
+                        status_policy = status.get("state_policy")
+                        if not isinstance(status_policy, dict) or not (
+                            self.workspace._temporary_state_metadata_matches(
+                                status_policy, creation_policy
+                            )
+                        ):
+                            item["reasons"].append(
+                                "topology_state_record_mismatch"
+                            )
+                        else:
+                            policy = status_policy
+                            if (
+                                observed_lease_identity is None
+                                or status_policy.get("lease_identity")
+                                != observed_lease_identity
+                            ):
+                                item["reasons"].append(
+                                    "state_lease_identity_mismatch"
+                                )
+                        liveness = [
+                            status["supervisor"].get("liveness"),
+                            *(
+                                service.get("liveness")
+                                for service in status["services"].values()
+                            ),
+                        ]
+                        if any(value == "live" for value in liveness):
+                            item["reasons"].append("live_topology")
+                        if any(value == "unreachable" for value in liveness):
+                            item["reasons"].append("unreachable_topology")
+                        if not isinstance(observation, dict):
+                            item["reasons"].append(
+                                "topology_observation_unverifiable"
+                            )
+                        else:
+                            if observation.get("control") == "reachable":
+                                item["reasons"].append(
+                                    "reachable_topology_control"
+                                )
+                            if observation.get("process_tree_lease") != "released":
+                                item["reasons"].append(
+                                    "process_tree_lease_unverifiable"
+                                )
+                            if observation.get("runtime_bundle_lease") not in {
+                                "released",
+                                "historical",
+                            }:
+                                item["reasons"].append(
+                                    "runtime_bundle_lease_unverifiable"
+                                )
+                            port = observation.get("port_reservation")
+                            if port is not None and (
+                                not isinstance(port, dict)
+                                or port.get("lease") != "released"
+                            ):
+                                item["reasons"].append(
+                                    "port_reservation_lease_unverifiable"
+                                )
+                except (OSError, RuntimeError, WorkspaceError) as error:
                     item["reasons"].append("topology_status_uncertain")
                     item["error"] = str(error)
+            item["state_policy"] = policy
+            lifecycle = policy.get("lifecycle")
+            if lifecycle in {"retained", "promotion-pending", "promoted"}:
+                item["reasons"].append(f"temporary_state_{lifecycle.replace('-', '_')}")
+            elif lifecycle != "disposable":
+                item["reasons"].append("invalid_temporary_state_lifecycle")
             created = _parse_time(policy.get("created_at"), "temporary state created_at")
             age = max(0, int((self.now - created).total_seconds()))
             item["age_seconds"] = age
@@ -3685,9 +3779,23 @@ class Cleanup:
                 Path(f"{path}.lock"),
                 f"temporary topology state {path}",
                 nonblocking=True,
-            ):
+            ) as state_lease:
+                lease_metadata = os.fstat(state_lease.fileno())
+                if (
+                    not stat.S_ISREG(lease_metadata.st_mode)
+                    or lease_metadata.st_nlink != 1
+                ):
+                    raise WorkspaceError(
+                        f"temporary state lease identity is invalid: {path}.lock"
+                    )
                 current = self._temporary_state_item(
-                    path, older_than_days, check_lock=False
+                    path,
+                    older_than_days,
+                    check_lock=False,
+                    held_lease_identity={
+                        "device": lease_metadata.st_dev,
+                        "inode": lease_metadata.st_ino,
+                    },
                 )
                 if (
                     current.get("_identity") != item.get("_identity")

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -3675,11 +3675,19 @@ class Cleanup:
             item["generation"] = generation
             policy = creation_policy
             observed_lease_identity = held_lease_identity
-            registered = {
-                self.workspace._canonical_state_path(Path(value))
-                for value in self.workspace._load_states().values()
-            }
-            if path in registered:
+            registered_state = False
+            for value in self.workspace._load_states().values():
+                registered = self.workspace._canonical_state_path(Path(value))
+                if registered == path:
+                    registered_state = True
+                    break
+                if registered.exists() and not registered.is_symlink() and (
+                    self.workspace._state_identity(registered)
+                    == {"device": metadata.st_dev, "inode": metadata.st_ino}
+                ):
+                    registered_state = True
+                    break
+            if registered_state:
                 item["reasons"].append("registered_state")
             if check_lock:
                 state_lock = Path(f"{path}.lock")

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -1114,6 +1114,7 @@ class Cleanup:
         item.pop("_sound_producer_identity", None)
         item.pop("_physical_path", None)
         item.pop("_lease_only", None)
+        item.pop("_orphan_rollback_lease", None)
 
     def _revalidate_target(
         self,
@@ -1149,10 +1150,12 @@ class Cleanup:
             filesystem_identity = item.get("_identity")
             physical = item.get("_physical_path")
             lease_only = item.get("_lease_only")
+            orphan_rollback_lease = item.get("_orphan_rollback_lease")
             self._strip_internal(item)
             item["_identity"] = filesystem_identity
             item["_physical_path"] = physical
             item["_lease_only"] = lease_only
+            item["_orphan_rollback_lease"] = orphan_rollback_lease
             return item
         references, reference_errors = self._references()
         registered, registered_error = self._registered_worktree_paths()
@@ -1373,6 +1376,23 @@ class Cleanup:
                 and state_policy.get("lifecycle") not in {"removed", "promoted"}
             ):
                 reasons.append("temporary_state_recovery_pending")
+            runtime = status.get("runtime")
+            mutable_outputs = (
+                runtime.get("mutable_state_outputs")
+                if isinstance(runtime, dict)
+                else None
+            )
+            if isinstance(mutable_outputs, list):
+                try:
+                    if any(
+                        Path(value).exists() or Path(value).is_symlink()
+                        for value in mutable_outputs
+                        if isinstance(value, str)
+                    ):
+                        reasons.append("mutable_state_outputs_present")
+                except (OSError, ValueError) as error:
+                    reasons.append("mutable_state_output_inventory_unverifiable")
+                    item["error"] = str(error)
             item["process_tree_lease"] = observation["process_tree_lease"]
             item["runtime_bundle_lease"] = observation.get(
                 "runtime_bundle_lease", "unverifiable"
@@ -3694,6 +3714,88 @@ class Cleanup:
             item["reasons"] = [f"stale_{kind.replace('-', '_')}"]
         return item
 
+    def _orphan_temporary_state_lease_item(
+        self, topology: Path, lock: Path, older_than_days: int
+    ) -> dict[str, Any]:
+        generation = lock.name.removesuffix(".lock")
+        state = lock.parent / generation
+        item = _base_item(
+            "temporary-state", "atrinik", "atrinik/atrinik", state
+        )
+        item["topology"] = topology.name
+        item["generation"] = generation
+        item["_orphan_rollback_lease"] = True
+        reasons: list[str] = []
+        try:
+            metadata = lock.stat(follow_symlinks=False)
+            item["_identity"] = (
+                metadata.st_dev,
+                metadata.st_ino,
+                metadata.st_ctime_ns,
+                stat.S_IFMT(metadata.st_mode),
+            )
+            if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+                raise WorkspaceError("orphan temporary state lease is invalid")
+            for candidate in (
+                state,
+                state.parent / f".{generation}.removal-pending",
+            ):
+                if candidate.exists() or candidate.is_symlink():
+                    raise WorkspaceError(
+                        "orphan temporary state lease still has state evidence"
+                    )
+            busy, lock_error = self._lock_busy(lock)
+            if lock_error:
+                reasons.append("state_lease_error")
+                item["error"] = lock_error
+            elif busy:
+                reasons.append("active_state_lease")
+            try:
+                status = self.workspace.topology_status(topology.name)
+            except (OSError, RuntimeError, WorkspaceError):
+                status_path = topology / "status.json"
+                if status_path.exists() or status_path.is_symlink():
+                    topology_fd = _open_directory_nofollow(
+                        topology,
+                        os.O_RDONLY
+                        | os.O_CLOEXEC
+                        | os.O_DIRECTORY
+                        | os.O_NOFOLLOW,
+                    )
+                    try:
+                        status = self.workspace._load_state_json_at(
+                            topology_fd,
+                            status_path.name,
+                            "orphan temporary state topology status",
+                        )
+                    finally:
+                        os.close(topology_fd)
+                    if not isinstance(status, dict):
+                        raise WorkspaceError(
+                            "orphan temporary state topology status is invalid"
+                        )
+                else:
+                    status = None
+            control = status.get("control") if isinstance(status, dict) else None
+            if isinstance(control, dict) and control.get("generation") == generation:
+                reasons.append("topology_generation_present")
+            created = datetime.fromtimestamp(metadata.st_mtime, timezone.utc)
+            age = max(0, int((self.now - created).total_seconds()))
+            item["age_seconds"] = age
+            item["age_basis"] = "lease-mtime"
+            if created > self.now:
+                reasons.append("future_creation_time")
+            elif age < older_than_days * 86400:
+                reasons.append("younger_than_grace_period")
+        except (OSError, RuntimeError, ValueError, WorkspaceError) as error:
+            reasons.append("invalid_orphan_temporary_state_lease")
+            item["error"] = str(error)
+        item["reasons"] = sorted(set(reasons)) or [
+            "stale_orphan_temporary_state_lease"
+        ]
+        item["disposition"] = "eligible" if not reasons else "protected"
+        return item
+
     def _temporary_states(self, older_than_days: int) -> list[dict[str, Any]]:
         if self.paths.topologies.is_symlink() or not self.paths.topologies.is_dir():
             return []
@@ -3703,6 +3805,7 @@ class Cleanup:
         except OSError:
             return []
         for topology in topologies:
+            topology_item_start = len(items)
             container = topology / "temporary-states"
             children: list[Path] = []
             if container.is_symlink() or (
@@ -3724,7 +3827,37 @@ class Cleanup:
                     item["error"] = str(error)
                     items.append(item)
             for path in children:
-                if path.name == MANAGED_MARKER or path.name.endswith(".lock"):
+                if path.name == MANAGED_MARKER:
+                    continue
+                if re.fullmatch(r"[0-9a-f]{64}\.lock", path.name):
+                    generation = path.name.removesuffix(".lock")
+                    logical = path.parent / generation
+                    pending = path.parent / f".{generation}.removal-pending"
+                    if not (
+                        logical.exists()
+                        or logical.is_symlink()
+                        or pending.exists()
+                        or pending.is_symlink()
+                    ):
+                        try:
+                            status = self.workspace.topology_status(topology.name)
+                            policy = status.get("state_policy")
+                        except (OSError, RuntimeError, WorkspaceError):
+                            policy = None
+                        if not (
+                            isinstance(policy, dict)
+                            and policy.get("mode") == "temporary"
+                            and policy.get("path") == str(logical)
+                            and policy.get("lifecycle")
+                            in {"removal-pending", "removed"}
+                        ):
+                            items.append(
+                                self._orphan_temporary_state_lease_item(
+                                    topology, path, older_than_days
+                                )
+                            )
+                    continue
+                if path.name.endswith(".lock"):
                     continue
                 pending = re.fullmatch(
                     r"\.([0-9a-f]{64})\.removal-pending", path.name
@@ -3776,7 +3909,9 @@ class Cleanup:
                         )
                 else:
                     items.append(self._temporary_state_item(path, older_than_days))
-            represented = {item["path"] for item in items}
+            represented = {
+                item["path"] for item in items[topology_item_start:]
+            }
             try:
                 status = self.workspace.topology_status(topology.name)
                 policy = status.get("state_policy")
@@ -3968,6 +4103,19 @@ class Cleanup:
         if walk_error:
             item["reasons"].append("filesystem_traversal_error")
             item["error"] = walk_error
+
+        def load_bounded_json(path_value: Path, description: str) -> Any:
+            parent_fd = _open_directory_nofollow(
+                path_value.parent,
+                os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
+            )
+            try:
+                return self.workspace._load_state_json_at(
+                    parent_fd, path_value.name, description
+                )
+            finally:
+                os.close(parent_fd)
+
         try:
             metadata = physical.lstat()
             item["_identity"] = (
@@ -3989,12 +4137,18 @@ class Cleanup:
                 != self.paths.topologies.resolve(strict=False)
             ):
                 raise WorkspaceError("temporary state path identity is invalid")
-            if load_json(container / MANAGED_MARKER) != {
+            if load_bounded_json(
+                container / MANAGED_MARKER,
+                "temporary state container marker",
+            ) != {
                 "schema_version": SCHEMA_VERSION,
                 "purpose": "topology-temporary-states",
             }:
                 raise WorkspaceError("temporary state container marker is invalid")
-            if load_json(topology / MANAGED_MARKER) != {
+            if load_bounded_json(
+                topology / MANAGED_MARKER,
+                "temporary state topology marker",
+            ) != {
                 "schema_version": SCHEMA_VERSION,
                 "purpose": f"topology:{topology_name}",
             }:
@@ -4036,14 +4190,20 @@ class Cleanup:
                     "state_policy": creation_policy,
                 }
             else:
-                if load_json(physical / MANAGED_MARKER) != {
+                if load_bounded_json(
+                    physical / MANAGED_MARKER,
+                    "temporary state ownership marker",
+                ) != {
                     "schema_version": SCHEMA_VERSION,
                     "purpose": "temporary-topology-state",
                     "topology": topology_name,
                     "generation": generation,
                 }:
                     raise WorkspaceError("temporary state ownership marker is invalid")
-                record = load_json(physical / TEMPORARY_STATE_METADATA)
+                record = load_bounded_json(
+                    physical / TEMPORARY_STATE_METADATA,
+                    "temporary state creation metadata",
+                )
                 creation_policy = (
                     record.get("state_policy") if isinstance(record, dict) else None
                 )
@@ -4247,6 +4407,80 @@ class Cleanup:
         if not isinstance(topology, str):
             raise WorkspaceError("temporary state topology identity is missing")
         root = self.workspace._topology_directory(topology)
+        if item.get("_orphan_rollback_lease"):
+            lock = Path(f"{path}.lock")
+            generation = path.name
+            with exclusive_lock(
+                root / "operation.lock",
+                f"topology {topology} operation",
+                nonblocking=True,
+            ):
+                for candidate in (
+                    path,
+                    path.parent / f".{generation}.removal-pending",
+                ):
+                    if candidate.exists() or candidate.is_symlink():
+                        raise WorkspaceError(
+                            "orphan temporary state lease gained state evidence"
+                        )
+                try:
+                    status = self.workspace.topology_status(topology)
+                except (OSError, RuntimeError, WorkspaceError):
+                    status_path = root / "status.json"
+                    if status_path.exists() or status_path.is_symlink():
+                        root_fd = _open_directory_nofollow(
+                            root,
+                            os.O_RDONLY
+                            | os.O_CLOEXEC
+                            | os.O_DIRECTORY
+                            | os.O_NOFOLLOW,
+                        )
+                        try:
+                            status = self.workspace._load_state_json_at(
+                                root_fd,
+                                status_path.name,
+                                "orphan temporary state topology status",
+                            )
+                        finally:
+                            os.close(root_fd)
+                        if not isinstance(status, dict):
+                            raise WorkspaceError(
+                                "orphan temporary state topology status is invalid"
+                            )
+                    else:
+                        status = None
+                control = (
+                    status.get("control") if isinstance(status, dict) else None
+                )
+                if (
+                    isinstance(control, dict)
+                    and control.get("generation") == generation
+                ):
+                    raise WorkspaceError(
+                        "orphan temporary state generation became current"
+                    )
+                with exclusive_lock(
+                    lock,
+                    f"orphan temporary topology state {path}",
+                    nonblocking=True,
+                ) as state_lease:
+                    metadata = os.fstat(state_lease.fileno())
+                    expected = item.get("_identity")
+                    if (
+                        not isinstance(expected, tuple)
+                        or expected[:2] != (metadata.st_dev, metadata.st_ino)
+                        or not stat.S_ISREG(metadata.st_mode)
+                        or metadata.st_nlink != 1
+                    ):
+                        raise WorkspaceError(
+                            "orphan temporary state lease identity changed"
+                        )
+                    self.workspace._unlink_temporary_state_lock(
+                        path,
+                        state_lease,
+                        {"device": metadata.st_dev, "inode": metadata.st_ino},
+                    )
+            return
         if item.get("_lease_only"):
             with exclusive_lock(
                 root / "operation.lock",

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -1115,6 +1115,7 @@ class Cleanup:
         item.pop("_physical_path", None)
         item.pop("_lease_only", None)
         item.pop("_orphan_rollback_lease", None)
+        item.pop("_temporary_state_container_identity", None)
 
     def _revalidate_target(
         self,
@@ -1151,11 +1152,15 @@ class Cleanup:
             physical = item.get("_physical_path")
             lease_only = item.get("_lease_only")
             orphan_rollback_lease = item.get("_orphan_rollback_lease")
+            container_identity = item.get(
+                "_temporary_state_container_identity"
+            )
             self._strip_internal(item)
             item["_identity"] = filesystem_identity
             item["_physical_path"] = physical
             item["_lease_only"] = lease_only
             item["_orphan_rollback_lease"] = orphan_rollback_lease
+            item["_temporary_state_container_identity"] = container_identity
             return item
         references, reference_errors = self._references()
         registered, registered_error = self._registered_worktree_paths()
@@ -1382,13 +1387,36 @@ class Cleanup:
                 if isinstance(runtime, dict)
                 else None
             )
+            mutable_output_identities = (
+                runtime.get("mutable_state_output_identities")
+                if isinstance(runtime, dict)
+                else None
+            )
             if isinstance(mutable_outputs, list):
                 try:
-                    if any(
-                        Path(value).exists() or Path(value).is_symlink()
-                        for value in mutable_outputs
-                        if isinstance(value, str)
-                    ):
+                    output_evidence = False
+                    for index, value in enumerate(mutable_outputs):
+                        if not isinstance(value, str):
+                            output_evidence = True
+                            break
+                        output = Path(value)
+                        if output.exists() or output.is_symlink():
+                            output_evidence = True
+                            break
+                        if (
+                            isinstance(mutable_output_identities, list)
+                            and index < len(mutable_output_identities)
+                            and isinstance(
+                                mutable_output_identities[index], dict
+                            )
+                        ):
+                            tombstone = _owned_tree_tombstone_path(
+                                output, mutable_output_identities[index]
+                            )
+                            if tombstone.exists() or tombstone.is_symlink():
+                                output_evidence = True
+                                break
+                    if output_evidence:
                         reasons.append("mutable_state_outputs_present")
                 except (OSError, ValueError) as error:
                     reasons.append("mutable_state_output_inventory_unverifiable")
@@ -3714,19 +3742,123 @@ class Cleanup:
             item["reasons"] = [f"stale_{kind.replace('-', '_')}"]
         return item
 
+    def _load_bounded_json(self, path: Path, description: str) -> Any:
+        parent_fd = _open_directory_nofollow(
+            path.parent,
+            os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
+        )
+        try:
+            return self.workspace._load_state_json_at(
+                parent_fd, path.name, description
+            )
+        finally:
+            os.close(parent_fd)
+
+    def _open_temporary_state_container(
+        self, topology: Path
+    ) -> tuple[int, tuple[int, int, int | tuple[int, int]]]:
+        if (
+            topology.parent.resolve(strict=False)
+            != self.paths.topologies.resolve(strict=False)
+        ):
+            raise WorkspaceError("temporary state topology path is invalid")
+        flags = os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW
+        topology_fd = _open_directory_nofollow(topology, flags)
+        container_fd: int | None = None
+        try:
+            topology_metadata = os.fstat(topology_fd)
+            if self.workspace._load_state_json_at(
+                topology_fd,
+                MANAGED_MARKER,
+                "temporary state topology marker",
+            ) != {
+                "schema_version": SCHEMA_VERSION,
+                "purpose": f"topology:{topology.name}",
+            }:
+                raise WorkspaceError("temporary state topology marker is invalid")
+            visible = os.stat(
+                "temporary-states",
+                dir_fd=topology_fd,
+                follow_symlinks=False,
+            )
+            if not stat.S_ISDIR(visible.st_mode):
+                raise WorkspaceError("temporary state container is invalid")
+            container_fd = os.open(
+                "temporary-states", flags, dir_fd=topology_fd
+            )
+            container_metadata = os.fstat(container_fd)
+            topology_mount = _descriptor_mount_id(topology_fd)
+            container_mount = _descriptor_mount_id(container_fd)
+            if (
+                (visible.st_dev, visible.st_ino)
+                != (container_metadata.st_dev, container_metadata.st_ino)
+                or container_mount != topology_mount
+                or container_metadata.st_dev != topology_metadata.st_dev
+            ):
+                raise WorkspaceError(
+                    "temporary state container changed or crossed a mount"
+                )
+            if self.workspace._load_state_json_at(
+                container_fd,
+                MANAGED_MARKER,
+                "temporary state container marker",
+            ) != {
+                "schema_version": SCHEMA_VERSION,
+                "purpose": "topology-temporary-states",
+            }:
+                raise WorkspaceError("temporary state container marker is invalid")
+            result = container_fd
+            container_fd = None
+            return result, (
+                container_metadata.st_dev,
+                container_metadata.st_ino,
+                container_mount,
+            )
+        finally:
+            if container_fd is not None:
+                os.close(container_fd)
+            os.close(topology_fd)
+
     def _orphan_temporary_state_lease_item(
-        self, topology: Path, lock: Path, older_than_days: int
+        self,
+        topology: Path,
+        lock: Path,
+        older_than_days: int,
+        *,
+        tombstone: bool = False,
     ) -> dict[str, Any]:
-        generation = lock.name.removesuffix(".lock")
+        if tombstone:
+            match = re.fullmatch(
+                r"\.([0-9a-f]{64})\.lock\.remove-([0-9a-f]+)-([0-9a-f]+)",
+                lock.name,
+            )
+            if match is None:
+                raise WorkspaceError("orphan temporary state lease tombstone is invalid")
+            generation = match.group(1)
+            expected_tombstone_identity = (
+                int(match.group(2), 16),
+                int(match.group(3), 16),
+            )
+        else:
+            generation = lock.name.removesuffix(".lock")
+            expected_tombstone_identity = None
         state = lock.parent / generation
         item = _base_item(
             "temporary-state", "atrinik", "atrinik/atrinik", state
         )
         item["topology"] = topology.name
         item["generation"] = generation
-        item["_orphan_rollback_lease"] = True
+        item["_physical_path"] = str(lock)
+        item["_orphan_rollback_lease"] = (
+            "tombstone" if tombstone else "lock"
+        )
         reasons: list[str] = []
         try:
+            container_fd, container_identity = (
+                self._open_temporary_state_container(topology)
+            )
+            os.close(container_fd)
+            item["_temporary_state_container_identity"] = container_identity
             metadata = lock.stat(follow_symlinks=False)
             item["_identity"] = (
                 metadata.st_dev,
@@ -3736,6 +3868,13 @@ class Cleanup:
             )
             if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
                 raise WorkspaceError("orphan temporary state lease is invalid")
+            if expected_tombstone_identity is not None and (
+                metadata.st_dev,
+                metadata.st_ino,
+            ) != expected_tombstone_identity:
+                raise WorkspaceError(
+                    "orphan temporary state lease tombstone identity is invalid"
+                )
             for candidate in (
                 state,
                 state.parent / f".{generation}.removal-pending",
@@ -3752,28 +3891,16 @@ class Cleanup:
                 reasons.append("active_state_lease")
             try:
                 status = self.workspace.topology_status(topology.name)
-            except (OSError, RuntimeError, WorkspaceError):
+            except (OSError, RuntimeError, WorkspaceError) as status_error:
                 status_path = topology / "status.json"
                 if status_path.exists() or status_path.is_symlink():
-                    topology_fd = _open_directory_nofollow(
-                        topology,
-                        os.O_RDONLY
-                        | os.O_CLOEXEC
-                        | os.O_DIRECTORY
-                        | os.O_NOFOLLOW,
+                    self._load_bounded_json(
+                        status_path,
+                        "orphan temporary state topology status",
                     )
-                    try:
-                        status = self.workspace._load_state_json_at(
-                            topology_fd,
-                            status_path.name,
-                            "orphan temporary state topology status",
-                        )
-                    finally:
-                        os.close(topology_fd)
-                    if not isinstance(status, dict):
-                        raise WorkspaceError(
-                            "orphan temporary state topology status is invalid"
-                        )
+                    reasons.append("topology_status_unverifiable")
+                    item["error"] = str(status_error)
+                    status = None
                 else:
                     status = None
             control = status.get("control") if isinstance(status, dict) else None
@@ -3857,6 +3984,19 @@ class Cleanup:
                                 )
                             )
                     continue
+                if re.fullmatch(
+                    r"\.[0-9a-f]{64}\.lock\.remove-[0-9a-f]+-[0-9a-f]+",
+                    path.name,
+                ):
+                    items.append(
+                        self._orphan_temporary_state_lease_item(
+                            topology,
+                            path,
+                            older_than_days,
+                            tombstone=True,
+                        )
+                    )
+                    continue
                 if path.name.endswith(".lock"):
                     continue
                 pending = re.fullmatch(
@@ -3874,7 +4014,10 @@ class Cleanup:
                 ):
                     try:
                         try:
-                            creation = load_json(path / TEMPORARY_STATE_METADATA)
+                            creation = self._load_bounded_json(
+                                path / TEMPORARY_STATE_METADATA,
+                                "temporary state removal metadata",
+                            )
                             policy = creation["state_policy"]
                         except (OSError, WorkspaceError):
                             status = self.workspace.topology_status(topology.name)
@@ -3942,7 +4085,10 @@ class Cleanup:
                         )
             except (KeyError, OSError, TypeError, ValueError, WorkspaceError) as error:
                 try:
-                    raw_status = load_json(topology / "status.json")
+                    raw_status = self._load_bounded_json(
+                        topology / "status.json",
+                        "temporary state topology status",
+                    )
                     raw_policy = (
                         raw_status.get("state_policy")
                         if isinstance(raw_status, dict)
@@ -3993,6 +4139,15 @@ class Cleanup:
         item["_lease_only"] = lifecycle == "removed"
         item["_identity"] = None
         item["_physical_path"] = None
+        try:
+            container_fd, container_identity = (
+                self._open_temporary_state_container(path.parent.parent)
+            )
+            os.close(container_fd)
+            item["_temporary_state_container_identity"] = container_identity
+        except (OSError, RuntimeError, ValueError, WorkspaceError) as error:
+            item["reasons"].append("invalid_temporary_state_container")
+            item["error"] = str(error)
         if path.exists() or path.is_symlink():
             item["reasons"].append("temporary_state_reappeared")
         if lifecycle == "removal-pending":
@@ -4098,23 +4253,21 @@ class Cleanup:
             else path
         )
         item["_physical_path"] = str(physical)
+        try:
+            container_fd, container_identity = (
+                self._open_temporary_state_container(path.parent.parent)
+            )
+            os.close(container_fd)
+            item["_temporary_state_container_identity"] = container_identity
+        except (OSError, RuntimeError, ValueError, WorkspaceError) as error:
+            item["reasons"] = ["invalid_temporary_state_container"]
+            item["error"] = str(error)
+            return item
         inodes, observed, walk_error = _temporary_tree_usage(physical)
         item["_inodes"] = inodes
         if walk_error:
             item["reasons"].append("filesystem_traversal_error")
             item["error"] = walk_error
-
-        def load_bounded_json(path_value: Path, description: str) -> Any:
-            parent_fd = _open_directory_nofollow(
-                path_value.parent,
-                os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
-            )
-            try:
-                return self.workspace._load_state_json_at(
-                    parent_fd, path_value.name, description
-                )
-            finally:
-                os.close(parent_fd)
 
         try:
             metadata = physical.lstat()
@@ -4137,7 +4290,7 @@ class Cleanup:
                 != self.paths.topologies.resolve(strict=False)
             ):
                 raise WorkspaceError("temporary state path identity is invalid")
-            if load_bounded_json(
+            if self._load_bounded_json(
                 container / MANAGED_MARKER,
                 "temporary state container marker",
             ) != {
@@ -4145,7 +4298,7 @@ class Cleanup:
                 "purpose": "topology-temporary-states",
             }:
                 raise WorkspaceError("temporary state container marker is invalid")
-            if load_bounded_json(
+            if self._load_bounded_json(
                 topology / MANAGED_MARKER,
                 "temporary state topology marker",
             ) != {
@@ -4190,7 +4343,7 @@ class Cleanup:
                     "state_policy": creation_policy,
                 }
             else:
-                if load_bounded_json(
+                if self._load_bounded_json(
                     physical / MANAGED_MARKER,
                     "temporary state ownership marker",
                 ) != {
@@ -4200,7 +4353,7 @@ class Cleanup:
                     "generation": generation,
                 }:
                     raise WorkspaceError("temporary state ownership marker is invalid")
-                record = load_bounded_json(
+                record = self._load_bounded_json(
                     physical / TEMPORARY_STATE_METADATA,
                     "temporary state creation metadata",
                 )
@@ -4415,38 +4568,47 @@ class Cleanup:
                 f"topology {topology} operation",
                 nonblocking=True,
             ):
+                container_fd, container_identity = (
+                    self._open_temporary_state_container(root)
+                )
+                expected_container = item.get(
+                    "_temporary_state_container_identity"
+                )
+                if container_identity != expected_container:
+                    os.close(container_fd)
+                    raise WorkspaceError(
+                        "temporary state container changed before cleanup"
+                    )
                 for candidate in (
                     path,
                     path.parent / f".{generation}.removal-pending",
                 ):
-                    if candidate.exists() or candidate.is_symlink():
+                    try:
+                        os.stat(
+                            candidate.name,
+                            dir_fd=container_fd,
+                            follow_symlinks=False,
+                        )
+                    except FileNotFoundError:
+                        continue
+                    else:
+                        os.close(container_fd)
                         raise WorkspaceError(
                             "orphan temporary state lease gained state evidence"
                         )
                 try:
                     status = self.workspace.topology_status(topology)
-                except (OSError, RuntimeError, WorkspaceError):
+                except (OSError, RuntimeError, WorkspaceError) as error:
                     status_path = root / "status.json"
                     if status_path.exists() or status_path.is_symlink():
-                        root_fd = _open_directory_nofollow(
-                            root,
-                            os.O_RDONLY
-                            | os.O_CLOEXEC
-                            | os.O_DIRECTORY
-                            | os.O_NOFOLLOW,
+                        self._load_bounded_json(
+                            status_path,
+                            "orphan temporary state topology status",
                         )
-                        try:
-                            status = self.workspace._load_state_json_at(
-                                root_fd,
-                                status_path.name,
-                                "orphan temporary state topology status",
-                            )
-                        finally:
-                            os.close(root_fd)
-                        if not isinstance(status, dict):
-                            raise WorkspaceError(
-                                "orphan temporary state topology status is invalid"
-                            )
+                        os.close(container_fd)
+                        raise WorkspaceError(
+                            "orphan temporary state topology status is invalid"
+                        ) from error
                     else:
                         status = None
                 control = (
@@ -4456,30 +4618,75 @@ class Cleanup:
                     isinstance(control, dict)
                     and control.get("generation") == generation
                 ):
+                    os.close(container_fd)
                     raise WorkspaceError(
                         "orphan temporary state generation became current"
                     )
-                with exclusive_lock(
-                    lock,
-                    f"orphan temporary topology state {path}",
-                    nonblocking=True,
-                ) as state_lease:
-                    metadata = os.fstat(state_lease.fileno())
-                    expected = item.get("_identity")
-                    if (
-                        not isinstance(expected, tuple)
-                        or expected[:2] != (metadata.st_dev, metadata.st_ino)
-                        or not stat.S_ISREG(metadata.st_mode)
-                        or metadata.st_nlink != 1
-                    ):
-                        raise WorkspaceError(
-                            "orphan temporary state lease identity changed"
+                if item.get("_orphan_rollback_lease") == "tombstone":
+                    try:
+                        evidence = Path(item["_physical_path"])
+                        metadata = os.stat(
+                            evidence.name,
+                            dir_fd=container_fd,
+                            follow_symlinks=False,
                         )
-                    self.workspace._unlink_temporary_state_lock(
-                        path,
-                        state_lease,
-                        {"device": metadata.st_dev, "inode": metadata.st_ino},
-                    )
+                        expected = item.get("_identity")
+                        if (
+                            not isinstance(expected, tuple)
+                            or expected[:2]
+                            != (metadata.st_dev, metadata.st_ino)
+                            or not stat.S_ISREG(metadata.st_mode)
+                            or metadata.st_nlink != 1
+                        ):
+                            raise WorkspaceError(
+                                "orphan temporary state lease tombstone changed"
+                            )
+                        if not self.workspace._finish_temporary_state_lock_tombstone(
+                            path,
+                            {
+                                "device": metadata.st_dev,
+                                "inode": metadata.st_ino,
+                            },
+                            container_fd,
+                        ):
+                            raise WorkspaceError(
+                                "orphan temporary state lease tombstone disappeared"
+                            )
+                    finally:
+                        os.close(container_fd)
+                    return
+                try:
+                    with exclusive_lock(
+                        lock,
+                        f"orphan temporary topology state {path}",
+                        nonblocking=True,
+                    ) as state_lease:
+                        metadata = os.fstat(state_lease.fileno())
+                        visible = os.stat(
+                            lock.name,
+                            dir_fd=container_fd,
+                            follow_symlinks=False,
+                        )
+                        expected = item.get("_identity")
+                        if (
+                            not isinstance(expected, tuple)
+                            or expected[:2] != (metadata.st_dev, metadata.st_ino)
+                            or (visible.st_dev, visible.st_ino)
+                            != (metadata.st_dev, metadata.st_ino)
+                            or not stat.S_ISREG(metadata.st_mode)
+                            or metadata.st_nlink != 1
+                        ):
+                            raise WorkspaceError(
+                                "orphan temporary state lease identity changed"
+                            )
+                        self.workspace._unlink_temporary_state_lock(
+                            path,
+                            state_lease,
+                            {"device": metadata.st_dev, "inode": metadata.st_ino},
+                            container_fd,
+                        )
+                finally:
+                    os.close(container_fd)
             return
         if item.get("_lease_only"):
             with exclusive_lock(
@@ -4487,33 +4694,50 @@ class Cleanup:
                 f"topology {topology} operation",
                 nonblocking=True,
             ):
-                status = self.workspace.topology_status(topology)
-                policy = status.get("state_policy")
-                if (
-                    not isinstance(policy, dict)
-                    or policy.get("mode") != "temporary"
-                    or policy.get("lifecycle") != "removed"
-                    or policy.get("path") != str(path)
+                container_fd, container_identity = (
+                    self._open_temporary_state_container(root)
+                )
+                if container_identity != item.get(
+                    "_temporary_state_container_identity"
                 ):
+                    os.close(container_fd)
                     raise WorkspaceError(
-                        "removed temporary state lease status changed before cleanup"
+                        "temporary state container changed before lease cleanup"
                     )
-                lock = Path(f"{path}.lock")
-                if lock.exists() or lock.is_symlink():
-                    with exclusive_lock(
-                        lock,
-                        f"temporary topology state {path}",
-                        nonblocking=True,
-                    ) as state_lease:
-                        self.workspace._unlink_temporary_state_lock(
-                            path, state_lease, policy["lease_identity"]
+                try:
+                    status = self.workspace.topology_status(topology)
+                    policy = status.get("state_policy")
+                    if (
+                        not isinstance(policy, dict)
+                        or policy.get("mode") != "temporary"
+                        or policy.get("lifecycle") != "removed"
+                        or policy.get("path") != str(path)
+                    ):
+                        raise WorkspaceError(
+                            "removed temporary state lease status changed before "
+                            "cleanup"
                         )
-                elif not self.workspace._finish_temporary_state_lock_tombstone(
-                    path, policy["lease_identity"]
-                ):
-                    raise WorkspaceError(
-                        f"removed temporary state lease is missing: {lock}"
-                    )
+                    lock = Path(f"{path}.lock")
+                    if lock.exists() or lock.is_symlink():
+                        with exclusive_lock(
+                            lock,
+                            f"temporary topology state {path}",
+                            nonblocking=True,
+                        ) as state_lease:
+                            self.workspace._unlink_temporary_state_lock(
+                                path,
+                                state_lease,
+                                policy["lease_identity"],
+                                container_fd,
+                            )
+                    elif not self.workspace._finish_temporary_state_lock_tombstone(
+                        path, policy["lease_identity"], container_fd
+                    ):
+                        raise WorkspaceError(
+                            f"removed temporary state lease is missing: {lock}"
+                        )
+                finally:
+                    os.close(container_fd)
             return
         with exclusive_lock(
             root / "operation.lock",
@@ -4569,18 +4793,35 @@ class Cleanup:
                     ),
                     None,
                 )
-                mutation_fd = (
-                    self.workspace._lock_state_directory_mutation(
-                        mutation_path, policy["identity"]
-                    )
-                    if mutation_path is not None
-                    else None
-                )
+                mutation_fd: int | None = None
+                container_fd: int | None = None
                 try:
+                    mutation_fd = (
+                        self.workspace._lock_state_directory_mutation(
+                            mutation_path, policy["identity"]
+                        )
+                        if mutation_path is not None
+                        else None
+                    )
+                    container_fd, container_identity = (
+                        self._open_temporary_state_container(root)
+                    )
+                    if container_identity != item.get(
+                        "_temporary_state_container_identity"
+                    ):
+                        raise WorkspaceError(
+                            "temporary state container changed before removal"
+                        )
                     self.workspace._commit_temporary_state_removal(
-                        topology, status, state_lease, mutation_fd
+                        topology,
+                        status,
+                        state_lease,
+                        mutation_fd,
+                        container_fd,
                     )
                 finally:
+                    if container_fd is not None:
+                        os.close(container_fd)
                     if mutation_fd is not None:
                         os.close(mutation_fd)
 

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -3767,7 +3767,7 @@ class Cleanup:
                         f".{lock.name}.remove-{lease_identity['device']:x}-"
                         f"{lease_identity['inode']:x}"
                     )
-                    if (
+                    if policy["lifecycle"] == "removal-pending" or (
                         lock.exists()
                         or lock.is_symlink()
                         or lock_tombstone.exists()

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -13,6 +13,7 @@ import re
 import secrets
 import stat
 import subprocess
+import sys
 from typing import Any, Iterable, Iterator
 
 from .locking import LockBusyError, active_lock_fds
@@ -396,18 +397,17 @@ def _temporary_tree_usage(
 
     sizes: dict[tuple[int, int], int] = {}
     maximum: float | None = None
-    descriptors: list[int] = []
+    root_fd: int | None = None
     try:
         root_fd = os.open(
             root,
             os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
         )
-        descriptors.append(root_fd)
         root_mount = _descriptor_mount_id(root_fd)
-        stack: list[tuple[int, Path]] = [(root_fd, root)]
         visited: set[tuple[int, int, int | tuple[int, int]]] = set()
-        while stack:
-            descriptor, display = stack.pop()
+
+        def walk(descriptor: int, display: Path) -> None:
+            nonlocal maximum
             directory = os.fstat(descriptor)
             coordinate = (directory.st_dev, directory.st_ino, root_mount)
             if coordinate in visited:
@@ -433,6 +433,27 @@ def _temporary_tree_usage(
                     if maximum is None
                     else max(maximum, child.st_mtime)
                 )
+                if stat.S_ISREG(child.st_mode):
+                    flags = os.O_NOFOLLOW
+                    if sys.platform == "linux":
+                        flags |= os.O_PATH
+                    else:
+                        flags |= os.O_RDONLY | os.O_NONBLOCK
+                    file_fd = os.open(name, flags, dir_fd=descriptor)
+                    try:
+                        opened = os.fstat(file_fd)
+                        if (
+                            (opened.st_dev, opened.st_ino)
+                            != (child.st_dev, child.st_ino)
+                            or _descriptor_mount_id(file_fd) != root_mount
+                        ):
+                            raise WorkspaceError(
+                                "temporary state traversal encountered a mount: "
+                                f"{display / name}"
+                            )
+                    finally:
+                        os.close(file_fd)
+                    continue
                 if not stat.S_ISDIR(child.st_mode):
                     continue
                 child_fd = os.open(
@@ -443,18 +464,22 @@ def _temporary_tree_usage(
                     | os.O_NOFOLLOW,
                     dir_fd=descriptor,
                 )
-                descriptors.append(child_fd)
-                opened = os.fstat(child_fd)
-                if (
-                    (opened.st_dev, opened.st_ino)
-                    != (child.st_dev, child.st_ino)
-                    or _descriptor_mount_id(child_fd) != root_mount
-                ):
-                    raise WorkspaceError(
-                        f"temporary state traversal encountered a mount: "
-                        f"{display / name}"
-                    )
-                stack.append((child_fd, display / name))
+                try:
+                    opened = os.fstat(child_fd)
+                    if (
+                        (opened.st_dev, opened.st_ino)
+                        != (child.st_dev, child.st_ino)
+                        or _descriptor_mount_id(child_fd) != root_mount
+                    ):
+                        raise WorkspaceError(
+                            f"temporary state traversal encountered a mount: "
+                            f"{display / name}"
+                        )
+                    walk(child_fd, display / name)
+                finally:
+                    os.close(child_fd)
+
+        walk(root_fd, root)
         observed = (
             datetime.fromtimestamp(maximum, timezone.utc)
             if maximum is not None
@@ -469,8 +494,8 @@ def _temporary_tree_usage(
         )
         return sizes, observed, str(error)
     finally:
-        for descriptor in reversed(descriptors):
-            os.close(descriptor)
+        if root_fd is not None:
+            os.close(root_fd)
 
 
 def _topology_tree_snapshot(
@@ -3731,7 +3756,8 @@ class Cleanup:
                 if (
                     isinstance(policy, dict)
                     and policy.get("mode") == "temporary"
-                    and policy.get("lifecycle") == "removed"
+                    and policy.get("lifecycle")
+                    in {"removal-pending", "removed"}
                     and policy.get("path") not in represented
                 ):
                     logical = Path(policy["path"])
@@ -3748,7 +3774,7 @@ class Cleanup:
                         or lock_tombstone.is_symlink()
                     ):
                         items.append(
-                            self._removed_temporary_state_lease_item(
+                            self._detached_temporary_state_item(
                                 topology.name, status, older_than_days
                             )
                         )
@@ -3756,7 +3782,7 @@ class Cleanup:
                 pass
         return items
 
-    def _removed_temporary_state_lease_item(
+    def _detached_temporary_state_item(
         self,
         topology: str,
         status: dict[str, Any],
@@ -3770,11 +3796,16 @@ class Cleanup:
         item["topology"] = topology
         item["generation"] = policy["owner"]["generation"]
         item["state_policy"] = policy
-        item["_lease_only"] = True
+        lifecycle = policy["lifecycle"]
+        item["_lease_only"] = lifecycle == "removed"
         item["_identity"] = None
         item["_physical_path"] = None
         if path.exists() or path.is_symlink():
             item["reasons"].append("temporary_state_reappeared")
+        if lifecycle == "removal-pending":
+            item["reasons"].append(
+                "temporary_state_ownership_evidence_missing"
+            )
         lock = Path(f"{path}.lock")
         lease_identity = policy["lease_identity"]
         lock_tombstone = lock.parent / (
@@ -3928,6 +3959,7 @@ class Cleanup:
                         "created_at",
                         "identity",
                         "implementation",
+                        "profile",
                         "server",
                     )
                 }

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -1366,6 +1366,13 @@ class Cleanup:
             item["liveness"] = liveness
             item["control_observation"] = observation["control"]
             item["generation"] = observation["generation"]
+            state_policy = status.get("state_policy")
+            if (
+                isinstance(state_policy, dict)
+                and state_policy.get("mode") == "temporary"
+                and state_policy.get("lifecycle") not in {"removed", "promoted"}
+            ):
+                reasons.append("temporary_state_recovery_pending")
             item["process_tree_lease"] = observation["process_tree_lease"]
             item["runtime_bundle_lease"] = observation.get(
                 "runtime_bundle_lease", "unverifiable"
@@ -3798,8 +3805,39 @@ class Cleanup:
                                 topology.name, status, older_than_days
                             )
                         )
-            except (KeyError, OSError, TypeError, WorkspaceError):
-                pass
+            except (KeyError, OSError, TypeError, ValueError, WorkspaceError) as error:
+                try:
+                    raw_status = load_json(topology / "status.json")
+                    raw_policy = (
+                        raw_status.get("state_policy")
+                        if isinstance(raw_status, dict)
+                        else None
+                    )
+                    raw_path = (
+                        raw_policy.get("path")
+                        if isinstance(raw_policy, dict)
+                        else None
+                    )
+                    if (
+                        isinstance(raw_policy, dict)
+                        and raw_policy.get("mode") == "temporary"
+                        and isinstance(raw_path, str)
+                        and raw_path
+                        and raw_path not in represented
+                    ):
+                        item = _base_item(
+                            "temporary-state",
+                            "atrinik",
+                            "atrinik/atrinik",
+                            Path(raw_path),
+                        )
+                        item["topology"] = topology.name
+                        item["state_policy"] = raw_policy
+                        item["reasons"] = ["temporary_state_status_unverifiable"]
+                        item["error"] = str(error)
+                        items.append(item)
+                except (OSError, RuntimeError, TypeError, ValueError, WorkspaceError):
+                    pass
         return items
 
     def _detached_temporary_state_item(
@@ -4064,7 +4102,7 @@ class Cleanup:
                         )
                     try:
                         self.workspace._validate_temporary_state_integrity(
-                            state_fd, physical
+                            state_fd, physical, policy.get("implementation")
                         )
                     except WorkspaceError as error:
                         message = str(error)

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -42,6 +42,7 @@ from .workspace import (
     TEMPORARY_STATE_METADATA,
     TEMPORARY_STATE_SCHEMA_VERSION,
     _descriptor_mount_id,
+    _open_directory_nofollow,
     _owned_tree_tombstone_path,
     _remote_matches,
     exclusive_lock,
@@ -403,7 +404,26 @@ def _temporary_tree_usage(
             root,
             os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
         )
+        root_metadata = os.fstat(root_fd)
         root_mount = _descriptor_mount_id(root_fd)
+        parent_fd = _open_directory_nofollow(
+            root.parent,
+            os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
+        )
+        try:
+            visible = os.stat(
+                root.name, dir_fd=parent_fd, follow_symlinks=False
+            )
+            if (
+                (visible.st_dev, visible.st_ino)
+                != (root_metadata.st_dev, root_metadata.st_ino)
+                or _descriptor_mount_id(parent_fd) != root_mount
+            ):
+                raise WorkspaceError(
+                    f"temporary state traversal encountered a root mount: {root}"
+                )
+        finally:
+            os.close(parent_fd)
         visited: set[tuple[int, int, int | tuple[int, int]]] = set()
 
         def walk(descriptor: int, display: Path) -> None:
@@ -3677,25 +3697,25 @@ class Cleanup:
             return []
         for topology in topologies:
             container = topology / "temporary-states"
-            if not container.exists() and not container.is_symlink():
-                continue
-            if container.is_symlink() or not container.is_dir():
+            children: list[Path] = []
+            if container.is_symlink() or (
+                container.exists() and not container.is_dir()
+            ):
                 item = _base_item(
                     "temporary-state", "atrinik", "atrinik/atrinik", container
                 )
                 item["reasons"] = ["invalid_temporary_state_container"]
                 items.append(item)
-                continue
-            try:
-                children = sorted(container.iterdir())
-            except OSError as error:
-                item = _base_item(
-                    "temporary-state", "atrinik", "atrinik/atrinik", container
-                )
-                item["reasons"] = ["temporary_state_inventory_error"]
-                item["error"] = str(error)
-                items.append(item)
-                continue
+            elif container.is_dir():
+                try:
+                    children = sorted(container.iterdir())
+                except OSError as error:
+                    item = _base_item(
+                        "temporary-state", "atrinik", "atrinik/atrinik", container
+                    )
+                    item["reasons"] = ["temporary_state_inventory_error"]
+                    item["error"] = str(error)
+                    items.append(item)
             for path in children:
                 if path.name == MANAGED_MARKER or path.name.endswith(".lock"):
                     continue
@@ -3864,14 +3884,21 @@ class Cleanup:
                 item["reasons"].append(
                     "port_reservation_lease_unverifiable"
                 )
-        created = _parse_time(policy.get("created_at"), "temporary state created_at")
-        age = max(0, int((self.now - created).total_seconds()))
-        item["age_seconds"] = age
-        item["age_basis"] = "created-at"
-        if created > self.now:
-            item["reasons"].append("future_creation_time")
-        elif age < older_than_days * 86400:
-            item["reasons"].append("younger_than_grace_period")
+        try:
+            created = _parse_time(
+                policy.get("created_at"), "temporary state created_at"
+            )
+        except WorkspaceError as error:
+            item["reasons"].append("invalid_temporary_state")
+            item["error"] = str(error)
+        else:
+            age = max(0, int((self.now - created).total_seconds()))
+            item["age_seconds"] = age
+            item["age_basis"] = "created-at"
+            if created > self.now:
+                item["reasons"].append("future_creation_time")
+            elif age < older_than_days * 86400:
+                item["reasons"].append("younger_than_grace_period")
         item["reasons"] = sorted(set(item["reasons"]))
         if not item["reasons"]:
             item["disposition"] = "eligible"

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -3760,14 +3760,20 @@ class Cleanup:
                                 item["reasons"].append(
                                     "runtime_bundle_lease_unverifiable"
                                 )
-                            port = observation.get("port_reservation")
-                            if port is not None and (
-                                not isinstance(port, dict)
-                                or port.get("lease") != "released"
-                            ):
-                                item["reasons"].append(
-                                    "port_reservation_lease_unverifiable"
-                                )
+                            if "server" in status.get("services", {}):
+                                endpoint = status.get("endpoint")
+                                port = observation.get("port_reservation")
+                                if (
+                                    not isinstance(endpoint, dict)
+                                    or not isinstance(port, dict)
+                                    or port.get("port") != endpoint.get("port")
+                                    or port.get("owner") != topology_name
+                                    or port.get("generation") != generation
+                                    or port.get("lease") != "released"
+                                ):
+                                    item["reasons"].append(
+                                        "port_reservation_lease_unverifiable"
+                                    )
                 except (OSError, RuntimeError, WorkspaceError) as error:
                     item["reasons"].append("topology_status_uncertain")
                     item["error"] = str(error)

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -982,6 +982,7 @@ class Cleanup:
         item.pop("_git_common", None)
         item.pop("_sound_worktree_identity", None)
         item.pop("_sound_producer_identity", None)
+        item.pop("_physical_path", None)
 
     def _revalidate_target(
         self,
@@ -1006,19 +1007,19 @@ class Cleanup:
                 )
             return item
         if kind == "temporary-state":
-            physical = target.get("_physical_path")
-            item = self._temporary_state_item(
-                path,
-                older_than_days,
-                physical_path=(
-                    Path(physical)
-                    if isinstance(physical, str) and not path.exists()
-                    else None
+            item = next(
+                (
+                    candidate
+                    for candidate in self._temporary_states(older_than_days)
+                    if candidate["path"] == str(path)
                 ),
+                self._temporary_state_item(path, older_than_days),
             )
             filesystem_identity = item.get("_identity")
+            physical = item.get("_physical_path")
             self._strip_internal(item)
             item["_identity"] = filesystem_identity
+            item["_physical_path"] = physical
             return item
         references, reference_errors = self._references()
         registered, registered_error = self._registered_worktree_paths()
@@ -3599,8 +3600,19 @@ class Cleanup:
                     r"\.remove-[0-9a-f]{16}-[0-9a-f]+-[0-9a-f]+", path.name
                 ):
                     try:
-                        creation = load_json(path / TEMPORARY_STATE_METADATA)
-                        policy = creation["state_policy"]
+                        try:
+                            creation = load_json(path / TEMPORARY_STATE_METADATA)
+                            policy = creation["state_policy"]
+                        except (OSError, WorkspaceError):
+                            status = self.workspace.topology_status(topology.name)
+                            policy = status["state_policy"]
+                            if policy.get("lifecycle") not in {
+                                "removal-pending",
+                                "removed",
+                            }:
+                                raise WorkspaceError(
+                                    "temporary state removal status is invalid"
+                                )
                         logical = Path(policy["path"])
                         identity = policy["identity"]
                         pending_path = logical.parent / (
@@ -3682,17 +3694,53 @@ class Cleanup:
                 "purpose": f"topology:{topology_name}",
             }:
                 raise WorkspaceError("temporary state topology marker is invalid")
-            if load_json(physical / MANAGED_MARKER) != {
-                "schema_version": SCHEMA_VERSION,
-                "purpose": "temporary-topology-state",
-                "topology": topology_name,
-                "generation": generation,
-            }:
-                raise WorkspaceError("temporary state ownership marker is invalid")
-            record = load_json(physical / TEMPORARY_STATE_METADATA)
-            creation_policy = (
-                record.get("state_policy") if isinstance(record, dict) else None
+            empty_removal_tombstone = physical != path and not any(
+                physical.iterdir()
             )
+            if empty_removal_tombstone:
+                status = self.workspace.topology_status(topology_name)
+                status_policy = status.get("state_policy")
+                if (
+                    not isinstance(status_policy, dict)
+                    or status_policy.get("lifecycle")
+                    not in {"removal-pending", "removed"}
+                    or status_policy.get("identity")
+                    != {"device": metadata.st_dev, "inode": metadata.st_ino}
+                ):
+                    raise WorkspaceError(
+                        "temporary state removal status is invalid"
+                    )
+                creation_policy = {
+                    key: status_policy[key]
+                    for key in (
+                        "mode",
+                        "path",
+                        "owner",
+                        "created_at",
+                        "identity",
+                        "implementation",
+                        "server",
+                    )
+                }
+                creation_policy.update(
+                    {"name": None, "lifecycle": "disposable"}
+                )
+                record: object = {
+                    "schema_version": TEMPORARY_STATE_SCHEMA_VERSION,
+                    "state_policy": creation_policy,
+                }
+            else:
+                if load_json(physical / MANAGED_MARKER) != {
+                    "schema_version": SCHEMA_VERSION,
+                    "purpose": "temporary-topology-state",
+                    "topology": topology_name,
+                    "generation": generation,
+                }:
+                    raise WorkspaceError("temporary state ownership marker is invalid")
+                record = load_json(physical / TEMPORARY_STATE_METADATA)
+                creation_policy = (
+                    record.get("state_policy") if isinstance(record, dict) else None
+                )
             if (
                 not isinstance(record, dict)
                 or record.get("schema_version") != TEMPORARY_STATE_SCHEMA_VERSION
@@ -3729,6 +3777,23 @@ class Cleanup:
                     break
             if registered_state:
                 item["reasons"].append("registered_state")
+            if not empty_removal_tombstone:
+                for directory, names, files in os.walk(
+                    physical, followlinks=False
+                ):
+                    current = Path(directory)
+                    linked = False
+                    for entry_name in (*names, *files):
+                        entry_metadata = (current / entry_name).lstat()
+                        if stat.S_ISLNK(entry_metadata.st_mode) or (
+                            stat.S_ISREG(entry_metadata.st_mode)
+                            and entry_metadata.st_nlink != 1
+                        ):
+                            item["reasons"].append("linked_state")
+                            linked = True
+                            break
+                    if linked:
+                        break
             if check_lock:
                 state_lock = Path(f"{path}.lock")
                 if not state_lock.exists() and not state_lock.is_symlink():
@@ -3828,7 +3893,7 @@ class Cleanup:
             lifecycle = policy.get("lifecycle")
             if lifecycle in {"retained", "promotion-pending", "promoted"}:
                 item["reasons"].append(f"temporary_state_{lifecycle.replace('-', '_')}")
-            elif lifecycle == "removal-pending" and physical != path:
+            elif lifecycle in {"removal-pending", "removed"} and physical != path:
                 pass
             elif lifecycle != "disposable":
                 item["reasons"].append("invalid_temporary_state_lifecycle")
@@ -3903,9 +3968,33 @@ class Cleanup:
                         f"{current.get('error', current['reasons'])}"
                     )
                 status = self.workspace.topology_status(topology)
-                self.workspace._commit_temporary_state_removal(
-                    topology, status, state_lease
+                policy = status["state_policy"]
+                pending = self.workspace._temporary_state_removal_path(policy)
+                removal_tombstone = _owned_tree_tombstone_path(
+                    pending, policy["identity"]
                 )
+                mutation_path = next(
+                    (
+                        candidate
+                        for candidate in (path, pending, removal_tombstone)
+                        if candidate.exists() or candidate.is_symlink()
+                    ),
+                    None,
+                )
+                mutation_fd = (
+                    self.workspace._lock_state_directory_mutation(
+                        mutation_path, policy["identity"]
+                    )
+                    if mutation_path is not None
+                    else None
+                )
+                try:
+                    self.workspace._commit_temporary_state_removal(
+                        topology, status, state_lease
+                    )
+                finally:
+                    if mutation_fd is not None:
+                        os.close(mutation_fd)
 
     def _any_build_lock_busy(self) -> tuple[bool, str | None]:
         locks = self.paths.builds / "locks"

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -983,6 +983,7 @@ class Cleanup:
         item.pop("_sound_worktree_identity", None)
         item.pop("_sound_producer_identity", None)
         item.pop("_physical_path", None)
+        item.pop("_lease_only", None)
 
     def _revalidate_target(
         self,
@@ -1017,9 +1018,11 @@ class Cleanup:
             )
             filesystem_identity = item.get("_identity")
             physical = item.get("_physical_path")
+            lease_only = item.get("_lease_only")
             self._strip_internal(item)
             item["_identity"] = filesystem_identity
             item["_physical_path"] = physical
+            item["_lease_only"] = lease_only
             return item
         references, reference_errors = self._references()
         registered, registered_error = self._registered_worktree_paths()
@@ -3636,7 +3639,128 @@ class Cleanup:
                         )
                 else:
                     items.append(self._temporary_state_item(path, older_than_days))
+            represented = {item["path"] for item in items}
+            try:
+                status = self.workspace.topology_status(topology.name)
+                policy = status.get("state_policy")
+                if (
+                    isinstance(policy, dict)
+                    and policy.get("mode") == "temporary"
+                    and policy.get("lifecycle") == "removed"
+                    and policy.get("path") not in represented
+                ):
+                    logical = Path(policy["path"])
+                    lock = Path(f"{logical}.lock")
+                    lease_identity = policy["lease_identity"]
+                    lock_tombstone = lock.parent / (
+                        f".{lock.name}.remove-{lease_identity['device']:x}-"
+                        f"{lease_identity['inode']:x}"
+                    )
+                    if (
+                        lock.exists()
+                        or lock.is_symlink()
+                        or lock_tombstone.exists()
+                        or lock_tombstone.is_symlink()
+                    ):
+                        items.append(
+                            self._removed_temporary_state_lease_item(
+                                topology.name, status, older_than_days
+                            )
+                        )
+            except (KeyError, OSError, TypeError, WorkspaceError):
+                pass
         return items
+
+    def _removed_temporary_state_lease_item(
+        self,
+        topology: str,
+        status: dict[str, Any],
+        older_than_days: int,
+    ) -> dict[str, Any]:
+        policy = status["state_policy"]
+        path = Path(policy["path"])
+        item = _base_item(
+            "temporary-state", "atrinik", "atrinik/atrinik", path
+        )
+        item["topology"] = topology
+        item["generation"] = policy["owner"]["generation"]
+        item["state_policy"] = policy
+        item["_lease_only"] = True
+        item["_identity"] = None
+        item["_physical_path"] = None
+        if path.exists() or path.is_symlink():
+            item["reasons"].append("temporary_state_reappeared")
+        lock = Path(f"{path}.lock")
+        lease_identity = policy["lease_identity"]
+        lock_tombstone = lock.parent / (
+            f".{lock.name}.remove-{lease_identity['device']:x}-"
+            f"{lease_identity['inode']:x}"
+        )
+        if lock.exists() or lock.is_symlink():
+            busy, lock_error, observed_identity = self._state_lock_observation(lock)
+            if lock_error:
+                item["reasons"].append("state_lease_error")
+                item["error"] = lock_error
+            elif busy:
+                item["reasons"].append("active_state_lease")
+            elif observed_identity != lease_identity:
+                item["reasons"].append("state_lease_identity_mismatch")
+        elif lock_tombstone.exists() or lock_tombstone.is_symlink():
+            metadata = lock_tombstone.stat(follow_symlinks=False)
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_nlink != 1
+                or {"device": metadata.st_dev, "inode": metadata.st_ino}
+                != lease_identity
+            ):
+                item["reasons"].append("state_lease_identity_mismatch")
+        else:
+            item["reasons"].append("state_lease_unverifiable")
+        observation = status.get("observation")
+        liveness = [
+            status["supervisor"].get("liveness"),
+            *(service.get("liveness") for service in status["services"].values()),
+        ]
+        if any(value in {"live", "unreachable"} for value in liveness):
+            item["reasons"].append("topology_liveness_unverifiable")
+        if not isinstance(observation, dict):
+            item["reasons"].append("topology_observation_unverifiable")
+        else:
+            if observation.get("control") == "reachable":
+                item["reasons"].append("reachable_topology_control")
+            if observation.get("process_tree_lease") != "released":
+                item["reasons"].append("process_tree_lease_unverifiable")
+            if observation.get("runtime_bundle_lease") not in {
+                "released",
+                "historical",
+            }:
+                item["reasons"].append("runtime_bundle_lease_unverifiable")
+            endpoint = status.get("endpoint")
+            port = observation.get("port_reservation")
+            if (
+                not isinstance(endpoint, dict)
+                or not isinstance(port, dict)
+                or port.get("port") != endpoint.get("port")
+                or port.get("owner") != topology
+                or port.get("generation") != item["generation"]
+                or port.get("lease") != "released"
+            ):
+                item["reasons"].append(
+                    "port_reservation_lease_unverifiable"
+                )
+        created = _parse_time(policy.get("created_at"), "temporary state created_at")
+        age = max(0, int((self.now - created).total_seconds()))
+        item["age_seconds"] = age
+        item["age_basis"] = "created-at"
+        if created > self.now:
+            item["reasons"].append("future_creation_time")
+        elif age < older_than_days * 86400:
+            item["reasons"].append("younger_than_grace_period")
+        item["reasons"] = sorted(set(item["reasons"]))
+        if not item["reasons"]:
+            item["disposition"] = "eligible"
+            item["reasons"] = ["stale_removed_temporary_state_lease"]
+        return item
 
     def _temporary_state_item(
         self,
@@ -3778,22 +3902,36 @@ class Cleanup:
             if registered_state:
                 item["reasons"].append("registered_state")
             if not empty_removal_tombstone:
-                for directory, names, files in os.walk(
-                    physical, followlinks=False
-                ):
-                    current = Path(directory)
-                    linked = False
-                    for entry_name in (*names, *files):
-                        entry_metadata = (current / entry_name).lstat()
-                        if stat.S_ISLNK(entry_metadata.st_mode) or (
-                            stat.S_ISREG(entry_metadata.st_mode)
-                            and entry_metadata.st_nlink != 1
-                        ):
-                            item["reasons"].append("linked_state")
-                            linked = True
-                            break
-                    if linked:
-                        break
+                state_fd = os.open(
+                    physical,
+                    os.O_RDONLY
+                    | os.O_CLOEXEC
+                    | os.O_DIRECTORY
+                    | os.O_NOFOLLOW,
+                )
+                try:
+                    opened = os.fstat(state_fd)
+                    if (opened.st_dev, opened.st_ino) != (
+                        metadata.st_dev,
+                        metadata.st_ino,
+                    ):
+                        raise WorkspaceError(
+                            "temporary state changed during integrity validation"
+                        )
+                    try:
+                        self.workspace._validate_temporary_state_integrity(
+                            state_fd, physical
+                        )
+                    except WorkspaceError as error:
+                        message = str(error)
+                        item["reasons"].append(
+                            "linked_state"
+                            if "link" in message or "mounted" in message
+                            else "malformed_state"
+                        )
+                        item["error"] = message
+                finally:
+                    os.close(state_fd)
             if check_lock:
                 state_lock = Path(f"{path}.lock")
                 if not state_lock.exists() and not state_lock.is_symlink():
@@ -3927,6 +4065,40 @@ class Cleanup:
         if not isinstance(topology, str):
             raise WorkspaceError("temporary state topology identity is missing")
         root = self.workspace._topology_directory(topology)
+        if item.get("_lease_only"):
+            with exclusive_lock(
+                root / "operation.lock",
+                f"topology {topology} operation",
+                nonblocking=True,
+            ):
+                status = self.workspace.topology_status(topology)
+                policy = status.get("state_policy")
+                if (
+                    not isinstance(policy, dict)
+                    or policy.get("mode") != "temporary"
+                    or policy.get("lifecycle") != "removed"
+                    or policy.get("path") != str(path)
+                ):
+                    raise WorkspaceError(
+                        "removed temporary state lease status changed before cleanup"
+                    )
+                lock = Path(f"{path}.lock")
+                if lock.exists() or lock.is_symlink():
+                    with exclusive_lock(
+                        lock,
+                        f"temporary topology state {path}",
+                        nonblocking=True,
+                    ) as state_lease:
+                        self.workspace._unlink_temporary_state_lock(
+                            path, state_lease, policy["lease_identity"]
+                        )
+                elif not self.workspace._finish_temporary_state_lock_tombstone(
+                    path, policy["lease_identity"]
+                ):
+                    raise WorkspaceError(
+                        f"removed temporary state lease is missing: {lock}"
+                    )
+            return
         with exclusive_lock(
             root / "operation.lock",
             f"topology {topology} operation",
@@ -3990,7 +4162,7 @@ class Cleanup:
                 )
                 try:
                     self.workspace._commit_temporary_state_removal(
-                        topology, status, state_lease
+                        topology, status, state_lease, mutation_fd
                     )
                 finally:
                     if mutation_fd is not None:

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -405,12 +405,20 @@ def _topology_tree_snapshot(
     parent_descriptor: int | None = None
     root_descriptor: int | None = None
 
-    def record(metadata: os.stat_result, relative: str, display: Path) -> None:
+    def record(
+        metadata: os.stat_result,
+        relative: str,
+        display: Path,
+        *,
+        allow_runtime_state_link: bool = False,
+    ) -> None:
         nonlocal maximum
         if metadata.st_dev != root_device:
             raise WorkspaceError(f"topology tree contains a mount: {display}")
         if not (
-            stat.S_ISDIR(metadata.st_mode) or stat.S_ISREG(metadata.st_mode)
+            stat.S_ISDIR(metadata.st_mode)
+            or stat.S_ISREG(metadata.st_mode)
+            or allow_runtime_state_link and stat.S_ISLNK(metadata.st_mode)
         ):
             raise WorkspaceError(f"topology tree contains a special file: {display}")
         if stat.S_ISREG(metadata.st_mode) and metadata.st_nlink != 1:
@@ -446,9 +454,19 @@ def _topology_tree_snapshot(
             child_relative = name if relative == "." else f"{relative}/{name}"
             metadata = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
             if stat.S_ISLNK(metadata.st_mode):
-                raise WorkspaceError(
-                    f"topology tree contains a symbolic link: {child_display}"
+                if not re.fullmatch(
+                    r"generations/[0-9a-f]{64}/server/data", child_relative
+                ):
+                    raise WorkspaceError(
+                        f"topology tree contains a symbolic link: {child_display}"
+                    )
+                record(
+                    metadata,
+                    child_relative,
+                    child_display,
+                    allow_runtime_state_link=True,
                 )
+                continue
             if stat.S_ISDIR(metadata.st_mode):
                 child_descriptor = os.open(
                     name,
@@ -3555,7 +3573,18 @@ class Cleanup:
             for path in children:
                 if path.name == MANAGED_MARKER or path.name.endswith(".lock"):
                     continue
-                items.append(self._temporary_state_item(path, older_than_days))
+                pending = re.fullmatch(
+                    r"\.([0-9a-f]{64})\.removal-pending", path.name
+                )
+                if pending:
+                    logical = path.parent / pending.group(1)
+                    items.append(
+                        self._temporary_state_item(
+                            logical, older_than_days, physical_path=path
+                        )
+                    )
+                else:
+                    items.append(self._temporary_state_item(path, older_than_days))
         return items
 
     def _temporary_state_item(
@@ -3565,24 +3594,32 @@ class Cleanup:
         *,
         check_lock: bool = True,
         held_lease_identity: dict[str, int] | None = None,
+        physical_path: Path | None = None,
     ) -> dict[str, Any]:
         item = _base_item(
             "temporary-state", "atrinik", "atrinik/atrinik", path
         )
-        inodes, observed, walk_error = _tree_usage(path)
+        pending_path = path.parent / f".{path.name}.removal-pending"
+        physical = physical_path or (
+            pending_path
+            if not (path.exists() or path.is_symlink())
+            and (pending_path.exists() or pending_path.is_symlink())
+            else path
+        )
+        inodes, observed, walk_error = _tree_usage(physical)
         item["_inodes"] = inodes
         if walk_error:
             item["reasons"].append("filesystem_traversal_error")
             item["error"] = walk_error
         try:
-            metadata = path.lstat()
+            metadata = physical.lstat()
             item["_identity"] = (
                 metadata.st_dev,
                 metadata.st_ino,
                 metadata.st_ctime_ns,
                 stat.S_IFMT(metadata.st_mode),
             )
-            if path.is_symlink() or not stat.S_ISDIR(metadata.st_mode):
+            if physical.is_symlink() or not stat.S_ISDIR(metadata.st_mode):
                 raise WorkspaceError("temporary state is not a normal directory")
             container = path.parent
             topology = container.parent
@@ -3605,14 +3642,14 @@ class Cleanup:
                 "purpose": f"topology:{topology_name}",
             }:
                 raise WorkspaceError("temporary state topology marker is invalid")
-            if load_json(path / MANAGED_MARKER) != {
+            if load_json(physical / MANAGED_MARKER) != {
                 "schema_version": SCHEMA_VERSION,
                 "purpose": "temporary-topology-state",
                 "topology": topology_name,
                 "generation": generation,
             }:
                 raise WorkspaceError("temporary state ownership marker is invalid")
-            record = load_json(path / TEMPORARY_STATE_METADATA)
+            record = load_json(physical / TEMPORARY_STATE_METADATA)
             creation_policy = (
                 record.get("state_policy") if isinstance(record, dict) else None
             )
@@ -3738,6 +3775,8 @@ class Cleanup:
             lifecycle = policy.get("lifecycle")
             if lifecycle in {"retained", "promotion-pending", "promoted"}:
                 item["reasons"].append(f"temporary_state_{lifecycle.replace('-', '_')}")
+            elif lifecycle == "removal-pending" and physical != path:
+                pass
             elif lifecycle != "disposable":
                 item["reasons"].append("invalid_temporary_state_lifecycle")
             created = _parse_time(policy.get("created_at"), "temporary state created_at")
@@ -3796,6 +3835,13 @@ class Cleanup:
                         "device": lease_metadata.st_dev,
                         "inode": lease_metadata.st_ino,
                     },
+                    physical_path=(
+                        self.workspace._temporary_state_removal_path(
+                            self.workspace.topology_status(topology)["state_policy"]
+                        )
+                        if not path.exists()
+                        else None
+                    ),
                 )
                 if (
                     current.get("_identity") != item.get("_identity")
@@ -3804,7 +3850,10 @@ class Cleanup:
                     raise WorkspaceError(
                         f"temporary state changed before removal: {path}"
                     )
-                remove_owned_tree(path)
+                status = self.workspace.topology_status(topology)
+                self.workspace._commit_temporary_state_removal(
+                    topology, status, state_lease
+                )
 
     def _any_build_lock_busy(self) -> tuple[bool, str | None]:
         locks = self.paths.builds / "locks"

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -3760,7 +3760,7 @@ class Cleanup:
                                 item["reasons"].append(
                                     "runtime_bundle_lease_unverifiable"
                                 )
-                            if "server" in status.get("services", {}):
+                            if status.get("endpoint") is not None:
                                 endpoint = status.get("endpoint")
                                 port = observation.get("port_reservation")
                                 if (

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -40,6 +40,7 @@ from .workspace import (
     COMPILER_CACHE_PURPOSE,
     TEMPORARY_STATE_METADATA,
     TEMPORARY_STATE_SCHEMA_VERSION,
+    _owned_tree_tombstone_path,
     _remote_matches,
     exclusive_lock,
     remove_owned_tree,
@@ -778,6 +779,8 @@ class Cleanup:
                             "disposition": match["disposition"],
                             "reasons": match["reasons"],
                         }
+                        if "error" in match:
+                            target["revalidation"]["error"] = match["error"]
                     report["aborted"] = True
                     break
                 credited = {
@@ -1003,7 +1006,16 @@ class Cleanup:
                 )
             return item
         if kind == "temporary-state":
-            item = self._temporary_state_item(path, older_than_days)
+            physical = target.get("_physical_path")
+            item = self._temporary_state_item(
+                path,
+                older_than_days,
+                physical_path=(
+                    Path(physical)
+                    if isinstance(physical, str) and not path.exists()
+                    else None
+                ),
+            )
             filesystem_identity = item.get("_identity")
             self._strip_internal(item)
             item["_identity"] = filesystem_identity
@@ -3583,6 +3595,33 @@ class Cleanup:
                             logical, older_than_days, physical_path=path
                         )
                     )
+                elif re.fullmatch(
+                    r"\.remove-[0-9a-f]{16}-[0-9a-f]+-[0-9a-f]+", path.name
+                ):
+                    try:
+                        creation = load_json(path / TEMPORARY_STATE_METADATA)
+                        policy = creation["state_policy"]
+                        logical = Path(policy["path"])
+                        identity = policy["identity"]
+                        pending_path = logical.parent / (
+                            f".{logical.name}.removal-pending"
+                        )
+                        if path not in {
+                            _owned_tree_tombstone_path(logical, identity),
+                            _owned_tree_tombstone_path(pending_path, identity),
+                        }:
+                            raise WorkspaceError(
+                                "temporary state removal tombstone is invalid"
+                            )
+                        items.append(
+                            self._temporary_state_item(
+                                logical, older_than_days, physical_path=path
+                            )
+                        )
+                    except (KeyError, OSError, TypeError, WorkspaceError):
+                        items.append(
+                            self._temporary_state_item(path, older_than_days)
+                        )
                 else:
                     items.append(self._temporary_state_item(path, older_than_days))
         return items
@@ -3606,6 +3645,7 @@ class Cleanup:
             and (pending_path.exists() or pending_path.is_symlink())
             else path
         )
+        item["_physical_path"] = str(physical)
         inodes, observed, walk_error = _tree_usage(physical)
         item["_inodes"] = inodes
         if walk_error:
@@ -3849,9 +3889,7 @@ class Cleanup:
                         "inode": lease_metadata.st_ino,
                     },
                     physical_path=(
-                        self.workspace._temporary_state_removal_path(
-                            self.workspace.topology_status(topology)["state_policy"]
-                        )
+                        Path(item["_physical_path"])
                         if not path.exists()
                         else None
                     ),
@@ -3861,7 +3899,8 @@ class Cleanup:
                     or current["disposition"] != "eligible"
                 ):
                     raise WorkspaceError(
-                        f"temporary state changed before removal: {path}"
+                        f"temporary state changed before removal: {path}: "
+                        f"{current.get('error', current['reasons'])}"
                     )
                 status = self.workspace.topology_status(topology)
                 self.workspace._commit_temporary_state_removal(

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -3760,20 +3760,19 @@ class Cleanup:
                                 item["reasons"].append(
                                     "runtime_bundle_lease_unverifiable"
                                 )
-                            if status.get("endpoint") is not None:
-                                endpoint = status.get("endpoint")
-                                port = observation.get("port_reservation")
-                                if (
-                                    not isinstance(endpoint, dict)
-                                    or not isinstance(port, dict)
-                                    or port.get("port") != endpoint.get("port")
-                                    or port.get("owner") != topology_name
-                                    or port.get("generation") != generation
-                                    or port.get("lease") != "released"
-                                ):
-                                    item["reasons"].append(
-                                        "port_reservation_lease_unverifiable"
-                                    )
+                            endpoint = status.get("endpoint")
+                            port = observation.get("port_reservation")
+                            if (
+                                not isinstance(endpoint, dict)
+                                or not isinstance(port, dict)
+                                or port.get("port") != endpoint.get("port")
+                                or port.get("owner") != topology_name
+                                or port.get("generation") != generation
+                                or port.get("lease") != "released"
+                            ):
+                                item["reasons"].append(
+                                    "port_reservation_lease_unverifiable"
+                                )
                 except (OSError, RuntimeError, WorkspaceError) as error:
                     item["reasons"].append("topology_status_uncertain")
                     item["error"] = str(error)

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -40,6 +40,7 @@ from .workspace import (
     COMPILER_CACHE_PURPOSE,
     TEMPORARY_STATE_METADATA,
     TEMPORARY_STATE_SCHEMA_VERSION,
+    _descriptor_mount_id,
     _owned_tree_tombstone_path,
     _remote_matches,
     exclusive_lock,
@@ -386,6 +387,90 @@ def _tree_usage(
         datetime.fromtimestamp(maximum, timezone.utc) if maximum is not None else None
     )
     return sizes, observed, None
+
+
+def _temporary_tree_usage(
+    root: Path,
+) -> tuple[dict[tuple[int, int], int], datetime | None, str | None]:
+    """Measure temporary state without following links or crossing mounts."""
+
+    sizes: dict[tuple[int, int], int] = {}
+    maximum: float | None = None
+    descriptors: list[int] = []
+    try:
+        root_fd = os.open(
+            root,
+            os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
+        )
+        descriptors.append(root_fd)
+        root_mount = _descriptor_mount_id(root_fd)
+        stack: list[tuple[int, Path]] = [(root_fd, root)]
+        visited: set[tuple[int, int, int | tuple[int, int]]] = set()
+        while stack:
+            descriptor, display = stack.pop()
+            directory = os.fstat(descriptor)
+            coordinate = (directory.st_dev, directory.st_ino, root_mount)
+            if coordinate in visited:
+                raise WorkspaceError(
+                    f"temporary state traversal encountered a cycle: {display}"
+                )
+            visited.add(coordinate)
+            sizes.setdefault(
+                (directory.st_dev, directory.st_ino), directory.st_blocks * 512
+            )
+            maximum = (
+                directory.st_mtime
+                if maximum is None
+                else max(maximum, directory.st_mtime)
+            )
+            for name in os.listdir(descriptor):
+                child = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
+                sizes.setdefault(
+                    (child.st_dev, child.st_ino), child.st_blocks * 512
+                )
+                maximum = (
+                    child.st_mtime
+                    if maximum is None
+                    else max(maximum, child.st_mtime)
+                )
+                if not stat.S_ISDIR(child.st_mode):
+                    continue
+                child_fd = os.open(
+                    name,
+                    os.O_RDONLY
+                    | os.O_CLOEXEC
+                    | os.O_DIRECTORY
+                    | os.O_NOFOLLOW,
+                    dir_fd=descriptor,
+                )
+                descriptors.append(child_fd)
+                opened = os.fstat(child_fd)
+                if (
+                    (opened.st_dev, opened.st_ino)
+                    != (child.st_dev, child.st_ino)
+                    or _descriptor_mount_id(child_fd) != root_mount
+                ):
+                    raise WorkspaceError(
+                        f"temporary state traversal encountered a mount: "
+                        f"{display / name}"
+                    )
+                stack.append((child_fd, display / name))
+        observed = (
+            datetime.fromtimestamp(maximum, timezone.utc)
+            if maximum is not None
+            else None
+        )
+        return sizes, observed, None
+    except (OSError, RuntimeError, WorkspaceError) as error:
+        observed = (
+            datetime.fromtimestamp(maximum, timezone.utc)
+            if maximum is not None
+            else None
+        )
+        return sizes, observed, str(error)
+    finally:
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
 
 
 def _topology_tree_snapshot(
@@ -3782,7 +3867,7 @@ class Cleanup:
             else path
         )
         item["_physical_path"] = str(physical)
-        inodes, observed, walk_error = _tree_usage(physical)
+        inodes, observed, walk_error = _temporary_tree_usage(physical)
         item["_inodes"] = inodes
         if walk_error:
             item["reasons"].append("filesystem_traversal_error")

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -39,6 +39,7 @@ from .workspace import (
     WORKER_DEPENDENCY_SCHEMA_VERSION,
     COMPILER_CACHE_MAX_SIZE,
     COMPILER_CACHE_PURPOSE,
+    RUNTIME_STATE_OUTPUT_TRANSACTION,
     TEMPORARY_STATE_METADATA,
     TEMPORARY_STATE_SCHEMA_VERSION,
     _descriptor_mount_id,
@@ -1330,6 +1331,9 @@ class Cleanup:
         if tree_error is not None:
             reasons.append("invalid_topology_tree")
             item["error"] = tree_error
+        output_transaction = path / RUNTIME_STATE_OUTPUT_TRANSACTION
+        if output_transaction.exists() or output_transaction.is_symlink():
+            reasons.append("runtime_state_output_transaction_pending")
 
         temporary_container = path / "temporary-states"
         if temporary_container.exists() or temporary_container.is_symlink():

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -38,6 +38,8 @@ from .workspace import (
     WORKER_DEPENDENCY_SCHEMA_VERSION,
     COMPILER_CACHE_MAX_SIZE,
     COMPILER_CACHE_PURPOSE,
+    TEMPORARY_STATE_METADATA,
+    TEMPORARY_STATE_SCHEMA_VERSION,
     _remote_matches,
     exclusive_lock,
     remove_owned_tree,
@@ -49,7 +51,13 @@ WORKER_DEPENDENCY_CLEANUP_SCHEMA_VERSIONS = frozenset(
     {1, 2, 3, WORKER_DEPENDENCY_SCHEMA_VERSION}
 )
 DEFAULT_SCOPES = ("worktrees", "builds")
-ALL_SCOPES = (*DEFAULT_SCOPES, "npm-cache", "compiler-cache", "sound-cache")
+ALL_SCOPES = (
+    *DEFAULT_SCOPES,
+    "temporary-states",
+    "npm-cache",
+    "compiler-cache",
+    "sound-cache",
+)
 SUPPORTED_SCOPES = (*ALL_SCOPES, "topologies")
 BUILD_RETENTION_RECORD = "retention.json"
 LEGACY_BUILD_METADATA_SCHEMA_VERSION = 1
@@ -854,8 +862,11 @@ class Cleanup:
         mode: str,
     ) -> dict[str, Any]:
         self._reset_inventory()
-        topology_only = set(scopes) == {"topologies"}
-        if topology_only:
+        runtime_only = bool(scopes) and set(scopes) <= {
+            "topologies",
+            "temporary-states",
+        }
+        if runtime_only:
             references = {
                 "profiles": {},
                 "scenarios": {},
@@ -869,7 +880,7 @@ class Cleanup:
             references, reference_errors = self._references()
         items: list[dict[str, Any]] = []
         registered: set[Path] = set()
-        if not topology_only:
+        if not runtime_only:
             registered, registered_error = self._registered_worktree_paths()
             if registered_error:
                 reference_errors.add("worktree_inventory_error")
@@ -898,6 +909,8 @@ class Cleanup:
                 )
             )
             items.extend(self._unmanaged_builds(registered))
+        if "temporary-states" in scopes and names is None:
+            items.extend(self._temporary_states(older_than_days))
         if "npm-cache" in scopes:
             cache = self._npm_cache(older_than_days, references, reference_errors)
             if cache is not None:
@@ -970,6 +983,12 @@ class Cleanup:
                 raise WorkspaceError(
                     f"topology changed during apply revalidation: {target['name']}"
                 )
+            return item
+        if kind == "temporary-state":
+            item = self._temporary_state_item(path, older_than_days)
+            filesystem_identity = item.get("_identity")
+            self._strip_internal(item)
+            item["_identity"] = filesystem_identity
             return item
         references, reference_errors = self._references()
         registered, registered_error = self._registered_worktree_paths()
@@ -1046,7 +1065,11 @@ class Cleanup:
             sound_worktree_identity = item.get("_sound_worktree_identity")
             sound_producer_identity = item.get("_sound_producer_identity")
             self._strip_internal(item)
-            if kind in {"worker-dependency-transaction", "sound-cache"}:
+            if kind in {
+                "worker-dependency-transaction",
+                "sound-cache",
+                "temporary-state",
+            }:
                 item["_identity"] = filesystem_identity
             if kind == "sound-cache":
                 item["_worktree_identity"] = worktree_identity
@@ -1135,6 +1158,20 @@ class Cleanup:
         if tree_error is not None:
             reasons.append("invalid_topology_tree")
             item["error"] = tree_error
+
+        temporary_container = path / "temporary-states"
+        if temporary_container.exists() or temporary_container.is_symlink():
+            try:
+                if temporary_container.is_symlink() or not temporary_container.is_dir():
+                    raise WorkspaceError("temporary state container is invalid")
+                if any(
+                    child.name != MANAGED_MARKER
+                    for child in temporary_container.iterdir()
+                ):
+                    reasons.append("temporary_states_present")
+            except (OSError, WorkspaceError) as error:
+                reasons.append("temporary_state_inventory_unverifiable")
+                item["error"] = str(error)
 
         if check_operation:
             operation_lock = path / "operation.lock"
@@ -1685,7 +1722,7 @@ class Cleanup:
                 build_root = status_value.get("build_root")
                 resolved = status_value.get("resolved")
                 if (
-                    status_value.get("schema_version") != SCHEMA_VERSION
+                    status_value.get("schema_version") not in {SCHEMA_VERSION, 2, 3}
                     or status_value.get("name") != root.name
                     or not isinstance(build_root, str)
                     or not Path(build_root).is_absolute()
@@ -3461,6 +3498,206 @@ class Cleanup:
             item["reasons"] = [f"stale_{kind.replace('-', '_')}"]
         return item
 
+    def _temporary_states(self, older_than_days: int) -> list[dict[str, Any]]:
+        if self.paths.topologies.is_symlink() or not self.paths.topologies.is_dir():
+            return []
+        items: list[dict[str, Any]] = []
+        try:
+            topologies = sorted(self.paths.topologies.iterdir())
+        except OSError:
+            return []
+        for topology in topologies:
+            container = topology / "temporary-states"
+            if not container.exists() and not container.is_symlink():
+                continue
+            if container.is_symlink() or not container.is_dir():
+                item = _base_item(
+                    "temporary-state", "atrinik", "atrinik/atrinik", container
+                )
+                item["reasons"] = ["invalid_temporary_state_container"]
+                items.append(item)
+                continue
+            try:
+                children = sorted(container.iterdir())
+            except OSError as error:
+                item = _base_item(
+                    "temporary-state", "atrinik", "atrinik/atrinik", container
+                )
+                item["reasons"] = ["temporary_state_inventory_error"]
+                item["error"] = str(error)
+                items.append(item)
+                continue
+            for path in children:
+                if path.name == MANAGED_MARKER or path.name.endswith(".lock"):
+                    continue
+                items.append(self._temporary_state_item(path, older_than_days))
+        return items
+
+    def _temporary_state_item(
+        self,
+        path: Path,
+        older_than_days: int,
+        *,
+        check_lock: bool = True,
+    ) -> dict[str, Any]:
+        item = _base_item(
+            "temporary-state", "atrinik", "atrinik/atrinik", path
+        )
+        inodes, observed, walk_error = _tree_usage(path)
+        item["_inodes"] = inodes
+        if walk_error:
+            item["reasons"].append("filesystem_traversal_error")
+            item["error"] = walk_error
+        try:
+            metadata = path.lstat()
+            item["_identity"] = (
+                metadata.st_dev,
+                metadata.st_ino,
+                metadata.st_ctime_ns,
+                stat.S_IFMT(metadata.st_mode),
+            )
+            if path.is_symlink() or not stat.S_ISDIR(metadata.st_mode):
+                raise WorkspaceError("temporary state is not a normal directory")
+            container = path.parent
+            topology = container.parent
+            topology_name = topology.name
+            generation = path.name
+            if (
+                not re.fullmatch(r"[0-9a-f]{64}", generation)
+                or container.name != "temporary-states"
+                or topology.parent.resolve(strict=False)
+                != self.paths.topologies.resolve(strict=False)
+            ):
+                raise WorkspaceError("temporary state path identity is invalid")
+            if load_json(container / MANAGED_MARKER) != {
+                "schema_version": SCHEMA_VERSION,
+                "purpose": "topology-temporary-states",
+            }:
+                raise WorkspaceError("temporary state container marker is invalid")
+            if load_json(topology / MANAGED_MARKER) != {
+                "schema_version": SCHEMA_VERSION,
+                "purpose": f"topology:{topology_name}",
+            }:
+                raise WorkspaceError("temporary state topology marker is invalid")
+            if load_json(path / MANAGED_MARKER) != {
+                "schema_version": SCHEMA_VERSION,
+                "purpose": "temporary-topology-state",
+                "topology": topology_name,
+                "generation": generation,
+            }:
+                raise WorkspaceError("temporary state ownership marker is invalid")
+            record = load_json(path / TEMPORARY_STATE_METADATA)
+            policy = record.get("state_policy") if isinstance(record, dict) else None
+            if (
+                not isinstance(record, dict)
+                or record.get("schema_version") != TEMPORARY_STATE_SCHEMA_VERSION
+                or not isinstance(policy, dict)
+                or policy.get("mode") != "temporary"
+                or policy.get("path") != str(path)
+                or policy.get("owner")
+                != {
+                    "kind": "topology-generation",
+                    "topology": topology_name,
+                    "generation": generation,
+                }
+                or policy.get("identity")
+                != {"device": metadata.st_dev, "inode": metadata.st_ino}
+            ):
+                raise WorkspaceError("temporary state metadata is invalid")
+            item["topology"] = topology_name
+            item["generation"] = generation
+            item["state_policy"] = policy
+            lifecycle = policy.get("lifecycle")
+            if lifecycle in {"retained", "promotion-pending", "promoted"}:
+                item["reasons"].append(f"temporary_state_{lifecycle.replace('-', '_')}")
+            elif lifecycle != "disposable":
+                item["reasons"].append("invalid_temporary_state_lifecycle")
+            registered = {
+                self.workspace._canonical_state_path(Path(value))
+                for value in self.workspace._load_states().values()
+            }
+            if path in registered:
+                item["reasons"].append("registered_state")
+            if check_lock:
+                busy, lock_error = self._lock_busy(Path(f"{path}.lock"))
+                if lock_error:
+                    item["reasons"].append("state_lease_error")
+                    item["error"] = lock_error
+                elif busy:
+                    item["reasons"].append("active_state_lease")
+            status_path = topology / "status.json"
+            if status_path.exists() or status_path.is_symlink():
+                try:
+                    if status_path.is_symlink() or not status_path.is_file():
+                        raise WorkspaceError("topology status is invalid")
+                    status = load_json(status_path)
+                    control = status.get("control") if isinstance(status, dict) else None
+                    current_generation = (
+                        control.get("generation")
+                        if isinstance(control, dict)
+                        else None
+                    )
+                    if (
+                        isinstance(status, dict)
+                        and current_generation == generation
+                        and status.get("state_policy") != policy
+                    ):
+                        item["reasons"].append("topology_state_record_mismatch")
+                except (OSError, WorkspaceError) as error:
+                    item["reasons"].append("topology_status_uncertain")
+                    item["error"] = str(error)
+            created = _parse_time(policy.get("created_at"), "temporary state created_at")
+            age = max(0, int((self.now - created).total_seconds()))
+            item["age_seconds"] = age
+            item["age_basis"] = "created-at"
+            if created > self.now:
+                item["reasons"].append("future_creation_time")
+            elif age < older_than_days * 86400:
+                item["reasons"].append("younger_than_grace_period")
+        except (OSError, RuntimeError, WorkspaceError) as error:
+            item["reasons"].append("invalid_temporary_state")
+            item["error"] = str(error)
+            if item["age_seconds"] is None and observed is not None:
+                item["age_seconds"] = max(
+                    0, int((self.now - observed).total_seconds())
+                )
+                item["age_basis"] = "tree-mtime"
+        item["reasons"] = sorted(set(item["reasons"]))
+        if not item["reasons"]:
+            item["disposition"] = "eligible"
+            item["reasons"] = ["stale_abandoned_temporary_state"]
+        return item
+
+    def _remove_temporary_state(
+        self, item: dict[str, Any], older_than_days: int
+    ) -> None:
+        path = Path(item["path"])
+        topology = item.get("topology")
+        if not isinstance(topology, str):
+            raise WorkspaceError("temporary state topology identity is missing")
+        root = self.workspace._topology_directory(topology)
+        with exclusive_lock(
+            root / "operation.lock",
+            f"topology {topology} operation",
+            nonblocking=True,
+        ):
+            with exclusive_lock(
+                Path(f"{path}.lock"),
+                f"temporary topology state {path}",
+                nonblocking=True,
+            ):
+                current = self._temporary_state_item(
+                    path, older_than_days, check_lock=False
+                )
+                if (
+                    current.get("_identity") != item.get("_identity")
+                    or current["disposition"] != "eligible"
+                ):
+                    raise WorkspaceError(
+                        f"temporary state changed before removal: {path}"
+                    )
+                remove_owned_tree(path)
+
     def _any_build_lock_busy(self) -> tuple[bool, str | None]:
         locks = self.paths.builds / "locks"
         if not locks.exists() and not locks.is_symlink():
@@ -3519,6 +3756,7 @@ class Cleanup:
             "npm-cache": 2,
             "compiler-cache": 2,
             "sound-cache": 0,
+            "temporary-state": 0,
             "prunable-metadata": 3,
         }
         return order.get(item["kind"], 99), item["path"]
@@ -3754,6 +3992,8 @@ class Cleanup:
                     ):
                         raise WorkspaceError("sound cache changed before removal")
                     remove_owned_tree(path)
+        elif item["kind"] == "temporary-state":
+            self._remove_temporary_state(item, older_than_days)
         elif item["kind"] == "prunable-metadata":
             primary = self._repositories[item["owner"]]
             _command(primary, "worktree", "prune", "--expire", "now")

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -183,8 +183,8 @@ def parser() -> argparse.ArgumentParser:
         "--scope",
         action="append",
         choices=[
-            "worktrees", "builds", "npm-cache", "compiler-cache",
-            "sound-cache", "topologies", "all",
+            "worktrees", "builds", "temporary-states", "npm-cache",
+            "compiler-cache", "sound-cache", "topologies", "all",
         ],
         default=[],
     )
@@ -246,7 +246,25 @@ def parser() -> argparse.ArgumentParser:
     )
     topology_show = topology_commands.add_parser("show")
     mark(topology_show.add_argument("profile", nargs="?", default="default"), "profile")
-    mark(topology_show.add_argument("--state", default="default"), "state")
+    topology_state = topology_show.add_mutually_exclusive_group()
+    mark(
+        topology_state.add_argument("--state", default="default"),
+        "state",
+    )
+    topology_state.add_argument(
+        "--temporary-state",
+        dest="state",
+        action="store_const",
+        const=None,
+        help="use a fresh disposable state owned by the topology generation",
+    )
+    topology_state.add_argument(
+        "--default-state",
+        dest="state",
+        action="store_const",
+        const="default",
+        help="use the legacy managed persistent default state explicitly",
+    )
     topology_show.add_argument(
         "--service", choices=["server", "client"], action="append"
     )
@@ -255,7 +273,22 @@ def parser() -> argparse.ArgumentParser:
     up = commands.add_parser("up", help="build and start a supervised topology")
     mark(up.add_argument("--name"), "none")
     mark(up.add_argument("--profile", default="default"), "profile")
-    mark(up.add_argument("--state", default="default"), "state")
+    up_state = up.add_mutually_exclusive_group()
+    mark(up_state.add_argument("--state", default="default"), "state")
+    up_state.add_argument(
+        "--temporary-state",
+        dest="state",
+        action="store_const",
+        const=None,
+        help="use a fresh disposable state owned by this topology generation",
+    )
+    up_state.add_argument(
+        "--default-state",
+        dest="state",
+        action="store_const",
+        const="default",
+        help="use the legacy managed persistent default state explicitly",
+    )
     mark(up.add_argument(
         "--port",
         type=int,
@@ -276,6 +309,11 @@ def parser() -> argparse.ArgumentParser:
 
     down = commands.add_parser("down", help="stop a supervised topology")
     mark(down.add_argument("name", nargs="?", default="default"), "topology")
+    down.add_argument(
+        "--retain-state",
+        action="store_true",
+        help="retain a cleanly stopped temporary state for later promotion",
+    )
     down.add_argument("--json", action="store_true")
 
     state = commands.add_parser("state", help="register persistent server state")
@@ -285,6 +323,12 @@ def parser() -> argparse.ArgumentParser:
     mark(state_add.add_argument("--path", type=Path), "path")
     state_list = state_commands.add_parser("list")
     state_list.add_argument("--json", action="store_true")
+    state_promote = state_commands.add_parser(
+        "promote", help="promote a stopped retained temporary topology state"
+    )
+    mark(state_promote.add_argument("topology"), "topology")
+    mark(state_promote.add_argument("name"), "none")
+    state_promote.add_argument("--json", action="store_true")
 
     scenario = commands.add_parser(
         "scenario", help="manage deterministic local test scenarios"
@@ -783,6 +827,13 @@ def main(arguments: list[str] | None = None) -> int:
                 for role, provider in sorted(summary["providers"].items()):
                     print(f"provider\t{role}\t{provider}")
                 print(f"state\t{summary['state'] or '-'}")
+                state_policy = summary.get("state_policy")
+                if isinstance(state_policy, dict):
+                    print(
+                        "state-policy\t"
+                        f"{state_policy['mode']}\t{state_policy['lifecycle']}\t"
+                        f"{state_policy.get('path') or 'allocated-on-start'}"
+                    )
                 print(f"build\t{summary['build_root']}")
                 for component, row in summary["components"].items():
                     cleanliness = "dirty" if row["dirty"] else "clean"
@@ -805,6 +856,13 @@ def main(arguments: list[str] | None = None) -> int:
                     else ""
                 )
                 print(f"topology {name}: started{suffix}")
+                state_policy = status.get("state_policy")
+                if isinstance(state_policy, dict):
+                    print(
+                        "state-policy\t"
+                        f"{state_policy['mode']}\t{state_policy['lifecycle']}\t"
+                        f"{state_policy['path']}"
+                    )
         elif options.command == "ps":
             statuses = (
                 [workspace.topology_status(options.name)]
@@ -835,6 +893,19 @@ def main(arguments: list[str] | None = None) -> int:
                             f"endpoint\t{endpoint['host']}:{endpoint['port']}\t"
                             f"{endpoint['fingerprint']}"
                         )
+                    state_policy = status.get("state_policy")
+                    if isinstance(state_policy, dict):
+                        owner = state_policy.get("owner", {})
+                        owner_kind = (
+                            owner.get("kind", "unknown")
+                            if isinstance(owner, dict)
+                            else "unknown"
+                        )
+                        print(
+                            "state-policy\t"
+                            f"{state_policy['mode']}\t{owner_kind}\t"
+                            f"{state_policy['lifecycle']}\t{state_policy['path']}"
+                        )
                     for service, row in status["services"].items():
                         print(
                             f"{service}\t{row.get('liveness', row['status'])}\t"
@@ -864,7 +935,11 @@ def main(arguments: list[str] | None = None) -> int:
                 options.name, options.service, options.tail, options.follow
             )
         elif options.command == "down":
-            status = workspace.topology_down(options.name)
+            status = (
+                workspace.topology_down(options.name, retain_state=True)
+                if options.retain_state
+                else workspace.topology_down(options.name)
+            )
             if options.json:
                 print(json.dumps(status, indent=2, sort_keys=True))
             else:
@@ -872,7 +947,7 @@ def main(arguments: list[str] | None = None) -> int:
         elif options.command == "state":
             if options.state_command == "add":
                 workspace.state_add(options.name, options.path)
-            else:
+            elif options.state_command == "list":
                 states = workspace.list_states()
                 if options.json:
                     print(
@@ -885,6 +960,17 @@ def main(arguments: list[str] | None = None) -> int:
                 else:
                     for name, path in sorted(states.items()):
                         print(f"{name}\t{path}")
+            else:
+                promoted = workspace.state_promote(
+                    options.topology, options.name
+                )
+                if options.json:
+                    print(json.dumps(promoted, indent=2, sort_keys=True))
+                else:
+                    print(
+                        f"state {options.name}: promoted from topology "
+                        f"{options.topology} at {promoted['path']}"
+                    )
         elif options.command == "scenario":
             if options.scenario_command == "create":
                 summary = workspace.scenario_create(

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -253,14 +253,14 @@ def parser() -> argparse.ArgumentParser:
     )
     topology_state.add_argument(
         "--temporary-state",
-        dest="state",
+        dest="state_mode",
         action="store_const",
-        const=None,
+        const="temporary",
         help="use a fresh disposable state owned by the topology generation",
     )
     topology_state.add_argument(
         "--default-state",
-        dest="state",
+        dest="state_mode",
         action="store_const",
         const="default",
         help="use the legacy managed persistent default state explicitly",
@@ -277,14 +277,14 @@ def parser() -> argparse.ArgumentParser:
     mark(up_state.add_argument("--state", default="default"), "state")
     up_state.add_argument(
         "--temporary-state",
-        dest="state",
+        dest="state_mode",
         action="store_const",
-        const=None,
+        const="temporary",
         help="use a fresh disposable state owned by this topology generation",
     )
     up_state.add_argument(
         "--default-state",
-        dest="state",
+        dest="state_mode",
         action="store_const",
         const="default",
         help="use the legacy managed persistent default state explicitly",
@@ -812,8 +812,12 @@ def main(arguments: list[str] | None = None) -> int:
                 )
             )
         elif options.command == "topology":
+            state = None if options.state_mode == "temporary" else options.state
             summary = workspace.topology_summary(
-                options.profile, options.state, options.service
+                options.profile,
+                state,
+                options.service,
+                state_mode=options.state_mode,
             )
             if options.json:
                 print(json.dumps(summary, indent=2, sort_keys=True))
@@ -831,7 +835,9 @@ def main(arguments: list[str] | None = None) -> int:
                 if isinstance(state_policy, dict):
                     print(
                         "state-policy\t"
-                        f"{state_policy['mode']}\t{state_policy['lifecycle']}\t"
+                        f"{state_policy['mode']}\t"
+                        f"{json.dumps(state_policy['owner'], sort_keys=True)}\t"
+                        f"{state_policy['lifecycle']}\t"
                         f"{state_policy.get('path') or 'allocated-on-start'}"
                     )
                 print(f"build\t{summary['build_root']}")
@@ -843,8 +849,14 @@ def main(arguments: list[str] | None = None) -> int:
                     )
         elif options.command == "up":
             name = options.name or options.profile
+            state = None if options.state_mode == "temporary" else options.state
             status = workspace.topology_up(
-                name, options.profile, options.state, options.service, options.port
+                name,
+                options.profile,
+                state,
+                options.service,
+                options.port,
+                state_mode=options.state_mode,
             )
             if options.json:
                 print(json.dumps(status, indent=2, sort_keys=True))
@@ -860,7 +872,9 @@ def main(arguments: list[str] | None = None) -> int:
                 if isinstance(state_policy, dict):
                     print(
                         "state-policy\t"
-                        f"{state_policy['mode']}\t{state_policy['lifecycle']}\t"
+                        f"{state_policy['mode']}\t"
+                        f"{json.dumps(state_policy['owner'], sort_keys=True)}\t"
+                        f"{state_policy['lifecycle']}\t"
                         f"{state_policy['path']}"
                     )
         elif options.command == "ps":

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -493,6 +493,7 @@ def supervise(
     process_tree_fd: int | None,
     port_reservation_fd: int | None,
     runtime_lock_fd: int | None = None,
+    state_directory_fd: int | None = None,
 ) -> int:
     with spec_path.open(encoding="utf-8") as stream:
         spec = json.load(stream)
@@ -548,6 +549,8 @@ def supervise(
         inherited_locks: list[int] = []
         if process_tree_fd is not None:
             inherited_locks.append(process_tree_fd)
+        if state_directory_fd is not None and name == "server":
+            inherited_locks.append(state_directory_fd)
         process = subprocess.Popen(
             command,
             cwd=service["cwd"],
@@ -597,6 +600,8 @@ def supervise(
                 port_reservation_fd,
             )
         )
+        if state_directory_fd is not None:
+            retained_fds = (*retained_fds, state_directory_fd)
         guardian_pid, guardian_write_fd = _start_guardian(
             process_tree_fd,
             *retained_fds,
@@ -709,6 +714,8 @@ def supervise(
             os.close(port_reservation_fd)
         if runtime_lock_fd is not None:
             os.close(runtime_lock_fd)
+        if state_directory_fd is not None:
+            os.close(state_directory_fd)
     return 0
 
 
@@ -721,12 +728,13 @@ def main() -> int:
     parser.add_argument("--process-tree-fd", type=int)
     parser.add_argument("--port-reservation-fd", type=int)
     parser.add_argument("--runtime-lock-fd", type=int)
+    parser.add_argument("--state-directory-fd", type=int)
     parser.add_argument("--daemonize", action="store_true")
     options = parser.parse_args()
     if options.daemonize and os.fork() != 0:
         return 0
     try:
-        return supervise(
+        arguments = (
             options.spec,
             options.lock_fd,
             options.layout_lock_fd,
@@ -734,6 +742,11 @@ def main() -> int:
             options.process_tree_fd,
             options.port_reservation_fd,
             options.runtime_lock_fd,
+        )
+        return (
+            supervise(*arguments, options.state_directory_fd)
+            if options.state_directory_fd is not None
+            else supervise(*arguments)
         )
     except BaseException as error:
         message = f"{type(error).__name__}: {error}"
@@ -770,6 +783,11 @@ def main() -> int:
         if options.runtime_lock_fd is not None:
             try:
                 os.close(options.runtime_lock_fd)
+            except OSError:
+                pass
+        if options.state_directory_fd is not None:
+            try:
+                os.close(options.state_directory_fd)
             except OSError:
                 pass
         return 1

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -108,6 +108,7 @@ def terminate(
         for process in processes.values()
         if process.returncode is None
     ]
+    group_observation_certain = True
 
     def signal_groups(signum: signal.Signals) -> None:
         for process_group in process_groups:
@@ -117,10 +118,12 @@ def terminate(
                 pass
 
     def groups_exist() -> bool:
+        nonlocal group_observation_certain
         groups = set(process_groups)
         try:
             entries = list(Path("/proc").iterdir())
         except OSError:
+            group_observation_certain = False
             entries = []
         for entry in entries:
             if not entry.name.isdigit():
@@ -129,7 +132,13 @@ def terminate(
                 fields = (entry / "stat").read_text().rsplit(")", 1)[1].split()
                 state = fields[0]
                 process_group = int(fields[2])
-            except (OSError, IndexError, ValueError):
+            except FileNotFoundError:
+                continue
+            except OSError:
+                group_observation_certain = False
+                continue
+            except (IndexError, ValueError):
+                group_observation_certain = False
                 continue
             if process_group in groups and state != "Z":
                 return True
@@ -153,7 +162,7 @@ def terminate(
         if not running:
             break
         time.sleep(0.1)
-    clean = not groups_exist()
+    clean = not groups_exist() and group_observation_certain
     if process_tree_fd is not None:
         clean = clean and not holders_exist(
             process_tree_fd,
@@ -188,6 +197,7 @@ def terminate(
             clean = False
         if process.returncode not in {0, -signal.SIGTERM}:
             clean = False
+    clean = clean and group_observation_certain
     return clean
 
 
@@ -505,6 +515,7 @@ def supervise(
     port_reservation_fd: int | None,
     runtime_lock_fd: int | None = None,
     state_directory_fd: int | None = None,
+    physical_state_lock_fd: int | None = None,
 ) -> int:
     with spec_path.open(encoding="utf-8") as stream:
         spec = json.load(stream)
@@ -614,6 +625,8 @@ def supervise(
         )
         if state_directory_fd is not None:
             retained_fds = (*retained_fds, state_directory_fd)
+        if physical_state_lock_fd is not None:
+            retained_fds = (*retained_fds, physical_state_lock_fd)
         guardian_pid, guardian_write_fd = _start_guardian(
             process_tree_fd,
             *retained_fds,
@@ -742,6 +755,8 @@ def supervise(
             os.close(runtime_lock_fd)
         if state_directory_fd is not None:
             os.close(state_directory_fd)
+        if physical_state_lock_fd is not None:
+            os.close(physical_state_lock_fd)
     return 0
 
 
@@ -755,6 +770,7 @@ def main() -> int:
     parser.add_argument("--port-reservation-fd", type=int)
     parser.add_argument("--runtime-lock-fd", type=int)
     parser.add_argument("--state-directory-fd", type=int)
+    parser.add_argument("--physical-state-lock-fd", type=int)
     parser.add_argument("--daemonize", action="store_true")
     options = parser.parse_args()
     if options.daemonize and os.fork() != 0:
@@ -769,10 +785,10 @@ def main() -> int:
             options.port_reservation_fd,
             options.runtime_lock_fd,
         )
-        return (
-            supervise(*arguments, options.state_directory_fd)
-            if options.state_directory_fd is not None
-            else supervise(*arguments)
+        return supervise(
+            *arguments,
+            options.state_directory_fd,
+            options.physical_state_lock_fd,
         )
     except BaseException as error:
         message = f"{type(error).__name__}: {error}"
@@ -814,6 +830,11 @@ def main() -> int:
         if options.state_directory_fd is not None:
             try:
                 os.close(options.state_directory_fd)
+            except OSError:
+                pass
+        if options.physical_state_lock_fd is not None:
+            try:
+                os.close(options.physical_state_lock_fd)
             except OSError:
                 pass
         return 1

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -515,6 +515,7 @@ def supervise(
     port_reservation_fd: int | None,
     runtime_lock_fd: int | None = None,
     state_directory_fd: int | None = None,
+    state_output_fd: int | None = None,
     physical_state_lock_fd: int | None = None,
 ) -> int:
     with spec_path.open(encoding="utf-8") as stream:
@@ -574,6 +575,8 @@ def supervise(
             inherited_locks.append(process_tree_fd)
         if state_directory_fd is not None and name == "server":
             inherited_locks.append(state_directory_fd)
+        if state_output_fd is not None and name == "server":
+            inherited_locks.append(state_output_fd)
         process = subprocess.Popen(
             command,
             cwd=service["cwd"],
@@ -625,6 +628,8 @@ def supervise(
         )
         if state_directory_fd is not None:
             retained_fds = (*retained_fds, state_directory_fd)
+        if state_output_fd is not None:
+            retained_fds = (*retained_fds, state_output_fd)
         if physical_state_lock_fd is not None:
             retained_fds = (*retained_fds, physical_state_lock_fd)
         guardian_pid, guardian_write_fd = _start_guardian(
@@ -755,6 +760,8 @@ def supervise(
             os.close(runtime_lock_fd)
         if state_directory_fd is not None:
             os.close(state_directory_fd)
+        if state_output_fd is not None:
+            os.close(state_output_fd)
         if physical_state_lock_fd is not None:
             os.close(physical_state_lock_fd)
     return 0
@@ -770,6 +777,7 @@ def main() -> int:
     parser.add_argument("--port-reservation-fd", type=int)
     parser.add_argument("--runtime-lock-fd", type=int)
     parser.add_argument("--state-directory-fd", type=int)
+    parser.add_argument("--state-output-fd", type=int)
     parser.add_argument("--physical-state-lock-fd", type=int)
     parser.add_argument("--daemonize", action="store_true")
     options = parser.parse_args()
@@ -788,6 +796,7 @@ def main() -> int:
         return supervise(
             *arguments,
             options.state_directory_fd,
+            options.state_output_fd,
             options.physical_state_lock_fd,
         )
     except BaseException as error:
@@ -830,6 +839,11 @@ def main() -> int:
         if options.state_directory_fd is not None:
             try:
                 os.close(options.state_directory_fd)
+            except OSError:
+                pass
+        if options.state_output_fd is not None:
+            try:
+                os.close(options.state_output_fd)
             except OSError:
                 pass
         if options.physical_state_lock_fd is not None:

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -17,6 +17,7 @@ import time
 from typing import Any, BinaryIO
 
 from .launch_identity import CLIENT_LAUNCH_LABEL_ENV, client_launch_label
+from .model import durable_atomic_json
 from .process_tree import control_socket_path, holders_exist, signal_holders
 from .port_reservation import PortReservationError, validate_held
 
@@ -98,7 +99,7 @@ def terminate(
     timeout: float = 10,
     *,
     exclude: tuple[int | None, ...] = (),
-) -> None:
+) -> bool:
     # An unreaped session leader pins its numeric process-group identity, so
     # these groups remain safe to signal until the final waits below. The lease
     # additionally finds descendants whose recorded leader was already reaped.
@@ -152,6 +153,12 @@ def terminate(
         if not running:
             break
         time.sleep(0.1)
+    clean = not groups_exist()
+    if process_tree_fd is not None:
+        clean = clean and not holders_exist(
+            process_tree_fd,
+            exclude=(os.getpid(), *(pid for pid in exclude if pid is not None)),
+        )
     signal_groups(signal.SIGKILL)
     if process_tree_fd is not None:
         signal_holders(
@@ -178,7 +185,8 @@ def terminate(
         try:
             process.wait(timeout=2)
         except subprocess.TimeoutExpired:
-            pass
+            clean = False
+    return clean
 
 
 class RotatingLog:
@@ -272,6 +280,7 @@ def _initial_status(spec: dict[str, Any], supervisor_start_time: str) -> dict[st
         "ready": False,
         "started_at": datetime.now(timezone.utc).isoformat(),
         "stopped_at": None,
+        **({"shutdown": None} if spec.get("schema_version") == 3 else {}),
         "supervisor": {
             "pid": os.getpid(),
             "start_time": supervisor_start_time,
@@ -505,6 +514,7 @@ def supervise(
         build_lock_fd = None
     status_path = spec_path.parent / "status.json"
     stop = False
+    control_stop_requested = False
     control_socket: socket.socket | None = None
     guardian_pid: int | None = None
     guardian_write_fd: int | None = None
@@ -613,7 +623,9 @@ def supervise(
             server = start_service("server", capture=capture)
             deadline = time.monotonic() + SERVER_READY_TIMEOUT
             while not capture.event.wait(timeout=0.1):
-                stop = stop or _serve_control(control_socket, spec)
+                requested = _serve_control(control_socket, spec)
+                control_stop_requested = control_stop_requested or requested
+                stop = stop or requested
                 code = _peek_exit_code(server)
                 if code is not None:
                     raise RuntimeError(
@@ -647,7 +659,9 @@ def supervise(
         atomic_status(status_path, status)
 
         while not stop:
-            stop = _serve_control(control_socket, spec)
+            requested = _serve_control(control_socket, spec)
+            control_stop_requested = control_stop_requested or requested
+            stop = requested
             changed = False
             running = True
             for name, process in processes.items():
@@ -668,7 +682,9 @@ def supervise(
         atomic_status(status_path, status)
         return 1
     finally:
-        terminate(processes, process_tree_fd, exclude=(guardian_pid,))
+        clean_termination = terminate(
+            processes, process_tree_fd, exclude=(guardian_pid,)
+        )
         for pump in pumps:
             pump.join(timeout=2)
         for name, process in processes.items():
@@ -680,7 +696,15 @@ def supervise(
             service_status["exit_code"] = code
         status["stopped_at"] = datetime.now(timezone.utc).isoformat()
         status["ready"] = False
-        atomic_status(status_path, status)
+        status["shutdown"] = {
+            "control_requested": control_stop_requested,
+            "clean": (
+                control_stop_requested
+                and clean_termination
+                and "error" not in status
+            ),
+        }
+        durable_atomic_json(status_path, status)
         for output in logs:
             output.close()
         if control_socket is not None:

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -186,6 +186,8 @@ def terminate(
             process.wait(timeout=2)
         except subprocess.TimeoutExpired:
             clean = False
+        if process.returncode not in {0, -signal.SIGTERM}:
+            clean = False
     return clean
 
 

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -257,6 +257,11 @@ def _initial_status(spec: dict[str, Any], supervisor_start_time: str) -> dict[st
         "profile": spec["profile"],
         "dependencies": spec["dependencies"],
         "state": spec["state"],
+        **(
+            {"state_policy": spec["state_policy"]}
+            if "state_policy" in spec
+            else {}
+        ),
         "build_root": spec["build_root"],
         "resolved": spec["resolved"],
         "endpoint": (
@@ -491,7 +496,7 @@ def supervise(
 ) -> int:
     with spec_path.open(encoding="utf-8") as stream:
         spec = json.load(stream)
-    if spec.get("schema_version") == 2:
+    if spec.get("schema_version") in {2, 3}:
         for descriptor in (layout_lock_fd, build_lock_fd):
             if descriptor is not None:
                 os.close(descriptor)
@@ -584,7 +589,7 @@ def supervise(
     try:
         retained_fds = (
             (port_reservation_fd, lock_fd, runtime_lock_fd)
-            if spec.get("schema_version") == 2
+            if spec.get("schema_version") in {2, 3}
             else (
                 lock_fd,
                 layout_lock_fd,

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -82,6 +82,7 @@ from .model import (
     durable_atomic_json,
     load_json,
     _managed_path_no_symlinks,
+    _open_directory_nofollow,
     managed_directory,
     managed_reset,
     profile_key,
@@ -659,15 +660,24 @@ def _remove_owned_tree_contents(
             os.unlink(name, dir_fd=descriptor)
 
 
-def remove_owned_tree(path: Path) -> None:
+def remove_owned_tree(
+    path: Path, *, expected_identity: dict[str, int] | None = None
+) -> None:
     if path.is_symlink() or not path.is_dir():
         raise WorkspaceError(f"owned removal root is invalid: {path}")
-    parent_descriptor = os.open(
-        path.parent, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    parent_descriptor = _open_directory_nofollow(
+        path.parent,
+        os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
     )
     descriptor: int | None = None
     try:
         before = os.stat(path.name, dir_fd=parent_descriptor, follow_symlinks=False)
+        if expected_identity is not None and (
+            set(expected_identity) != {"device", "inode"}
+            or (before.st_dev, before.st_ino)
+            != (expected_identity["device"], expected_identity["inode"])
+        ):
+            raise WorkspaceError(f"owned removal root identity changed: {path}")
         parent_mount_id = _descriptor_mount_id(parent_descriptor)
         descriptor = _open_owned_tree_directory(
             parent_descriptor,
@@ -678,6 +688,7 @@ def remove_owned_tree(path: Path) -> None:
             root=True,
         )
         opened = os.fstat(descriptor)
+        expected = (opened.st_dev, opened.st_ino)
         root_mount_id = _descriptor_mount_id(descriptor)
         _prepare_owned_tree_removal(
             descriptor,
@@ -686,12 +697,22 @@ def remove_owned_tree(path: Path) -> None:
             path,
             stat.S_IMODE(before.st_mode),
         )
+        visible = os.stat(
+            path.name, dir_fd=parent_descriptor, follow_symlinks=False
+        )
+        if (visible.st_dev, visible.st_ino) != expected:
+            raise WorkspaceError(f"owned removal root identity changed: {path}")
         os.fchmod(descriptor, stat.S_IRWXU)
         _remove_owned_tree_contents(
             descriptor, opened.st_dev, root_mount_id, path
         )
         os.close(descriptor)
         descriptor = None
+        visible = os.stat(
+            path.name, dir_fd=parent_descriptor, follow_symlinks=False
+        )
+        if (visible.st_dev, visible.st_ino) != expected:
+            raise WorkspaceError(f"owned removal root identity changed: {path}")
         os.rmdir(path.name, dir_fd=parent_descriptor)
     finally:
         if descriptor is not None:
@@ -8057,6 +8078,205 @@ class Workspace:
             )
 
     @staticmethod
+    def _load_state_json_at(
+        directory_fd: int, name: str, description: str
+    ) -> Any:
+        descriptor: int | None = None
+        try:
+            descriptor = os.open(
+                name, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW,
+                dir_fd=directory_fd,
+            )
+            metadata = os.fstat(descriptor)
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_nlink != 1
+                or metadata.st_size > 4 * 1024 * 1024
+            ):
+                raise WorkspaceError(f"{description} is invalid")
+            with os.fdopen(descriptor, encoding="utf-8", closefd=False) as stream:
+                return json.load(stream, object_pairs_hook=_reject_duplicate_keys)
+        except (OSError, UnicodeError, ValueError, RecursionError) as error:
+            raise WorkspaceError(f"cannot read {description}: {error}") from error
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+
+    @staticmethod
+    def _write_state_json_no_replace_at(
+        directory_fd: int, name: str, value: Any
+    ) -> None:
+        temporary = f".{name}.{secrets.token_hex(12)}.tmp"
+        descriptor: int | None = None
+        linked = False
+        try:
+            descriptor = os.open(
+                temporary,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW,
+                0o600,
+                dir_fd=directory_fd,
+            )
+            with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+                descriptor = None
+                json.dump(value, stream, indent=2, sort_keys=True)
+                stream.write("\n")
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.link(
+                temporary,
+                name,
+                src_dir_fd=directory_fd,
+                dst_dir_fd=directory_fd,
+                follow_symlinks=False,
+            )
+            linked = True
+            os.unlink(temporary, dir_fd=directory_fd)
+            os.fsync(directory_fd)
+        except FileExistsError as error:
+            raise WorkspaceError(
+                "server state implementation marker appeared during publication"
+            ) from error
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot publish server state implementation marker: {error}"
+            ) from error
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+            if not linked:
+                try:
+                    os.unlink(temporary, dir_fd=directory_fd)
+                except FileNotFoundError:
+                    pass
+
+    def _validate_state_descriptor(
+        self,
+        directory_fd: int,
+        path: Path,
+        implementation: dict[str, str] | None,
+        *,
+        write_implementation: bool,
+    ) -> None:
+        for name in EXPECTED_SERVER_DATA["files"]:
+            try:
+                metadata = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+            except OSError as error:
+                raise WorkspaceError(
+                    f"server state lacks required file {name}: {path}"
+                ) from error
+            if not stat.S_ISREG(metadata.st_mode):
+                raise WorkspaceError(f"server state lacks required file {name}: {path}")
+        for name in EXPECTED_SERVER_DATA["directories"]:
+            try:
+                metadata = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+            except OSError as error:
+                raise WorkspaceError(
+                    f"server state lacks required directory {name}: {path}"
+                ) from error
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise WorkspaceError(
+                    f"server state lacks required directory {name}: {path}"
+                )
+        marker_missing = False
+        try:
+            marker_metadata = os.stat(
+                STATE_IMPLEMENTATION_MARKER,
+                dir_fd=directory_fd,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            marker_missing = True
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot inspect server state implementation marker: {path}: {error}"
+            ) from error
+        if marker_missing and implementation is not None and write_implementation:
+            self._write_state_json_no_replace_at(
+                directory_fd,
+                STATE_IMPLEMENTATION_MARKER,
+                {
+                    "schema_version": STATE_IMPLEMENTATION_SCHEMA_VERSION,
+                    **implementation,
+                },
+            )
+            marker_metadata = os.stat(
+                STATE_IMPLEMENTATION_MARKER,
+                dir_fd=directory_fd,
+                follow_symlinks=False,
+            )
+            marker_missing = False
+        if not marker_missing:
+            if not stat.S_ISREG(marker_metadata.st_mode):
+                raise WorkspaceError(
+                    f"server state implementation marker is invalid: {path}"
+                )
+            expected = (
+                {
+                    "schema_version": STATE_IMPLEMENTATION_SCHEMA_VERSION,
+                    **implementation,
+                }
+                if implementation is not None
+                else None
+            )
+            if self._load_state_json_at(
+                directory_fd,
+                STATE_IMPLEMENTATION_MARKER,
+                f"server state implementation marker {path}",
+            ) != expected:
+                raise WorkspaceError(
+                    "server state implementation does not match the selected "
+                    f"server: {path}"
+                )
+        try:
+            os.mkdir("tmp", dir_fd=directory_fd)
+        except FileExistsError:
+            pass
+        tmp_metadata = os.stat("tmp", dir_fd=directory_fd, follow_symlinks=False)
+        if not stat.S_ISDIR(tmp_metadata.st_mode):
+            raise WorkspaceError(f"server state tmp path is invalid: {path}")
+
+    def _open_validated_state_directory(
+        self,
+        path: Path,
+        implementation: dict[str, str] | None,
+        *,
+        write_implementation: bool,
+    ) -> int:
+        flags = os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW
+        try:
+            descriptor = _open_directory_nofollow(path, flags)
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot open server state without following links: {path}: {error}"
+            ) from error
+        try:
+            opened = os.fstat(descriptor)
+            visible = path.stat(follow_symlinks=False)
+            if (
+                not stat.S_ISDIR(opened.st_mode)
+                or (opened.st_dev, opened.st_ino) != (visible.st_dev, visible.st_ino)
+                or self._canonical_state_path(path) != path
+            ):
+                raise WorkspaceError(
+                    f"server state identity changed during validation: {path}"
+                )
+            self._validate_state_descriptor(
+                descriptor,
+                path,
+                implementation,
+                write_implementation=write_implementation,
+            )
+            visible = path.stat(follow_symlinks=False)
+            if (opened.st_dev, opened.st_ino) != (visible.st_dev, visible.st_ino):
+                raise WorkspaceError(
+                    f"server state identity changed during validation: {path}"
+                )
+            return descriptor
+        except BaseException:
+            os.close(descriptor)
+            raise
+
+    @staticmethod
     def _temporary_state_metadata_matches(
         policy: dict[str, Any], creation_policy: object
     ) -> bool:
@@ -8108,7 +8328,8 @@ class Workspace:
         *,
         implementation: dict[str, str] | None = None,
         write_implementation: bool = False,
-    ) -> Path:
+        keep_descriptor: bool = False,
+    ) -> Path | tuple[Path, int]:
         validate_name(name, "state name")
         path = resolved_path or self._state_location(name)
         path = self._canonical_state_path(path)
@@ -8136,30 +8357,58 @@ class Workspace:
             except BaseException:
                 shutil.rmtree(staging, ignore_errors=True)
                 raise
-        self._validate_state(path)
-        if implementation is not None:
-            marker = path / STATE_IMPLEMENTATION_MARKER
-            if write_implementation and not marker.exists() and not marker.is_symlink():
-                descriptor, temporary_name = tempfile.mkstemp(
-                    prefix=f".{STATE_IMPLEMENTATION_MARKER}.", dir=path
-                )
-                os.close(descriptor)
-                temporary = Path(temporary_name)
-                try:
-                    durable_atomic_json(
-                        temporary,
-                        {
-                            "schema_version": STATE_IMPLEMENTATION_SCHEMA_VERSION,
-                            **implementation,
-                        },
-                    )
-                    rename_no_replace(temporary, marker)
-                except BaseException:
-                    temporary.unlink(missing_ok=True)
-                    raise
-            self._validate_state_implementation(path, implementation)
-        (path / "tmp").mkdir(exist_ok=True)
+        descriptor = self._open_validated_state_directory(
+            path,
+            implementation,
+            write_implementation=write_implementation,
+        )
+        if keep_descriptor:
+            return path, descriptor
+        os.close(descriptor)
         return path
+
+    def _prepared_state_path(
+        self,
+        name: str,
+        server_source: Path,
+        resolved_path: Path,
+        implementation: dict[str, str],
+        expected_identity: dict[str, int] | None,
+    ) -> tuple[Path, int]:
+        prepared = self.state_path(
+            name,
+            server_source,
+            resolved_path=resolved_path,
+            implementation=implementation,
+            write_implementation=True,
+            keep_descriptor=True,
+        )
+        assert isinstance(prepared, tuple)
+        path, descriptor = prepared
+        opened = os.fstat(descriptor)
+        try:
+            visible = path.stat(follow_symlinks=False)
+            canonical = self._canonical_state_path(path)
+        except BaseException:
+            os.close(descriptor)
+            raise
+        if (
+            canonical != path
+            or (opened.st_dev, opened.st_ino) != (visible.st_dev, visible.st_ino)
+        ):
+            os.close(descriptor)
+            raise WorkspaceError(
+                f"server state identity changed while preparing topology: {path}"
+            )
+        if expected_identity is not None and expected_identity != {
+            "device": opened.st_dev,
+            "inode": opened.st_ino,
+        }:
+            os.close(descriptor)
+            raise WorkspaceError(
+                f"server state identity changed while preparing topology: {path}"
+            )
+        return path, descriptor
 
     def _persistent_state_policy(
         self,
@@ -8223,13 +8472,65 @@ class Workspace:
         return container
 
     @contextmanager
-    def _topology_state_lock(self, path: Path) -> Iterator[TextIO]:
+    def _topology_state_lock(
+        self, path: Path, *, preparing_topology: str | None = None
+    ) -> Iterator[TextIO]:
         try:
             with exclusive_lock(
                 Path(f"{path}.lock"),
                 f"server state {path}",
                 nonblocking=True,
             ) as lock:
+                for topology in sorted(self.paths.topologies.iterdir()):
+                    if topology.name == preparing_topology:
+                        continue
+                    if topology.is_symlink() or not topology.is_dir():
+                        continue
+                    status_path = topology / "status.json"
+                    if not status_path.is_file() or status_path.is_symlink():
+                        continue
+                    try:
+                        raw_status = load_regular_json(
+                            status_path, "topology state ownership status"
+                        )
+                    except WorkspaceError as error:
+                        raise WorkspaceError(
+                            "cannot confirm exact server state ownership while "
+                            f"topology status is uncertain: {path}"
+                        ) from error
+                    if (
+                        not isinstance(raw_status, dict)
+                        or raw_status.get("state") != str(path)
+                    ):
+                        continue
+                    try:
+                        status = self.topology_status(topology.name)
+                    except WorkspaceError as error:
+                        control = raw_status.get("control")
+                        if (
+                            isinstance(control, dict)
+                            and not self._topology_process_tree_active(
+                                topology, control
+                            )
+                        ):
+                            continue
+                        raise WorkspaceError(
+                            "cannot confirm exact server state ownership while "
+                            f"topology {topology.name} status is uncertain: {path}"
+                        ) from error
+                    observation = status.get("observation")
+                    control = status.get("control")
+                    if (
+                        status.get("state") == str(path)
+                        and isinstance(observation, dict)
+                        and observation.get("process_tree_lease") == "retained"
+                        and isinstance(control, dict)
+                    ):
+                        raise WorkspaceError(
+                            f"server state {path} is owned by topology "
+                            f"{status['name']} generation {control['generation']}; "
+                            f"run ./atrinik down {status['name']} and retry"
+                        )
                 yield lock
                 return
         except LockBusyError as error:
@@ -9786,6 +10087,10 @@ class Workspace:
                 or path.exists()
                 or path.is_symlink()
             ):
+                if lifecycle == "removed":
+                    raise WorkspaceError(
+                        f"removed temporary topology state still exists: {name}"
+                    )
                 marker = path / MANAGED_MARKER
                 metadata_path = path / TEMPORARY_STATE_METADATA
                 if (
@@ -9826,10 +10131,6 @@ class Workspace:
                     raise WorkspaceError(
                         f"promoted temporary state registration is invalid: {name}"
                     )
-            elif lifecycle == "removed" and (path.exists() or path.is_symlink()):
-                raise WorkspaceError(
-                    f"removed temporary topology state still exists: {name}"
-                )
         else:
             expected_name = "default" if mode == "default" else policy.get("name")
             expected_persistent = (
@@ -9880,6 +10181,7 @@ class Workspace:
             "port_reservation",
             "runtime",
             "state_policy",
+            "shutdown",
         }
         topology_schema = status.get("schema_version") if isinstance(status, dict) else None
         current_runtime_record = topology_schema in {
@@ -9978,6 +10280,16 @@ class Workspace:
                 validate_sound_record(status["sound"])
             except WorkspaceError as error:
                 raise WorkspaceError(f"topology status is invalid: {name}") from error
+        shutdown = status.get("shutdown")
+        if shutdown is not None and (
+            not isinstance(shutdown, dict)
+            or set(shutdown) != {"control_requested", "clean"}
+            or not isinstance(shutdown.get("control_requested"), bool)
+            or not isinstance(shutdown.get("clean"), bool)
+            or shutdown["clean"] and not shutdown["control_requested"]
+            or shutdown["clean"] and status.get("error") is not None
+        ):
+            raise WorkspaceError(f"topology shutdown status is invalid: {name}")
         if historical_record:
             status["stack"] = "classic"
             status["providers"] = {
@@ -10901,12 +11213,17 @@ class Workspace:
 
                 state_location: Path | None = None
                 state_lock: TextIO | None = None
+                state_expected_identity: dict[str, int] | None = None
                 if "server" in selected_services and state_mode != "temporary":
                     assert state_name is not None
                     state_location = self._state_location(state_name)
                     state_lock = stack.enter_context(
-                        self._topology_state_lock(state_location)
+                        self._topology_state_lock(
+                            state_location, preparing_topology=name
+                        )
                     )
+                    if state_location.exists() or state_location.is_symlink():
+                        state_expected_identity = self._state_identity(state_location)
 
                 root = self._build_resolved(
                     "topology", profile_name, False, targets, selected
@@ -10945,17 +11262,20 @@ class Workspace:
                             else None
                         )
                         state_lock = stack.enter_context(
-                            self._topology_state_lock(state_location)
+                            self._topology_state_lock(
+                                state_location, preparing_topology=name
+                            )
                         )
                     else:
                         assert state_name is not None and state_location is not None
-                        state = self.state_path(
+                        state, state_directory_fd = self._prepared_state_path(
                             state_name,
                             selected["server"],
-                            resolved_path=state_location,
-                            implementation=implementation,
-                            write_implementation=True,
+                            state_location,
+                            implementation,
+                            state_expected_identity,
                         )
+                        stack.callback(os.close, state_directory_fd)
                         state_policy = self._persistent_state_policy(
                             state_name, state, implementation
                         )
@@ -10975,11 +11295,31 @@ class Workspace:
                             "inode": lock_metadata.st_ino,
                         },
                     }
-                    state_directory_fd = os.open(
-                        state,
-                        os.O_PATH | os.O_DIRECTORY | os.O_NOFOLLOW,
-                    )
-                    stack.callback(os.close, state_directory_fd)
+                    try:
+                        visible_lock = Path(f"{state}.lock").stat(
+                            follow_symlinks=False
+                        )
+                    except OSError as error:
+                        raise WorkspaceError(
+                            f"server state lease changed before publication: {state}.lock"
+                        ) from error
+                    if (
+                        visible_lock.st_dev,
+                        visible_lock.st_ino,
+                    ) != (
+                        lock_metadata.st_dev,
+                        lock_metadata.st_ino,
+                    ):
+                        raise WorkspaceError(
+                            f"server state lease changed before publication: {state}.lock"
+                        )
+                    if state_directory_fd is None:
+                        state_directory_fd = self._open_validated_state_directory(
+                            state,
+                            implementation,
+                            write_implementation=False,
+                        )
+                        stack.callback(os.close, state_directory_fd)
                     state_metadata = os.fstat(state_directory_fd)
                     if state_policy["identity"] != {
                         "device": state_metadata.st_dev,
@@ -11377,7 +11717,15 @@ class Workspace:
             if not active and not current["supervisor"]["running"] and not any(
                 service["running"] for service in current["services"].values()
             ):
-                return current, requested
+                shutdown = current.get("shutdown")
+                confirmed_clean = bool(
+                    requested
+                    and isinstance(shutdown, dict)
+                    and shutdown.get("control_requested") is True
+                    and shutdown.get("clean") is True
+                    and current.get("error") is None
+                )
+                return current, confirmed_clean
             time.sleep(0.1)
         if not requested:
             raise WorkspaceError(
@@ -11409,6 +11757,99 @@ class Workspace:
         durable_atomic_json(status_path, {**raw_status, "state_policy": policy})
         return self.topology_status(name)
 
+    @staticmethod
+    def _temporary_state_removal_path(policy: dict[str, Any]) -> Path:
+        state = Path(policy["path"])
+        generation = policy["owner"]["generation"]
+        return state.parent / f".{generation}.removal-pending"
+
+    @staticmethod
+    def _unlink_temporary_state_lock(
+        state: Path,
+        state_lease: TextIO,
+        lease_identity: dict[str, int],
+    ) -> None:
+        lock = Path(f"{state}.lock")
+        try:
+            visible = lock.stat(follow_symlinks=False)
+        except FileNotFoundError:
+            return
+        opened = os.fstat(state_lease.fileno())
+        expected = (lease_identity["device"], lease_identity["inode"])
+        if (
+            not stat.S_ISREG(visible.st_mode)
+            or visible.st_nlink != 1
+            or (visible.st_dev, visible.st_ino) != expected
+            or (opened.st_dev, opened.st_ino) != expected
+        ):
+            raise WorkspaceError(
+                f"temporary topology state lease changed before removal: {lock}"
+            )
+        parent_fd = os.open(
+            lock.parent,
+            os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
+        )
+        try:
+            os.unlink(lock.name, dir_fd=parent_fd)
+            os.fsync(parent_fd)
+        finally:
+            os.close(parent_fd)
+
+    def _commit_temporary_state_removal(
+        self,
+        name: str,
+        status: dict[str, Any],
+        state_lease: TextIO,
+    ) -> dict[str, Any]:
+        policy = status["state_policy"]
+        state = Path(policy["path"])
+        tombstone = self._temporary_state_removal_path(policy)
+        identity = policy["identity"]
+        lifecycle = policy["lifecycle"]
+        current = status
+        if lifecycle not in {"removal-pending", "removed"}:
+            pending = {**policy, "lifecycle": "removal-pending"}
+            current = self._write_temporary_state_policy(name, current, pending)
+            policy = current["state_policy"]
+            lifecycle = "removal-pending"
+        if lifecycle == "removal-pending":
+            state_present = state.exists() or state.is_symlink()
+            tombstone_present = tombstone.exists() or tombstone.is_symlink()
+            if state_present and tombstone_present:
+                raise WorkspaceError(
+                    f"temporary state removal paths conflict: {state}"
+                )
+            if state_present:
+                if self._state_identity(state) != identity:
+                    raise WorkspaceError(
+                        f"temporary state identity changed before removal: {state}"
+                    )
+                rename_no_replace(state, tombstone)
+                tombstone_present = True
+            if tombstone_present:
+                tombstone_metadata = tombstone.stat(follow_symlinks=False)
+                if (
+                    not stat.S_ISDIR(tombstone_metadata.st_mode)
+                    or {
+                        "device": tombstone_metadata.st_dev,
+                        "inode": tombstone_metadata.st_ino,
+                    }
+                    != identity
+                ):
+                    raise WorkspaceError(
+                        f"temporary state removal identity is invalid: {tombstone}"
+                    )
+                remove_owned_tree(tombstone, expected_identity=identity)
+            removed = {**policy, "lifecycle": "removed"}
+            current = self._write_temporary_state_policy(name, current, removed)
+            policy = current["state_policy"]
+        elif tombstone.exists() or tombstone.is_symlink():
+            remove_owned_tree(tombstone, expected_identity=identity)
+        self._unlink_temporary_state_lock(
+            state, state_lease, policy["lease_identity"]
+        )
+        return self.topology_status(name)
+
     def _finish_temporary_state_down(
         self,
         name: str,
@@ -11422,7 +11863,6 @@ class Workspace:
         if policy.get("lifecycle") in {
             "promoted",
             "promotion-pending",
-            "removed",
             "retained",
         }:
             return status
@@ -11434,11 +11874,16 @@ class Workspace:
                 )
             return status
         state = Path(policy["path"])
+        lock_path = Path(f"{state}.lock")
+        if policy.get("lifecycle") == "removed" and not (
+            lock_path.exists() or lock_path.is_symlink()
+        ):
+            return status
         with exclusive_lock(
-            Path(f"{state}.lock"),
+            lock_path,
             f"temporary topology state {state}",
             nonblocking=True,
-        ):
+        ) as state_lease:
             current = self.topology_status(name)
             if current.get("state_policy") != policy:
                 raise WorkspaceError(
@@ -11447,29 +11892,9 @@ class Workspace:
             if retain_state:
                 retained = {**policy, "lifecycle": "retained"}
                 return self._write_temporary_state_policy(name, current, retained)
-            pending = {**policy, "lifecycle": "removal-pending"}
-            if policy != pending:
-                current = self._write_temporary_state_policy(
-                    name, current, pending
-                )
-            if state.exists() or state.is_symlink():
-                remove_owned_tree(state)
-            removed = {**pending, "lifecycle": "removed"}
-            raw_status = load_json(
-                self._topology_directory(name) / "status.json"
+            return self._commit_temporary_state_removal(
+                name, current, state_lease
             )
-            if (
-                not isinstance(raw_status, dict)
-                or raw_status.get("state_policy") != pending
-            ):
-                raise WorkspaceError(
-                    f"temporary topology state status changed before removal: {name}"
-                )
-            updated = {**raw_status, "state_policy": removed}
-            durable_atomic_json(
-                self._topology_directory(name) / "status.json", updated
-            )
-            return self.topology_status(name)
 
     def state_promote(self, topology_name: str, state_name: str) -> dict[str, Any]:
         """Promote one stopped, explicitly retained temporary state in place."""
@@ -11664,8 +12089,13 @@ class Workspace:
         paths = [(item, path) for item, path in paths if path.is_file()]
         if not paths:
             raise WorkspaceError(f"topology has no matching logs: {name}")
-        policy = self.topology_status(name).get("state_policy")
-        if isinstance(policy, dict):
+        policy: object = None
+        status_path = root / "status.json"
+        if status_path.is_file() and not status_path.is_symlink():
+            raw_status = load_regular_json(status_path, "topology status")
+            if isinstance(raw_status, dict):
+                policy = raw_status.get("state_policy")
+        if isinstance(policy, dict) and self._log_state_policy_is_safe(policy):
             print(
                 "==> state-policy "
                 f"mode={policy['mode']} owner={json.dumps(policy['owner'], sort_keys=True)} "
@@ -11724,6 +12154,31 @@ class Workspace:
             if not running and not changed:
                 break
             time.sleep(0.25)
+
+    @staticmethod
+    def _log_state_policy_is_safe(policy: dict[str, Any]) -> bool:
+        mode = policy.get("mode")
+        path = policy.get("path")
+        owner = policy.get("owner")
+        lifecycle = policy.get("lifecycle")
+        return bool(
+            mode in {"temporary", "named", "default"}
+            and isinstance(path, str)
+            and Path(path).is_absolute()
+            and "\n" not in path
+            and "\r" not in path
+            and isinstance(owner, dict)
+            and all(
+                isinstance(key, str)
+                and isinstance(value, str)
+                and "\n" not in value
+                and "\r" not in value
+                for key, value in owner.items()
+            )
+            and isinstance(lifecycle, str)
+            and "\n" not in lifecycle
+            and "\r" not in lifecycle
+        )
 
     def run_client(
         self,

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -142,6 +142,7 @@ LEGACY_RUNTIME_TOPOLOGY_STATUS_SCHEMA_VERSION = 2
 RUNTIME_GENERATION_SCHEMA_VERSION = 1
 RUNTIME_GENERATION_LEASE = "generation.lease"
 RUNTIME_GENERATION_MANIFEST = "manifest.json"
+RUNTIME_STATE_OUTPUT_TRANSACTION = "runtime-state-output-transaction.json"
 STATE_IMPLEMENTATION_MARKER = ".atrinik-state.json"
 STATE_IMPLEMENTATION_SCHEMA_VERSION = 1
 TEMPORARY_STATE_METADATA = "state.json"
@@ -8869,28 +8870,87 @@ class Workspace:
             "generation": record["generation"],
         }
 
-    def _temporary_state_container(self, topology_root: Path) -> Path:
+    def _temporary_state_container(self, topology_root: Path) -> tuple[Path, int]:
         container = topology_root / "temporary-states"
-        marker = container / MANAGED_MARKER
         expected = {
             "schema_version": SCHEMA_VERSION,
             "purpose": "topology-temporary-states",
         }
-        if container.exists() or container.is_symlink():
+        flags = os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW
+        root_fd = _open_directory_nofollow(topology_root, flags)
+        container_fd: int | None = None
+        try:
+            root_marker = self._load_state_json_at(
+                root_fd, MANAGED_MARKER, "topology ownership marker"
+            )
+            if root_marker != {
+                "schema_version": SCHEMA_VERSION,
+                "purpose": f"topology:{topology_root.name}",
+            }:
+                raise WorkspaceError(
+                    f"topology ownership marker is invalid: {topology_root}"
+                )
+            try:
+                visible = os.stat(
+                    "temporary-states", dir_fd=root_fd, follow_symlinks=False
+                )
+            except FileNotFoundError:
+                staging = f".temporary-states.{secrets.token_hex(12)}.tmp"
+                staging_fd: int | None = None
+                try:
+                    os.mkdir(staging, mode=0o700, dir_fd=root_fd)
+                    staging_fd = os.open(staging, flags, dir_fd=root_fd)
+                    durable_atomic_json_at(
+                        staging_fd, MANAGED_MARKER, expected
+                    )
+                    rename_no_replace_at(
+                        root_fd, staging, root_fd, "temporary-states"
+                    )
+                    os.fsync(root_fd)
+                except BaseException:
+                    if staging_fd is not None:
+                        os.close(staging_fd)
+                    try:
+                        remove_owned_tree(
+                            topology_root / staging,
+                            parent_directory_fd=root_fd,
+                        )
+                    except FileNotFoundError:
+                        pass
+                    raise
+                else:
+                    if staging_fd is not None:
+                        os.close(staging_fd)
+                visible = os.stat(
+                    "temporary-states", dir_fd=root_fd, follow_symlinks=False
+                )
+                container_fd = os.open("temporary-states", flags, dir_fd=root_fd)
+            else:
+                container_fd = os.open("temporary-states", flags, dir_fd=root_fd)
+            opened = os.fstat(container_fd)
             if (
-                container.is_symlink()
-                or not container.is_dir()
-                or marker.is_symlink()
-                or not marker.is_file()
-                or load_json(marker) != expected
+                not stat.S_ISDIR(visible.st_mode)
+                or (visible.st_dev, visible.st_ino)
+                != (opened.st_dev, opened.st_ino)
+                or _descriptor_mount_id(container_fd)
+                != _descriptor_mount_id(root_fd)
+                or self._load_state_json_at(
+                    container_fd,
+                    MANAGED_MARKER,
+                    "temporary state container marker",
+                )
+                != expected
             ):
                 raise WorkspaceError(
                     f"temporary state container is invalid: {container}"
                 )
-        else:
-            container.mkdir()
-            durable_atomic_json(marker, expected)
-        return container
+            result = container_fd
+            container_fd = None
+            return container, result
+        finally:
+            if container_fd is not None:
+                os.close(container_fd)
+            os.close(root_fd)
 
     @contextmanager
     def _topology_state_lock(
@@ -9043,15 +9103,39 @@ class Workspace:
         implementation: dict[str, str],
         server_coordinate: dict[str, Any],
     ) -> tuple[Path, dict[str, Any]]:
-        container = self._temporary_state_container(topology_root)
+        container, container_fd = self._temporary_state_container(topology_root)
         destination = container / generation
-        if destination.exists() or destination.is_symlink():
+        try:
+            os.stat(generation, dir_fd=container_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            os.close(container_fd)
             raise WorkspaceError(
                 f"temporary topology state already exists for generation {generation}"
             )
-        staging = Path(
-            tempfile.mkdtemp(prefix=f".{generation}.", dir=container)
-        )
+        staging: Path | None = None
+        try:
+            staging = Path(tempfile.mkdtemp(
+                prefix=f".{generation}.", dir=f"/proc/self/fd/{container_fd}"
+            ))
+            staging_name = staging.name
+            staging_fd = os.open(
+                staging_name,
+                os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
+                dir_fd=container_fd,
+            )
+        except BaseException:
+            if staging is not None:
+                try:
+                    remove_owned_tree(
+                        staging, parent_directory_fd=container_fd
+                    )
+                except FileNotFoundError:
+                    pass
+            os.close(container_fd)
+            raise
+        published_identity: dict[str, int] | None = None
         created_at = datetime.now(timezone.utc).isoformat()
         install_data = server_source / "install_data"
         try:
@@ -9070,16 +9154,26 @@ class Workspace:
                     "selected server install_data changed during temporary state "
                     "initialization"
                 )
-            (staging / "tmp").mkdir()
-            durable_atomic_json(
-                staging / STATE_IMPLEMENTATION_MARKER,
+            os.mkdir("tmp", dir_fd=staging_fd)
+            durable_atomic_json_at(
+                staging_fd,
+                STATE_IMPLEMENTATION_MARKER,
                 {
                     "schema_version": STATE_IMPLEMENTATION_SCHEMA_VERSION,
                     **implementation,
                 },
             )
-            self._validate_state(staging)
-            identity = self._state_identity(staging)
+            self._validate_state_descriptor(
+                staging_fd,
+                destination,
+                implementation,
+                write_implementation=False,
+            )
+            staging_metadata = os.fstat(staging_fd)
+            identity = {
+                "device": staging_metadata.st_dev,
+                "inode": staging_metadata.st_ino,
+            }
             policy = {
                 "mode": "temporary",
                 "name": None,
@@ -9096,8 +9190,9 @@ class Workspace:
                 "profile": profile_name,
                 "server": server_coordinate,
             }
-            durable_atomic_json(
-                staging / MANAGED_MARKER,
+            durable_atomic_json_at(
+                staging_fd,
+                MANAGED_MARKER,
                 {
                     "schema_version": SCHEMA_VERSION,
                     "purpose": "temporary-topology-state",
@@ -9105,23 +9200,58 @@ class Workspace:
                     "generation": generation,
                 },
             )
-            durable_atomic_json(
-                staging / TEMPORARY_STATE_METADATA,
+            durable_atomic_json_at(
+                staging_fd,
+                TEMPORARY_STATE_METADATA,
                 {
                     "schema_version": TEMPORARY_STATE_SCHEMA_VERSION,
                     "state_policy": policy,
                 },
             )
-            rename_no_replace(staging, destination)
-            if self._state_identity(destination) != identity:
+            rename_no_replace_at(
+                container_fd, staging_name, container_fd, generation
+            )
+            published_identity = identity
+            published = os.stat(
+                generation, dir_fd=container_fd, follow_symlinks=False
+            )
+            visible_container = container.stat(follow_symlinks=False)
+            opened_container = os.fstat(container_fd)
+            if (
+                (published.st_dev, published.st_ino)
+                != (identity["device"], identity["inode"])
+                or (visible_container.st_dev, visible_container.st_ino)
+                != (opened_container.st_dev, opened_container.st_ino)
+            ):
                 raise WorkspaceError(
                     f"temporary topology state identity changed during publication: {destination}"
                 )
             return destination, policy
         except BaseException:
-            if staging.exists() and not staging.is_symlink():
-                remove_owned_tree(staging)
+            if published_identity is not None:
+                remove_owned_tree(
+                    destination,
+                    expected_identity=published_identity,
+                    parent_directory_fd=container_fd,
+                )
+            else:
+                try:
+                    os.stat(
+                        staging_name,
+                        dir_fd=container_fd,
+                        follow_symlinks=False,
+                    )
+                except FileNotFoundError:
+                    pass
+                else:
+                    remove_owned_tree(
+                        staging,
+                        parent_directory_fd=container_fd,
+                    )
             raise
+        finally:
+            os.close(staging_fd)
+            os.close(container_fd)
 
     def _validate_state(self, path: Path) -> None:
         if not path.is_dir():
@@ -10208,6 +10338,7 @@ class Workspace:
         generation: str,
         state_directory_fd: int | None = None,
         expected_identity: dict[str, int] | None = None,
+        keep_tombstone: bool = False,
     ) -> None:
         if state_directory_fd is not None:
             flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
@@ -10281,18 +10412,45 @@ class Workspace:
                         raise WorkspaceError(
                             f"server runtime state output tombstone is invalid: {path}"
                         )
-                marker = Workspace._load_state_json_at(
-                    generation_fd,
-                    MANAGED_MARKER,
-                    "server runtime state output ownership",
-                )
-                if marker != {
-                    "schema_version": SCHEMA_VERSION,
-                    "purpose": f"runtime-state-output:{generation}",
-                }:
-                    raise WorkspaceError(
-                        f"server runtime state output ownership is invalid: {path}"
+                if not already_tombstoned:
+                    marker = Workspace._load_state_json_at(
+                        generation_fd,
+                        MANAGED_MARKER,
+                        "server runtime state output ownership",
                     )
+                    if marker != {
+                        "schema_version": SCHEMA_VERSION,
+                        "purpose": f"runtime-state-output:{generation}",
+                    }:
+                        raise WorkspaceError(
+                            "server runtime state output ownership is invalid: "
+                            f"{path}"
+                        )
+                    tombstone = _owned_tree_tombstone_name(
+                        generation, metadata.st_dev, metadata.st_ino
+                    )
+                    rename_no_replace_at(
+                        parent_fd, generation, parent_fd, tombstone
+                    )
+                    moved = os.stat(
+                        tombstone, dir_fd=parent_fd, follow_symlinks=False
+                    )
+                    if (moved.st_dev, moved.st_ino) != (
+                        metadata.st_dev,
+                        metadata.st_ino,
+                    ):
+                        try:
+                            rename_no_replace_at(
+                                parent_fd, tombstone, parent_fd, generation
+                            )
+                        except WorkspaceError:
+                            pass
+                        raise WorkspaceError(
+                            f"server runtime state output path changed: {path}"
+                        )
+                    entry_name = tombstone
+                else:
+                    tombstone = entry_name
                 mount_id = _descriptor_mount_id(generation_fd)
                 _prepare_owned_tree_removal(
                     generation_fd,
@@ -10304,9 +10462,7 @@ class Workspace:
                 _remove_owned_tree_contents(
                     generation_fd, metadata.st_dev, mount_id, path
                 )
-                visible = os.stat(
-                    entry_name, dir_fd=parent_fd, follow_symlinks=False
-                )
+                visible = os.stat(tombstone, dir_fd=parent_fd, follow_symlinks=False)
                 opened = os.fstat(generation_fd)
                 if (visible.st_dev, visible.st_ino) != (
                     opened.st_dev,
@@ -10315,30 +10471,8 @@ class Workspace:
                     raise WorkspaceError(
                         f"server runtime state output path changed: {path}"
                     )
-                tombstone = _owned_tree_tombstone_name(
-                    generation, opened.st_dev, opened.st_ino
-                )
-                if not already_tombstoned:
-                    rename_no_replace_at(
-                        parent_fd, generation, parent_fd, tombstone
-                    )
-                moved = os.stat(
-                    tombstone, dir_fd=parent_fd, follow_symlinks=False
-                )
-                if (moved.st_dev, moved.st_ino) != (
-                    opened.st_dev,
-                    opened.st_ino,
-                ):
-                    try:
-                        rename_no_replace_at(
-                            parent_fd, tombstone, parent_fd, generation
-                        )
-                    except WorkspaceError:
-                        pass
-                    raise WorkspaceError(
-                        f"server runtime state output path changed: {path}"
-                    )
-                os.rmdir(tombstone, dir_fd=parent_fd)
+                if not keep_tombstone:
+                    os.rmdir(tombstone, dir_fd=parent_fd)
                 return
             finally:
                 for descriptor in reversed(descriptors):
@@ -10359,6 +10493,236 @@ class Workspace:
                 f"server runtime state output ownership is invalid: {path}"
             )
         remove_owned_tree(path)
+
+    @staticmethod
+    def _finish_runtime_state_output_tombstone(
+        state_directory_fd: int,
+        generation: str,
+        expected_identity: dict[str, int],
+    ) -> bool:
+        flags = os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW
+        descriptors = [os.dup(state_directory_fd)]
+        state_mount_id = _descriptor_mount_id(descriptors[0])
+        try:
+            for name in ("tmp", "runtime-assets"):
+                try:
+                    descriptor = os.open(
+                        name, flags, dir_fd=descriptors[-1]
+                    )
+                except FileNotFoundError:
+                    return False
+                if _descriptor_mount_id(descriptor) != state_mount_id:
+                    os.close(descriptor)
+                    raise WorkspaceError(
+                        "server runtime state output tombstone crosses a mount"
+                    )
+                descriptors.append(descriptor)
+            parent_fd = descriptors[-1]
+            tombstone = _owned_tree_tombstone_name(
+                generation,
+                expected_identity["device"],
+                expected_identity["inode"],
+            )
+            try:
+                visible = os.stat(
+                    tombstone, dir_fd=parent_fd, follow_symlinks=False
+                )
+            except FileNotFoundError:
+                return False
+            descriptor = os.open(tombstone, flags, dir_fd=parent_fd)
+            descriptors.append(descriptor)
+            opened = os.fstat(descriptor)
+            if (
+                not stat.S_ISDIR(visible.st_mode)
+                or (visible.st_dev, visible.st_ino)
+                != (expected_identity["device"], expected_identity["inode"])
+                or (opened.st_dev, opened.st_ino)
+                != (visible.st_dev, visible.st_ino)
+                or _descriptor_mount_id(descriptor) != state_mount_id
+                or os.listdir(descriptor)
+            ):
+                raise WorkspaceError(
+                    "server runtime state output tombstone is invalid"
+                )
+            os.rmdir(tombstone, dir_fd=parent_fd)
+            os.fsync(parent_fd)
+            return True
+        finally:
+            for descriptor in reversed(descriptors):
+                os.close(descriptor)
+
+    @staticmethod
+    def _runtime_state_output_entry_exists(
+        state_directory_fd: int, generation: str
+    ) -> bool:
+        flags = os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW
+        descriptors = [os.dup(state_directory_fd)]
+        state_mount_id = _descriptor_mount_id(descriptors[0])
+        try:
+            for name in ("tmp", "runtime-assets"):
+                try:
+                    descriptor = os.open(
+                        name, flags, dir_fd=descriptors[-1]
+                    )
+                except FileNotFoundError:
+                    return False
+                if _descriptor_mount_id(descriptor) != state_mount_id:
+                    os.close(descriptor)
+                    raise WorkspaceError(
+                        "server runtime state output parent crosses a mount"
+                    )
+                descriptors.append(descriptor)
+            try:
+                os.stat(
+                    generation,
+                    dir_fd=descriptors[-1],
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                return False
+            return True
+        finally:
+            for descriptor in reversed(descriptors):
+                os.close(descriptor)
+
+    @staticmethod
+    def _valid_state_identity(value: Any) -> bool:
+        return bool(
+            isinstance(value, dict)
+            and set(value) == {"device", "inode"}
+            and all(
+                isinstance(value[key], int)
+                and not isinstance(value[key], bool)
+                and value[key] >= 0
+                for key in ("device", "inode")
+            )
+        )
+
+    @staticmethod
+    def _clear_runtime_state_output_transaction(topology_root: Path) -> None:
+        transaction = topology_root / RUNTIME_STATE_OUTPUT_TRANSACTION
+        try:
+            metadata = transaction.stat(follow_symlinks=False)
+        except FileNotFoundError:
+            return
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+            raise WorkspaceError(
+                f"runtime state output transaction is invalid: {transaction}"
+            )
+        transaction.unlink()
+        descriptor = _open_directory_nofollow(
+            topology_root,
+            os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
+        )
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+
+    def _recover_runtime_state_output_transaction(
+        self, topology_root: Path, topology_name: str
+    ) -> None:
+        transaction_path = topology_root / RUNTIME_STATE_OUTPUT_TRANSACTION
+        if not transaction_path.exists() and not transaction_path.is_symlink():
+            return
+        transaction = load_regular_json(
+            transaction_path, "runtime state output transaction"
+        )
+        if (
+            not isinstance(transaction, dict)
+            or set(transaction)
+            != {
+                "schema_version",
+                "generation",
+                "state",
+                "state_identity",
+                "phase",
+                "output_identity",
+            }
+            or transaction.get("schema_version") != SCHEMA_VERSION
+            or not isinstance(transaction.get("generation"), str)
+            or re.fullmatch(r"[0-9a-f]{64}", transaction["generation"]) is None
+            or not isinstance(transaction.get("state"), str)
+            or not Path(transaction["state"]).is_absolute()
+            or transaction.get("phase") not in {"creating", "prepared", "complete"}
+            or not self._valid_state_identity(transaction.get("state_identity"))
+            or (
+                transaction["phase"] in {"prepared", "complete"}
+                and not self._valid_state_identity(
+                    transaction.get("output_identity")
+                )
+            )
+            or (
+                transaction["phase"] == "creating"
+                and transaction.get("output_identity") is not None
+            )
+        ):
+            raise WorkspaceError(
+                f"runtime state output transaction is invalid: {transaction_path}"
+            )
+        generation = transaction["generation"]
+        status_path = topology_root / "status.json"
+        if status_path.is_file() and not status_path.is_symlink():
+            try:
+                status = self.topology_status(topology_name)
+            except WorkspaceError:
+                status = None
+            runtime = status.get("runtime") if isinstance(status, dict) else None
+            control = status.get("control") if isinstance(status, dict) else None
+            if (
+                isinstance(runtime, dict)
+                and isinstance(control, dict)
+                and control.get("generation") == generation
+                and runtime.get("mutable_state_output_identities")
+                == [transaction.get("output_identity")]
+            ):
+                self._clear_runtime_state_output_transaction(topology_root)
+                return
+        state = Path(transaction["state"])
+        identity = transaction["state_identity"]
+        with self._topology_state_lock(
+            state, preparing_topology=topology_name
+        ) as lease:
+            descriptor = self._lock_state_directory_mutation(
+                state, identity, "server state"
+            )
+            try:
+                lease.bind(identity)
+                if transaction["phase"] == "creating":
+                    if self._runtime_state_output_entry_exists(
+                        descriptor, generation
+                    ):
+                        raise WorkspaceError(
+                            "runtime state output creation was interrupted before "
+                            "exact ownership was recorded; preserve the state and "
+                            f"inspect {transaction_path}"
+                        )
+                    self._clear_runtime_state_output_transaction(topology_root)
+                    return
+                output = state / "tmp" / "runtime-assets" / generation
+                output_identity = transaction["output_identity"]
+                if transaction["phase"] == "prepared":
+                    self._remove_runtime_state_output(
+                        output,
+                        generation,
+                        descriptor,
+                        output_identity,
+                        keep_tombstone=True,
+                    )
+                    durable_atomic_json(
+                        transaction_path,
+                        {**transaction, "phase": "complete"},
+                    )
+                if self._runtime_state_output_entry_exists(descriptor, generation):
+                    raise WorkspaceError(
+                        f"completed runtime state output reappeared: {output}"
+                    )
+                self._finish_runtime_state_output_tombstone(
+                    descriptor, generation, output_identity
+                )
+                self._clear_runtime_state_output_transaction(topology_root)
+            finally:
+                os.close(descriptor)
 
     @staticmethod
     def _seal_runtime_generation(root: Path) -> None:
@@ -10480,6 +10844,8 @@ class Workspace:
         state_output_access: Path | None = None
         state_output_identity: dict[str, int] | None = None
         state_output_fd: int | None = None
+        output_transaction = owner_root / RUNTIME_STATE_OUTPUT_TRANSACTION
+        topology_output = identity.get("kind") == "topology" and "server" in services
         try:
             input_digests = self._runtime_publication_input_digests(
                 build_root, selected, services, sound_root
@@ -10547,6 +10913,26 @@ class Workspace:
                     ),
                     target_is_directory=True,
                 )
+                if topology_output:
+                    state_metadata = (
+                        os.fstat(state_directory_fd)
+                        if state_directory_fd is not None
+                        else state.stat(follow_symlinks=False)
+                    )
+                    durable_atomic_json(
+                        output_transaction,
+                        {
+                            "schema_version": SCHEMA_VERSION,
+                            "generation": generation,
+                            "state": str(state),
+                            "state_identity": {
+                                "device": state_metadata.st_dev,
+                                "inode": state_metadata.st_ino,
+                            },
+                            "phase": "creating",
+                            "output_identity": None,
+                        },
+                    )
                 (
                     state_output,
                     state_output_fd,
@@ -10554,6 +10940,21 @@ class Workspace:
                 ) = self._prepare_runtime_state_output(
                     state, generation, state_directory_fd
                 )
+                if topology_output:
+                    durable_atomic_json(
+                        output_transaction,
+                        {
+                            "schema_version": SCHEMA_VERSION,
+                            "generation": generation,
+                            "state": str(state),
+                            "state_identity": {
+                                "device": os.fstat(state_directory_fd).st_dev,
+                                "inode": os.fstat(state_directory_fd).st_ino,
+                            },
+                            "phase": "prepared",
+                            "output_identity": state_output_identity,
+                        },
+                    )
                 state_output_access = Path(f"/proc/self/fd/{state_output_fd}")
                 os.mkdir("data", dir_fd=state_output_fd)
                 client_maps = build_root / "runtime" / "client-maps"
@@ -10678,6 +11079,7 @@ class Workspace:
             if staging.exists():
                 remove_owned_tree(staging)
             cleanup_output = state_output_access or state_output
+            output_cleanup_complete = state_output is None
             if cleanup_output is not None and cleanup_output.exists():
                 if (
                     state_output_identity is None
@@ -10691,7 +11093,25 @@ class Workspace:
                     generation,
                     state_directory_fd,
                     state_output_identity,
+                    keep_tombstone=topology_output,
                 )
+                if topology_output and state_directory_fd is not None:
+                    transaction = load_regular_json(
+                        output_transaction, "runtime state output transaction"
+                    )
+                    durable_atomic_json(
+                        output_transaction, {**transaction, "phase": "complete"}
+                    )
+                    self._finish_runtime_state_output_tombstone(
+                        state_directory_fd, generation, state_output_identity
+                    )
+                    output_cleanup_complete = True
+            if (
+                topology_output
+                and output_cleanup_complete
+                and output_transaction.exists()
+            ):
+                self._clear_runtime_state_output_transaction(owner_root)
             raise
         finally:
             if lease_fd is not None:
@@ -12120,6 +12540,9 @@ class Workspace:
             process_tree_path = topology_root / TOPOLOGY_PROCESS_TREE_LEASE
             status_path = topology_root / "status.json"
             startup_error_path = topology_root / "startup-error.json"
+            self._recover_runtime_state_output_transaction(
+                topology_root, name
+            )
             if status_path.is_file():
                 if status_path.is_symlink():
                     raise WorkspaceError(f"topology status is invalid: {name}")
@@ -12160,10 +12583,32 @@ class Workspace:
                         legacy_outputs = previous_runtime[
                             "mutable_state_outputs"
                         ]
-                        if any(
-                            Path(value).exists() or Path(value).is_symlink()
-                            for value in legacy_outputs
-                        ):
+                        legacy_evidence = False
+                        for value in legacy_outputs:
+                            output = Path(value)
+                            if output.exists() or output.is_symlink():
+                                legacy_evidence = True
+                                break
+                            digest = hashlib.sha256(
+                                output.name.encode("utf-8")
+                            ).hexdigest()[:16]
+                            try:
+                                if any(
+                                    re.fullmatch(
+                                        rf"\.remove-{digest}-[0-9a-f]+-"
+                                        r"[0-9a-f]+",
+                                        candidate.name,
+                                    )
+                                    for candidate in output.parent.iterdir()
+                                ):
+                                    legacy_evidence = True
+                                    break
+                            except OSError as error:
+                                raise WorkspaceError(
+                                    "legacy mutable state output inventory is "
+                                    f"unverifiable: {output}"
+                                ) from error
+                        if legacy_evidence:
                             raise WorkspaceError(
                                 f"topology {name} retains legacy mutable state "
                                 "output without exact ownership evidence; remove "
@@ -12749,6 +13194,14 @@ class Workspace:
                         )
                     if status_path.is_file():
                         status = self.topology_status(name)
+                        runtime = status.get("runtime")
+                        if (
+                            isinstance(runtime, dict)
+                            and runtime.get("generation") == generation
+                        ):
+                            self._clear_runtime_state_output_transaction(
+                                topology_root
+                            )
                         if status.get("error"):
                             raise WorkspaceError(
                                 f"topology supervisor failed: {status['error']}"
@@ -12937,6 +13390,16 @@ class Workspace:
                 zip(outputs, identities, strict=True)
             ):
                 if entries[index]["status"] == "complete":
+                    if self._runtime_state_output_entry_exists(
+                        descriptor, control["generation"]
+                    ):
+                        raise WorkspaceError(
+                            "completed server runtime state output reappeared: "
+                            f"{value}"
+                        )
+                    self._finish_runtime_state_output_tombstone(
+                        descriptor, control["generation"], output_identity
+                    )
                     continue
                 output = Path(value)
                 try:
@@ -12945,50 +13408,13 @@ class Workspace:
                         control["generation"],
                         descriptor,
                         output_identity,
+                        keep_tombstone=True,
                     )
-                except FileNotFoundError:
-                    parent_fds: list[int] = []
-                    try:
-                        parent_fds.append(
-                            os.open(
-                                "tmp",
-                                os.O_RDONLY
-                                | os.O_CLOEXEC
-                                | os.O_DIRECTORY
-                                | os.O_NOFOLLOW,
-                                dir_fd=descriptor,
-                            )
-                        )
-                        parent_fds.append(
-                            os.open(
-                                "runtime-assets",
-                                os.O_RDONLY
-                                | os.O_CLOEXEC
-                                | os.O_DIRECTORY
-                                | os.O_NOFOLLOW,
-                                dir_fd=parent_fds[-1],
-                            )
-                        )
-                    except FileNotFoundError:
-                        pass
-                    else:
-                        for candidate in os.listdir(parent_fds[-1]):
-                            metadata = os.stat(
-                                candidate,
-                                dir_fd=parent_fds[-1],
-                                follow_symlinks=False,
-                            )
-                            if {
-                                "device": metadata.st_dev,
-                                "inode": metadata.st_ino,
-                            } == output_identity:
-                                raise WorkspaceError(
-                                    "server runtime state output was renamed "
-                                    f"before cleanup: {output} -> {candidate}"
-                                )
-                    finally:
-                        for parent_fd in reversed(parent_fds):
-                            os.close(parent_fd)
+                except FileNotFoundError as error:
+                    raise WorkspaceError(
+                        "server runtime state output ownership evidence is "
+                        f"missing before cleanup: {output}"
+                    ) from error
                 updated_entries = [dict(entry) for entry in entries]
                 updated_entries[index]["status"] = "complete"
                 cleanup = {**cleanup, "entries": updated_entries}
@@ -13004,6 +13430,13 @@ class Workspace:
                 )
                 status = self.topology_status(name)
                 entries = updated_entries
+                if not self._finish_runtime_state_output_tombstone(
+                    descriptor, control["generation"], output_identity
+                ):
+                    raise WorkspaceError(
+                        "server runtime state output cleanup tombstone is missing: "
+                        f"{output}"
+                    )
         finally:
             os.close(descriptor)
         return status

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -9363,13 +9363,60 @@ class Workspace:
                     "state_policy": policy,
                 },
             )
-            self._validate_temporary_state_integrity(
-                staging_fd,
-                destination,
-                implementation,
-                container_fd,
-                staging_name,
-            )
+            managed_record = {
+                "schema_version": SCHEMA_VERSION,
+                "purpose": "temporary-topology-state",
+                "topology": topology_name,
+                "generation": generation,
+            }
+            creation_record = {
+                "schema_version": TEMPORARY_STATE_SCHEMA_VERSION,
+                "state_policy": policy,
+            }
+
+            def validate_publication_state() -> None:
+                self._validate_temporary_state_integrity(
+                    staging_fd,
+                    destination,
+                    implementation,
+                    container_fd,
+                    staging_name if published_identity is None else generation,
+                )
+                if self._load_state_json_at(
+                    staging_fd,
+                    MANAGED_MARKER,
+                    "temporary state ownership marker",
+                ) != managed_record or self._load_state_json_at(
+                    staging_fd,
+                    TEMPORARY_STATE_METADATA,
+                    "temporary state creation record",
+                ) != creation_record:
+                    raise WorkspaceError(
+                        "temporary topology state metadata changed before publication"
+                    )
+                tmp_fd = os.open(
+                    "tmp",
+                    os.O_RDONLY
+                    | os.O_CLOEXEC
+                    | os.O_DIRECTORY
+                    | os.O_NOFOLLOW,
+                    dir_fd=staging_fd,
+                )
+                try:
+                    tmp_metadata = os.fstat(tmp_fd)
+                    if (
+                        tmp_metadata.st_dev != staging_metadata.st_dev
+                        or _descriptor_mount_id(tmp_fd)
+                        != _descriptor_mount_id(staging_fd)
+                        or os.listdir(tmp_fd)
+                    ):
+                        raise WorkspaceError(
+                            "temporary topology state mutable output is not empty"
+                        )
+                finally:
+                    os.close(tmp_fd)
+
+            validate_publication_state()
             copied_exclusions = {
                 "tmp",
                 STATE_IMPLEMENTATION_MARKER,
@@ -9389,6 +9436,15 @@ class Workspace:
                 raise WorkspaceError(
                     "selected server install_data changed before temporary state "
                     "publication"
+                )
+            full_tree_digest = _tree_digest_descriptor(staging_fd, destination)
+            validate_publication_state()
+            if (
+                _tree_digest_descriptor(staging_fd, destination)
+                != full_tree_digest
+            ):
+                raise WorkspaceError(
+                    "temporary topology state changed before publication"
                 )
             visible_staging = os.stat(
                 staging_name, dir_fd=container_fd, follow_symlinks=False
@@ -9416,6 +9472,14 @@ class Workspace:
                 raise WorkspaceError(
                     "selected server install_data changed during temporary state "
                     "publication"
+                )
+            validate_publication_state()
+            if (
+                _tree_digest_descriptor(staging_fd, destination)
+                != full_tree_digest
+            ):
+                raise WorkspaceError(
+                    "temporary topology state changed during publication"
                 )
             published = os.stat(
                 generation, dir_fd=container_fd, follow_symlinks=False

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -605,6 +605,7 @@ def _prepare_owned_tree_removal(
     mount_id: int | tuple[int, int],
     display: Path,
     original_mode: int | None = None,
+    reject_links: bool = False,
 ) -> None:
     root = os.fstat(descriptor)
     if (
@@ -625,6 +626,13 @@ def _prepare_owned_tree_removal(
                 raise WorkspaceError(
                     f"owned removal encountered a mount: {child_display}"
                 )
+            if reject_links and (
+                stat.S_ISLNK(child.st_mode)
+                or (stat.S_ISREG(child.st_mode) and child.st_nlink != 1)
+            ):
+                raise WorkspaceError(
+                    f"owned removal encountered linked state: {child_display}"
+                )
             if stat.S_ISDIR(child.st_mode):
                 child_descriptor = _open_owned_tree_directory(
                     descriptor, name, child, mount_id, child_display
@@ -636,6 +644,7 @@ def _prepare_owned_tree_removal(
                         mount_id,
                         child_display,
                         stat.S_IMODE(child.st_mode),
+                        reject_links,
                     )
                 finally:
                     os.close(child_descriptor)
@@ -680,6 +689,7 @@ def _remove_owned_tree_contents(
     device: int,
     mount_id: int | tuple[int, int],
     display: Path,
+    reject_links: bool = False,
 ) -> None:
     def move_to_tombstone(name: str, child: os.stat_result) -> str:
         tombstone = _owned_tree_tombstone_name(
@@ -717,13 +727,24 @@ def _remove_owned_tree_contents(
             raise WorkspaceError(
                 f"owned removal encountered a mount: {child_display}"
             )
+        if reject_links and (
+            stat.S_ISLNK(child.st_mode)
+            or (stat.S_ISREG(child.st_mode) and child.st_nlink != 1)
+        ):
+            raise WorkspaceError(
+                f"owned removal encountered linked state: {child_display}"
+            )
         if stat.S_ISDIR(child.st_mode):
             child_descriptor = _open_owned_tree_directory(
                 descriptor, name, child, mount_id, child_display
             )
             try:
                 _remove_owned_tree_contents(
-                    child_descriptor, device, mount_id, child_display
+                    child_descriptor,
+                    device,
+                    mount_id,
+                    child_display,
+                    reject_links,
                 )
             finally:
                 os.close(child_descriptor)
@@ -742,6 +763,7 @@ def remove_owned_tree(
     *,
     expected_identity: dict[str, int] | None = None,
     keep_root: bool = False,
+    reject_links: bool = False,
 ) -> None:
     if expected_identity is not None and (
         set(expected_identity) != {"device", "inode"}
@@ -809,6 +831,7 @@ def remove_owned_tree(
             root_mount_id,
             path,
             stat.S_IMODE(before.st_mode),
+            reject_links,
         )
         visible = os.stat(
             entry_name, dir_fd=parent_descriptor, follow_symlinks=False
@@ -817,7 +840,11 @@ def remove_owned_tree(
             raise WorkspaceError(f"owned removal root identity changed: {path}")
         os.fchmod(descriptor, stat.S_IRWXU)
         _remove_owned_tree_contents(
-            descriptor, opened.st_dev, root_mount_id, path
+            descriptor,
+            opened.st_dev,
+            root_mount_id,
+            path,
+            reject_links,
         )
         os.close(descriptor)
         descriptor = None
@@ -9070,6 +9097,7 @@ class Workspace:
         """Fail closed before deleting wrapper-owned mutable server state."""
 
         root = os.fstat(directory_fd)
+        root_mount = _descriptor_mount_id(directory_fd)
         for name in EXPECTED_SERVER_DATA["files"]:
             try:
                 metadata = os.stat(
@@ -9140,9 +9168,10 @@ class Workspace:
                     if (opened.st_dev, opened.st_ino) != (
                         metadata.st_dev,
                         metadata.st_ino,
-                    ):
+                    ) or _descriptor_mount_id(child_fd) != root_mount:
                         raise WorkspaceError(
-                            "temporary server state entry changed during "
+                            "temporary server state entry changed or crossed a "
+                            "mount during "
                             f"validation: {child_display}"
                         )
                     validate_directory(child_fd, child_display)
@@ -10692,7 +10721,8 @@ class Workspace:
     ) -> None:
         policy = status.get("state_policy")
         state = status.get("state")
-        server_present = state is not None
+        services = status.get("services")
+        server_present = isinstance(services, dict) and "server" in services
         if not server_present:
             if policy is not None or state is not None:
                 raise WorkspaceError(f"topology state policy is invalid: {name}")
@@ -11957,13 +11987,33 @@ class Workspace:
                             resolved_status[server_provider],
                         )
                         state_location = state
-                        state_lock = stack.enter_context(
-                            self._topology_state_lock(
-                                state_location,
-                                preparing_topology=name,
-                                physical_identity=False,
+                        try:
+                            state_lock = stack.enter_context(
+                                self._topology_state_lock(
+                                    state_location,
+                                    preparing_topology=name,
+                                    physical_identity=False,
+                                )
                             )
-                        )
+                        except BaseException:
+                            with exclusive_lock(
+                                Path(f"{state_location}.lock"),
+                                f"temporary topology state {state_location}",
+                                nonblocking=True,
+                            ) as rollback_lease:
+                                rollback_metadata = os.fstat(
+                                    rollback_lease.fileno()
+                                )
+                                self._rollback_temporary_state_creation(
+                                    state_location,
+                                    rollback_lease,
+                                    state_policy["identity"],
+                                    {
+                                        "device": rollback_metadata.st_dev,
+                                        "inode": rollback_metadata.st_ino,
+                                    },
+                                )
+                            raise
                     else:
                         assert state_name is not None and state_location is not None
                         state, state_directory_fd = self._prepared_state_path(
@@ -12758,6 +12808,14 @@ class Workspace:
                     raise WorkspaceError(
                         f"temporary state identity changed before removal: {state}"
                     )
+                if state_directory_fd is None:
+                    raise WorkspaceError(
+                        "temporary state integrity lease is missing while "
+                        "resuming removal"
+                    )
+                self._validate_temporary_state_integrity(
+                    state_directory_fd, state
+                )
                 rename_no_replace(state, tombstone)
                 tombstone_present = True
             if tombstone_present:
@@ -12773,9 +12831,16 @@ class Workspace:
                     raise WorkspaceError(
                         f"temporary state removal identity is invalid: {tombstone}"
                     )
+            if not (tombstone_present or removal_tombstone_present):
+                raise WorkspaceError(
+                    f"temporary state removal ownership evidence is missing: {state}"
+                )
             if tombstone_present or removal_tombstone_present:
                 remove_owned_tree(
-                    tombstone, expected_identity=identity, keep_root=True
+                    tombstone,
+                    expected_identity=identity,
+                    keep_root=True,
+                    reject_links=True,
                 )
                 if removal_tombstone_present and not tombstone.exists():
                     rename_no_replace(removal_tombstone, tombstone)

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -658,6 +658,23 @@ def _remove_owned_tree_contents(
     mount_id: int | tuple[int, int],
     display: Path,
 ) -> None:
+    def move_to_tombstone(name: str, child: os.stat_result) -> str:
+        tombstone = f".{name}.remove-{secrets.token_hex(16)}"
+        rename_no_replace_at(descriptor, name, descriptor, tombstone)
+        moved = os.stat(tombstone, dir_fd=descriptor, follow_symlinks=False)
+        if (moved.st_dev, moved.st_ino) != (
+            child.st_dev,
+            child.st_ino,
+        ):
+            try:
+                rename_no_replace_at(descriptor, tombstone, descriptor, name)
+            except WorkspaceError:
+                pass
+            raise WorkspaceError(
+                f"owned removal entry identity changed: {display / name}"
+            )
+        return tombstone
+
     for name in sorted(os.listdir(descriptor)):
         child_display = display / name
         child = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
@@ -675,12 +692,14 @@ def _remove_owned_tree_contents(
                 )
             finally:
                 os.close(child_descriptor)
-            os.rmdir(name, dir_fd=descriptor)
+            tombstone = move_to_tombstone(name, child)
+            os.rmdir(tombstone, dir_fd=descriptor)
         else:
             _probe_owned_tree_entry_mount(
                 descriptor, name, child, mount_id, child_display
             )
-            os.unlink(name, dir_fd=descriptor)
+            tombstone = move_to_tombstone(name, child)
+            os.unlink(tombstone, dir_fd=descriptor)
 
 
 def remove_owned_tree(
@@ -1341,12 +1360,19 @@ def durable_atomic_json_at(directory_fd: int, name: str, value: Any) -> None:
             stream.write("\n")
             stream.flush()
             os.fsync(stream.fileno())
-        os.rename(
-            temporary,
-            name,
-            src_dir_fd=directory_fd,
-            dst_dir_fd=directory_fd,
-        )
+        try:
+            os.link(
+                temporary,
+                name,
+                src_dir_fd=directory_fd,
+                dst_dir_fd=directory_fd,
+                follow_symlinks=False,
+            )
+        except FileExistsError as error:
+            raise WorkspaceError(
+                f"descriptor-relative JSON appeared before publication: {name}"
+            ) from error
+        os.unlink(temporary, dir_fd=directory_fd)
         os.fsync(directory_fd)
     except BaseException:
         try:
@@ -1357,6 +1383,46 @@ def durable_atomic_json_at(directory_fd: int, name: str, value: Any) -> None:
     finally:
         if descriptor is not None:
             os.close(descriptor)
+
+
+def rename_no_replace_at(
+    source_directory_fd: int,
+    source: str,
+    destination_directory_fd: int,
+    destination: str,
+) -> None:
+    try:
+        renameat2 = ctypes.CDLL(None, use_errno=True).renameat2
+    except AttributeError as error:
+        raise WorkspaceError("atomic descriptor-relative rename is unsupported") from error
+    renameat2.argtypes = [
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_uint,
+    ]
+    renameat2.restype = ctypes.c_int
+    if (
+        renameat2(
+            source_directory_fd,
+            os.fsencode(source),
+            destination_directory_fd,
+            os.fsencode(destination),
+            1,
+        )
+        == 0
+    ):
+        return
+    error_number = ctypes.get_errno()
+    if error_number == errno.EEXIST:
+        raise WorkspaceError(
+            f"descriptor-relative destination already exists: {destination}"
+        )
+    raise WorkspaceError(
+        "cannot move descriptor-relative path without replacement: "
+        f"{source} -> {destination}: {os.strerror(error_number)}"
+    )
 
 
 def load_regular_json_at(
@@ -8570,26 +8636,33 @@ class Workspace:
                     f"promoted state provenance is missing: {record_path}; "
                     "retry its originating state promote command"
                 )
-            if self.paths.topologies.is_dir() and not self.paths.topologies.is_symlink():
-                for topology in self.paths.topologies.iterdir():
-                    status_path = topology / "status.json"
-                    if status_path.is_symlink() or not status_path.is_file():
-                        continue
-                    status = load_regular_json(
-                        status_path, "promoted state origin status"
+            creation_path = path / TEMPORARY_STATE_METADATA
+            if creation_path.is_symlink():
+                raise WorkspaceError(
+                    f"promoted state creation metadata is invalid: {creation_path}"
+                )
+            if creation_path.is_file():
+                creation = load_regular_json(
+                    creation_path, "promoted state creation metadata"
+                )
+                creation_policy = (
+                    creation.get("state_policy")
+                    if isinstance(creation, dict)
+                    else None
+                )
+                if (
+                    isinstance(creation, dict)
+                    and
+                    creation.get("schema_version")
+                    == TEMPORARY_STATE_SCHEMA_VERSION
+                    and isinstance(creation_policy, dict)
+                    and creation_policy.get("mode") == "temporary"
+                    and creation_policy.get("path") == str(path)
+                ):
+                    raise WorkspaceError(
+                        f"promoted state provenance is missing: {record_path}; "
+                        "retry its originating state promote command"
                     )
-                    policy = status.get("state_policy") if isinstance(status, dict) else None
-                    if (
-                        isinstance(policy, dict)
-                        and policy.get("mode") == "temporary"
-                        and policy.get("lifecycle") in {"promotion-pending", "promoted"}
-                        and policy.get("name") == state_name
-                        and policy.get("path") == str(path)
-                    ):
-                        raise WorkspaceError(
-                            f"promoted state provenance is missing: {record_path}; "
-                            f"retry ./atrinik state promote {topology.name} {state_name}"
-                        )
             return None
         record = load_regular_json(record_path, "promoted state provenance")
         if (
@@ -8653,12 +8726,11 @@ class Workspace:
                 def bind_identity(identity: dict[str, int]) -> TextIO | None:
                     if not physical_identity:
                         return None
-                    identity_root = self._lease_namespace / "state-identities"
-                    identity_root.mkdir(exist_ok=True)
                     return leases.enter_context(
                         exclusive_lock(
-                            identity_root
-                            / f"{identity['device']}-{identity['inode']}.lock",
+                            self._lease_namespace
+                            / f"state-identity-{identity['device']}-"
+                            f"{identity['inode']}.lock",
                             f"physical server state {path}",
                             nonblocking=True,
                         )
@@ -9704,7 +9776,28 @@ class Workspace:
                 _remove_owned_tree_contents(
                     generation_fd, metadata.st_dev, mount_id, output
                 )
-                os.rmdir(generation, dir_fd=descriptors[-2])
+                parent_fd = descriptors[-2]
+                tombstone = f".{generation}.remove-{secrets.token_hex(16)}"
+                rename_no_replace_at(
+                    parent_fd, generation, parent_fd, tombstone
+                )
+                moved = os.stat(
+                    tombstone, dir_fd=parent_fd, follow_symlinks=False
+                )
+                if (moved.st_dev, moved.st_ino) != (
+                    metadata.st_dev,
+                    metadata.st_ino,
+                ):
+                    try:
+                        rename_no_replace_at(
+                            parent_fd, tombstone, parent_fd, generation
+                        )
+                    except WorkspaceError:
+                        pass
+                    raise WorkspaceError(
+                        f"server runtime state output path changed: {output}"
+                    )
+                os.rmdir(tombstone, dir_fd=parent_fd)
             if isinstance(error, WorkspaceError):
                 raise
             if not isinstance(error, (OSError, ValueError)):
@@ -9786,7 +9879,27 @@ class Workspace:
                     raise WorkspaceError(
                         f"server runtime state output path changed: {path}"
                     )
-                os.rmdir(generation, dir_fd=parent_fd)
+                tombstone = f".{generation}.remove-{secrets.token_hex(16)}"
+                rename_no_replace_at(
+                    parent_fd, generation, parent_fd, tombstone
+                )
+                moved = os.stat(
+                    tombstone, dir_fd=parent_fd, follow_symlinks=False
+                )
+                if (moved.st_dev, moved.st_ino) != (
+                    opened.st_dev,
+                    opened.st_ino,
+                ):
+                    try:
+                        rename_no_replace_at(
+                            parent_fd, tombstone, parent_fd, generation
+                        )
+                    except WorkspaceError:
+                        pass
+                    raise WorkspaceError(
+                        f"server runtime state output path changed: {path}"
+                    )
+                os.rmdir(tombstone, dir_fd=parent_fd)
                 return
             finally:
                 for descriptor in reversed(descriptors):
@@ -12163,22 +12276,11 @@ class Workspace:
         state_lease: TextIO,
         lease_identity: dict[str, int],
     ) -> None:
+        Workspace._validate_temporary_state_lock(
+            state, state_lease, lease_identity
+        )
         lock = Path(f"{state}.lock")
-        try:
-            visible = lock.stat(follow_symlinks=False)
-        except FileNotFoundError:
-            return
-        opened = os.fstat(state_lease.fileno())
-        expected = (lease_identity["device"], lease_identity["inode"])
-        if (
-            not stat.S_ISREG(visible.st_mode)
-            or visible.st_nlink != 1
-            or (visible.st_dev, visible.st_ino) != expected
-            or (opened.st_dev, opened.st_ino) != expected
-        ):
-            raise WorkspaceError(
-                f"temporary topology state lease changed before removal: {lock}"
-            )
+
         parent_fd = os.open(
             lock.parent,
             os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
@@ -12188,6 +12290,32 @@ class Workspace:
             os.fsync(parent_fd)
         finally:
             os.close(parent_fd)
+
+    @staticmethod
+    def _validate_temporary_state_lock(
+        state: Path,
+        state_lease: TextIO,
+        lease_identity: dict[str, int],
+    ) -> None:
+        lock = Path(f"{state}.lock")
+        try:
+            visible = lock.stat(follow_symlinks=False)
+        except FileNotFoundError as error:
+            raise WorkspaceError(
+                f"temporary topology state lease is missing: {lock}"
+            ) from error
+        opened = os.fstat(state_lease.fileno())
+        expected = (lease_identity["device"], lease_identity["inode"])
+        if (
+            not stat.S_ISREG(visible.st_mode)
+            or visible.st_nlink != 1
+            or (visible.st_dev, visible.st_ino) != expected
+            or (opened.st_dev, opened.st_ino) != expected
+        ):
+            raise WorkspaceError(
+                "temporary topology state lease changed before lifecycle "
+                f"mutation: {lock}"
+            )
 
     def _commit_temporary_state_removal(
         self,
@@ -12278,6 +12406,9 @@ class Workspace:
             f"temporary topology state {state}",
             nonblocking=True,
         ) as state_lease:
+            self._validate_temporary_state_lock(
+                state, state_lease, policy["lease_identity"]
+            )
             current = self.topology_status(name)
             if current.get("state_policy") != policy:
                 raise WorkspaceError(
@@ -12344,12 +12475,15 @@ class Workspace:
                 )
             state = Path(policy["path"])
             with ExitStack() as promotion:
-                promotion.enter_context(
+                state_lease = promotion.enter_context(
                     exclusive_lock(
                         Path(f"{state}.lock"),
                         f"temporary topology state {state}",
                         nonblocking=True,
                     )
+                )
+                self._validate_temporary_state_lock(
+                    state, state_lease, policy["lease_identity"]
                 )
                 state_fd = os.open(
                     state, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
@@ -12465,9 +12599,31 @@ class Workspace:
                             )
                         raise
                     promoted = {**pending, "lifecycle": "promoted"}
-                    status = self._write_temporary_state_policy(
-                        topology_name, status, promoted
-                    )
+                    try:
+                        status = self._write_temporary_state_policy(
+                            topology_name, status, promoted
+                        )
+                        verify_visible_state()
+                    except BaseException:
+                        status_path = root / "status.json"
+                        raw_status = load_regular_json(
+                            status_path, "temporary state promotion status"
+                        )
+                        if raw_status.get("state_policy") == promoted:
+                            durable_atomic_json(
+                                status_path,
+                                {**raw_status, "state_policy": pending},
+                            )
+                        if registry_added and states.get(state_name) is not None:
+                            del states[state_name]
+                            durable_atomic_json(
+                                self.paths.states_file,
+                                {
+                                    "schema_version": SCHEMA_VERSION,
+                                    "states": states,
+                                },
+                            )
+                        raise
                     return {
                         "topology": topology_name,
                         "name": state_name,
@@ -12897,12 +13053,16 @@ class Workspace:
                 assert isinstance(prepared_state, tuple)
                 state, state_fd = prepared_state
                 opened_state = os.fstat(state_fd)
-                state_lock.bind(
-                    {
-                        "device": opened_state.st_dev,
-                        "inode": opened_state.st_ino,
-                    }
-                )
+                try:
+                    state_lock.bind(
+                        {
+                            "device": opened_state.st_dev,
+                            "inode": opened_state.st_ino,
+                        }
+                    )
+                except BaseException:
+                    os.close(state_fd)
+                    raise
                 generation = secrets.token_hex(32)
                 try:
                     generation_root, runtime_fd, _runtime_record = (

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -7518,6 +7518,12 @@ class Workspace:
             raise WorkspaceError(f"state path is not a directory: {resolved}")
         if resolved.exists():
             self._validate_state(resolved)
+            temporary_marker = resolved / TEMPORARY_STATE_METADATA
+            if temporary_marker.is_file() and not temporary_marker.is_symlink():
+                raise WorkspaceError(
+                    "temporary topology state can only be registered through "
+                    "state promote"
+                )
         self._register_state(name, resolved)
         print(resolved)
         return resolved
@@ -8440,6 +8446,9 @@ class Workspace:
         ):
             owner = {"kind": "scenario", "name": state_name.removeprefix("scenario-")}
             lifecycle = "scenario-owned"
+        elif (promoted := self._promoted_state_owner(state_name, path)) is not None:
+            owner = promoted
+            lifecycle = "persistent-promoted"
         elif path.is_relative_to(self.paths.state.resolve(strict=False)):
             owner = {"kind": "workspace"}
             lifecycle = "persistent"
@@ -8447,6 +8456,39 @@ class Workspace:
             owner = {"kind": "external"}
             lifecycle = "persistent-external"
         return owner, lifecycle
+
+    def _promoted_state_owner(
+        self, state_name: str, path: Path
+    ) -> dict[str, str] | None:
+        if self.paths.topologies.is_symlink() or not self.paths.topologies.is_dir():
+            return None
+        for topology in sorted(self.paths.topologies.iterdir()):
+            status_path = topology / "status.json"
+            if status_path.is_symlink() or not status_path.is_file():
+                continue
+            try:
+                status = load_regular_json(status_path, "promoted state status")
+            except WorkspaceError:
+                continue
+            policy = status.get("state_policy") if isinstance(status, dict) else None
+            owner = policy.get("owner") if isinstance(policy, dict) else None
+            if (
+                isinstance(policy, dict)
+                and policy.get("mode") == "temporary"
+                and policy.get("lifecycle") == "promoted"
+                and policy.get("name") == state_name
+                and policy.get("path") == str(path)
+                and isinstance(owner, dict)
+                and owner.get("kind") == "topology-generation"
+                and owner.get("topology") == topology.name
+                and isinstance(owner.get("generation"), str)
+            ):
+                return {
+                    "kind": "promoted-topology-state",
+                    "topology": topology.name,
+                    "generation": owner["generation"],
+                }
+        return None
 
     def _temporary_state_container(self, topology_root: Path) -> Path:
         container = topology_root / "temporary-states"
@@ -8473,14 +8515,33 @@ class Workspace:
 
     @contextmanager
     def _topology_state_lock(
-        self, path: Path, *, preparing_topology: str | None = None
+        self,
+        path: Path,
+        *,
+        preparing_topology: str | None = None,
+        physical_identity: bool = True,
     ) -> Iterator[TextIO]:
         try:
-            with exclusive_lock(
-                Path(f"{path}.lock"),
-                f"server state {path}",
-                nonblocking=True,
-            ) as lock:
+            with ExitStack() as leases:
+                if physical_identity and path.exists() and not path.is_symlink():
+                    identity = self._state_identity(path)
+                    identity_root = self._lease_namespace / "state-identities"
+                    identity_root.mkdir(exist_ok=True)
+                    leases.enter_context(
+                        exclusive_lock(
+                            identity_root
+                            / f"{identity['device']}-{identity['inode']}.lock",
+                            f"physical server state {path}",
+                            nonblocking=True,
+                        )
+                    )
+                lock = leases.enter_context(
+                    exclusive_lock(
+                        Path(f"{path}.lock"),
+                        f"server state {path}",
+                        nonblocking=True,
+                    )
+                )
                 for topology in sorted(self.paths.topologies.iterdir()):
                     if topology.name == preparing_topology:
                         continue
@@ -8578,10 +8639,21 @@ class Workspace:
             tempfile.mkdtemp(prefix=f".{generation}.", dir=container)
         )
         created_at = datetime.now(timezone.utc).isoformat()
+        install_data = server_source / "install_data"
+        source_digest = _tree_digest(install_data, set(), reject_symlinks=True)
         try:
             shutil.copytree(
-                server_source / "install_data", staging, dirs_exist_ok=True
+                install_data, staging, dirs_exist_ok=True
             )
+            if (
+                _tree_digest(staging, set(), reject_symlinks=True) != source_digest
+                or _tree_digest(install_data, set(), reject_symlinks=True)
+                != source_digest
+            ):
+                raise WorkspaceError(
+                    "selected server install_data changed during temporary state "
+                    "initialization"
+                )
             (staging / "tmp").mkdir()
             durable_atomic_json(
                 staging / STATE_IMPLEMENTATION_MARKER,
@@ -9376,7 +9448,9 @@ class Workspace:
         return sorted(entries, key=lambda entry: entry["path"])
 
     @staticmethod
-    def _prepare_runtime_state_output(state: Path, generation: str) -> Path:
+    def _prepare_runtime_state_output(
+        state: Path, generation: str, state_directory_fd: int | None = None
+    ) -> Path:
         flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
         descriptors: list[int] = []
         created_generation = False
@@ -9406,11 +9480,19 @@ class Workspace:
             return descriptor
 
         try:
-            state_before = state.stat(follow_symlinks=False)
-            state_fd = os.open(state, flags)
+            state_fd = (
+                os.dup(state_directory_fd)
+                if state_directory_fd is not None
+                else os.open(state, flags)
+            )
             descriptors.append(state_fd)
-            if Workspace._runtime_tree_identity(os.fstat(state_fd)) != (
-                Workspace._runtime_tree_identity(state_before)
+            state_metadata = os.fstat(state_fd)
+            if not stat.S_ISDIR(state_metadata.st_mode):
+                raise WorkspaceError(f"server state is invalid: {state}")
+            if state_directory_fd is None and Workspace._runtime_tree_identity(
+                state_metadata
+            ) != Workspace._runtime_tree_identity(
+                state.stat(follow_symlinks=False)
             ):
                 raise WorkspaceError(
                     f"server state changed before runtime publication: {state}"
@@ -9583,6 +9665,7 @@ class Workspace:
         *,
         identity: dict[str, Any],
         state: Path | None = None,
+        state_directory_fd: int | None = None,
         sound_root: Path | None = None,
     ) -> tuple[Path, int, dict[str, Any]]:
         generations = owner_root / "generations"
@@ -9599,6 +9682,7 @@ class Workspace:
         )
         lease_fd: int | None = None
         state_output: Path | None = None
+        state_output_access: Path | None = None
         try:
             input_digests = self._runtime_publication_input_digests(
                 build_root, selected, services, sound_root
@@ -9662,18 +9746,26 @@ class Workspace:
                     state, target_is_directory=True
                 )
                 state_output = self._prepare_runtime_state_output(
-                    state, generation
+                    state, generation, state_directory_fd
                 )
-                (state_output / "data").mkdir()
+                state_output_access = (
+                    Path(f"/proc/self/fd/{state_directory_fd}")
+                    / "tmp"
+                    / "runtime-assets"
+                    / generation
+                    if state_directory_fd is not None
+                    else state_output
+                )
+                (state_output_access / "data").mkdir()
                 client_maps = build_root / "runtime" / "client-maps"
                 self._validate_region_maps(client_maps)
                 self._copy_runtime_tree(
-                    client_maps, state_output / "client-maps"
+                    client_maps, state_output_access / "client-maps"
                 )
                 state_output_entries = self._runtime_generation_entries(
-                    state_output / "client-maps", None
+                    state_output_access / "client-maps", None
                 )
-                self._seal_runtime_generation(state_output / "client-maps")
+                self._seal_runtime_generation(state_output_access / "client-maps")
             else:
                 state_output_entries = []
 
@@ -11263,7 +11355,9 @@ class Workspace:
                         )
                         state_lock = stack.enter_context(
                             self._topology_state_lock(
-                                state_location, preparing_topology=name
+                                state_location,
+                                preparing_topology=name,
+                                physical_identity=False,
                             )
                         )
                     else:
@@ -11380,6 +11474,7 @@ class Workspace:
                             "providers": providers,
                         },
                         state=state,
+                        state_directory_fd=state_directory_fd,
                         sound_root=sound_root,
                     )
                 )
@@ -11421,7 +11516,12 @@ class Workspace:
                                 else []
                             ),
                             "--assetspath="
-                            f"{runtime_record['mutable_state_outputs'][0]}",
+                            + (
+                                f"/proc/self/fd/{state_directory_fd}/tmp/"
+                                f"runtime-assets/{generation}"
+                                if state_directory_fd is not None
+                                else runtime_record["mutable_state_outputs"][0]
+                            ),
                             "--no_console",
                         ],
                         "cwd": str(server_runtime),
@@ -11448,6 +11548,22 @@ class Workspace:
                             "ATRINIK_CONFIG_DIR": str(client_config.resolve())
                         },
                     }
+                if state is not None and state_directory_fd is not None:
+                    pinned = os.fstat(state_directory_fd)
+                    try:
+                        visible = state.stat(follow_symlinks=False)
+                        canonical = self._canonical_state_path(state)
+                    except OSError as error:
+                        raise WorkspaceError(
+                            f"server state changed before topology launch: {state}"
+                        ) from error
+                    if canonical != state or (pinned.st_dev, pinned.st_ino) != (
+                        visible.st_dev,
+                        visible.st_ino,
+                    ):
+                        raise WorkspaceError(
+                            f"server state changed before topology launch: {state}"
+                        )
                 # All fallible preparation is complete. Retire the stopped
                 # record and bind/publish the new generation without exposing
                 # old status against rewritten lease contents.
@@ -11719,8 +11835,7 @@ class Workspace:
             ):
                 shutdown = current.get("shutdown")
                 confirmed_clean = bool(
-                    requested
-                    and isinstance(shutdown, dict)
+                    isinstance(shutdown, dict)
                     and shutdown.get("control_requested") is True
                     and shutdown.get("clean") is True
                     and current.get("error") is None
@@ -12338,6 +12453,7 @@ class Workspace:
             return prepared
         runtime_fd = prepared["runtime_fd"]
         state_fd = prepared["state_fd"]
+        state_lock_fd = prepared["state_lock_fd"]
         generation_root = prepared["generation_root"]
         state_output = prepared["state_output"]
         try:
@@ -12346,10 +12462,11 @@ class Workspace:
                     prepared["command"],
                     cwd=prepared["cwd"],
                     diagnostics_to_stderr=False,
-                    pass_fds=(runtime_fd, state_fd),
+                    pass_fds=(runtime_fd, state_fd, state_lock_fd),
                 )
             return prepared["executable"]
         finally:
+            os.close(state_lock_fd)
             os.close(state_fd)
             os.close(runtime_fd)
             remove_owned_tree(generation_root)
@@ -12373,42 +12490,55 @@ class Workspace:
         targets = self._expand_build_target("server", profile_name)
         selected = self._resolve_build_profile(profile_name, {"server"})
         state_location = self._state_location(state_name)
-        lock_path = Path(f"{state_location}.lock")
-        with exclusive_lock(
-            lock_path, f"server state {state_location}", nonblocking=True
-        ) as state_lock:
+        with self._topology_state_lock(state_location) as state_lock:
             root = self._build_resolved(
                 "server", profile_name, False, targets, selected
             )
             with self._profile_build_lock(root, profile_name):
-                state = self.state_path(
-                    state_name, selected["server"], resolved_path=state_location
-                )
                 resolved = self._topology_resolved_status(profile_name, selected)
                 profile = self._load_profile(profile_name, require_file=False)
                 selected_stack = self.manifest.stack(profile["stack"])
-                generation = secrets.token_hex(32)
-                generation_root, runtime_fd, _runtime_record = (
-                    self._publish_runtime_generation(
-                        self._foreground_runtime_owner(),
-                        generation,
-                        profile_name,
-                        root,
-                        selected,
-                        resolved,
-                        ["server"],
-                        identity={
-                            "kind": "foreground-server",
-                            "stack": selected_stack.name,
-                            "providers": {
-                                role: selected_stack.providers[role].name
-                                for role in sorted(selected)
-                            },
-                        },
-                        state=state,
-                    )
+                providers = {
+                    role: selected_stack.providers[role].name
+                    for role in sorted(selected)
+                }
+                implementation = self._state_implementation(
+                    selected_stack.name, providers, resolved
                 )
-                state_fd = os.dup(state_lock.fileno())
+                prepared_state = self.state_path(
+                    state_name,
+                    selected["server"],
+                    resolved_path=state_location,
+                    implementation=implementation,
+                    write_implementation=True,
+                    keep_descriptor=True,
+                )
+                assert isinstance(prepared_state, tuple)
+                state, state_fd = prepared_state
+                generation = secrets.token_hex(32)
+                try:
+                    generation_root, runtime_fd, _runtime_record = (
+                        self._publish_runtime_generation(
+                            self._foreground_runtime_owner(),
+                            generation,
+                            profile_name,
+                            root,
+                            selected,
+                            resolved,
+                            ["server"],
+                            identity={
+                                "kind": "foreground-server",
+                                "stack": selected_stack.name,
+                                "providers": providers,
+                            },
+                            state=state,
+                            state_directory_fd=state_fd,
+                        )
+                    )
+                except BaseException:
+                    os.close(state_fd)
+                    raise
+                state_lock_fd = os.dup(state_lock.fileno())
                 runtime = generation_root / "server"
                 executable = runtime / "atrinik-server"
                 command = [
@@ -12417,8 +12547,9 @@ class Workspace:
                     "--port_mapping=off",
                     "--stun_server=off",
                     *arguments,
+                    f"--datapath=/proc/self/fd/{state_fd}",
                     "--assetspath="
-                    f"{_runtime_record['mutable_state_outputs'][0]}",
+                    f"/proc/self/fd/{state_fd}/tmp/runtime-assets/{generation}",
                 ]
                 print(f"state: {state}")
                 print(f"cwd: {runtime}")
@@ -12431,6 +12562,7 @@ class Workspace:
                     "generation_root": generation_root,
                     "runtime_fd": runtime_fd,
                     "state_fd": state_fd,
+                    "state_lock_fd": state_lock_fd,
                     "state_output": (
                         Path(_runtime_record["mutable_state_outputs"][0])
                         if _runtime_record["mutable_state_outputs"]

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -136,10 +136,15 @@ COMPILER_CACHE_MAX_SIZE = "5G"
 TOPOLOGY_SERVICES = ("server", "client")
 TOPOLOGY_PROCESS_TREE_LEASE = "process-tree.lease"
 TOPOLOGY_PORT_RESERVATION_RECORD = "port-reservation.json"
-TOPOLOGY_STATUS_SCHEMA_VERSION = 2
+TOPOLOGY_STATUS_SCHEMA_VERSION = 3
+LEGACY_RUNTIME_TOPOLOGY_STATUS_SCHEMA_VERSION = 2
 RUNTIME_GENERATION_SCHEMA_VERSION = 1
 RUNTIME_GENERATION_LEASE = "generation.lease"
 RUNTIME_GENERATION_MANIFEST = "manifest.json"
+STATE_IMPLEMENTATION_MARKER = ".atrinik-state.json"
+STATE_IMPLEMENTATION_SCHEMA_VERSION = 1
+TEMPORARY_STATE_METADATA = "state.json"
+TEMPORARY_STATE_SCHEMA_VERSION = 1
 PRE_MONOREPO_REPOSITORIES = {
     "client": "legacy-client",
     "server": "legacy-server",
@@ -7479,11 +7484,13 @@ class Workspace:
     def _state_add(self, name: str, path: Path | None) -> Path:
         validate_name(name, "state name")
         if path is None:
-            resolved = (self.paths.state / "server" / name).resolve(strict=False)
+            resolved = self._canonical_state_path(
+                self.paths.state / "server" / name
+            )
         else:
             if not path.is_absolute():
                 raise WorkspaceError("state path must be absolute")
-            resolved = path.expanduser().resolve(strict=False)
+            resolved = self._canonical_state_path(path)
         if resolved == Path("/") or resolved == self.paths.repository:
             raise WorkspaceError(f"refusing unsafe state path: {resolved}")
         if resolved.exists() and not resolved.is_dir():
@@ -7981,6 +7988,74 @@ class Workspace:
             states[name] = path
         return states
 
+    @staticmethod
+    def _canonical_state_path(path: Path) -> Path:
+        """Return a lexical absolute state path after rejecting existing links."""
+
+        candidate = Path(os.path.abspath(path.expanduser()))
+        current = Path(candidate.anchor)
+        for part in candidate.parts[1:]:
+            current /= part
+            try:
+                metadata = current.lstat()
+            except FileNotFoundError:
+                break
+            except OSError as error:
+                raise WorkspaceError(
+                    f"cannot inspect server state path {current}: {error}"
+                ) from error
+            if stat.S_ISLNK(metadata.st_mode):
+                raise WorkspaceError(f"server state path contains a symlink: {current}")
+            if current != candidate and not stat.S_ISDIR(metadata.st_mode):
+                raise WorkspaceError(
+                    f"server state parent is not a directory: {current}"
+                )
+        return candidate
+
+    @staticmethod
+    def _state_identity(path: Path) -> dict[str, int]:
+        metadata = path.stat(follow_symlinks=False)
+        if not stat.S_ISDIR(metadata.st_mode):
+            raise WorkspaceError(f"server state is not a directory: {path}")
+        return {"device": metadata.st_dev, "inode": metadata.st_ino}
+
+    @staticmethod
+    def _state_implementation(
+        stack: str,
+        providers: dict[str, str],
+        resolved: dict[str, dict[str, Any]],
+    ) -> dict[str, str]:
+        provider = providers["server"]
+        coordinate = resolved[provider]
+        return {
+            "stack": stack,
+            "provider": provider,
+            "repository": coordinate["repository"],
+        }
+
+    @staticmethod
+    def _validate_state_implementation(
+        path: Path, implementation: dict[str, str] | None
+    ) -> None:
+        marker = path / STATE_IMPLEMENTATION_MARKER
+        if not marker.exists() and not marker.is_symlink():
+            return
+        if marker.is_symlink() or not marker.is_file():
+            raise WorkspaceError(f"server state implementation marker is invalid: {path}")
+        value = load_json(marker)
+        expected = (
+            {
+                "schema_version": STATE_IMPLEMENTATION_SCHEMA_VERSION,
+                **implementation,
+            }
+            if implementation is not None
+            else None
+        )
+        if expected is None or value != expected:
+            raise WorkspaceError(
+                f"server state implementation does not match the selected server: {path}"
+            )
+
     def list_states(self) -> dict[str, str]:
         self.paths.ensure()
         states = self._load_states()
@@ -7995,17 +8070,25 @@ class Workspace:
         validate_name(name, "state name")
         states = self._load_states()
         if name in states:
-            return Path(states[name]).resolve(strict=False)
+            return self._canonical_state_path(Path(states[name]))
         if name == "default":
-            return (self.paths.state / "server" / "default").resolve(strict=False)
+            return self._canonical_state_path(
+                self.paths.state / "server" / "default"
+            )
         raise WorkspaceError(f"state does not exist: {name}")
 
     def state_path(
-        self, name: str, server_source: Path, resolved_path: Path | None = None
+        self,
+        name: str,
+        server_source: Path,
+        resolved_path: Path | None = None,
+        *,
+        implementation: dict[str, str] | None = None,
+        write_implementation: bool = False,
     ) -> Path:
         validate_name(name, "state name")
         path = resolved_path or self._state_location(name)
-        path = path.resolve(strict=False)
+        path = self._canonical_state_path(path)
         server_source = server_source.resolve()
         if server_source == path or server_source in path.parents:
             raise WorkspaceError(f"server state must be outside its source worktree: {path}")
@@ -8015,15 +8098,192 @@ class Workspace:
             try:
                 shutil.copytree(server_source / "install_data", staging, dirs_exist_ok=True)
                 (staging / "tmp").mkdir()
+                if implementation is not None and write_implementation:
+                    durable_atomic_json(
+                        staging / STATE_IMPLEMENTATION_MARKER,
+                        {
+                            "schema_version": STATE_IMPLEMENTATION_SCHEMA_VERSION,
+                            **implementation,
+                        },
+                    )
+                self._validate_state(staging)
                 if path.exists():
                     raise WorkspaceError(f"state appeared during initialization: {path}")
-                staging.replace(path)
+                rename_no_replace(staging, path)
             except BaseException:
                 shutil.rmtree(staging, ignore_errors=True)
                 raise
         self._validate_state(path)
+        if implementation is not None:
+            self._validate_state_implementation(path, implementation)
         (path / "tmp").mkdir(exist_ok=True)
-        return path.resolve()
+        return path
+
+    def _persistent_state_policy(
+        self,
+        state_name: str,
+        path: Path,
+        implementation: dict[str, str],
+    ) -> dict[str, Any]:
+        registered = self._load_states()
+        scenario_root = self.paths.scenarios / state_name.removeprefix("scenario-")
+        scenario_path = scenario_root / "state"
+        if (
+            state_name.startswith("scenario-")
+            and state_name in registered
+            and self._canonical_state_path(scenario_path) == path
+        ):
+            owner = {"kind": "scenario", "name": state_name.removeprefix("scenario-")}
+            lifecycle = "scenario-owned"
+        elif path.is_relative_to(self.paths.state.resolve(strict=False)):
+            owner = {"kind": "workspace"}
+            lifecycle = "persistent"
+        else:
+            owner = {"kind": "external"}
+            lifecycle = "persistent-external"
+        return {
+            "mode": "default" if state_name == "default" else "named",
+            "name": state_name,
+            "path": str(path),
+            "owner": owner,
+            "lifecycle": lifecycle,
+            "identity": self._state_identity(path),
+            "implementation": implementation,
+        }
+
+    def _temporary_state_container(self, topology_root: Path) -> Path:
+        container = topology_root / "temporary-states"
+        marker = container / MANAGED_MARKER
+        expected = {
+            "schema_version": SCHEMA_VERSION,
+            "purpose": "topology-temporary-states",
+        }
+        if container.exists() or container.is_symlink():
+            if (
+                container.is_symlink()
+                or not container.is_dir()
+                or marker.is_symlink()
+                or not marker.is_file()
+                or load_json(marker) != expected
+            ):
+                raise WorkspaceError(
+                    f"temporary state container is invalid: {container}"
+                )
+        else:
+            container.mkdir()
+            durable_atomic_json(marker, expected)
+        return container
+
+    @contextmanager
+    def _topology_state_lock(self, path: Path) -> Iterator[TextIO]:
+        try:
+            with exclusive_lock(
+                Path(f"{path}.lock"),
+                f"server state {path}",
+                nonblocking=True,
+            ) as lock:
+                yield lock
+                return
+        except LockBusyError as error:
+            owner: tuple[str, str] | None = None
+            try:
+                for status in self.topology_statuses():
+                    observation = status.get("observation")
+                    control = status.get("control")
+                    if (
+                        status.get("state") == str(path)
+                        and isinstance(observation, dict)
+                        and observation.get("process_tree_lease") == "retained"
+                        and isinstance(control, dict)
+                    ):
+                        owner = (status["name"], control["generation"])
+                        break
+            except WorkspaceError:
+                pass
+            if owner is not None:
+                raise WorkspaceError(
+                    f"server state {path} is owned by topology {owner[0]} "
+                    f"generation {owner[1]}; run ./atrinik down {owner[0]} and retry"
+                ) from error
+            raise WorkspaceError(
+                f"server state {path} is busy but its exact owner cannot be "
+                "confirmed; inspect ./atrinik ps --json and preserve the state"
+            ) from error
+
+    def _create_temporary_state(
+        self,
+        topology_root: Path,
+        topology_name: str,
+        generation: str,
+        server_source: Path,
+        implementation: dict[str, str],
+        server_coordinate: dict[str, Any],
+    ) -> tuple[Path, dict[str, Any]]:
+        container = self._temporary_state_container(topology_root)
+        destination = container / generation
+        if destination.exists() or destination.is_symlink():
+            raise WorkspaceError(
+                f"temporary topology state already exists for generation {generation}"
+            )
+        staging = Path(
+            tempfile.mkdtemp(prefix=f".{generation}.", dir=container)
+        )
+        created_at = datetime.now(timezone.utc).isoformat()
+        try:
+            shutil.copytree(
+                server_source / "install_data", staging, dirs_exist_ok=True
+            )
+            (staging / "tmp").mkdir()
+            durable_atomic_json(
+                staging / STATE_IMPLEMENTATION_MARKER,
+                {
+                    "schema_version": STATE_IMPLEMENTATION_SCHEMA_VERSION,
+                    **implementation,
+                },
+            )
+            self._validate_state(staging)
+            identity = self._state_identity(staging)
+            policy = {
+                "mode": "temporary",
+                "name": None,
+                "path": str(destination),
+                "owner": {
+                    "kind": "topology-generation",
+                    "topology": topology_name,
+                    "generation": generation,
+                },
+                "lifecycle": "disposable",
+                "created_at": created_at,
+                "identity": identity,
+                "implementation": implementation,
+                "server": server_coordinate,
+            }
+            durable_atomic_json(
+                staging / MANAGED_MARKER,
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "purpose": "temporary-topology-state",
+                    "topology": topology_name,
+                    "generation": generation,
+                },
+            )
+            durable_atomic_json(
+                staging / TEMPORARY_STATE_METADATA,
+                {
+                    "schema_version": TEMPORARY_STATE_SCHEMA_VERSION,
+                    "state_policy": policy,
+                },
+            )
+            rename_no_replace(staging, destination)
+            if self._state_identity(destination) != identity:
+                raise WorkspaceError(
+                    f"temporary topology state identity changed during publication: {destination}"
+                )
+            return destination, policy
+        except BaseException:
+            if staging.exists() and not staging.is_symlink():
+                remove_owned_tree(staging)
+            raise
 
     def _validate_state(self, path: Path) -> None:
         if not path.is_dir():
@@ -8047,10 +8307,14 @@ class Workspace:
     def topology_summary(
         self,
         profile_name: str,
-        state_name: str,
+        state_name: str | None,
         services: list[str] | None = None,
+        state_mode: str | None = None,
     ) -> dict[str, Any]:
         selected_services = self._topology_services(services)
+        state_mode, state_name = self._normalize_topology_state_request(
+            state_mode, state_name, selected_services
+        )
         requested = set(selected_services)
         profile = self._load_profile(profile_name, require_file=False)
         stack = self.manifest.stack(profile["stack"])
@@ -8060,11 +8324,35 @@ class Workspace:
         checkout_states = self._selected_checkout_states(
             profile, resolved, include_dirty=True
         )
-        state = (
-            str(self._state_location(state_name))
-            if "server" in selected_services
-            else None
-        )
+        state: str | None = None
+        state_policy: dict[str, Any] | None = None
+        if "server" in selected_services:
+            if state_mode == "temporary":
+                state_policy = {
+                    "mode": "temporary",
+                    "name": None,
+                    "path": None,
+                    "owner": {"kind": "topology-generation"},
+                    "lifecycle": "disposable",
+                }
+            else:
+                assert state_name is not None
+                state = str(self._state_location(state_name))
+                state_policy = {
+                    "mode": state_mode,
+                    "name": state_name,
+                    "path": state,
+                    "owner": {
+                        "kind": (
+                            "workspace"
+                            if Path(state).is_relative_to(
+                                self.paths.state.resolve(strict=False)
+                            )
+                            else "external"
+                        )
+                    },
+                    "lifecycle": "persistent",
+                }
         return {
             "profile": profile_name,
             "stack": stack.name,
@@ -8080,6 +8368,7 @@ class Workspace:
                 role: stack.providers[role].name for role in sorted(required)
             },
             "state": state,
+            "state_policy": state_policy,
             "build_root": str(
                 self.paths.builds / "profiles" / f"{profile_name}-{key}"
             ),
@@ -8100,6 +8389,39 @@ class Workspace:
                 for role, path in sorted(resolved.items())
             },
         }
+
+    @staticmethod
+    def _normalize_topology_state_request(
+        state_mode: str | None,
+        state_name: str | None,
+        services: list[str],
+    ) -> tuple[str, str | None]:
+        if "server" not in services:
+            if state_mode == "temporary":
+                raise WorkspaceError("temporary state requires the server service")
+            return "default", None
+        if state_mode is None:
+            state_mode = (
+                "temporary"
+                if state_name is None
+                else "default"
+                if state_name == "default"
+                else "named"
+            )
+        if state_mode not in {"temporary", "named", "default"}:
+            raise WorkspaceError(f"unknown topology state policy: {state_mode}")
+        if state_mode == "temporary":
+            if state_name is not None:
+                raise WorkspaceError("temporary state cannot also name persistent state")
+            return state_mode, None
+        if state_mode == "default":
+            if state_name not in {None, "default"}:
+                raise WorkspaceError("default state cannot also name persistent state")
+            return state_mode, "default"
+        if state_name is None or state_name == "default":
+            raise WorkspaceError("named state policy requires a non-default state name")
+        validate_name(state_name, "state name")
+        return state_mode, state_name
 
     def _topology_directory(self, name: str, create: bool = False) -> Path:
         validate_name(name, "topology name")
@@ -9315,6 +9637,160 @@ class Workspace:
                 f"cannot inspect topology process-tree lease {path}: {error}"
             ) from error
 
+    def _validate_topology_state_policy(
+        self,
+        name: str,
+        root: Path,
+        status: dict[str, Any],
+        control: dict[str, Any] | None,
+    ) -> None:
+        policy = status.get("state_policy")
+        state = status.get("state")
+        server_present = state is not None
+        if not server_present:
+            if policy is not None or state is not None:
+                raise WorkspaceError(f"topology state policy is invalid: {name}")
+            return
+        if not isinstance(policy, dict) or not isinstance(state, str):
+            raise WorkspaceError(f"topology state policy is invalid: {name}")
+        common = {
+            "mode",
+            "name",
+            "path",
+            "owner",
+            "lifecycle",
+            "identity",
+            "implementation",
+        }
+        mode = policy.get("mode")
+        expected_keys = common | ({"created_at", "server"} if mode == "temporary" else set())
+        identity = policy.get("identity")
+        implementation = policy.get("implementation")
+        providers = status.get("providers")
+        resolved = status.get("resolved")
+        if (
+            mode not in {"temporary", "named", "default"}
+            or set(policy) != expected_keys
+            or policy.get("path") != state
+            or not isinstance(policy.get("owner"), dict)
+            or not isinstance(policy.get("lifecycle"), str)
+            or not isinstance(identity, dict)
+            or set(identity) != {"device", "inode"}
+            or not all(
+                isinstance(value, int) and not isinstance(value, bool) and value >= 0
+                for value in identity.values()
+            )
+            or not isinstance(implementation, dict)
+            or set(implementation) != {"stack", "provider", "repository"}
+            or not isinstance(providers, dict)
+            or not isinstance(resolved, dict)
+            or "server" not in providers
+            or providers["server"] not in resolved
+            or implementation
+            != self._state_implementation(status["stack"], providers, resolved)
+        ):
+            raise WorkspaceError(f"topology state policy is invalid: {name}")
+        path = self._canonical_state_path(Path(state))
+        lifecycle = policy["lifecycle"]
+        if mode == "temporary":
+            generation = control.get("generation") if isinstance(control, dict) else None
+            expected_path = root / "temporary-states" / str(generation)
+            promoted_name = policy.get("name")
+            if (
+                (
+                    lifecycle in {"promotion-pending", "promoted"}
+                    and (
+                        not isinstance(promoted_name, str)
+                        or promoted_name == "default"
+                    )
+                )
+                or lifecycle not in {"promotion-pending", "promoted"}
+                and promoted_name is not None
+                or generation is None
+                or path != expected_path
+                or policy["owner"]
+                != {
+                    "kind": "topology-generation",
+                    "topology": name,
+                    "generation": generation,
+                }
+                or lifecycle
+                not in {
+                    "disposable",
+                    "retained",
+                    "promotion-pending",
+                    "promoted",
+                    "removed",
+                }
+                or not isinstance(policy.get("created_at"), str)
+                or not policy["created_at"]
+                or policy.get("server") != resolved[providers["server"]]
+            ):
+                raise WorkspaceError(f"temporary topology state policy is invalid: {name}")
+            if lifecycle != "removed":
+                marker = path / MANAGED_MARKER
+                metadata_path = path / TEMPORARY_STATE_METADATA
+                if (
+                    path.is_symlink()
+                    or not path.is_dir()
+                    or self._state_identity(path) != identity
+                    or marker.is_symlink()
+                    or not marker.is_file()
+                    or load_json(marker)
+                    != {
+                        "schema_version": SCHEMA_VERSION,
+                        "purpose": "temporary-topology-state",
+                        "topology": name,
+                        "generation": generation,
+                    }
+                    or metadata_path.is_symlink()
+                    or not metadata_path.is_file()
+                ):
+                    raise WorkspaceError(
+                        f"temporary topology state identity is invalid: {name}"
+                    )
+                metadata = load_json(metadata_path)
+                if (
+                    not isinstance(metadata, dict)
+                    or metadata.get("schema_version")
+                    != TEMPORARY_STATE_SCHEMA_VERSION
+                    or metadata.get("state_policy") != policy
+                ):
+                    raise WorkspaceError(
+                        f"temporary topology state metadata is invalid: {name}"
+                    )
+                self._validate_state_implementation(path, implementation)
+                if lifecycle == "promoted" and self._canonical_state_path(
+                    Path(self._load_states().get(str(promoted_name), "/"))
+                ) != path:
+                    raise WorkspaceError(
+                        f"promoted temporary state registration is invalid: {name}"
+                    )
+            elif path.exists() or path.is_symlink():
+                raise WorkspaceError(
+                    f"removed temporary topology state still exists: {name}"
+                )
+        else:
+            expected_name = "default" if mode == "default" else policy.get("name")
+            expected_persistent = (
+                self._persistent_state_policy(
+                    expected_name, path, implementation
+                )
+                if isinstance(expected_name, str)
+                else None
+            )
+            if (
+                not isinstance(expected_name, str)
+                or policy.get("name") != expected_name
+                or not isinstance(expected_persistent, dict)
+                or policy.get("owner") != expected_persistent["owner"]
+                or lifecycle != expected_persistent["lifecycle"]
+                or path != self._state_location(expected_name)
+                or self._state_identity(path) != identity
+            ):
+                raise WorkspaceError(f"persistent topology state policy is invalid: {name}")
+            self._validate_state_implementation(path, implementation)
+
     def topology_status(self, name: str) -> dict[str, Any]:
         root = self._topology_directory(name)
         status_path = root / "status.json"
@@ -9343,11 +9819,17 @@ class Workspace:
             "control",
             "port_reservation",
             "runtime",
+            "state_policy",
         }
         topology_schema = status.get("schema_version") if isinstance(status, dict) else None
-        current_runtime_record = topology_schema == TOPOLOGY_STATUS_SCHEMA_VERSION
+        current_runtime_record = topology_schema in {
+            LEGACY_RUNTIME_TOPOLOGY_STATUS_SCHEMA_VERSION,
+            TOPOLOGY_STATUS_SCHEMA_VERSION,
+        }
         if current_runtime_record:
             required.add("runtime")
+        if topology_schema == TOPOLOGY_STATUS_SCHEMA_VERSION:
+            required.add("state_policy")
         historical_record = isinstance(status, dict) and not (
             {"stack", "providers"} & set(status)
         )
@@ -9398,7 +9880,11 @@ class Workspace:
         )
         if (
             not isinstance(status, dict)
-            or topology_schema not in {SCHEMA_VERSION, TOPOLOGY_STATUS_SCHEMA_VERSION}
+            or topology_schema not in {
+                SCHEMA_VERSION,
+                LEGACY_RUNTIME_TOPOLOGY_STATUS_SCHEMA_VERSION,
+                TOPOLOGY_STATUS_SCHEMA_VERSION,
+            }
             or status.get("name") != name
             or not required <= set(status) <= required | optional | {"error"}
             or not isinstance(status.get("dependencies"), list)
@@ -9863,6 +10349,8 @@ class Workspace:
             or not set(services) <= set(TOPOLOGY_SERVICES)
         ):
             raise WorkspaceError(f"topology service status is invalid: {name}")
+        if topology_schema == TOPOLOGY_STATUS_SCHEMA_VERSION:
+            self._validate_topology_state_policy(name, root, status, control)
         if not historical_record and "client" in services and "sound" not in status:
             raise WorkspaceError(f"topology status is invalid: {name}")
         for service in services.values():
@@ -10160,9 +10648,10 @@ class Workspace:
         self,
         name: str,
         profile_name: str,
-        state_name: str,
+        state_name: str | None,
         services: list[str] | None = None,
         port: int | None = None,
+        state_mode: str | None = None,
     ) -> dict[str, Any]:
         self.paths.ensure()
         selected_services = self._topology_services(services)
@@ -10184,6 +10673,7 @@ class Workspace:
                     state_name,
                     services,
                     port,
+                    state_mode,
                 )
 
     def _topology_resolved_status(
@@ -10214,11 +10704,15 @@ class Workspace:
         self,
         name: str,
         profile_name: str,
-        state_name: str,
+        state_name: str | None,
         services: list[str] | None = None,
         port: int | None = None,
+        state_mode: str | None = None,
     ) -> dict[str, Any]:
         selected_services = self._topology_services(services)
+        state_mode, state_name = self._normalize_topology_state_request(
+            state_mode, state_name, selected_services
+        )
         if "client" in selected_services:
             client_launch_label(profile_name, name)
         if "server" not in selected_services and port is not None:
@@ -10258,6 +10752,12 @@ class Workspace:
                 for service in ("client", "server")
                 if service in selected_services
             ]
+            profile = self._load_profile(profile_name, require_file=False)
+            selected_stack = self.manifest.stack(profile["stack"])
+            providers = {
+                role: selected_stack.providers[role].name
+                for role in sorted(required)
+            }
 
             with ExitStack() as stack:
                 process_tree_fd = open_regular_file(
@@ -10330,19 +10830,65 @@ class Workspace:
 
                 state_location: Path | None = None
                 state_lock: TextIO | None = None
-                if "server" in selected_services:
+                if "server" in selected_services and state_mode != "temporary":
+                    assert state_name is not None
                     state_location = self._state_location(state_name)
                     state_lock = stack.enter_context(
-                        exclusive_lock(
-                            Path(f"{state_location}.lock"),
-                            f"server state {state_location}",
-                            nonblocking=True,
-                        )
+                        self._topology_state_lock(state_location)
                     )
 
                 root = self._build_resolved(
                     "topology", profile_name, False, targets, selected
                 )
+                resolved_status = self._topology_resolved_status(
+                    profile_name, selected
+                )
+                implementation = (
+                    self._state_implementation(
+                        selected_stack.name, providers, resolved_status
+                    )
+                    if "server" in selected_services
+                    else None
+                )
+                state: Path | None = None
+                state_policy: dict[str, Any] | None = None
+                temporary_state_owner: list[Path] = []
+                if "server" in selected_services:
+                    assert implementation is not None
+                    if state_mode == "temporary":
+                        server_provider = providers["server"]
+                        state, state_policy = self._create_temporary_state(
+                            topology_root,
+                            name,
+                            generation,
+                            selected["server"],
+                            implementation,
+                            resolved_status[server_provider],
+                        )
+                        state_location = state
+                        temporary_state_owner.append(state)
+                        stack.callback(
+                            lambda: remove_owned_tree(temporary_state_owner.pop())
+                            if temporary_state_owner
+                            else None
+                        )
+                        state_lock = stack.enter_context(
+                            self._topology_state_lock(state_location)
+                        )
+                    else:
+                        assert state_name is not None and state_location is not None
+                        state = self.state_path(
+                            state_name,
+                            selected["server"],
+                            resolved_path=state_location,
+                            implementation=implementation,
+                            write_implementation=state_location.is_relative_to(
+                                self.paths.state.resolve(strict=False)
+                            ),
+                        )
+                        state_policy = self._persistent_state_policy(
+                            state_name, state, implementation
+                        )
                 build_lock = stack.enter_context(
                     self._profile_build_lock(root, profile_name)
                 )
@@ -10352,14 +10898,6 @@ class Workspace:
                     if isinstance(build_metadata, dict)
                     else None
                 )
-                state: Path | None = None
-                if "server" in selected_services:
-                    assert state_location is not None
-                    state = self.state_path(
-                        state_name,
-                        selected["server"],
-                        resolved_path=state_location,
-                    )
                 sound_root: Path | None = None
                 if "client" in selected_services:
                     try:
@@ -10368,7 +10906,6 @@ class Workspace:
                         raise WorkspaceError(
                             f"build sound metadata is invalid for profile {profile_name}"
                         ) from error
-                    profile = self._load_profile(profile_name, require_file=False)
                     if validated_sound["mode"] != profile["sound_mode"]:
                         raise WorkspaceError(
                             f"profile {profile_name} sound mode does not match build metadata"
@@ -10388,11 +10925,6 @@ class Workspace:
                         raise WorkspaceError(
                             f"profile {profile_name} source sound root changed before topology preparation"
                         )
-                profile = self._load_profile(profile_name, require_file=False)
-                selected_stack = self.manifest.stack(profile["stack"])
-                resolved_status = self._topology_resolved_status(
-                    profile_name, selected
-                )
                 generation_root, runtime_lock_fd, runtime_record = (
                     self._publish_runtime_generation(
                         topology_root,
@@ -10406,10 +10938,7 @@ class Workspace:
                             "kind": "topology",
                             "name": name,
                             "stack": selected_stack.name,
-                            "providers": {
-                                role: selected_stack.providers[role].name
-                                for role in sorted(required)
-                            },
+                            "providers": providers,
                         },
                         state=state,
                         sound_root=sound_root,
@@ -10491,6 +11020,7 @@ class Workspace:
                     },
                     "dependencies": sorted(required),
                     "state": str(state_location) if state_location else None,
+                    "state_policy": state_policy,
                     "build_root": str(root),
                     "resolved": resolved_status,
                     "endpoint": endpoint,
@@ -10577,6 +11107,7 @@ class Workspace:
                     )
                     published_generation_owner.clear()
                     published_state_output_owner.clear()
+                    temporary_state_owner.clear()
                     os.close(process_tree_owner.pop())
                     if port_reservation_owner:
                         os.close(port_reservation_owner.pop())
@@ -10627,14 +11158,28 @@ class Workspace:
                     f"{topology_root / 'supervisor.log'}"
                 )
 
-    def topology_down(self, name: str, timeout: float = 15) -> dict[str, Any]:
+    def topology_down(
+        self, name: str, timeout: float = 15, *, retain_state: bool = False
+    ) -> dict[str, Any]:
         root = self._topology_directory(name)
         with exclusive_lock(
             root / "operation.lock", f"topology {name} operation", nonblocking=True
         ):
             status = self.topology_status(name)
+            policy = status.get("state_policy")
+            if retain_state and (
+                not isinstance(policy, dict) or policy.get("mode") != "temporary"
+            ):
+                raise WorkspaceError(
+                    "--retain-state requires a temporary topology state"
+                )
             if "control" in status:
-                return self._controlled_topology_down(name, status, timeout)
+                stopped, confirmed_clean = self._controlled_topology_down(
+                    name, status, timeout
+                )
+                return self._finish_temporary_state_down(
+                    name, stopped, retain_state, confirmed_clean
+                )
             process_tree_path = root / TOPOLOGY_PROCESS_TREE_LEASE
             if process_tree_path.is_symlink():
                 raise WorkspaceError(
@@ -10662,7 +11207,9 @@ class Workspace:
                     )
                     if recorded_running:
                         return self._legacy_topology_down(name, status, timeout)
-                    return status
+                    return self._finish_temporary_state_down(
+                        name, status, retain_state, False
+                    )
                 signal_holders(
                     process_tree_fd, signal.SIGTERM, exclude=(os.getpid(),)
                 )
@@ -10676,7 +11223,9 @@ class Workspace:
                     if not holders_exist(
                         process_tree_fd, exclude=(os.getpid(),)
                     ) and not recorded_running:
-                        return current
+                        return self._finish_temporary_state_down(
+                            name, current, retain_state, False
+                        )
                     time.sleep(0.1)
                 signal_holders(
                     process_tree_fd, signal.SIGKILL, exclude=(os.getpid(),)
@@ -10696,7 +11245,9 @@ class Workspace:
                     if not holders_exist(
                         process_tree_fd, exclude=(os.getpid(),)
                     ) and not recorded_running:
-                        return current
+                        return self._finish_temporary_state_down(
+                            name, current, retain_state, False
+                        )
                     time.sleep(0.05)
             finally:
                 os.close(process_tree_fd)
@@ -10706,7 +11257,7 @@ class Workspace:
 
     def _controlled_topology_down(
         self, name: str, status: dict[str, Any], timeout: float
-    ) -> dict[str, Any]:
+    ) -> tuple[dict[str, Any], bool]:
         root = self._topology_directory(name)
         control = status["control"]
         requested = self._topology_control_request(name, control, "stop")
@@ -10717,7 +11268,7 @@ class Workspace:
             if not active and not current["supervisor"]["running"] and not any(
                 service["running"] for service in current["services"].values()
             ):
-                return current
+                return current, requested
             time.sleep(0.1)
         if not requested:
             raise WorkspaceError(
@@ -10729,6 +11280,189 @@ class Workspace:
         raise WorkspaceError(
             f"topology did not stop within {timeout:g} seconds: {name}"
         )
+
+    def _write_temporary_state_policy(
+        self,
+        name: str,
+        status: dict[str, Any],
+        policy: dict[str, Any],
+    ) -> dict[str, Any]:
+        root = self._topology_directory(name)
+        state = Path(policy["path"])
+        metadata_path = state / TEMPORARY_STATE_METADATA
+        durable_atomic_json(
+            metadata_path,
+            {
+                "schema_version": TEMPORARY_STATE_SCHEMA_VERSION,
+                "state_policy": policy,
+            },
+        )
+        status_path = root / "status.json"
+        raw_status = load_json(status_path)
+        if (
+            not isinstance(raw_status, dict)
+            or raw_status.get("state_policy") != status.get("state_policy")
+        ):
+            raise WorkspaceError(
+                f"temporary topology state status changed before update: {name}"
+            )
+        durable_atomic_json(status_path, {**raw_status, "state_policy": policy})
+        return self.topology_status(name)
+
+    def _finish_temporary_state_down(
+        self,
+        name: str,
+        status: dict[str, Any],
+        retain_state: bool,
+        confirmed_clean: bool,
+    ) -> dict[str, Any]:
+        policy = status.get("state_policy")
+        if not isinstance(policy, dict) or policy.get("mode") != "temporary":
+            return status
+        if policy.get("lifecycle") in {
+            "promoted",
+            "promotion-pending",
+            "removed",
+            "retained",
+        }:
+            return status
+        if not confirmed_clean:
+            if retain_state:
+                raise WorkspaceError(
+                    f"topology {name} did not complete a confirmed clean down; "
+                    "temporary state was retained for diagnosis"
+                )
+            return status
+        state = Path(policy["path"])
+        with exclusive_lock(
+            Path(f"{state}.lock"),
+            f"temporary topology state {state}",
+            nonblocking=True,
+        ):
+            current = self.topology_status(name)
+            if current.get("state_policy") != policy:
+                raise WorkspaceError(
+                    f"temporary topology state changed before down finalization: {name}"
+                )
+            if retain_state:
+                retained = {**policy, "lifecycle": "retained"}
+                return self._write_temporary_state_policy(name, current, retained)
+            remove_owned_tree(state)
+            removed = {**policy, "lifecycle": "removed"}
+            raw_status = load_json(
+                self._topology_directory(name) / "status.json"
+            )
+            if (
+                not isinstance(raw_status, dict)
+                or raw_status.get("state_policy") != policy
+            ):
+                raise WorkspaceError(
+                    f"temporary topology state status changed before removal: {name}"
+                )
+            updated = {**raw_status, "state_policy": removed}
+            durable_atomic_json(
+                self._topology_directory(name) / "status.json", updated
+            )
+            return self.topology_status(name)
+
+    def state_promote(self, topology_name: str, state_name: str) -> dict[str, Any]:
+        """Promote one stopped, explicitly retained temporary state in place."""
+
+        validate_name(state_name, "state name")
+        if state_name == "default":
+            raise WorkspaceError("temporary state cannot be promoted as default")
+        root = self._topology_directory(topology_name)
+        with exclusive_lock(
+            root / "operation.lock",
+            f"topology {topology_name} operation",
+            nonblocking=True,
+        ):
+            status = self.topology_status(topology_name)
+            policy = status.get("state_policy")
+            if (
+                isinstance(policy, dict)
+                and policy.get("mode") == "temporary"
+                and policy.get("lifecycle") == "promoted"
+            ):
+                state = Path(policy["path"])
+                states = self._load_states()
+                if (
+                    policy.get("name") == state_name
+                    and states.get(state_name) is not None
+                    and self._canonical_state_path(Path(states[state_name])) == state
+                ):
+                    return {
+                        "topology": topology_name,
+                        "name": state_name,
+                        "path": str(state),
+                        "state_policy": policy,
+                    }
+            if (
+                not isinstance(policy, dict)
+                or policy.get("mode") != "temporary"
+                or policy.get("lifecycle") not in {"retained", "promotion-pending"}
+            ):
+                raise WorkspaceError(
+                    f"topology does not have a retained temporary state: {topology_name}"
+                )
+            if (
+                status["supervisor"]["running"]
+                or any(service["running"] for service in status["services"].values())
+                or status["observation"]["process_tree_lease"] == "retained"
+            ):
+                raise WorkspaceError(
+                    f"temporary topology state is still active: {topology_name}"
+                )
+            state = Path(policy["path"])
+            with exclusive_lock(
+                Path(f"{state}.lock"),
+                f"temporary topology state {state}",
+                nonblocking=True,
+            ):
+                with exclusive_lock(
+                    self.paths.workspace / "states.lock", "states registry"
+                ):
+                    states = self._load_states()
+                    existing = states.get(state_name)
+                    if existing is not None and self._canonical_state_path(
+                        Path(existing)
+                    ) != state:
+                        raise WorkspaceError(f"state already exists: {state_name}")
+                    aliases = [
+                        name
+                        for name, value in states.items()
+                        if name != state_name
+                        and self._canonical_state_path(Path(value)) == state
+                    ]
+                    if aliases:
+                        raise WorkspaceError(
+                            f"temporary state is already registered as: {aliases[0]}"
+                        )
+                    pending = {
+                        **policy,
+                        "name": state_name,
+                        "lifecycle": "promotion-pending",
+                    }
+                    if policy != pending:
+                        status = self._write_temporary_state_policy(
+                            topology_name, status, pending
+                        )
+                    if existing is None:
+                        states[state_name] = str(state)
+                        durable_atomic_json(
+                            self.paths.states_file,
+                            {"schema_version": SCHEMA_VERSION, "states": states},
+                        )
+                    promoted = {**pending, "lifecycle": "promoted"}
+                    status = self._write_temporary_state_policy(
+                        topology_name, status, promoted
+                    )
+                    return {
+                        "topology": topology_name,
+                        "name": state_name,
+                        "path": str(state),
+                        "state_policy": status["state_policy"],
+                    }
 
     def _legacy_topology_down(
         self, name: str, status: dict[str, Any], timeout: float

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -8315,7 +8315,7 @@ class Workspace:
                 metadata = current.lstat()
             except FileNotFoundError:
                 break
-            except OSError as error:
+            except (OSError, ValueError) as error:
                 raise WorkspaceError(
                     f"cannot inspect server state path {current}: {error}"
                 ) from error
@@ -8350,7 +8350,8 @@ class Workspace:
 
     @staticmethod
     def _validate_state_implementation(
-        path: Path, implementation: dict[str, str] | None
+        path: Path,
+        implementation: dict[str, str] | None,
     ) -> None:
         marker = path / STATE_IMPLEMENTATION_MARKER
         if not marker.exists() and not marker.is_symlink():
@@ -8378,7 +8379,8 @@ class Workspace:
         descriptor: int | None = None
         try:
             descriptor = os.open(
-                name, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW,
+                name,
+                os.O_RDONLY | os.O_NONBLOCK | os.O_CLOEXEC | os.O_NOFOLLOW,
                 dir_fd=directory_fd,
             )
             metadata = os.fstat(descriptor)
@@ -9128,7 +9130,9 @@ class Workspace:
 
     @staticmethod
     def _validate_temporary_state_integrity(
-        directory_fd: int, path: Path
+        directory_fd: int,
+        path: Path,
+        implementation: dict[str, str] | None = None,
     ) -> None:
         """Fail closed before deleting wrapper-owned mutable server state."""
 
@@ -9151,6 +9155,32 @@ class Workspace:
                 )
         finally:
             os.close(parent_fd)
+        marker = Workspace._load_state_json_at(
+            directory_fd,
+            STATE_IMPLEMENTATION_MARKER,
+            "temporary state implementation marker",
+        )
+        if implementation is None:
+            marker_valid = bool(
+                isinstance(marker, dict)
+                and set(marker)
+                == {"schema_version", "stack", "provider", "repository"}
+                and marker.get("schema_version")
+                == STATE_IMPLEMENTATION_SCHEMA_VERSION
+                and all(
+                    isinstance(marker.get(key), str) and marker[key]
+                    for key in ("stack", "provider", "repository")
+                )
+            )
+        else:
+            marker_valid = marker == {
+                "schema_version": STATE_IMPLEMENTATION_SCHEMA_VERSION,
+                **implementation,
+            }
+        if not marker_valid:
+            raise WorkspaceError(
+                f"temporary state implementation marker is invalid: {path}"
+            )
         for name in EXPECTED_SERVER_DATA["files"]:
             try:
                 metadata = os.stat(
@@ -9984,6 +10014,29 @@ class Workspace:
         return sorted(entries, key=lambda entry: entry["path"])
 
     @staticmethod
+    def _runtime_state_output_identity_at(
+        state_directory_fd: int, generation: str
+    ) -> dict[str, int]:
+        flags = os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW
+        descriptors: list[int] = []
+        state_mount_id = _descriptor_mount_id(state_directory_fd)
+        try:
+            parent = state_directory_fd
+            for name in ("tmp", "runtime-assets", generation):
+                descriptor = os.open(name, flags, dir_fd=parent)
+                descriptors.append(descriptor)
+                if _descriptor_mount_id(descriptor) != state_mount_id:
+                    raise WorkspaceError(
+                        "server runtime state output crosses a mount"
+                    )
+                parent = descriptor
+            metadata = os.fstat(descriptors[-1])
+            return {"device": metadata.st_dev, "inode": metadata.st_ino}
+        finally:
+            for descriptor in reversed(descriptors):
+                os.close(descriptor)
+
+    @staticmethod
     def _prepare_runtime_state_output(
         state: Path, generation: str, state_directory_fd: int | None = None
     ) -> Path:
@@ -9991,6 +10044,7 @@ class Workspace:
         descriptors: list[int] = []
         created_generation = False
         output = state / "tmp" / "runtime-assets" / generation
+        state_mount_id: int | None = None
 
         def open_directory(parent: int, name: str, create: bool) -> int:
             if create:
@@ -10013,6 +10067,14 @@ class Workspace:
                 raise WorkspaceError(
                     f"server runtime state output path changed: {output}"
                 )
+            if (
+                state_mount_id is not None
+                and _descriptor_mount_id(descriptor) != state_mount_id
+            ):
+                os.close(descriptor)
+                raise WorkspaceError(
+                    f"server runtime state output crosses a mount: {output}"
+                )
             return descriptor
 
         try:
@@ -10023,6 +10085,7 @@ class Workspace:
             )
             descriptors.append(state_fd)
             state_metadata = os.fstat(state_fd)
+            state_mount_id = _descriptor_mount_id(state_fd)
             if not stat.S_ISDIR(state_metadata.st_mode):
                 raise WorkspaceError(f"server state is invalid: {state}")
             if state_directory_fd is None and Workspace._runtime_tree_identity(
@@ -10123,10 +10186,12 @@ class Workspace:
         path: Path,
         generation: str,
         state_directory_fd: int | None = None,
+        expected_identity: dict[str, int] | None = None,
     ) -> None:
         if state_directory_fd is not None:
             flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
             descriptors = [os.dup(state_directory_fd)]
+            state_mount_id = _descriptor_mount_id(descriptors[0])
 
             def open_exact_directory(parent: int, name: str) -> int:
                 visible = os.stat(name, dir_fd=parent, follow_symlinks=False)
@@ -10142,6 +10207,11 @@ class Workspace:
                     os.close(descriptor)
                     raise WorkspaceError(
                         f"server runtime state output path changed: {path}"
+                    )
+                if _descriptor_mount_id(descriptor) != state_mount_id:
+                    os.close(descriptor)
+                    raise WorkspaceError(
+                        f"server runtime state output crosses a mount: {path}"
                     )
                 return descriptor
 
@@ -10171,6 +10241,13 @@ class Workspace:
                     already_tombstoned = True
                 descriptors.append(generation_fd)
                 metadata = os.fstat(generation_fd)
+                if expected_identity is None or expected_identity != {
+                    "device": metadata.st_dev,
+                    "inode": metadata.st_ino,
+                }:
+                    raise WorkspaceError(
+                        f"server runtime state output identity changed: {path}"
+                    )
                 if already_tombstoned:
                     match = re.fullmatch(
                         r"\.remove-[0-9a-f]{16}-([0-9a-f]+)-([0-9a-f]+)",
@@ -10183,13 +10260,11 @@ class Workspace:
                         raise WorkspaceError(
                             f"server runtime state output tombstone is invalid: {path}"
                         )
-                marker_fd = os.open(
+                marker = Workspace._load_state_json_at(
+                    generation_fd,
                     MANAGED_MARKER,
-                    os.O_RDONLY | os.O_NOFOLLOW,
-                    dir_fd=generation_fd,
+                    "server runtime state output ownership",
                 )
-                with os.fdopen(marker_fd, encoding="utf-8") as stream:
-                    marker = json.load(stream)
                 if marker != {
                     "schema_version": SCHEMA_VERSION,
                     "purpose": f"runtime-state-output:{generation}",
@@ -10382,6 +10457,7 @@ class Workspace:
         lease_fd: int | None = None
         state_output: Path | None = None
         state_output_access: Path | None = None
+        state_output_identity: dict[str, int] | None = None
         try:
             input_digests = self._runtime_publication_input_digests(
                 build_root, selected, services, sound_root
@@ -10460,6 +10536,13 @@ class Workspace:
                     if state_directory_fd is not None
                     else state_output
                 )
+                state_output_identity = (
+                    self._runtime_state_output_identity_at(
+                        state_directory_fd, generation
+                    )
+                    if state_directory_fd is not None
+                    else self._state_identity(state_output_access)
+                )
                 (state_output_access / "data").mkdir()
                 client_maps = build_root / "runtime" / "client-maps"
                 self._validate_region_maps(client_maps)
@@ -10516,6 +10599,11 @@ class Workspace:
                 "mutable_state_outputs": (
                     [str(state_output)] if state_output is not None else []
                 ),
+                "mutable_state_output_identities": (
+                    [state_output_identity]
+                    if state_output_identity is not None
+                    else []
+                ),
                 "mutable_state_output_entries": state_output_entries,
                 "entries": self._runtime_generation_entries(staging, state),
             }
@@ -10548,6 +10636,11 @@ class Workspace:
                 "mutable_state_outputs": (
                     [str(state_output)] if state_output is not None else []
                 ),
+                "mutable_state_output_identities": (
+                    [state_output_identity]
+                    if state_output_identity is not None
+                    else []
+                ),
             }
             result_fd = lease_fd
             lease_fd = None
@@ -10557,10 +10650,18 @@ class Workspace:
                 remove_owned_tree(staging)
             cleanup_output = state_output_access or state_output
             if cleanup_output is not None and cleanup_output.exists():
+                if (
+                    state_output_identity is None
+                    and state_directory_fd is not None
+                ):
+                    state_output_identity = self._runtime_state_output_identity_at(
+                        state_directory_fd, generation
+                    )
                 self._remove_runtime_state_output(
                     state_output or cleanup_output,
                     generation,
                     state_directory_fd,
+                    state_output_identity,
                 )
             raise
         finally:
@@ -11288,6 +11389,7 @@ class Workspace:
                     "lease",
                     "external_state",
                     "mutable_state_outputs",
+                    "mutable_state_output_identities",
                 }
                 or runtime.get("schema_version")
                 != RUNTIME_GENERATION_SCHEMA_VERSION
@@ -11308,6 +11410,22 @@ class Workspace:
                     ]
                     if status.get("state") is not None
                     else []
+                )
+                or not isinstance(
+                    runtime.get("mutable_state_output_identities"), list
+                )
+                or len(runtime["mutable_state_output_identities"])
+                != len(runtime["mutable_state_outputs"])
+                or any(
+                    not isinstance(identity, dict)
+                    or set(identity) != {"device", "inode"}
+                    or any(
+                        not isinstance(value, int)
+                        or isinstance(value, bool)
+                        or value < 0
+                        for value in identity.values()
+                    )
+                    for identity in runtime["mutable_state_output_identities"]
                 )
                 or not isinstance(runtime.get("lease"), dict)
                 or set(runtime["lease"]) != {"device", "inode"}
@@ -11389,6 +11507,7 @@ class Workspace:
                     "build",
                     "external_state",
                     "mutable_state_outputs",
+                    "mutable_state_output_identities",
                     "mutable_state_output_entries",
                     "entries",
                 }
@@ -11401,6 +11520,8 @@ class Workspace:
                 or runtime_manifest.get("external_state") != status.get("state")
                 or runtime_manifest.get("mutable_state_outputs")
                 != runtime["mutable_state_outputs"]
+                or runtime_manifest.get("mutable_state_output_identities")
+                != runtime["mutable_state_output_identities"]
                 or not isinstance(manifest_services, list)
                 or not manifest_services
                 or len(manifest_services) != len(set(manifest_services))
@@ -12056,7 +12177,14 @@ class Workspace:
                 state_policy: dict[str, Any] | None = None
                 state_directory_fd: int | None = None
                 temporary_state_owner: list[
-                    tuple[Path, TextIO, dict[str, int], dict[str, int], int]
+                    tuple[
+                        Path,
+                        TextIO,
+                        dict[str, int],
+                        dict[str, int],
+                        int,
+                        dict[str, str],
+                    ]
                 ] = []
                 if "server" in selected_services:
                     assert implementation is not None
@@ -12168,6 +12296,7 @@ class Workspace:
                                 state_policy["identity"],
                                 state_policy["lease_identity"],
                                 state_directory_fd,
+                                state_policy["implementation"],
                             )
                         )
                         stack.callback(
@@ -12262,6 +12391,7 @@ class Workspace:
                         published_state_output_owner.pop(),
                         generation,
                         state_directory_fd,
+                        runtime_record["mutable_state_output_identities"][0],
                     )
                     if published_state_output_owner
                     else None
@@ -12618,7 +12748,13 @@ class Workspace:
         ):
             return
         outputs = runtime.get("mutable_state_outputs")
-        if not isinstance(outputs, list) or not outputs:
+        identities = runtime.get("mutable_state_output_identities")
+        if (
+            not isinstance(outputs, list)
+            or not outputs
+            or not isinstance(identities, list)
+            or len(identities) != len(outputs)
+        ):
             return
         state = Path(policy["path"])
         descriptor = _open_directory_nofollow(
@@ -12637,11 +12773,14 @@ class Workspace:
                 raise WorkspaceError(
                     f"server state identity changed before runtime cleanup: {state}"
                 )
-            for value in outputs:
+            for value, output_identity in zip(outputs, identities, strict=True):
                 output = Path(value)
                 try:
                     self._remove_runtime_state_output(
-                        output, control["generation"], descriptor
+                        output,
+                        control["generation"],
+                        descriptor,
+                        output_identity,
                     )
                 except FileNotFoundError:
                     continue
@@ -12746,7 +12885,32 @@ class Workspace:
                 raise WorkspaceError(
                     f"temporary topology state lease changed before removal: {lock}"
                 )
-            os.unlink(tombstone, dir_fd=parent_fd)
+            if not stat.S_ISREG(moved.st_mode) or moved.st_nlink != 1:
+                raise WorkspaceError(
+                    f"temporary topology state lease changed before removal: {lock}"
+                )
+            tombstone_fd = os.open(
+                tombstone, os.O_PATH | os.O_CLOEXEC | os.O_NOFOLLOW,
+                dir_fd=parent_fd,
+            )
+            try:
+                opened = os.fstat(tombstone_fd)
+                visible = os.stat(
+                    tombstone, dir_fd=parent_fd, follow_symlinks=False
+                )
+                if (
+                    not stat.S_ISREG(opened.st_mode)
+                    or opened.st_nlink != 1
+                    or (opened.st_dev, opened.st_ino) != expected
+                    or (visible.st_dev, visible.st_ino) != expected
+                    or visible.st_nlink != 1
+                ):
+                    raise WorkspaceError(
+                        f"temporary topology state lease changed before removal: {lock}"
+                    )
+                os.unlink(tombstone, dir_fd=parent_fd)
+            finally:
+                os.close(tombstone_fd)
             os.fsync(parent_fd)
         finally:
             os.close(parent_fd)
@@ -12788,18 +12952,39 @@ class Workspace:
         )
         if not tombstone.exists() and not tombstone.is_symlink():
             return False
-        metadata = tombstone.stat(follow_symlinks=False)
-        if (
-            not stat.S_ISREG(metadata.st_mode)
-            or metadata.st_nlink != 1
-            or (metadata.st_dev, metadata.st_ino)
-            != (lease_identity["device"], lease_identity["inode"])
-        ):
-            raise WorkspaceError(
-                f"temporary topology state lease tombstone is invalid: {tombstone}"
+        parent_fd = os.open(
+            tombstone.parent,
+            os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
+        )
+        try:
+            descriptor = os.open(
+                tombstone.name,
+                os.O_PATH | os.O_CLOEXEC | os.O_NOFOLLOW,
+                dir_fd=parent_fd,
             )
-        tombstone.unlink()
-        _fsync_directory(tombstone.parent)
+            try:
+                metadata = os.fstat(descriptor)
+                visible = os.stat(
+                    tombstone.name, dir_fd=parent_fd, follow_symlinks=False
+                )
+                expected = (lease_identity["device"], lease_identity["inode"])
+                if (
+                    not stat.S_ISREG(metadata.st_mode)
+                    or metadata.st_nlink != 1
+                    or (metadata.st_dev, metadata.st_ino) != expected
+                    or (visible.st_dev, visible.st_ino) != expected
+                    or visible.st_nlink != 1
+                ):
+                    raise WorkspaceError(
+                        "temporary topology state lease tombstone is invalid: "
+                        f"{tombstone}"
+                    )
+                os.unlink(tombstone.name, dir_fd=parent_fd)
+                os.fsync(parent_fd)
+            finally:
+                os.close(descriptor)
+        finally:
+            os.close(parent_fd)
         return True
 
     @staticmethod
@@ -12845,6 +13030,7 @@ class Workspace:
         state_identity: dict[str, int],
         lease_identity: dict[str, int],
         state_directory_fd: int | None = None,
+        implementation: dict[str, str] | None = None,
     ) -> None:
         Workspace._validate_temporary_state_lock(
             state, state_lease, lease_identity
@@ -12859,7 +13045,7 @@ class Workspace:
             close_descriptor = True
         try:
             Workspace._validate_temporary_state_integrity(
-                owned_descriptor, state
+                owned_descriptor, state, implementation
             )
             remove_owned_tree(
                 state,
@@ -12892,7 +13078,7 @@ class Workspace:
                     "temporary state integrity lease is missing before removal"
                 )
             self._validate_temporary_state_integrity(
-                state_directory_fd, state
+                state_directory_fd, state, policy["implementation"]
             )
             pending = {**policy, "lifecycle": "removal-pending"}
             current = self._write_temporary_state_policy(name, current, pending)
@@ -12920,7 +13106,7 @@ class Workspace:
                         "resuming removal"
                     )
                 self._validate_temporary_state_integrity(
-                    state_directory_fd, state
+                    state_directory_fd, state, policy["implementation"]
                 )
                 rename_no_replace(state, tombstone)
                 tombstone_present = True
@@ -12987,6 +13173,13 @@ class Workspace:
             "retained",
         }:
             return status
+        if retain_state and policy.get("lifecycle") in {
+            "removal-pending",
+            "removed",
+        }:
+            raise WorkspaceError(
+                "temporary state removal has already begun and cannot be retained"
+            )
         if not confirmed_clean and policy.get("lifecycle") != "removal-pending":
             if retain_state:
                 raise WorkspaceError(
@@ -13044,7 +13237,7 @@ class Workspace:
                 }:
                     try:
                         self._validate_temporary_state_integrity(
-                            mutation_fd, state
+                            mutation_fd, state, policy["implementation"]
                         )
                     except WorkspaceError as error:
                         retained = {**policy, "lifecycle": "retained"}
@@ -13113,6 +13306,14 @@ class Workspace:
                 raise WorkspaceError(
                     f"temporary topology state is still active: {topology_name}"
                 )
+            if (
+                policy.get("lifecycle") == "promotion-pending"
+                and policy.get("name") != state_name
+            ):
+                raise WorkspaceError(
+                    "temporary state promotion target cannot change while "
+                    f"promotion is pending: {policy.get('name')}"
+                )
             state = Path(policy["path"])
             with ExitStack() as promotion:
                 state_lease = promotion.enter_context(
@@ -13159,6 +13360,9 @@ class Workspace:
                         )
 
                 verify_visible_state()
+                self._validate_temporary_state_integrity(
+                    state_fd, state, policy["implementation"]
+                )
                 with exclusive_lock(
                     self.paths.workspace / "states.lock", "states registry"
                 ):
@@ -13654,6 +13858,7 @@ class Workspace:
                         state_output,
                         generation_root.name,
                         state_fd,
+                        prepared["state_output_identity"],
                     )
             finally:
                 if physical_state_lock_fd is not None:
@@ -13742,6 +13947,11 @@ class Workspace:
                     if _runtime_record["mutable_state_outputs"]
                     else None
                 )
+                state_output_identity = (
+                    _runtime_record["mutable_state_output_identities"][0]
+                    if _runtime_record["mutable_state_output_identities"]
+                    else None
+                )
                 state_lock_fd: int | None = None
                 physical_state_lock_fd: int | None = None
                 try:
@@ -13759,7 +13969,10 @@ class Workspace:
                     try:
                         if state_output is not None:
                             self._remove_runtime_state_output(
-                                state_output, generation, state_fd
+                                state_output,
+                                generation,
+                                state_fd,
+                                state_output_identity,
                             )
                     finally:
                         os.close(state_fd)
@@ -13793,6 +14006,7 @@ class Workspace:
                     "state_lock_fd": state_lock_fd,
                     "physical_state_lock_fd": physical_state_lock_fd,
                     "state_output": state_output,
+                    "state_output_identity": state_output_identity,
                 }
 
     def _foreground_runtime_owner(self) -> Path:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -665,6 +665,16 @@ def _owned_tree_tombstone_path(
     )
 
 
+def _fsync_directory(path: Path) -> None:
+    descriptor = _open_directory_nofollow(
+        path, os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW
+    )
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
 def _remove_owned_tree_contents(
     descriptor: int,
     device: int,
@@ -728,7 +738,10 @@ def _remove_owned_tree_contents(
 
 
 def remove_owned_tree(
-    path: Path, *, expected_identity: dict[str, int] | None = None
+    path: Path,
+    *,
+    expected_identity: dict[str, int] | None = None,
+    keep_root: bool = False,
 ) -> None:
     if expected_identity is not None and (
         set(expected_identity) != {"device", "inode"}
@@ -813,6 +826,9 @@ def remove_owned_tree(
         )
         if (visible.st_dev, visible.st_ino) != expected:
             raise WorkspaceError(f"owned removal root identity changed: {path}")
+        if keep_root:
+            os.fsync(parent_descriptor)
+            return
         tombstone = root_tombstone_name(expected)
         if not already_tombstoned:
             rename_no_replace_at(
@@ -12284,6 +12300,8 @@ class Workspace:
                 stopped, confirmed_clean = self._controlled_topology_down(
                     name, status, timeout
                 )
+                if confirmed_clean:
+                    self._cleanup_topology_mutable_state_outputs(stopped)
                 return self._finish_temporary_state_down(
                     name, stopped, retain_state, confirmed_clean
                 )
@@ -12361,6 +12379,45 @@ class Workspace:
             raise WorkspaceError(
                 f"topology did not stop within {timeout:g} seconds: {name}"
             )
+
+    def _cleanup_topology_mutable_state_outputs(
+        self, status: dict[str, Any]
+    ) -> None:
+        policy = status.get("state_policy")
+        runtime = status.get("runtime")
+        control = status.get("control")
+        if (
+            not isinstance(policy, dict)
+            or policy.get("mode") == "temporary"
+            or not isinstance(runtime, dict)
+            or not isinstance(control, dict)
+        ):
+            return
+        outputs = runtime.get("mutable_state_outputs")
+        if not isinstance(outputs, list) or not outputs:
+            return
+        state = Path(policy["path"])
+        descriptor = self._open_validated_state_directory(
+            state, policy["implementation"], write_implementation=False
+        )
+        try:
+            opened = os.fstat(descriptor)
+            if {"device": opened.st_dev, "inode": opened.st_ino} != policy.get(
+                "identity"
+            ):
+                raise WorkspaceError(
+                    f"server state identity changed before runtime cleanup: {state}"
+                )
+            for value in outputs:
+                output = Path(value)
+                try:
+                    self._remove_runtime_state_output(
+                        output, control["generation"], descriptor
+                    )
+                except FileNotFoundError:
+                    continue
+        finally:
+            os.close(descriptor)
 
     def _controlled_topology_down(
         self, name: str, status: dict[str, Any], timeout: float
@@ -12513,7 +12570,7 @@ class Workspace:
                 f"temporary topology state lease tombstone is invalid: {tombstone}"
             )
         tombstone.unlink()
-        fsync_directory(tombstone.parent)
+        _fsync_directory(tombstone.parent)
         return True
 
     @staticmethod
@@ -12616,12 +12673,27 @@ class Workspace:
                         f"temporary state removal identity is invalid: {tombstone}"
                     )
             if tombstone_present or removal_tombstone_present:
-                remove_owned_tree(tombstone, expected_identity=identity)
+                remove_owned_tree(
+                    tombstone, expected_identity=identity, keep_root=True
+                )
+                if removal_tombstone_present and not tombstone.exists():
+                    rename_no_replace(removal_tombstone, tombstone)
             removed = {**policy, "lifecycle": "removed"}
             current = self._write_temporary_state_policy(name, current, removed)
             policy = current["state_policy"]
-        elif tombstone.exists() or tombstone.is_symlink():
-            remove_owned_tree(tombstone, expected_identity=identity)
+        if tombstone.exists() or tombstone.is_symlink():
+            metadata = tombstone.stat(follow_symlinks=False)
+            if (
+                not stat.S_ISDIR(metadata.st_mode)
+                or (metadata.st_dev, metadata.st_ino)
+                != (identity["device"], identity["inode"])
+                or any(tombstone.iterdir())
+            ):
+                raise WorkspaceError(
+                    f"temporary state removal root is invalid: {tombstone}"
+                )
+            tombstone.rmdir()
+            _fsync_directory(tombstone.parent)
         self._unlink_temporary_state_lock(
             state, state_lease, policy["lease_identity"]
         )

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -1243,7 +1243,11 @@ def _tree_digest(
     return digest.hexdigest()
 
 
-def _tree_digest_descriptor(root_fd: int, display: Path) -> str:
+def _tree_digest_descriptor(
+    root_fd: int,
+    display: Path,
+    root_exclusions: set[str] | None = None,
+) -> str:
     """Hash an exact pinned regular tree without following child links."""
 
     digest = hashlib.sha256()
@@ -1259,6 +1263,8 @@ def _tree_digest_descriptor(root_fd: int, display: Path) -> str:
 
     def visit(directory_fd: int, relative: PurePosixPath) -> None:
         for name in sorted(os.listdir(directory_fd)):
+            if not relative.parts and name in (root_exclusions or set()):
+                continue
             child = relative / name
             child_display = display / child.as_posix()
             metadata = os.stat(
@@ -1305,6 +1311,7 @@ def _tree_digest_descriptor(root_fd: int, display: Path) -> str:
                     opened = os.fstat(descriptor)
                     if (
                         not stat.S_ISREG(opened.st_mode)
+                        or opened.st_nlink != 1
                         or (opened.st_dev, opened.st_ino)
                         != (metadata.st_dev, metadata.st_ino)
                         or _descriptor_mount_id(descriptor) != root_mount
@@ -9363,6 +9370,26 @@ class Workspace:
                 container_fd,
                 staging_name,
             )
+            copied_exclusions = {
+                "tmp",
+                STATE_IMPLEMENTATION_MARKER,
+                MANAGED_MARKER,
+                TEMPORARY_STATE_METADATA,
+            }
+            if (
+                _tree_digest_descriptor(
+                    staging_fd,
+                    destination,
+                    copied_exclusions,
+                )
+                != source_digest
+                or _tree_digest(install_data, set(), reject_symlinks=True)
+                != source_digest
+            ):
+                raise WorkspaceError(
+                    "selected server install_data changed before temporary state "
+                    "publication"
+                )
             visible_staging = os.stat(
                 staging_name, dir_fd=container_fd, follow_symlinks=False
             )
@@ -9376,6 +9403,20 @@ class Workspace:
                 container_fd, staging_name, container_fd, generation
             )
             published_identity = identity
+            if (
+                _tree_digest_descriptor(
+                    staging_fd,
+                    destination,
+                    copied_exclusions,
+                )
+                != source_digest
+                or _tree_digest(install_data, set(), reject_symlinks=True)
+                != source_digest
+            ):
+                raise WorkspaceError(
+                    "selected server install_data changed during temporary state "
+                    "publication"
+                )
             published = os.stat(
                 generation, dir_fd=container_fd, follow_symlinks=False
             )
@@ -9544,7 +9585,8 @@ class Workspace:
                     try:
                         opened = os.fstat(child_fd)
                         if (
-                            (opened.st_dev, opened.st_ino)
+                            opened.st_nlink != 1
+                            or (opened.st_dev, opened.st_ino)
                             != (metadata.st_dev, metadata.st_ino)
                             or _descriptor_mount_id(child_fd) != root_mount
                         ):

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -12485,13 +12485,18 @@ class Workspace:
         if not isinstance(outputs, list) or not outputs:
             return
         state = Path(policy["path"])
-        descriptor = self._open_validated_state_directory(
-            state, policy["implementation"], write_implementation=False
+        descriptor = _open_directory_nofollow(
+            state,
+            os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
         )
         try:
             opened = os.fstat(descriptor)
-            if {"device": opened.st_dev, "inode": opened.st_ino} != policy.get(
-                "identity"
+            visible = state.stat(follow_symlinks=False)
+            identity = policy.get("identity")
+            if (
+                {"device": opened.st_dev, "inode": opened.st_ino} != identity
+                or {"device": visible.st_dev, "inode": visible.st_ino}
+                != identity
             ):
                 raise WorkspaceError(
                     f"server state identity changed before runtime cleanup: {state}"

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -145,6 +145,7 @@ RUNTIME_GENERATION_MANIFEST = "manifest.json"
 STATE_IMPLEMENTATION_MARKER = ".atrinik-state.json"
 STATE_IMPLEMENTATION_SCHEMA_VERSION = 1
 TEMPORARY_STATE_METADATA = "state.json"
+PROMOTED_STATE_METADATA = ".atrinik-promoted-state.json"
 TEMPORARY_STATE_SCHEMA_VERSION = 1
 PRE_MONOREPO_REPOSITORIES = {
     "client": "legacy-client",
@@ -214,6 +215,20 @@ WORKER_NPM_FILE_CONFIG_KEYS = {
 }
 RUNTIME_INPUT_METADATA = ".atrinik-dependency.json"
 RUNTIME_INPUT_SCHEMA_VERSION = 1
+
+
+@dataclass
+class StateLease:
+    path_lock: TextIO
+    bind_identity: Callable[[dict[str, int]], TextIO | None]
+    physical_lock: TextIO | None = None
+
+    def fileno(self) -> int:
+        return self.path_lock.fileno()
+
+    def bind(self, identity: dict[str, int]) -> None:
+        if self.physical_lock is None:
+            self.physical_lock = self.bind_identity(identity)
 
 
 @dataclass(frozen=True)
@@ -7519,7 +7534,20 @@ class Workspace:
         if resolved.exists():
             self._validate_state(resolved)
             temporary_marker = resolved / TEMPORARY_STATE_METADATA
-            if temporary_marker.is_file() and not temporary_marker.is_symlink():
+            ownership_marker = resolved / MANAGED_MARKER
+            ownership = (
+                load_json(ownership_marker)
+                if ownership_marker.is_file() and not ownership_marker.is_symlink()
+                else None
+            )
+            if (
+                temporary_marker.exists()
+                or temporary_marker.is_symlink()
+                or (
+                    isinstance(ownership, dict)
+                    and ownership.get("purpose") == "temporary-topology-state"
+                )
+            ):
                 raise WorkspaceError(
                     "temporary topology state can only be registered through "
                     "state promote"
@@ -8460,35 +8488,27 @@ class Workspace:
     def _promoted_state_owner(
         self, state_name: str, path: Path
     ) -> dict[str, str] | None:
-        if self.paths.topologies.is_symlink() or not self.paths.topologies.is_dir():
+        record_path = path / PROMOTED_STATE_METADATA
+        if record_path.is_symlink() or not record_path.is_file():
             return None
-        for topology in sorted(self.paths.topologies.iterdir()):
-            status_path = topology / "status.json"
-            if status_path.is_symlink() or not status_path.is_file():
-                continue
-            try:
-                status = load_regular_json(status_path, "promoted state status")
-            except WorkspaceError:
-                continue
-            policy = status.get("state_policy") if isinstance(status, dict) else None
-            owner = policy.get("owner") if isinstance(policy, dict) else None
-            if (
-                isinstance(policy, dict)
-                and policy.get("mode") == "temporary"
-                and policy.get("lifecycle") == "promoted"
-                and policy.get("name") == state_name
-                and policy.get("path") == str(path)
-                and isinstance(owner, dict)
-                and owner.get("kind") == "topology-generation"
-                and owner.get("topology") == topology.name
-                and isinstance(owner.get("generation"), str)
-            ):
-                return {
-                    "kind": "promoted-topology-state",
-                    "topology": topology.name,
-                    "generation": owner["generation"],
-                }
-        return None
+        record = load_regular_json(record_path, "promoted state provenance")
+        if (
+            not isinstance(record, dict)
+            or record.get("schema_version") != SCHEMA_VERSION
+            or record.get("name") != state_name
+            or record.get("path") != str(path)
+            or not isinstance(record.get("topology"), str)
+            or not isinstance(record.get("generation"), str)
+            or not re.fullmatch(r"[0-9a-f]{64}", record["generation"])
+        ):
+            raise WorkspaceError(
+                f"promoted state provenance is invalid: {record_path}"
+            )
+        return {
+            "kind": "promoted-topology-state",
+            "topology": record["topology"],
+            "generation": record["generation"],
+        }
 
     def _temporary_state_container(self, topology_root: Path) -> Path:
         container = topology_root / "temporary-states"
@@ -8520,14 +8540,17 @@ class Workspace:
         *,
         preparing_topology: str | None = None,
         physical_identity: bool = True,
-    ) -> Iterator[TextIO]:
+    ) -> Iterator[StateLease]:
         try:
             with ExitStack() as leases:
-                if physical_identity and path.exists() and not path.is_symlink():
-                    identity = self._state_identity(path)
+                state_lease: StateLease
+
+                def bind_identity(identity: dict[str, int]) -> TextIO | None:
+                    if not physical_identity:
+                        return None
                     identity_root = self._lease_namespace / "state-identities"
                     identity_root.mkdir(exist_ok=True)
-                    leases.enter_context(
+                    return leases.enter_context(
                         exclusive_lock(
                             identity_root
                             / f"{identity['device']}-{identity['inode']}.lock",
@@ -8535,13 +8558,16 @@ class Workspace:
                             nonblocking=True,
                         )
                     )
-                lock = leases.enter_context(
+                path_lock = leases.enter_context(
                     exclusive_lock(
                         Path(f"{path}.lock"),
                         f"server state {path}",
                         nonblocking=True,
                     )
                 )
+                state_lease = StateLease(path_lock, bind_identity)
+                if physical_identity and path.exists() and not path.is_symlink():
+                    state_lease.bind(self._state_identity(path))
                 for topology in sorted(self.paths.topologies.iterdir()):
                     if topology.name == preparing_topology:
                         continue
@@ -8592,7 +8618,7 @@ class Workspace:
                             f"{status['name']} generation {control['generation']}; "
                             f"run ./atrinik down {status['name']} and retry"
                         )
-                yield lock
+                yield state_lease
                 return
         except LockBusyError as error:
             owner: tuple[str, str] | None = None
@@ -8640,8 +8666,10 @@ class Workspace:
         )
         created_at = datetime.now(timezone.utc).isoformat()
         install_data = server_source / "install_data"
-        source_digest = _tree_digest(install_data, set(), reject_symlinks=True)
         try:
+            source_digest = _tree_digest(
+                install_data, set(), reject_symlinks=True
+            )
             shutil.copytree(
                 install_data, staging, dirs_exist_ok=True
             )
@@ -9533,8 +9561,21 @@ class Workspace:
                 os.close(marker_fd)
             return output
         except BaseException as error:
-            if created_generation and output.is_dir() and not output.is_symlink():
-                remove_owned_tree(output)
+            if created_generation and len(descriptors) >= 4:
+                generation_fd = descriptors[-1]
+                metadata = os.fstat(generation_fd)
+                mount_id = _descriptor_mount_id(generation_fd)
+                _prepare_owned_tree_removal(
+                    generation_fd,
+                    metadata.st_dev,
+                    mount_id,
+                    output,
+                    stat.S_IMODE(metadata.st_mode),
+                )
+                _remove_owned_tree_contents(
+                    generation_fd, metadata.st_dev, mount_id, output
+                )
+                os.rmdir(generation, dir_fd=descriptors[-2])
             if isinstance(error, WorkspaceError):
                 raise
             if not isinstance(error, (OSError, ValueError)):
@@ -9547,7 +9588,53 @@ class Workspace:
                 os.close(descriptor)
 
     @staticmethod
-    def _remove_runtime_state_output(path: Path, generation: str) -> None:
+    def _remove_runtime_state_output(
+        path: Path,
+        generation: str,
+        state_directory_fd: int | None = None,
+    ) -> None:
+        if state_directory_fd is not None:
+            flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+            descriptors = [os.dup(state_directory_fd)]
+            try:
+                for name in ("tmp", "runtime-assets"):
+                    descriptors.append(os.open(name, flags, dir_fd=descriptors[-1]))
+                parent_fd = descriptors[-1]
+                metadata = os.stat(
+                    generation, dir_fd=parent_fd, follow_symlinks=False
+                )
+                generation_fd = os.open(generation, flags, dir_fd=parent_fd)
+                descriptors.append(generation_fd)
+                marker_fd = os.open(
+                    MANAGED_MARKER,
+                    os.O_RDONLY | os.O_NOFOLLOW,
+                    dir_fd=generation_fd,
+                )
+                with os.fdopen(marker_fd, encoding="utf-8") as stream:
+                    marker = json.load(stream)
+                if marker != {
+                    "schema_version": SCHEMA_VERSION,
+                    "purpose": f"runtime-state-output:{generation}",
+                }:
+                    raise WorkspaceError(
+                        f"server runtime state output ownership is invalid: {path}"
+                    )
+                mount_id = _descriptor_mount_id(generation_fd)
+                _prepare_owned_tree_removal(
+                    generation_fd,
+                    metadata.st_dev,
+                    mount_id,
+                    path,
+                    stat.S_IMODE(metadata.st_mode),
+                )
+                _remove_owned_tree_contents(
+                    generation_fd, metadata.st_dev, mount_id, path
+                )
+                os.rmdir(generation, dir_fd=parent_fd)
+                return
+            finally:
+                for descriptor in reversed(descriptors):
+                    os.close(descriptor)
         marker = path / MANAGED_MARKER
         if (
             path.is_symlink()
@@ -9743,7 +9830,12 @@ class Workspace:
                     server_runtime / "resources",
                 )
                 (server_runtime / "data").symlink_to(
-                    state, target_is_directory=True
+                    (
+                        Path(f"/proc/self/fd/{state_directory_fd}")
+                        if state_directory_fd is not None
+                        else state
+                    ),
+                    target_is_directory=True,
                 )
                 state_output = self._prepare_runtime_state_output(
                     state, generation, state_directory_fd
@@ -9851,8 +9943,13 @@ class Workspace:
         except BaseException:
             if staging.exists():
                 remove_owned_tree(staging)
-            if state_output is not None and state_output.exists():
-                self._remove_runtime_state_output(state_output, generation)
+            cleanup_output = state_output_access or state_output
+            if cleanup_output is not None and cleanup_output.exists():
+                self._remove_runtime_state_output(
+                    state_output or cleanup_output,
+                    generation,
+                    state_directory_fd,
+                )
             raise
         finally:
             if lease_fd is not None:
@@ -11370,6 +11467,13 @@ class Workspace:
                             state_expected_identity,
                         )
                         stack.callback(os.close, state_directory_fd)
+                        opened_state = os.fstat(state_directory_fd)
+                        state_lock.bind(
+                            {
+                                "device": opened_state.st_dev,
+                                "inode": opened_state.st_ino,
+                            }
+                        )
                         state_policy = self._persistent_state_policy(
                             state_name, state, implementation
                         )
@@ -11485,11 +11589,20 @@ class Workspace:
                     else None
                 )
                 published_state_output_owner = [
-                    Path(runtime_record["mutable_state_outputs"][0])
+                    (
+                        Path(f"/proc/self/fd/{state_directory_fd}")
+                        / "tmp"
+                        / "runtime-assets"
+                        / generation
+                        if state_directory_fd is not None
+                        else Path(runtime_record["mutable_state_outputs"][0])
+                    )
                 ] if runtime_record["mutable_state_outputs"] else []
                 stack.callback(
                     lambda: self._remove_runtime_state_output(
-                        published_state_output_owner.pop(), generation
+                        published_state_output_owner.pop(),
+                        generation,
+                        state_directory_fd,
                     )
                     if published_state_output_owner
                     else None
@@ -11631,6 +11744,16 @@ class Workspace:
                     if state_lock is not None:
                         command.extend(["--lock-fd", str(state_lock.fileno())])
                         inherited_locks.append(state_lock.fileno())
+                        if state_lock.physical_lock is not None:
+                            command.extend(
+                                [
+                                    "--physical-state-lock-fd",
+                                    str(state_lock.physical_lock.fileno()),
+                                ]
+                            )
+                            inherited_locks.append(
+                                state_lock.physical_lock.fileno()
+                            )
                     if state_directory_fd is not None:
                         command.extend(
                             ["--state-directory-fd", str(state_directory_fd)]
@@ -12093,6 +12216,35 @@ class Workspace:
                         status = self._write_temporary_state_policy(
                             topology_name, status, pending
                         )
+                    owner = pending.get("owner")
+                    if not isinstance(owner, dict) or not isinstance(
+                        owner.get("generation"), str
+                    ):
+                        raise WorkspaceError(
+                            "temporary state promotion owner is invalid"
+                        )
+                    provenance = {
+                        "schema_version": SCHEMA_VERSION,
+                        "name": state_name,
+                        "path": str(state),
+                        "topology": topology_name,
+                        "generation": owner["generation"],
+                    }
+                    provenance_path = state / PROMOTED_STATE_METADATA
+                    if provenance_path.exists() or provenance_path.is_symlink():
+                        if (
+                            provenance_path.is_symlink()
+                            or not provenance_path.is_file()
+                            or load_regular_json(
+                                provenance_path, "promoted state provenance"
+                            )
+                            != provenance
+                        ):
+                            raise WorkspaceError(
+                                f"promoted state provenance is invalid: {provenance_path}"
+                            )
+                    else:
+                        durable_atomic_json(provenance_path, provenance)
                     if existing is None:
                         states[state_name] = str(state)
                         durable_atomic_json(
@@ -12454,6 +12606,7 @@ class Workspace:
         runtime_fd = prepared["runtime_fd"]
         state_fd = prepared["state_fd"]
         state_lock_fd = prepared["state_lock_fd"]
+        physical_state_lock_fd = prepared["physical_state_lock_fd"]
         generation_root = prepared["generation_root"]
         state_output = prepared["state_output"]
         try:
@@ -12462,18 +12615,33 @@ class Workspace:
                     prepared["command"],
                     cwd=prepared["cwd"],
                     diagnostics_to_stderr=False,
-                    pass_fds=(runtime_fd, state_fd, state_lock_fd),
+                    pass_fds=tuple(
+                        descriptor
+                        for descriptor in (
+                            runtime_fd,
+                            state_fd,
+                            state_lock_fd,
+                            physical_state_lock_fd,
+                        )
+                        if descriptor is not None
+                    ),
                 )
             return prepared["executable"]
         finally:
-            os.close(state_lock_fd)
-            os.close(state_fd)
-            os.close(runtime_fd)
-            remove_owned_tree(generation_root)
-            if state_output is not None:
-                self._remove_runtime_state_output(
-                    state_output, generation_root.name
-                )
+            try:
+                if state_output is not None:
+                    self._remove_runtime_state_output(
+                        state_output,
+                        generation_root.name,
+                        state_fd,
+                    )
+            finally:
+                if physical_state_lock_fd is not None:
+                    os.close(physical_state_lock_fd)
+                os.close(state_lock_fd)
+                os.close(state_fd)
+                os.close(runtime_fd)
+                remove_owned_tree(generation_root)
 
     def _run_server(
         self,
@@ -12515,6 +12683,13 @@ class Workspace:
                 )
                 assert isinstance(prepared_state, tuple)
                 state, state_fd = prepared_state
+                opened_state = os.fstat(state_fd)
+                state_lock.bind(
+                    {
+                        "device": opened_state.st_dev,
+                        "inode": opened_state.st_ino,
+                    }
+                )
                 generation = secrets.token_hex(32)
                 try:
                     generation_root, runtime_fd, _runtime_record = (
@@ -12539,6 +12714,11 @@ class Workspace:
                     os.close(state_fd)
                     raise
                 state_lock_fd = os.dup(state_lock.fileno())
+                physical_state_lock_fd = (
+                    os.dup(state_lock.physical_lock.fileno())
+                    if state_lock.physical_lock is not None
+                    else None
+                )
                 runtime = generation_root / "server"
                 executable = runtime / "atrinik-server"
                 command = [
@@ -12563,6 +12743,7 @@ class Workspace:
                     "runtime_fd": runtime_fd,
                     "state_fd": state_fd,
                     "state_lock_fd": state_lock_fd,
+                    "physical_state_lock_fd": physical_state_lock_fd,
                     "state_output": (
                         Path(_runtime_record["mutable_state_outputs"][0])
                         if _runtime_record["mutable_state_outputs"]

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -8570,6 +8570,7 @@ class Workspace:
             "created_at",
             "identity",
             "implementation",
+            "profile",
             "server",
         }
         return bool(
@@ -8810,6 +8811,7 @@ class Workspace:
                         )
             return None
         record = load_regular_json(record_path, "promoted state provenance")
+        identity = record.get("identity") if isinstance(record, dict) else None
         if (
             not isinstance(record, dict)
             or record.get("schema_version") != SCHEMA_VERSION
@@ -8818,6 +8820,27 @@ class Workspace:
             or not isinstance(record.get("topology"), str)
             or not isinstance(record.get("generation"), str)
             or not re.fullmatch(r"[0-9a-f]{64}", record["generation"])
+            or not isinstance(identity, dict)
+            or set(identity) != {"device", "inode"}
+            or not all(
+                isinstance(value, int)
+                and not isinstance(value, bool)
+                and value >= 0
+                for value in identity.values()
+            )
+        ):
+            raise WorkspaceError(
+                f"promoted state provenance is invalid: {record_path}"
+            )
+        try:
+            visible = path.stat(follow_symlinks=False)
+        except OSError as error:
+            raise WorkspaceError(
+                f"promoted state provenance is invalid: {record_path}: {error}"
+            ) from error
+        if (
+            not stat.S_ISDIR(visible.st_mode)
+            or {"device": visible.st_dev, "inode": visible.st_ino} != identity
         ):
             raise WorkspaceError(
                 f"promoted state provenance is invalid: {record_path}"
@@ -8996,6 +9019,7 @@ class Workspace:
         self,
         topology_root: Path,
         topology_name: str,
+        profile_name: str,
         generation: str,
         server_source: Path,
         implementation: dict[str, str],
@@ -9051,6 +9075,7 @@ class Workspace:
                 "created_at": created_at,
                 "identity": identity,
                 "implementation": implementation,
+                "profile": profile_name,
                 "server": server_coordinate,
             }
             durable_atomic_json(
@@ -9144,6 +9169,25 @@ class Workspace:
                             f"temporary server state contains a hard-linked file: "
                             f"{child_display}"
                         )
+                    flags = os.O_NOFOLLOW
+                    if sys.platform == "linux":
+                        flags |= os.O_PATH
+                    else:
+                        flags |= os.O_RDONLY | os.O_NONBLOCK
+                    child_fd = os.open(name, flags, dir_fd=descriptor)
+                    try:
+                        opened = os.fstat(child_fd)
+                        if (
+                            (opened.st_dev, opened.st_ino)
+                            != (metadata.st_dev, metadata.st_ino)
+                            or _descriptor_mount_id(child_fd) != root_mount
+                        ):
+                            raise WorkspaceError(
+                                "temporary server state file changed or crossed "
+                                f"a mount during validation: {child_display}"
+                            )
+                    finally:
+                        os.close(child_fd)
                     continue
                 if not stat.S_ISDIR(metadata.st_mode):
                     raise WorkspaceError(
@@ -10722,7 +10766,11 @@ class Workspace:
         policy = status.get("state_policy")
         state = status.get("state")
         services = status.get("services")
-        server_present = isinstance(services, dict) and "server" in services
+        server_present = (
+            state is not None
+            or policy is not None
+            or isinstance(services, dict) and "server" in services
+        )
         if not server_present:
             if policy is not None or state is not None:
                 raise WorkspaceError(f"topology state policy is invalid: {name}")
@@ -10740,7 +10788,11 @@ class Workspace:
             "implementation",
         }
         mode = policy.get("mode")
-        expected_keys = common | ({"created_at", "server"} if mode == "temporary" else set())
+        expected_keys = common | (
+            {"created_at", "profile", "server"}
+            if mode == "temporary"
+            else set()
+        )
         identity = policy.get("identity")
         lease_identity = policy.get("lease_identity")
         implementation = policy.get("implementation")
@@ -10809,6 +10861,7 @@ class Workspace:
                 }
                 or not isinstance(policy.get("created_at"), str)
                 or not policy["created_at"]
+                or policy.get("profile") != status.get("profile")
                 or policy.get("server") != resolved[providers["server"]]
             ):
                 raise WorkspaceError(f"temporary topology state policy is invalid: {name}")
@@ -11981,6 +12034,7 @@ class Workspace:
                         state, state_policy = self._create_temporary_state(
                             topology_root,
                             name,
+                            profile_name,
                             generation,
                             selected["server"],
                             implementation,
@@ -13094,6 +13148,7 @@ class Workspace:
                         "path": str(state),
                         "topology": topology_name,
                         "generation": owner["generation"],
+                        "identity": policy["identity"],
                     }
                     provenance_path = state / PROMOTED_STATE_METADATA
                     try:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -652,6 +652,19 @@ def _prepare_owned_tree_removal(
             ) from restore_error
 
 
+def _owned_tree_tombstone_name(name: str, device: int, inode: int) -> str:
+    digest = hashlib.sha256(name.encode("utf-8")).hexdigest()[:16]
+    return f".remove-{digest}-{device:x}-{inode:x}"
+
+
+def _owned_tree_tombstone_path(
+    path: Path, identity: dict[str, int]
+) -> Path:
+    return path.parent / _owned_tree_tombstone_name(
+        path.name, identity["device"], identity["inode"]
+    )
+
+
 def _remove_owned_tree_contents(
     descriptor: int,
     device: int,
@@ -659,7 +672,9 @@ def _remove_owned_tree_contents(
     display: Path,
 ) -> None:
     def move_to_tombstone(name: str, child: os.stat_result) -> str:
-        tombstone = f".{name}.remove-{child.st_dev:x}-{child.st_ino:x}"
+        tombstone = _owned_tree_tombstone_name(
+            name, child.st_dev, child.st_ino
+        )
         rename_no_replace_at(descriptor, name, descriptor, tombstone)
         moved = os.stat(tombstone, dir_fd=descriptor, follow_symlinks=False)
         if (moved.st_dev, moved.st_ino) != (
@@ -679,11 +694,11 @@ def _remove_owned_tree_contents(
         child_display = display / name
         child = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
         tombstone_match = re.fullmatch(
-            r"\.(.+)\.remove-([0-9a-f]+)-([0-9a-f]+)", name
+            r"\.remove-[0-9a-f]{16}-([0-9a-f]+)-([0-9a-f]+)", name
         )
         if tombstone_match and (child.st_dev, child.st_ino) != (
+            int(tombstone_match.group(1), 16),
             int(tombstone_match.group(2), 16),
-            int(tombstone_match.group(3), 16),
         ):
             raise WorkspaceError(
                 f"owned removal has an uncertain tombstone: {child_display}"
@@ -723,6 +738,14 @@ def remove_owned_tree(
         )
     ):
         raise WorkspaceError(f"owned removal root identity is invalid: {path}")
+    def root_tombstone_name(identity: dict[str, int] | tuple[int, int]) -> str:
+        device, inode = (
+            (identity["device"], identity["inode"])
+            if isinstance(identity, dict)
+            else identity
+        )
+        return _owned_tree_tombstone_name(path.name, device, inode)
+
     parent_descriptor = _open_directory_nofollow(
         path.parent,
         os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
@@ -738,10 +761,7 @@ def remove_owned_tree(
         except FileNotFoundError:
             if expected_identity is None:
                 raise WorkspaceError(f"owned removal root is invalid: {path}")
-            entry_name = (
-                f".{path.name}.remove-{expected_identity['device']:x}-"
-                f"{expected_identity['inode']:x}"
-            )
+            entry_name = root_tombstone_name(expected_identity)
             try:
                 before = os.stat(
                     entry_name, dir_fd=parent_descriptor, follow_symlinks=False
@@ -793,7 +813,7 @@ def remove_owned_tree(
         )
         if (visible.st_dev, visible.st_ino) != expected:
             raise WorkspaceError(f"owned removal root identity changed: {path}")
-        tombstone = f".{path.name}.remove-{expected[0]:x}-{expected[1]:x}"
+        tombstone = root_tombstone_name(expected)
         if not already_tombstoned:
             rename_no_replace_at(
                 parent_descriptor,
@@ -8178,15 +8198,18 @@ class Workspace:
                 and isinstance(value.get("checkout_path"), str)
             }
             state = root / "state"
-            with exclusive_lock(
-                Path(f"{state}.lock"),
-                f"server state {state}",
-                nonblocking=True,
-            ):
-                staging_root = Path(
-                    tempfile.mkdtemp(prefix=f".{name}-reset-", dir=self.paths.scenarios)
+            with self._topology_state_lock(state):
+                state_identity = self._state_identity(state)
+                state_fd = self._lock_state_directory_mutation(
+                    state, state_identity, "scenario server state"
                 )
+                staging_root: Path | None = None
                 try:
+                    staging_root = Path(
+                        tempfile.mkdtemp(
+                            prefix=f".{name}-reset-", dir=self.paths.scenarios
+                        )
+                    )
                     server_source = self.component_path("server", metadata["profile"])
                     staging_state = self.state_path(
                         metadata["state"],
@@ -8204,7 +8227,8 @@ class Workspace:
                     durable_atomic_json(root / "scenario.json", metadata)
                     self._publish_scenario_references(name, metadata)
                 finally:
-                    if staging_root.exists():
+                    os.close(state_fd)
+                    if staging_root is not None and staging_root.exists():
                         shutil.rmtree(staging_root)
         return self.scenario_show(name)
 
@@ -9855,7 +9879,9 @@ class Workspace:
                     generation_fd, metadata.st_dev, mount_id, output
                 )
                 parent_fd = descriptors[-2]
-                tombstone = f".{generation}.remove-{secrets.token_hex(16)}"
+                tombstone = _owned_tree_tombstone_name(
+                    generation, metadata.st_dev, metadata.st_ino
+                )
                 rename_no_replace_at(
                     parent_fd, generation, parent_fd, tombstone
                 )
@@ -9918,9 +9944,40 @@ class Workspace:
                 for name in ("tmp", "runtime-assets"):
                     descriptors.append(open_exact_directory(descriptors[-1], name))
                 parent_fd = descriptors[-1]
-                generation_fd = open_exact_directory(parent_fd, generation)
+                entry_name = generation
+                already_tombstoned = False
+                try:
+                    generation_fd = open_exact_directory(parent_fd, entry_name)
+                except FileNotFoundError:
+                    digest = hashlib.sha256(
+                        generation.encode("utf-8")
+                    ).hexdigest()[:16]
+                    candidates = [
+                        name
+                        for name in os.listdir(parent_fd)
+                        if re.fullmatch(
+                            rf"\.remove-{digest}-[0-9a-f]+-[0-9a-f]+", name
+                        )
+                    ]
+                    if len(candidates) != 1:
+                        raise
+                    entry_name = candidates[0]
+                    generation_fd = open_exact_directory(parent_fd, entry_name)
+                    already_tombstoned = True
                 descriptors.append(generation_fd)
                 metadata = os.fstat(generation_fd)
+                if already_tombstoned:
+                    match = re.fullmatch(
+                        r"\.remove-[0-9a-f]{16}-([0-9a-f]+)-([0-9a-f]+)",
+                        entry_name,
+                    )
+                    if match is None or (metadata.st_dev, metadata.st_ino) != (
+                        int(match.group(1), 16),
+                        int(match.group(2), 16),
+                    ):
+                        raise WorkspaceError(
+                            f"server runtime state output tombstone is invalid: {path}"
+                        )
                 marker_fd = os.open(
                     MANAGED_MARKER,
                     os.O_RDONLY | os.O_NOFOLLOW,
@@ -9947,7 +10004,7 @@ class Workspace:
                     generation_fd, metadata.st_dev, mount_id, path
                 )
                 visible = os.stat(
-                    generation, dir_fd=parent_fd, follow_symlinks=False
+                    entry_name, dir_fd=parent_fd, follow_symlinks=False
                 )
                 opened = os.fstat(generation_fd)
                 if (visible.st_dev, visible.st_ino) != (
@@ -9957,10 +10014,13 @@ class Workspace:
                     raise WorkspaceError(
                         f"server runtime state output path changed: {path}"
                     )
-                tombstone = f".{generation}.remove-{secrets.token_hex(16)}"
-                rename_no_replace_at(
-                    parent_fd, generation, parent_fd, tombstone
+                tombstone = _owned_tree_tombstone_name(
+                    generation, opened.st_dev, opened.st_ino
                 )
+                if not already_tombstoned:
+                    rename_no_replace_at(
+                        parent_fd, generation, parent_fd, tombstone
+                    )
                 moved = os.stat(
                     tombstone, dir_fd=parent_fd, follow_symlinks=False
                 )
@@ -12457,6 +12517,42 @@ class Workspace:
         return True
 
     @staticmethod
+    def _lock_state_directory_mutation(
+        path: Path,
+        identity: dict[str, int],
+        description: str = "temporary state",
+    ) -> int:
+        descriptor = _open_directory_nofollow(
+            path, os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW
+        )
+        try:
+            opened = os.fstat(descriptor)
+            visible = path.stat(follow_symlinks=False)
+            expected = (identity["device"], identity["inode"])
+            if (
+                not stat.S_ISDIR(opened.st_mode)
+                or (opened.st_dev, opened.st_ino) != expected
+                or (visible.st_dev, visible.st_ino) != expected
+            ):
+                raise WorkspaceError(
+                    f"{description} identity changed before mutation: {path}"
+                )
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError as error:
+                if error.errno in {errno.EACCES, errno.EAGAIN}:
+                    raise WorkspaceError(
+                        f"{description} is already in use: {path}"
+                    ) from error
+                raise WorkspaceError(
+                    f"cannot lock {description} for mutation: {path}: {error}"
+                ) from error
+            return descriptor
+        except BaseException:
+            os.close(descriptor)
+            raise
+
+    @staticmethod
     def _rollback_temporary_state_creation(
         state: Path,
         state_lease: TextIO,
@@ -12491,6 +12587,10 @@ class Workspace:
         if lifecycle == "removal-pending":
             state_present = state.exists() or state.is_symlink()
             tombstone_present = tombstone.exists() or tombstone.is_symlink()
+            removal_tombstone = _owned_tree_tombstone_path(tombstone, identity)
+            removal_tombstone_present = (
+                removal_tombstone.exists() or removal_tombstone.is_symlink()
+            )
             if state_present and tombstone_present:
                 raise WorkspaceError(
                     f"temporary state removal paths conflict: {state}"
@@ -12515,6 +12615,7 @@ class Workspace:
                     raise WorkspaceError(
                         f"temporary state removal identity is invalid: {tombstone}"
                     )
+            if tombstone_present or removal_tombstone_present:
                 remove_owned_tree(tombstone, expected_identity=identity)
             removed = {**policy, "lifecycle": "removed"}
             current = self._write_temporary_state_policy(name, current, removed)
@@ -12573,9 +12674,31 @@ class Workspace:
             if retain_state:
                 retained = {**policy, "lifecycle": "retained"}
                 return self._write_temporary_state_policy(name, current, retained)
-            return self._commit_temporary_state_removal(
-                name, current, state_lease
+            removal_path = self._temporary_state_removal_path(policy)
+            removal_root_tombstone = _owned_tree_tombstone_path(
+                removal_path, policy["identity"]
             )
+            mutation_path = next(
+                (
+                    candidate
+                    for candidate in (state, removal_path, removal_root_tombstone)
+                    if candidate.exists() or candidate.is_symlink()
+                ),
+                None,
+            )
+            if mutation_path is None:
+                return self._commit_temporary_state_removal(
+                    name, current, state_lease
+                )
+            mutation_fd = self._lock_state_directory_mutation(
+                mutation_path, policy["identity"]
+            )
+            try:
+                return self._commit_temporary_state_removal(
+                    name, current, state_lease
+                )
+            finally:
+                os.close(mutation_fd)
 
     def state_promote(self, topology_name: str, state_name: str) -> dict[str, Any]:
         """Promote one stopped, explicitly retained temporary state in place."""
@@ -12646,6 +12769,16 @@ class Workspace:
                 )
                 promotion.callback(os.close, state_fd)
                 opened_state = os.fstat(state_fd)
+                try:
+                    fcntl.flock(state_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except OSError as error:
+                    if error.errno in {errno.EACCES, errno.EAGAIN}:
+                        raise WorkspaceError(
+                            f"temporary state is already in use: {state}"
+                        ) from error
+                    raise WorkspaceError(
+                        f"cannot lock temporary state for promotion: {state}: {error}"
+                    ) from error
 
                 def verify_visible_state() -> None:
                     visible_state = state.stat(follow_symlinks=False)

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -222,13 +222,21 @@ class StateLease:
     path_lock: TextIO
     bind_identity: Callable[[dict[str, int]], TextIO | None]
     physical_lock: TextIO | None = None
+    physical_identity: dict[str, int] | None = None
 
     def fileno(self) -> int:
         return self.path_lock.fileno()
 
     def bind(self, identity: dict[str, int]) -> None:
-        if self.physical_lock is None:
-            self.physical_lock = self.bind_identity(identity)
+        if self.physical_lock is not None:
+            if self.physical_identity != identity:
+                raise WorkspaceError(
+                    "server state identity changed while acquiring its lease"
+                )
+            return
+        self.physical_lock = self.bind_identity(identity)
+        if self.physical_lock is not None:
+            self.physical_identity = dict(identity)
 
 
 @dataclass(frozen=True)
@@ -1309,6 +1317,64 @@ def load_regular_json(path: Path, description: str, *, limit: int = 4 * 1024 * 1
             return json.load(stream, object_pairs_hook=_reject_duplicate_keys)
     except (OSError, UnicodeError, ValueError, RecursionError) as error:
         raise WorkspaceError(f"cannot read {description} {path}: {error}") from error
+    finally:
+        os.close(descriptor)
+
+
+def durable_atomic_json_at(directory_fd: int, name: str, value: Any) -> None:
+    """Durably replace one JSON file relative to an already pinned directory."""
+
+    if Path(name).name != name:
+        raise WorkspaceError(f"descriptor-relative JSON name is invalid: {name}")
+    temporary = f".{name}.{secrets.token_hex(12)}.tmp"
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            0o600,
+            dir_fd=directory_fd,
+        )
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            descriptor = None
+            json.dump(value, stream, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.rename(
+            temporary,
+            name,
+            src_dir_fd=directory_fd,
+            dst_dir_fd=directory_fd,
+        )
+        os.fsync(directory_fd)
+    except BaseException:
+        try:
+            os.unlink(temporary, dir_fd=directory_fd)
+        except FileNotFoundError:
+            pass
+        raise
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def load_regular_json_at(
+    directory_fd: int, name: str, description: str, *, limit: int = 4 * 1024 * 1024
+) -> Any:
+    descriptor = os.open(name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=directory_fd)
+    try:
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+            or metadata.st_size > limit
+        ):
+            raise WorkspaceError(f"{description} identity is unsafe: {name}")
+        with os.fdopen(descriptor, encoding="utf-8", closefd=False) as stream:
+            return json.load(stream, object_pairs_hook=_reject_duplicate_keys)
+    except (OSError, UnicodeError, ValueError, RecursionError) as error:
+        raise WorkspaceError(f"cannot read {description} {name}: {error}") from error
     finally:
         os.close(descriptor)
 
@@ -8490,6 +8556,40 @@ class Workspace:
     ) -> dict[str, str] | None:
         record_path = path / PROMOTED_STATE_METADATA
         if record_path.is_symlink() or not record_path.is_file():
+            ownership_path = path / MANAGED_MARKER
+            ownership = (
+                load_regular_json(ownership_path, "promoted state ownership")
+                if ownership_path.is_file() and not ownership_path.is_symlink()
+                else None
+            )
+            if (
+                isinstance(ownership, dict)
+                and ownership.get("purpose") == "temporary-topology-state"
+            ):
+                raise WorkspaceError(
+                    f"promoted state provenance is missing: {record_path}; "
+                    "retry its originating state promote command"
+                )
+            if self.paths.topologies.is_dir() and not self.paths.topologies.is_symlink():
+                for topology in self.paths.topologies.iterdir():
+                    status_path = topology / "status.json"
+                    if status_path.is_symlink() or not status_path.is_file():
+                        continue
+                    status = load_regular_json(
+                        status_path, "promoted state origin status"
+                    )
+                    policy = status.get("state_policy") if isinstance(status, dict) else None
+                    if (
+                        isinstance(policy, dict)
+                        and policy.get("mode") == "temporary"
+                        and policy.get("lifecycle") in {"promotion-pending", "promoted"}
+                        and policy.get("name") == state_name
+                        and policy.get("path") == str(path)
+                    ):
+                        raise WorkspaceError(
+                            f"promoted state provenance is missing: {record_path}; "
+                            f"retry ./atrinik state promote {topology.name} {state_name}"
+                        )
             return None
         record = load_regular_json(record_path, "promoted state provenance")
         if (
@@ -8541,6 +8641,11 @@ class Workspace:
         preparing_topology: str | None = None,
         physical_identity: bool = True,
     ) -> Iterator[StateLease]:
+        requested_identity = (
+            self._state_identity(path)
+            if physical_identity and path.exists() and not path.is_symlink()
+            else None
+        )
         try:
             with ExitStack() as leases:
                 state_lease: StateLease
@@ -8566,8 +8671,8 @@ class Workspace:
                     )
                 )
                 state_lease = StateLease(path_lock, bind_identity)
-                if physical_identity and path.exists() and not path.is_symlink():
-                    state_lease.bind(self._state_identity(path))
+                if requested_identity is not None:
+                    state_lease.bind(requested_identity)
                 for topology in sorted(self.paths.topologies.iterdir()):
                     if topology.name == preparing_topology:
                         continue
@@ -8585,10 +8690,20 @@ class Workspace:
                             "cannot confirm exact server state ownership while "
                             f"topology status is uncertain: {path}"
                         ) from error
-                    if (
-                        not isinstance(raw_status, dict)
-                        or raw_status.get("state") != str(path)
-                    ):
+                    raw_policy = (
+                        raw_status.get("state_policy")
+                        if isinstance(raw_status, dict)
+                        else None
+                    )
+                    same_state = isinstance(raw_status, dict) and (
+                        raw_status.get("state") == str(path)
+                        or (
+                            requested_identity is not None
+                            and isinstance(raw_policy, dict)
+                            and raw_policy.get("identity") == requested_identity
+                        )
+                    )
+                    if not same_state:
                         continue
                     try:
                         status = self.topology_status(topology.name)
@@ -8608,7 +8723,14 @@ class Workspace:
                     observation = status.get("observation")
                     control = status.get("control")
                     if (
-                        status.get("state") == str(path)
+                        (
+                            status.get("state") == str(path)
+                            or (
+                                requested_identity is not None
+                                and status.get("state_policy", {}).get("identity")
+                                == requested_identity
+                            )
+                        )
                         and isinstance(observation, dict)
                         and observation.get("process_tree_lease") == "retained"
                         and isinstance(control, dict)
@@ -8627,7 +8749,14 @@ class Workspace:
                     observation = status.get("observation")
                     control = status.get("control")
                     if (
-                        status.get("state") == str(path)
+                        (
+                            status.get("state") == str(path)
+                            or (
+                                requested_identity is not None
+                                and status.get("state_policy", {}).get("identity")
+                                == requested_identity
+                            )
+                        )
                         and isinstance(observation, dict)
                         and observation.get("process_tree_lease") == "retained"
                         and isinstance(control, dict)
@@ -9596,15 +9725,31 @@ class Workspace:
         if state_directory_fd is not None:
             flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
             descriptors = [os.dup(state_directory_fd)]
+
+            def open_exact_directory(parent: int, name: str) -> int:
+                visible = os.stat(name, dir_fd=parent, follow_symlinks=False)
+                if not stat.S_ISDIR(visible.st_mode):
+                    raise WorkspaceError(
+                        f"server runtime state output path is invalid: {path}"
+                    )
+                descriptor = os.open(name, flags, dir_fd=parent)
+                opened = os.fstat(descriptor)
+                if Workspace._runtime_tree_identity(opened) != (
+                    Workspace._runtime_tree_identity(visible)
+                ):
+                    os.close(descriptor)
+                    raise WorkspaceError(
+                        f"server runtime state output path changed: {path}"
+                    )
+                return descriptor
+
             try:
                 for name in ("tmp", "runtime-assets"):
-                    descriptors.append(os.open(name, flags, dir_fd=descriptors[-1]))
+                    descriptors.append(open_exact_directory(descriptors[-1], name))
                 parent_fd = descriptors[-1]
-                metadata = os.stat(
-                    generation, dir_fd=parent_fd, follow_symlinks=False
-                )
-                generation_fd = os.open(generation, flags, dir_fd=parent_fd)
+                generation_fd = open_exact_directory(parent_fd, generation)
                 descriptors.append(generation_fd)
+                metadata = os.fstat(generation_fd)
                 marker_fd = os.open(
                     MANAGED_MARKER,
                     os.O_RDONLY | os.O_NOFOLLOW,
@@ -9630,6 +9775,17 @@ class Workspace:
                 _remove_owned_tree_contents(
                     generation_fd, metadata.st_dev, mount_id, path
                 )
+                visible = os.stat(
+                    generation, dir_fd=parent_fd, follow_symlinks=False
+                )
+                opened = os.fstat(generation_fd)
+                if (visible.st_dev, visible.st_ino) != (
+                    opened.st_dev,
+                    opened.st_ino,
+                ):
+                    raise WorkspaceError(
+                        f"server runtime state output path changed: {path}"
+                    )
                 os.rmdir(generation, dir_fd=parent_fd)
                 return
             finally:
@@ -12159,7 +12315,10 @@ class Workspace:
                     policy.get("name") == state_name
                     and states.get(state_name) is not None
                     and self._canonical_state_path(Path(states[state_name])) == state
+                    and (state / PROMOTED_STATE_METADATA).is_file()
+                    and not (state / PROMOTED_STATE_METADATA).is_symlink()
                 ):
+                    self._promoted_state_owner(state_name, state)
                     return {
                         "topology": topology_name,
                         "name": state_name,
@@ -12169,7 +12328,8 @@ class Workspace:
             if (
                 not isinstance(policy, dict)
                 or policy.get("mode") != "temporary"
-                or policy.get("lifecycle") not in {"retained", "promotion-pending"}
+                or policy.get("lifecycle")
+                not in {"retained", "promotion-pending", "promoted"}
             ):
                 raise WorkspaceError(
                     f"topology does not have a retained temporary state: {topology_name}"
@@ -12183,11 +12343,38 @@ class Workspace:
                     f"temporary topology state is still active: {topology_name}"
                 )
             state = Path(policy["path"])
-            with exclusive_lock(
-                Path(f"{state}.lock"),
-                f"temporary topology state {state}",
-                nonblocking=True,
-            ):
+            with ExitStack() as promotion:
+                promotion.enter_context(
+                    exclusive_lock(
+                        Path(f"{state}.lock"),
+                        f"temporary topology state {state}",
+                        nonblocking=True,
+                    )
+                )
+                state_fd = os.open(
+                    state, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+                )
+                promotion.callback(os.close, state_fd)
+                opened_state = os.fstat(state_fd)
+
+                def verify_visible_state() -> None:
+                    visible_state = state.stat(follow_symlinks=False)
+                    if (
+                        not stat.S_ISDIR(visible_state.st_mode)
+                        or self._canonical_state_path(state) != state
+                        or {
+                            "device": opened_state.st_dev,
+                            "inode": opened_state.st_ino,
+                        }
+                        != policy.get("identity")
+                        or (visible_state.st_dev, visible_state.st_ino)
+                        != (opened_state.st_dev, opened_state.st_ino)
+                    ):
+                        raise WorkspaceError(
+                            f"temporary state changed during promotion: {state}"
+                        )
+
+                verify_visible_state()
                 with exclusive_lock(
                     self.paths.workspace / "states.lock", "states registry"
                 ):
@@ -12231,12 +12418,20 @@ class Workspace:
                         "generation": owner["generation"],
                     }
                     provenance_path = state / PROMOTED_STATE_METADATA
-                    if provenance_path.exists() or provenance_path.is_symlink():
-                        if (
-                            provenance_path.is_symlink()
-                            or not provenance_path.is_file()
-                            or load_regular_json(
-                                provenance_path, "promoted state provenance"
+                    try:
+                        provenance_metadata = os.stat(
+                            PROMOTED_STATE_METADATA,
+                            dir_fd=state_fd,
+                            follow_symlinks=False,
+                        )
+                    except FileNotFoundError:
+                        provenance_metadata = None
+                    if provenance_metadata is not None:
+                        if not stat.S_ISREG(provenance_metadata.st_mode) or (
+                            load_regular_json_at(
+                                state_fd,
+                                PROMOTED_STATE_METADATA,
+                                "promoted state provenance",
                             )
                             != provenance
                         ):
@@ -12244,13 +12439,31 @@ class Workspace:
                                 f"promoted state provenance is invalid: {provenance_path}"
                             )
                     else:
-                        durable_atomic_json(provenance_path, provenance)
+                        durable_atomic_json_at(
+                            state_fd, PROMOTED_STATE_METADATA, provenance
+                        )
+                    verify_visible_state()
+                    registry_added = False
                     if existing is None:
                         states[state_name] = str(state)
                         durable_atomic_json(
                             self.paths.states_file,
                             {"schema_version": SCHEMA_VERSION, "states": states},
                         )
+                        registry_added = True
+                    try:
+                        verify_visible_state()
+                    except BaseException:
+                        if registry_added:
+                            del states[state_name]
+                            durable_atomic_json(
+                                self.paths.states_file,
+                                {
+                                    "schema_version": SCHEMA_VERSION,
+                                    "states": states,
+                                },
+                            )
+                        raise
                     promoted = {**pending, "lifecycle": "promoted"}
                     status = self._write_temporary_state_policy(
                         topology_name, status, promoted
@@ -12713,12 +12926,36 @@ class Workspace:
                 except BaseException:
                     os.close(state_fd)
                     raise
-                state_lock_fd = os.dup(state_lock.fileno())
-                physical_state_lock_fd = (
-                    os.dup(state_lock.physical_lock.fileno())
-                    if state_lock.physical_lock is not None
+                state_output = (
+                    Path(_runtime_record["mutable_state_outputs"][0])
+                    if _runtime_record["mutable_state_outputs"]
                     else None
                 )
+                state_lock_fd: int | None = None
+                physical_state_lock_fd: int | None = None
+                try:
+                    state_lock_fd = os.dup(state_lock.fileno())
+                    physical_state_lock_fd = (
+                        os.dup(state_lock.physical_lock.fileno())
+                        if state_lock.physical_lock is not None
+                        else None
+                    )
+                except BaseException:
+                    if physical_state_lock_fd is not None:
+                        os.close(physical_state_lock_fd)
+                    if state_lock_fd is not None:
+                        os.close(state_lock_fd)
+                    try:
+                        if state_output is not None:
+                            self._remove_runtime_state_output(
+                                state_output, generation, state_fd
+                            )
+                    finally:
+                        os.close(state_fd)
+                        os.close(runtime_fd)
+                        remove_owned_tree(generation_root)
+                    raise
+                assert state_lock_fd is not None
                 runtime = generation_root / "server"
                 executable = runtime / "atrinik-server"
                 command = [
@@ -12744,11 +12981,7 @@ class Workspace:
                     "state_fd": state_fd,
                     "state_lock_fd": state_lock_fd,
                     "physical_state_lock_fd": physical_state_lock_fd,
-                    "state_output": (
-                        Path(_runtime_record["mutable_state_outputs"][0])
-                        if _runtime_record["mutable_state_outputs"]
-                        else None
-                    ),
+                    "state_output": state_output,
                 }
 
     def _foreground_runtime_owner(self) -> Path:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -1247,6 +1247,8 @@ def _tree_digest_descriptor(root_fd: int, display: Path) -> str:
     """Hash an exact pinned regular tree without following child links."""
 
     digest = hashlib.sha256()
+    root = os.fstat(root_fd)
+    root_mount = _descriptor_mount_id(root_fd)
 
     def record(*fields: object) -> None:
         encoded = json.dumps(
@@ -1264,6 +1266,10 @@ def _tree_digest_descriptor(root_fd: int, display: Path) -> str:
             )
             mode = stat.S_IMODE(metadata.st_mode)
             if stat.S_ISDIR(metadata.st_mode):
+                if metadata.st_dev != root.st_dev:
+                    raise WorkspaceError(
+                        f"Worker source contains a mounted directory: {child_display}"
+                    )
                 record("directory", child.as_posix(), mode)
                 descriptor = os.open(
                     name,
@@ -1278,7 +1284,7 @@ def _tree_digest_descriptor(root_fd: int, display: Path) -> str:
                     if (opened.st_dev, opened.st_ino) != (
                         metadata.st_dev,
                         metadata.st_ino,
-                    ):
+                    ) or _descriptor_mount_id(descriptor) != root_mount:
                         raise WorkspaceError(
                             f"Worker source changed during inventory: {child_display}"
                         )
@@ -1286,6 +1292,10 @@ def _tree_digest_descriptor(root_fd: int, display: Path) -> str:
                 finally:
                     os.close(descriptor)
             elif stat.S_ISREG(metadata.st_mode):
+                if metadata.st_nlink != 1 or metadata.st_dev != root.st_dev:
+                    raise WorkspaceError(
+                        f"Worker source contains a linked file: {child_display}"
+                    )
                 descriptor = os.open(
                     name,
                     os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW,
@@ -1297,6 +1307,7 @@ def _tree_digest_descriptor(root_fd: int, display: Path) -> str:
                         not stat.S_ISREG(opened.st_mode)
                         or (opened.st_dev, opened.st_ino)
                         != (metadata.st_dev, metadata.st_ino)
+                        or _descriptor_mount_id(descriptor) != root_mount
                     ):
                         raise WorkspaceError(
                             f"Worker source changed during inventory: {child_display}"
@@ -1322,7 +1333,6 @@ def _tree_digest_descriptor(root_fd: int, display: Path) -> str:
                     f"Worker source contains an unsupported file type: {child_display}"
                 )
 
-    root = os.fstat(root_fd)
     if not stat.S_ISDIR(root.st_mode):
         raise WorkspaceError(f"Worker source is not a regular directory: {display}")
     record("root", stat.S_IMODE(root.st_mode))
@@ -9346,6 +9356,13 @@ class Workspace:
                     "state_policy": policy,
                 },
             )
+            self._validate_temporary_state_integrity(
+                staging_fd,
+                destination,
+                implementation,
+                container_fd,
+                staging_name,
+            )
             visible_staging = os.stat(
                 staging_name, dir_fd=container_fd, follow_symlinks=False
             )
@@ -9416,18 +9433,26 @@ class Workspace:
         directory_fd: int,
         path: Path,
         implementation: dict[str, str] | None = None,
+        parent_directory_fd: int | None = None,
+        entry_name: str | None = None,
     ) -> None:
         """Fail closed before deleting wrapper-owned mutable server state."""
 
         root = os.fstat(directory_fd)
         root_mount = _descriptor_mount_id(directory_fd)
-        parent_fd = _open_directory_nofollow(
-            path.parent,
-            os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
+        parent_fd = (
+            os.dup(parent_directory_fd)
+            if parent_directory_fd is not None
+            else _open_directory_nofollow(
+                path.parent,
+                os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
+            )
         )
         try:
             visible = os.stat(
-                path.name, dir_fd=parent_fd, follow_symlinks=False
+                entry_name or path.name,
+                dir_fd=parent_fd,
+                follow_symlinks=False,
             )
             if (
                 (visible.st_dev, visible.st_ino) != (root.st_dev, root.st_ino)
@@ -10399,6 +10424,8 @@ class Workspace:
             descriptors.append(tmp_fd)
             container_fd = open_directory(tmp_fd, "runtime-assets", True)
             descriptors.append(container_fd)
+            if cleanup_proof is not None:
+                cleanup_proof[0] = False
             try:
                 os.mkdir(generation, 0o700, dir_fd=container_fd)
             except FileExistsError as error:
@@ -10406,8 +10433,6 @@ class Workspace:
                     f"server runtime state output already exists: {output}"
                 ) from error
             created_generation = True
-            if cleanup_proof is not None:
-                cleanup_proof[0] = False
             generation_fd = open_directory(container_fd, generation, False)
             descriptors.append(generation_fd)
             marker = json.dumps(
@@ -10807,6 +10832,15 @@ class Workspace:
                     opened.st_dev,
                     opened.st_ino,
                 ):
+                    try:
+                        rename_no_replace_at(
+                            descriptor,
+                            tombstone,
+                            descriptor,
+                            RUNTIME_STATE_OUTPUT_TRANSACTION,
+                        )
+                    except WorkspaceError:
+                        pass
                     raise WorkspaceError(
                         "runtime state output transaction changed before removal"
                     )

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -9764,6 +9764,7 @@ class Workspace:
         source: Path,
         destination: Path,
         exclusions: frozenset[str] = frozenset(),
+        pinned_destination_parent_fd: int | None = None,
     ) -> int:
         flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
         retained_destination_fd: int | None = None
@@ -9783,10 +9784,16 @@ class Workspace:
                 raise WorkspaceError(
                     f"topology runtime input changed during copy: {source}"
                 )
-            destination_parent_before = destination.parent.stat(
-                follow_symlinks=False
+            destination_parent_before = (
+                os.fstat(pinned_destination_parent_fd)
+                if pinned_destination_parent_fd is not None
+                else destination.parent.stat(follow_symlinks=False)
             )
-            destination_parent_fd = os.open(destination.parent, flags)
+            destination_parent_fd = (
+                os.dup(pinned_destination_parent_fd)
+                if pinned_destination_parent_fd is not None
+                else os.open(destination.parent, flags)
+            )
             if self._runtime_tree_identity(os.fstat(destination_parent_fd)) != (
                 self._runtime_tree_identity(destination_parent_before)
             ):
@@ -9890,9 +9897,13 @@ class Workspace:
         source: Path,
         destination: Path,
         exclusions: frozenset[str] = frozenset(),
+        pinned_destination_parent_fd: int | None = None,
     ) -> None:
         descriptor = self._copy_topology_runtime_tree(
-            source, destination, exclusions
+            source,
+            destination,
+            exclusions,
+            pinned_destination_parent_fd,
         )
         os.close(descriptor)
 
@@ -10039,7 +10050,7 @@ class Workspace:
     @staticmethod
     def _prepare_runtime_state_output(
         state: Path, generation: str, state_directory_fd: int | None = None
-    ) -> Path:
+    ) -> tuple[Path, int, dict[str, int]]:
         flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
         descriptors: list[int] = []
         created_generation = False
@@ -10130,7 +10141,12 @@ class Workspace:
                     os.fsync(stream.fileno())
             finally:
                 os.close(marker_fd)
-            return output
+            metadata = os.fstat(generation_fd)
+            result_fd = os.dup(generation_fd)
+            return output, result_fd, {
+                "device": metadata.st_dev,
+                "inode": metadata.st_ino,
+            }
         except BaseException as error:
             if created_generation and len(descriptors) >= 4:
                 generation_fd = descriptors[-1]
@@ -10441,7 +10457,7 @@ class Workspace:
         state: Path | None = None,
         state_directory_fd: int | None = None,
         sound_root: Path | None = None,
-    ) -> tuple[Path, int, dict[str, Any]]:
+    ) -> tuple[Path, int, dict[str, Any], int | None]:
         generations = owner_root / "generations"
         generations.mkdir(exist_ok=True)
         if generations.is_symlink() or not generations.is_dir():
@@ -10458,6 +10474,7 @@ class Workspace:
         state_output: Path | None = None
         state_output_access: Path | None = None
         state_output_identity: dict[str, int] | None = None
+        state_output_fd: int | None = None
         try:
             input_digests = self._runtime_publication_input_digests(
                 build_root, selected, services, sound_root
@@ -10525,29 +10542,21 @@ class Workspace:
                     ),
                     target_is_directory=True,
                 )
-                state_output = self._prepare_runtime_state_output(
+                (
+                    state_output,
+                    state_output_fd,
+                    state_output_identity,
+                ) = self._prepare_runtime_state_output(
                     state, generation, state_directory_fd
                 )
-                state_output_access = (
-                    Path(f"/proc/self/fd/{state_directory_fd}")
-                    / "tmp"
-                    / "runtime-assets"
-                    / generation
-                    if state_directory_fd is not None
-                    else state_output
-                )
-                state_output_identity = (
-                    self._runtime_state_output_identity_at(
-                        state_directory_fd, generation
-                    )
-                    if state_directory_fd is not None
-                    else self._state_identity(state_output_access)
-                )
-                (state_output_access / "data").mkdir()
+                state_output_access = Path(f"/proc/self/fd/{state_output_fd}")
+                os.mkdir("data", dir_fd=state_output_fd)
                 client_maps = build_root / "runtime" / "client-maps"
                 self._validate_region_maps(client_maps)
                 self._copy_runtime_tree(
-                    client_maps, state_output_access / "client-maps"
+                    client_maps,
+                    state_output / "client-maps",
+                    pinned_destination_parent_fd=state_output_fd,
                 )
                 state_output_entries = self._runtime_generation_entries(
                     state_output_access / "client-maps", None
@@ -10562,6 +10571,19 @@ class Workspace:
                 raise WorkspaceError(
                     "runtime publication inputs changed during staging"
                 )
+            if state_output is not None and state_output_identity is not None:
+                visible_output_identity = (
+                    self._runtime_state_output_identity_at(
+                        state_directory_fd, generation
+                    )
+                    if state_directory_fd is not None
+                    else self._state_identity(state_output)
+                )
+                if visible_output_identity != state_output_identity:
+                    raise WorkspaceError(
+                        "server runtime state output changed during publication: "
+                        f"{state_output}"
+                    )
 
             build_metadata = build_root / BUILD_METADATA
             source_trees: dict[str, str] = {}
@@ -10644,7 +10666,9 @@ class Workspace:
             }
             result_fd = lease_fd
             lease_fd = None
-            return published, result_fd, runtime_record
+            result_state_output_fd = state_output_fd
+            state_output_fd = None
+            return published, result_fd, runtime_record, result_state_output_fd
         except BaseException:
             if staging.exists():
                 remove_owned_tree(staging)
@@ -10667,6 +10691,8 @@ class Workspace:
         finally:
             if lease_fd is not None:
                 os.close(lease_fd)
+            if state_output_fd is not None:
+                os.close(state_output_fd)
 
     def _copy_topology_runtime_inputs(
         self,
@@ -11378,19 +11404,20 @@ class Workspace:
             if not current_control:
                 raise WorkspaceError(f"topology runtime identity is invalid: {name}")
             expected_runtime_path = root / "generations" / control["generation"]
+            runtime_keys = {
+                "schema_version",
+                "generation",
+                "path",
+                "manifest_sha256",
+                "lease",
+                "external_state",
+                "mutable_state_outputs",
+            }
+            if topology_schema == TOPOLOGY_STATUS_SCHEMA_VERSION:
+                runtime_keys.add("mutable_state_output_identities")
             if (
                 not isinstance(runtime, dict)
-                or set(runtime)
-                != {
-                    "schema_version",
-                    "generation",
-                    "path",
-                    "manifest_sha256",
-                    "lease",
-                    "external_state",
-                    "mutable_state_outputs",
-                    "mutable_state_output_identities",
-                }
+                or set(runtime) != runtime_keys
                 or runtime.get("schema_version")
                 != RUNTIME_GENERATION_SCHEMA_VERSION
                 or runtime.get("generation") != control["generation"]
@@ -11411,21 +11438,26 @@ class Workspace:
                     if status.get("state") is not None
                     else []
                 )
-                or not isinstance(
-                    runtime.get("mutable_state_output_identities"), list
-                )
-                or len(runtime["mutable_state_output_identities"])
-                != len(runtime["mutable_state_outputs"])
-                or any(
-                    not isinstance(identity, dict)
-                    or set(identity) != {"device", "inode"}
-                    or any(
-                        not isinstance(value, int)
-                        or isinstance(value, bool)
-                        or value < 0
-                        for value in identity.values()
+                or topology_schema == TOPOLOGY_STATUS_SCHEMA_VERSION
+                and (
+                    not isinstance(
+                        runtime.get("mutable_state_output_identities"), list
                     )
-                    for identity in runtime["mutable_state_output_identities"]
+                    or len(runtime["mutable_state_output_identities"])
+                    != len(runtime["mutable_state_outputs"])
+                    or any(
+                        not isinstance(identity, dict)
+                        or set(identity) != {"device", "inode"}
+                        or any(
+                            not isinstance(value, int)
+                            or isinstance(value, bool)
+                            or value < 0
+                            for value in identity.values()
+                        )
+                        for identity in runtime[
+                            "mutable_state_output_identities"
+                        ]
+                    )
                 )
                 or not isinstance(runtime.get("lease"), dict)
                 or set(runtime["lease"]) != {"device", "inode"}
@@ -11492,25 +11524,26 @@ class Workspace:
                 if isinstance(runtime_manifest, dict)
                 else None
             )
+            manifest_keys = {
+                "schema_version",
+                "generation",
+                "profile",
+                "identity",
+                "services",
+                "resolved",
+                "source_trees",
+                "input_digests",
+                "build",
+                "external_state",
+                "mutable_state_outputs",
+                "mutable_state_output_entries",
+                "entries",
+            }
+            if topology_schema == TOPOLOGY_STATUS_SCHEMA_VERSION:
+                manifest_keys.add("mutable_state_output_identities")
             if (
                 not isinstance(runtime_manifest, dict)
-                or set(runtime_manifest)
-                != {
-                    "schema_version",
-                    "generation",
-                    "profile",
-                    "identity",
-                    "services",
-                    "resolved",
-                    "source_trees",
-                    "input_digests",
-                    "build",
-                    "external_state",
-                    "mutable_state_outputs",
-                    "mutable_state_output_identities",
-                    "mutable_state_output_entries",
-                    "entries",
-                }
+                or set(runtime_manifest) != manifest_keys
                 or runtime_manifest.get("schema_version")
                 != RUNTIME_GENERATION_SCHEMA_VERSION
                 or runtime_manifest.get("generation") != control["generation"]
@@ -11520,7 +11553,8 @@ class Workspace:
                 or runtime_manifest.get("external_state") != status.get("state")
                 or runtime_manifest.get("mutable_state_outputs")
                 != runtime["mutable_state_outputs"]
-                or runtime_manifest.get("mutable_state_output_identities")
+                or topology_schema == TOPOLOGY_STATUS_SCHEMA_VERSION
+                and runtime_manifest.get("mutable_state_output_identities")
                 != runtime["mutable_state_output_identities"]
                 or not isinstance(manifest_services, list)
                 or not manifest_services
@@ -12057,6 +12091,23 @@ class Workspace:
                         f"topology {name} retains temporary generation state; "
                         "promote it or complete its safe cleanup before restart"
                     )
+                previous_runtime = previous.get("runtime")
+                if (
+                    isinstance(previous_policy, dict)
+                    and previous_policy.get("mode") != "temporary"
+                    and isinstance(previous_runtime, dict)
+                    and previous_runtime.get("mutable_state_outputs")
+                ):
+                    identities = previous_runtime.get(
+                        "mutable_state_output_identities"
+                    )
+                    if not isinstance(identities, list) or not identities:
+                        raise WorkspaceError(
+                            f"topology {name} retains legacy mutable state output "
+                            "without exact ownership evidence; choose a new "
+                            "topology name"
+                        )
+                    self._cleanup_topology_mutable_state_outputs(previous)
 
             if "client" in selected_services:
                 self._require_client_display()
@@ -12225,6 +12276,9 @@ class Workspace:
                                         "device": rollback_metadata.st_dev,
                                         "inode": rollback_metadata.st_ino,
                                     },
+                                    implementation=state_policy[
+                                        "implementation"
+                                    ],
                                 )
                             raise
                     else:
@@ -12350,7 +12404,12 @@ class Workspace:
                         raise WorkspaceError(
                             f"profile {profile_name} source sound root changed before topology preparation"
                         )
-                generation_root, runtime_lock_fd, runtime_record = (
+                (
+                    generation_root,
+                    runtime_lock_fd,
+                    runtime_record,
+                    state_output_fd,
+                ) = (
                     self._publish_runtime_generation(
                         topology_root,
                         generation,
@@ -12370,6 +12429,8 @@ class Workspace:
                         sound_root=sound_root,
                     )
                 )
+                if state_output_fd is not None:
+                    stack.callback(os.close, state_output_fd)
                 published_generation_owner = [generation_root]
                 stack.callback(
                     lambda: remove_owned_tree(published_generation_owner.pop())
@@ -12419,9 +12480,8 @@ class Workspace:
                             ),
                             "--assetspath="
                             + (
-                                f"/proc/self/fd/{state_directory_fd}/tmp/"
-                                f"runtime-assets/{generation}"
-                                if state_directory_fd is not None
+                                f"/proc/self/fd/{state_output_fd}"
+                                if state_output_fd is not None
                                 else runtime_record["mutable_state_outputs"][0]
                             ),
                             "--no_console",
@@ -12548,6 +12608,11 @@ class Workspace:
                             ["--state-directory-fd", str(state_directory_fd)]
                         )
                         inherited_locks.append(state_directory_fd)
+                    if state_output_fd is not None:
+                        command.extend(
+                            ["--state-output-fd", str(state_output_fd)]
+                        )
+                        inherited_locks.append(state_output_fd)
                     command.extend(
                         ["--runtime-lock-fd", str(runtime_lock_fd)]
                     )
@@ -13763,7 +13828,7 @@ class Workspace:
                 )
             resolved = self._topology_resolved_status(profile_name, selected)
             generation = secrets.token_hex(32)
-            generation_root, runtime_fd, _runtime_record = (
+            generation_root, runtime_fd, _runtime_record, state_output_fd = (
                 self._publish_runtime_generation(
                     self._foreground_runtime_owner(),
                     generation,
@@ -13783,6 +13848,8 @@ class Workspace:
                     sound_root=sound_root,
                 )
             )
+            if state_output_fd is not None:
+                os.close(state_output_fd)
             working = generation_root / "client"
             executable = working / "atrinik"
             command = [
@@ -13831,6 +13898,7 @@ class Workspace:
         state_fd = prepared["state_fd"]
         state_lock_fd = prepared["state_lock_fd"]
         physical_state_lock_fd = prepared["physical_state_lock_fd"]
+        state_output_fd = prepared["state_output_fd"]
         generation_root = prepared["generation_root"]
         state_output = prepared["state_output"]
         try:
@@ -13846,6 +13914,7 @@ class Workspace:
                             state_fd,
                             state_lock_fd,
                             physical_state_lock_fd,
+                            state_output_fd,
                         )
                         if descriptor is not None
                     ),
@@ -13863,6 +13932,7 @@ class Workspace:
             finally:
                 if physical_state_lock_fd is not None:
                     os.close(physical_state_lock_fd)
+                os.close(state_output_fd)
                 os.close(state_lock_fd)
                 os.close(state_fd)
                 os.close(runtime_fd)
@@ -13921,7 +13991,12 @@ class Workspace:
                     raise
                 generation = secrets.token_hex(32)
                 try:
-                    generation_root, runtime_fd, _runtime_record = (
+                    (
+                        generation_root,
+                        runtime_fd,
+                        _runtime_record,
+                        state_output_fd,
+                    ) = (
                         self._publish_runtime_generation(
                             self._foreground_runtime_owner(),
                             generation,
@@ -13952,6 +14027,7 @@ class Workspace:
                     if _runtime_record["mutable_state_output_identities"]
                     else None
                 )
+                assert state_output_fd is not None
                 state_lock_fd: int | None = None
                 physical_state_lock_fd: int | None = None
                 try:
@@ -13975,6 +14051,7 @@ class Workspace:
                                 state_output_identity,
                             )
                     finally:
+                        os.close(state_output_fd)
                         os.close(state_fd)
                         os.close(runtime_fd)
                         remove_owned_tree(generation_root)
@@ -13989,8 +14066,7 @@ class Workspace:
                     "--stun_server=off",
                     *arguments,
                     f"--datapath=/proc/self/fd/{state_fd}",
-                    "--assetspath="
-                    f"/proc/self/fd/{state_fd}/tmp/runtime-assets/{generation}",
+                    f"--assetspath=/proc/self/fd/{state_output_fd}",
                 ]
                 print(f"state: {state}")
                 print(f"cwd: {runtime}")
@@ -14007,6 +14083,7 @@ class Workspace:
                     "physical_state_lock_fd": physical_state_lock_fd,
                     "state_output": state_output,
                     "state_output_identity": state_output_identity,
+                    "state_output_fd": state_output_fd,
                 }
 
     def _foreground_runtime_owner(self) -> Path:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -626,9 +626,9 @@ def _prepare_owned_tree_removal(
                 raise WorkspaceError(
                     f"owned removal encountered a mount: {child_display}"
                 )
-            if reject_links and (
-                stat.S_ISLNK(child.st_mode)
-                or (stat.S_ISREG(child.st_mode) and child.st_nlink != 1)
+            if reject_links and not (
+                stat.S_ISDIR(child.st_mode)
+                or (stat.S_ISREG(child.st_mode) and child.st_nlink == 1)
             ):
                 raise WorkspaceError(
                     f"owned removal encountered linked state: {child_display}"
@@ -708,9 +708,9 @@ def _remove_owned_tree_contents(
             raise WorkspaceError(
                 f"owned removal entry identity changed: {display / name}"
             )
-        if reject_links and (
-            stat.S_ISLNK(moved.st_mode)
-            or (stat.S_ISREG(moved.st_mode) and moved.st_nlink != 1)
+        if reject_links and not (
+            stat.S_ISDIR(moved.st_mode)
+            or (stat.S_ISREG(moved.st_mode) and moved.st_nlink == 1)
         ):
             try:
                 rename_no_replace_at(descriptor, tombstone, descriptor, name)
@@ -738,9 +738,9 @@ def _remove_owned_tree_contents(
             raise WorkspaceError(
                 f"owned removal encountered a mount: {child_display}"
             )
-        if reject_links and (
-            stat.S_ISLNK(child.st_mode)
-            or (stat.S_ISREG(child.st_mode) and child.st_nlink != 1)
+        if reject_links and not (
+            stat.S_ISDIR(child.st_mode)
+            or (stat.S_ISREG(child.st_mode) and child.st_nlink == 1)
         ):
             raise WorkspaceError(
                 f"owned removal encountered linked state: {child_display}"
@@ -775,6 +775,7 @@ def remove_owned_tree(
     expected_identity: dict[str, int] | None = None,
     keep_root: bool = False,
     reject_links: bool = False,
+    parent_directory_fd: int | None = None,
 ) -> None:
     if expected_identity is not None and (
         set(expected_identity) != {"device", "inode"}
@@ -792,9 +793,13 @@ def remove_owned_tree(
         )
         return _owned_tree_tombstone_name(path.name, device, inode)
 
-    parent_descriptor = _open_directory_nofollow(
-        path.parent,
-        os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
+    parent_descriptor = (
+        os.dup(parent_directory_fd)
+        if parent_directory_fd is not None
+        else _open_directory_nofollow(
+            path.parent,
+            os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
+        )
     )
     descriptor: int | None = None
     try:
@@ -11123,6 +11128,7 @@ class Workspace:
             "runtime",
             "state_policy",
             "shutdown",
+            "mutable_state_cleanup",
         }
         topology_schema = status.get("schema_version") if isinstance(status, dict) else None
         current_runtime_record = topology_schema in {
@@ -11231,6 +11237,39 @@ class Workspace:
             or shutdown["clean"] and status.get("error") is not None
         ):
             raise WorkspaceError(f"topology shutdown status is invalid: {name}")
+        mutable_state_cleanup = status.get("mutable_state_cleanup")
+        if mutable_state_cleanup is not None:
+            cleanup_entries = (
+                mutable_state_cleanup.get("entries")
+                if isinstance(mutable_state_cleanup, dict)
+                else None
+            )
+            if (
+                topology_schema != TOPOLOGY_STATUS_SCHEMA_VERSION
+                or not isinstance(mutable_state_cleanup, dict)
+                or set(mutable_state_cleanup)
+                != {"schema_version", "generation", "entries"}
+                or mutable_state_cleanup.get("schema_version") != SCHEMA_VERSION
+                or not isinstance(cleanup_entries, list)
+                or any(
+                    not isinstance(entry, dict)
+                    or set(entry) != {"path", "identity", "status"}
+                    or not isinstance(entry.get("path"), str)
+                    or not isinstance(entry.get("identity"), dict)
+                    or set(entry["identity"]) != {"device", "inode"}
+                    or any(
+                        not isinstance(value, int)
+                        or isinstance(value, bool)
+                        or value < 0
+                        for value in entry["identity"].values()
+                    )
+                    or entry.get("status") not in {"pending", "complete"}
+                    for entry in cleanup_entries
+                )
+            ):
+                raise WorkspaceError(
+                    f"topology mutable state cleanup status is invalid: {name}"
+                )
         if historical_record:
             status["stack"] = "classic"
             status["providers"] = {
@@ -11469,6 +11508,20 @@ class Workspace:
                 )
             ):
                 raise WorkspaceError(f"topology runtime identity is invalid: {name}")
+            if mutable_state_cleanup is not None and (
+                mutable_state_cleanup.get("generation")
+                != control["generation"]
+                or [entry["path"] for entry in mutable_state_cleanup["entries"]]
+                != runtime["mutable_state_outputs"]
+                or [
+                    entry["identity"]
+                    for entry in mutable_state_cleanup["entries"]
+                ]
+                != runtime.get("mutable_state_output_identities")
+            ):
+                raise WorkspaceError(
+                    f"topology mutable state cleanup identity is invalid: {name}"
+                )
             marker = expected_runtime_path / MANAGED_MARKER
             manifest = expected_runtime_path / RUNTIME_GENERATION_MANIFEST
             if (
@@ -12093,8 +12146,10 @@ class Workspace:
                     )
                 previous_runtime = previous.get("runtime")
                 if (
-                    isinstance(previous_policy, dict)
-                    and previous_policy.get("mode") != "temporary"
+                    (
+                        not isinstance(previous_policy, dict)
+                        or previous_policy.get("mode") != "temporary"
+                    )
                     and isinstance(previous_runtime, dict)
                     and previous_runtime.get("mutable_state_outputs")
                 ):
@@ -12102,12 +12157,26 @@ class Workspace:
                         "mutable_state_output_identities"
                     )
                     if not isinstance(identities, list) or not identities:
-                        raise WorkspaceError(
-                            f"topology {name} retains legacy mutable state output "
-                            "without exact ownership evidence; choose a new "
-                            "topology name"
+                        legacy_outputs = previous_runtime[
+                            "mutable_state_outputs"
+                        ]
+                        if any(
+                            Path(value).exists() or Path(value).is_symlink()
+                            for value in legacy_outputs
+                        ):
+                            raise WorkspaceError(
+                                f"topology {name} retains legacy mutable state "
+                                "output without exact ownership evidence; remove "
+                                "it through the pre-upgrade wrapper or choose a "
+                                "new topology name"
+                            )
+                        continue_cleanup = False
+                    else:
+                        continue_cleanup = True
+                    if continue_cleanup:
+                        previous = self._cleanup_topology_mutable_state_outputs(
+                            previous
                         )
-                    self._cleanup_topology_mutable_state_outputs(previous)
 
             if "client" in selected_services:
                 self._require_client_display()
@@ -12720,7 +12789,7 @@ class Workspace:
                     name, status, timeout
                 )
                 if confirmed_clean:
-                    self._cleanup_topology_mutable_state_outputs(stopped)
+                    stopped = self._cleanup_topology_mutable_state_outputs(stopped)
                 return self._finish_temporary_state_down(
                     name, stopped, retain_state, confirmed_clean
                 )
@@ -12801,7 +12870,7 @@ class Workspace:
 
     def _cleanup_topology_mutable_state_outputs(
         self, status: dict[str, Any]
-    ) -> None:
+    ) -> dict[str, Any]:
         policy = status.get("state_policy")
         runtime = status.get("runtime")
         control = status.get("control")
@@ -12811,7 +12880,7 @@ class Workspace:
             or not isinstance(runtime, dict)
             or not isinstance(control, dict)
         ):
-            return
+            return status
         outputs = runtime.get("mutable_state_outputs")
         identities = runtime.get("mutable_state_output_identities")
         if (
@@ -12820,7 +12889,33 @@ class Workspace:
             or not isinstance(identities, list)
             or len(identities) != len(outputs)
         ):
-            return
+            return status
+        name = status["name"]
+        status_path = self._topology_directory(name) / "status.json"
+        cleanup = status.get("mutable_state_cleanup")
+        if cleanup is None:
+            cleanup = {
+                "schema_version": SCHEMA_VERSION,
+                "generation": control["generation"],
+                "entries": [
+                    {
+                        "path": value,
+                        "identity": identity,
+                        "status": "pending",
+                    }
+                    for value, identity in zip(outputs, identities, strict=True)
+                ],
+            }
+            raw = load_json(status_path)
+            if raw.get("control") != status.get("control"):
+                raise WorkspaceError(
+                    f"topology changed before mutable state cleanup: {name}"
+                )
+            durable_atomic_json(
+                status_path, {**raw, "mutable_state_cleanup": cleanup}
+            )
+            status = self.topology_status(name)
+        entries = cleanup["entries"]
         state = Path(policy["path"])
         descriptor = _open_directory_nofollow(
             state,
@@ -12838,7 +12933,11 @@ class Workspace:
                 raise WorkspaceError(
                     f"server state identity changed before runtime cleanup: {state}"
                 )
-            for value, output_identity in zip(outputs, identities, strict=True):
+            for index, (value, output_identity) in enumerate(
+                zip(outputs, identities, strict=True)
+            ):
+                if entries[index]["status"] == "complete":
+                    continue
                 output = Path(value)
                 try:
                     self._remove_runtime_state_output(
@@ -12848,9 +12947,66 @@ class Workspace:
                         output_identity,
                     )
                 except FileNotFoundError:
-                    continue
+                    parent_fds: list[int] = []
+                    try:
+                        parent_fds.append(
+                            os.open(
+                                "tmp",
+                                os.O_RDONLY
+                                | os.O_CLOEXEC
+                                | os.O_DIRECTORY
+                                | os.O_NOFOLLOW,
+                                dir_fd=descriptor,
+                            )
+                        )
+                        parent_fds.append(
+                            os.open(
+                                "runtime-assets",
+                                os.O_RDONLY
+                                | os.O_CLOEXEC
+                                | os.O_DIRECTORY
+                                | os.O_NOFOLLOW,
+                                dir_fd=parent_fds[-1],
+                            )
+                        )
+                    except FileNotFoundError:
+                        pass
+                    else:
+                        for candidate in os.listdir(parent_fds[-1]):
+                            metadata = os.stat(
+                                candidate,
+                                dir_fd=parent_fds[-1],
+                                follow_symlinks=False,
+                            )
+                            if {
+                                "device": metadata.st_dev,
+                                "inode": metadata.st_ino,
+                            } == output_identity:
+                                raise WorkspaceError(
+                                    "server runtime state output was renamed "
+                                    f"before cleanup: {output} -> {candidate}"
+                                )
+                    finally:
+                        for parent_fd in reversed(parent_fds):
+                            os.close(parent_fd)
+                updated_entries = [dict(entry) for entry in entries]
+                updated_entries[index]["status"] = "complete"
+                cleanup = {**cleanup, "entries": updated_entries}
+                raw = load_json(status_path)
+                if raw.get("mutable_state_cleanup") != status.get(
+                    "mutable_state_cleanup"
+                ):
+                    raise WorkspaceError(
+                        f"topology changed during mutable state cleanup: {name}"
+                    )
+                durable_atomic_json(
+                    status_path, {**raw, "mutable_state_cleanup": cleanup}
+                )
+                status = self.topology_status(name)
+                entries = updated_entries
         finally:
             os.close(descriptor)
+        return status
 
     def _controlled_topology_down(
         self, name: str, status: dict[str, Any], timeout: float
@@ -12915,15 +13071,20 @@ class Workspace:
         state: Path,
         state_lease: TextIO,
         lease_identity: dict[str, int],
+        parent_directory_fd: int | None = None,
     ) -> None:
         Workspace._validate_temporary_state_lock(
             state, state_lease, lease_identity
         )
         lock = Path(f"{state}.lock")
 
-        parent_fd = os.open(
-            lock.parent,
-            os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
+        parent_fd = (
+            os.dup(parent_directory_fd)
+            if parent_directory_fd is not None
+            else os.open(
+                lock.parent,
+                os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
+            )
         )
         try:
             tombstone = (
@@ -13008,18 +13169,34 @@ class Workspace:
 
     @staticmethod
     def _finish_temporary_state_lock_tombstone(
-        state: Path, lease_identity: dict[str, int]
+        state: Path,
+        lease_identity: dict[str, int],
+        parent_directory_fd: int | None = None,
     ) -> bool:
         lock = Path(f"{state}.lock")
         tombstone = lock.parent / (
             f".{lock.name}.remove-{lease_identity['device']:x}-"
             f"{lease_identity['inode']:x}"
         )
-        if not tombstone.exists() and not tombstone.is_symlink():
-            return False
-        parent_fd = os.open(
-            tombstone.parent,
-            os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
+        if parent_directory_fd is None:
+            if not tombstone.exists() and not tombstone.is_symlink():
+                return False
+        else:
+            try:
+                os.stat(
+                    tombstone.name,
+                    dir_fd=parent_directory_fd,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                return False
+        parent_fd = (
+            os.dup(parent_directory_fd)
+            if parent_directory_fd is not None
+            else os.open(
+                tombstone.parent,
+                os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
+            )
         )
         try:
             descriptor = os.open(
@@ -13088,6 +13265,51 @@ class Workspace:
             os.close(descriptor)
             raise
 
+    def _open_temporary_state_container_for_mutation(
+        self, name: str, state: Path
+    ) -> int:
+        root = self._topology_directory(name)
+        if state.parent != root / "temporary-states":
+            raise WorkspaceError("temporary state container path is invalid")
+        flags = os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW
+        root_fd = _open_directory_nofollow(root, flags)
+        container_fd: int | None = None
+        try:
+            visible = os.stat(
+                "temporary-states", dir_fd=root_fd, follow_symlinks=False
+            )
+            container_fd = os.open(
+                "temporary-states", flags, dir_fd=root_fd
+            )
+            opened = os.fstat(container_fd)
+            if (
+                not stat.S_ISDIR(visible.st_mode)
+                or (visible.st_dev, visible.st_ino)
+                != (opened.st_dev, opened.st_ino)
+                or _descriptor_mount_id(container_fd)
+                != _descriptor_mount_id(root_fd)
+            ):
+                raise WorkspaceError(
+                    "temporary state container changed or crossed a mount"
+                )
+            marker = self._load_state_json_at(
+                container_fd,
+                MANAGED_MARKER,
+                "temporary state container marker",
+            )
+            if marker != {
+                "schema_version": SCHEMA_VERSION,
+                "purpose": "topology-temporary-states",
+            }:
+                raise WorkspaceError("temporary state container marker is invalid")
+            result = container_fd
+            container_fd = None
+            return result
+        finally:
+            if container_fd is not None:
+                os.close(container_fd)
+            os.close(root_fd)
+
     @staticmethod
     def _rollback_temporary_state_creation(
         state: Path,
@@ -13130,6 +13352,7 @@ class Workspace:
         status: dict[str, Any],
         state_lease: TextIO,
         state_directory_fd: int | None = None,
+        state_container_fd: int | None = None,
     ) -> dict[str, Any]:
         policy = status["state_policy"]
         state = Path(policy["path"])
@@ -13137,6 +13360,19 @@ class Workspace:
         identity = policy["identity"]
         lifecycle = policy["lifecycle"]
         current = status
+
+        def entry_present(candidate: Path) -> bool:
+            if state_container_fd is None:
+                return candidate.exists() or candidate.is_symlink()
+            try:
+                os.stat(
+                    candidate.name,
+                    dir_fd=state_container_fd,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                return False
+            return True
         if lifecycle not in {"removal-pending", "removed"}:
             if state_directory_fd is None:
                 raise WorkspaceError(
@@ -13150,18 +13386,32 @@ class Workspace:
             policy = current["state_policy"]
             lifecycle = "removal-pending"
         if lifecycle == "removal-pending":
-            state_present = state.exists() or state.is_symlink()
-            tombstone_present = tombstone.exists() or tombstone.is_symlink()
+            state_present = entry_present(state)
+            tombstone_present = entry_present(tombstone)
             removal_tombstone = _owned_tree_tombstone_path(tombstone, identity)
             removal_tombstone_present = (
-                removal_tombstone.exists() or removal_tombstone.is_symlink()
+                entry_present(removal_tombstone)
             )
             if state_present and tombstone_present:
                 raise WorkspaceError(
                     f"temporary state removal paths conflict: {state}"
                 )
             if state_present:
-                if self._state_identity(state) != identity:
+                observed_state = (
+                    self._state_identity(state)
+                    if state_container_fd is None
+                    else {
+                        "device": (
+                            state_metadata := os.stat(
+                                state.name,
+                                dir_fd=state_container_fd,
+                                follow_symlinks=False,
+                            )
+                        ).st_dev,
+                        "inode": state_metadata.st_ino,
+                    }
+                )
+                if observed_state != identity:
                     raise WorkspaceError(
                         f"temporary state identity changed before removal: {state}"
                     )
@@ -13173,10 +13423,26 @@ class Workspace:
                 self._validate_temporary_state_integrity(
                     state_directory_fd, state, policy["implementation"]
                 )
-                rename_no_replace(state, tombstone)
+                if state_container_fd is None:
+                    rename_no_replace(state, tombstone)
+                else:
+                    rename_no_replace_at(
+                        state_container_fd,
+                        state.name,
+                        state_container_fd,
+                        tombstone.name,
+                    )
                 tombstone_present = True
             if tombstone_present:
-                tombstone_metadata = tombstone.stat(follow_symlinks=False)
+                tombstone_metadata = (
+                    tombstone.stat(follow_symlinks=False)
+                    if state_container_fd is None
+                    else os.stat(
+                        tombstone.name,
+                        dir_fd=state_container_fd,
+                        follow_symlinks=False,
+                    )
+                )
                 if (
                     not stat.S_ISDIR(tombstone_metadata.st_mode)
                     or {
@@ -13198,27 +13464,70 @@ class Workspace:
                     expected_identity=identity,
                     keep_root=True,
                     reject_links=True,
+                    parent_directory_fd=state_container_fd,
                 )
-                if removal_tombstone_present and not tombstone.exists():
-                    rename_no_replace(removal_tombstone, tombstone)
+                if removal_tombstone_present and not entry_present(tombstone):
+                    if state_container_fd is None:
+                        rename_no_replace(removal_tombstone, tombstone)
+                    else:
+                        rename_no_replace_at(
+                            state_container_fd,
+                            removal_tombstone.name,
+                            state_container_fd,
+                            tombstone.name,
+                        )
             removed = {**policy, "lifecycle": "removed"}
             current = self._write_temporary_state_policy(name, current, removed)
             policy = current["state_policy"]
-        if tombstone.exists() or tombstone.is_symlink():
-            metadata = tombstone.stat(follow_symlinks=False)
+        if entry_present(tombstone):
+            metadata = (
+                tombstone.stat(follow_symlinks=False)
+                if state_container_fd is None
+                else os.stat(
+                    tombstone.name,
+                    dir_fd=state_container_fd,
+                    follow_symlinks=False,
+                )
+            )
+            tombstone_fd = (
+                None
+                if state_container_fd is None
+                else os.open(
+                    tombstone.name,
+                    os.O_RDONLY
+                    | os.O_CLOEXEC
+                    | os.O_DIRECTORY
+                    | os.O_NOFOLLOW,
+                    dir_fd=state_container_fd,
+                )
+            )
             if (
                 not stat.S_ISDIR(metadata.st_mode)
                 or (metadata.st_dev, metadata.st_ino)
                 != (identity["device"], identity["inode"])
-                or any(tombstone.iterdir())
+                or (
+                    any(tombstone.iterdir())
+                    if tombstone_fd is None
+                    else bool(os.listdir(tombstone_fd))
+                )
             ):
+                if tombstone_fd is not None:
+                    os.close(tombstone_fd)
                 raise WorkspaceError(
                     f"temporary state removal root is invalid: {tombstone}"
                 )
-            tombstone.rmdir()
-            _fsync_directory(tombstone.parent)
+            if tombstone_fd is not None:
+                os.close(tombstone_fd)
+                os.rmdir(tombstone.name, dir_fd=state_container_fd)
+                os.fsync(state_container_fd)
+            else:
+                tombstone.rmdir()
+                _fsync_directory(tombstone.parent)
         self._unlink_temporary_state_lock(
-            state, state_lease, policy["lease_identity"]
+            state,
+            state_lease,
+            policy["lease_identity"],
+            state_container_fd,
         )
         return self.topology_status(name)
 
@@ -13256,9 +13565,15 @@ class Workspace:
         lock_path = Path(f"{state}.lock")
         if policy.get("lifecycle") == "removed":
             if not (lock_path.exists() or lock_path.is_symlink()):
-                self._finish_temporary_state_lock_tombstone(
-                    state, policy["lease_identity"]
+                container_fd = self._open_temporary_state_container_for_mutation(
+                    name, state
                 )
+                try:
+                    self._finish_temporary_state_lock_tombstone(
+                        state, policy["lease_identity"], container_fd
+                    )
+                finally:
+                    os.close(container_fd)
                 return status
         with exclusive_lock(
             lock_path,
@@ -13289,13 +13604,26 @@ class Workspace:
                 None,
             )
             if mutation_path is None:
-                return self._commit_temporary_state_removal(
-                    name, current, state_lease
+                container_fd = self._open_temporary_state_container_for_mutation(
+                    name, state
                 )
-            mutation_fd = self._lock_state_directory_mutation(
-                mutation_path, policy["identity"]
+                try:
+                    return self._commit_temporary_state_removal(
+                        name,
+                        current,
+                        state_lease,
+                        state_container_fd=container_fd,
+                    )
+                finally:
+                    os.close(container_fd)
+            container_fd = self._open_temporary_state_container_for_mutation(
+                name, state
             )
+            mutation_fd: int | None = None
             try:
+                mutation_fd = self._lock_state_directory_mutation(
+                    mutation_path, policy["identity"]
+                )
                 if policy.get("lifecycle") not in {
                     "removal-pending",
                     "removed",
@@ -13314,10 +13642,16 @@ class Workspace:
                             f"could not be proved: {state}: {error}"
                         ) from error
                 return self._commit_temporary_state_removal(
-                    name, current, state_lease, mutation_fd
+                    name,
+                    current,
+                    state_lease,
+                    mutation_fd,
+                    container_fd,
                 )
             finally:
-                os.close(mutation_fd)
+                if mutation_fd is not None:
+                    os.close(mutation_fd)
+                os.close(container_fd)
 
     def state_promote(self, topology_name: str, state_name: str) -> dict[str, Any]:
         """Promote one stopped, explicitly retained temporary state in place."""

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -1243,6 +1243,93 @@ def _tree_digest(
     return digest.hexdigest()
 
 
+def _tree_digest_descriptor(root_fd: int, display: Path) -> str:
+    """Hash an exact pinned regular tree without following child links."""
+
+    digest = hashlib.sha256()
+
+    def record(*fields: object) -> None:
+        encoded = json.dumps(
+            fields, ensure_ascii=True, separators=(",", ":")
+        ).encode()
+        digest.update(len(encoded).to_bytes(8, "big"))
+        digest.update(encoded)
+
+    def visit(directory_fd: int, relative: PurePosixPath) -> None:
+        for name in sorted(os.listdir(directory_fd)):
+            child = relative / name
+            child_display = display / child.as_posix()
+            metadata = os.stat(
+                name, dir_fd=directory_fd, follow_symlinks=False
+            )
+            mode = stat.S_IMODE(metadata.st_mode)
+            if stat.S_ISDIR(metadata.st_mode):
+                record("directory", child.as_posix(), mode)
+                descriptor = os.open(
+                    name,
+                    os.O_RDONLY
+                    | os.O_CLOEXEC
+                    | os.O_DIRECTORY
+                    | os.O_NOFOLLOW,
+                    dir_fd=directory_fd,
+                )
+                try:
+                    opened = os.fstat(descriptor)
+                    if (opened.st_dev, opened.st_ino) != (
+                        metadata.st_dev,
+                        metadata.st_ino,
+                    ):
+                        raise WorkspaceError(
+                            f"Worker source changed during inventory: {child_display}"
+                        )
+                    visit(descriptor, child)
+                finally:
+                    os.close(descriptor)
+            elif stat.S_ISREG(metadata.st_mode):
+                descriptor = os.open(
+                    name,
+                    os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW,
+                    dir_fd=directory_fd,
+                )
+                try:
+                    opened = os.fstat(descriptor)
+                    if (
+                        not stat.S_ISREG(opened.st_mode)
+                        or (opened.st_dev, opened.st_ino)
+                        != (metadata.st_dev, metadata.st_ino)
+                    ):
+                        raise WorkspaceError(
+                            f"Worker source changed during inventory: {child_display}"
+                        )
+                    file_digest = hashlib.sha256()
+                    while chunk := os.read(descriptor, 1024 * 1024):
+                        file_digest.update(chunk)
+                    record(
+                        "file",
+                        child.as_posix(),
+                        mode,
+                        metadata.st_size,
+                        file_digest.hexdigest(),
+                    )
+                finally:
+                    os.close(descriptor)
+            elif stat.S_ISLNK(metadata.st_mode):
+                raise WorkspaceError(
+                    f"Worker source contains a symbolic link: {child_display}"
+                )
+            else:
+                raise WorkspaceError(
+                    f"Worker source contains an unsupported file type: {child_display}"
+                )
+
+    root = os.fstat(root_fd)
+    if not stat.S_ISDIR(root.st_mode):
+        raise WorkspaceError(f"Worker source is not a regular directory: {display}")
+    record("root", stat.S_IMODE(root.st_mode))
+    visit(root_fd, PurePosixPath())
+    return digest.hexdigest()
+
+
 def _copy_worker_source(
     source: Path,
     destination: Path,
@@ -8897,12 +8984,39 @@ class Workspace:
             except FileNotFoundError:
                 staging = f".temporary-states.{secrets.token_hex(12)}.tmp"
                 staging_fd: int | None = None
+                staging_identity: dict[str, int] | None = None
                 try:
                     os.mkdir(staging, mode=0o700, dir_fd=root_fd)
+                    created = os.stat(
+                        staging, dir_fd=root_fd, follow_symlinks=False
+                    )
+                    staging_identity = {
+                        "device": created.st_dev,
+                        "inode": created.st_ino,
+                    }
                     staging_fd = os.open(staging, flags, dir_fd=root_fd)
+                    opened_staging = os.fstat(staging_fd)
+                    if (
+                        not stat.S_ISDIR(created.st_mode)
+                        or (opened_staging.st_dev, opened_staging.st_ino)
+                        != (created.st_dev, created.st_ino)
+                    ):
+                        raise WorkspaceError(
+                            "temporary state container staging changed"
+                        )
                     durable_atomic_json_at(
                         staging_fd, MANAGED_MARKER, expected
                     )
+                    visible_staging = os.stat(
+                        staging, dir_fd=root_fd, follow_symlinks=False
+                    )
+                    if (visible_staging.st_dev, visible_staging.st_ino) != (
+                        created.st_dev,
+                        created.st_ino,
+                    ):
+                        raise WorkspaceError(
+                            "temporary state container staging changed"
+                        )
                     rename_no_replace_at(
                         root_fd, staging, root_fd, "temporary-states"
                     )
@@ -8913,6 +9027,7 @@ class Workspace:
                     try:
                         remove_owned_tree(
                             topology_root / staging,
+                            expected_identity=staging_identity,
                             parent_directory_fd=root_fd,
                         )
                     except FileNotFoundError:
@@ -9115,21 +9230,40 @@ class Workspace:
                 f"temporary topology state already exists for generation {generation}"
             )
         staging: Path | None = None
+        staging_identity: dict[str, int] | None = None
         try:
             staging = Path(tempfile.mkdtemp(
                 prefix=f".{generation}.", dir=f"/proc/self/fd/{container_fd}"
             ))
             staging_name = staging.name
+            created = os.stat(
+                staging_name, dir_fd=container_fd, follow_symlinks=False
+            )
+            staging_identity = {
+                "device": created.st_dev,
+                "inode": created.st_ino,
+            }
             staging_fd = os.open(
                 staging_name,
                 os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
                 dir_fd=container_fd,
             )
+            opened_staging = os.fstat(staging_fd)
+            if (
+                not stat.S_ISDIR(created.st_mode)
+                or (opened_staging.st_dev, opened_staging.st_ino)
+                != (created.st_dev, created.st_ino)
+            ):
+                raise WorkspaceError(
+                    "temporary topology state staging changed"
+                )
         except BaseException:
             if staging is not None:
                 try:
                     remove_owned_tree(
-                        staging, parent_directory_fd=container_fd
+                        staging,
+                        expected_identity=staging_identity,
+                        parent_directory_fd=container_fd,
                     )
                 except FileNotFoundError:
                     pass
@@ -9138,15 +9272,18 @@ class Workspace:
         published_identity: dict[str, int] | None = None
         created_at = datetime.now(timezone.utc).isoformat()
         install_data = server_source / "install_data"
+        staging_access = Path(f"/proc/self/fd/{staging_fd}")
         try:
             source_digest = _tree_digest(
                 install_data, set(), reject_symlinks=True
             )
             shutil.copytree(
-                install_data, staging, dirs_exist_ok=True
+                install_data, staging_access, dirs_exist_ok=True
             )
             if (
-                _tree_digest(staging, set(), reject_symlinks=True) != source_digest
+                _tree_digest_descriptor(staging_fd, destination) != source_digest
+                or _tree_digest(install_data, set(), reject_symlinks=True)
+                != source_digest
                 or _tree_digest(install_data, set(), reject_symlinks=True)
                 != source_digest
             ):
@@ -9208,6 +9345,15 @@ class Workspace:
                     "state_policy": policy,
                 },
             )
+            visible_staging = os.stat(
+                staging_name, dir_fd=container_fd, follow_symlinks=False
+            )
+            if (visible_staging.st_dev, visible_staging.st_ino) != (
+                identity["device"], identity["inode"]
+            ):
+                raise WorkspaceError(
+                    "temporary topology state staging changed before publication"
+                )
             rename_no_replace_at(
                 container_fd, staging_name, container_fd, generation
             )
@@ -9246,6 +9392,7 @@ class Workspace:
                 else:
                     remove_owned_tree(
                         staging,
+                        expected_identity=staging_identity,
                         parent_directory_fd=container_fd,
                     )
             raise
@@ -10184,11 +10331,16 @@ class Workspace:
 
     @staticmethod
     def _prepare_runtime_state_output(
-        state: Path, generation: str, state_directory_fd: int | None = None
+        state: Path,
+        generation: str,
+        state_directory_fd: int | None = None,
+        cleanup_proof: list[bool] | None = None,
     ) -> tuple[Path, int, dict[str, int]]:
         flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
         descriptors: list[int] = []
         created_generation = False
+        if cleanup_proof is not None:
+            cleanup_proof[0] = True
         output = state / "tmp" / "runtime-assets" / generation
         state_mount_id: int | None = None
 
@@ -10253,6 +10405,8 @@ class Workspace:
                     f"server runtime state output already exists: {output}"
                 ) from error
             created_generation = True
+            if cleanup_proof is not None:
+                cleanup_proof[0] = False
             generation_fd = open_directory(container_fd, generation, False)
             descriptors.append(generation_fd)
             marker = json.dumps(
@@ -10321,6 +10475,9 @@ class Workspace:
                         f"server runtime state output path changed: {output}"
                     )
                 os.rmdir(tombstone, dir_fd=parent_fd)
+                os.fsync(parent_fd)
+                if cleanup_proof is not None:
+                    cleanup_proof[0] = True
             if isinstance(error, WorkspaceError):
                 raise
             if not isinstance(error, (OSError, ValueError)):
@@ -10601,23 +10758,102 @@ class Workspace:
     @staticmethod
     def _clear_runtime_state_output_transaction(topology_root: Path) -> None:
         transaction = topology_root / RUNTIME_STATE_OUTPUT_TRANSACTION
-        try:
-            metadata = transaction.stat(follow_symlinks=False)
-        except FileNotFoundError:
-            return
-        if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
-            raise WorkspaceError(
-                f"runtime state output transaction is invalid: {transaction}"
-            )
-        transaction.unlink()
         descriptor = _open_directory_nofollow(
             topology_root,
             os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
         )
         try:
+            try:
+                visible = os.stat(
+                    RUNTIME_STATE_OUTPUT_TRANSACTION,
+                    dir_fd=descriptor,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                return
+            if not stat.S_ISREG(visible.st_mode) or visible.st_nlink != 1:
+                raise WorkspaceError(
+                    f"runtime state output transaction is invalid: {transaction}"
+                )
+            opened_fd = os.open(
+                RUNTIME_STATE_OUTPUT_TRANSACTION,
+                os.O_PATH | os.O_CLOEXEC | os.O_NOFOLLOW,
+                dir_fd=descriptor,
+            )
+            try:
+                opened = os.fstat(opened_fd)
+                if (opened.st_dev, opened.st_ino) != (
+                    visible.st_dev,
+                    visible.st_ino,
+                ):
+                    raise WorkspaceError(
+                        "runtime state output transaction changed before removal"
+                    )
+                tombstone = (
+                    f".{RUNTIME_STATE_OUTPUT_TRANSACTION}.remove-"
+                    f"{opened.st_dev:x}-{opened.st_ino:x}"
+                )
+                rename_no_replace_at(
+                    descriptor,
+                    RUNTIME_STATE_OUTPUT_TRANSACTION,
+                    descriptor,
+                    tombstone,
+                )
+                moved = os.stat(
+                    tombstone, dir_fd=descriptor, follow_symlinks=False
+                )
+                if (moved.st_dev, moved.st_ino) != (
+                    opened.st_dev,
+                    opened.st_ino,
+                ):
+                    raise WorkspaceError(
+                        "runtime state output transaction changed before removal"
+                    )
+                os.unlink(tombstone, dir_fd=descriptor)
+            finally:
+                os.close(opened_fd)
             os.fsync(descriptor)
         finally:
             os.close(descriptor)
+
+    def _rollback_runtime_state_output_transaction(
+        self,
+        topology_root: Path,
+        output: Path,
+        generation: str,
+        state_directory_fd: int,
+        output_identity: dict[str, int],
+    ) -> None:
+        transaction_path = topology_root / RUNTIME_STATE_OUTPUT_TRANSACTION
+        transaction = load_regular_json(
+            transaction_path, "runtime state output transaction"
+        )
+        if (
+            not isinstance(transaction, dict)
+            or transaction.get("generation") != generation
+            or transaction.get("phase") != "prepared"
+            or transaction.get("output_identity") != output_identity
+        ):
+            raise WorkspaceError(
+                f"runtime state output transaction is invalid: {transaction_path}"
+            )
+        self._remove_runtime_state_output(
+            output,
+            generation,
+            state_directory_fd,
+            output_identity,
+            keep_tombstone=True,
+        )
+        durable_atomic_json(
+            transaction_path, {**transaction, "phase": "complete"}
+        )
+        if not self._finish_runtime_state_output_tombstone(
+            state_directory_fd, generation, output_identity
+        ):
+            raise WorkspaceError(
+                f"runtime state output cleanup tombstone is missing: {output}"
+            )
+        self._clear_runtime_state_output_transaction(topology_root)
 
     def _recover_runtime_state_output_transaction(
         self, topology_root: Path, topology_name: str
@@ -10689,16 +10925,11 @@ class Workspace:
             try:
                 lease.bind(identity)
                 if transaction["phase"] == "creating":
-                    if self._runtime_state_output_entry_exists(
-                        descriptor, generation
-                    ):
-                        raise WorkspaceError(
-                            "runtime state output creation was interrupted before "
-                            "exact ownership was recorded; preserve the state and "
-                            f"inspect {transaction_path}"
-                        )
-                    self._clear_runtime_state_output_transaction(topology_root)
-                    return
+                    raise WorkspaceError(
+                        "runtime state output creation was interrupted before "
+                        "exact ownership was recorded; preserve the state and "
+                        f"inspect {transaction_path}"
+                    )
                 output = state / "tmp" / "runtime-assets" / generation
                 output_identity = transaction["output_identity"]
                 if transaction["phase"] == "prepared":
@@ -10844,6 +11075,7 @@ class Workspace:
         state_output_access: Path | None = None
         state_output_identity: dict[str, int] | None = None
         state_output_fd: int | None = None
+        preparation_cleanup_proof = [False]
         output_transaction = owner_root / RUNTIME_STATE_OUTPUT_TRANSACTION
         topology_output = identity.get("kind") == "topology" and "server" in services
         try:
@@ -10938,7 +11170,10 @@ class Workspace:
                     state_output_fd,
                     state_output_identity,
                 ) = self._prepare_runtime_state_output(
-                    state, generation, state_directory_fd
+                    state,
+                    generation,
+                    state_directory_fd,
+                    preparation_cleanup_proof,
                 )
                 if topology_output:
                     durable_atomic_json(
@@ -11079,7 +11314,9 @@ class Workspace:
             if staging.exists():
                 remove_owned_tree(staging)
             cleanup_output = state_output_access or state_output
-            output_cleanup_complete = state_output is None
+            output_cleanup_complete = (
+                state_output is None and preparation_cleanup_proof[0]
+            )
             if cleanup_output is not None and cleanup_output.exists():
                 if (
                     state_output_identity is None
@@ -12580,45 +12817,12 @@ class Workspace:
                         "mutable_state_output_identities"
                     )
                     if not isinstance(identities, list) or not identities:
-                        legacy_outputs = previous_runtime[
-                            "mutable_state_outputs"
-                        ]
-                        legacy_evidence = False
-                        for value in legacy_outputs:
-                            output = Path(value)
-                            if output.exists() or output.is_symlink():
-                                legacy_evidence = True
-                                break
-                            digest = hashlib.sha256(
-                                output.name.encode("utf-8")
-                            ).hexdigest()[:16]
-                            try:
-                                if any(
-                                    re.fullmatch(
-                                        rf"\.remove-{digest}-[0-9a-f]+-"
-                                        r"[0-9a-f]+",
-                                        candidate.name,
-                                    )
-                                    for candidate in output.parent.iterdir()
-                                ):
-                                    legacy_evidence = True
-                                    break
-                            except OSError as error:
-                                raise WorkspaceError(
-                                    "legacy mutable state output inventory is "
-                                    f"unverifiable: {output}"
-                                ) from error
-                        if legacy_evidence:
-                            raise WorkspaceError(
-                                f"topology {name} retains legacy mutable state "
-                                "output without exact ownership evidence; remove "
-                                "it through the pre-upgrade wrapper or choose a "
-                                "new topology name"
-                            )
-                        continue_cleanup = False
+                        raise WorkspaceError(
+                            f"topology {name} retains legacy mutable state "
+                            "output without exact ownership evidence; preserve "
+                            "the historical record and choose a new topology name"
+                        )
                     else:
-                        continue_cleanup = True
-                    if continue_cleanup:
                         previous = self._cleanup_topology_mutable_state_outputs(
                             previous
                         )
@@ -12961,16 +13165,27 @@ class Workspace:
                         else Path(runtime_record["mutable_state_outputs"][0])
                     )
                 ] if runtime_record["mutable_state_outputs"] else []
-                stack.callback(
-                    lambda: self._remove_runtime_state_output(
-                        published_state_output_owner.pop(),
-                        generation,
-                        state_directory_fd,
-                        runtime_record["mutable_state_output_identities"][0],
-                    )
-                    if published_state_output_owner
-                    else None
-                )
+
+                def rollback_published_state_output() -> None:
+                    if not published_state_output_owner:
+                        return
+                    assert state_directory_fd is not None
+                    output = published_state_output_owner.pop()
+                    try:
+                        self._rollback_runtime_state_output_transaction(
+                            topology_root,
+                            output,
+                            generation,
+                            state_directory_fd,
+                            runtime_record[
+                                "mutable_state_output_identities"
+                            ][0],
+                        )
+                    except BaseException:
+                        temporary_state_owner.clear()
+                        raise
+
+                stack.callback(rollback_published_state_output)
                 runtime_lock_owner = [runtime_lock_fd]
                 stack.callback(
                     lambda: os.close(runtime_lock_owner.pop())

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -659,7 +659,7 @@ def _remove_owned_tree_contents(
     display: Path,
 ) -> None:
     def move_to_tombstone(name: str, child: os.stat_result) -> str:
-        tombstone = f".{name}.remove-{secrets.token_hex(16)}"
+        tombstone = f".{name}.remove-{child.st_dev:x}-{child.st_ino:x}"
         rename_no_replace_at(descriptor, name, descriptor, tombstone)
         moved = os.stat(tombstone, dir_fd=descriptor, follow_symlinks=False)
         if (moved.st_dev, moved.st_ino) != (
@@ -678,6 +678,16 @@ def _remove_owned_tree_contents(
     for name in sorted(os.listdir(descriptor)):
         child_display = display / name
         child = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
+        tombstone_match = re.fullmatch(
+            r"\.(.+)\.remove-([0-9a-f]+)-([0-9a-f]+)", name
+        )
+        if tombstone_match and (child.st_dev, child.st_ino) != (
+            int(tombstone_match.group(2), 16),
+            int(tombstone_match.group(3), 16),
+        ):
+            raise WorkspaceError(
+                f"owned removal has an uncertain tombstone: {child_display}"
+            )
         if child.st_dev != device:
             raise WorkspaceError(
                 f"owned removal encountered a mount: {child_display}"
@@ -692,38 +702,66 @@ def _remove_owned_tree_contents(
                 )
             finally:
                 os.close(child_descriptor)
-            tombstone = move_to_tombstone(name, child)
+            tombstone = name if tombstone_match else move_to_tombstone(name, child)
             os.rmdir(tombstone, dir_fd=descriptor)
         else:
             _probe_owned_tree_entry_mount(
                 descriptor, name, child, mount_id, child_display
             )
-            tombstone = move_to_tombstone(name, child)
+            tombstone = name if tombstone_match else move_to_tombstone(name, child)
             os.unlink(tombstone, dir_fd=descriptor)
 
 
 def remove_owned_tree(
     path: Path, *, expected_identity: dict[str, int] | None = None
 ) -> None:
-    if path.is_symlink() or not path.is_dir():
-        raise WorkspaceError(f"owned removal root is invalid: {path}")
+    if expected_identity is not None and (
+        set(expected_identity) != {"device", "inode"}
+        or any(
+            not isinstance(value, int) or isinstance(value, bool) or value < 0
+            for value in expected_identity.values()
+        )
+    ):
+        raise WorkspaceError(f"owned removal root identity is invalid: {path}")
     parent_descriptor = _open_directory_nofollow(
         path.parent,
         os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
     )
     descriptor: int | None = None
     try:
-        before = os.stat(path.name, dir_fd=parent_descriptor, follow_symlinks=False)
-        if expected_identity is not None and (
-            set(expected_identity) != {"device", "inode"}
-            or (before.st_dev, before.st_ino)
-            != (expected_identity["device"], expected_identity["inode"])
+        entry_name = path.name
+        already_tombstoned = False
+        try:
+            before = os.stat(
+                entry_name, dir_fd=parent_descriptor, follow_symlinks=False
+            )
+        except FileNotFoundError:
+            if expected_identity is None:
+                raise WorkspaceError(f"owned removal root is invalid: {path}")
+            entry_name = (
+                f".{path.name}.remove-{expected_identity['device']:x}-"
+                f"{expected_identity['inode']:x}"
+            )
+            try:
+                before = os.stat(
+                    entry_name, dir_fd=parent_descriptor, follow_symlinks=False
+                )
+            except FileNotFoundError as error:
+                raise WorkspaceError(
+                    f"owned removal root is invalid: {path}"
+                ) from error
+            already_tombstoned = True
+        if not stat.S_ISDIR(before.st_mode):
+            raise WorkspaceError(f"owned removal root is invalid: {path}")
+        if expected_identity is not None and (before.st_dev, before.st_ino) != (
+            expected_identity["device"],
+            expected_identity["inode"],
         ):
             raise WorkspaceError(f"owned removal root identity changed: {path}")
         parent_mount_id = _descriptor_mount_id(parent_descriptor)
         descriptor = _open_owned_tree_directory(
             parent_descriptor,
-            path.name,
+            entry_name,
             before,
             parent_mount_id,
             path,
@@ -740,7 +778,7 @@ def remove_owned_tree(
             stat.S_IMODE(before.st_mode),
         )
         visible = os.stat(
-            path.name, dir_fd=parent_descriptor, follow_symlinks=False
+            entry_name, dir_fd=parent_descriptor, follow_symlinks=False
         )
         if (visible.st_dev, visible.st_ino) != expected:
             raise WorkspaceError(f"owned removal root identity changed: {path}")
@@ -751,11 +789,33 @@ def remove_owned_tree(
         os.close(descriptor)
         descriptor = None
         visible = os.stat(
-            path.name, dir_fd=parent_descriptor, follow_symlinks=False
+            entry_name, dir_fd=parent_descriptor, follow_symlinks=False
         )
         if (visible.st_dev, visible.st_ino) != expected:
             raise WorkspaceError(f"owned removal root identity changed: {path}")
-        os.rmdir(path.name, dir_fd=parent_descriptor)
+        tombstone = f".{path.name}.remove-{expected[0]:x}-{expected[1]:x}"
+        if not already_tombstoned:
+            rename_no_replace_at(
+                parent_descriptor,
+                path.name,
+                parent_descriptor,
+                tombstone,
+            )
+        moved = os.stat(
+            tombstone, dir_fd=parent_descriptor, follow_symlinks=False
+        )
+        if (moved.st_dev, moved.st_ino) != expected:
+            try:
+                rename_no_replace_at(
+                    parent_descriptor,
+                    tombstone,
+                    parent_descriptor,
+                    path.name,
+                )
+            except WorkspaceError:
+                pass
+            raise WorkspaceError(f"owned removal root identity changed: {path}")
+        os.rmdir(tombstone, dir_fd=parent_descriptor)
     finally:
         if descriptor is not None:
             os.close(descriptor)
@@ -1360,19 +1420,9 @@ def durable_atomic_json_at(directory_fd: int, name: str, value: Any) -> None:
             stream.write("\n")
             stream.flush()
             os.fsync(stream.fileno())
-        try:
-            os.link(
-                temporary,
-                name,
-                src_dir_fd=directory_fd,
-                dst_dir_fd=directory_fd,
-                follow_symlinks=False,
-            )
-        except FileExistsError as error:
-            raise WorkspaceError(
-                f"descriptor-relative JSON appeared before publication: {name}"
-            ) from error
-        os.unlink(temporary, dir_fd=directory_fd)
+        rename_no_replace_at(
+            directory_fd, temporary, directory_fd, name
+        )
         os.fsync(directory_fd)
     except BaseException:
         try:
@@ -8274,7 +8324,6 @@ class Workspace:
     ) -> None:
         temporary = f".{name}.{secrets.token_hex(12)}.tmp"
         descriptor: int | None = None
-        linked = False
         try:
             descriptor = os.open(
                 temporary,
@@ -8288,20 +8337,10 @@ class Workspace:
                 stream.write("\n")
                 stream.flush()
                 os.fsync(stream.fileno())
-            os.link(
-                temporary,
-                name,
-                src_dir_fd=directory_fd,
-                dst_dir_fd=directory_fd,
-                follow_symlinks=False,
+            rename_no_replace_at(
+                directory_fd, temporary, directory_fd, name
             )
-            linked = True
-            os.unlink(temporary, dir_fd=directory_fd)
             os.fsync(directory_fd)
-        except FileExistsError as error:
-            raise WorkspaceError(
-                "server state implementation marker appeared during publication"
-            ) from error
         except OSError as error:
             raise WorkspaceError(
                 f"cannot publish server state implementation marker: {error}"
@@ -8309,11 +8348,10 @@ class Workspace:
         finally:
             if descriptor is not None:
                 os.close(descriptor)
-            if not linked:
-                try:
-                    os.unlink(temporary, dir_fd=directory_fd)
-                except FileNotFoundError:
-                    pass
+            try:
+                os.unlink(temporary, dir_fd=directory_fd)
+            except FileNotFoundError:
+                pass
 
     def _validate_state_descriptor(
         self,
@@ -8426,6 +8464,16 @@ class Workspace:
                 raise WorkspaceError(
                     f"server state identity changed during validation: {path}"
                 )
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError as error:
+                if error.errno in {errno.EACCES, errno.EAGAIN}:
+                    raise WorkspaceError(
+                        f"physical server state is already in use: {path}"
+                    ) from error
+                raise WorkspaceError(
+                    f"cannot lock physical server state: {path}: {error}"
+                ) from error
             self._validate_state_descriptor(
                 descriptor,
                 path,
@@ -8637,11 +8685,11 @@ class Workspace:
                     "retry its originating state promote command"
                 )
             creation_path = path / TEMPORARY_STATE_METADATA
-            if creation_path.is_symlink():
-                raise WorkspaceError(
-                    f"promoted state creation metadata is invalid: {creation_path}"
-                )
-            if creation_path.is_file():
+            if creation_path.exists() or creation_path.is_symlink():
+                if creation_path.is_symlink() or not creation_path.is_file():
+                    raise WorkspaceError(
+                        f"promoted state creation metadata is invalid: {creation_path}"
+                    )
                 creation = load_regular_json(
                     creation_path, "promoted state creation metadata"
                 )
@@ -8651,18 +8699,48 @@ class Workspace:
                     else None
                 )
                 if (
-                    isinstance(creation, dict)
-                    and
-                    creation.get("schema_version")
-                    == TEMPORARY_STATE_SCHEMA_VERSION
-                    and isinstance(creation_policy, dict)
-                    and creation_policy.get("mode") == "temporary"
-                    and creation_policy.get("path") == str(path)
+                    not isinstance(creation, dict)
+                    or creation.get("schema_version")
+                    != TEMPORARY_STATE_SCHEMA_VERSION
+                    or not isinstance(creation_policy, dict)
+                    or creation_policy.get("mode") != "temporary"
+                    or creation_policy.get("path") != str(path)
                 ):
                     raise WorkspaceError(
-                        f"promoted state provenance is missing: {record_path}; "
-                        "retry its originating state promote command"
+                        f"promoted state creation metadata is invalid: {creation_path}"
                     )
+                raise WorkspaceError(
+                    f"promoted state provenance is missing: {record_path}; "
+                    "retry its originating state promote command"
+                )
+            if self.paths.topologies.is_dir() and not self.paths.topologies.is_symlink():
+                for topology in self.paths.topologies.iterdir():
+                    status_path = topology / "status.json"
+                    if status_path.is_symlink() or not status_path.is_file():
+                        continue
+                    try:
+                        status = load_regular_json(
+                            status_path, "promoted state origin status"
+                        )
+                    except WorkspaceError:
+                        continue
+                    policy = (
+                        status.get("state_policy")
+                        if isinstance(status, dict)
+                        else None
+                    )
+                    if (
+                        isinstance(policy, dict)
+                        and policy.get("mode") == "temporary"
+                        and policy.get("lifecycle")
+                        in {"promotion-pending", "promoted"}
+                        and policy.get("name") == state_name
+                        and policy.get("path") == str(path)
+                    ):
+                        raise WorkspaceError(
+                            f"promoted state provenance is missing: {record_path}; "
+                            f"retry ./atrinik state promote {topology.name} {state_name}"
+                        )
             return None
         record = load_regular_json(record_path, "promoted state provenance")
         if (
@@ -11699,7 +11777,9 @@ class Workspace:
                 state: Path | None = None
                 state_policy: dict[str, Any] | None = None
                 state_directory_fd: int | None = None
-                temporary_state_owner: list[Path] = []
+                temporary_state_owner: list[
+                    tuple[Path, TextIO, dict[str, int], dict[str, int]]
+                ] = []
                 if "server" in selected_services:
                     assert implementation is not None
                     if state_mode == "temporary":
@@ -11713,12 +11793,6 @@ class Workspace:
                             resolved_status[server_provider],
                         )
                         state_location = state
-                        temporary_state_owner.append(state)
-                        stack.callback(
-                            lambda: remove_owned_tree(temporary_state_owner.pop())
-                            if temporary_state_owner
-                            else None
-                        )
                         state_lock = stack.enter_context(
                             self._topology_state_lock(
                                 state_location,
@@ -11762,6 +11836,22 @@ class Workspace:
                             "inode": lock_metadata.st_ino,
                         },
                     }
+                    if state_mode == "temporary":
+                        temporary_state_owner.append(
+                            (
+                                state,
+                                state_lock.path_lock,
+                                state_policy["identity"],
+                                state_policy["lease_identity"],
+                            )
+                        )
+                        stack.callback(
+                            lambda: self._rollback_temporary_state_creation(
+                                *temporary_state_owner.pop()
+                            )
+                            if temporary_state_owner
+                            else None
+                        )
                     try:
                         visible_lock = Path(f"{state}.lock").stat(
                             follow_symlinks=False
@@ -12286,7 +12376,31 @@ class Workspace:
             os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
         )
         try:
-            os.unlink(lock.name, dir_fd=parent_fd)
+            tombstone = (
+                f".{lock.name}.remove-{lease_identity['device']:x}-"
+                f"{lease_identity['inode']:x}"
+            )
+            rename_no_replace_at(
+                parent_fd, lock.name, parent_fd, tombstone
+            )
+            moved = os.stat(
+                tombstone, dir_fd=parent_fd, follow_symlinks=False
+            )
+            expected = (
+                lease_identity["device"],
+                lease_identity["inode"],
+            )
+            if (moved.st_dev, moved.st_ino) != expected:
+                try:
+                    rename_no_replace_at(
+                        parent_fd, tombstone, parent_fd, lock.name
+                    )
+                except WorkspaceError:
+                    pass
+                raise WorkspaceError(
+                    f"temporary topology state lease changed before removal: {lock}"
+                )
+            os.unlink(tombstone, dir_fd=parent_fd)
             os.fsync(parent_fd)
         finally:
             os.close(parent_fd)
@@ -12316,6 +12430,46 @@ class Workspace:
                 "temporary topology state lease changed before lifecycle "
                 f"mutation: {lock}"
             )
+
+    @staticmethod
+    def _finish_temporary_state_lock_tombstone(
+        state: Path, lease_identity: dict[str, int]
+    ) -> bool:
+        lock = Path(f"{state}.lock")
+        tombstone = lock.parent / (
+            f".{lock.name}.remove-{lease_identity['device']:x}-"
+            f"{lease_identity['inode']:x}"
+        )
+        if not tombstone.exists() and not tombstone.is_symlink():
+            return False
+        metadata = tombstone.stat(follow_symlinks=False)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+            or (metadata.st_dev, metadata.st_ino)
+            != (lease_identity["device"], lease_identity["inode"])
+        ):
+            raise WorkspaceError(
+                f"temporary topology state lease tombstone is invalid: {tombstone}"
+            )
+        tombstone.unlink()
+        fsync_directory(tombstone.parent)
+        return True
+
+    @staticmethod
+    def _rollback_temporary_state_creation(
+        state: Path,
+        state_lease: TextIO,
+        state_identity: dict[str, int],
+        lease_identity: dict[str, int],
+    ) -> None:
+        Workspace._validate_temporary_state_lock(
+            state, state_lease, lease_identity
+        )
+        remove_owned_tree(state, expected_identity=state_identity)
+        Workspace._unlink_temporary_state_lock(
+            state, state_lease, lease_identity
+        )
 
     def _commit_temporary_state_removal(
         self,
@@ -12397,10 +12551,12 @@ class Workspace:
             return status
         state = Path(policy["path"])
         lock_path = Path(f"{state}.lock")
-        if policy.get("lifecycle") == "removed" and not (
-            lock_path.exists() or lock_path.is_symlink()
-        ):
-            return status
+        if policy.get("lifecycle") == "removed":
+            if not (lock_path.exists() or lock_path.is_symlink()):
+                self._finish_temporary_state_lock_tombstone(
+                    state, policy["lease_identity"]
+                )
+                return status
         with exclusive_lock(
             lock_path,
             f"temporary topology state {state}",

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -9024,14 +9024,15 @@ class Workspace:
                 except BaseException:
                     if staging_fd is not None:
                         os.close(staging_fd)
-                    try:
-                        remove_owned_tree(
-                            topology_root / staging,
-                            expected_identity=staging_identity,
-                            parent_directory_fd=root_fd,
-                        )
-                    except FileNotFoundError:
-                        pass
+                    if staging_identity is not None:
+                        try:
+                            remove_owned_tree(
+                                topology_root / staging,
+                                expected_identity=staging_identity,
+                                parent_directory_fd=root_fd,
+                            )
+                        except FileNotFoundError:
+                            pass
                     raise
                 else:
                     if staging_fd is not None:
@@ -9258,7 +9259,7 @@ class Workspace:
                     "temporary topology state staging changed"
                 )
         except BaseException:
-            if staging is not None:
+            if staging is not None and staging_identity is not None:
                 try:
                     remove_owned_tree(
                         staging,

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -9063,6 +9063,94 @@ class Workspace:
             if not (path / name).is_dir():
                 raise WorkspaceError(f"server state lacks required directory {name}: {path}")
 
+    @staticmethod
+    def _validate_temporary_state_integrity(
+        directory_fd: int, path: Path
+    ) -> None:
+        """Fail closed before deleting wrapper-owned mutable server state."""
+
+        root = os.fstat(directory_fd)
+        for name in EXPECTED_SERVER_DATA["files"]:
+            try:
+                metadata = os.stat(
+                    name, dir_fd=directory_fd, follow_symlinks=False
+                )
+            except OSError as error:
+                raise WorkspaceError(
+                    f"temporary server state lacks required file {name}: {path}"
+                ) from error
+            if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+                raise WorkspaceError(
+                    f"temporary server state required file is linked or invalid "
+                    f"{name}: {path}"
+                )
+        for name in EXPECTED_SERVER_DATA["directories"]:
+            try:
+                metadata = os.stat(
+                    name, dir_fd=directory_fd, follow_symlinks=False
+                )
+            except OSError as error:
+                raise WorkspaceError(
+                    f"temporary server state lacks required directory {name}: {path}"
+                ) from error
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise WorkspaceError(
+                    "temporary server state required directory is linked or "
+                    f"invalid {name}: {path}"
+                )
+
+        def validate_directory(descriptor: int, display: Path) -> None:
+            for name in os.listdir(descriptor):
+                child_display = display / name
+                metadata = os.stat(
+                    name, dir_fd=descriptor, follow_symlinks=False
+                )
+                if stat.S_ISLNK(metadata.st_mode):
+                    raise WorkspaceError(
+                        f"temporary server state contains a symbolic link: "
+                        f"{child_display}"
+                    )
+                if stat.S_ISREG(metadata.st_mode):
+                    if metadata.st_nlink != 1:
+                        raise WorkspaceError(
+                            f"temporary server state contains a hard-linked file: "
+                            f"{child_display}"
+                        )
+                    continue
+                if not stat.S_ISDIR(metadata.st_mode):
+                    raise WorkspaceError(
+                        f"temporary server state contains a special entry: "
+                        f"{child_display}"
+                    )
+                if metadata.st_dev != root.st_dev:
+                    raise WorkspaceError(
+                        f"temporary server state contains a mounted directory: "
+                        f"{child_display}"
+                    )
+                child_fd = os.open(
+                    name,
+                    os.O_RDONLY
+                    | os.O_CLOEXEC
+                    | os.O_DIRECTORY
+                    | os.O_NOFOLLOW,
+                    dir_fd=descriptor,
+                )
+                try:
+                    opened = os.fstat(child_fd)
+                    if (opened.st_dev, opened.st_ino) != (
+                        metadata.st_dev,
+                        metadata.st_ino,
+                    ):
+                        raise WorkspaceError(
+                            "temporary server state entry changed during "
+                            f"validation: {child_display}"
+                        )
+                    validate_directory(child_fd, child_display)
+                finally:
+                    os.close(child_fd)
+
+        validate_directory(directory_fd, path)
+
     def _topology_services(self, services: list[str] | None) -> list[str]:
         requested = set(services or TOPOLOGY_SERVICES)
         unknown = sorted(requested - set(TOPOLOGY_SERVICES))
@@ -12629,6 +12717,7 @@ class Workspace:
         name: str,
         status: dict[str, Any],
         state_lease: TextIO,
+        state_directory_fd: int | None = None,
     ) -> dict[str, Any]:
         policy = status["state_policy"]
         state = Path(policy["path"])
@@ -12637,6 +12726,13 @@ class Workspace:
         lifecycle = policy["lifecycle"]
         current = status
         if lifecycle not in {"removal-pending", "removed"}:
+            if state_directory_fd is None:
+                raise WorkspaceError(
+                    "temporary state integrity lease is missing before removal"
+                )
+            self._validate_temporary_state_integrity(
+                state_directory_fd, state
+            )
             pending = {**policy, "lifecycle": "removal-pending"}
             current = self._write_temporary_state_policy(name, current, pending)
             policy = current["state_policy"]
@@ -12766,8 +12862,25 @@ class Workspace:
                 mutation_path, policy["identity"]
             )
             try:
+                if policy.get("lifecycle") not in {
+                    "removal-pending",
+                    "removed",
+                }:
+                    try:
+                        self._validate_temporary_state_integrity(
+                            mutation_fd, state
+                        )
+                    except WorkspaceError as error:
+                        retained = {**policy, "lifecycle": "retained"}
+                        self._write_temporary_state_policy(
+                            name, current, retained
+                        )
+                        raise WorkspaceError(
+                            f"temporary state was retained because its integrity "
+                            f"could not be proved: {state}: {error}"
+                        ) from error
                 return self._commit_temporary_state_removal(
-                    name, current, state_lease
+                    name, current, state_lease, mutation_fd
                 )
             finally:
                 os.close(mutation_fd)

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -8056,6 +8056,29 @@ class Workspace:
                 f"server state implementation does not match the selected server: {path}"
             )
 
+    @staticmethod
+    def _temporary_state_metadata_matches(
+        policy: dict[str, Any], creation_policy: object
+    ) -> bool:
+        """Match mutable lifecycle policy to its immutable creation record."""
+
+        immutable = {
+            "mode",
+            "path",
+            "owner",
+            "created_at",
+            "identity",
+            "implementation",
+            "server",
+        }
+        return bool(
+            isinstance(creation_policy, dict)
+            and set(creation_policy) == immutable | {"name", "lifecycle"}
+            and creation_policy.get("name") is None
+            and creation_policy.get("lifecycle") == "disposable"
+            and all(creation_policy.get(key) == policy.get(key) for key in immutable)
+        )
+
     def list_states(self) -> dict[str, str]:
         self.paths.ensure()
         states = self._load_states()
@@ -8115,6 +8138,25 @@ class Workspace:
                 raise
         self._validate_state(path)
         if implementation is not None:
+            marker = path / STATE_IMPLEMENTATION_MARKER
+            if write_implementation and not marker.exists() and not marker.is_symlink():
+                descriptor, temporary_name = tempfile.mkstemp(
+                    prefix=f".{STATE_IMPLEMENTATION_MARKER}.", dir=path
+                )
+                os.close(descriptor)
+                temporary = Path(temporary_name)
+                try:
+                    durable_atomic_json(
+                        temporary,
+                        {
+                            "schema_version": STATE_IMPLEMENTATION_SCHEMA_VERSION,
+                            **implementation,
+                        },
+                    )
+                    rename_no_replace(temporary, marker)
+                except BaseException:
+                    temporary.unlink(missing_ok=True)
+                    raise
             self._validate_state_implementation(path, implementation)
         (path / "tmp").mkdir(exist_ok=True)
         return path
@@ -8125,6 +8167,20 @@ class Workspace:
         path: Path,
         implementation: dict[str, str],
     ) -> dict[str, Any]:
+        owner, lifecycle = self._persistent_state_ownership(state_name, path)
+        return {
+            "mode": "default" if state_name == "default" else "named",
+            "name": state_name,
+            "path": str(path),
+            "owner": owner,
+            "lifecycle": lifecycle,
+            "identity": self._state_identity(path),
+            "implementation": implementation,
+        }
+
+    def _persistent_state_ownership(
+        self, state_name: str, path: Path
+    ) -> tuple[dict[str, str], str]:
         registered = self._load_states()
         scenario_root = self.paths.scenarios / state_name.removeprefix("scenario-")
         scenario_path = scenario_root / "state"
@@ -8141,15 +8197,7 @@ class Workspace:
         else:
             owner = {"kind": "external"}
             lifecycle = "persistent-external"
-        return {
-            "mode": "default" if state_name == "default" else "named",
-            "name": state_name,
-            "path": str(path),
-            "owner": owner,
-            "lifecycle": lifecycle,
-            "identity": self._state_identity(path),
-            "implementation": implementation,
-        }
+        return owner, lifecycle
 
     def _temporary_state_container(self, topology_root: Path) -> Path:
         container = topology_root / "temporary-states"
@@ -8338,20 +8386,15 @@ class Workspace:
             else:
                 assert state_name is not None
                 state = str(self._state_location(state_name))
+                owner, lifecycle = self._persistent_state_ownership(
+                    state_name, Path(state)
+                )
                 state_policy = {
                     "mode": state_mode,
                     "name": state_name,
                     "path": state,
-                    "owner": {
-                        "kind": (
-                            "workspace"
-                            if Path(state).is_relative_to(
-                                self.paths.state.resolve(strict=False)
-                            )
-                            else "external"
-                        )
-                    },
-                    "lifecycle": "persistent",
+                    "owner": owner,
+                    "lifecycle": lifecycle,
                 }
         return {
             "profile": profile_name,
@@ -8987,7 +9030,7 @@ class Workspace:
                         raise WorkspaceError(
                             f"runtime publication contains a link: {path}"
                         )
-                    if path.resolve(strict=False) != target.resolve(strict=False):
+                    if path.resolve(strict=False) != state.resolve(strict=False):
                         raise WorkspaceError(
                             f"runtime publication state link changed: {path}"
                         )
@@ -9314,7 +9357,9 @@ class Workspace:
                     build_root / "runtime" / "resources",
                     server_runtime / "resources",
                 )
-                (server_runtime / "data").symlink_to(state, target_is_directory=True)
+                (server_runtime / "data").symlink_to(
+                    state, target_is_directory=True
+                )
                 state_output = self._prepare_runtime_state_output(
                     state, generation
                 )
@@ -9660,11 +9705,13 @@ class Workspace:
             "owner",
             "lifecycle",
             "identity",
+            "lease_identity",
             "implementation",
         }
         mode = policy.get("mode")
         expected_keys = common | ({"created_at", "server"} if mode == "temporary" else set())
         identity = policy.get("identity")
+        lease_identity = policy.get("lease_identity")
         implementation = policy.get("implementation")
         providers = status.get("providers")
         resolved = status.get("resolved")
@@ -9679,6 +9726,12 @@ class Workspace:
             or not all(
                 isinstance(value, int) and not isinstance(value, bool) and value >= 0
                 for value in identity.values()
+            )
+            or not isinstance(lease_identity, dict)
+            or set(lease_identity) != {"device", "inode"}
+            or not all(
+                isinstance(value, int) and not isinstance(value, bool) and value >= 0
+                for value in lease_identity.values()
             )
             or not isinstance(implementation, dict)
             or set(implementation) != {"stack", "provider", "repository"}
@@ -9718,6 +9771,7 @@ class Workspace:
                 not in {
                     "disposable",
                     "retained",
+                    "removal-pending",
                     "promotion-pending",
                     "promoted",
                     "removed",
@@ -9727,7 +9781,11 @@ class Workspace:
                 or policy.get("server") != resolved[providers["server"]]
             ):
                 raise WorkspaceError(f"temporary topology state policy is invalid: {name}")
-            if lifecycle != "removed":
+            if (
+                lifecycle not in {"removed", "removal-pending"}
+                or path.exists()
+                or path.is_symlink()
+            ):
                 marker = path / MANAGED_MARKER
                 metadata_path = path / TEMPORARY_STATE_METADATA
                 if (
@@ -9754,7 +9812,9 @@ class Workspace:
                     not isinstance(metadata, dict)
                     or metadata.get("schema_version")
                     != TEMPORARY_STATE_SCHEMA_VERSION
-                    or metadata.get("state_policy") != policy
+                    or not self._temporary_state_metadata_matches(
+                        policy, metadata.get("state_policy")
+                    )
                 ):
                     raise WorkspaceError(
                         f"temporary topology state metadata is invalid: {name}"
@@ -9766,7 +9826,7 @@ class Workspace:
                     raise WorkspaceError(
                         f"promoted temporary state registration is invalid: {name}"
                     )
-            elif path.exists() or path.is_symlink():
+            elif lifecycle == "removed" and (path.exists() or path.is_symlink()):
                 raise WorkspaceError(
                     f"removed temporary topology state still exists: {name}"
                 )
@@ -10739,6 +10799,17 @@ class Workspace:
                     service["running"] for service in previous["services"].values()
                 ):
                     raise WorkspaceError(f"topology is already running: {name}")
+                previous_policy = previous.get("state_policy")
+                if (
+                    isinstance(previous_policy, dict)
+                    and previous_policy.get("mode") == "temporary"
+                    and previous_policy.get("lifecycle")
+                    not in {"removed", "promoted"}
+                ):
+                    raise WorkspaceError(
+                        f"topology {name} retains temporary generation state; "
+                        "promote it or complete its safe cleanup before restart"
+                    )
 
             if "client" in selected_services:
                 self._require_client_display()
@@ -10852,6 +10923,7 @@ class Workspace:
                 )
                 state: Path | None = None
                 state_policy: dict[str, Any] | None = None
+                state_directory_fd: int | None = None
                 temporary_state_owner: list[Path] = []
                 if "server" in selected_services:
                     assert implementation is not None
@@ -10882,12 +10954,39 @@ class Workspace:
                             selected["server"],
                             resolved_path=state_location,
                             implementation=implementation,
-                            write_implementation=state_location.is_relative_to(
-                                self.paths.state.resolve(strict=False)
-                            ),
+                            write_implementation=True,
                         )
                         state_policy = self._persistent_state_policy(
                             state_name, state, implementation
+                        )
+                    assert state_lock is not None
+                    lock_metadata = os.fstat(state_lock.fileno())
+                    if (
+                        not stat.S_ISREG(lock_metadata.st_mode)
+                        or lock_metadata.st_nlink != 1
+                    ):
+                        raise WorkspaceError(
+                            f"server state lease identity is invalid: {state}.lock"
+                        )
+                    state_policy = {
+                        **state_policy,
+                        "lease_identity": {
+                            "device": lock_metadata.st_dev,
+                            "inode": lock_metadata.st_ino,
+                        },
+                    }
+                    state_directory_fd = os.open(
+                        state,
+                        os.O_PATH | os.O_DIRECTORY | os.O_NOFOLLOW,
+                    )
+                    stack.callback(os.close, state_directory_fd)
+                    state_metadata = os.fstat(state_directory_fd)
+                    if state_policy["identity"] != {
+                        "device": state_metadata.st_dev,
+                        "inode": state_metadata.st_ino,
+                    }:
+                        raise WorkspaceError(
+                            f"server state identity changed before runtime publication: {state}"
                         )
                 build_lock = stack.enter_context(
                     self._profile_build_lock(root, profile_name)
@@ -10976,6 +11075,11 @@ class Workspace:
                             f"--port_quic={endpoint['port']}",
                             "--port_mapping=off",
                             "--stun_server=off",
+                            *(
+                                [f"--datapath=/proc/self/fd/{state_directory_fd}"]
+                                if state_directory_fd is not None
+                                else []
+                            ),
                             "--assetspath="
                             f"{runtime_record['mutable_state_outputs'][0]}",
                             "--no_console",
@@ -11071,6 +11175,11 @@ class Workspace:
                     if state_lock is not None:
                         command.extend(["--lock-fd", str(state_lock.fileno())])
                         inherited_locks.append(state_lock.fileno())
+                    if state_directory_fd is not None:
+                        command.extend(
+                            ["--state-directory-fd", str(state_directory_fd)]
+                        )
+                        inherited_locks.append(state_directory_fd)
                     command.extend(
                         ["--runtime-lock-fd", str(runtime_lock_fd)]
                     )
@@ -11288,15 +11397,6 @@ class Workspace:
         policy: dict[str, Any],
     ) -> dict[str, Any]:
         root = self._topology_directory(name)
-        state = Path(policy["path"])
-        metadata_path = state / TEMPORARY_STATE_METADATA
-        durable_atomic_json(
-            metadata_path,
-            {
-                "schema_version": TEMPORARY_STATE_SCHEMA_VERSION,
-                "state_policy": policy,
-            },
-        )
         status_path = root / "status.json"
         raw_status = load_json(status_path)
         if (
@@ -11326,7 +11426,7 @@ class Workspace:
             "retained",
         }:
             return status
-        if not confirmed_clean:
+        if not confirmed_clean and policy.get("lifecycle") != "removal-pending":
             if retain_state:
                 raise WorkspaceError(
                     f"topology {name} did not complete a confirmed clean down; "
@@ -11347,14 +11447,20 @@ class Workspace:
             if retain_state:
                 retained = {**policy, "lifecycle": "retained"}
                 return self._write_temporary_state_policy(name, current, retained)
-            remove_owned_tree(state)
-            removed = {**policy, "lifecycle": "removed"}
+            pending = {**policy, "lifecycle": "removal-pending"}
+            if policy != pending:
+                current = self._write_temporary_state_policy(
+                    name, current, pending
+                )
+            if state.exists() or state.is_symlink():
+                remove_owned_tree(state)
+            removed = {**pending, "lifecycle": "removed"}
             raw_status = load_json(
                 self._topology_directory(name) / "status.json"
             )
             if (
                 not isinstance(raw_status, dict)
-                or raw_status.get("state_policy") != policy
+                or raw_status.get("state_policy") != pending
             ):
                 raise WorkspaceError(
                     f"temporary topology state status changed before removal: {name}"
@@ -11558,6 +11664,13 @@ class Workspace:
         paths = [(item, path) for item, path in paths if path.is_file()]
         if not paths:
             raise WorkspaceError(f"topology has no matching logs: {name}")
+        policy = self.topology_status(name).get("state_policy")
+        if isinstance(policy, dict):
+            print(
+                "==> state-policy "
+                f"mode={policy['mode']} owner={json.dumps(policy['owner'], sort_keys=True)} "
+                f"path={policy['path']} lifecycle={policy['lifecycle']} <=="
+            )
         positions: dict[Path, tuple[int, int, int]] = {}
         for item, path in paths:
             with os.fdopen(

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -708,6 +708,17 @@ def _remove_owned_tree_contents(
             raise WorkspaceError(
                 f"owned removal entry identity changed: {display / name}"
             )
+        if reject_links and (
+            stat.S_ISLNK(moved.st_mode)
+            or (stat.S_ISREG(moved.st_mode) and moved.st_nlink != 1)
+        ):
+            try:
+                rename_no_replace_at(descriptor, tombstone, descriptor, name)
+            except WorkspaceError:
+                pass
+            raise WorkspaceError(
+                f"owned removal encountered linked state: {display / name}"
+            )
         return tombstone
 
     for name in sorted(os.listdir(descriptor)):
@@ -9123,6 +9134,23 @@ class Workspace:
 
         root = os.fstat(directory_fd)
         root_mount = _descriptor_mount_id(directory_fd)
+        parent_fd = _open_directory_nofollow(
+            path.parent,
+            os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
+        )
+        try:
+            visible = os.stat(
+                path.name, dir_fd=parent_fd, follow_symlinks=False
+            )
+            if (
+                (visible.st_dev, visible.st_ino) != (root.st_dev, root.st_ino)
+                or _descriptor_mount_id(parent_fd) != root_mount
+            ):
+                raise WorkspaceError(
+                    f"temporary server state root changed or crossed a mount: {path}"
+                )
+        finally:
+            os.close(parent_fd)
         for name in EXPECTED_SERVER_DATA["files"]:
             try:
                 metadata = os.stat(
@@ -10766,11 +10794,14 @@ class Workspace:
         policy = status.get("state_policy")
         state = status.get("state")
         services = status.get("services")
-        server_present = (
-            state is not None
-            or policy is not None
-            or isinstance(services, dict) and "server" in services
+        server_service = isinstance(services, dict) and "server" in services
+        pre_service_failure = (
+            bool(status.get("error"))
+            and services == {}
+            and state is not None
+            and policy is not None
         )
+        server_present = server_service or pre_service_failure
         if not server_present:
             if policy is not None or state is not None:
                 raise WorkspaceError(f"topology state policy is invalid: {name}")
@@ -12025,7 +12056,7 @@ class Workspace:
                 state_policy: dict[str, Any] | None = None
                 state_directory_fd: int | None = None
                 temporary_state_owner: list[
-                    tuple[Path, TextIO, dict[str, int], dict[str, int]]
+                    tuple[Path, TextIO, dict[str, int], dict[str, int], int]
                 ] = []
                 if "server" in selected_services:
                     assert implementation is not None
@@ -12104,22 +12135,6 @@ class Workspace:
                             "inode": lock_metadata.st_ino,
                         },
                     }
-                    if state_mode == "temporary":
-                        temporary_state_owner.append(
-                            (
-                                state,
-                                state_lock.path_lock,
-                                state_policy["identity"],
-                                state_policy["lease_identity"],
-                            )
-                        )
-                        stack.callback(
-                            lambda: self._rollback_temporary_state_creation(
-                                *temporary_state_owner.pop()
-                            )
-                            if temporary_state_owner
-                            else None
-                        )
                     try:
                         visible_lock = Path(f"{state}.lock").stat(
                             follow_symlinks=False
@@ -12145,6 +12160,23 @@ class Workspace:
                             write_implementation=False,
                         )
                         stack.callback(os.close, state_directory_fd)
+                    if state_mode == "temporary":
+                        temporary_state_owner.append(
+                            (
+                                state,
+                                state_lock.path_lock,
+                                state_policy["identity"],
+                                state_policy["lease_identity"],
+                                state_directory_fd,
+                            )
+                        )
+                        stack.callback(
+                            lambda: self._rollback_temporary_state_creation(
+                                *temporary_state_owner.pop()
+                            )
+                            if temporary_state_owner
+                            else None
+                        )
                     state_metadata = os.fstat(state_directory_fd)
                     if state_policy["identity"] != {
                         "device": state_metadata.st_dev,
@@ -12812,11 +12844,31 @@ class Workspace:
         state_lease: TextIO,
         state_identity: dict[str, int],
         lease_identity: dict[str, int],
+        state_directory_fd: int | None = None,
     ) -> None:
         Workspace._validate_temporary_state_lock(
             state, state_lease, lease_identity
         )
-        remove_owned_tree(state, expected_identity=state_identity)
+        owned_descriptor = state_directory_fd
+        close_descriptor = False
+        if owned_descriptor is None:
+            owned_descriptor = os.open(
+                state,
+                os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
+            )
+            close_descriptor = True
+        try:
+            Workspace._validate_temporary_state_integrity(
+                owned_descriptor, state
+            )
+            remove_owned_tree(
+                state,
+                expected_identity=state_identity,
+                reject_links=True,
+            )
+        finally:
+            if close_descriptor:
+                os.close(owned_descriptor)
         Workspace._unlink_temporary_state_lock(
             state, state_lease, lease_identity
         )

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -735,9 +735,11 @@ termination, and exact lease release; the durable proof permits a later
 `down` invocation to finish an interrupted removal transaction.
 `down --retain-state` instead records a retained lifecycle. `state
 promote` requires that stopped retained identity, serializes
-topology/state/registry mutation, publishes a promotion-pending record, and
+topology/state/registry mutation, pins and revalidates the retained directory,
+publishes descriptor-relative provenance plus a promotion-pending record, and
 atomically adds the exact path under a previously unused persistent name before
-finalizing it as promoted. Creation metadata remains immutable and status owns
+finalizing it as promoted. A raced path replacement rolls registry publication
+back before returning an error. Creation metadata remains immutable and status owns
 the mutable lifecycle, so interruption after either durable promotion write is
 recoverable by retry. Independent immutable promotion provenance binds the
 registered name and path to the source topology generation, including while the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -678,9 +678,12 @@ leases. Processes started outside the coordinator do not
 participate in the state lock, so operators must not point those processes at
 the same state concurrently. Startup also opens the selected state directory
 without following links, verifies its recorded device/inode identity, and hands
-that descriptor to the supervisor and server. The server consumes the pinned
-directory through its inherited descriptor even if an external path component
-is replaced after admission.
+that descriptor and its physical-identity lease to the supervisor and guardian.
+The server consumes the pinned directory, including pre-option configuration
+reads and disposable runtime output, through its inherited descriptor even if
+an external path component is replaced after admission. Rollback removes that
+output relative to the same pinned descriptor and never follows the replaced
+lexical path.
 
 The current topology record and human/JSON status surfaces retain the state
 policy, owner, exact path identity, implementation, and lifecycle. A same-state
@@ -736,8 +739,10 @@ topology/state/registry mutation, publishes a promotion-pending record, and
 atomically adds the exact path under a previously unused persistent name before
 finalizing it as promoted. Creation metadata remains immutable and status owns
 the mutable lifecycle, so interruption after either durable promotion write is
-recoverable by retry. Its persistent policy continues to identify the source
-topology generation rather than collapsing to generic external ownership. It
+recoverable by retry. Independent immutable promotion provenance binds the
+registered name and path to the source topology generation, including while the
+origin status is temporarily unavailable or promotion is pending. Its
+persistent policy therefore never collapses to generic external ownership. It
 never overwrites a name or directory. A crash,
 unreachable control endpoint, failed post-spawn startup, malformed identity,
 linked path, uncertain lock, or incomplete promotion remains on disk for

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -138,6 +138,7 @@ workspace/
   build/compiler-cache/              bounded shared native compiler cache
   build/retention.json               optional strict build pin/rollback record
   topologies/<name>/                 supervised process state and rotated logs
+    temporary-states/<generation>/   disposable or retained exact state
   state/server/<name>/               persistent mutable server data
   states.json                        named external-state registry
 ~~~
@@ -635,12 +636,27 @@ match; dirty inputs deliberately regenerate.
 
 For the currently runnable classic profile, server launch preparation assembles
 a disposable working directory with links to the selected build, plugins,
-collected Classic-target `content@main`, resources, configuration, GPL tools, and named
-persistent state. GPL tools are not part of the replacement/default role graph.
-First use initializes a state atomically from the selected server's
-`install_data`; an existing directory is validated and never overlaid. State
-inside a server source worktree is rejected. Replacement runtime preparation
-remains unavailable until its native component contracts land.
+collected Classic-target `content@main`, resources, configuration, GPL tools,
+and one explicit state policy. GPL tools are not part of the
+replacement/default role graph. `temporary` allocates a fresh topology-
+generation-owned state, `named` selects an existing registered persistent
+state, and `default` explicitly identifies the legacy managed persistent
+default. Scenario state remains registered and scenario-owned rather than
+becoming a fourth generic topology policy. Omitting a selector retains the
+legacy `default` behavior for human compatibility; automation can select
+`temporary` without creating a registry entry.
+
+Temporary initialization copies the exact selected server generation's
+validated `install_data` into a unique sibling below the marker-owned topology,
+writes topology/generation, stack/provider, server-coordinate, creation-time,
+path, device, and inode identity, validates the complete state shape, and uses
+an atomic no-replace rename to publish it. Named/default first use follows the
+same stage/validate/no-replace rule. Existing paths are never overlaid, state
+inside a server source worktree is rejected, existing symlinked paths fail
+closed, and an implementation marker rejects a known incompatible server
+format. Unmarked historical state remains compatible pending the typed-state
+migration in #277. Replacement runtime preparation remains unavailable until
+its native component contracts land.
 
 The server's configured `assetspath` is a disposable transport-neutral runtime
 view. Its real `data` directory receives generated core data, while its
@@ -658,6 +674,12 @@ server. Profile builds have their own blocking lock, and server launch views are
 keyed by state path. Processes started outside the coordinator do not
 participate in the state lock, so operators must not point those processes at
 the same state concurrently.
+
+The current topology record and human/JSON status surfaces retain the state
+policy, owner, exact path identity, implementation, and lifecycle. A same-state
+conflict names the owning topology and generation when that identity is
+observable. Different named states and generation-owned temporary states use
+different exact locks and can overlap.
 
 Profiles are stack-aware source-topology definitions for supervised runtime as
 well as builds. For a complete Classic profile, `up` resolves the common
@@ -691,10 +713,20 @@ holders and retain the generation until their absence is proven.
 Runtime-generation and state leases remain held by the supervisor and guardian
 rather than service-inherited, so a descendant that closes its process-tree
 identity cannot retain those resources. The guardian releases them only after exact
-process-tree recovery completes. Another namespace
-waits or fails closed with the owning topology and recovery action. Normal
-shutdown asks the supervisor to gracefully stop children before releasing
-state. For a paired topology it starts the server
+process-tree recovery completes. Another namespace waits or fails closed with
+the owning topology and recovery action. Normal shutdown asks the supervisor to
+gracefully stop children before releasing state. After a confirmed clean
+`down`, the caller reacquires and revalidates the exact temporary-state identity
+after every process/state lease is released, then removes only a disposable
+state. `down --retain-state` instead records a retained lifecycle. `state
+promote` requires that stopped retained identity, serializes
+topology/state/registry mutation, publishes a promotion-pending record, and
+atomically adds the exact path under a previously unused persistent name before
+finalizing it as promoted. It never overwrites a name or directory. A crash,
+unreachable control endpoint, failed post-spawn startup, malformed identity,
+linked path, uncertain lock, or incomplete promotion remains on disk for
+diagnosis. Foreground and scenario state keep their separate lifecycles. For a
+paired topology it starts the server
 first, waits for its fingerprint and final ready signal, and then pins the
 client to that authenticated loopback endpoint. Omitted ports and explicit port
 zero use automatic allocation. A short workspace allocator transaction probes a
@@ -734,6 +766,14 @@ advance. Generation directories stay with the marker-owned topology record so
 the preview-first topology reclamation contract in #397 can remove only an
 inactive, released, fully validated record; malformed, linked, unreachable, or
 retained generations fail closed.
+Generation-owned state has its own `temporary-states` cleanup scope. Dry-run
+inventory reports exact topology/generation ownership and only classifies an
+old disposable state as eligible after proving its markers, metadata, path
+identity, registry absence, stopped topology, and released exact state lease.
+Apply repeats those checks while holding the topology operation and state
+locks. Live, unreachable, busy, linked, malformed, registered, retained,
+promoted, or uncertain state is protected; cleanup never performs an implicit
+`down`.
 A topology may select one service, and distinct runtime names permit concurrent
 combinations as long as their server ports and mutable state directories do not
 conflict. When replacement runtime support lands, a concurrent `classic` and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -654,9 +654,10 @@ an atomic no-replace rename to publish it. Named/default first use follows the
 same stage/validate/no-replace rule. Existing paths are never overlaid, state
 inside a server source worktree is rejected, existing symlinked paths fail
 closed, and an implementation marker rejects a known incompatible server
-format. Unmarked historical state remains compatible pending the typed-state
-migration in #277. Replacement runtime preparation remains unavailable until
-its native component contracts land.
+format. First supervised use atomically binds an unmarked historical directory
+to the selected implementation under the exact state lock, so a later provider
+cannot silently reuse an untyped directory. Replacement runtime preparation
+remains unavailable until its native component contracts land.
 
 The server's configured `assetspath` is a disposable transport-neutral runtime
 view. Its real `data` directory receives generated core data, while its
@@ -673,7 +674,11 @@ before build/runtime preparation and holds it for the lifetime of a launched
 server. Profile builds have their own blocking lock, and server launch views are
 keyed by state path. Processes started outside the coordinator do not
 participate in the state lock, so operators must not point those processes at
-the same state concurrently.
+the same state concurrently. Startup also opens the selected state directory
+without following links, verifies its recorded device/inode identity, and hands
+that descriptor to the supervisor and server. The server consumes the pinned
+directory through its inherited descriptor even if an external path component
+is replaced after admission.
 
 The current topology record and human/JSON status surfaces retain the state
 policy, owner, exact path identity, implementation, and lifecycle. A same-state
@@ -717,12 +722,16 @@ process-tree recovery completes. Another namespace waits or fails closed with
 the owning topology and recovery action. Normal shutdown asks the supervisor to
 gracefully stop children before releasing state. After a confirmed clean
 `down`, the caller reacquires and revalidates the exact temporary-state identity
-after every process/state lease is released, then removes only a disposable
-state. `down --retain-state` instead records a retained lifecycle. `state
+after every process/state lease is released, records a removal-pending
+lifecycle, then removes only a disposable state and finalizes it as removed.
+An interrupted removal is safe to retry without requiring another live
+generation. `down --retain-state` instead records a retained lifecycle. `state
 promote` requires that stopped retained identity, serializes
 topology/state/registry mutation, publishes a promotion-pending record, and
 atomically adds the exact path under a previously unused persistent name before
-finalizing it as promoted. It never overwrites a name or directory. A crash,
+finalizing it as promoted. Creation metadata remains immutable and status owns
+the mutable lifecycle, so interruption after either durable promotion write is
+recoverable by retry. It never overwrites a name or directory. A crash,
 unreachable control endpoint, failed post-spawn startup, malformed identity,
 linked path, uncertain lock, or incomplete promotion remains on disk for
 diagnosis. Foreground and scenario state keep their separate lifecycles. For a
@@ -769,11 +778,12 @@ retained generations fail closed.
 Generation-owned state has its own `temporary-states` cleanup scope. Dry-run
 inventory reports exact topology/generation ownership and only classifies an
 old disposable state as eligible after proving its markers, metadata, path
-identity, registry absence, stopped topology, and released exact state lease.
+identity, registry absence, stopped matching topology generation, and released
+process-tree, runtime-bundle, port-reservation, and exact state leases.
 Apply repeats those checks while holding the topology operation and state
 locks. Live, unreachable, busy, linked, malformed, registered, retained,
-promoted, or uncertain state is protected; cleanup never performs an implicit
-`down`.
+promoted, or uncertain state is protected; missing or replaced lease evidence
+fails closed and cleanup never performs an implicit `down`.
 A topology may select one service, and distinct runtime names permit concurrent
 combinations as long as their server ports and mutable state directories do not
 conflict. When replacement runtime support lands, a concurrent `classic` and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -685,7 +685,11 @@ The server consumes the pinned directory, including pre-option configuration
 reads and disposable runtime output, through its inherited descriptor even if
 an external path component is replaced after admission. Rollback removes that
 output relative to the same pinned descriptor and never follows the replaced
-lexical path.
+lexical path. Before creating a topology-owned mutable output, startup durably
+records its generation and state identity; after creation it adds the output
+inode. A restart either adopts that evidence from a published status record or
+completes the exact tombstone transaction before creating another generation,
+so a hard interruption cannot silently orphan the output.
 
 The current topology record and human/JSON status surfaces retain the state
 policy, owner, exact path identity, implementation, and lifecycle. A same-state
@@ -808,8 +812,10 @@ promoted, or uncertain state is protected; missing or replaced lease evidence
 fails closed and cleanup never performs an implicit `down`.
 Persistent-state runtime outputs have a separate durable pending/complete
 cleanup record. It binds every output path to its creation inode before
-deletion, detects an output renamed under another sibling name, and lets a
-retry distinguish a completed removal from unresolved ownership evidence.
+deletion, renames the exact inode to a deterministic tombstone before removing
+its contents, and lets a retry distinguish a completed removal from unresolved
+ownership evidence. A missing or arbitrarily renamed output remains pending;
+the wrapper never reacquires deletion ownership from a mutable pathname.
 Topology-record cleanup also protects an identity-derived removal tombstone.
 A topology may select one service, and distinct runtime names permit concurrent
 combinations as long as their server ports and mutable state directories do not

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -674,7 +674,9 @@ before build/runtime preparation and holds it for the lifetime of a launched
 server. Profile builds have their own blocking lock, and server launch views are
 keyed by state path and, for existing persistent directories, by physical
 device/inode identity so alternate mounted names cannot obtain distinct
-leases. Processes started outside the coordinator do not
+leases. Physical state locks are flat entries in the already classified lease
+namespace, so replacing a dynamically created child directory cannot fork the
+identity coordinate. Processes started outside the coordinator do not
 participate in the state lock, so operators must not point those processes at
 the same state concurrently. Startup also opens the selected state directory
 without following links, verifies its recorded device/inode identity, and hands
@@ -795,7 +797,10 @@ old disposable state as eligible after proving its markers, metadata, path
 identity, registry absence, stopped matching topology generation, and released
 process-tree, runtime-bundle, port-reservation, and exact state leases.
 Apply repeats those checks while holding the topology operation and state
-locks. Live, unreachable, busy, linked, malformed, registered, retained,
+locks. Registry exclusion compares physical directory identity as well as the
+canonical path. Owned deletion first moves each verified entry to a private
+no-replace tombstone and rechecks its inode before unlinking. Live, unreachable,
+busy, linked, malformed, registered, retained,
 promoted, or uncertain state is protected; missing or replaced lease evidence
 fails closed and cleanup never performs an implicit `down`.
 A topology may select one service, and distinct runtime names permit concurrent

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -797,12 +797,20 @@ old disposable state as eligible after proving its markers, metadata, path
 identity, registry absence, stopped matching topology generation, and released
 process-tree, runtime-bundle, port-reservation, and exact state leases.
 Apply repeats those checks while holding the topology operation and state
-locks. Registry exclusion compares physical directory identity as well as the
-canonical path. Owned deletion first moves each verified entry to a private
+locks. The topology root, `temporary-states` container, state, and lease are
+opened as one no-follow, same-mount descriptor chain; apply retains that chain
+through descriptor-relative rename and deletion. Registry exclusion compares
+physical directory identity as well as the canonical path. Owned deletion
+first moves each verified entry to a private
 no-replace tombstone and rechecks its inode before unlinking. Live, unreachable,
 busy, linked, malformed, registered, retained,
 promoted, or uncertain state is protected; missing or replaced lease evidence
 fails closed and cleanup never performs an implicit `down`.
+Persistent-state runtime outputs have a separate durable pending/complete
+cleanup record. It binds every output path to its creation inode before
+deletion, detects an output renamed under another sibling name, and lets a
+retry distinguish a completed removal from unresolved ownership evidence.
+Topology-record cleanup also protects an identity-derived removal tombstone.
 A topology may select one service, and distinct runtime names permit concurrent
 combinations as long as their server ports and mutable state directories do not
 conflict. When replacement runtime support lands, a concurrent `classic` and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -672,7 +672,9 @@ topology retention and are replaced on the next launch of that topology name.
 The coordinator takes an advisory exclusive lock next to the state directory
 before build/runtime preparation and holds it for the lifetime of a launched
 server. Profile builds have their own blocking lock, and server launch views are
-keyed by state path. Processes started outside the coordinator do not
+keyed by state path and, for existing persistent directories, by physical
+device/inode identity so alternate mounted names cannot obtain distinct
+leases. Processes started outside the coordinator do not
 participate in the state lock, so operators must not point those processes at
 the same state concurrently. Startup also opens the selected state directory
 without following links, verifies its recorded device/inode identity, and hands
@@ -725,13 +727,18 @@ gracefully stop children before releasing state. After a confirmed clean
 after every process/state lease is released, records a removal-pending
 lifecycle, then removes only a disposable state and finalizes it as removed.
 An interrupted removal is safe to retry without requiring another live
-generation. `down --retain-state` instead records a retained lifecycle. `state
+generation. Clean proof includes expected service exit status, absence of forced
+termination, and exact lease release; the durable proof permits a later
+`down` invocation to finish an interrupted removal transaction.
+`down --retain-state` instead records a retained lifecycle. `state
 promote` requires that stopped retained identity, serializes
 topology/state/registry mutation, publishes a promotion-pending record, and
 atomically adds the exact path under a previously unused persistent name before
 finalizing it as promoted. Creation metadata remains immutable and status owns
 the mutable lifecycle, so interruption after either durable promotion write is
-recoverable by retry. It never overwrites a name or directory. A crash,
+recoverable by retry. Its persistent policy continues to identify the source
+topology generation rather than collapsing to generic external ownership. It
+never overwrites a name or directory. A crash,
 unreachable control endpoint, failed post-spawn startup, malformed identity,
 linked path, uncertain lock, or incomplete promotion remains on disk for
 diagnosis. Foreground and scenario state keep their separate lifecycles. For a

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -245,6 +245,25 @@ class CleanupTests(unittest.TestCase):
         self.assertEqual(item["liveness"], "exited")
         self.assertEqual(item["age_basis"], "stopped-at")
 
+    def test_topology_cleanup_preserves_generation_owned_state(self) -> None:
+        root = self.make_topology_record("stateful-history")
+        container = root / "temporary-states"
+        container.mkdir()
+        atomic_json(
+            container / MANAGED_MARKER,
+            {
+                "schema_version": SCHEMA_VERSION,
+                "purpose": "topology-temporary-states",
+            },
+        )
+        (container / ("a" * 64)).mkdir()
+
+        report = self.workspace.cleanup(["topologies"], 7, [], False)
+
+        item = next(row for row in report["items"] if row["path"] == str(root))
+        self.assertEqual(item["disposition"], "protected")
+        self.assertIn("temporary_states_present", item["reasons"])
+
     def test_missing_topology_container_is_an_empty_inventory(self) -> None:
         self.workspace.paths.topologies.rmdir()
 
@@ -3481,7 +3500,11 @@ class CleanupTests(unittest.TestCase):
             self.assertEqual(
                 cleanup._normalize_scopes(["all"]),
                 [
-                    "worktrees", "builds", "npm-cache", "compiler-cache",
+                    "worktrees",
+                    "builds",
+                    "temporary-states",
+                    "npm-cache",
+                    "compiler-cache",
                     "sound-cache",
                 ],
             )

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -13,6 +13,7 @@ import threading
 import unittest
 from unittest import mock
 
+from atrinik_workspace import cleanup as cleanup_module
 from atrinik_workspace.cleanup import (
     ALL_SCOPES,
     Cleanup,
@@ -3558,6 +3559,45 @@ class CleanupTests(unittest.TestCase):
         self.assertEqual(
             first["allocated_bytes"] + second["allocated_bytes"], 16384
         )
+
+    def test_temporary_tree_usage_bounds_open_descriptors_for_wide_tree(self) -> None:
+        state = self.root / "wide-temporary-state"
+        state.mkdir()
+        for index in range(80):
+            child = state / f"child-{index}"
+            child.mkdir()
+            (child / "payload").write_text("data\n", encoding="utf-8")
+        real_open = os.open
+        real_close = os.close
+        active: set[int] = set()
+        maximum = 0
+
+        def tracked_open(*args: object, **kwargs: object) -> int:
+            nonlocal maximum
+            descriptor = real_open(*args, **kwargs)
+            active.add(descriptor)
+            maximum = max(maximum, len(active))
+            if maximum > 4:
+                real_close(descriptor)
+                active.remove(descriptor)
+                raise OSError("simulated descriptor exhaustion")
+            return descriptor
+
+        def tracked_close(descriptor: int) -> None:
+            active.discard(descriptor)
+            real_close(descriptor)
+
+        with (
+            mock.patch.object(cleanup_module.os, "open", side_effect=tracked_open),
+            mock.patch.object(cleanup_module.os, "close", side_effect=tracked_close),
+        ):
+            sizes, observed, error = cleanup_module._temporary_tree_usage(state)
+
+        self.assertIsNone(error)
+        self.assertIsNotNone(observed)
+        self.assertTrue(sizes)
+        self.assertLessEqual(maximum, 4)
+        self.assertEqual(active, set())
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -794,6 +794,69 @@ class ParserTests(unittest.TestCase):
         )
         output.assert_called_once_with("topology review: started at 127.0.0.1:17300")
 
+    def test_topology_state_policy_options_are_mutually_exclusive(self) -> None:
+        temporary = parser().parse_args(
+            ["up", "--profile", "review", "--temporary-state"]
+        )
+        explicit_default = parser().parse_args(
+            ["topology", "show", "review", "--default-state"]
+        )
+        self.assertIsNone(temporary.state)
+        self.assertEqual(explicit_default.state, "default")
+        with self.assertRaises(SystemExit):
+            parser().parse_args(
+                ["up", "--temporary-state", "--state", "shared"]
+            )
+
+    def test_temporary_state_start_retain_and_promotion_dispatch(self) -> None:
+        status = {
+            "supervisor": {"running": True},
+            "endpoint": None,
+            "state_policy": {
+                "mode": "temporary",
+                "lifecycle": "disposable",
+                "path": "/workspace/topologies/review/temporary-states/abc",
+            },
+        }
+        promoted = {
+            "topology": "review",
+            "name": "saved-review",
+            "path": status["state_policy"]["path"],
+        }
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace = workspace_type.return_value
+            workspace.topology_up.return_value = status
+            workspace.state_promote.return_value = promoted
+            with mock.patch("builtins.print"):
+                self.assertEqual(
+                    main(
+                        [
+                            "up",
+                            "--name",
+                            "review",
+                            "--profile",
+                            "review",
+                            "--temporary-state",
+                            "--service",
+                            "server",
+                        ]
+                    ),
+                    0,
+                )
+                self.assertEqual(main(["down", "review", "--retain-state"]), 0)
+                self.assertEqual(
+                    main(["state", "promote", "review", "saved-review"]), 0
+                )
+        workspace.topology_up.assert_called_once_with(
+            "review", "review", None, ["server"], None
+        )
+        workspace.topology_down.assert_called_once_with(
+            "review", retain_state=True
+        )
+        workspace.state_promote.assert_called_once_with(
+            "review", "saved-review"
+        )
+
     def test_topology_show_supports_json(self) -> None:
         summary = {
             "profile": "review",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -790,7 +790,12 @@ class ParserTests(unittest.TestCase):
 
         self.assertEqual(result, 0)
         workspace_type.return_value.topology_up.assert_called_once_with(
-            "review", "review", "shared", ["server"], 17300
+            "review",
+            "review",
+            "shared",
+            ["server"],
+            17300,
+            state_mode=None,
         )
         output.assert_called_once_with("topology review: started at 127.0.0.1:17300")
 
@@ -801,12 +806,152 @@ class ParserTests(unittest.TestCase):
         explicit_default = parser().parse_args(
             ["topology", "show", "review", "--default-state"]
         )
-        self.assertIsNone(temporary.state)
+        self.assertEqual(temporary.state, "default")
+        self.assertEqual(temporary.state_mode, "temporary")
         self.assertEqual(explicit_default.state, "default")
+        self.assertEqual(explicit_default.state_mode, "default")
         with self.assertRaises(SystemExit):
             parser().parse_args(
                 ["up", "--temporary-state", "--state", "shared"]
             )
+
+    def test_client_only_temporary_state_selector_is_not_silently_ignored(
+        self,
+    ) -> None:
+        error = WorkspaceError("temporary state requires the server service")
+        cases = (
+            (
+                [
+                    "topology",
+                    "show",
+                    "review",
+                    "--temporary-state",
+                    "--service",
+                    "client",
+                ],
+                "topology_summary",
+                mock.call(
+                    "review", None, ["client"], state_mode="temporary"
+                ),
+            ),
+            (
+                [
+                    "up",
+                    "--name",
+                    "client-only",
+                    "--profile",
+                    "review",
+                    "--temporary-state",
+                    "--service",
+                    "client",
+                ],
+                "topology_up",
+                mock.call(
+                    "client-only",
+                    "review",
+                    None,
+                    ["client"],
+                    None,
+                    state_mode="temporary",
+                ),
+            ),
+        )
+        for arguments, method_name, expected_call in cases:
+            with self.subTest(command=arguments[0]):
+                with mock.patch(
+                    "atrinik_workspace.cli.Workspace"
+                ) as workspace_type:
+                    method = getattr(workspace_type.return_value, method_name)
+                    method.side_effect = error
+                    with mock.patch("builtins.print"):
+                        self.assertEqual(main(arguments), 1)
+                self.assertEqual(method.call_args, expected_call)
+
+    def test_human_topology_state_policy_output_includes_stable_owner(self) -> None:
+        generation = "a" * 64
+        summary = {
+            "profile": "review",
+            "stack": "classic",
+            "sound": {"mode": "source"},
+            "services": ["server"],
+            "dependencies": ["server"],
+            "providers": {"server": "classic-server"},
+            "state": None,
+            "state_policy": {
+                "mode": "temporary",
+                "owner": {"kind": "topology-generation"},
+                "lifecycle": "disposable",
+                "path": None,
+            },
+            "build_root": "/workspace/build/review",
+            "components": {},
+        }
+        status = {
+            "endpoint": None,
+            "state_policy": {
+                "mode": "temporary",
+                "owner": {
+                    "topology": "review",
+                    "kind": "topology-generation",
+                    "generation": generation,
+                },
+                "lifecycle": "disposable",
+                "path": "/workspace/topologies/review/temporary-states/abc",
+            },
+        }
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace = workspace_type.return_value
+            workspace.topology_summary.return_value = summary
+            workspace.topology_up.return_value = status
+            with mock.patch("builtins.print") as output:
+                self.assertEqual(
+                    main(
+                        [
+                            "topology",
+                            "show",
+                            "review",
+                            "--temporary-state",
+                            "--service",
+                            "server",
+                        ]
+                    ),
+                    0,
+                )
+                self.assertIn(
+                    mock.call(
+                        'state-policy\ttemporary\t'
+                        '{"kind": "topology-generation"}\t'
+                        "disposable\tallocated-on-start"
+                    ),
+                    output.call_args_list,
+                )
+                output.reset_mock()
+                self.assertEqual(
+                    main(
+                        [
+                            "up",
+                            "--name",
+                            "review",
+                            "--profile",
+                            "review",
+                            "--temporary-state",
+                            "--service",
+                            "server",
+                        ]
+                    ),
+                    0,
+                )
+                self.assertEqual(
+                    output.call_args_list[-1],
+                    mock.call(
+                        'state-policy\ttemporary\t'
+                        f'{{"generation": "{generation}", '
+                        '"kind": "topology-generation", '
+                        '"topology": "review"}\t'
+                        "disposable\t/workspace/topologies/review/"
+                        "temporary-states/abc"
+                    ),
+                )
 
     def test_temporary_state_start_retain_and_promotion_dispatch(self) -> None:
         status = {
@@ -814,6 +959,11 @@ class ParserTests(unittest.TestCase):
             "endpoint": None,
             "state_policy": {
                 "mode": "temporary",
+                "owner": {
+                    "kind": "topology-generation",
+                    "topology": "review",
+                    "generation": "a" * 64,
+                },
                 "lifecycle": "disposable",
                 "path": "/workspace/topologies/review/temporary-states/abc",
             },
@@ -848,7 +998,12 @@ class ParserTests(unittest.TestCase):
                     main(["state", "promote", "review", "saved-review"]), 0
                 )
         workspace.topology_up.assert_called_once_with(
-            "review", "review", None, ["server"], None
+            "review",
+            "review",
+            None,
+            ["server"],
+            None,
+            state_mode="temporary",
         )
         workspace.topology_down.assert_called_once_with(
             "review", retain_state=True
@@ -875,7 +1030,7 @@ class ParserTests(unittest.TestCase):
 
         self.assertEqual(result, 0)
         workspace_type.return_value.topology_summary.assert_called_once_with(
-            "review", "default", ["server"]
+            "review", "default", ["server"], state_mode=None
         )
         self.assertEqual(json.loads(output.call_args.args[0]), summary)
 

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -145,6 +145,25 @@ class CompletionTests(unittest.TestCase):
         _, values = complete(parser(), self.wrapper, words, 4)
         self.assertIn("--scope", values)
 
+        _, values = self.candidates("up", "-")
+        self.assertTrue(
+            {"--state", "--temporary-state", "--default-state"} <= set(values)
+        )
+        _, values = self.candidates("up", "--temporary-state", "-")
+        self.assertTrue(
+            {"--state", "--temporary-state", "--default-state"}.isdisjoint(
+                values
+            )
+        )
+        _, values = self.candidates(
+            "topology", "show", "default", "--default-state", "-"
+        )
+        self.assertTrue(
+            {"--state", "--temporary-state", "--default-state"}.isdisjoint(
+                values
+            )
+        )
+
     def test_run_remainder_and_double_dash_stop_wrapper_completion(self) -> None:
         for words in (
             ["atrinik", "run", "server", "--", "--ver"],
@@ -369,6 +388,16 @@ class CompletionTests(unittest.TestCase):
         self.assertEqual(
             self.candidates("logs", ""),
             ("candidates", ["completion-review"]),
+        )
+        self.assertEqual(
+            self.candidates("state", "promote", ""),
+            ("candidates", ["completion-review"]),
+        )
+        self.assertEqual(
+            self.candidates(
+                "state", "promote", "completion-review", ""
+            ),
+            ("candidates", []),
         )
 
         status_path = self.workspace / "topologies" / "completion-review" / "status.json"

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -423,6 +423,19 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                 process.kill()
                 process.wait(timeout=2)
 
+    def test_terminate_rejects_process_group_observation_uncertainty(self) -> None:
+        process = mock.Mock(pid=1234, returncode=0)
+        with mock.patch.object(
+            supervisor_module.Path,
+            "iterdir",
+            side_effect=OSError("proc unavailable"),
+        ):
+            self.assertFalse(
+                supervisor_module.terminate(
+                    {"server": process}, None, timeout=0
+                )
+            )
+
     def test_requires_fingerprint_and_finished_server_startup(self) -> None:
         capture = ServerReadinessCapture()
 
@@ -507,7 +520,7 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                 self.assertEqual(supervisor_module.main(), 1)
 
         supervise_call.assert_called_once_with(
-            spec_path, None, None, None, None, None, 9
+            spec_path, None, None, None, None, None, 9, None, None
         )
         status.assert_called_once_with(
             spec_path.parent / "startup-error.json",

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -520,7 +520,7 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                 self.assertEqual(supervisor_module.main(), 1)
 
         supervise_call.assert_called_once_with(
-            spec_path, None, None, None, None, None, 9, None, None
+                spec_path, None, None, None, None, None, 9, None, None, None
         )
         status.assert_called_once_with(
             spec_path.parent / "startup-error.json",

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -436,6 +436,27 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                 )
             )
 
+        for failure in (OSError("stat unavailable"), ValueError("malformed stat")):
+            with self.subTest(failure=type(failure).__name__):
+                with (
+                    mock.patch.object(
+                        supervisor_module.Path,
+                        "iterdir",
+                        return_value=[Path("/proc/1234")],
+                    ),
+                    mock.patch.object(
+                        supervisor_module.Path,
+                        "read_text",
+                        side_effect=failure,
+                    ),
+                    mock.patch.object(supervisor_module.os, "killpg"),
+                ):
+                    self.assertFalse(
+                        supervisor_module.terminate(
+                            {"server": process}, None, timeout=0
+                        )
+                    )
+
     def test_requires_fingerprint_and_finished_server_startup(self) -> None:
         capture = ServerReadinessCapture()
 
@@ -606,6 +627,46 @@ class ServerReadinessCaptureTests(unittest.TestCase):
             mock.patch.object(sys, "stderr"),
         ):
             self.assertEqual(supervisor_module.main(), 1)
+
+    def test_main_closes_every_current_lease_after_startup_failure(self) -> None:
+        arguments = [
+            "atrinik-supervisor",
+            "--spec",
+            "/tmp/spec.json",
+            "--lock-fd",
+            "3",
+            "--layout-lock-fd",
+            "4",
+            "--build-lock-fd",
+            "5",
+            "--process-tree-fd",
+            "6",
+            "--port-reservation-fd",
+            "7",
+            "--runtime-lock-fd",
+            "8",
+            "--state-directory-fd",
+            "9",
+            "--state-output-fd",
+            "10",
+            "--physical-state-lock-fd",
+            "11",
+        ]
+        with (
+            mock.patch.object(sys, "argv", arguments),
+            mock.patch.object(
+                supervisor_module,
+                "supervise",
+                side_effect=RuntimeError("invalid runtime"),
+            ),
+            mock.patch.object(supervisor_module, "atomic_status"),
+            mock.patch.object(supervisor_module.os, "close") as close,
+            mock.patch.object(sys, "stderr"),
+        ):
+            self.assertEqual(supervisor_module.main(), 1)
+        self.assertEqual(
+            {call.args[0] for call in close.call_args_list}, set(range(3, 12))
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -395,6 +395,34 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                 process.kill()
                 process.wait(timeout=2)
 
+    def test_terminate_rejects_abnormal_service_exit_as_clean(self) -> None:
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "import signal, sys, time; "
+                "signal.signal(signal.SIGTERM, lambda *_args: sys.exit(23)); "
+                "print('ready', flush=True); time.sleep(60)",
+            ],
+            start_new_session=True,
+            stdout=subprocess.PIPE,
+        )
+        try:
+            assert process.stdout is not None
+            self.assertEqual(process.stdout.readline(), b"ready\n")
+            self.assertFalse(
+                supervisor_module.terminate(
+                    {"server": process}, None, timeout=2
+                )
+            )
+            self.assertEqual(process.returncode, 23)
+        finally:
+            if process.stdout is not None:
+                process.stdout.close()
+            if process.poll() is None:
+                process.kill()
+                process.wait(timeout=2)
+
     def test_requires_fingerprint_and_finished_server_startup(self) -> None:
         capture = ServerReadinessCapture()
 

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -187,8 +187,8 @@ class ServerReadinessCaptureTests(unittest.TestCase):
             terminate.assert_called_once()
             self.assertEqual(terminate.call_args.args[0], {"client": process})
             self.assertIsNone(terminate.call_args.args[1])
-            self.assertEqual(
-                {call.args[0] for call in close.call_args_list}, {7, 8}
+            self.assertTrue(
+                {7, 8} <= {call.args[0] for call in close.call_args_list}
             )
 
     def test_current_supervisor_releases_broad_leases_and_retains_runtime(self) -> None:
@@ -245,8 +245,9 @@ class ServerReadinessCaptureTests(unittest.TestCase):
 
             start_guardian.assert_called_once_with(None, None, 6, 9)
             terminate.assert_called_once()
-            self.assertEqual(
-                {call.args[0] for call in close.call_args_list}, {6, 7, 8, 9}
+            self.assertTrue(
+                {6, 7, 8, 9}
+                <= {call.args[0] for call in close.call_args_list}
             )
             status = json.loads(
                 (root / "status.json").read_text(encoding="utf-8")
@@ -524,9 +525,9 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                     supervise(spec_path, None, None, None, None, 8, 9), 0
                 )
 
-        self.assertEqual(
-            {call.args[0] for call in close.call_args_list}, {8, 9}
-        )
+            self.assertTrue(
+                {8, 9} <= {call.args[0] for call in close.call_args_list}
+            )
 
     def test_main_daemon_parent_returns_without_supervising(self) -> None:
         with (

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -423,6 +423,19 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                 process.kill()
                 process.wait(timeout=2)
 
+    def test_terminate_timeout_cannot_be_clean(self) -> None:
+        process = mock.Mock(pid=1234, returncode=0)
+        process.wait.side_effect = subprocess.TimeoutExpired("server", 2)
+        with (
+            mock.patch.object(supervisor_module.Path, "iterdir", return_value=[]),
+            mock.patch.object(supervisor_module.os, "killpg"),
+        ):
+            self.assertFalse(
+                supervisor_module.terminate(
+                    {"server": process}, None, timeout=0
+                )
+            )
+
     def test_terminate_rejects_process_group_observation_uncertainty(self) -> None:
         process = mock.Mock(pid=1234, returncode=0)
         with mock.patch.object(
@@ -580,15 +593,128 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                 mock.patch.object(
                     supervisor_module, "_serve_control", return_value=True
                 ),
+                mock.patch.object(
+                    supervisor_module, "_peek_exit_code", return_value=None
+                ),
                 mock.patch.object(supervisor_module, "terminate"),
                 mock.patch.object(supervisor_module.os, "close") as close,
             ):
                 self.assertEqual(
-                    supervise(spec_path, None, None, None, None, 8, 9), 0
+                    supervise(
+                        spec_path,
+                        None,
+                        None,
+                        None,
+                        None,
+                        8,
+                        9,
+                        10,
+                        11,
+                        12,
+                    ),
+                    0,
                 )
 
             self.assertTrue(
-                {8, 9} <= {call.args[0] for call in close.call_args_list}
+                set(range(8, 13))
+                <= {call.args[0] for call in close.call_args_list}
+            )
+
+    def test_server_launch_inherits_exact_state_descriptors(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            spec_path = root / "spec.json"
+            spec_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 3,
+                        "name": "state-fds",
+                        "profile": "classic",
+                        "dependencies": ["server"],
+                        "state": str(root / "state"),
+                        "state_policy": {"mode": "named"},
+                        "build_root": "/tmp/build",
+                        "resolved": {},
+                        "endpoint": {
+                            "host": "127.0.0.1",
+                            "port": 13327,
+                            "fingerprint": None,
+                        },
+                        "runtime": {"generation": "a" * 64},
+                        "control": {
+                            "generation": "a" * 64,
+                            "socket": str(root / "control.sock"),
+                        },
+                        "services": {
+                            "server": {
+                                "command": ["server"],
+                                "cwd": str(root),
+                                "log": str(root / "server.log"),
+                            }
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            process = mock.MagicMock(pid=1234)
+            process.poll.return_value = 0
+            capture = mock.Mock(
+                event=mock.Mock(wait=mock.Mock(side_effect=[False, True])),
+                fingerprint="a" * 64,
+            )
+            control = mock.Mock()
+            with (
+                mock.patch.object(
+                    supervisor_module,
+                    "process_start_time",
+                    side_effect=["1", "2"],
+                ),
+                mock.patch.object(supervisor_module, "_validate_port_reservation"),
+                mock.patch.object(supervisor_module, "_require_server_port_available"),
+                mock.patch.object(
+                    supervisor_module, "_start_guardian", return_value=(None, 99)
+                ) as guardian,
+                mock.patch.object(
+                    supervisor_module, "_open_control", return_value=control
+                ),
+                mock.patch.object(
+                    supervisor_module,
+                    "_serve_control",
+                    side_effect=[False, True],
+                ),
+                mock.patch.object(
+                    supervisor_module, "_peek_exit_code", return_value=None
+                ),
+                mock.patch.object(
+                    supervisor_module, "ServerReadinessCapture", return_value=capture
+                ),
+                mock.patch.object(
+                    supervisor_module.subprocess, "Popen", return_value=process
+                ) as popen,
+                mock.patch.object(supervisor_module.threading, "Thread"),
+                mock.patch.object(supervisor_module, "terminate", return_value=True),
+                mock.patch.object(supervisor_module.os, "close") as close,
+            ):
+                self.assertEqual(
+                    supervise(
+                        spec_path,
+                        3,
+                        None,
+                        None,
+                        4,
+                        5,
+                        6,
+                        7,
+                        8,
+                        9,
+                    ),
+                    0,
+                )
+            self.assertEqual(popen.call_args.kwargs["pass_fds"], (4, 7, 8))
+            guardian.assert_called_once_with(4, 5, 3, 6, 7, 8, 9)
+            self.assertTrue(
+                {3, 4, 5, 6, 7, 8, 9, 99}
+                <= {call.args[0] for call in close.call_args_list}
             )
 
     def test_main_daemon_parent_returns_without_supervising(self) -> None:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -12809,6 +12809,61 @@ class WorkspaceTests(unittest.TestCase):
             {MANAGED_MARKER},
         )
 
+    def test_temporary_state_revalidates_metadata_at_publication(self) -> None:
+        topology = self.workspace._topology_directory(
+            "staging-metadata-validation", create=True
+        )
+        server = self.workspace.paths.repositories / "server"
+        generation = "5" * 64
+        original_digest = workspace_module._tree_digest_descriptor
+        full_digest_calls = 0
+
+        def change_metadata_after_snapshot(
+            directory_fd: int,
+            display: Path,
+            root_exclusions: set[str] | None = None,
+        ) -> str:
+            nonlocal full_digest_calls
+            digest = original_digest(directory_fd, display, root_exclusions)
+            if root_exclusions is None:
+                full_digest_calls += 1
+                if full_digest_calls == 2:
+                    state_fd = os.open(
+                        workspace_module.TEMPORARY_STATE_METADATA,
+                        os.O_WRONLY | os.O_TRUNC | os.O_NOFOLLOW,
+                        dir_fd=directory_fd,
+                    )
+                    try:
+                        os.write(state_fd, b'{}\n')
+                    finally:
+                        os.close(state_fd)
+            return digest
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace._tree_digest_descriptor",
+                side_effect=change_metadata_after_snapshot,
+            ),
+            self.assertRaisesRegex(WorkspaceError, "metadata changed"),
+        ):
+            self.workspace._create_temporary_state(
+                topology,
+                "staging-metadata-validation",
+                "default",
+                generation,
+                server,
+                {
+                    "stack": "default",
+                    "provider": "server",
+                    "repository": "atrinik/server",
+                },
+                self.scenario_resolved_fixture()["server"],
+            )
+        self.assertEqual(
+            {path.name for path in (topology / "temporary-states").iterdir()},
+            {MANAGED_MARKER},
+        )
+
     def test_temporary_startup_rollback_removes_state_and_lease(self) -> None:
         topology = self.workspace._topology_directory("rollback", create=True)
         server = self.workspace.paths.repositories / "server"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -5302,6 +5302,59 @@ class WorkspaceTests(unittest.TestCase):
         finally:
             os.close(state_fd)
 
+    def test_runtime_state_output_cleanup_rejects_generation_swap(self) -> None:
+        state = self.root / "state-output-race"
+        state.mkdir()
+        state_fd = os.open(state, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        generation = "b" * 32
+        output = self.workspace._prepare_runtime_state_output(
+            state, generation, state_fd
+        )
+        replacement = self.root / "replacement-output"
+        replacement.mkdir()
+        atomic_json(
+            replacement / MANAGED_MARKER,
+            {
+                "schema_version": 1,
+                "purpose": f"runtime-state-output:{generation}",
+            },
+        )
+        sentinel = replacement / "sentinel"
+        sentinel.write_text("replacement\n", encoding="utf-8")
+        displaced = self.root / "displaced-output"
+        real_open = os.open
+        swapped = False
+
+        def open_after_swap(
+            path: object, flags: int, *args: object, **kwargs: object
+        ) -> int:
+            nonlocal swapped
+            if path == generation and not swapped:
+                swapped = True
+                output.rename(displaced)
+                replacement.rename(output)
+            return real_open(path, flags, *args, **kwargs)
+
+        try:
+            with (
+                mock.patch(
+                    "atrinik_workspace.workspace.os.open",
+                    side_effect=open_after_swap,
+                ),
+                self.assertRaisesRegex(WorkspaceError, "output path changed"),
+            ):
+                self.workspace._remove_runtime_state_output(
+                    output, generation, state_fd
+                )
+            self.assertTrue(swapped)
+            self.assertEqual(
+                (output / "sentinel").read_text(encoding="utf-8"),
+                "replacement\n",
+            )
+            self.assertTrue((displaced / MANAGED_MARKER).is_file())
+        finally:
+            os.close(state_fd)
+
     def test_topology_runtime_set_copies_read_only_directories(self) -> None:
         topology = self.root / "topology"
         topology.mkdir()
@@ -10311,6 +10364,45 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertEqual(retained_item["disposition"], "protected")
         self.assertIn("temporary_state_retained", retained_item["reasons"])
+        displaced_state = retained_path.with_name("promotion-displaced")
+        replacement_sentinel = retained_path / "replacement-sentinel"
+        real_durable_json_at = workspace_module.durable_atomic_json_at
+        swapped = False
+
+        def swap_before_provenance(
+            directory_fd: int, name: str, value: object
+        ) -> None:
+            nonlocal swapped
+            if name == workspace_module.PROMOTED_STATE_METADATA and not swapped:
+                swapped = True
+                retained_path.rename(displaced_state)
+                retained_path.mkdir()
+                replacement_sentinel.write_text(
+                    "replacement\n", encoding="utf-8"
+                )
+            real_durable_json_at(directory_fd, name, value)
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.durable_atomic_json_at",
+                side_effect=swap_before_provenance,
+            ),
+            self.assertRaisesRegex(
+                WorkspaceError, "temporary state changed during promotion"
+            ),
+        ):
+            self.workspace.state_promote(
+                "temporary-retained", "promotion-swap-review"
+            )
+        self.assertTrue(swapped)
+        self.assertEqual(
+            replacement_sentinel.read_text(encoding="utf-8"), "replacement\n"
+        )
+        self.assertNotIn("promotion-swap-review", self.workspace._load_states())
+        shutil.rmtree(retained_path)
+        displaced_state.rename(retained_path)
+        (retained_path / workspace_module.PROMOTED_STATE_METADATA).unlink()
+        atomic_json(retained_status_path, retained_record)
         sessions = [Workspace(self.wrapper), Workspace(self.wrapper)]
         with ThreadPoolExecutor(max_workers=2) as executor:
             futures = [
@@ -10368,6 +10460,22 @@ class WorkspaceTests(unittest.TestCase):
             promoted_summary["state_policy"]["lifecycle"],
             "persistent-promoted",
         )
+        provenance = retained_path / workspace_module.PROMOTED_STATE_METADATA
+        provenance.unlink()
+        origin_status.rename(hidden_status)
+        try:
+            with self.assertRaisesRegex(
+                WorkspaceError, "promoted state provenance is missing"
+            ):
+                self.workspace.topology_summary(
+                    "default", str(promoted["name"]), ["server"]
+                )
+        finally:
+            hidden_status.rename(origin_status)
+        self.workspace.state_promote(
+            "temporary-retained", str(promoted["name"])
+        )
+        self.assertTrue(provenance.is_file())
         (rendezvous / "temporary.bound").unlink()
         with mock.patch.object(
             self.workspace, "_build_resolved", return_value=build_root
@@ -10469,12 +10577,18 @@ class WorkspaceTests(unittest.TestCase):
             self.workspace.paths.topologies / "temporary-crash" / "status.json"
         )
         raw_status = load_json(status_path)
-        without_port_evidence = copy.deepcopy(raw_status)
-        without_port_evidence.pop("port_reservation", None)
-        atomic_json(status_path, without_port_evidence)
-        missing_port = self.workspace.cleanup(
-            ["temporary-states"], 0, [], False
-        )
+        without_port_evidence = copy.deepcopy(recovered)
+        without_port_evidence["endpoint"] = None
+        without_port_evidence["services"] = {}
+        without_port_evidence["observation"]["port_reservation"] = None
+        with mock.patch.object(
+            self.workspace,
+            "topology_status",
+            return_value=without_port_evidence,
+        ):
+            missing_port = self.workspace.cleanup(
+                ["temporary-states"], 0, [], False
+            )
         missing_port_item = next(
             item for item in missing_port["items"] if item["path"] == str(state)
         )
@@ -10483,7 +10597,6 @@ class WorkspaceTests(unittest.TestCase):
             "port_reservation_lease_unverifiable",
             missing_port_item["reasons"],
         )
-        atomic_json(status_path, raw_status)
         state_lock = Path(f"{state}.lock")
         saved_state_lock = state_lock.with_suffix(".saved-lock")
         state_lock.rename(saved_state_lock)
@@ -11024,6 +11137,47 @@ class WorkspaceTests(unittest.TestCase):
         ):
             with self.workspace._topology_state_lock(second):
                 self.fail("physical aliases must not receive distinct leases")
+
+    def test_physical_state_alias_conflict_reports_live_owner(self) -> None:
+        first = self.root / "owner-alias"
+        second = self.root / "contender-alias"
+        first.mkdir()
+        second.mkdir()
+        shared_identity = {"device": 51, "inode": 83}
+        status = {
+            "name": "alias-owner",
+            "state": str(first),
+            "control": {"generation": "d" * 64},
+            "observation": {"process_tree_lease": "retained"},
+            "state_policy": {"identity": shared_identity},
+        }
+        with (
+            mock.patch.object(
+                self.workspace, "_state_identity", return_value=shared_identity
+            ),
+            self.workspace._topology_state_lock(first),
+            mock.patch.object(
+                self.workspace, "topology_statuses", return_value=[status]
+            ),
+            self.assertRaisesRegex(
+                WorkspaceError, "owned by topology alias-owner generation"
+            ),
+        ):
+            with self.workspace._topology_state_lock(second):
+                self.fail("physical alias conflict must report its live owner")
+
+    def test_state_lease_rejects_identity_change_after_path_lock(self) -> None:
+        state = self.root / "state-before-lock"
+        state.mkdir()
+        original_identity = self.workspace._state_identity(state)
+        with self.workspace._topology_state_lock(state) as lease:
+            self.assertEqual(lease.physical_identity, original_identity)
+            state.rename(self.root / "state-after-lock")
+            state.mkdir()
+            with self.assertRaisesRegex(
+                WorkspaceError, "state identity changed"
+            ):
+                lease.bind(self.workspace._state_identity(state))
 
     def test_temporary_state_publication_interruption_leaves_no_partial_state(self) -> None:
         topology = self.workspace._topology_directory("interrupted", create=True)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -13043,6 +13043,99 @@ class WorkspaceTests(unittest.TestCase):
         self.assertFalse(lock.exists())
         self.assertFalse(lock_tombstone.exists())
 
+    def test_orphan_temporary_lease_inventory_fails_closed(self) -> None:
+        topology = self.workspace._topology_directory(
+            "orphan-lease-uncertainty", create=True
+        )
+        container, container_fd = self.workspace._temporary_state_container(topology)
+        os.close(container_fd)
+        generation = "a" * 64
+        state = container / generation
+        lock = Path(f"{state}.lock")
+        with exclusive_lock(lock, "orphan lease fixture"):
+            pass
+        cleanup = cleanup_module.Cleanup(self.workspace)
+
+        with self.assertRaisesRegex(WorkspaceError, "tombstone is invalid"):
+            cleanup._orphan_temporary_state_lease_item(
+                topology, lock, 0, tombstone=True
+            )
+
+        invalid_tombstone = container / f".{lock.name}.remove-0-0"
+        invalid_tombstone.write_text("invalid\n", encoding="utf-8")
+        invalid_item = cleanup._orphan_temporary_state_lease_item(
+            topology, invalid_tombstone, 0, tombstone=True
+        )
+        self.assertIn(
+            "invalid_orphan_temporary_state_lease", invalid_item["reasons"]
+        )
+        invalid_tombstone.unlink()
+
+        state.mkdir()
+        state_item = cleanup._orphan_temporary_state_lease_item(
+            topology, lock, 0
+        )
+        self.assertIn(
+            "invalid_orphan_temporary_state_lease", state_item["reasons"]
+        )
+        state.rmdir()
+
+        with exclusive_lock(lock, "busy orphan lease"):
+            busy_item = cleanup._orphan_temporary_state_lease_item(
+                topology, lock, 0
+            )
+        self.assertIn("active_state_lease", busy_item["reasons"])
+
+        with mock.patch.object(
+            cleanup, "_lock_busy", return_value=(False, "invalid lease")
+        ):
+            lock_error_item = cleanup._orphan_temporary_state_lease_item(
+                topology, lock, 0
+            )
+        self.assertIn("state_lease_error", lock_error_item["reasons"])
+
+        with mock.patch.object(
+            self.workspace,
+            "topology_status",
+            return_value={"control": {"generation": generation}},
+        ):
+            current_item = cleanup._orphan_temporary_state_lease_item(
+                topology, lock, 0
+            )
+        self.assertIn("topology_generation_present", current_item["reasons"])
+
+        future_cleanup = cleanup_module.Cleanup(self.workspace)
+        future_cleanup.now = future_cleanup.now.replace(year=1970)
+        future_item = future_cleanup._orphan_temporary_state_lease_item(
+            topology, lock, 0
+        )
+        self.assertIn("future_creation_time", future_item["reasons"])
+        young_item = cleanup_module.Cleanup(
+            self.workspace
+        )._orphan_temporary_state_lease_item(topology, lock, 999)
+        self.assertIn("younger_than_grace_period", young_item["reasons"])
+
+        extra_link = self.root / "orphan-lease-extra-link"
+        os.link(lock, extra_link)
+        linked_item = cleanup._orphan_temporary_state_lease_item(
+            topology, lock, 0
+        )
+        self.assertIn(
+            "invalid_orphan_temporary_state_lease", linked_item["reasons"]
+        )
+        extra_link.unlink()
+
+        atomic_json(topology / "status.json", {})
+        with mock.patch.object(
+            self.workspace,
+            "topology_status",
+            side_effect=WorkspaceError("invalid topology status"),
+        ):
+            status_item = cleanup._orphan_temporary_state_lease_item(
+                topology, lock, 0
+            )
+        self.assertIn("topology_status_unverifiable", status_item["reasons"])
+
     def test_temporary_startup_rollback_retains_linked_state(self) -> None:
         topology = self.workspace._topology_directory(
             "linked-rollback", create=True

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -963,6 +963,10 @@ class WorkspaceTests(unittest.TestCase):
             "import os, pathlib, socket, sys, time\n"
             "port = int(next(value.split('=', 1)[1] for value in sys.argv "
             "if value.startswith('--port_quic=')))\n"
+            "datapath = pathlib.Path(next(value.split('=', 1)[1] for value in "
+            "sys.argv if value.startswith('--datapath=')))\n"
+            "(datapath / 'rendezvous-state-proof').write_text('pinned\\n', "
+            "encoding='utf-8')\n"
             f"rendezvous = pathlib.Path({str(rendezvous)!r})\n"
             f"marker = rendezvous / {marker!r}\n"
             "udp = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\n"
@@ -9746,6 +9750,7 @@ class WorkspaceTests(unittest.TestCase):
         self.assertIn("'--port_quic=17300'", server_log.read_text())
         self.assertIn("'--port_mapping=off'", server_log.read_text())
         self.assertIn("'--stun_server=off'", server_log.read_text())
+        self.assertRegex(server_log.read_text(), r"'--datapath=/proc/self/fd/\d+'")
         self.assertIn(
             f"'--assetspath={mutable_asset_output}'", server_log.read_text()
         )
@@ -10048,7 +10053,26 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual(first["state_policy"]["lifecycle"], "disposable")
         self.assertEqual(first["state"], str(first_path))
         self.assertTrue(first_path.is_dir())
+        self.assertEqual(
+            (first_path / "rendezvous-state-proof").read_text(encoding="utf-8"),
+            "pinned\n",
+        )
         self.assertNotIn(str(first_path), self.workspace._load_states().values())
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.remove_owned_tree",
+                side_effect=WorkspaceError("simulated removal interruption"),
+            ),
+            self.assertRaisesRegex(WorkspaceError, "simulated removal interruption"),
+        ):
+            self.workspace.topology_down("temporary-clean", timeout=5)
+        self.assertEqual(
+            self.workspace.topology_status("temporary-clean")["state_policy"][
+                "lifecycle"
+            ],
+            "removal-pending",
+        )
+        self.assertTrue(first_path.is_dir())
         stopped = self.workspace.topology_down("temporary-clean", timeout=5)
         self.assertEqual(stopped["state_policy"]["lifecycle"], "removed")
         self.assertFalse(first_path.exists())
@@ -10066,6 +10090,31 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertEqual(stopped["state_policy"]["lifecycle"], "retained")
         self.assertTrue(retained_path.is_dir())
+        with (
+            mock.patch.object(
+                self.workspace, "_build_resolved", return_value=build_root
+            ),
+            self.assertRaisesRegex(
+                WorkspaceError, "retains temporary generation state"
+            ),
+        ):
+            self.workspace.topology_up(
+                "temporary-retained", "default", None, ["server"], 0
+            )
+        with mock.patch("builtins.print") as output:
+            self.workspace.topology_logs(
+                "temporary-retained", "server", 1, False
+            )
+        policy_header = output.call_args_list[0].args[0]
+        self.assertIn("state-policy mode=temporary", policy_header)
+        self.assertIn("lifecycle=retained", policy_header)
+        self.assertIn(str(retained_path), policy_header)
+        self.assertEqual(
+            load_json(
+                retained_path / workspace_module.TEMPORARY_STATE_METADATA
+            )["state_policy"]["lifecycle"],
+            "disposable",
+        )
         self.assertEqual(
             self.workspace.topology_down("temporary-retained", timeout=5)[
                 "state_policy"
@@ -10117,6 +10166,60 @@ class WorkspaceTests(unittest.TestCase):
             promoted,
         )
 
+        (rendezvous / "temporary.bound").unlink()
+        with mock.patch.object(
+            self.workspace, "_build_resolved", return_value=build_root
+        ):
+            retry = self.workspace.topology_up(
+                "temporary-promotion-retry", "default", None, ["server"], 0
+            )
+        retry_path = Path(retry["state_policy"]["path"])
+        self.workspace.topology_down(
+            "temporary-promotion-retry", timeout=5, retain_state=True
+        )
+        write_policy = self.workspace._write_temporary_state_policy
+        writes = 0
+
+        def interrupt_after_registry(
+            topology: str,
+            current: dict[str, object],
+            policy: dict[str, object],
+        ) -> dict[str, object]:
+            nonlocal writes
+            writes += 1
+            if writes == 2:
+                raise WorkspaceError("simulated promoted-status interruption")
+            return write_policy(topology, current, policy)
+
+        with (
+            mock.patch.object(
+                self.workspace,
+                "_write_temporary_state_policy",
+                side_effect=interrupt_after_registry,
+            ),
+            self.assertRaisesRegex(
+                WorkspaceError, "simulated promoted-status interruption"
+            ),
+        ):
+            self.workspace.state_promote(
+                "temporary-promotion-retry", "promoted-retry"
+            )
+        self.assertEqual(
+            self.workspace._state_location("promoted-retry"), retry_path
+        )
+        self.assertEqual(
+            self.workspace.topology_status("temporary-promotion-retry")[
+                "state_policy"
+            ]["lifecycle"],
+            "promotion-pending",
+        )
+        self.assertEqual(
+            self.workspace.state_promote(
+                "temporary-promotion-retry", "promoted-retry"
+            )["state_policy"]["lifecycle"],
+            "promoted",
+        )
+
     def test_temporary_topology_state_is_retained_after_supervisor_crash(self) -> None:
         source = self.workspace.paths.repositories / "server"
         (source / "tools").mkdir()
@@ -10135,6 +10238,14 @@ class WorkspaceTests(unittest.TestCase):
                 "temporary-crash", "default", None, ["server"], 0
             )
         state = Path(status["state_policy"]["path"])
+        live_preview = self.workspace.cleanup(
+            ["temporary-states"], 0, [], False
+        )
+        live_item = next(
+            item for item in live_preview["items"] if item["path"] == str(state)
+        )
+        self.assertEqual(live_item["disposition"], "protected")
+        self.assertIn("live_topology", live_item["reasons"])
         supervisor = status["supervisor"]
         pidfd = os.pidfd_open(supervisor["pid"])
         try:
@@ -10152,6 +10263,30 @@ class WorkspaceTests(unittest.TestCase):
         recovered = self.workspace.topology_down("temporary-crash", timeout=5)
         self.assertEqual(recovered["state_policy"]["lifecycle"], "disposable")
         self.assertTrue(state.is_dir())
+        state_lock = Path(f"{state}.lock")
+        saved_state_lock = state_lock.with_suffix(".saved-lock")
+        state_lock.rename(saved_state_lock)
+        missing_lease = self.workspace.cleanup(
+            ["temporary-states"], 0, [], False
+        )
+        missing_item = next(
+            item for item in missing_lease["items"] if item["path"] == str(state)
+        )
+        self.assertEqual(missing_item["disposition"], "protected")
+        self.assertIn("state_lease_unverifiable", missing_item["reasons"])
+        state_lock.touch(mode=0o600)
+        replaced_lease = self.workspace.cleanup(
+            ["temporary-states"], 0, [], False
+        )
+        replaced_item = next(
+            item for item in replaced_lease["items"] if item["path"] == str(state)
+        )
+        self.assertEqual(replaced_item["disposition"], "protected")
+        self.assertIn(
+            "state_lease_identity_mismatch", replaced_item["reasons"]
+        )
+        state_lock.unlink()
+        saved_state_lock.rename(state_lock)
         preview = self.workspace.cleanup(
             ["temporary-states"], 0, [], False
         )
@@ -10384,6 +10519,21 @@ class WorkspaceTests(unittest.TestCase):
     def test_state_paths_reject_links_and_incompatible_implementation_markers(self) -> None:
         server = self.workspace.paths.repositories / "server"
         state = self.workspace.state_path("default", server)
+        implementation = {
+            "stack": "classic",
+            "provider": "server",
+            "repository": "atrinik/server",
+        }
+        self.workspace.state_path(
+            "default",
+            server,
+            implementation=implementation,
+            write_implementation=True,
+        )
+        self.assertEqual(
+            load_json(state / workspace_module.STATE_IMPLEMENTATION_MARKER),
+            {"schema_version": 1, **implementation},
+        )
         atomic_json(
             state / workspace_module.STATE_IMPLEMENTATION_MARKER,
             {
@@ -10399,11 +10549,7 @@ class WorkspaceTests(unittest.TestCase):
             self.workspace.state_path(
                 "default",
                 server,
-                implementation={
-                    "stack": "classic",
-                    "provider": "server",
-                    "repository": "atrinik/server",
-                },
+                implementation=implementation,
             )
 
         linked = self.root / "linked-state"
@@ -10464,6 +10610,17 @@ class WorkspaceTests(unittest.TestCase):
             self.assertEqual(credentials["account"], created["account"])
             self.assertEqual(credentials["character"], created["character"])
             self.assertTrue(credentials["password"])
+            scenario_summary = self.workspace.topology_summary(
+                "default", "scenario-issue-42", ["server"]
+            )
+            self.assertEqual(
+                scenario_summary["state_policy"]["owner"],
+                {"kind": "scenario", "name": "issue-42"},
+            )
+            self.assertEqual(
+                scenario_summary["state_policy"]["lifecycle"],
+                "scenario-owned",
+            )
 
             (state / "accounts").mkdir()
             reset = self.workspace.scenario_reset("issue-42")

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -9493,7 +9493,7 @@ class WorkspaceTests(unittest.TestCase):
                 candidate.bind(("0.0.0.0", 0))
                 return int(candidate.getsockname()[1])
 
-        for mode in ("explicit", "automatic", "temporary"):
+        for mode in ("explicit", "automatic", "temporary", "mixed-policy"):
             with self.subTest(mode=mode):
                 rendezvous = self.root / f"{mode}-port-rendezvous"
                 rendezvous.mkdir()
@@ -9505,11 +9505,13 @@ class WorkspaceTests(unittest.TestCase):
                     self.make_rendezvous_server_build(
                         root, rendezvous, f"{index}.bound"
                     )
-                states: list[str | None] = (
-                    [None, None]
-                    if mode == "temporary"
-                    else [f"{mode}-state-{index}" for index in range(2)]
-                )
+                states: list[str | None]
+                if mode == "temporary":
+                    states = [None, None]
+                elif mode == "mixed-policy":
+                    states = [None, "mixed-policy-state"]
+                else:
+                    states = [f"{mode}-state-{index}" for index in range(2)]
                 for state in states:
                     if state is not None:
                         self.workspace.state_add(state, None)
@@ -9561,6 +9563,21 @@ class WorkspaceTests(unittest.TestCase):
                         )
                         registered = set(self.workspace._load_states().values())
                         self.assertTrue(state_paths.isdisjoint(registered))
+                    elif mode == "mixed-policy":
+                        self.assertEqual(
+                            [
+                                status["state_policy"]["mode"]
+                                for status in statuses
+                            ],
+                            ["temporary", "named"],
+                        )
+                        registered = set(self.workspace._load_states().values())
+                        self.assertNotIn(
+                            statuses[0]["state_policy"]["path"], registered
+                        )
+                        self.assertIn(
+                            statuses[1]["state_policy"]["path"], registered
+                        )
                     observer = Workspace(self.wrapper)
                     for index, name in enumerate(names):
                         observed = observer.topology_status(name)
@@ -9929,8 +9946,7 @@ class WorkspaceTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "already in use"):
             with exclusive_lock(
                 self.workspace._lease_namespace
-                / "state-identities"
-                / f"{identity['device']}-{identity['inode']}.lock",
+                / f"state-identity-{identity['device']}-{identity['inode']}.lock",
                 "live physical state",
                 nonblocking=True,
             ):
@@ -10403,6 +10419,47 @@ class WorkspaceTests(unittest.TestCase):
         displaced_state.rename(retained_path)
         (retained_path / workspace_module.PROMOTED_STATE_METADATA).unlink()
         atomic_json(retained_status_path, retained_record)
+        real_policy_write = self.workspace._write_temporary_state_policy
+        final_swap = False
+
+        def swap_before_promoted_status(
+            topology_name: str,
+            current: dict[str, object],
+            policy: dict[str, object],
+        ) -> dict[str, object]:
+            nonlocal final_swap
+            if policy.get("lifecycle") == "promoted" and not final_swap:
+                final_swap = True
+                retained_path.rename(displaced_state)
+                retained_path.mkdir()
+                replacement_sentinel.write_text(
+                    "final replacement\n", encoding="utf-8"
+                )
+            return real_policy_write(topology_name, current, policy)
+
+        with (
+            mock.patch.object(
+                self.workspace,
+                "_write_temporary_state_policy",
+                side_effect=swap_before_promoted_status,
+            ),
+            self.assertRaises(WorkspaceError),
+        ):
+            self.workspace.state_promote(
+                "temporary-retained", "promotion-final-swap-review"
+            )
+        self.assertTrue(final_swap)
+        self.assertNotIn(
+            "promotion-final-swap-review", self.workspace._load_states()
+        )
+        self.assertEqual(
+            load_json(retained_status_path)["state_policy"]["lifecycle"],
+            "promotion-pending",
+        )
+        shutil.rmtree(retained_path)
+        displaced_state.rename(retained_path)
+        (retained_path / workspace_module.PROMOTED_STATE_METADATA).unlink()
+        atomic_json(retained_status_path, retained_record)
         sessions = [Workspace(self.wrapper), Workspace(self.wrapper)]
         with ThreadPoolExecutor(max_workers=2) as executor:
             futures = [
@@ -10463,6 +10520,9 @@ class WorkspaceTests(unittest.TestCase):
         provenance = retained_path / workspace_module.PROMOTED_STATE_METADATA
         provenance.unlink()
         origin_status.rename(hidden_status)
+        ownership_marker = retained_path / MANAGED_MARKER
+        hidden_ownership = retained_path / "managed.hidden"
+        ownership_marker.rename(hidden_ownership)
         try:
             with self.assertRaisesRegex(
                 WorkspaceError, "promoted state provenance is missing"
@@ -10471,6 +10531,7 @@ class WorkspaceTests(unittest.TestCase):
                     "default", str(promoted["name"]), ["server"]
                 )
         finally:
+            hidden_ownership.rename(ownership_marker)
             hidden_status.rename(origin_status)
         self.workspace.state_promote(
             "temporary-retained", str(promoted["name"])
@@ -10514,9 +10575,8 @@ class WorkspaceTests(unittest.TestCase):
             self.workspace.state_promote(
                 "temporary-promotion-retry", "promoted-retry"
             )
-        self.assertEqual(
-            self.workspace._state_location("promoted-retry"), retry_path
-        )
+        with self.assertRaisesRegex(WorkspaceError, "state does not exist"):
+            self.workspace._state_location("promoted-retry")
         self.assertEqual(
             self.workspace.topology_status("temporary-promotion-retry")[
                 "state_policy"
@@ -10621,6 +10681,35 @@ class WorkspaceTests(unittest.TestCase):
         )
         state_lock.unlink()
         saved_state_lock.rename(state_lock)
+        registered_alias = self.root / "registered-physical-alias"
+        registered_alias.mkdir()
+        real_state_identity = self.workspace._state_identity
+
+        def alias_identity(path: Path) -> dict[str, int]:
+            if path == registered_alias:
+                return crashed["state_policy"]["identity"]
+            return real_state_identity(path)
+
+        with (
+            mock.patch.object(
+                self.workspace,
+                "_load_states",
+                return_value={"registered-alias": str(registered_alias)},
+            ),
+            mock.patch.object(
+                self.workspace,
+                "_state_identity",
+                side_effect=alias_identity,
+            ),
+        ):
+            aliased = self.workspace.cleanup(
+                ["temporary-states"], 0, [], False
+            )
+        aliased_item = next(
+            item for item in aliased["items"] if item["path"] == str(state)
+        )
+        self.assertEqual(aliased_item["disposition"], "protected")
+        self.assertIn("registered_state", aliased_item["reasons"])
         preview = self.workspace.cleanup(
             ["temporary-states"], 0, [], False
         )
@@ -11178,6 +11267,24 @@ class WorkspaceTests(unittest.TestCase):
                 WorkspaceError, "state identity changed"
             ):
                 lease.bind(self.workspace._state_identity(state))
+
+    def test_temporary_lifecycle_rejects_replaced_state_lock(self) -> None:
+        state = self.root / "temporary-lock-aba"
+        state.mkdir()
+        lock = Path(f"{state}.lock")
+        lock.touch(mode=0o600)
+        with exclusive_lock(lock, "recorded temporary state") as recorded:
+            metadata = os.fstat(recorded.fileno())
+            identity = {"device": metadata.st_dev, "inode": metadata.st_ino}
+            lock.unlink()
+            lock.touch(mode=0o600)
+            with exclusive_lock(lock, "replacement temporary state") as replacement:
+                with self.assertRaisesRegex(
+                    WorkspaceError, "lease changed before lifecycle mutation"
+                ):
+                    self.workspace._validate_temporary_state_lock(
+                        state, replacement, identity
+                    )
 
     def test_temporary_state_publication_interruption_leaves_no_partial_state(self) -> None:
         topology = self.workspace._topology_directory("interrupted", create=True)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -10340,7 +10340,62 @@ class WorkspaceTests(unittest.TestCase):
             restarted_clean["state_policy"]["path"],
             first["state_policy"]["path"],
         )
-        self.workspace.topology_down("temporary-clean", timeout=5)
+        restarted_path = Path(restarted_clean["state_policy"]["path"])
+        unsafe_target = self.root / "temporary-clean-symlink-target"
+        unsafe_target.write_text("preserve\n", encoding="utf-8")
+        (restarted_path / "unsafe-link").symlink_to(unsafe_target)
+        with self.assertRaisesRegex(
+            WorkspaceError, "retained because its integrity could not be proved"
+        ):
+            self.workspace.topology_down("temporary-clean", timeout=5)
+        linked_down = self.workspace.topology_status("temporary-clean")
+        self.assertEqual(linked_down["state_policy"]["lifecycle"], "retained")
+        self.assertTrue(restarted_path.is_dir())
+        self.assertEqual(unsafe_target.read_text(encoding="utf-8"), "preserve\n")
+
+        (rendezvous / "temporary.bound").unlink()
+        with mock.patch.object(
+            self.workspace, "_build_resolved", return_value=build_root
+        ):
+            hardlinked = self.workspace.topology_up(
+                "temporary-hardlinked", "default", None, ["server"], 0
+            )
+        hardlinked_path = Path(hardlinked["state_policy"]["path"])
+        hardlink_target = self.root / "temporary-clean-hardlink"
+        os.link(hardlinked_path / "motd", hardlink_target)
+        with self.assertRaisesRegex(
+            WorkspaceError, "retained because its integrity could not be proved"
+        ):
+            self.workspace.topology_down("temporary-hardlinked", timeout=5)
+        self.assertEqual(
+            self.workspace.topology_status("temporary-hardlinked")["state_policy"][
+                "lifecycle"
+            ],
+            "retained",
+        )
+        self.assertTrue(hardlinked_path.is_dir())
+        hardlink_target.unlink()
+
+        (rendezvous / "temporary.bound").unlink()
+        with mock.patch.object(
+            self.workspace, "_build_resolved", return_value=build_root
+        ):
+            malformed = self.workspace.topology_up(
+                "temporary-malformed", "default", None, ["server"], 0
+            )
+        malformed_path = Path(malformed["state_policy"]["path"])
+        (malformed_path / "motd").unlink()
+        with self.assertRaisesRegex(
+            WorkspaceError, "retained because its integrity could not be proved"
+        ):
+            self.workspace.topology_down("temporary-malformed", timeout=5)
+        self.assertEqual(
+            self.workspace.topology_status("temporary-malformed")["state_policy"][
+                "lifecycle"
+            ],
+            "retained",
+        )
+        self.assertTrue(malformed_path.is_dir())
 
         external_state = self.root / "external-supervised-state"
         shutil.copytree(source / "install_data", external_state)
@@ -10772,6 +10827,79 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertEqual(aliased_item["disposition"], "protected")
         self.assertIn("registered_state", aliased_item["reasons"])
+        required_file = state / "motd"
+        saved_required_file = state / "motd.saved"
+        required_file.rename(saved_required_file)
+        malformed_preview = self.workspace.cleanup(
+            ["temporary-states"], 0, [], False
+        )
+        malformed_item = next(
+            item
+            for item in malformed_preview["items"]
+            if item["path"] == str(state)
+        )
+        self.assertEqual(malformed_item["disposition"], "protected")
+        self.assertIn("malformed_state", malformed_item["reasons"])
+        malformed_apply = self.workspace.cleanup(
+            ["temporary-states"], 0, [], True
+        )
+        malformed_applied_item = next(
+            item
+            for item in malformed_apply["items"]
+            if item["path"] == str(state)
+        )
+        self.assertEqual(malformed_applied_item["disposition"], "protected")
+        self.assertTrue(state.is_dir())
+        saved_required_file.rename(required_file)
+        required_directory = state / "keys"
+        saved_required_directory = state / "keys.saved"
+        required_directory.rename(saved_required_directory)
+        missing_directory_preview = self.workspace.cleanup(
+            ["temporary-states"], 0, [], False
+        )
+        missing_directory_item = next(
+            item
+            for item in missing_directory_preview["items"]
+            if item["path"] == str(state)
+        )
+        self.assertEqual(missing_directory_item["disposition"], "protected")
+        self.assertIn("malformed_state", missing_directory_item["reasons"])
+        missing_directory_apply = self.workspace.cleanup(
+            ["temporary-states"], 0, [], True
+        )
+        missing_directory_applied_item = next(
+            item
+            for item in missing_directory_apply["items"]
+            if item["path"] == str(state)
+        )
+        self.assertEqual(
+            missing_directory_applied_item["disposition"], "protected"
+        )
+        self.assertTrue(state.is_dir())
+        saved_required_directory.rename(required_directory)
+        special = state / "unsafe-fifo"
+        os.mkfifo(special)
+        special_preview = self.workspace.cleanup(
+            ["temporary-states"], 0, [], False
+        )
+        special_item = next(
+            item
+            for item in special_preview["items"]
+            if item["path"] == str(state)
+        )
+        self.assertEqual(special_item["disposition"], "protected")
+        self.assertIn("malformed_state", special_item["reasons"])
+        special_apply = self.workspace.cleanup(
+            ["temporary-states"], 0, [], True
+        )
+        special_applied_item = next(
+            item
+            for item in special_apply["items"]
+            if item["path"] == str(state)
+        )
+        self.assertEqual(special_applied_item["disposition"], "protected")
+        self.assertTrue(state.is_dir())
+        special.unlink()
         linked_file = next(
             path
             for path in state.rglob("*")
@@ -10829,6 +10957,24 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertTrue(pending_state.is_dir())
         self.assertEqual(list(pending_state.iterdir()), [])
+        with mock.patch.object(
+            self.workspace,
+            "_unlink_temporary_state_lock",
+            side_effect=WorkspaceError(
+                "simulated lease finalization interruption"
+            ),
+        ):
+            lease_interrupted = self.workspace.cleanup(
+                ["temporary-states"], 0, [], True
+            )
+        lease_interrupted_item = next(
+            item
+            for item in lease_interrupted["items"]
+            if item["path"] == str(state)
+        )
+        self.assertEqual(lease_interrupted_item["disposition"], "error")
+        self.assertFalse(pending_state.exists())
+        self.assertTrue(Path(f"{state}.lock").is_file())
         applied = self.workspace.cleanup(
             ["temporary-states"], 0, [], True
         )

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -5549,6 +5549,63 @@ class WorkspaceTests(unittest.TestCase):
         self.assertFalse(output.exists())
         self.assertFalse(transaction.exists())
 
+        atomic_json(
+            transaction,
+            {
+                "schema_version": 1,
+                "generation": "2" * 64,
+                "state": str(state),
+                "state_identity": self.workspace._state_identity(state),
+                "phase": "creating",
+                "output_identity": None,
+            },
+        )
+        with self.assertRaisesRegex(
+            WorkspaceError, "before exact ownership was recorded"
+        ):
+            self.workspace._recover_runtime_state_output_transaction(
+                topology, "runtime-output-transaction"
+            )
+        self.assertTrue(transaction.is_file())
+
+    def test_pre_spawn_runtime_output_rollback_completes_transaction(self) -> None:
+        topology = self.workspace._topology_directory(
+            "runtime-output-pre-spawn", create=True
+        )
+        state = self.root / "runtime-output-pre-spawn-state"
+        state.mkdir()
+        state_fd = os.open(state, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        generation = "3" * 64
+        output, output_fd, output_identity = (
+            self.workspace._prepare_runtime_state_output(
+                state, generation, state_fd
+            )
+        )
+        os.close(output_fd)
+        transaction = topology / workspace_module.RUNTIME_STATE_OUTPUT_TRANSACTION
+        atomic_json(
+            transaction,
+            {
+                "schema_version": 1,
+                "generation": generation,
+                "state": str(state),
+                "state_identity": self.workspace._state_identity(state),
+                "phase": "prepared",
+                "output_identity": output_identity,
+            },
+        )
+        try:
+            self.workspace._rollback_runtime_state_output_transaction(
+                topology, output, generation, state_fd, output_identity
+            )
+            self.assertFalse(output.exists())
+            self.assertFalse(transaction.exists())
+            self.workspace._recover_runtime_state_output_transaction(
+                topology, "runtime-output-pre-spawn"
+            )
+        finally:
+            os.close(state_fd)
+
     def test_runtime_output_removal_retries_from_empty_tombstone(self) -> None:
         state = self.root / "runtime-output-removal-retry"
         state.mkdir()
@@ -5610,8 +5667,7 @@ class WorkspaceTests(unittest.TestCase):
             self.workspace.topology_up(
                 "legacy-output", "default", "default", ["server"], 0
             )
-        digest = hashlib.sha256(output.name.encode("utf-8")).hexdigest()[:16]
-        output.rename(output.parent / f".remove-{digest}-1-2")
+        output.rename(output.parent / "operator-renamed-legacy-output")
         with (
             mock.patch.object(
                 self.workspace, "topology_status", return_value=previous
@@ -12473,6 +12529,65 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual(
             {path.name for path in displaced.iterdir()}, {MANAGED_MARKER}
         )
+
+    def test_temporary_state_staging_rollback_rejects_replacement(self) -> None:
+        topology = self.workspace._topology_directory(
+            "staging-replaced", create=True
+        )
+        server = self.workspace.paths.repositories / "server"
+        generation = "4" * 64
+        original_digest = workspace_module._tree_digest
+        displaced = topology / "displaced-state-staging"
+        replaced = False
+
+        def replace_staging(*args: object, **kwargs: object) -> str:
+            nonlocal replaced
+            digest = original_digest(*args, **kwargs)
+            if not replaced and Path(args[0]) == server / "install_data":
+                replaced = True
+                container = topology / "temporary-states"
+                staging = next(
+                    path
+                    for path in container.iterdir()
+                    if path.name.startswith(f".{generation}.")
+                )
+                staging.rename(displaced)
+                staging.mkdir()
+                (staging / "sentinel").write_text(
+                    "preserve\n", encoding="utf-8"
+                )
+            return digest
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace._tree_digest",
+                side_effect=replace_staging,
+            ),
+            self.assertRaisesRegex(WorkspaceError, "identity changed"),
+        ):
+            self.workspace._create_temporary_state(
+                topology,
+                "staging-replaced",
+                "default",
+                generation,
+                server,
+                {
+                    "stack": "default",
+                    "provider": "server",
+                    "repository": "atrinik/server",
+                },
+                self.scenario_resolved_fixture()["server"],
+            )
+        replacement = next(
+            path
+            for path in (topology / "temporary-states").iterdir()
+            if path.name.startswith(f".{generation}.")
+        )
+        self.assertEqual(
+            (replacement / "sentinel").read_text(encoding="utf-8"),
+            "preserve\n",
+        )
+        self.assertTrue(displaced.is_dir())
 
     def test_temporary_startup_rollback_removes_state_and_lease(self) -> None:
         topology = self.workspace._topology_directory("rollback", create=True)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -6055,6 +6055,43 @@ class WorkspaceTests(unittest.TestCase):
             )
         self.assertEqual(tombstone.read_text(encoding="utf-8"), "must survive\n")
 
+    def test_owned_tree_removal_rechecks_links_after_tombstoning(self) -> None:
+        root = self.root / "linked-after-tombstone"
+        root.mkdir()
+        payload = root / "payload"
+        payload.write_text("preserve\n", encoding="utf-8")
+        external = self.root / "external-hard-link"
+        real_rename = workspace_module.rename_no_replace_at
+
+        def link_after_rename(
+            source_fd: int,
+            source: str,
+            destination_fd: int,
+            destination: str,
+        ) -> None:
+            real_rename(source_fd, source, destination_fd, destination)
+            if source == "payload":
+                os.link(
+                    destination,
+                    external,
+                    src_dir_fd=destination_fd,
+                    follow_symlinks=False,
+                )
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.rename_no_replace_at",
+                side_effect=link_after_rename,
+            ),
+            self.assertRaisesRegex(WorkspaceError, "linked state"),
+        ):
+            remove_owned_tree(
+                root,
+                expected_identity=self.workspace._state_identity(root),
+                reject_links=True,
+            )
+        self.assertEqual(external.read_text(encoding="utf-8"), "preserve\n")
+
     def test_owned_tree_removal_supports_name_max_entries(self) -> None:
         root = self.root / "name-max-removal"
         root.mkdir()
@@ -10374,6 +10411,43 @@ class WorkspaceTests(unittest.TestCase):
             missing_all_item["reasons"],
         )
         self.assertIn("state_lease_unverifiable", missing_all_item["reasons"])
+        pending_status_path = (
+            self.workspace.paths.topologies / "temporary-clean" / "status.json"
+        )
+        pending_status = load_json(pending_status_path)
+        malformed_created_at = copy.deepcopy(pending_status)
+        malformed_created_at["state_policy"]["created_at"] = "not-a-timestamp"
+        atomic_json(pending_status_path, malformed_created_at)
+        malformed_pending = self.workspace.cleanup(
+            ["temporary-states"], 0, [], False
+        )
+        malformed_pending_item = next(
+            item
+            for item in malformed_pending["items"]
+            if item["path"] == str(first_path)
+        )
+        self.assertEqual(malformed_pending_item["disposition"], "protected")
+        self.assertIn(
+            "invalid_temporary_state", malformed_pending_item["reasons"]
+        )
+        atomic_json(pending_status_path, pending_status)
+        container = first_path.parent
+        displaced_container = container.with_name("temporary-states.displaced")
+        container.rename(displaced_container)
+        missing_container = self.workspace.cleanup(
+            ["temporary-states"], 0, [], False
+        )
+        missing_container_item = next(
+            item
+            for item in missing_container["items"]
+            if item["path"] == str(first_path)
+        )
+        self.assertEqual(missing_container_item["disposition"], "protected")
+        self.assertIn(
+            "temporary_state_ownership_evidence_missing",
+            missing_container_item["reasons"],
+        )
+        displaced_container.rename(container)
         displaced_lock.rename(state_lock)
         displaced.rename(first_path)
         with (
@@ -10955,6 +11029,47 @@ class WorkspaceTests(unittest.TestCase):
         self.assertIn("registered_state", aliased_item["reasons"])
         real_mount_id = cleanup_module._descriptor_mount_id
 
+        def simulated_root_mount_id(
+            descriptor: int,
+        ) -> int | tuple[int, int]:
+            target = Path(os.readlink(f"/proc/self/fd/{descriptor}"))
+            if target == state:
+                return 999999997
+            return real_mount_id(descriptor)
+
+        with mock.patch.object(
+            cleanup_module,
+            "_descriptor_mount_id",
+            side_effect=simulated_root_mount_id,
+        ):
+            root_mount_preview = self.workspace.cleanup(
+                ["temporary-states"], 0, [], False
+            )
+        root_mount_item = next(
+            item
+            for item in root_mount_preview["items"]
+            if item["path"] == str(state)
+        )
+        self.assertEqual(root_mount_item["disposition"], "protected")
+        self.assertIn(
+            "filesystem_traversal_error", root_mount_item["reasons"]
+        )
+        state_fd = os.open(state, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        try:
+            with (
+                mock.patch.object(
+                    workspace_module,
+                    "_descriptor_mount_id",
+                    side_effect=simulated_root_mount_id,
+                ),
+                self.assertRaisesRegex(WorkspaceError, "root.*mount"),
+            ):
+                self.workspace._validate_temporary_state_integrity(
+                    state_fd, state
+                )
+        finally:
+            os.close(state_fd)
+
         def simulated_mount_id(descriptor: int) -> int | tuple[int, int]:
             target = Path(os.readlink(f"/proc/self/fd/{descriptor}"))
             if target == state / "keys":
@@ -11243,6 +11358,19 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual(pre_service["services"], {})
         self.assertEqual(pre_service["state_policy"]["mode"], "temporary")
         self.assertIsNotNone(pre_service["error"])
+        pre_service_status_path = (
+            self.workspace.paths.topologies
+            / "temporary-pre-service-failure"
+            / "status.json"
+        )
+        raw_pre_service = load_json(pre_service_status_path)
+        invalid_without_error = {**raw_pre_service, "error": None}
+        atomic_json(pre_service_status_path, invalid_without_error)
+        with self.assertRaisesRegex(
+            WorkspaceError, "topology .*invalid"
+        ):
+            self.workspace.topology_status("temporary-pre-service-failure")
+        atomic_json(pre_service_status_path, raw_pre_service)
         pre_service_state = Path(pre_service["state_policy"]["path"])
         recovered_pre_service = self.workspace.topology_down(
             "temporary-pre-service-failure", timeout=5
@@ -11880,6 +12008,43 @@ class WorkspaceTests(unittest.TestCase):
             )
         self.assertFalse(state.exists())
         self.assertFalse(lock.exists())
+
+    def test_temporary_startup_rollback_retains_linked_state(self) -> None:
+        topology = self.workspace._topology_directory(
+            "linked-rollback", create=True
+        )
+        server = self.workspace.paths.repositories / "server"
+        state, policy = self.workspace._create_temporary_state(
+            topology,
+            "linked-rollback",
+            "default",
+            "f" * 64,
+            server,
+            {
+                "stack": "default",
+                "provider": "server",
+                "repository": "atrinik/server",
+            },
+            self.scenario_resolved_fixture()["server"],
+        )
+        lock = Path(f"{state}.lock")
+        linked_target = self.root / "rollback-link-target"
+        linked_target.write_text("preserve\n", encoding="utf-8")
+        (state / "unsafe-link").symlink_to(linked_target)
+        state_fd = os.open(state, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        with exclusive_lock(lock, "temporary rollback") as state_lease:
+            metadata = os.fstat(state_lease.fileno())
+            with self.assertRaisesRegex(WorkspaceError, "symbolic link"):
+                self.workspace._rollback_temporary_state_creation(
+                    state,
+                    state_lease,
+                    policy["identity"],
+                    {"device": metadata.st_dev, "inode": metadata.st_ino},
+                    state_fd,
+                )
+        os.close(state_fd)
+        self.assertTrue(state.is_dir())
+        self.assertTrue((state / "unsafe-link").is_symlink())
 
     def test_temporary_mutation_refuses_live_physical_alias(self) -> None:
         state = self.root / "temporary-physical-alias"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -557,6 +557,15 @@ def synthetic_server_start_process(
             # kernel availability check.
             reserved_port.close()
 
+            def prepared_state_path(
+                *_args: object, **kwargs: object
+            ) -> Path | tuple[Path, int]:
+                if kwargs.get("keep_descriptor"):
+                    return state, os.open(
+                        state, os.O_PATH | os.O_DIRECTORY | os.O_NOFOLLOW
+                    )
+                return state
+
             with (
                 mock.patch.object(
                     locking_module.fcntl, "flock", side_effect=observe_flock
@@ -565,7 +574,9 @@ def synthetic_server_start_process(
                 mock.patch.object(
                     workspace, "_state_location", return_value=state
                 ),
-                mock.patch.object(workspace, "state_path", return_value=state),
+                mock.patch.object(
+                    workspace, "state_path", side_effect=prepared_state_path
+                ),
                 mock.patch.object(
                     workspace, "_build_resolved", return_value=root
                 ),
@@ -9807,8 +9818,11 @@ class WorkspaceTests(unittest.TestCase):
         self.assertIn("'--port_mapping=off'", server_log.read_text())
         self.assertIn("'--stun_server=off'", server_log.read_text())
         self.assertRegex(server_log.read_text(), r"'--datapath=/proc/self/fd/\d+'")
-        self.assertIn(
-            f"'--assetspath={mutable_asset_output}'", server_log.read_text()
+        self.assertRegex(
+            server_log.read_text(),
+            r"'--assetspath=/proc/self/fd/\d+/tmp/runtime-assets/"
+            + status["control"]["generation"]
+            + r"'",
         )
         self.assertIn(
             f"'--server=127.0.0.1 17300 {'a' * 64}'", client_log.read_text()
@@ -10161,6 +10175,31 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.workspace.topology_down("temporary-clean", timeout=5)
 
+        external_state = self.root / "external-supervised-state"
+        shutil.copytree(source / "install_data", external_state)
+        (external_state / "external-sentinel").write_text(
+            "preserve\n", encoding="utf-8"
+        )
+        self.workspace.state_add("external-supervised", external_state)
+        with mock.patch.object(
+            self.workspace, "_build_resolved", return_value=build_root
+        ):
+            external_status = self.workspace.topology_up(
+                "external-supervised", "default", "external-supervised", ["server"], 0
+            )
+        self.assertEqual(
+            external_status["state_policy"]["owner"], {"kind": "external"}
+        )
+        self.assertEqual(
+            external_status["state_policy"]["lifecycle"],
+            "persistent-external",
+        )
+        self.workspace.topology_down("external-supervised", timeout=5)
+        self.assertEqual(
+            (external_state / "external-sentinel").read_text(encoding="utf-8"),
+            "preserve\n",
+        )
+
         (rendezvous / "temporary.bound").unlink()
         with mock.patch.object(
             self.workspace, "_build_resolved", return_value=build_root
@@ -10174,6 +10213,10 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertEqual(stopped["state_policy"]["lifecycle"], "retained")
         self.assertTrue(retained_path.is_dir())
+        with self.assertRaisesRegex(
+            WorkspaceError, "only be registered through state promote"
+        ):
+            self.workspace.state_add("unsafe-temporary-alias", retained_path)
         retained_status_path = (
             self.workspace.paths.topologies / "temporary-retained" / "status.json"
         )
@@ -10254,6 +10297,21 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertEqual(
             self.workspace._state_location(str(promoted["name"])), retained_path
+        )
+        promoted_summary = self.workspace.topology_summary(
+            "default", str(promoted["name"]), ["server"]
+        )
+        self.assertEqual(
+            promoted_summary["state_policy"]["owner"],
+            {
+                "kind": "promoted-topology-state",
+                "topology": "temporary-retained",
+                "generation": retained["control"]["generation"],
+            },
+        )
+        self.assertEqual(
+            promoted_summary["state_policy"]["lifecycle"],
+            "persistent-promoted",
         )
         self.assertEqual(
             self.workspace.state_promote(
@@ -10359,6 +10417,25 @@ class WorkspaceTests(unittest.TestCase):
         recovered = self.workspace.topology_down("temporary-crash", timeout=5)
         self.assertEqual(recovered["state_policy"]["lifecycle"], "disposable")
         self.assertTrue(state.is_dir())
+        status_path = (
+            self.workspace.paths.topologies / "temporary-crash" / "status.json"
+        )
+        raw_status = load_json(status_path)
+        without_port_evidence = copy.deepcopy(raw_status)
+        without_port_evidence.pop("port_reservation", None)
+        atomic_json(status_path, without_port_evidence)
+        missing_port = self.workspace.cleanup(
+            ["temporary-states"], 0, [], False
+        )
+        missing_port_item = next(
+            item for item in missing_port["items"] if item["path"] == str(state)
+        )
+        self.assertEqual(missing_port_item["disposition"], "protected")
+        self.assertIn(
+            "port_reservation_lease_unverifiable",
+            missing_port_item["reasons"],
+        )
+        atomic_json(status_path, raw_status)
         state_lock = Path(f"{state}.lock")
         saved_state_lock = state_lock.with_suffix(".saved-lock")
         state_lock.rename(saved_state_lock)
@@ -10422,6 +10499,50 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual(cleaned["state_policy"]["lifecycle"], "removed")
         self.assertFalse(Path(f"{state}.lock").exists())
 
+    def test_failed_post_spawn_temporary_startup_retains_diagnostic_state(self) -> None:
+        source = self.workspace.paths.repositories / "server"
+        (source / "tools").mkdir()
+        for filename in ("ca-bundle.crt", "permissions.cfg", "server.cfg"):
+            (source / filename).write_text("test\n", encoding="utf-8")
+        rendezvous = self.root / "failed-startup-rendezvous"
+        rendezvous.mkdir()
+        build_root = self.workspace.paths.builds / "failed-startup-server"
+        self.make_rendezvous_server_build(
+            build_root, rendezvous, "unused.bound", peers=1
+        )
+        executable = build_root / "build" / "server" / "atrinik-server"
+        executable.write_text(
+            "#!/usr/bin/env python3\n"
+            "import pathlib, sys\n"
+            "datapath = pathlib.Path(next(value.split('=', 1)[1] for value in "
+            "sys.argv if value.startswith('--datapath=')))\n"
+            "(datapath / 'failed-startup-proof').write_text('retained\\n', "
+            "encoding='utf-8')\n"
+            "raise SystemExit(23)\n",
+            encoding="utf-8",
+        )
+        executable.chmod(0o755)
+        with (
+            mock.patch.object(
+                self.workspace, "_build_resolved", return_value=build_root
+            ),
+            self.assertRaisesRegex(WorkspaceError, "topology supervisor failed"),
+        ):
+            self.workspace.topology_up(
+                "temporary-failed-startup", "default", None, ["server"], 0
+            )
+        failed = self.workspace.topology_status("temporary-failed-startup")
+        failed_state = Path(failed["state_policy"]["path"])
+        self.assertEqual(failed["state_policy"]["lifecycle"], "disposable")
+        self.assertTrue(failed_state.is_dir())
+        self.assertEqual(
+            (failed_state / "failed-startup-proof").read_text(encoding="utf-8"),
+            "retained\n",
+        )
+        self.assertNotIn(
+            str(failed_state), self.workspace._load_states().values()
+        )
+
     def test_stop_acknowledgement_without_clean_shutdown_proof_retains_state(
         self,
     ) -> None:
@@ -10453,6 +10574,33 @@ class WorkspaceTests(unittest.TestCase):
             )
         self.assertIs(observed, stopped)
         self.assertFalse(confirmed_clean)
+
+    def test_persisted_clean_shutdown_proof_allows_down_retry(self) -> None:
+        control = {"generation": "a" * 64}
+        stopped = {
+            "control": control,
+            "shutdown": {"control_requested": True, "clean": True},
+            "error": None,
+            "supervisor": {"running": False},
+            "services": {"server": {"running": False}},
+        }
+        self.workspace._topology_directory("clean-down-retry", create=True)
+        with (
+            mock.patch.object(
+                self.workspace, "_topology_control_request", return_value=False
+            ),
+            mock.patch.object(
+                self.workspace, "_topology_process_tree_active", return_value=False
+            ),
+            mock.patch.object(
+                self.workspace, "topology_status", return_value=stopped
+            ),
+        ):
+            observed, confirmed_clean = self.workspace._controlled_topology_down(
+                "clean-down-retry", {"control": control}, 1
+            )
+        self.assertIs(observed, stopped)
+        self.assertTrue(confirmed_clean)
 
     def test_topology_port_selection_rejects_unavailable_port(self) -> None:
         candidate = mock.MagicMock()
@@ -10813,6 +10961,22 @@ class WorkspaceTests(unittest.TestCase):
                 with self.workspace._topology_state_lock(state):
                     self.fail("replacement lock must not grant state ownership")
 
+    def test_physical_state_aliases_share_one_exclusive_lease(self) -> None:
+        first = self.root / "state-alias-first"
+        second = self.root / "state-alias-second"
+        first.mkdir()
+        second.mkdir()
+        shared_identity = {"device": 41, "inode": 73}
+        with (
+            mock.patch.object(
+                self.workspace, "_state_identity", return_value=shared_identity
+            ),
+            self.workspace._topology_state_lock(first),
+            self.assertRaisesRegex(WorkspaceError, "exact owner cannot be confirmed"),
+        ):
+            with self.workspace._topology_state_lock(second):
+                self.fail("physical aliases must not receive distinct leases")
+
     def test_temporary_state_publication_interruption_leaves_no_partial_state(self) -> None:
         topology = self.workspace._topology_directory("interrupted", create=True)
         generation = "a" * 64
@@ -10838,6 +11002,48 @@ class WorkspaceTests(unittest.TestCase):
         container = topology / "temporary-states"
         self.assertEqual(
             {path.name for path in container.iterdir()}, {MANAGED_MARKER}
+        )
+
+    def test_temporary_state_rejects_install_data_mutation_during_copy(self) -> None:
+        topology = self.workspace._topology_directory("copy-race", create=True)
+        server = self.workspace.paths.repositories / "server"
+        original_tree_digest = workspace_module._tree_digest
+        digest_calls = 0
+
+        def digest_then_mutate(*args: object, **kwargs: object) -> str:
+            nonlocal digest_calls
+            digest_calls += 1
+            digest = original_tree_digest(*args, **kwargs)
+            if digest_calls == 2:
+                (server / "install_data" / "motd").write_text(
+                    "changed\n", encoding="utf-8"
+                )
+            return digest
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace._tree_digest",
+                side_effect=digest_then_mutate,
+            ),
+            self.assertRaisesRegex(
+                WorkspaceError, "install_data changed during temporary state"
+            ),
+        ):
+            self.workspace._create_temporary_state(
+                topology,
+                "copy-race",
+                "b" * 64,
+                server,
+                {
+                    "stack": "default",
+                    "provider": "server",
+                    "repository": "atrinik/server",
+                },
+                self.scenario_resolved_fixture()["server"],
+            )
+        self.assertEqual(
+            {path.name for path in (topology / "temporary-states").iterdir()},
+            {MANAGED_MARKER},
         )
 
     def test_scenario_lifecycle_owns_isolated_state_and_credentials(self) -> None:
@@ -11620,7 +11826,7 @@ class WorkspaceTests(unittest.TestCase):
             }
 
         def execute_server(*_arguments: object, **_keywords: object) -> None:
-            self.assertEqual(len(_keywords["pass_fds"]), 2)
+            self.assertEqual(len(_keywords["pass_fds"]), 3)
             for path, description in (
                 (
                     resource_lock_path(
@@ -11669,7 +11875,13 @@ class WorkspaceTests(unittest.TestCase):
                 self.workspace, "_build_resolved", return_value=build_root
             ),
             mock.patch.object(
-                self.workspace, "_topology_resolved_status", return_value={}
+                self.workspace,
+                "_topology_resolved_status",
+                return_value={
+                    "server": {
+                        "repository": "https://github.com/atrinik/server.git"
+                    }
+                },
             ),
             mock.patch.object(
                 self.workspace,
@@ -11696,6 +11908,12 @@ class WorkspaceTests(unittest.TestCase):
 
         self.assertEqual(result.name, "atrinik-server")
         self.assertFalse(result.exists())
+        implementation = load_json(
+            self.workspace._state_location("default")
+            / workspace_module.STATE_IMPLEMENTATION_MARKER
+        )
+        self.assertEqual(implementation["stack"], "default")
+        self.assertEqual(implementation["provider"], "server")
         rendered = "\n".join(str(call.args[0]) for call in output.call_args_list)
         self.assertIn("--port_quic=1731", rendered)
         self.assertIn("--port_mapping=off", rendered)
@@ -11703,10 +11921,9 @@ class WorkspaceTests(unittest.TestCase):
         self.assertIn("--no_console", rendered)
         self.assertLess(
             rendered.index("--assetspath=/tmp/untrusted"),
-            rendered.index(
-                f"--assetspath={self.root / 'foreground-server-state-output'}"
-            ),
+            rendered.index("--assetspath=/proc/self/fd/"),
         )
+        self.assertIn("--datapath=/proc/self/fd/", rendered)
 
     def test_foreground_launch_rejects_invalid_port(self) -> None:
         with self.assertRaisesRegex(WorkspaceError, "between 1 and 65535"):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -5435,6 +5435,85 @@ class WorkspaceTests(unittest.TestCase):
         finally:
             os.close(state_fd)
 
+    def test_runtime_state_output_cleanup_tracks_pending_renames(self) -> None:
+        topology = self.workspace._topology_directory(
+            "runtime-output-recovery", create=True
+        )
+        state = self.root / "runtime-output-recovery-state"
+        state.mkdir()
+        state_fd = os.open(state, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        generation = "e" * 64
+        output, output_fd, output_identity = (
+            self.workspace._prepare_runtime_state_output(
+                state, generation, state_fd
+            )
+        )
+        os.close(output_fd)
+        os.close(state_fd)
+        displaced = output.parent / "operator-renamed-output"
+        output.rename(displaced)
+        status = {
+            "name": "runtime-output-recovery",
+            "state_policy": {
+                "mode": "named",
+                "path": str(state),
+                "identity": self.workspace._state_identity(state),
+            },
+            "control": {"generation": generation},
+            "runtime": {
+                "mutable_state_outputs": [str(output)],
+                "mutable_state_output_identities": [output_identity],
+            },
+        }
+        status_path = topology / "status.json"
+        atomic_json(status_path, status)
+        with mock.patch.object(
+            self.workspace,
+            "topology_status",
+            side_effect=lambda _name: load_json(status_path),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "was renamed"):
+                self.workspace._cleanup_topology_mutable_state_outputs(status)
+            pending = load_json(status_path)
+            self.assertEqual(
+                pending["mutable_state_cleanup"]["entries"][0]["status"],
+                "pending",
+            )
+            displaced.rename(output)
+            completed = self.workspace._cleanup_topology_mutable_state_outputs(
+                pending
+            )
+        self.assertEqual(
+            completed["mutable_state_cleanup"]["entries"][0]["status"],
+            "complete",
+        )
+        self.assertFalse(output.exists())
+
+    def test_schema_two_restart_preserves_unowned_mutable_output(self) -> None:
+        topology = self.workspace._topology_directory(
+            "legacy-output", create=True
+        )
+        atomic_json(topology / "status.json", {})
+        output = self.root / "legacy-runtime-output"
+        output.mkdir()
+        previous = {
+            "schema_version": workspace_module.LEGACY_RUNTIME_TOPOLOGY_STATUS_SCHEMA_VERSION,
+            "supervisor": {"running": False},
+            "services": {"server": {"running": False}},
+            "runtime": {"mutable_state_outputs": [str(output)]},
+        }
+        with (
+            mock.patch.object(
+                self.workspace, "topology_status", return_value=previous
+            ),
+            self.assertRaisesRegex(
+                WorkspaceError, "legacy mutable state output"
+            ),
+        ):
+            self.workspace.topology_up(
+                "legacy-output", "default", "default", ["server"], 0
+            )
+
     def test_topology_runtime_set_copies_read_only_directories(self) -> None:
         topology = self.root / "topology"
         topology.mkdir()
@@ -10093,9 +10172,7 @@ class WorkspaceTests(unittest.TestCase):
         self.assertRegex(server_log.read_text(), r"'--datapath=/proc/self/fd/\d+'")
         self.assertRegex(
             server_log.read_text(),
-            r"'--assetspath=/proc/self/fd/\d+/tmp/runtime-assets/"
-            + status["control"]["generation"]
-            + r"'",
+            r"'--assetspath=/proc/self/fd/\d+'",
         )
         self.assertIn(
             f"'--server=127.0.0.1 17300 {'a' * 64}'", client_log.read_text()
@@ -10413,16 +10490,23 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertNotIn(str(first_path), self.workspace._load_states().values())
         tombstone = first_path.parent / f".{first_path.name}.removal-pending"
-        real_rename_no_replace = workspace_module.rename_no_replace
+        real_rename_no_replace_at = workspace_module.rename_no_replace_at
 
-        def interrupt_before_removal_rename(source: Path, target: Path) -> None:
-            if source == first_path and target == tombstone:
+        def interrupt_before_removal_rename(
+            source_parent: int,
+            source: str,
+            target_parent: int,
+            target: str,
+        ) -> None:
+            if source == first_path.name and target == tombstone.name:
                 raise WorkspaceError("simulated pre-rename interruption")
-            real_rename_no_replace(source, target)
+            real_rename_no_replace_at(
+                source_parent, source, target_parent, target
+            )
 
         with (
             mock.patch(
-                "atrinik_workspace.workspace.rename_no_replace",
+                "atrinik_workspace.workspace.rename_no_replace_at",
                 side_effect=interrupt_before_removal_rename,
             ),
             self.assertRaisesRegex(WorkspaceError, "pre-rename interruption"),
@@ -11360,9 +11444,75 @@ class WorkspaceTests(unittest.TestCase):
                 if item["path"] == str(state)
             )
             self.assertEqual(fifo_item["disposition"], "protected")
-            self.assertIn("invalid_temporary_state", fifo_item["reasons"])
+            self.assertTrue(
+                {"invalid_temporary_state", "invalid_temporary_state_container"}
+                & set(fifo_item["reasons"])
+            )
             metadata_path.unlink()
             metadata_path.write_bytes(metadata_payload)
+        state_identity = self.workspace._state_identity(state)
+        removal_tombstone = workspace_module._owned_tree_tombstone_path(
+            state, state_identity
+        )
+        state.rename(removal_tombstone)
+        creation_path = removal_tombstone / workspace_module.TEMPORARY_STATE_METADATA
+        creation_payload = creation_path.read_bytes()
+        creation_path.unlink()
+        os.mkfifo(creation_path)
+        tombstone_preview = self.workspace.cleanup(
+            ["temporary-states"], 0, [], False
+        )
+        tombstone_item = next(
+            item
+            for item in tombstone_preview["items"]
+            if item["path"] == str(removal_tombstone)
+        )
+        self.assertEqual(tombstone_item["disposition"], "protected")
+        creation_path.unlink()
+        symlink_target = self.root / "temporary-state-creation-record"
+        symlink_target.write_bytes(creation_payload)
+        creation_path.symlink_to(symlink_target)
+        symlink_tombstone_preview = self.workspace.cleanup(
+            ["temporary-states"], 0, [], False
+        )
+        symlink_tombstone_item = next(
+            item
+            for item in symlink_tombstone_preview["items"]
+            if item["path"] == str(removal_tombstone)
+        )
+        self.assertEqual(symlink_tombstone_item["disposition"], "protected")
+        creation_path.unlink()
+        creation_path.write_bytes(creation_payload)
+        removal_tombstone.rename(state)
+
+        status_path = state.parent.parent / "status.json"
+        status_payload = status_path.read_bytes()
+        status_path.unlink()
+        os.mkfifo(status_path)
+        invalid_status_preview = self.workspace.cleanup(
+            ["temporary-states"], 0, [], False
+        )
+        invalid_status_item = next(
+            item
+            for item in invalid_status_preview["items"]
+            if item["path"] == str(state)
+        )
+        self.assertEqual(invalid_status_item["disposition"], "protected")
+        status_path.unlink()
+        status_symlink_target = self.root / "temporary-topology-status"
+        status_symlink_target.write_bytes(status_payload)
+        status_path.symlink_to(status_symlink_target)
+        symlink_status_preview = self.workspace.cleanup(
+            ["temporary-states"], 0, [], False
+        )
+        symlink_status_item = next(
+            item
+            for item in symlink_status_preview["items"]
+            if item["path"] == str(state)
+        )
+        self.assertEqual(symlink_status_item["disposition"], "protected")
+        status_path.unlink()
+        status_path.write_bytes(status_payload)
         linked_file = next(
             path
             for path in state.rglob("*")
@@ -12224,6 +12374,47 @@ class WorkspaceTests(unittest.TestCase):
         self.assertIn(
             "stale_orphan_temporary_state_lease", item["reasons"]
         )
+        container_marker = state.parent / MANAGED_MARKER
+        container_payload = container_marker.read_bytes()
+        container_marker.unlink()
+        unowned_preview = self.workspace.cleanup(
+            ["temporary-states"], 0, [], False
+        )
+        unowned_item = next(
+            value
+            for value in unowned_preview["items"]
+            if value["path"] == str(state)
+        )
+        self.assertEqual(unowned_item["disposition"], "protected")
+        self.assertIn(
+            "invalid_orphan_temporary_state_lease", unowned_item["reasons"]
+        )
+        container_marker.write_bytes(container_payload)
+        with (
+            mock.patch(
+                "atrinik_workspace.cleanup._descriptor_mount_id",
+                side_effect=[1, 2],
+            ),
+            self.assertRaisesRegex(WorkspaceError, "crossed a mount"),
+        ):
+            cleanup_module.Cleanup(
+                self.workspace
+            )._open_temporary_state_container(topology)
+        lock_metadata = lock.stat(follow_symlinks=False)
+        lock_tombstone = lock.parent / (
+            f".{lock.name}.remove-{lock_metadata.st_dev:x}-"
+            f"{lock_metadata.st_ino:x}"
+        )
+        lock.rename(lock_tombstone)
+        tombstone_preview = self.workspace.cleanup(
+            ["temporary-states"], 0, [], False
+        )
+        tombstone_item = next(
+            value
+            for value in tombstone_preview["items"]
+            if value["path"] == str(state)
+        )
+        self.assertEqual(tombstone_item["disposition"], "eligible")
         applied = self.workspace.cleanup(
             ["temporary-states"], 0, [], True
         )
@@ -12232,6 +12423,7 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertEqual(applied_item["disposition"], "removed")
         self.assertFalse(lock.exists())
+        self.assertFalse(lock_tombstone.exists())
 
     def test_temporary_startup_rollback_retains_linked_state(self) -> None:
         topology = self.workspace._topology_directory(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -5568,6 +5568,90 @@ class WorkspaceTests(unittest.TestCase):
             )
         self.assertTrue(transaction.is_file())
 
+    def test_runtime_output_creation_marks_uncertainty_before_mkdir(self) -> None:
+        state = self.root / "runtime-output-mkdir-interruption"
+        state.mkdir()
+        state_fd = os.open(state, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        generation = "9" * 64
+        proof = [True]
+        real_mkdir = os.mkdir
+
+        def mkdir_then_interrupt(
+            name: str | bytes,
+            mode: int = 0o777,
+            *,
+            dir_fd: int | None = None,
+        ) -> None:
+            real_mkdir(name, mode, dir_fd=dir_fd)
+            if name == generation:
+                raise KeyboardInterrupt("simulated interruption after mkdir")
+
+        try:
+            with (
+                mock.patch(
+                    "atrinik_workspace.workspace.os.mkdir",
+                    side_effect=mkdir_then_interrupt,
+                ),
+                self.assertRaisesRegex(KeyboardInterrupt, "after mkdir"),
+            ):
+                self.workspace._prepare_runtime_state_output(
+                    state,
+                    generation,
+                    state_fd,
+                    cleanup_proof=proof,
+                )
+            self.assertFalse(proof[0])
+            self.assertTrue(
+                (state / "tmp" / "runtime-assets" / generation).is_dir()
+            )
+        finally:
+            os.close(state_fd)
+
+    def test_runtime_output_transaction_clear_restores_replacement(self) -> None:
+        topology = self.workspace._topology_directory(
+            "runtime-output-clear-race", create=True
+        )
+        transaction = topology / workspace_module.RUNTIME_STATE_OUTPUT_TRANSACTION
+        atomic_json(transaction, {"schema_version": 1, "value": "original"})
+        displaced = topology / "displaced-transaction"
+        real_rename_at = workspace_module.rename_no_replace_at
+        raced = False
+
+        def replace_before_rename(
+            source_fd: int,
+            source: str,
+            destination_fd: int,
+            destination: str,
+        ) -> None:
+            nonlocal raced
+            if source == workspace_module.RUNTIME_STATE_OUTPUT_TRANSACTION and not raced:
+                raced = True
+                os.rename(source, displaced.name, src_dir_fd=source_fd, dst_dir_fd=source_fd)
+                replacement_fd = os.open(
+                    source,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                    0o600,
+                    dir_fd=source_fd,
+                )
+                try:
+                    os.write(replacement_fd, b'{"replacement": true}\n')
+                finally:
+                    os.close(replacement_fd)
+            real_rename_at(source_fd, source, destination_fd, destination)
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.rename_no_replace_at",
+                side_effect=replace_before_rename,
+            ),
+            self.assertRaisesRegex(WorkspaceError, "changed before removal"),
+        ):
+            self.workspace._clear_runtime_state_output_transaction(topology)
+        self.assertEqual(load_json(transaction), {"replacement": True})
+        self.assertEqual(
+            load_json(displaced), {"schema_version": 1, "value": "original"}
+        )
+
     def test_pre_spawn_runtime_output_rollback_completes_transaction(self) -> None:
         topology = self.workspace._topology_directory(
             "runtime-output-pre-spawn", create=True
@@ -12588,6 +12672,91 @@ class WorkspaceTests(unittest.TestCase):
             "preserve\n",
         )
         self.assertTrue(displaced.is_dir())
+
+    def test_temporary_state_staging_rejects_hardlinks(self) -> None:
+        topology = self.workspace._topology_directory(
+            "staging-hardlink", create=True
+        )
+        server = self.workspace.paths.repositories / "server"
+        generation = "8" * 64
+        original_copytree = shutil.copytree
+
+        def link_copied_file(*args: object, **kwargs: object) -> object:
+            result = original_copytree(*args, **kwargs)
+            if Path(args[0]) == server / "install_data":
+                destination = Path(args[1])
+                copied = destination / "motd"
+                copied.unlink()
+                os.link(server / "install_data" / "motd", copied)
+            return result
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.shutil.copytree",
+                side_effect=link_copied_file,
+            ),
+            self.assertRaisesRegex(WorkspaceError, "linked file"),
+        ):
+            self.workspace._create_temporary_state(
+                topology,
+                "staging-hardlink",
+                "default",
+                generation,
+                server,
+                {
+                    "stack": "default",
+                    "provider": "server",
+                    "repository": "atrinik/server",
+                },
+                self.scenario_resolved_fixture()["server"],
+            )
+        self.assertEqual(
+            {path.name for path in (topology / "temporary-states").iterdir()},
+            {MANAGED_MARKER},
+        )
+
+    def test_temporary_state_revalidates_after_metadata_publication(self) -> None:
+        topology = self.workspace._topology_directory(
+            "staging-final-validation", create=True
+        )
+        server = self.workspace.paths.repositories / "server"
+        generation = "7" * 64
+        original_atomic_json_at = workspace_module.durable_atomic_json_at
+
+        def add_late_link(
+            directory_fd: int,
+            name: str,
+            value: object,
+            **kwargs: object,
+        ) -> None:
+            original_atomic_json_at(directory_fd, name, value, **kwargs)
+            if name == workspace_module.TEMPORARY_STATE_METADATA:
+                os.symlink("motd", "late-link", dir_fd=directory_fd)
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.durable_atomic_json_at",
+                side_effect=add_late_link,
+            ),
+            self.assertRaisesRegex(WorkspaceError, "symbolic link"),
+        ):
+            self.workspace._create_temporary_state(
+                topology,
+                "staging-final-validation",
+                "default",
+                generation,
+                server,
+                {
+                    "stack": "default",
+                    "provider": "server",
+                    "repository": "atrinik/server",
+                },
+                self.scenario_resolved_fixture()["server"],
+            )
+        self.assertEqual(
+            {path.name for path in (topology / "temporary-states").iterdir()},
+            {MANAGED_MARKER},
+        )
 
     def test_temporary_startup_rollback_removes_state_and_lease(self) -> None:
         topology = self.workspace._topology_directory("rollback", create=True)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -6005,6 +6005,51 @@ class WorkspaceTests(unittest.TestCase):
                         "owned\n",
                     )
 
+    def test_owned_tree_removal_recovers_identity_named_tombstones(self) -> None:
+        root = self.root / "recover-root-tombstone"
+        root.mkdir()
+        (root / "payload").write_text("owned\n", encoding="utf-8")
+        identity = self.workspace._state_identity(root)
+        root_tombstone = root.parent / (
+            f".{root.name}.remove-{identity['device']:x}-{identity['inode']:x}"
+        )
+        root.rename(root_tombstone)
+        remove_owned_tree(root, expected_identity=identity)
+        self.assertFalse(root_tombstone.exists())
+
+        child_root = self.root / "recover-child-tombstone"
+        child_root.mkdir()
+        child = child_root / "payload"
+        child.write_text("owned\n", encoding="utf-8")
+        child_metadata = child.stat()
+        child_tombstone = child_root / (
+            f".{child.name}.remove-{child_metadata.st_dev:x}-"
+            f"{child_metadata.st_ino:x}"
+        )
+        child.rename(child_tombstone)
+        remove_owned_tree(
+            child_root,
+            expected_identity=self.workspace._state_identity(child_root),
+        )
+        self.assertFalse(child_root.exists())
+
+    def test_owned_tree_removal_rejects_unverified_tombstone(self) -> None:
+        root = self.root / "uncertain-child-tombstone"
+        root.mkdir()
+        original = root / "payload"
+        original.write_text("owned\n", encoding="utf-8")
+        metadata = original.stat()
+        tombstone = root / (
+            f".{original.name}.remove-{metadata.st_dev:x}-{metadata.st_ino:x}"
+        )
+        original.rename(self.root / "preserved-original")
+        tombstone.write_text("must survive\n", encoding="utf-8")
+        with self.assertRaisesRegex(WorkspaceError, "uncertain tombstone"):
+            remove_owned_tree(
+                root, expected_identity=self.workspace._state_identity(root)
+            )
+        self.assertEqual(tombstone.read_text(encoding="utf-8"), "must survive\n")
+
     def test_replaced_directory_recovery_rejects_invalid_states(self) -> None:
         def snapshot(parent: Path) -> dict[str, tuple[object, ...]]:
             result: dict[str, tuple[object, ...]] = {}
@@ -11227,6 +11272,55 @@ class WorkspaceTests(unittest.TestCase):
             with self.workspace._topology_state_lock(second):
                 self.fail("physical aliases must not receive distinct leases")
 
+    def test_open_state_directory_retains_inode_bound_lease(self) -> None:
+        server = self.workspace.paths.repositories / "server"
+        state = self.workspace.state_path("default", server)
+        first = self.workspace._open_validated_state_directory(
+            state, None, write_implementation=False
+        )
+        try:
+            with self.assertRaisesRegex(
+                WorkspaceError, "physical server state is already in use"
+            ):
+                self.workspace._open_validated_state_directory(
+                    state, None, write_implementation=False
+                )
+        finally:
+            os.close(first)
+        reopened = self.workspace._open_validated_state_directory(
+            state, None, write_implementation=False
+        )
+        os.close(reopened)
+
+    def test_state_marker_no_replace_publication_retries_cleanly(self) -> None:
+        state = self.root / "marker-publication"
+        state.mkdir()
+        directory_fd = os.open(state, os.O_RDONLY | os.O_DIRECTORY)
+        marker = ".atrinik-state.json"
+        value = {"schema_version": 1, "stack": "classic", "provider": "server"}
+        try:
+            with (
+                mock.patch(
+                    "atrinik_workspace.workspace.rename_no_replace_at",
+                    side_effect=WorkspaceError("simulated publication interruption"),
+                ),
+                self.assertRaisesRegex(
+                    WorkspaceError, "simulated publication interruption"
+                ),
+            ):
+                self.workspace._write_state_json_no_replace_at(
+                    directory_fd, marker, value
+                )
+            self.assertFalse((state / marker).exists())
+            self.assertEqual(list(state.iterdir()), [])
+            self.workspace._write_state_json_no_replace_at(
+                directory_fd, marker, value
+            )
+            self.assertEqual(load_json(state / marker), value)
+            self.assertEqual((state / marker).stat().st_nlink, 1)
+        finally:
+            os.close(directory_fd)
+
     def test_physical_state_alias_conflict_reports_live_owner(self) -> None:
         first = self.root / "owner-alias"
         second = self.root / "contender-alias"
@@ -11312,6 +11406,33 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual(
             {path.name for path in container.iterdir()}, {MANAGED_MARKER}
         )
+
+    def test_temporary_startup_rollback_removes_state_and_lease(self) -> None:
+        topology = self.workspace._topology_directory("rollback", create=True)
+        server = self.workspace.paths.repositories / "server"
+        state, policy = self.workspace._create_temporary_state(
+            topology,
+            "rollback",
+            "e" * 64,
+            server,
+            {
+                "stack": "default",
+                "provider": "server",
+                "repository": "atrinik/server",
+            },
+            self.scenario_resolved_fixture()["server"],
+        )
+        lock = Path(f"{state}.lock")
+        with exclusive_lock(lock, "temporary rollback") as state_lease:
+            metadata = os.fstat(state_lease.fileno())
+            self.workspace._rollback_temporary_state_creation(
+                state,
+                state_lease,
+                policy["identity"],
+                {"device": metadata.st_dev, "inode": metadata.st_ino},
+            )
+        self.assertFalse(state.exists())
+        self.assertFalse(lock.exists())
 
     def test_temporary_state_first_digest_failure_removes_staging(self) -> None:
         topology = self.workspace._topology_directory("digest-failure", create=True)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -5404,7 +5404,12 @@ class WorkspaceTests(unittest.TestCase):
                 if isinstance(directory_fd, int)
                 else None
             )
-            if path == "payload" and parent is not None and parent.name == "previous":
+            if (
+                isinstance(path, str)
+                and path.startswith(".remove-")
+                and parent is not None
+                and parent.name == "previous"
+            ):
                 raise PermissionError("read only")
             real_unlink(path, *args, **kwargs)
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -6010,8 +6010,8 @@ class WorkspaceTests(unittest.TestCase):
         root.mkdir()
         (root / "payload").write_text("owned\n", encoding="utf-8")
         identity = self.workspace._state_identity(root)
-        root_tombstone = root.parent / (
-            f".{root.name}.remove-{identity['device']:x}-{identity['inode']:x}"
+        root_tombstone = workspace_module._owned_tree_tombstone_path(
+            root, identity
         )
         root.rename(root_tombstone)
         remove_owned_tree(root, expected_identity=identity)
@@ -6022,9 +6022,8 @@ class WorkspaceTests(unittest.TestCase):
         child = child_root / "payload"
         child.write_text("owned\n", encoding="utf-8")
         child_metadata = child.stat()
-        child_tombstone = child_root / (
-            f".{child.name}.remove-{child_metadata.st_dev:x}-"
-            f"{child_metadata.st_ino:x}"
+        child_tombstone = child_root / workspace_module._owned_tree_tombstone_name(
+            child.name, child_metadata.st_dev, child_metadata.st_ino
         )
         child.rename(child_tombstone)
         remove_owned_tree(
@@ -6039,8 +6038,8 @@ class WorkspaceTests(unittest.TestCase):
         original = root / "payload"
         original.write_text("owned\n", encoding="utf-8")
         metadata = original.stat()
-        tombstone = root / (
-            f".{original.name}.remove-{metadata.st_dev:x}-{metadata.st_ino:x}"
+        tombstone = root / workspace_module._owned_tree_tombstone_name(
+            original.name, metadata.st_dev, metadata.st_ino
         )
         original.rename(self.root / "preserved-original")
         tombstone.write_text("must survive\n", encoding="utf-8")
@@ -6049,6 +6048,14 @@ class WorkspaceTests(unittest.TestCase):
                 root, expected_identity=self.workspace._state_identity(root)
             )
         self.assertEqual(tombstone.read_text(encoding="utf-8"), "must survive\n")
+
+    def test_owned_tree_removal_supports_name_max_entries(self) -> None:
+        root = self.root / "name-max-removal"
+        root.mkdir()
+        (root / ("f" * 255)).write_text("owned\n", encoding="utf-8")
+        (root / ("d" * 255)).mkdir()
+        remove_owned_tree(root, expected_identity=self.workspace._state_identity(root))
+        self.assertFalse(root.exists())
 
     def test_replaced_directory_recovery_rejects_invalid_states(self) -> None:
         def snapshot(parent: Path) -> dict[str, tuple[object, ...]]:
@@ -10762,9 +10769,18 @@ class WorkspaceTests(unittest.TestCase):
             item for item in preview["items"] if item["path"] == str(state)
         )
         self.assertEqual(candidate["disposition"], "eligible")
+        pending_state = state.parent / f".{state.name}.removal-pending"
+        removal_tombstone = workspace_module._owned_tree_tombstone_path(
+            pending_state, crashed["state_policy"]["identity"]
+        )
+
+        def interrupt_after_root_tombstone(*_args: object, **_kwargs: object) -> None:
+            pending_state.rename(removal_tombstone)
+            raise WorkspaceError("simulated cleanup removal interruption")
+
         with mock.patch(
             "atrinik_workspace.workspace.remove_owned_tree",
-            side_effect=WorkspaceError("simulated cleanup removal interruption"),
+            side_effect=interrupt_after_root_tombstone,
         ):
             interrupted = self.workspace.cleanup(
                 ["temporary-states"], 0, [], True
@@ -10779,9 +10795,7 @@ class WorkspaceTests(unittest.TestCase):
             ],
             "removal-pending",
         )
-        self.assertTrue(
-            (state.parent / f".{state.name}.removal-pending").is_dir()
-        )
+        self.assertTrue(removal_tombstone.is_dir())
         applied = self.workspace.cleanup(
             ["temporary-states"], 0, [], True
         )
@@ -11433,6 +11447,20 @@ class WorkspaceTests(unittest.TestCase):
             )
         self.assertFalse(state.exists())
         self.assertFalse(lock.exists())
+
+    def test_temporary_mutation_refuses_live_physical_alias(self) -> None:
+        state = self.root / "temporary-physical-alias"
+        state.mkdir()
+        identity = self.workspace._state_identity(state)
+        alias_fd = os.open(state, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            fcntl.flock(alias_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            with self.assertRaisesRegex(
+                WorkspaceError, "temporary state is already in use"
+            ):
+                self.workspace._lock_state_directory_mutation(state, identity)
+        finally:
+            os.close(alias_fd)
 
     def test_temporary_state_first_digest_failure_removes_staging(self) -> None:
         topology = self.workspace._topology_directory("digest-failure", create=True)
@@ -12120,8 +12148,18 @@ class WorkspaceTests(unittest.TestCase):
 
         state = self.workspace.paths.scenarios / "locked" / "state"
         with exclusive_lock(Path(f"{state}.lock"), "test state"):
-            with self.assertRaisesRegex(WorkspaceError, "already in use"):
+            with self.assertRaisesRegex(WorkspaceError, "already in use|busy"):
                 self.workspace.scenario_reset("locked")
+
+        descriptor = os.open(state, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            with self.assertRaisesRegex(
+                WorkspaceError, "scenario server state is already in use"
+            ):
+                self.workspace.scenario_reset("locked")
+        finally:
+            os.close(descriptor)
 
     def test_foreground_client_pins_matching_server_state(self) -> None:
         server = self.workspace.paths.repositories / "server"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -10332,6 +10332,31 @@ class WorkspaceTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "ownership evidence is missing"):
             self.workspace.topology_down("temporary-clean", timeout=5)
         self.assertTrue(displaced.is_dir())
+        missing_evidence_preview = self.workspace.cleanup(
+            ["temporary-states"], 0, [], False
+        )
+        missing_evidence_item = next(
+            item
+            for item in missing_evidence_preview["items"]
+            if item["path"] == str(first_path)
+        )
+        self.assertEqual(missing_evidence_item["disposition"], "protected")
+        self.assertIn(
+            "temporary_state_ownership_evidence_missing",
+            missing_evidence_item["reasons"],
+        )
+        missing_evidence_apply = self.workspace.cleanup(
+            ["temporary-states"], 0, [], True
+        )
+        missing_evidence_applied_item = next(
+            item
+            for item in missing_evidence_apply["items"]
+            if item["path"] == str(first_path)
+        )
+        self.assertEqual(
+            missing_evidence_applied_item["disposition"], "protected"
+        )
+        self.assertTrue(displaced.is_dir())
         displaced.rename(first_path)
         with (
             mock.patch(
@@ -10499,6 +10524,7 @@ class WorkspaceTests(unittest.TestCase):
                 "temporary-retained", "default", None, ["server"], 0
             )
         retained_path = Path(retained["state_policy"]["path"])
+        self.assertEqual(retained["state_policy"]["profile"], "default")
         stopped = self.workspace.topology_down(
             "temporary-retained", timeout=5, retain_state=True
         )
@@ -10698,6 +10724,24 @@ class WorkspaceTests(unittest.TestCase):
             promoted_summary["state_policy"]["lifecycle"],
             "persistent-promoted",
         )
+        provenance = retained_path / workspace_module.PROMOTED_STATE_METADATA
+        replaced_promoted = retained_path.with_name("promoted-original")
+        retained_path.rename(replaced_promoted)
+        retained_path.mkdir()
+        shutil.copy2(
+            replaced_promoted / workspace_module.PROMOTED_STATE_METADATA,
+            provenance,
+        )
+        try:
+            with self.assertRaisesRegex(
+                WorkspaceError, "promoted state provenance is invalid"
+            ):
+                self.workspace.topology_summary(
+                    "default", str(promoted["name"]), ["server"]
+                )
+        finally:
+            shutil.rmtree(retained_path)
+            replaced_promoted.rename(retained_path)
         provenance = retained_path / workspace_module.PROMOTED_STATE_METADATA
         provenance.unlink()
         origin_status.rename(hidden_status)
@@ -10914,6 +10958,47 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertEqual(mounted_item["disposition"], "protected")
         self.assertIn("filesystem_traversal_error", mounted_item["reasons"])
+
+        def simulated_file_mount_id(
+            descriptor: int,
+        ) -> int | tuple[int, int]:
+            target = Path(os.readlink(f"/proc/self/fd/{descriptor}"))
+            if target == state / "motd":
+                return 999999998
+            return real_mount_id(descriptor)
+
+        with mock.patch.object(
+            cleanup_module,
+            "_descriptor_mount_id",
+            side_effect=simulated_file_mount_id,
+        ):
+            mounted_file_preview = self.workspace.cleanup(
+                ["temporary-states"], 0, [], False
+            )
+        mounted_file_item = next(
+            item
+            for item in mounted_file_preview["items"]
+            if item["path"] == str(state)
+        )
+        self.assertEqual(mounted_file_item["disposition"], "protected")
+        self.assertIn(
+            "filesystem_traversal_error", mounted_file_item["reasons"]
+        )
+        state_fd = os.open(state, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        try:
+            with (
+                mock.patch.object(
+                    workspace_module,
+                    "_descriptor_mount_id",
+                    side_effect=simulated_file_mount_id,
+                ),
+                self.assertRaisesRegex(WorkspaceError, "crossed a mount"),
+            ):
+                self.workspace._validate_temporary_state_integrity(
+                    state_fd, state
+                )
+        finally:
+            os.close(state_fd)
         required_file = state / "motd"
         saved_required_file = state / "motd.saved"
         required_file.rename(saved_required_file)
@@ -11120,6 +11205,34 @@ class WorkspaceTests(unittest.TestCase):
             {MANAGED_MARKER},
         )
         executable = build_root / "build" / "server" / "atrinik-server"
+        executable.unlink()
+        with (
+            mock.patch.object(
+                self.workspace, "_build_resolved", return_value=build_root
+            ),
+            self.assertRaisesRegex(WorkspaceError, "supervisor failed"),
+        ):
+            self.workspace.topology_up(
+                "temporary-pre-service-failure",
+                "default",
+                None,
+                ["server"],
+                0,
+            )
+        pre_service = self.workspace.topology_status(
+            "temporary-pre-service-failure"
+        )
+        self.assertEqual(pre_service["services"], {})
+        self.assertEqual(pre_service["state_policy"]["mode"], "temporary")
+        self.assertIsNotNone(pre_service["error"])
+        pre_service_state = Path(pre_service["state_policy"]["path"])
+        recovered_pre_service = self.workspace.topology_down(
+            "temporary-pre-service-failure", timeout=5
+        )
+        self.assertEqual(
+            recovered_pre_service["state_policy"]["lifecycle"], "disposable"
+        )
+        self.assertTrue(pre_service_state.is_dir())
         executable.write_text(
             "#!/usr/bin/env python3\n"
             "import pathlib, sys\n"
@@ -11707,6 +11820,7 @@ class WorkspaceTests(unittest.TestCase):
                 self.workspace._create_temporary_state(
                     topology,
                     "interrupted",
+                    "default",
                     generation,
                     server,
                     {
@@ -11727,6 +11841,7 @@ class WorkspaceTests(unittest.TestCase):
         state, policy = self.workspace._create_temporary_state(
             topology,
             "rollback",
+            "default",
             "e" * 64,
             server,
             {
@@ -11775,6 +11890,7 @@ class WorkspaceTests(unittest.TestCase):
             self.workspace._create_temporary_state(
                 topology,
                 "digest-failure",
+                "default",
                 "c" * 64,
                 server,
                 {
@@ -11817,6 +11933,7 @@ class WorkspaceTests(unittest.TestCase):
             self.workspace._create_temporary_state(
                 topology,
                 "copy-race",
+                "default",
                 "b" * 64,
                 server,
                 {

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -5607,6 +5607,46 @@ class WorkspaceTests(unittest.TestCase):
         finally:
             os.close(state_fd)
 
+    def test_runtime_output_preparation_failure_removes_created_generation(self) -> None:
+        state = self.root / "runtime-output-preparation-failure"
+        state.mkdir()
+        state_fd = os.open(state, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        generation = "4" * 64
+        proof = [False]
+        real_open = os.open
+
+        def fail_marker_open(
+            path: str | bytes,
+            flags: int,
+            mode: int = 0o777,
+            *,
+            dir_fd: int | None = None,
+        ) -> int:
+            if path == MANAGED_MARKER and dir_fd is not None:
+                raise OSError("simulated marker publication failure")
+            return real_open(path, flags, mode, dir_fd=dir_fd)
+
+        try:
+            with (
+                mock.patch(
+                    "atrinik_workspace.workspace.os.open",
+                    side_effect=fail_marker_open,
+                ),
+                self.assertRaisesRegex(WorkspaceError, "marker publication failure"),
+            ):
+                self.workspace._prepare_runtime_state_output(
+                    state,
+                    generation,
+                    state_fd,
+                    cleanup_proof=proof,
+                )
+            self.assertTrue(proof[0])
+            self.assertFalse(
+                (state / "tmp" / "runtime-assets" / generation).exists()
+            )
+        finally:
+            os.close(state_fd)
+
     def test_runtime_output_transaction_clear_restores_replacement(self) -> None:
         topology = self.workspace._topology_directory(
             "runtime-output-clear-race", create=True
@@ -12968,6 +13008,16 @@ class WorkspaceTests(unittest.TestCase):
             cleanup_module.Cleanup(
                 self.workspace
             )._open_temporary_state_container(topology)
+        cleanup = cleanup_module.Cleanup(self.workspace)
+        normal_item = next(
+            value
+            for value in cleanup._temporary_states(0)
+            if value["path"] == str(state)
+        )
+        cleanup._remove_temporary_state(normal_item, 0)
+        self.assertFalse(lock.exists())
+        with exclusive_lock(lock, "recreated orphan rollback lease"):
+            pass
         lock_metadata = lock.stat(follow_symlinks=False)
         lock_tombstone = lock.parent / (
             f".{lock.name}.remove-{lock_metadata.st_dev:x}-"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -9340,7 +9340,7 @@ class WorkspaceTests(unittest.TestCase):
                 candidate.bind(("0.0.0.0", 0))
                 return int(candidate.getsockname()[1])
 
-        for mode in ("explicit", "automatic"):
+        for mode in ("explicit", "automatic", "temporary"):
             with self.subTest(mode=mode):
                 rendezvous = self.root / f"{mode}-port-rendezvous"
                 rendezvous.mkdir()
@@ -9352,9 +9352,14 @@ class WorkspaceTests(unittest.TestCase):
                     self.make_rendezvous_server_build(
                         root, rendezvous, f"{index}.bound"
                     )
-                states = [f"{mode}-state-{index}" for index in range(2)]
+                states: list[str | None] = (
+                    [None, None]
+                    if mode == "temporary"
+                    else [f"{mode}-state-{index}" for index in range(2)]
+                )
                 for state in states:
-                    self.workspace.state_add(state, None)
+                    if state is not None:
+                        self.workspace.state_add(state, None)
                 names = [f"{mode}-topology-{index}" for index in range(2)]
                 if mode == "explicit":
                     ports: list[int | None] = [free_port(), free_port()]
@@ -9393,6 +9398,16 @@ class WorkspaceTests(unittest.TestCase):
                         {path.name for path in rendezvous.glob("*.bound")},
                         {"0.bound", "1.bound"},
                     )
+                    if mode == "temporary":
+                        state_paths = {
+                            status["state_policy"]["path"] for status in statuses
+                        }
+                        self.assertEqual(len(state_paths), 2)
+                        self.assertTrue(
+                            all(Path(path).is_dir() for path in state_paths)
+                        )
+                        registered = set(self.workspace._load_states().values())
+                        self.assertTrue(state_paths.isdisjoint(registered))
                     observer = Workspace(self.wrapper)
                     for index, name in enumerate(names):
                         observed = observer.topology_status(name)
@@ -9637,6 +9652,8 @@ class WorkspaceTests(unittest.TestCase):
             ["client", "server"],
         )
         self.assertTrue(status["ready"])
+        self.assertEqual(status["state_policy"]["mode"], "default")
+        self.assertEqual(status["state_policy"]["lifecycle"], "persistent")
         self.assertEqual(status["endpoint"]["port"], 17300)
         self.assertEqual(status["port_reservation"]["port"], 17300)
         self.assertEqual(status["port_reservation"]["topology"], "server-review")
@@ -9784,6 +9801,7 @@ class WorkspaceTests(unittest.TestCase):
                     "server-review-two", "default", "second", ["server"], 17301
                 )
             self.assertTrue(second["ready"])
+            self.assertEqual(second["state_policy"]["mode"], "named")
             self.assertEqual(second["endpoint"]["port"], 17301)
             self.assertIn("client", second["dependencies"])
             self.assertNotIn("client", second["services"])
@@ -10007,6 +10025,149 @@ class WorkspaceTests(unittest.TestCase):
         ):
             pass
 
+    def test_temporary_topology_state_clean_retain_and_promote_lifecycle(self) -> None:
+        source = self.workspace.paths.repositories / "server"
+        (source / "tools").mkdir()
+        for filename in ("ca-bundle.crt", "permissions.cfg", "server.cfg"):
+            (source / filename).write_text("test\n", encoding="utf-8")
+        rendezvous = self.root / "temporary-state-rendezvous"
+        rendezvous.mkdir()
+        build_root = self.workspace.paths.builds / "temporary-state-server"
+        self.make_rendezvous_server_build(
+            build_root, rendezvous, "temporary.bound", peers=1
+        )
+
+        with mock.patch.object(
+            self.workspace, "_build_resolved", return_value=build_root
+        ):
+            first = self.workspace.topology_up(
+                "temporary-clean", "default", None, ["server"], 0
+            )
+        first_path = Path(first["state_policy"]["path"])
+        self.assertEqual(first["state_policy"]["mode"], "temporary")
+        self.assertEqual(first["state_policy"]["lifecycle"], "disposable")
+        self.assertEqual(first["state"], str(first_path))
+        self.assertTrue(first_path.is_dir())
+        self.assertNotIn(str(first_path), self.workspace._load_states().values())
+        stopped = self.workspace.topology_down("temporary-clean", timeout=5)
+        self.assertEqual(stopped["state_policy"]["lifecycle"], "removed")
+        self.assertFalse(first_path.exists())
+
+        (rendezvous / "temporary.bound").unlink()
+        with mock.patch.object(
+            self.workspace, "_build_resolved", return_value=build_root
+        ):
+            retained = self.workspace.topology_up(
+                "temporary-retained", "default", None, ["server"], 0
+            )
+        retained_path = Path(retained["state_policy"]["path"])
+        stopped = self.workspace.topology_down(
+            "temporary-retained", timeout=5, retain_state=True
+        )
+        self.assertEqual(stopped["state_policy"]["lifecycle"], "retained")
+        self.assertTrue(retained_path.is_dir())
+        self.assertEqual(
+            self.workspace.topology_down("temporary-retained", timeout=5)[
+                "state_policy"
+            ]["lifecycle"],
+            "retained",
+        )
+        retained_preview = self.workspace.cleanup(
+            ["temporary-states"], 0, [], False
+        )
+        retained_item = next(
+            item
+            for item in retained_preview["items"]
+            if item["path"] == str(retained_path)
+        )
+        self.assertEqual(retained_item["disposition"], "protected")
+        self.assertIn("temporary_state_retained", retained_item["reasons"])
+        sessions = [Workspace(self.wrapper), Workspace(self.wrapper)]
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [
+                executor.submit(
+                    sessions[index].state_promote,
+                    "temporary-retained",
+                    f"promoted-review-{index}",
+                )
+                for index in range(2)
+            ]
+            outcomes: list[dict[str, object] | WorkspaceError] = []
+            for future in futures:
+                try:
+                    outcomes.append(future.result(timeout=10))
+                except WorkspaceError as error:
+                    outcomes.append(error)
+        successes = [value for value in outcomes if isinstance(value, dict)]
+        failures = [value for value in outcomes if isinstance(value, WorkspaceError)]
+        self.assertEqual(len(successes), 1)
+        self.assertEqual(len(failures), 1)
+        promoted = successes[0]
+        self.assertEqual(promoted["path"], str(retained_path))
+        self.assertEqual(
+            promoted["state_policy"]["lifecycle"], "promoted"
+        )
+        self.assertEqual(
+            self.workspace._state_location(str(promoted["name"])), retained_path
+        )
+        self.assertEqual(
+            self.workspace.state_promote(
+                "temporary-retained", str(promoted["name"])
+            ),
+            promoted,
+        )
+
+    def test_temporary_topology_state_is_retained_after_supervisor_crash(self) -> None:
+        source = self.workspace.paths.repositories / "server"
+        (source / "tools").mkdir()
+        for filename in ("ca-bundle.crt", "permissions.cfg", "server.cfg"):
+            (source / filename).write_text("test\n", encoding="utf-8")
+        rendezvous = self.root / "temporary-crash-rendezvous"
+        rendezvous.mkdir()
+        build_root = self.workspace.paths.builds / "temporary-crash-server"
+        self.make_rendezvous_server_build(
+            build_root, rendezvous, "temporary.bound", peers=1
+        )
+        with mock.patch.object(
+            self.workspace, "_build_resolved", return_value=build_root
+        ):
+            status = self.workspace.topology_up(
+                "temporary-crash", "default", None, ["server"], 0
+            )
+        state = Path(status["state_policy"]["path"])
+        supervisor = status["supervisor"]
+        pidfd = os.pidfd_open(supervisor["pid"])
+        try:
+            signal.pidfd_send_signal(pidfd, signal.SIGKILL)
+        finally:
+            os.close(pidfd)
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            crashed = self.workspace.topology_status("temporary-crash")
+            if crashed["observation"]["process_tree_lease"] == "released":
+                break
+            time.sleep(0.05)
+        self.assertEqual(crashed["state_policy"]["lifecycle"], "disposable")
+        self.assertTrue(state.is_dir())
+        recovered = self.workspace.topology_down("temporary-crash", timeout=5)
+        self.assertEqual(recovered["state_policy"]["lifecycle"], "disposable")
+        self.assertTrue(state.is_dir())
+        preview = self.workspace.cleanup(
+            ["temporary-states"], 0, [], False
+        )
+        candidate = next(
+            item for item in preview["items"] if item["path"] == str(state)
+        )
+        self.assertEqual(candidate["disposition"], "eligible")
+        applied = self.workspace.cleanup(
+            ["temporary-states"], 0, [], True
+        )
+        removed = next(
+            item for item in applied["items"] if item["path"] == str(state)
+        )
+        self.assertEqual(removed["disposition"], "removed", applied)
+        self.assertFalse(state.exists())
+
     def test_topology_port_selection_rejects_unavailable_port(self) -> None:
         candidate = mock.MagicMock()
         candidate.__enter__.return_value = candidate
@@ -10219,6 +10380,63 @@ class WorkspaceTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "lacks required file"):
             self.workspace.state_add("bad", malformed)
         self.assertEqual((malformed / "unrelated").read_text(), "keep\n")
+
+    def test_state_paths_reject_links_and_incompatible_implementation_markers(self) -> None:
+        server = self.workspace.paths.repositories / "server"
+        state = self.workspace.state_path("default", server)
+        atomic_json(
+            state / workspace_module.STATE_IMPLEMENTATION_MARKER,
+            {
+                "schema_version": 1,
+                "stack": "replacement",
+                "provider": "server",
+                "repository": "atrinik/server",
+            },
+        )
+        with self.assertRaisesRegex(
+            WorkspaceError, "does not match the selected server"
+        ):
+            self.workspace.state_path(
+                "default",
+                server,
+                implementation={
+                    "stack": "classic",
+                    "provider": "server",
+                    "repository": "atrinik/server",
+                },
+            )
+
+        linked = self.root / "linked-state"
+        linked.symlink_to(state, target_is_directory=True)
+        with self.assertRaisesRegex(WorkspaceError, "contains a symlink"):
+            self.workspace.state_add("linked", linked)
+
+    def test_temporary_state_publication_interruption_leaves_no_partial_state(self) -> None:
+        topology = self.workspace._topology_directory("interrupted", create=True)
+        generation = "a" * 64
+        server = self.workspace.paths.repositories / "server"
+        coordinate = self.scenario_resolved_fixture()["server"]
+        with mock.patch(
+            "atrinik_workspace.workspace.rename_no_replace",
+            side_effect=WorkspaceError("simulated interruption"),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "simulated interruption"):
+                self.workspace._create_temporary_state(
+                    topology,
+                    "interrupted",
+                    generation,
+                    server,
+                    {
+                        "stack": "default",
+                        "provider": "server",
+                        "repository": "atrinik/server",
+                    },
+                    coordinate,
+                )
+        container = topology / "temporary-states"
+        self.assertEqual(
+            {path.name for path in container.iterdir()}, {MANAGED_MARKER}
+        )
 
     def test_scenario_lifecycle_owns_isolated_state_and_credentials(self) -> None:
         resolved = self.scenario_resolved_fixture()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -10361,7 +10361,12 @@ class WorkspaceTests(unittest.TestCase):
             external_status["state_policy"]["lifecycle"],
             "persistent-external",
         )
+        external_runtime_output = Path(
+            external_status["runtime"]["mutable_state_outputs"][0]
+        )
+        self.assertTrue(external_runtime_output.is_dir())
         self.workspace.topology_down("external-supervised", timeout=5)
+        self.assertFalse(external_runtime_output.exists())
         self.assertEqual(
             (external_state / "external-sentinel").read_text(encoding="utf-8"),
             "preserve\n",
@@ -10767,6 +10772,26 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertEqual(aliased_item["disposition"], "protected")
         self.assertIn("registered_state", aliased_item["reasons"])
+        linked_file = next(
+            path
+            for path in state.rglob("*")
+            if path.is_file() and not path.is_symlink()
+        )
+        external_link = self.root / "temporary-state-hardlink"
+        os.link(linked_file, external_link)
+        symlink = state / "unsafe-link"
+        symlink.symlink_to(external_link)
+        linked_preview = self.workspace.cleanup(
+            ["temporary-states"], 0, [], False
+        )
+        linked_item = next(
+            item for item in linked_preview["items"] if item["path"] == str(state)
+        )
+        self.assertEqual(linked_item["disposition"], "protected")
+        self.assertIn("linked_state", linked_item["reasons"])
+        self.assertFalse(any(key.startswith("_") for key in linked_item))
+        symlink.unlink()
+        external_link.unlink()
         preview = self.workspace.cleanup(
             ["temporary-states"], 0, [], False
         )
@@ -10775,16 +10800,18 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertEqual(candidate["disposition"], "eligible")
         pending_state = state.parent / f".{state.name}.removal-pending"
-        removal_tombstone = workspace_module._owned_tree_tombstone_path(
-            pending_state, crashed["state_policy"]["identity"]
-        )
 
-        def interrupt_after_root_tombstone(*_args: object, **_kwargs: object) -> None:
-            pending_state.rename(removal_tombstone)
-            raise WorkspaceError("simulated cleanup removal interruption")
+        real_rmdir = os.rmdir
+
+        def interrupt_after_root_tombstone(
+            path: object, *args: object, **kwargs: object
+        ) -> None:
+            if Path(path).name == pending_state.name:
+                raise PermissionError("simulated cleanup removal interruption")
+            real_rmdir(path, *args, **kwargs)
 
         with mock.patch(
-            "atrinik_workspace.workspace.remove_owned_tree",
+            "atrinik_workspace.workspace.os.rmdir",
             side_effect=interrupt_after_root_tombstone,
         ):
             interrupted = self.workspace.cleanup(
@@ -10798,9 +10825,10 @@ class WorkspaceTests(unittest.TestCase):
             self.workspace.topology_status("temporary-crash")["state_policy"][
                 "lifecycle"
             ],
-            "removal-pending",
+            "removed",
         )
-        self.assertTrue(removal_tombstone.is_dir())
+        self.assertTrue(pending_state.is_dir())
+        self.assertEqual(list(pending_state.iterdir()), [])
         applied = self.workspace.cleanup(
             ["temporary-states"], 0, [], True
         )

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -5273,6 +5273,35 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual(sorted(path.name for path in external.iterdir()), ["sentinel"])
         self.assertEqual(list(topology.iterdir()), [])
 
+    def test_runtime_state_output_cleanup_remains_bound_to_pinned_state(
+        self,
+    ) -> None:
+        state = self.root / "external-state"
+        state.mkdir()
+        state_fd = os.open(state, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        generation = "a" * 32
+        relocated = self.root / "relocated-state"
+        try:
+            output = self.workspace._prepare_runtime_state_output(
+                state, generation, state_fd
+            )
+            state.rename(relocated)
+            state.mkdir()
+            sentinel = state / "sentinel"
+            sentinel.write_text("replacement\n", encoding="utf-8")
+
+            self.workspace._remove_runtime_state_output(
+                output, generation, state_fd
+            )
+
+            self.assertFalse(
+                (relocated / "tmp" / "runtime-assets" / generation).exists()
+            )
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "replacement\n")
+            self.assertEqual(sorted(path.name for path in state.iterdir()), ["sentinel"])
+        finally:
+            os.close(state_fd)
+
     def test_topology_runtime_set_copies_read_only_directories(self) -> None:
         topology = self.root / "topology"
         topology.mkdir()
@@ -9843,6 +9872,16 @@ class WorkspaceTests(unittest.TestCase):
             client_log.read_text(),
         )
         state = self.workspace._state_location("default")
+        identity = self.workspace._state_identity(state)
+        with self.assertRaisesRegex(WorkspaceError, "already in use"):
+            with exclusive_lock(
+                self.workspace._lease_namespace
+                / "state-identities"
+                / f"{identity['device']}-{identity['inode']}.lock",
+                "live physical state",
+                nonblocking=True,
+            ):
+                self.fail("supervisor released the physical state lease")
         second_state = self.workspace.state_add("second", None)
         source_lock = resource_lock_path(
             self.workspace._lease_namespace,
@@ -10021,9 +10060,11 @@ class WorkspaceTests(unittest.TestCase):
             ):
                 with exclusive_lock(path, description, nonblocking=True):
                     pass
-            descendant_path = Path(
-                server_only["services"]["server"]["cwd"]
-            ) / "data" / "tmp" / "descendant.pid"
+            descendant_path = (
+                self.workspace._state_location("default")
+                / "tmp"
+                / "descendant.pid"
+            )
             deadline = time.monotonic() + 5
             while time.monotonic() < deadline and not descendant_path.is_file():
                 time.sleep(0.05)
@@ -10298,9 +10339,23 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual(
             self.workspace._state_location(str(promoted["name"])), retained_path
         )
-        promoted_summary = self.workspace.topology_summary(
-            "default", str(promoted["name"]), ["server"]
+        self.assertEqual(
+            self.workspace.state_promote(
+                "temporary-retained", str(promoted["name"])
+            ),
+            promoted,
         )
+        origin_status = (
+            self.workspace.paths.topologies / "temporary-retained" / "status.json"
+        )
+        hidden_status = origin_status.with_name("status.hidden")
+        origin_status.rename(hidden_status)
+        try:
+            promoted_summary = self.workspace.topology_summary(
+                "default", str(promoted["name"]), ["server"]
+            )
+        finally:
+            hidden_status.rename(origin_status)
         self.assertEqual(
             promoted_summary["state_policy"]["owner"],
             {
@@ -10313,13 +10368,6 @@ class WorkspaceTests(unittest.TestCase):
             promoted_summary["state_policy"]["lifecycle"],
             "persistent-promoted",
         )
-        self.assertEqual(
-            self.workspace.state_promote(
-                "temporary-retained", str(promoted["name"])
-            ),
-            promoted,
-        )
-
         (rendezvous / "temporary.bound").unlink()
         with mock.patch.object(
             self.workspace, "_build_resolved", return_value=build_root
@@ -11002,6 +11050,33 @@ class WorkspaceTests(unittest.TestCase):
         container = topology / "temporary-states"
         self.assertEqual(
             {path.name for path in container.iterdir()}, {MANAGED_MARKER}
+        )
+
+    def test_temporary_state_first_digest_failure_removes_staging(self) -> None:
+        topology = self.workspace._topology_directory("digest-failure", create=True)
+        server = self.workspace.paths.repositories / "server"
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace._tree_digest",
+                side_effect=WorkspaceError("invalid install_data"),
+            ),
+            self.assertRaisesRegex(WorkspaceError, "invalid install_data"),
+        ):
+            self.workspace._create_temporary_state(
+                topology,
+                "digest-failure",
+                "c" * 64,
+                server,
+                {
+                    "stack": "default",
+                    "provider": "server",
+                    "repository": "atrinik/server",
+                },
+                self.scenario_resolved_fixture()["server"],
+            )
+        self.assertEqual(
+            {path.name for path in (topology / "temporary-states").iterdir()},
+            {MANAGED_MARKER},
         )
 
     def test_temporary_state_rejects_install_data_mutation_during_copy(self) -> None:
@@ -11812,8 +11887,13 @@ class WorkspaceTests(unittest.TestCase):
             descriptor = os.open(lease, os.O_RDWR | os.O_CREAT, 0o600)
             workspace_module.initialize_lease(descriptor, "a" * 64)
             fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            state_output = self.root / "foreground-server-state-output"
-            state_output.mkdir()
+            state_output = (
+                self.workspace._state_location("default")
+                / "tmp"
+                / "runtime-assets"
+                / "foreground-server-generation"
+            )
+            state_output.mkdir(parents=True)
             atomic_json(
                 state_output / MANAGED_MARKER,
                 {
@@ -11826,7 +11906,7 @@ class WorkspaceTests(unittest.TestCase):
             }
 
         def execute_server(*_arguments: object, **_keywords: object) -> None:
-            self.assertEqual(len(_keywords["pass_fds"]), 3)
+            self.assertEqual(len(_keywords["pass_fds"]), 4)
             for path, description in (
                 (
                     resource_lock_path(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -13105,7 +13105,9 @@ class WorkspaceTests(unittest.TestCase):
         self.assertIn("topology_generation_present", current_item["reasons"])
 
         future_cleanup = cleanup_module.Cleanup(self.workspace)
-        future_cleanup.now = future_cleanup.now.replace(year=1970)
+        future_cleanup.now = future_cleanup.now.replace(
+            year=1970, month=1, day=1
+        )
         future_item = future_cleanup._orphan_temporary_state_lease_item(
             topology, lock, 0
         )

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -10357,6 +10357,24 @@ class WorkspaceTests(unittest.TestCase):
             missing_evidence_applied_item["disposition"], "protected"
         )
         self.assertTrue(displaced.is_dir())
+        state_lock = Path(f"{first_path}.lock")
+        displaced_lock = self.root / "displaced-temporary-state.lock"
+        state_lock.rename(displaced_lock)
+        missing_all_evidence = self.workspace.cleanup(
+            ["temporary-states"], 0, [], False
+        )
+        missing_all_item = next(
+            item
+            for item in missing_all_evidence["items"]
+            if item["path"] == str(first_path)
+        )
+        self.assertEqual(missing_all_item["disposition"], "protected")
+        self.assertIn(
+            "temporary_state_ownership_evidence_missing",
+            missing_all_item["reasons"],
+        )
+        self.assertIn("state_lease_unverifiable", missing_all_item["reasons"])
+        displaced_lock.rename(state_lock)
         displaced.rename(first_path)
         with (
             mock.patch(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -13138,6 +13138,116 @@ class WorkspaceTests(unittest.TestCase):
             )
         self.assertIn("topology_status_unverifiable", status_item["reasons"])
 
+    def test_detached_temporary_state_classifies_every_uncertainty(self) -> None:
+        topology = self.workspace._topology_directory(
+            "detached-state-uncertainty", create=True
+        )
+        container, container_fd = self.workspace._temporary_state_container(topology)
+        os.close(container_fd)
+        generation = "b" * 64
+        state = container / generation
+        state.mkdir()
+        cleanup = cleanup_module.Cleanup(self.workspace)
+        policy = {
+            "mode": "temporary",
+            "path": str(state),
+            "owner": {
+                "kind": "topology-generation",
+                "topology": topology.name,
+                "generation": generation,
+            },
+            "lifecycle": "removal-pending",
+            "lease_identity": {"device": 1, "inode": 2},
+            "created_at": "invalid",
+        }
+        uncertain = cleanup._detached_temporary_state_item(
+            topology.name,
+            {
+                "state_policy": policy,
+                "supervisor": {"liveness": "live"},
+                "services": {"server": {"liveness": "unreachable"}},
+                "observation": None,
+            },
+            0,
+        )
+        self.assertTrue(
+            {
+                "temporary_state_reappeared",
+                "temporary_state_ownership_evidence_missing",
+                "state_lease_unverifiable",
+                "topology_liveness_unverifiable",
+                "topology_observation_unverifiable",
+                "invalid_temporary_state",
+            }
+            <= set(uncertain["reasons"])
+        )
+        state.rmdir()
+
+        lock = Path(f"{state}.lock")
+        with exclusive_lock(lock, "detached lease fixture"):
+            pass
+        lock_metadata = lock.stat(follow_symlinks=False)
+        released_policy = {
+            **policy,
+            "lifecycle": "removed",
+            "lease_identity": {
+                "device": lock_metadata.st_dev,
+                "inode": lock_metadata.st_ino,
+            },
+            "created_at": cleanup.now.replace(
+                year=cleanup.now.year + 1, month=1, day=1
+            ).isoformat(),
+        }
+        observed_status = {
+            "state_policy": released_policy,
+            "supervisor": {"liveness": "stale"},
+            "services": {},
+            "observation": {
+                "control": "reachable",
+                "process_tree_lease": "retained",
+                "runtime_bundle_lease": "unverifiable",
+                "port_reservation": None,
+            },
+            "endpoint": None,
+        }
+        with mock.patch.object(
+            cleanup,
+            "_state_lock_observation",
+            return_value=(False, "invalid lease", None),
+        ):
+            lease_error = cleanup._detached_temporary_state_item(
+                topology.name, observed_status, 0
+            )
+        self.assertTrue(
+            {
+                "state_lease_error",
+                "reachable_topology_control",
+                "process_tree_lease_unverifiable",
+                "runtime_bundle_lease_unverifiable",
+                "port_reservation_lease_unverifiable",
+                "future_creation_time",
+            }
+            <= set(lease_error["reasons"])
+        )
+        with mock.patch.object(
+            cleanup,
+            "_state_lock_observation",
+            return_value=(True, None, released_policy["lease_identity"]),
+        ):
+            busy = cleanup._detached_temporary_state_item(
+                topology.name, observed_status, 0
+            )
+        self.assertIn("active_state_lease", busy["reasons"])
+        with mock.patch.object(
+            cleanup,
+            "_state_lock_observation",
+            return_value=(False, None, {"device": 9, "inode": 9}),
+        ):
+            mismatch = cleanup._detached_temporary_state_item(
+                topology.name, observed_status, 0
+            )
+        self.assertIn("state_lease_identity_mismatch", mismatch["reasons"])
+
     def test_temporary_startup_rollback_retains_linked_state(self) -> None:
         topology = self.workspace._topology_directory(
             "linked-rollback", create=True

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -27,6 +27,7 @@ import unittest
 from unittest import mock
 
 from atrinik_workspace import workspace as workspace_module
+from atrinik_workspace import cleanup as cleanup_module
 from atrinik_workspace import locking as locking_module
 from atrinik_workspace.locking import (
     LeaseRequest,
@@ -10295,6 +10296,43 @@ class WorkspaceTests(unittest.TestCase):
             "pinned\n",
         )
         self.assertNotIn(str(first_path), self.workspace._load_states().values())
+        tombstone = first_path.parent / f".{first_path.name}.removal-pending"
+        real_rename_no_replace = workspace_module.rename_no_replace
+
+        def interrupt_before_removal_rename(source: Path, target: Path) -> None:
+            if source == first_path and target == tombstone:
+                raise WorkspaceError("simulated pre-rename interruption")
+            real_rename_no_replace(source, target)
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.rename_no_replace",
+                side_effect=interrupt_before_removal_rename,
+            ),
+            self.assertRaisesRegex(WorkspaceError, "pre-rename interruption"),
+        ):
+            self.workspace.topology_down("temporary-clean", timeout=5)
+        self.assertEqual(
+            self.workspace.topology_status("temporary-clean")["state_policy"][
+                "lifecycle"
+            ],
+            "removal-pending",
+        )
+        pending_link_target = self.root / "pending-link-target"
+        pending_link_target.write_text("preserve\n", encoding="utf-8")
+        pending_link = first_path / "pending-link"
+        pending_link.symlink_to(pending_link_target)
+        with self.assertRaisesRegex(WorkspaceError, "symbolic link"):
+            self.workspace.topology_down("temporary-clean", timeout=5)
+        self.assertTrue(first_path.is_dir())
+        self.assertTrue(pending_link.is_symlink())
+        pending_link.unlink()
+        displaced = self.root / "displaced-temporary-state"
+        first_path.rename(displaced)
+        with self.assertRaisesRegex(WorkspaceError, "ownership evidence is missing"):
+            self.workspace.topology_down("temporary-clean", timeout=5)
+        self.assertTrue(displaced.is_dir())
+        displaced.rename(first_path)
         with (
             mock.patch(
                 "atrinik_workspace.workspace.remove_owned_tree",
@@ -10309,14 +10347,40 @@ class WorkspaceTests(unittest.TestCase):
             ],
             "removal-pending",
         )
-        tombstone = first_path.parent / f".{first_path.name}.removal-pending"
         self.assertFalse(first_path.exists())
         self.assertTrue(tombstone.is_dir())
+        tombstone_link = tombstone / "late-link"
+        tombstone_link.symlink_to(pending_link_target)
+        with self.assertRaisesRegex(WorkspaceError, "linked state"):
+            self.workspace.topology_down("temporary-clean", timeout=5)
+        self.assertTrue(tombstone.is_dir())
+        self.assertTrue(tombstone_link.is_symlink())
+        tombstone_link.unlink()
+        tombstone_hardlink = self.root / "pending-hardlink"
+        os.link(tombstone / "motd", tombstone_hardlink)
+        with self.assertRaisesRegex(WorkspaceError, "linked state"):
+            self.workspace.topology_down("temporary-clean", timeout=5)
+        self.assertTrue(tombstone.is_dir())
+        tombstone_hardlink.unlink()
         stopped = self.workspace.topology_down("temporary-clean", timeout=5)
         self.assertEqual(stopped["state_policy"]["lifecycle"], "removed")
         self.assertFalse(first_path.exists())
         self.assertFalse(tombstone.exists())
         self.assertFalse(Path(f"{first_path}.lock").exists())
+        clean_status_path = (
+            self.workspace.paths.topologies / "temporary-clean" / "status.json"
+        )
+        clean_status_record = load_json(clean_status_path)
+        missing_server_state = copy.deepcopy(clean_status_record)
+        missing_server_state["state"] = None
+        missing_server_state["state_policy"] = None
+        with self.assertRaisesRegex(WorkspaceError, "state policy is invalid"):
+            self.workspace._validate_topology_state_policy(
+                "temporary-clean",
+                clean_status_path.parent,
+                missing_server_state,
+                missing_server_state["control"],
+            )
         topology_preview = self.workspace.cleanup(["topologies"], 0, [], False)
         temporary_clean_item = next(
             item
@@ -10827,6 +10891,29 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertEqual(aliased_item["disposition"], "protected")
         self.assertIn("registered_state", aliased_item["reasons"])
+        real_mount_id = cleanup_module._descriptor_mount_id
+
+        def simulated_mount_id(descriptor: int) -> int | tuple[int, int]:
+            target = Path(os.readlink(f"/proc/self/fd/{descriptor}"))
+            if target == state / "keys":
+                return 999999999
+            return real_mount_id(descriptor)
+
+        with mock.patch.object(
+            cleanup_module,
+            "_descriptor_mount_id",
+            side_effect=simulated_mount_id,
+        ):
+            mounted_preview = self.workspace.cleanup(
+                ["temporary-states"], 0, [], False
+            )
+        mounted_item = next(
+            item
+            for item in mounted_preview["items"]
+            if item["path"] == str(state)
+        )
+        self.assertEqual(mounted_item["disposition"], "protected")
+        self.assertIn("filesystem_traversal_error", mounted_item["reasons"])
         required_file = state / "motd"
         saved_required_file = state / "motd.saved"
         required_file.rename(saved_required_file)
@@ -10997,6 +11084,40 @@ class WorkspaceTests(unittest.TestCase):
         build_root = self.workspace.paths.builds / "failed-startup-server"
         self.make_rendezvous_server_build(
             build_root, rendezvous, "unused.bound", peers=1
+        )
+
+        @contextmanager
+        def fail_temporary_state_lease(
+            path: Path, **_kwargs: object
+        ):
+            with exclusive_lock(
+                Path(f"{path}.lock"), "simulated temporary state lease"
+            ):
+                raise WorkspaceError("simulated state lease admission failure")
+            yield
+
+        with (
+            mock.patch.object(
+                self.workspace, "_build_resolved", return_value=build_root
+            ),
+            mock.patch.object(
+                self.workspace,
+                "_topology_state_lock",
+                new=fail_temporary_state_lease,
+            ),
+            self.assertRaisesRegex(WorkspaceError, "lease admission failure"),
+        ):
+            self.workspace.topology_up(
+                "temporary-lease-failure", "default", None, ["server"], 0
+            )
+        failed_container = (
+            self.workspace.paths.topologies
+            / "temporary-lease-failure"
+            / "temporary-states"
+        )
+        self.assertEqual(
+            {path.name for path in failed_container.iterdir()},
+            {MANAGED_MARKER},
         )
         executable = build_root / "build" / "server" / "atrinik-server"
         executable.write_text(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -5283,10 +5283,10 @@ class WorkspaceTests(unittest.TestCase):
         generation = "a" * 32
         relocated = self.root / "relocated-state"
         try:
-            output = self.workspace._prepare_runtime_state_output(
+            output, output_fd, output_identity = self.workspace._prepare_runtime_state_output(
                 state, generation, state_fd
             )
-            output_identity = self.workspace._state_identity(output)
+            os.close(output_fd)
             state.rename(relocated)
             state.mkdir()
             sentinel = state / "sentinel"
@@ -5309,10 +5309,10 @@ class WorkspaceTests(unittest.TestCase):
         state.mkdir()
         state_fd = os.open(state, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
         generation = "b" * 32
-        output = self.workspace._prepare_runtime_state_output(
+        output, output_fd, output_identity = self.workspace._prepare_runtime_state_output(
             state, generation, state_fd
         )
-        output_identity = self.workspace._state_identity(output)
+        os.close(output_fd)
         replacement = self.root / "replacement-output"
         replacement.mkdir()
         atomic_json(
@@ -5363,10 +5363,9 @@ class WorkspaceTests(unittest.TestCase):
         state.mkdir()
         state_fd = os.open(state, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
         generation = "c" * 32
-        output = self.workspace._prepare_runtime_state_output(
+        output, output_fd, output_identity = self.workspace._prepare_runtime_state_output(
             state, generation, state_fd
         )
-        output_identity = self.workspace._state_identity(output)
         displaced = self.root / "displaced-runtime-output"
         output.rename(displaced)
         output.mkdir()
@@ -5380,6 +5379,13 @@ class WorkspaceTests(unittest.TestCase):
         sentinel = output / "sentinel"
         sentinel.write_text("replacement\n", encoding="utf-8")
         try:
+            pinned = Path(f"/proc/self/fd/{output_fd}") / "pinned-sentinel"
+            pinned.write_text("original\n", encoding="utf-8")
+            self.assertEqual(
+                (displaced / "pinned-sentinel").read_text(encoding="utf-8"),
+                "original\n",
+            )
+            self.assertFalse((output / "pinned-sentinel").exists())
             with self.assertRaisesRegex(WorkspaceError, "identity changed"):
                 self.workspace._remove_runtime_state_output(
                     output, generation, state_fd, output_identity
@@ -5387,6 +5393,7 @@ class WorkspaceTests(unittest.TestCase):
             self.assertEqual(sentinel.read_text(encoding="utf-8"), "replacement\n")
             self.assertTrue((displaced / MANAGED_MARKER).is_file())
         finally:
+            os.close(output_fd)
             os.close(state_fd)
 
     def test_runtime_state_output_cleanup_rejects_fifo_marker_and_mount(self) -> None:
@@ -5394,10 +5401,10 @@ class WorkspaceTests(unittest.TestCase):
         state.mkdir()
         state_fd = os.open(state, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
         generation = "d" * 32
-        output = self.workspace._prepare_runtime_state_output(
+        output, output_fd, output_identity = self.workspace._prepare_runtime_state_output(
             state, generation, state_fd
         )
-        output_identity = self.workspace._state_identity(output)
+        os.close(output_fd)
         marker = output / MANAGED_MARKER
         marker.unlink()
         os.mkfifo(marker)
@@ -11335,10 +11342,38 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual(special_applied_item["disposition"], "protected")
         self.assertTrue(state.is_dir())
         special.unlink()
+        for metadata_path in (
+            state / MANAGED_MARKER,
+            state / workspace_module.TEMPORARY_STATE_METADATA,
+            state.parent / MANAGED_MARKER,
+            state.parent.parent / MANAGED_MARKER,
+        ):
+            metadata_payload = metadata_path.read_bytes()
+            metadata_path.unlink()
+            os.mkfifo(metadata_path)
+            fifo_preview = self.workspace.cleanup(
+                ["temporary-states"], 0, [], False
+            )
+            fifo_item = next(
+                item
+                for item in fifo_preview["items"]
+                if item["path"] == str(state)
+            )
+            self.assertEqual(fifo_item["disposition"], "protected")
+            self.assertIn("invalid_temporary_state", fifo_item["reasons"])
+            metadata_path.unlink()
+            metadata_path.write_bytes(metadata_payload)
         linked_file = next(
             path
             for path in state.rglob("*")
-            if path.is_file() and not path.is_symlink()
+            if path.is_file()
+            and not path.is_symlink()
+            and path.name
+            not in {
+                MANAGED_MARKER,
+                workspace_module.TEMPORARY_STATE_METADATA,
+                workspace_module.STATE_IMPLEMENTATION_MARKER,
+            }
         )
         external_link = self.root / "temporary-state-hardlink"
         os.link(linked_file, external_link)
@@ -12135,8 +12170,67 @@ class WorkspaceTests(unittest.TestCase):
                 state_lease,
                 policy["identity"],
                 {"device": metadata.st_dev, "inode": metadata.st_ino},
+                implementation=policy["implementation"],
             )
         self.assertFalse(state.exists())
+        self.assertFalse(lock.exists())
+
+    def test_temporary_startup_rollback_orphan_lease_is_reclaimable(self) -> None:
+        topology = self.workspace._topology_directory(
+            "rollback-orphan", create=True
+        )
+        server = self.workspace.paths.repositories / "server"
+        state, policy = self.workspace._create_temporary_state(
+            topology,
+            "rollback-orphan",
+            "default",
+            "d" * 64,
+            server,
+            {
+                "stack": "default",
+                "provider": "server",
+                "repository": "atrinik/server",
+            },
+            self.scenario_resolved_fixture()["server"],
+        )
+        lock = Path(f"{state}.lock")
+        with exclusive_lock(lock, "temporary rollback") as state_lease:
+            metadata = os.fstat(state_lease.fileno())
+            with (
+                mock.patch(
+                    "atrinik_workspace.workspace.Workspace."
+                    "_unlink_temporary_state_lock",
+                    side_effect=WorkspaceError("simulated lease interruption"),
+                ),
+                self.assertRaisesRegex(
+                    WorkspaceError, "simulated lease interruption"
+                ),
+            ):
+                self.workspace._rollback_temporary_state_creation(
+                    state,
+                    state_lease,
+                    policy["identity"],
+                    {"device": metadata.st_dev, "inode": metadata.st_ino},
+                    implementation=policy["implementation"],
+                )
+        self.assertFalse(state.exists())
+        preview = self.workspace.cleanup(
+            ["temporary-states"], 0, [], False
+        )
+        item = next(
+            value for value in preview["items"] if value["path"] == str(state)
+        )
+        self.assertEqual(item["disposition"], "eligible")
+        self.assertIn(
+            "stale_orphan_temporary_state_lease", item["reasons"]
+        )
+        applied = self.workspace.cleanup(
+            ["temporary-states"], 0, [], True
+        )
+        applied_item = next(
+            value for value in applied["items"] if value["path"] == str(state)
+        )
+        self.assertEqual(applied_item["disposition"], "removed")
         self.assertFalse(lock.exists())
 
     def test_temporary_startup_rollback_retains_linked_state(self) -> None:
@@ -12175,6 +12269,49 @@ class WorkspaceTests(unittest.TestCase):
         os.close(state_fd)
         self.assertTrue(state.is_dir())
         self.assertTrue((state / "unsafe-link").is_symlink())
+
+    def test_temporary_startup_rollback_requires_exact_implementation(self) -> None:
+        topology = self.workspace._topology_directory(
+            "typed-rollback", create=True
+        )
+        server = self.workspace.paths.repositories / "server"
+        state, policy = self.workspace._create_temporary_state(
+            topology,
+            "typed-rollback",
+            "default",
+            "9" * 64,
+            server,
+            {
+                "stack": "default",
+                "provider": "server",
+                "repository": "atrinik/server",
+            },
+            self.scenario_resolved_fixture()["server"],
+        )
+        replacement = dict(policy["implementation"])
+        replacement["provider"] = "replacement-server"
+        atomic_json(
+            state / workspace_module.STATE_IMPLEMENTATION_MARKER,
+            {
+                "schema_version": workspace_module.STATE_IMPLEMENTATION_SCHEMA_VERSION,
+                **replacement,
+            },
+        )
+        lock = Path(f"{state}.lock")
+        with exclusive_lock(lock, "temporary rollback") as state_lease:
+            metadata = os.fstat(state_lease.fileno())
+            with self.assertRaisesRegex(
+                WorkspaceError, "implementation marker is invalid"
+            ):
+                self.workspace._rollback_temporary_state_creation(
+                    state,
+                    state_lease,
+                    policy["identity"],
+                    {"device": metadata.st_dev, "inode": metadata.st_ino},
+                    implementation=policy["implementation"],
+                )
+        self.assertTrue(state.is_dir())
+        self.assertTrue(lock.is_file())
 
     def test_temporary_mutation_refuses_live_physical_alias(self) -> None:
         state = self.root / "temporary-physical-alias"
@@ -13051,15 +13188,35 @@ class WorkspaceTests(unittest.TestCase):
                     "purpose": "runtime-state-output:foreground-server-generation",
                 },
             )
-            return generation_root, descriptor, {
-                "mutable_state_outputs": [str(state_output)],
-                "mutable_state_output_identities": [
-                    self.workspace._state_identity(state_output)
-                ],
-            }
+            return (
+                generation_root,
+                descriptor,
+                {
+                    "mutable_state_outputs": [str(state_output)],
+                    "mutable_state_output_identities": [
+                        self.workspace._state_identity(state_output)
+                    ],
+                },
+                os.open(
+                    state_output,
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                ),
+            )
 
         def execute_server(*_arguments: object, **_keywords: object) -> None:
-            self.assertEqual(len(_keywords["pass_fds"]), 4)
+            self.assertEqual(len(_keywords["pass_fds"]), 5)
+            asset_argument = next(
+                value
+                for value in reversed(_arguments[0])
+                if value.startswith("--assetspath=")
+            )
+            asset_path = Path(asset_argument.split("=", 1)[1])
+            self.assertEqual(asset_path.parent, Path("/proc/self/fd"))
+            self.assertIn(int(asset_path.name), _keywords["pass_fds"])
+            self.assertEqual(
+                load_json(asset_path / MANAGED_MARKER)["purpose"],
+                "runtime-state-output:foreground-server-generation",
+            )
             for path, description in (
                 (
                     resource_lock_path(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -5286,13 +5286,14 @@ class WorkspaceTests(unittest.TestCase):
             output = self.workspace._prepare_runtime_state_output(
                 state, generation, state_fd
             )
+            output_identity = self.workspace._state_identity(output)
             state.rename(relocated)
             state.mkdir()
             sentinel = state / "sentinel"
             sentinel.write_text("replacement\n", encoding="utf-8")
 
             self.workspace._remove_runtime_state_output(
-                output, generation, state_fd
+                output, generation, state_fd, output_identity
             )
 
             self.assertFalse(
@@ -5311,6 +5312,7 @@ class WorkspaceTests(unittest.TestCase):
         output = self.workspace._prepare_runtime_state_output(
             state, generation, state_fd
         )
+        output_identity = self.workspace._state_identity(output)
         replacement = self.root / "replacement-output"
         replacement.mkdir()
         atomic_json(
@@ -5345,7 +5347,7 @@ class WorkspaceTests(unittest.TestCase):
                 self.assertRaisesRegex(WorkspaceError, "output path changed"),
             ):
                 self.workspace._remove_runtime_state_output(
-                    output, generation, state_fd
+                    output, generation, state_fd, output_identity
                 )
             self.assertTrue(swapped)
             self.assertEqual(
@@ -5353,6 +5355,76 @@ class WorkspaceTests(unittest.TestCase):
                 "replacement\n",
             )
             self.assertTrue((displaced / MANAGED_MARKER).is_file())
+        finally:
+            os.close(state_fd)
+
+    def test_runtime_state_output_cleanup_rejects_completed_replacement(self) -> None:
+        state = self.root / "state-output-replaced"
+        state.mkdir()
+        state_fd = os.open(state, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        generation = "c" * 32
+        output = self.workspace._prepare_runtime_state_output(
+            state, generation, state_fd
+        )
+        output_identity = self.workspace._state_identity(output)
+        displaced = self.root / "displaced-runtime-output"
+        output.rename(displaced)
+        output.mkdir()
+        atomic_json(
+            output / MANAGED_MARKER,
+            {
+                "schema_version": 1,
+                "purpose": f"runtime-state-output:{generation}",
+            },
+        )
+        sentinel = output / "sentinel"
+        sentinel.write_text("replacement\n", encoding="utf-8")
+        try:
+            with self.assertRaisesRegex(WorkspaceError, "identity changed"):
+                self.workspace._remove_runtime_state_output(
+                    output, generation, state_fd, output_identity
+                )
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "replacement\n")
+            self.assertTrue((displaced / MANAGED_MARKER).is_file())
+        finally:
+            os.close(state_fd)
+
+    def test_runtime_state_output_cleanup_rejects_fifo_marker_and_mount(self) -> None:
+        state = self.root / "state-output-invalid"
+        state.mkdir()
+        state_fd = os.open(state, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        generation = "d" * 32
+        output = self.workspace._prepare_runtime_state_output(
+            state, generation, state_fd
+        )
+        output_identity = self.workspace._state_identity(output)
+        marker = output / MANAGED_MARKER
+        marker.unlink()
+        os.mkfifo(marker)
+        try:
+            with self.assertRaisesRegex(WorkspaceError, "ownership.*invalid"):
+                self.workspace._remove_runtime_state_output(
+                    output, generation, state_fd, output_identity
+                )
+            marker.unlink()
+            atomic_json(
+                marker,
+                {
+                    "schema_version": 1,
+                    "purpose": f"runtime-state-output:{generation}",
+                },
+            )
+            with (
+                mock.patch(
+                    "atrinik_workspace.workspace._descriptor_mount_id",
+                    side_effect=[1, 1, 2],
+                ),
+                self.assertRaisesRegex(WorkspaceError, "crosses a mount"),
+            ):
+                self.workspace._remove_runtime_state_output(
+                    output, generation, state_fd, output_identity
+                )
+            self.assertTrue(marker.is_file())
         finally:
             os.close(state_fd)
 
@@ -10355,6 +10427,25 @@ class WorkspaceTests(unittest.TestCase):
             ],
             "removal-pending",
         )
+        with self.assertRaisesRegex(
+            WorkspaceError, "removal has already begun"
+        ):
+            self.workspace.topology_down(
+                "temporary-clean", timeout=5, retain_state=True
+            )
+        topology_preview = self.workspace.cleanup(
+            ["topologies"], 0, [], False
+        )
+        pending_topology_item = next(
+            item
+            for item in topology_preview["items"]
+            if item.get("name") == "temporary-clean"
+        )
+        self.assertEqual(pending_topology_item["disposition"], "protected")
+        self.assertIn(
+            "temporary_state_recovery_pending",
+            pending_topology_item["reasons"],
+        )
         pending_link_target = self.root / "pending-link-target"
         pending_link_target.write_text("preserve\n", encoding="utf-8")
         pending_link = first_path / "pending-link"
@@ -10617,6 +10708,24 @@ class WorkspaceTests(unittest.TestCase):
             )
         retained_path = Path(retained["state_policy"]["path"])
         self.assertEqual(retained["state_policy"]["profile"], "default")
+        retained_status_path = (
+            self.workspace.paths.topologies / "temporary-retained" / "status.json"
+        )
+        implementation_marker = (
+            retained_path / workspace_module.STATE_IMPLEMENTATION_MARKER
+        )
+        implementation_payload = implementation_marker.read_bytes()
+        implementation_marker.unlink()
+        with self.assertRaisesRegex(
+            WorkspaceError, "retained because its integrity could not be proved"
+        ):
+            self.workspace.topology_down("temporary-retained", timeout=5)
+        self.assertTrue(retained_path.is_dir())
+        self.assertEqual(
+            load_json(retained_status_path)["state_policy"]["lifecycle"],
+            "retained",
+        )
+        implementation_marker.write_bytes(implementation_payload)
         stopped = self.workspace.topology_down(
             "temporary-retained", timeout=5, retain_state=True
         )
@@ -10679,6 +10788,15 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertEqual(retained_item["disposition"], "protected")
         self.assertIn("temporary_state_retained", retained_item["reasons"])
+        implementation_marker.unlink()
+        with self.assertRaisesRegex(
+            WorkspaceError, "implementation marker"
+        ):
+            self.workspace.state_promote(
+                "temporary-retained", "markerless-promotion"
+            )
+        self.assertNotIn("markerless-promotion", self.workspace._load_states())
+        implementation_marker.write_bytes(implementation_payload)
         displaced_state = retained_path.with_name("promotion-displaced")
         replacement_sentinel = retained_path / "replacement-sentinel"
         real_durable_json_at = workspace_module.durable_atomic_json_at
@@ -10899,6 +11017,18 @@ class WorkspaceTests(unittest.TestCase):
                 "state_policy"
             ]["lifecycle"],
             "promotion-pending",
+        )
+        with self.assertRaisesRegex(
+            WorkspaceError, "promotion target cannot change"
+        ):
+            self.workspace.state_promote(
+                "temporary-promotion-retry", "different-promoted-retry"
+            )
+        self.assertEqual(
+            self.workspace.topology_status("temporary-promotion-retry")[
+                "state_policy"
+            ]["name"],
+            "promoted-retry",
         )
         self.assertEqual(
             self.workspace.state_promote(
@@ -12923,6 +13053,9 @@ class WorkspaceTests(unittest.TestCase):
             )
             return generation_root, descriptor, {
                 "mutable_state_outputs": [str(state_output)],
+                "mutable_state_output_identities": [
+                    self.workspace._state_identity(state_output)
+                ],
             }
 
         def execute_server(*_arguments: object, **_keywords: object) -> None:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -12758,6 +12758,57 @@ class WorkspaceTests(unittest.TestCase):
             {MANAGED_MARKER},
         )
 
+    def test_temporary_state_revalidates_copied_bytes_before_publication(self) -> None:
+        topology = self.workspace._topology_directory(
+            "staging-content-validation", create=True
+        )
+        server = self.workspace.paths.repositories / "server"
+        generation = "6" * 64
+        original_atomic_json_at = workspace_module.durable_atomic_json_at
+
+        def change_copied_file(
+            directory_fd: int,
+            name: str,
+            value: object,
+            **kwargs: object,
+        ) -> None:
+            original_atomic_json_at(directory_fd, name, value, **kwargs)
+            if name == workspace_module.TEMPORARY_STATE_METADATA:
+                motd_fd = os.open(
+                    "motd",
+                    os.O_WRONLY | os.O_TRUNC | os.O_NOFOLLOW,
+                    dir_fd=directory_fd,
+                )
+                try:
+                    os.write(motd_fd, b"changed after validation\n")
+                finally:
+                    os.close(motd_fd)
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.durable_atomic_json_at",
+                side_effect=change_copied_file,
+            ),
+            self.assertRaisesRegex(WorkspaceError, "changed before.*publication"),
+        ):
+            self.workspace._create_temporary_state(
+                topology,
+                "staging-content-validation",
+                "default",
+                generation,
+                server,
+                {
+                    "stack": "default",
+                    "provider": "server",
+                    "repository": "atrinik/server",
+                },
+                self.scenario_resolved_fixture()["server"],
+            )
+        self.assertEqual(
+            {path.name for path in (topology / "temporary-states").iterdir()},
+            {MANAGED_MARKER},
+        )
+
     def test_temporary_startup_rollback_removes_state_and_lease(self) -> None:
         topology = self.workspace._topology_directory("rollback", create=True)
         server = self.workspace.paths.repositories / "server"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -5856,6 +5856,62 @@ class WorkspaceTests(unittest.TestCase):
             self.assertEqual(stat.S_IMODE(root.stat().st_mode), root_mode)
             self.assertEqual(stat.S_IMODE(nested.stat().st_mode), nested_mode)
 
+    def test_owned_tree_removal_rejects_root_rebinding(self) -> None:
+        for phase in ("before-contents", "before-rmdir"):
+            with self.subTest(phase=phase):
+                parent = self.root / phase
+                parent.mkdir()
+                owned = parent / "owned"
+                owned.mkdir()
+                (owned / "payload").write_text("owned\n", encoding="utf-8")
+                identity = self.workspace._state_identity(owned)
+                moved = parent / "moved"
+                real_prepare = workspace_module._prepare_owned_tree_removal
+                real_remove = workspace_module._remove_owned_tree_contents
+
+                def replace_before_contents(*args: object, **kwargs: object) -> None:
+                    real_prepare(*args, **kwargs)
+                    owned.rename(moved)
+                    owned.mkdir()
+                    (owned / "replacement").write_text(
+                        "preserve\n", encoding="utf-8"
+                    )
+
+                def replace_before_rmdir(*args: object, **kwargs: object) -> None:
+                    real_remove(*args, **kwargs)
+                    owned.rename(moved)
+                    owned.mkdir()
+                    (owned / "replacement").write_text(
+                        "preserve\n", encoding="utf-8"
+                    )
+
+                target = (
+                    "atrinik_workspace.workspace._prepare_owned_tree_removal"
+                    if phase == "before-contents"
+                    else "atrinik_workspace.workspace._remove_owned_tree_contents"
+                )
+                replacement = (
+                    replace_before_contents
+                    if phase == "before-contents"
+                    else replace_before_rmdir
+                )
+                with (
+                    mock.patch(target, side_effect=replacement),
+                    self.assertRaisesRegex(
+                        WorkspaceError, "owned removal root identity changed"
+                    ),
+                ):
+                    remove_owned_tree(owned, expected_identity=identity)
+                self.assertEqual(
+                    (owned / "replacement").read_text(encoding="utf-8"),
+                    "preserve\n",
+                )
+                if phase == "before-contents":
+                    self.assertEqual(
+                        (moved / "payload").read_text(encoding="utf-8"),
+                        "owned\n",
+                    )
+
     def test_replaced_directory_recovery_rejects_invalid_states(self) -> None:
         def snapshot(parent: Path) -> dict[str, tuple[object, ...]]:
             result: dict[str, tuple[object, ...]] = {}
@@ -10072,10 +10128,38 @@ class WorkspaceTests(unittest.TestCase):
             ],
             "removal-pending",
         )
-        self.assertTrue(first_path.is_dir())
+        tombstone = first_path.parent / f".{first_path.name}.removal-pending"
+        self.assertFalse(first_path.exists())
+        self.assertTrue(tombstone.is_dir())
         stopped = self.workspace.topology_down("temporary-clean", timeout=5)
         self.assertEqual(stopped["state_policy"]["lifecycle"], "removed")
         self.assertFalse(first_path.exists())
+        self.assertFalse(tombstone.exists())
+        self.assertFalse(Path(f"{first_path}.lock").exists())
+        topology_preview = self.workspace.cleanup(["topologies"], 0, [], False)
+        temporary_clean_item = next(
+            item
+            for item in topology_preview["items"]
+            if item.get("name") == "temporary-clean"
+        )
+        self.assertEqual(
+            temporary_clean_item["disposition"], "eligible", temporary_clean_item
+        )
+        with mock.patch.object(
+            self.workspace, "_build_resolved", return_value=build_root
+        ):
+            restarted_clean = self.workspace.topology_up(
+                "temporary-clean", "default", None, ["server"], 0
+            )
+        self.assertNotEqual(
+            restarted_clean["control"]["generation"],
+            first["control"]["generation"],
+        )
+        self.assertNotEqual(
+            restarted_clean["state_policy"]["path"],
+            first["state_policy"]["path"],
+        )
+        self.workspace.topology_down("temporary-clean", timeout=5)
 
         (rendezvous / "temporary.bound").unlink()
         with mock.patch.object(
@@ -10090,6 +10174,18 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertEqual(stopped["state_policy"]["lifecycle"], "retained")
         self.assertTrue(retained_path.is_dir())
+        retained_status_path = (
+            self.workspace.paths.topologies / "temporary-retained" / "status.json"
+        )
+        retained_record = load_json(retained_status_path)
+        invalid_removed = copy.deepcopy(retained_record)
+        invalid_removed["state_policy"]["lifecycle"] = "removed"
+        atomic_json(retained_status_path, invalid_removed)
+        with self.assertRaisesRegex(
+            WorkspaceError, "removed temporary topology state still exists"
+        ):
+            self.workspace.topology_status("temporary-retained")
+        atomic_json(retained_status_path, retained_record)
         with (
             mock.patch.object(
                 self.workspace, "_build_resolved", return_value=build_root
@@ -10294,6 +10390,26 @@ class WorkspaceTests(unittest.TestCase):
             item for item in preview["items"] if item["path"] == str(state)
         )
         self.assertEqual(candidate["disposition"], "eligible")
+        with mock.patch(
+            "atrinik_workspace.workspace.remove_owned_tree",
+            side_effect=WorkspaceError("simulated cleanup removal interruption"),
+        ):
+            interrupted = self.workspace.cleanup(
+                ["temporary-states"], 0, [], True
+            )
+        interrupted_item = next(
+            item for item in interrupted["items"] if item["path"] == str(state)
+        )
+        self.assertEqual(interrupted_item["disposition"], "error")
+        self.assertEqual(
+            self.workspace.topology_status("temporary-crash")["state_policy"][
+                "lifecycle"
+            ],
+            "removal-pending",
+        )
+        self.assertTrue(
+            (state.parent / f".{state.name}.removal-pending").is_dir()
+        )
         applied = self.workspace.cleanup(
             ["temporary-states"], 0, [], True
         )
@@ -10302,6 +10418,41 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertEqual(removed["disposition"], "removed", applied)
         self.assertFalse(state.exists())
+        cleaned = self.workspace.topology_status("temporary-crash")
+        self.assertEqual(cleaned["state_policy"]["lifecycle"], "removed")
+        self.assertFalse(Path(f"{state}.lock").exists())
+
+    def test_stop_acknowledgement_without_clean_shutdown_proof_retains_state(
+        self,
+    ) -> None:
+        control = {"generation": "a" * 64}
+        stopped = {
+            "control": control,
+            "shutdown": None,
+            "supervisor": {"running": False},
+            "services": {"server": {"running": False}},
+        }
+        self.workspace._topology_directory(
+            "acknowledged-then-crashed", create=True
+        )
+        with (
+            mock.patch.object(
+                self.workspace, "_topology_control_request", return_value=True
+            ),
+            mock.patch.object(
+                self.workspace, "_topology_process_tree_active", return_value=False
+            ),
+            mock.patch.object(
+                self.workspace, "topology_status", return_value=stopped
+            ),
+        ):
+            observed, confirmed_clean = self.workspace._controlled_topology_down(
+                "acknowledged-then-crashed",
+                {"control": control},
+                1,
+            )
+        self.assertIs(observed, stopped)
+        self.assertFalse(confirmed_clean)
 
     def test_topology_port_selection_rejects_unavailable_port(self) -> None:
         candidate = mock.MagicMock()
@@ -10556,6 +10707,111 @@ class WorkspaceTests(unittest.TestCase):
         linked.symlink_to(state, target_is_directory=True)
         with self.assertRaisesRegex(WorkspaceError, "contains a symlink"):
             self.workspace.state_add("linked", linked)
+
+    def test_prepared_state_rejects_directory_and_ancestor_replacement(self) -> None:
+        server = self.workspace.paths.repositories / "server"
+        implementation = {
+            "stack": "classic",
+            "provider": "server",
+            "repository": "atrinik/server",
+        }
+        state = self.workspace.state_path(
+            "default",
+            server,
+            implementation=implementation,
+            write_implementation=True,
+        )
+        identity = self.workspace._state_identity(state)
+        replacement = state.parent / "replacement"
+        shutil.copytree(state, replacement)
+        previous = state.parent / "previous"
+
+        def replace_state(*_args: object, **_kwargs: object) -> tuple[Path, int]:
+            state.rename(previous)
+            replacement.rename(state)
+            return state, os.open(previous, os.O_PATH | os.O_DIRECTORY)
+
+        with (
+            mock.patch.object(
+                self.workspace, "state_path", side_effect=replace_state
+            ),
+            self.assertRaisesRegex(
+                WorkspaceError, "identity changed while preparing topology"
+            ),
+        ):
+            self.workspace._prepared_state_path(
+                "default", server, state, implementation, identity
+            )
+
+        external_parent = self.root / "external-parent"
+        external_parent.mkdir()
+        external_state = external_parent / "state"
+        shutil.copytree(previous, external_state)
+        attacker_parent = self.root / "attacker-parent"
+        attacker_parent.mkdir()
+        shutil.copytree(previous, attacker_parent / "state")
+        original_parent = self.root / "original-parent"
+        external_identity = self.workspace._state_identity(external_state)
+
+        def replace_ancestor(
+            *_args: object, **_kwargs: object
+        ) -> tuple[Path, int]:
+            external_parent.rename(original_parent)
+            external_parent.symlink_to(attacker_parent, target_is_directory=True)
+            return (
+                external_state,
+                os.open(original_parent / "state", os.O_PATH | os.O_DIRECTORY),
+            )
+
+        with (
+            mock.patch.object(
+                self.workspace, "state_path", side_effect=replace_ancestor
+            ),
+            self.assertRaisesRegex(
+                WorkspaceError, "without following links|contains a symlink"
+            ),
+        ):
+            self.workspace._prepared_state_path(
+                "external",
+                server,
+                external_state,
+                implementation,
+                external_identity,
+            )
+
+    def test_state_lock_replacement_does_not_bypass_live_owner(self) -> None:
+        server = self.workspace.paths.repositories / "server"
+        state = self.workspace.state_path("default", server)
+        lock_path = Path(f"{state}.lock")
+        lock_path.touch(mode=0o600)
+        with exclusive_lock(lock_path, "original state") as original:
+            original_identity = os.fstat(original.fileno())
+            lock_path.unlink()
+            lock_path.touch(mode=0o600)
+            status = {
+                "name": "owner",
+                "state": str(state),
+                "control": {"generation": "a" * 64},
+                "observation": {"process_tree_lease": "retained"},
+                "state_policy": {
+                    "lease_identity": {
+                        "device": original_identity.st_dev,
+                        "inode": original_identity.st_ino,
+                    }
+                },
+            }
+            owner_root = self.workspace._topology_directory("owner", create=True)
+            atomic_json(owner_root / "status.json", {"state": str(state)})
+            with (
+                mock.patch.object(
+                    self.workspace, "topology_status", return_value=status
+                ),
+                self.assertRaisesRegex(
+                    WorkspaceError, "owned by topology owner generation"
+                ),
+            ):
+                with self.workspace._topology_state_lock(state):
+                    self.fail("replacement lock must not grant state ownership")
 
     def test_temporary_state_publication_interruption_leaves_no_partial_state(self) -> None:
         topology = self.workspace._topology_directory("interrupted", create=True)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -5450,7 +5450,9 @@ class WorkspaceTests(unittest.TestCase):
         )
         os.close(output_fd)
         os.close(state_fd)
-        displaced = output.parent / "operator-renamed-output"
+        quarantine = state / "quarantine"
+        quarantine.mkdir()
+        displaced = quarantine / "operator-renamed-output"
         output.rename(displaced)
         status = {
             "name": "runtime-output-recovery",
@@ -5472,7 +5474,9 @@ class WorkspaceTests(unittest.TestCase):
             "topology_status",
             side_effect=lambda _name: load_json(status_path),
         ):
-            with self.assertRaisesRegex(WorkspaceError, "was renamed"):
+            with self.assertRaisesRegex(
+                WorkspaceError, "ownership evidence is missing"
+            ):
                 self.workspace._cleanup_topology_mutable_state_outputs(status)
             pending = load_json(status_path)
             self.assertEqual(
@@ -5488,6 +5492,99 @@ class WorkspaceTests(unittest.TestCase):
             "complete",
         )
         self.assertFalse(output.exists())
+        output.mkdir()
+        with (
+            mock.patch.object(
+                self.workspace,
+                "topology_status",
+                side_effect=lambda _name: load_json(status_path),
+            ),
+            self.assertRaisesRegex(WorkspaceError, "output reappeared"),
+        ):
+            self.workspace._cleanup_topology_mutable_state_outputs(completed)
+
+    def test_interrupted_runtime_output_publication_is_recovered(self) -> None:
+        topology = self.workspace._topology_directory(
+            "runtime-output-transaction", create=True
+        )
+        state = self.root / "runtime-output-transaction-state"
+        state.mkdir()
+        state_fd = os.open(state, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        generation = "f" * 64
+        output, output_fd, output_identity = (
+            self.workspace._prepare_runtime_state_output(
+                state, generation, state_fd
+            )
+        )
+        os.close(output_fd)
+        os.close(state_fd)
+        transaction = topology / workspace_module.RUNTIME_STATE_OUTPUT_TRANSACTION
+        atomic_json(
+            transaction,
+            {
+                "schema_version": 1,
+                "generation": generation,
+                "state": str(state),
+                "state_identity": self.workspace._state_identity(state),
+                "phase": "prepared",
+                "output_identity": output_identity,
+            },
+        )
+        preview = self.workspace.cleanup(["topologies"], 0, [], False)
+        topology_item = next(
+            item
+            for item in preview["items"]
+            if item["path"] == str(topology)
+        )
+        self.assertEqual(topology_item["disposition"], "protected")
+        self.assertIn(
+            "runtime_state_output_transaction_pending",
+            topology_item["reasons"],
+        )
+
+        self.workspace._recover_runtime_state_output_transaction(
+            topology, "runtime-output-transaction"
+        )
+
+        self.assertFalse(output.exists())
+        self.assertFalse(transaction.exists())
+
+    def test_runtime_output_removal_retries_from_empty_tombstone(self) -> None:
+        state = self.root / "runtime-output-removal-retry"
+        state.mkdir()
+        state_fd = os.open(state, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        generation = "1" * 64
+        output, output_fd, output_identity = (
+            self.workspace._prepare_runtime_state_output(
+                state, generation, state_fd
+            )
+        )
+        os.close(output_fd)
+        original_remove = workspace_module._remove_owned_tree_contents
+
+        def remove_then_interrupt(*args: object, **kwargs: object) -> None:
+            original_remove(*args, **kwargs)
+            raise WorkspaceError("simulated output removal interruption")
+
+        try:
+            with (
+                mock.patch(
+                    "atrinik_workspace.workspace._remove_owned_tree_contents",
+                    side_effect=remove_then_interrupt,
+                ),
+                self.assertRaisesRegex(
+                    WorkspaceError, "simulated output removal interruption"
+                ),
+            ):
+                self.workspace._remove_runtime_state_output(
+                    output, generation, state_fd, output_identity
+                )
+            self.workspace._remove_runtime_state_output(
+                output, generation, state_fd, output_identity
+            )
+            self.assertFalse(output.exists())
+        finally:
+            os.close(state_fd)
 
     def test_schema_two_restart_preserves_unowned_mutable_output(self) -> None:
         topology = self.workspace._topology_directory(
@@ -5502,6 +5599,19 @@ class WorkspaceTests(unittest.TestCase):
             "services": {"server": {"running": False}},
             "runtime": {"mutable_state_outputs": [str(output)]},
         }
+        with (
+            mock.patch.object(
+                self.workspace, "topology_status", return_value=previous
+            ),
+            self.assertRaisesRegex(
+                WorkspaceError, "legacy mutable state output"
+            ),
+        ):
+            self.workspace.topology_up(
+                "legacy-output", "default", "default", ["server"], 0
+            )
+        digest = hashlib.sha256(output.name.encode("utf-8")).hexdigest()[:16]
+        output.rename(output.parent / f".remove-{digest}-1-2")
         with (
             mock.patch.object(
                 self.workspace, "topology_status", return_value=previous
@@ -12273,9 +12383,21 @@ class WorkspaceTests(unittest.TestCase):
         generation = "a" * 64
         server = self.workspace.paths.repositories / "server"
         coordinate = self.scenario_resolved_fixture()["server"]
+        real_rename_at = workspace_module.rename_no_replace_at
+
+        def interrupt_publication(
+            source_fd: int,
+            source: str,
+            destination_fd: int,
+            destination: str,
+        ) -> None:
+            if destination == generation:
+                raise WorkspaceError("simulated interruption")
+            real_rename_at(source_fd, source, destination_fd, destination)
+
         with mock.patch(
-            "atrinik_workspace.workspace.rename_no_replace",
-            side_effect=WorkspaceError("simulated interruption"),
+            "atrinik_workspace.workspace.rename_no_replace_at",
+            side_effect=interrupt_publication,
         ):
             with self.assertRaisesRegex(WorkspaceError, "simulated interruption"):
                 self.workspace._create_temporary_state(
@@ -12294,6 +12416,62 @@ class WorkspaceTests(unittest.TestCase):
         container = topology / "temporary-states"
         self.assertEqual(
             {path.name for path in container.iterdir()}, {MANAGED_MARKER}
+        )
+
+    def test_temporary_state_publication_rejects_container_replacement(self) -> None:
+        topology = self.workspace._topology_directory(
+            "container-replaced", create=True
+        )
+        server = self.workspace.paths.repositories / "server"
+        generation = "b" * 64
+        original_copytree = shutil.copytree
+        displaced = topology / "displaced-temporary-states"
+        replacement = topology / "temporary-states"
+
+        def replace_container(*args: object, **kwargs: object) -> object:
+            result = original_copytree(*args, **kwargs)
+            if Path(args[0]) != server / "install_data":
+                return result
+            replacement.rename(displaced)
+            replacement.mkdir()
+            atomic_json(
+                replacement / MANAGED_MARKER,
+                {
+                    "schema_version": 1,
+                    "purpose": "topology-temporary-states",
+                },
+            )
+            (replacement / "sentinel").write_text(
+                "preserve\n", encoding="utf-8"
+            )
+            return result
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.shutil.copytree",
+                side_effect=replace_container,
+            ),
+            self.assertRaisesRegex(WorkspaceError, "identity changed"),
+        ):
+            self.workspace._create_temporary_state(
+                topology,
+                "container-replaced",
+                "default",
+                generation,
+                server,
+                {
+                    "stack": "default",
+                    "provider": "server",
+                    "repository": "atrinik/server",
+                },
+                self.scenario_resolved_fixture()["server"],
+            )
+        self.assertEqual(
+            (replacement / "sentinel").read_text(encoding="utf-8"),
+            "preserve\n",
+        )
+        self.assertEqual(
+            {path.name for path in displaced.iterdir()}, {MANAGED_MARKER}
         )
 
     def test_temporary_startup_rollback_removes_state_and_lease(self) -> None:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -10727,7 +10727,7 @@ class WorkspaceTests(unittest.TestCase):
             )
         retry_path = Path(retry["state_policy"]["path"])
         self.workspace.topology_down(
-            "temporary-promotion-retry", timeout=5, retain_state=True
+            "temporary-promotion-retry", timeout=10, retain_state=True
         )
         write_policy = self.workspace._write_temporary_state_policy
         writes = 0


### PR DESCRIPTION
Closes #403

## Summary

- add explicit temporary, named, and default state policies to topology show/up/ps/logs, including stable machine-readable ownership and lifecycle metadata
- create generation-owned temporary Classic server state atomically from the exact selected `install_data`, retain it after crashes or uncertainty, and support explicit retain/promotion workflows
- enforce descriptor-bound state identity, implementation typing, physical alias exclusion, durable shutdown/removal/output transactions, and fail-closed cleanup classification
- preserve schema-2 topology compatibility while preventing unproven legacy mutable output from being silently discarded
- synchronize runtime, cleanup, scenario, completion, architecture, and contributor guidance with the new contracts

## Validation

- `python3 -m unittest tests.test_workspace tests.test_cleanup tests.test_supervisor tests.test_cli tests.test_completion` — 475 passed
- `/workspaces/atrinik/.venv/bin/python -m coverage run -m unittest discover` — 809 tests exercised; one timing-sensitive lease assertion failed once and passed immediately in isolation under coverage, followed by a clean complete rerun
- `/workspaces/atrinik/.venv/bin/python -m unittest discover` — 809 passed on the final production head; subsequent test-only commits add passing fallback, lease, and detached-state uncertainty regressions
- `/workspaces/atrinik/.venv/bin/python -m coverage report --show-missing` — 82% total coverage
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `./atrinik cleanup --scope all --older-than 7 --dry-run --json` — 304 protected, 0 candidates, 0 errors; no apply performed
- `git diff --check 4b78256e563fe8fd1f839b9f9eded5e7f46f5dd8..HEAD`

## Review

Three independent final whole-diff reviews covered safety/security, correctness/recovery, and acceptance/docs/CLI/tests at `d46b10e2c`. All reported zero known actionable findings.

## Manual verification

The dedicated worktree's `classic` profile is not initialized, so a real Classic server smoke test would require cloning and building the component repositories. Socket-backed supervised lifecycle behavior is covered by the passing integration tests above.
