### PR TITLE
fix(runtime): exclude client build headers from publication

### DIFF
--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -11789,7 +11789,7 @@ class Workspace:
                     ),
                     "client-binary": (
                         self._classic_binary_directory(build_root, "client"),
-                        set(),
+                        {"src"},
                     ),
                     "sound": (
                         sound_root or selected["sound"],
@@ -11892,6 +11892,7 @@ class Workspace:
                 self._copy_runtime_directory_contents(
                     self._classic_binary_directory(build_root, "client"),
                     client_runtime,
+                    frozenset({"src"}),
                 )
             if "server" in services:
                 if state is None:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -5973,6 +5973,55 @@ class WorkspaceTests(unittest.TestCase):
 
         self.assertEqual(list((owner / "generations").iterdir()), [])
 
+    def test_runtime_generation_ignores_client_build_headers(self) -> None:
+        owner = self.root / "runtime-owner"
+        owner.mkdir()
+        client = self.root / "runtime-client"
+        sound = self.root / "runtime-sound"
+        binary = self.root / "runtime-client-binary"
+        (client / "src").mkdir(parents=True)
+        (sound / "sound").mkdir(parents=True)
+        (binary / "src" / "include").mkdir(parents=True)
+        (client / "src" / "main.c").write_text("source\n", encoding="utf-8")
+        (binary / "src" / "include" / "version.h").write_text(
+            "generated\n", encoding="utf-8"
+        )
+        executable = binary / "atrinik"
+        executable.write_text("client\n", encoding="utf-8")
+        executable.chmod(0o755)
+
+        with mock.patch.object(
+            self.workspace, "_classic_binary_directory", return_value=binary
+        ):
+            published, lease_fd, _record, state_output_fd = (
+                self.workspace._publish_runtime_generation(
+                    owner,
+                    "a" * 64,
+                    "default",
+                    self.root / "build",
+                    {"client": client, "sound": sound},
+                    {},
+                    ["client"],
+                    identity={"kind": "test"},
+                    sound_root=sound,
+                )
+            )
+
+        try:
+            self.assertIsNone(state_output_fd)
+            self.assertEqual(
+                (published / "client" / "src" / "main.c").read_text(
+                    encoding="utf-8"
+                ),
+                "source\n",
+            )
+            self.assertFalse(
+                (published / "client" / "src" / "include" / "version.h").exists()
+            )
+            self.assertTrue((published / "client" / "atrinik").is_file())
+        finally:
+            os.close(lease_fd)
+
     def test_topology_runtime_set_copy_failure_preserves_all_snapshots(self) -> None:
         topology = self.root / "topology"
         runtime = topology / "runtime"


### PR DESCRIPTION
## Summary

- exclude the Classic client build tree's generated `src` directory from immutable runtime digests and copies
- preserve the authored client `src` tree and the built executable in the published runtime
- cover the source/build `src` collision with a regression test

Follow-up to #408.

## Review

- verified the current Classic client build layout: its build-tree `src` contains only generated `include/cmake.h` and `include/version.h`; runtime binaries and assets remain at the build root
- kept digest and publication exclusions aligned so generated headers cannot invalidate or overwrite an otherwise identical runtime
- updated the regression test for the current four-value publication result and asserted that client-only publication returns no state output descriptor

## Validation

- `python3 -m unittest discover` — 837 tests passed
- `python3 -m unittest tests.test_workspace.WorkspaceTests.test_runtime_generation_ignores_client_build_headers`
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `git diff --check`

Coverage was not available in the local environment (`No module named coverage`); GitHub CI remains the coverage authority for this PR.
