### PR TITLE
fix(workspace): verify source generation Git trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,17 +717,20 @@ reclaimed regardless of age unless another protection applies.
 
 Immutable source generations use the same default `builds` scope and grace
 period. Cleanup authenticates their checkout/key path, ownership marker,
-closed commit/tree/subpath metadata, complete tree digest, and exact path,
+and closed commit/tree/subpath metadata before considering removal. Build
+selection separately proves the complete tree digest and exact path,
 entry-type, executable-mode, symlink-target, and blob identity against the
-recorded Git source tree. A mismatch fails the build without deleting the
-generation. Inspect recovery with `./atrinik cleanup --scope builds
+recorded Git source tree; a mismatch fails the build without deleting the
+generation. Once ownership is unambiguous, cleanup reports content-digest
+corruption as an explicitly eligible `corrupt_source_generation`. Inspect
+recovery with `./atrinik cleanup --scope builds
 --older-than 0 --dry-run --json`; after reviewing the exact protected or
 eligible generation, use the same scoped command with `--apply`. An active
 build holds the generation's shared lock; apply takes its exclusive side and
-repeats identity, digest, and age validation before bounded removal. Generation
-staging transactions within the marker-owned container are separately
-inventoried, remain protected under an active generation lock, and are
-reclaimable after interruption and the normal grace period.
+repeats ownership, content state, and age validation before bounded removal.
+Generation staging transactions within the marker-owned container are
+separately inventoried, remain protected under an active generation lock, and
+are reclaimable after interruption and the normal grace period.
 
 Worker dependency entries under `workspace/build/worker-dependencies/` use the
 same default `builds` scope and grace period. Cleanup requires the exact parent

--- a/README.md
+++ b/README.md
@@ -717,12 +717,17 @@ reclaimed regardless of age unless another protection applies.
 
 Immutable source generations use the same default `builds` scope and grace
 period. Cleanup authenticates their checkout/key path, ownership marker,
-closed commit/tree/subpath metadata, and complete tree digest. An active build
-holds the generation's shared lock; apply takes its exclusive side and repeats
-identity, digest, and age validation before bounded removal. Generation staging
-transactions within the marker-owned container are separately inventoried,
-remain protected under an active generation lock, and are reclaimable after
-interruption and the normal grace period.
+closed commit/tree/subpath metadata, complete tree digest, and exact path,
+entry-type, executable-mode, symlink-target, and blob identity against the
+recorded Git source tree. A mismatch fails the build without deleting the
+generation. Inspect recovery with `./atrinik cleanup --scope builds
+--older-than 0 --dry-run --json`; after reviewing the exact protected or
+eligible generation, use the same scoped command with `--apply`. An active
+build holds the generation's shared lock; apply takes its exclusive side and
+repeats identity, digest, and age validation before bounded removal. Generation
+staging transactions within the marker-owned container are separately
+inventoried, remain protected under an active generation lock, and are
+reclaimable after interruption and the normal grace period.
 
 Worker dependency entries under `workspace/build/worker-dependencies/` use the
 same default `builds` scope and grace period. Cleanup requires the exact parent

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -45,6 +45,7 @@ from .workspace import (
     TEMPORARY_STATE_METADATA,
     TEMPORARY_STATE_SCHEMA_VERSION,
     _descriptor_mount_id,
+    _descriptor_path,
     _open_directory_nofollow,
     _owned_tree_tombstone_path,
     _remote_matches,
@@ -406,6 +407,73 @@ def _tree_usage(
         return {}, None, str(error)
     observed = (
         datetime.fromtimestamp(maximum, timezone.utc) if maximum is not None else None
+    )
+    return sizes, observed, None
+
+
+def _tree_usage_descriptor(
+    root_fd: int, display: Path
+) -> tuple[dict[tuple[int, int], int], datetime | None, str | None]:
+    """Measure one pinned tree without following child links."""
+
+    sizes: dict[tuple[int, int], int] = {}
+    maximum: float | None = None
+    root = os.fstat(root_fd)
+    root_mount = _descriptor_mount_id(root_fd)
+
+    def record(metadata: os.stat_result) -> None:
+        nonlocal maximum
+        sizes.setdefault(
+            (metadata.st_dev, metadata.st_ino), metadata.st_blocks * 512
+        )
+        maximum = (
+            metadata.st_mtime
+            if maximum is None
+            else max(maximum, metadata.st_mtime)
+        )
+
+    def visit(directory_fd: int, relative: PurePosixPath) -> None:
+        for name in os.listdir(directory_fd):
+            child = os.stat(
+                name,
+                dir_fd=directory_fd,
+                follow_symlinks=False,
+            )
+            record(child)
+            if stat.S_ISDIR(child.st_mode):
+                descriptor = os.open(
+                    name,
+                    os.O_RDONLY
+                    | os.O_CLOEXEC
+                    | os.O_DIRECTORY
+                    | os.O_NOFOLLOW,
+                    dir_fd=directory_fd,
+                )
+                try:
+                    opened = os.fstat(descriptor)
+                    if (
+                        (opened.st_dev, opened.st_ino)
+                        != (child.st_dev, child.st_ino)
+                        or opened.st_dev != root.st_dev
+                        or _descriptor_mount_id(descriptor) != root_mount
+                    ):
+                        raise WorkspaceError(
+                            "source generation changed during usage inventory: "
+                            f"{display / (relative / name).as_posix()}"
+                        )
+                    visit(descriptor, relative / name)
+                finally:
+                    os.close(descriptor)
+
+    try:
+        record(root)
+        visit(root_fd, PurePosixPath())
+    except (OSError, RuntimeError, WorkspaceError) as error:
+        return {}, None, str(error)
+    observed = (
+        datetime.fromtimestamp(maximum, timezone.utc)
+        if maximum is not None
+        else None
     )
     return sizes, observed, None
 
@@ -2967,7 +3035,9 @@ class Cleanup:
             path,
         )
         item["checkout"] = checkout
-        inodes, observed, walk_error = _tree_usage(path)
+        inodes: dict[tuple[int, int], int] = {}
+        observed: datetime | None = None
+        walk_error: str | None = None
         item["_inodes"] = inodes
         try:
             path_status = path.lstat()
@@ -3058,14 +3128,34 @@ class Cleanup:
         key = path.name
         item["key"] = key
         item["checkout"] = checkout
-        if walk_error:
-            item["reasons"].append("filesystem_traversal_error")
-            item["error"] = walk_error
+        parent_fd: int | None = None
+        root_fd: int | None = None
         try:
-            root_status = path.stat(follow_symlinks=False)
-            marker = path / MANAGED_MARKER
-            metadata_path = path / SOURCE_GENERATION_METADATA
-            source = path / "source"
+            flags = os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW
+            parent_fd = _open_directory_nofollow(path.parent, flags)
+            root_status = os.stat(
+                path.name,
+                dir_fd=parent_fd,
+                follow_symlinks=False,
+            )
+            root_fd = os.open(path.name, flags, dir_fd=parent_fd)
+            opened_root = os.fstat(root_fd)
+            if (
+                (opened_root.st_dev, opened_root.st_ino)
+                != (root_status.st_dev, root_status.st_ino)
+                or opened_root.st_dev != os.fstat(parent_fd).st_dev
+                or _descriptor_mount_id(root_fd)
+                != _descriptor_mount_id(parent_fd)
+            ):
+                raise WorkspaceError(
+                    "source generation root changed or is mounted"
+                )
+            stable_root = _descriptor_path(root_fd)
+            inodes, observed, walk_error = _tree_usage_descriptor(root_fd, path)
+            item["_inodes"] = inodes
+            marker = stable_root / MANAGED_MARKER
+            metadata_path = stable_root / SOURCE_GENERATION_METADATA
+            source = stable_root / "source"
             metadata = load_regular_json(
                 metadata_path, "immutable source generation metadata"
             )
@@ -3095,15 +3185,12 @@ class Cleanup:
             )
             if (
                 not re.fullmatch(r"[0-9a-f]{64}", key)
-                or not stat.S_ISDIR(root_status.st_mode)
-                or marker.is_symlink()
-                or load_json(marker)
+                or not stat.S_ISDIR(opened_root.st_mode)
+                or load_regular_json(marker, "source generation ownership marker")
                 != {
                     "schema_version": SCHEMA_VERSION,
                     "purpose": f"source-generation:{key}",
                 }
-                or metadata_path.is_symlink()
-                or not metadata_path.is_file()
                 or not isinstance(metadata, dict)
                 or set(metadata) != SOURCE_GENERATION_METADATA_KEYS
                 or metadata.get("schema_version")
@@ -3139,21 +3226,33 @@ class Cleanup:
             except (OSError, RuntimeError, WorkspaceError) as error:
                 item["reasons"].append("corrupt_source_generation")
                 item["content_error"] = str(error)
-            current_root = path.stat(follow_symlinks=False)
+            current_root = os.stat(
+                path.name,
+                dir_fd=parent_fd,
+                follow_symlinks=False,
+            )
             if (current_root.st_dev, current_root.st_ino) != (
-                root_status.st_dev,
-                root_status.st_ino,
+                opened_root.st_dev,
+                opened_root.st_ino,
             ):
                 raise WorkspaceError(
                     "source generation identity changed during validation"
                 )
             item["_identity"] = {
-                "device": root_status.st_dev,
-                "inode": root_status.st_ino,
+                "device": opened_root.st_dev,
+                "inode": opened_root.st_ino,
             }
         except (OSError, RuntimeError, WorkspaceError) as error:
             item["reasons"].append("invalid_source_generation")
             item["error"] = str(error)
+        finally:
+            if root_fd is not None:
+                os.close(root_fd)
+            if parent_fd is not None:
+                os.close(parent_fd)
+        if walk_error:
+            item["reasons"].append("filesystem_traversal_error")
+            item["error"] = walk_error
         if check_lock and re.fullmatch(r"[0-9a-f]{64}", key):
             busy, lock_error = self._lock_busy(
                 self.paths.builds / "locks" / f"source-generation-{key}.lock"

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -3120,16 +3120,24 @@ class Cleanup:
                         "source_tree_sha256",
                     )
                 )
-                or metadata.get("source_tree_sha256")
-                != _tree_digest(
+            ):
+                raise WorkspaceError("source generation metadata is invalid")
+            item["source_tree_sha256"] = metadata["source_tree_sha256"]
+            try:
+                observed_digest = _tree_digest(
                     source,
                     set(),
                     bounded_symlinks=True,
                     reject_hardlinks=True,
                 )
-            ):
-                raise WorkspaceError("source generation metadata is invalid")
-            item["source_tree_sha256"] = metadata["source_tree_sha256"]
+                item["source_tree_observed_sha256"] = observed_digest
+                if observed_digest != metadata["source_tree_sha256"]:
+                    raise WorkspaceError(
+                        "source generation content digest does not match metadata"
+                    )
+            except (OSError, RuntimeError, WorkspaceError) as error:
+                item["reasons"].append("corrupt_source_generation")
+                item["content_error"] = str(error)
         except (OSError, RuntimeError, WorkspaceError) as error:
             item["reasons"].append("invalid_source_generation")
             item["error"] = str(error)
@@ -3153,9 +3161,11 @@ class Cleanup:
             elif age < older_than_days * 86400:
                 item["reasons"].append("younger_than_grace_period")
         item["reasons"] = sorted(set(item["reasons"]))
-        if not item["reasons"]:
+        blocking_reasons = set(item["reasons"]) - {"corrupt_source_generation"}
+        if not blocking_reasons:
             item["disposition"] = "eligible"
-            item["reasons"] = ["stale_source_generation"]
+            if not item["reasons"]:
+                item["reasons"] = ["stale_source_generation"]
         return item
 
     def _worker_dependency_caches(
@@ -5378,6 +5388,9 @@ class Cleanup:
                     current["disposition"] != "eligible"
                     or current.get("source_tree_sha256")
                     != item.get("source_tree_sha256")
+                    or current.get("source_tree_observed_sha256")
+                    != item.get("source_tree_observed_sha256")
+                    or current.get("content_error") != item.get("content_error")
                 ):
                     raise WorkspaceError(
                         "source generation changed before removal"

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -49,7 +49,6 @@ from .workspace import (
     _open_directory_nofollow,
     _owned_tree_tombstone_path,
     _remote_matches,
-    _tree_digest,
     exclusive_lock,
     load_regular_json,
     remove_owned_tree,
@@ -413,13 +412,30 @@ def _tree_usage(
 
 def _tree_usage_descriptor(
     root_fd: int, display: Path
-) -> tuple[dict[tuple[int, int], int], datetime | None, str | None]:
-    """Measure one pinned tree without following child links."""
+) -> tuple[
+    dict[tuple[int, int], int],
+    datetime | None,
+    str | None,
+    str | None,
+    str | None,
+    str | None,
+]:
+    """Measure and fingerprint one pinned source generation tree."""
 
     sizes: dict[tuple[int, int], int] = {}
     maximum: float | None = None
     root = os.fstat(root_fd)
     root_mount = _descriptor_mount_id(root_fd)
+    evidence = hashlib.sha256()
+    semantic = hashlib.sha256()
+    content_errors: list[str] = []
+
+    def digest_record(digest: Any, *fields: object) -> None:
+        encoded = json.dumps(
+            fields, ensure_ascii=True, separators=(",", ":")
+        ).encode()
+        digest.update(len(encoded).to_bytes(8, "big"))
+        digest.update(encoded)
 
     def record(metadata: os.stat_result) -> None:
         nonlocal maximum
@@ -433,13 +449,25 @@ def _tree_usage_descriptor(
         )
 
     def visit(directory_fd: int, relative: PurePosixPath) -> None:
-        for name in os.listdir(directory_fd):
+        for name in sorted(os.listdir(directory_fd)):
             child = os.stat(
                 name,
                 dir_fd=directory_fd,
                 follow_symlinks=False,
             )
             record(child)
+            child_relative = relative / name
+            child_display = display / child_relative.as_posix()
+            evidence_fields = (
+                child_relative.as_posix(),
+                child.st_dev,
+                child.st_ino,
+                child.st_mode,
+                child.st_nlink,
+                child.st_size,
+                child.st_mtime_ns,
+                child.st_ctime_ns,
+            )
             if stat.S_ISDIR(child.st_mode):
                 descriptor = os.open(
                     name,
@@ -459,23 +487,134 @@ def _tree_usage_descriptor(
                     ):
                         raise WorkspaceError(
                             "source generation changed during usage inventory: "
-                            f"{display / (relative / name).as_posix()}"
+                            f"{child_display}"
                         )
-                    visit(descriptor, relative / name)
+                    digest_record(evidence, "directory", *evidence_fields)
+                    digest_record(
+                        semantic,
+                        "directory",
+                        child_relative.as_posix(),
+                        stat.S_IMODE(opened.st_mode),
+                    )
+                    visit(descriptor, child_relative)
                 finally:
                     os.close(descriptor)
+            elif stat.S_ISREG(child.st_mode):
+                descriptor = os.open(
+                    name,
+                    os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW,
+                    dir_fd=directory_fd,
+                )
+                try:
+                    opened = os.fstat(descriptor)
+                    if (
+                        (opened.st_dev, opened.st_ino)
+                        != (child.st_dev, child.st_ino)
+                        or opened.st_dev != root.st_dev
+                        or _descriptor_mount_id(descriptor) != root_mount
+                    ):
+                        raise WorkspaceError(
+                            "source generation changed during usage inventory: "
+                            f"{child_display}"
+                        )
+                    digest = hashlib.sha256()
+                    while chunk := os.read(descriptor, 1024 * 1024):
+                        digest.update(chunk)
+                    after = os.fstat(descriptor)
+                    if (
+                        (after.st_dev, after.st_ino, after.st_mode, after.st_nlink,
+                         after.st_size, after.st_mtime_ns, after.st_ctime_ns)
+                        != (opened.st_dev, opened.st_ino, opened.st_mode,
+                            opened.st_nlink, opened.st_size, opened.st_mtime_ns,
+                            opened.st_ctime_ns)
+                    ):
+                        raise WorkspaceError(
+                            "source generation changed during usage inventory: "
+                            f"{child_display}"
+                        )
+                    file_digest = digest.hexdigest()
+                    digest_record(evidence, "file", *evidence_fields, file_digest)
+                    digest_record(
+                        semantic,
+                        "file",
+                        child_relative.as_posix(),
+                        stat.S_IMODE(opened.st_mode),
+                        opened.st_size,
+                        file_digest,
+                    )
+                    if opened.st_nlink != 1:
+                        content_errors.append(
+                            "generated source contains a hard-linked file: "
+                            f"{child_display}"
+                        )
+                finally:
+                    os.close(descriptor)
+            elif stat.S_ISLNK(child.st_mode):
+                target = os.readlink(name, dir_fd=directory_fd)
+                after = os.stat(
+                    name, dir_fd=directory_fd, follow_symlinks=False
+                )
+                if (after.st_dev, after.st_ino, after.st_mode, after.st_ctime_ns) != (
+                    child.st_dev,
+                    child.st_ino,
+                    child.st_mode,
+                    child.st_ctime_ns,
+                ):
+                    raise WorkspaceError(
+                        "source generation changed during usage inventory: "
+                        f"{child_display}"
+                    )
+                digest_record(evidence, "symlink", *evidence_fields, target)
+                digest_record(
+                    semantic,
+                    "symlink",
+                    child_relative.as_posix(),
+                    stat.S_IMODE(child.st_mode),
+                    target,
+                )
+                target_path = PurePosixPath(target)
+                normalized = child_relative.parent.joinpath(target_path)
+                if target_path.is_absolute() or ".." in normalized.parts:
+                    content_errors.append(
+                        f"source generation contains an unsafe link: {child_display}"
+                    )
+            else:
+                digest_record(evidence, "unsupported", *evidence_fields)
+                content_errors.append(
+                    "source generation contains an unsupported entry: "
+                    f"{child_display}"
+                )
 
     try:
         record(root)
+        digest_record(
+            evidence,
+            "root",
+            root.st_dev,
+            root.st_ino,
+            root.st_mode,
+            root.st_nlink,
+            root.st_size,
+            root.st_mtime_ns,
+            root.st_ctime_ns,
+        )
+        digest_record(semantic, "root", stat.S_IMODE(root.st_mode))
         visit(root_fd, PurePosixPath())
     except (OSError, RuntimeError, WorkspaceError) as error:
-        return {}, None, str(error)
+        return {}, None, str(error), None, None, None
     observed = (
         datetime.fromtimestamp(maximum, timezone.utc)
         if maximum is not None
         else None
     )
-    return sizes, observed, None
+    return (
+        sizes,
+        observed,
+        None,
+        evidence.hexdigest(),
+        semantic.hexdigest(),
+        content_errors[0] if content_errors else None,
+    )
 
 
 def _temporary_tree_usage(
@@ -3035,9 +3174,7 @@ class Cleanup:
             path,
         )
         item["checkout"] = checkout
-        inodes: dict[tuple[int, int], int] = {}
-        observed: datetime | None = None
-        walk_error: str | None = None
+        inodes, observed, walk_error = _tree_usage(path)
         item["_inodes"] = inodes
         try:
             path_status = path.lstat()
@@ -3123,13 +3260,16 @@ class Cleanup:
             else "atrinik/atrinik"
         )
         item = _base_item("source-generation", checkout, repository, path)
-        inodes, observed, walk_error = _tree_usage(path)
+        inodes: dict[tuple[int, int], int] = {}
+        observed: datetime | None = None
+        walk_error: str | None = None
         item["_inodes"] = inodes
         key = path.name
         item["key"] = key
         item["checkout"] = checkout
         parent_fd: int | None = None
         root_fd: int | None = None
+        source_fd: int | None = None
         try:
             flags = os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW
             parent_fd = _open_directory_nofollow(path.parent, flags)
@@ -3151,13 +3291,31 @@ class Cleanup:
                     "source generation root changed or is mounted"
                 )
             stable_root = _descriptor_path(root_fd)
-            inodes, observed, walk_error = _tree_usage_descriptor(root_fd, path)
+            (
+                inodes,
+                observed,
+                walk_error,
+                generation_evidence,
+                _generation_digest,
+                generation_content_error,
+            ) = _tree_usage_descriptor(root_fd, path)
             item["_inodes"] = inodes
+            if walk_error or generation_evidence is None:
+                raise WorkspaceError(
+                    walk_error or "source generation evidence is unavailable"
+                )
             marker = stable_root / MANAGED_MARKER
             metadata_path = stable_root / SOURCE_GENERATION_METADATA
-            source = stable_root / "source"
             metadata = load_regular_json(
                 metadata_path, "immutable source generation metadata"
+            )
+            marker_status = os.stat(
+                MANAGED_MARKER, dir_fd=root_fd, follow_symlinks=False
+            )
+            metadata_status = os.stat(
+                SOURCE_GENERATION_METADATA,
+                dir_fd=root_fd,
+                follow_symlinks=False,
             )
             identity = (
                 {
@@ -3186,6 +3344,12 @@ class Cleanup:
             if (
                 not re.fullmatch(r"[0-9a-f]{64}", key)
                 or not stat.S_ISDIR(opened_root.st_mode)
+                or not stat.S_ISREG(marker_status.st_mode)
+                or marker_status.st_nlink != 1
+                or marker_status.st_dev != opened_root.st_dev
+                or not stat.S_ISREG(metadata_status.st_mode)
+                or metadata_status.st_nlink != 1
+                or metadata_status.st_dev != opened_root.st_dev
                 or load_regular_json(marker, "source generation ownership marker")
                 != {
                     "schema_version": SCHEMA_VERSION,
@@ -3212,13 +3376,38 @@ class Cleanup:
                 raise WorkspaceError("source generation metadata is invalid")
             item["source_tree_sha256"] = metadata["source_tree_sha256"]
             try:
-                observed_digest = _tree_digest(
-                    source,
-                    set(),
-                    bounded_symlinks=True,
-                    reject_hardlinks=True,
+                source_status = os.stat(
+                    "source", dir_fd=root_fd, follow_symlinks=False
                 )
+                source_fd = os.open("source", flags, dir_fd=root_fd)
+                opened_source = os.fstat(source_fd)
+                if (
+                    (opened_source.st_dev, opened_source.st_ino)
+                    != (source_status.st_dev, source_status.st_ino)
+                    or opened_source.st_dev != opened_root.st_dev
+                    or _descriptor_mount_id(source_fd)
+                    != _descriptor_mount_id(root_fd)
+                ):
+                    raise WorkspaceError(
+                        "source generation content root changed or is mounted"
+                    )
+                (
+                    _source_inodes,
+                    _source_observed,
+                    source_walk_error,
+                    _source_evidence,
+                    observed_digest,
+                    source_content_error,
+                ) = _tree_usage_descriptor(source_fd, path / "source")
+                if source_walk_error or observed_digest is None:
+                    raise WorkspaceError(
+                        source_walk_error
+                        or "source generation content evidence is unavailable"
+                    )
                 item["source_tree_observed_sha256"] = observed_digest
+                content_error = source_content_error or generation_content_error
+                if content_error:
+                    raise WorkspaceError(content_error)
                 if observed_digest != metadata["source_tree_sha256"]:
                     raise WorkspaceError(
                         "source generation content digest does not match metadata"
@@ -3226,14 +3415,45 @@ class Cleanup:
             except (OSError, RuntimeError, WorkspaceError) as error:
                 item["reasons"].append("corrupt_source_generation")
                 item["content_error"] = str(error)
+            (
+                _final_inodes,
+                _final_observed,
+                final_walk_error,
+                final_evidence,
+                _final_digest,
+                _final_content_error,
+            ) = _tree_usage_descriptor(root_fd, path)
+            if (
+                final_walk_error
+                or final_evidence is None
+                or final_evidence != generation_evidence
+            ):
+                raise WorkspaceError(
+                    final_walk_error
+                    or "source generation changed during validation"
+                )
+            item["generation_evidence_sha256"] = final_evidence
             current_root = os.stat(
                 path.name,
                 dir_fd=parent_fd,
                 follow_symlinks=False,
             )
-            if (current_root.st_dev, current_root.st_ino) != (
+            if (
+                current_root.st_dev,
+                current_root.st_ino,
+                current_root.st_mode,
+                current_root.st_nlink,
+                current_root.st_size,
+                current_root.st_mtime_ns,
+                current_root.st_ctime_ns,
+            ) != (
                 opened_root.st_dev,
                 opened_root.st_ino,
+                opened_root.st_mode,
+                opened_root.st_nlink,
+                opened_root.st_size,
+                opened_root.st_mtime_ns,
+                opened_root.st_ctime_ns,
             ):
                 raise WorkspaceError(
                     "source generation identity changed during validation"
@@ -3246,6 +3466,8 @@ class Cleanup:
             item["reasons"].append("invalid_source_generation")
             item["error"] = str(error)
         finally:
+            if source_fd is not None:
+                os.close(source_fd)
             if root_fd is not None:
                 os.close(root_fd)
             if parent_fd is not None:
@@ -5503,6 +5725,8 @@ class Cleanup:
                     or current.get("source_tree_observed_sha256")
                     != item.get("source_tree_observed_sha256")
                     or current.get("content_error") != item.get("content_error")
+                    or current.get("generation_evidence_sha256")
+                    != item.get("generation_evidence_sha256")
                     or current.get("_identity") != item.get("_identity")
                 ):
                     raise WorkspaceError(

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -469,14 +469,33 @@ def _tree_usage_descriptor(
                 child.st_ctime_ns,
             )
             if stat.S_ISDIR(child.st_mode):
-                descriptor = os.open(
-                    name,
-                    os.O_RDONLY
-                    | os.O_CLOEXEC
-                    | os.O_DIRECTORY
-                    | os.O_NOFOLLOW,
-                    dir_fd=directory_fd,
-                )
+                try:
+                    descriptor = os.open(
+                        name,
+                        os.O_RDONLY
+                        | os.O_CLOEXEC
+                        | os.O_DIRECTORY
+                        | os.O_NOFOLLOW,
+                        dir_fd=directory_fd,
+                    )
+                except OSError as error:
+                    digest_record(
+                        evidence,
+                        "unreadable-directory",
+                        *evidence_fields,
+                        error.errno,
+                    )
+                    digest_record(
+                        semantic,
+                        "directory",
+                        child_relative.as_posix(),
+                        stat.S_IMODE(child.st_mode),
+                    )
+                    content_errors.append(
+                        "cannot read generated source directory: "
+                        f"{child_display}: {error}"
+                    )
+                    continue
                 try:
                     opened = os.fstat(descriptor)
                     if (

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -1266,6 +1266,7 @@ class Cleanup:
             self._strip_internal(item)
             if kind in {
                 "worker-dependency-transaction",
+                "source-generation",
                 "source-generation-transaction",
                 "sound-cache",
                 "temporary-state",
@@ -3061,6 +3062,7 @@ class Cleanup:
             item["reasons"].append("filesystem_traversal_error")
             item["error"] = walk_error
         try:
+            root_status = path.stat(follow_symlinks=False)
             marker = path / MANAGED_MARKER
             metadata_path = path / SOURCE_GENERATION_METADATA
             source = path / "source"
@@ -3093,8 +3095,7 @@ class Cleanup:
             )
             if (
                 not re.fullmatch(r"[0-9a-f]{64}", key)
-                or path.is_symlink()
-                or not path.is_dir()
+                or not stat.S_ISDIR(root_status.st_mode)
                 or marker.is_symlink()
                 or load_json(marker)
                 != {
@@ -3138,6 +3139,18 @@ class Cleanup:
             except (OSError, RuntimeError, WorkspaceError) as error:
                 item["reasons"].append("corrupt_source_generation")
                 item["content_error"] = str(error)
+            current_root = path.stat(follow_symlinks=False)
+            if (current_root.st_dev, current_root.st_ino) != (
+                root_status.st_dev,
+                root_status.st_ino,
+            ):
+                raise WorkspaceError(
+                    "source generation identity changed during validation"
+                )
+            item["_identity"] = {
+                "device": root_status.st_dev,
+                "inode": root_status.st_ino,
+            }
         except (OSError, RuntimeError, WorkspaceError) as error:
             item["reasons"].append("invalid_source_generation")
             item["error"] = str(error)
@@ -5391,11 +5404,15 @@ class Cleanup:
                     or current.get("source_tree_observed_sha256")
                     != item.get("source_tree_observed_sha256")
                     or current.get("content_error") != item.get("content_error")
+                    or current.get("_identity") != item.get("_identity")
                 ):
                     raise WorkspaceError(
                         "source generation changed before removal"
                     )
-                remove_owned_tree(path)
+                remove_owned_tree(
+                    path,
+                    expected_identity=current["_identity"],
+                )
         elif item["kind"] == "source-generation-transaction":
             key = item["key"]
             lock = self.paths.builds / "locks" / f"source-generation-{key}.lock"

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -500,11 +500,24 @@ def _tree_usage_descriptor(
                 finally:
                     os.close(descriptor)
             elif stat.S_ISREG(child.st_mode):
-                descriptor = os.open(
-                    name,
-                    os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW,
-                    dir_fd=directory_fd,
-                )
+                try:
+                    descriptor = os.open(
+                        name,
+                        os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW,
+                        dir_fd=directory_fd,
+                    )
+                except OSError as error:
+                    digest_record(
+                        evidence,
+                        "unreadable-file",
+                        *evidence_fields,
+                        error.errno,
+                    )
+                    content_errors.append(
+                        "cannot read generated source file: "
+                        f"{child_display}: {error}"
+                    )
+                    continue
                 try:
                     opened = os.fstat(descriptor)
                     if (
@@ -573,8 +586,19 @@ def _tree_usage_descriptor(
                     target,
                 )
                 target_path = PurePosixPath(target)
-                normalized = child_relative.parent.joinpath(target_path)
-                if target_path.is_absolute() or ".." in normalized.parts:
+                bounded = not target_path.is_absolute()
+                normalized_parts = list(child_relative.parent.parts)
+                for part in target_path.parts:
+                    if part in {"", "."}:
+                        continue
+                    if part == "..":
+                        if not normalized_parts:
+                            bounded = False
+                            break
+                        normalized_parts.pop()
+                    else:
+                        normalized_parts.append(part)
+                if not bounded:
                     content_errors.append(
                         f"source generation contains an unsafe link: {child_display}"
                     )

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -2443,6 +2443,18 @@ class Workspace:
                     f"{source}"
                 )
             visit(root_fd, b"")
+            if set(actual) != set(expected) or any(
+                actual[path][:2] != expected[path][:2]
+                or (
+                    actual[path][1] != b"tree"
+                    and actual[path][2] != expected[path][2]
+                )
+                for path in actual.keys() & expected.keys()
+            ):
+                raise WorkspaceError(
+                    "immutable source generation does not match its recorded "
+                    f"Git tree: {source}"
+                )
             visible_after = os.stat(
                 source.name,
                 dir_fd=parent_fd,
@@ -2487,15 +2499,6 @@ class Workspace:
                 os.close(root_fd)
             if parent_fd is not None:
                 os.close(parent_fd)
-        if set(actual) != set(expected) or any(
-            actual[path][:2] != expected[path][:2]
-            or (actual[path][1] != b"tree" and actual[path][2] != expected[path][2])
-            for path in actual.keys() & expected.keys()
-        ):
-            raise WorkspaceError(
-                "immutable source generation does not match its recorded Git tree: "
-                f"{source}"
-            )
 
     def _materialize_primary_source(
         self,

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -2252,6 +2252,10 @@ class Workspace:
 
         algorithm = hashlib.sha1 if len(source_tree) == 40 else hashlib.sha256
         actual: dict[bytes, tuple[bytes, bytes, bytes]] = {}
+        retained_descriptors: list[tuple[int, os.stat_result, Path]] = []
+        retained_symlinks: list[
+            tuple[int, str, os.stat_result, str, Path]
+        ] = []
 
         def blob_id(payload: bytes) -> bytes:
             digest = algorithm()
@@ -2320,6 +2324,8 @@ class Workspace:
                                 "immutable source generation changed while "
                                 f"reading: {display}"
                             )
+                        retained_descriptors.append((descriptor, opened, display))
+                        descriptor = None
                     elif stat.S_ISREG(status.st_mode):
                         if status.st_nlink != 1:
                             raise WorkspaceError(
@@ -2359,6 +2365,8 @@ class Workspace:
                             )
                         mode = b"100755" if opened.st_mode & 0o111 else b"100644"
                         value = (mode, b"blob", digest.hexdigest().encode())
+                        retained_descriptors.append((descriptor, opened, display))
+                        descriptor = None
                     elif stat.S_ISLNK(status.st_mode):
                         target = os.fsencode(
                             os.readlink(entry_name, dir_fd=directory_fd)
@@ -2373,6 +2381,15 @@ class Workspace:
                                 "immutable source generation changed while "
                                 f"reading: {display}"
                             )
+                        retained_symlinks.append(
+                            (
+                                directory_fd,
+                                entry_name,
+                                status,
+                                os.fsdecode(target),
+                                display,
+                            )
+                        )
                         value = (b"120000", b"blob", blob_id(target))
                     else:
                         raise WorkspaceError(
@@ -2401,21 +2418,36 @@ class Workspace:
                     f"{source / os.fsdecode(prefix)}"
                 )
 
+        parent_fd: int | None = None
         root_fd: int | None = None
         try:
-            visible_root = source.stat(follow_symlinks=False)
-            root_fd = _open_directory_nofollow(
-                source,
-                os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
+            flags = os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW
+            parent_fd = _open_directory_nofollow(source.parent, flags)
+            parent_status = os.fstat(parent_fd)
+            parent_mount = _descriptor_mount_id(parent_fd)
+            visible_root = os.stat(
+                source.name,
+                dir_fd=parent_fd,
+                follow_symlinks=False,
             )
+            root_fd = os.open(source.name, flags, dir_fd=parent_fd)
             root_status = os.fstat(root_fd)
             root_mount = _descriptor_mount_id(root_fd)
-            if changed(visible_root, root_status):
+            if (
+                changed(visible_root, root_status)
+                or root_status.st_dev != parent_status.st_dev
+                or root_mount != parent_mount
+            ):
                 raise WorkspaceError(
-                    f"immutable source generation changed while reading: {source}"
+                    "immutable source generation root changed or is mounted: "
+                    f"{source}"
                 )
             visit(root_fd, b"")
-            visible_after = source.stat(follow_symlinks=False)
+            visible_after = os.stat(
+                source.name,
+                dir_fd=parent_fd,
+                follow_symlinks=False,
+            )
             if (
                 changed(root_status, os.fstat(root_fd))
                 or changed(root_status, visible_after)
@@ -2423,6 +2455,25 @@ class Workspace:
                 raise WorkspaceError(
                     f"immutable source generation changed while reading: {source}"
                 )
+            for descriptor, opened, display in retained_descriptors:
+                if changed(opened, os.fstat(descriptor)):
+                    raise WorkspaceError(
+                        "immutable source generation changed while reading: "
+                        f"{display}"
+                    )
+            for directory_fd, name, before, target, display in retained_symlinks:
+                after = os.stat(
+                    name,
+                    dir_fd=directory_fd,
+                    follow_symlinks=False,
+                )
+                if changed(before, after) or os.readlink(
+                    name, dir_fd=directory_fd
+                ) != target:
+                    raise WorkspaceError(
+                        "immutable source generation changed while reading: "
+                        f"{display}"
+                    )
         except WorkspaceError:
             raise
         except OSError as error:
@@ -2430,8 +2481,12 @@ class Workspace:
                 f"cannot inspect immutable source generation {source}: {error}"
             ) from error
         finally:
+            for descriptor, _opened, _display in reversed(retained_descriptors):
+                os.close(descriptor)
             if root_fd is not None:
                 os.close(root_fd)
+            if parent_fd is not None:
+                os.close(parent_fd)
         if set(actual) != set(expected) or any(
             actual[path][:2] != expected[path][:2]
             or (actual[path][1] != b"tree" and actual[path][2] != expected[path][2])

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -2201,6 +2201,7 @@ class Workspace:
             result = subprocess.run(
                 [
                     "git",
+                    "--no-replace-objects",
                     "-C",
                     str(checkout),
                     "ls-tree",
@@ -2258,66 +2259,135 @@ class Workspace:
             digest.update(payload)
             return digest.hexdigest().encode()
 
-        def file_blob_id(path: Path, size: int) -> bytes:
-            descriptor: int | None = None
-            try:
-                descriptor = open_regular_file(
-                    path, os.O_RDONLY, "immutable source generation file"
-                )
-                digest = algorithm()
-                digest.update(f"blob {size}\0".encode())
-                observed = 0
-                with os.fdopen(descriptor, "rb") as stream:
-                    descriptor = None
-                    while chunk := stream.read(1024 * 1024):
-                        observed += len(chunk)
-                        digest.update(chunk)
-                if observed != size:
-                    raise WorkspaceError(
-                        f"immutable source generation file changed while reading: {path}"
-                    )
-                return digest.hexdigest().encode()
-            finally:
-                if descriptor is not None:
-                    os.close(descriptor)
+        def stable_identity(value: os.stat_result) -> tuple[int, ...]:
+            return (
+                value.st_dev,
+                value.st_ino,
+                value.st_mode,
+                value.st_nlink,
+                value.st_size,
+                value.st_mtime_ns,
+                value.st_ctime_ns,
+            )
 
-        def visit(directory: Path, prefix: bytes) -> None:
+        def changed(
+            before: os.stat_result, after: os.stat_result
+        ) -> bool:
+            return stable_identity(before) != stable_identity(after)
+
+        def visit(directory_fd: int, prefix: bytes) -> None:
+            directory_before = os.fstat(directory_fd)
             try:
-                entries = list(directory.iterdir())
+                entries = sorted(os.listdir(directory_fd))
             except OSError as error:
                 raise WorkspaceError(
-                    f"cannot inspect immutable source generation {directory}: {error}"
+                    f"cannot inspect immutable source generation {source}: {error}"
                 ) from error
-            for path in entries:
-                name = os.fsencode(path.name)
+            for entry_name in entries:
+                name = os.fsencode(entry_name)
                 relative = prefix + (b"/" if prefix else b"") + name
+                display = source / os.fsdecode(relative)
+                descriptor: int | None = None
                 try:
-                    status = path.lstat()
+                    status = os.stat(
+                        entry_name,
+                        dir_fd=directory_fd,
+                        follow_symlinks=False,
+                    )
                     if stat.S_ISDIR(status.st_mode):
+                        descriptor = os.open(
+                            entry_name,
+                            os.O_RDONLY
+                            | os.O_CLOEXEC
+                            | os.O_DIRECTORY
+                            | os.O_NOFOLLOW,
+                            dir_fd=directory_fd,
+                        )
+                        opened = os.fstat(descriptor)
+                        if (
+                            changed(status, opened)
+                            or opened.st_dev != root_status.st_dev
+                            or _descriptor_mount_id(descriptor) != root_mount
+                        ):
+                            raise WorkspaceError(
+                                "immutable source generation changed while "
+                                f"reading: {display}"
+                            )
                         value = (b"040000", b"tree", b"")
-                        visit(path, relative)
+                        visit(descriptor, relative)
+                        if changed(opened, os.fstat(descriptor)):
+                            raise WorkspaceError(
+                                "immutable source generation changed while "
+                                f"reading: {display}"
+                            )
                     elif stat.S_ISREG(status.st_mode):
                         if status.st_nlink != 1:
                             raise WorkspaceError(
                                 "generated source contains a hard-linked file: "
-                                f"{path}"
+                                f"{display}"
                             )
-                        mode = b"100755" if status.st_mode & 0o111 else b"100644"
-                        value = (mode, b"blob", file_blob_id(path, status.st_size))
+                        descriptor = os.open(
+                            entry_name,
+                            os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW,
+                            dir_fd=directory_fd,
+                        )
+                        opened = os.fstat(descriptor)
+                        if (
+                            changed(status, opened)
+                            or not stat.S_ISREG(opened.st_mode)
+                            or opened.st_nlink != 1
+                            or opened.st_dev != root_status.st_dev
+                            or _descriptor_mount_id(descriptor) != root_mount
+                        ):
+                            raise WorkspaceError(
+                                "immutable source generation changed while "
+                                f"reading: {display}"
+                            )
+                        digest = algorithm()
+                        digest.update(f"blob {opened.st_size}\0".encode())
+                        observed = 0
+                        while chunk := os.read(descriptor, 1024 * 1024):
+                            observed += len(chunk)
+                            digest.update(chunk)
+                        if (
+                            observed != opened.st_size
+                            or changed(opened, os.fstat(descriptor))
+                        ):
+                            raise WorkspaceError(
+                                "immutable source generation changed while "
+                                f"reading: {display}"
+                            )
+                        mode = b"100755" if opened.st_mode & 0o111 else b"100644"
+                        value = (mode, b"blob", digest.hexdigest().encode())
                     elif stat.S_ISLNK(status.st_mode):
-                        target = os.fsencode(os.readlink(path))
+                        target = os.fsencode(
+                            os.readlink(entry_name, dir_fd=directory_fd)
+                        )
+                        after = os.stat(
+                            entry_name,
+                            dir_fd=directory_fd,
+                            follow_symlinks=False,
+                        )
+                        if changed(status, after):
+                            raise WorkspaceError(
+                                "immutable source generation changed while "
+                                f"reading: {display}"
+                            )
                         value = (b"120000", b"blob", blob_id(target))
                     else:
                         raise WorkspaceError(
                             "immutable source generation contains an unsupported "
-                            f"entry: {path}"
+                            f"entry: {display}"
                         )
                 except WorkspaceError:
                     raise
                 except OSError as error:
                     raise WorkspaceError(
-                        f"cannot inspect immutable source generation {path}: {error}"
+                        f"cannot inspect immutable source generation {display}: {error}"
                     ) from error
+                finally:
+                    if descriptor is not None:
+                        os.close(descriptor)
                 if relative in actual:
                     raise WorkspaceError(
                         "immutable source generation repeats a path: "
@@ -2325,11 +2395,43 @@ class Workspace:
                     )
                 actual[relative] = value
 
-        if source.is_symlink() or not source.is_dir():
-            raise WorkspaceError(
-                f"immutable source generation is not a regular directory: {source}"
+            if changed(directory_before, os.fstat(directory_fd)):
+                raise WorkspaceError(
+                    "immutable source generation changed while reading: "
+                    f"{source / os.fsdecode(prefix)}"
+                )
+
+        root_fd: int | None = None
+        try:
+            visible_root = source.stat(follow_symlinks=False)
+            root_fd = _open_directory_nofollow(
+                source,
+                os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
             )
-        visit(source, b"")
+            root_status = os.fstat(root_fd)
+            root_mount = _descriptor_mount_id(root_fd)
+            if changed(visible_root, root_status):
+                raise WorkspaceError(
+                    f"immutable source generation changed while reading: {source}"
+                )
+            visit(root_fd, b"")
+            visible_after = source.stat(follow_symlinks=False)
+            if (
+                changed(root_status, os.fstat(root_fd))
+                or changed(root_status, visible_after)
+            ):
+                raise WorkspaceError(
+                    f"immutable source generation changed while reading: {source}"
+                )
+        except WorkspaceError:
+            raise
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot inspect immutable source generation {source}: {error}"
+            ) from error
+        finally:
+            if root_fd is not None:
+                os.close(root_fd)
         if set(actual) != set(expected) or any(
             actual[path][:2] != expected[path][:2]
             or (actual[path][1] != b"tree" and actual[path][2] != expected[path][2])
@@ -2374,6 +2476,7 @@ class Workspace:
         commit = state["head"]
         tree = git(
             checkout,
+            "--no-replace-objects",
             "rev-parse",
             f"{commit}^{{tree}}",
             capture=True,
@@ -2381,6 +2484,7 @@ class Workspace:
         )
         source_tree = git(
             checkout,
+            "--no-replace-objects",
             "rev-parse",
             (
                 f"{commit}^{{tree}}"
@@ -2506,21 +2610,17 @@ class Workspace:
                         "purpose": f"source-generation:{key}",
                     },
                 )
-                archive_ref = (
-                    commit
-                    if component.source == "."
-                    else f"{commit}:{component.source}"
-                )
                 try:
                     subprocess.run(
                         [
                             "git",
+                            "--no-replace-objects",
                             "-C",
                             str(checkout),
                             "archive",
                             "--format=tar",
                             f"--output={archive_path}",
-                            archive_ref,
+                            source_tree,
                         ],
                         check=True,
                         stderr=subprocess.PIPE,
@@ -2561,6 +2661,7 @@ class Workspace:
                     != commit
                     or git(
                         checkout,
+                        "--no-replace-objects",
                         "rev-parse",
                         f"{commit}^{{tree}}",
                         capture=True,
@@ -2571,6 +2672,11 @@ class Workspace:
                     raise WorkspaceError(
                         f"clean primary source changed during materialization: {checkout}"
                     )
+                self._validate_source_generation_git_tree(
+                    checkout,
+                    staging / "source",
+                    source_tree,
+                )
                 self._seal_runtime_generation(staging / "source")
                 record = {
                     **identity,

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -2191,6 +2191,155 @@ class Workspace:
                 f"cannot extract immutable Git source archive: {error}"
             ) from error
 
+    @staticmethod
+    def _validate_source_generation_git_tree(
+        checkout: Path, source: Path, source_tree: str
+    ) -> None:
+        """Prove a materialized source has the recorded Git tree identity."""
+
+        try:
+            result = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(checkout),
+                    "ls-tree",
+                    "-r",
+                    "-t",
+                    "--full-tree",
+                    "-z",
+                    source_tree,
+                ],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                pass_fds=active_lock_fds(),
+            )
+        except FileNotFoundError as error:
+            raise WorkspaceError("required command not found: git") from error
+        except subprocess.CalledProcessError as error:
+            detail = error.stderr.decode("utf-8", errors="replace").strip()
+            suffix = f": {detail}" if detail else ""
+            raise WorkspaceError(
+                "cannot inspect recorded immutable Git source tree" + suffix
+            ) from error
+
+        expected: dict[bytes, tuple[bytes, bytes, bytes]] = {}
+        for entry in result.stdout.split(b"\0"):
+            if not entry:
+                continue
+            try:
+                metadata, relative = entry.split(b"\t", 1)
+                mode, kind, object_id = metadata.split(b" ", 2)
+            except ValueError as error:
+                raise WorkspaceError(
+                    "recorded immutable Git source tree listing is invalid"
+                ) from error
+            if (
+                not relative
+                or relative in expected
+                or kind not in {b"blob", b"tree", b"commit"}
+                or mode
+                not in {b"040000", b"100644", b"100755", b"120000", b"160000"}
+                or len(object_id) not in {40, 64}
+                or not re.fullmatch(b"[0-9a-f]+", object_id)
+            ):
+                raise WorkspaceError(
+                    "recorded immutable Git source tree listing is invalid"
+                )
+            expected[relative] = (mode, kind, object_id)
+
+        algorithm = hashlib.sha1 if len(source_tree) == 40 else hashlib.sha256
+        actual: dict[bytes, tuple[bytes, bytes, bytes]] = {}
+
+        def blob_id(payload: bytes) -> bytes:
+            digest = algorithm()
+            digest.update(f"blob {len(payload)}\0".encode())
+            digest.update(payload)
+            return digest.hexdigest().encode()
+
+        def file_blob_id(path: Path, size: int) -> bytes:
+            descriptor: int | None = None
+            try:
+                descriptor = open_regular_file(
+                    path, os.O_RDONLY, "immutable source generation file"
+                )
+                digest = algorithm()
+                digest.update(f"blob {size}\0".encode())
+                observed = 0
+                with os.fdopen(descriptor, "rb") as stream:
+                    descriptor = None
+                    while chunk := stream.read(1024 * 1024):
+                        observed += len(chunk)
+                        digest.update(chunk)
+                if observed != size:
+                    raise WorkspaceError(
+                        f"immutable source generation file changed while reading: {path}"
+                    )
+                return digest.hexdigest().encode()
+            finally:
+                if descriptor is not None:
+                    os.close(descriptor)
+
+        def visit(directory: Path, prefix: bytes) -> None:
+            try:
+                entries = list(directory.iterdir())
+            except OSError as error:
+                raise WorkspaceError(
+                    f"cannot inspect immutable source generation {directory}: {error}"
+                ) from error
+            for path in entries:
+                name = os.fsencode(path.name)
+                relative = prefix + (b"/" if prefix else b"") + name
+                try:
+                    status = path.lstat()
+                    if stat.S_ISDIR(status.st_mode):
+                        value = (b"040000", b"tree", b"")
+                        visit(path, relative)
+                    elif stat.S_ISREG(status.st_mode):
+                        if status.st_nlink != 1:
+                            raise WorkspaceError(
+                                "generated source contains a hard-linked file: "
+                                f"{path}"
+                            )
+                        mode = b"100755" if status.st_mode & 0o111 else b"100644"
+                        value = (mode, b"blob", file_blob_id(path, status.st_size))
+                    elif stat.S_ISLNK(status.st_mode):
+                        target = os.fsencode(os.readlink(path))
+                        value = (b"120000", b"blob", blob_id(target))
+                    else:
+                        raise WorkspaceError(
+                            "immutable source generation contains an unsupported "
+                            f"entry: {path}"
+                        )
+                except WorkspaceError:
+                    raise
+                except OSError as error:
+                    raise WorkspaceError(
+                        f"cannot inspect immutable source generation {path}: {error}"
+                    ) from error
+                if relative in actual:
+                    raise WorkspaceError(
+                        "immutable source generation repeats a path: "
+                        f"{os.fsdecode(relative)}"
+                    )
+                actual[relative] = value
+
+        if source.is_symlink() or not source.is_dir():
+            raise WorkspaceError(
+                f"immutable source generation is not a regular directory: {source}"
+            )
+        visit(source, b"")
+        if set(actual) != set(expected) or any(
+            actual[path][:2] != expected[path][:2]
+            or (actual[path][1] != b"tree" and actual[path][2] != expected[path][2])
+            for path in actual.keys() & expected.keys()
+        ):
+            raise WorkspaceError(
+                "immutable source generation does not match its recorded Git tree: "
+                f"{source}"
+            )
+
     def _materialize_primary_source(
         self,
         component: Component,
@@ -2338,6 +2487,11 @@ class Workspace:
                     raise WorkspaceError(
                         f"clean primary source changed before generation reuse: {checkout}"
                     )
+                self._validate_source_generation_git_tree(
+                    checkout,
+                    generation / "source",
+                    source_tree,
+                )
                 return generation / "source"
 
             staging = Path(
@@ -2617,6 +2771,12 @@ class Workspace:
                                 "immutable source generation changed before lease handoff: "
                                 f"{path}"
                             )
+                        checkout = states[expected_record["checkout"]]["path"]
+                        self._validate_source_generation_git_tree(
+                            checkout,
+                            path,
+                            expected_record["source_tree"],
+                        )
                     retained = []
                     for coordinate, context in reversed(source_contexts):
                         if coordinate in released:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -2252,10 +2252,6 @@ class Workspace:
 
         algorithm = hashlib.sha1 if len(source_tree) == 40 else hashlib.sha256
         actual: dict[bytes, tuple[bytes, bytes, bytes]] = {}
-        retained_descriptors: list[tuple[int, os.stat_result, Path]] = []
-        retained_symlinks: list[
-            tuple[int, str, os.stat_result, str, Path]
-        ] = []
 
         def blob_id(payload: bytes) -> bytes:
             digest = algorithm()
@@ -2324,8 +2320,6 @@ class Workspace:
                                 "immutable source generation changed while "
                                 f"reading: {display}"
                             )
-                        retained_descriptors.append((descriptor, opened, display))
-                        descriptor = None
                     elif stat.S_ISREG(status.st_mode):
                         if status.st_nlink != 1:
                             raise WorkspaceError(
@@ -2365,8 +2359,6 @@ class Workspace:
                             )
                         mode = b"100755" if opened.st_mode & 0o111 else b"100644"
                         value = (mode, b"blob", digest.hexdigest().encode())
-                        retained_descriptors.append((descriptor, opened, display))
-                        descriptor = None
                     elif stat.S_ISLNK(status.st_mode):
                         target = os.fsencode(
                             os.readlink(entry_name, dir_fd=directory_fd)
@@ -2381,15 +2373,6 @@ class Workspace:
                                 "immutable source generation changed while "
                                 f"reading: {display}"
                             )
-                        retained_symlinks.append(
-                            (
-                                directory_fd,
-                                entry_name,
-                                status,
-                                os.fsdecode(target),
-                                display,
-                            )
-                        )
                         value = (b"120000", b"blob", blob_id(target))
                     else:
                         raise WorkspaceError(
@@ -2418,13 +2401,35 @@ class Workspace:
                     f"{source / os.fsdecode(prefix)}"
                 )
 
+        container_fd: int | None = None
         parent_fd: int | None = None
         root_fd: int | None = None
         try:
             flags = os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW
-            parent_fd = _open_directory_nofollow(source.parent, flags)
+            container_fd = _open_directory_nofollow(source.parent.parent, flags)
+            container_status = os.fstat(container_fd)
+            container_mount = _descriptor_mount_id(container_fd)
+            visible_parent = os.stat(
+                source.parent.name,
+                dir_fd=container_fd,
+                follow_symlinks=False,
+            )
+            parent_fd = os.open(
+                source.parent.name,
+                flags,
+                dir_fd=container_fd,
+            )
             parent_status = os.fstat(parent_fd)
             parent_mount = _descriptor_mount_id(parent_fd)
+            if (
+                changed(visible_parent, parent_status)
+                or parent_status.st_dev != container_status.st_dev
+                or parent_mount != container_mount
+            ):
+                raise WorkspaceError(
+                    "immutable source generation parent changed or is mounted: "
+                    f"{source.parent}"
+                )
             visible_root = os.stat(
                 source.name,
                 dir_fd=parent_fd,
@@ -2443,6 +2448,14 @@ class Workspace:
                     f"{source}"
                 )
             visit(root_fd, b"")
+            first_inventory = dict(actual)
+            actual.clear()
+            visit(root_fd, b"")
+            if actual != first_inventory:
+                raise WorkspaceError(
+                    "immutable source generation changed between inventories: "
+                    f"{source}"
+                )
             if set(actual) != set(expected) or any(
                 actual[path][:2] != expected[path][:2]
                 or (
@@ -2460,32 +2473,20 @@ class Workspace:
                 dir_fd=parent_fd,
                 follow_symlinks=False,
             )
+            visible_parent_after = os.stat(
+                source.parent.name,
+                dir_fd=container_fd,
+                follow_symlinks=False,
+            )
             if (
                 changed(root_status, os.fstat(root_fd))
                 or changed(root_status, visible_after)
+                or changed(parent_status, os.fstat(parent_fd))
+                or changed(parent_status, visible_parent_after)
             ):
                 raise WorkspaceError(
                     f"immutable source generation changed while reading: {source}"
                 )
-            for descriptor, opened, display in retained_descriptors:
-                if changed(opened, os.fstat(descriptor)):
-                    raise WorkspaceError(
-                        "immutable source generation changed while reading: "
-                        f"{display}"
-                    )
-            for directory_fd, name, before, target, display in retained_symlinks:
-                after = os.stat(
-                    name,
-                    dir_fd=directory_fd,
-                    follow_symlinks=False,
-                )
-                if changed(before, after) or os.readlink(
-                    name, dir_fd=directory_fd
-                ) != target:
-                    raise WorkspaceError(
-                        "immutable source generation changed while reading: "
-                        f"{display}"
-                    )
         except WorkspaceError:
             raise
         except OSError as error:
@@ -2493,12 +2494,12 @@ class Workspace:
                 f"cannot inspect immutable source generation {source}: {error}"
             ) from error
         finally:
-            for descriptor, _opened, _display in reversed(retained_descriptors):
-                os.close(descriptor)
             if root_fd is not None:
                 os.close(root_fd)
             if parent_fd is not None:
                 os.close(parent_fd)
+            if container_fd is not None:
+                os.close(container_fd)
 
     def _materialize_primary_source(
         self,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -347,12 +347,15 @@ helper repeats containment, symlink, marker, schema, and purpose validation
 immediately before deletion.
 
 Commit-keyed source generations have closed repository/branch/checkout/tree/
-subpath metadata and a complete tree digest. Builds hold a per-key shared lock;
-default `builds` cleanup revalidates identity and age under its exclusive side
-before bounded removal. First-use container publication is checkout-serialized.
-Interrupted staging remains a recognized child of its marker-owned container,
-is protected while its generation lock is busy, and becomes independently
-reclaimable after the normal grace period.
+subpath metadata and a complete tree digest. Reuse additionally enumerates the
+exact recorded Git tree and proves every generated path, entry type, executable
+mode, symlink target, and blob object ID before selection. A mismatch fails
+closed and leaves recovery to the explicit preview-first `builds` cleanup
+boundary. Builds hold a per-key shared lock; cleanup apply revalidates identity
+and age under its exclusive side before bounded removal. First-use container
+publication is checkout-serialized. Interrupted staging remains a recognized
+child of its marker-owned container, is protected while its generation lock is
+busy, and becomes independently reclaimable after the normal grace period.
 
 The npm and compiler caches have exact purpose markers and atomically refreshed
 `.atrinik-cache.json` timestamps. The compiler cache metadata also fixes its

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -348,10 +348,13 @@ immediately before deletion.
 
 Commit-keyed source generations have closed repository/branch/checkout/tree/
 subpath metadata and a complete tree digest. Reuse additionally enumerates the
-exact recorded Git tree and proves every generated path, entry type, executable
-mode, symlink target, and blob object ID before selection. A mismatch fails
-closed and leaves recovery to the explicit preview-first `builds` cleanup
-boundary. Builds hold a per-key shared lock; cleanup apply revalidates identity
+exact recorded Git tree without replacement-object indirection and proves every
+generated path, entry type, executable mode, symlink target, and blob object ID
+through a pinned, no-follow descriptor traversal before selection. A mismatch
+fails closed and leaves recovery to the explicit preview-first `builds` cleanup
+boundary. Once path, marker, key, and closed metadata ownership are exact,
+cleanup classifies a content-digest mismatch as removable corruption. Builds
+hold a per-key shared lock; cleanup apply revalidates ownership, content state,
 and age under its exclusive side before bounded removal. First-use container
 publication is checkout-serialized. Interrupted staging remains a recognized
 child of its marker-owned container, is protected while its generation lock is

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2491,6 +2491,66 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual(candidate["disposition"], "eligible", candidate)
         self.assertEqual(candidate["reasons"], ["stale_source_generation"])
 
+    def test_source_generation_cleanup_evidence_bounds_unsafe_shapes(self) -> None:
+        tree = self.root / "generation-evidence"
+        tree.mkdir()
+        (tree / "a-escape").symlink_to("../outside")
+        os.mkfifo(tree / "z-special")
+        flags = os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW
+        descriptor = os.open(tree, flags)
+        try:
+            (
+                sizes,
+                observed,
+                walk_error,
+                evidence,
+                semantic,
+                content_error,
+            ) = cleanup_module._tree_usage_descriptor(descriptor, tree)
+            self.assertTrue(sizes)
+            self.assertIsNotNone(observed)
+            self.assertIsNone(walk_error)
+            self.assertIsNotNone(evidence)
+            self.assertIsNotNone(semantic)
+            self.assertIn("unsafe link", content_error or "")
+
+            with mock.patch(
+                "atrinik_workspace.cleanup.os.listdir",
+                side_effect=OSError(errno.EIO, "inventory failed"),
+            ):
+                failed = cleanup_module._tree_usage_descriptor(descriptor, tree)
+            self.assertEqual(failed[0], {})
+            self.assertIsNone(failed[1])
+            self.assertIn("inventory failed", failed[2] or "")
+            self.assertEqual(failed[3:], (None, None, None))
+        finally:
+            os.close(descriptor)
+
+        for kind in ("directory", "file"):
+            with self.subTest(mounted_entry=kind):
+                mounted = self.root / f"mounted-{kind}-evidence"
+                mounted.mkdir()
+                child = mounted / "child"
+                if kind == "directory":
+                    child.mkdir()
+                else:
+                    child.write_text("payload\n", encoding="utf-8")
+                descriptor = os.open(mounted, flags)
+                try:
+                    with mock.patch(
+                        "atrinik_workspace.cleanup._descriptor_mount_id",
+                        side_effect=[1, 2],
+                    ):
+                        failed = cleanup_module._tree_usage_descriptor(
+                            descriptor, mounted
+                        )
+                    self.assertEqual(failed[0], {})
+                    self.assertIsNone(failed[1])
+                    self.assertIn("changed during usage inventory", failed[2] or "")
+                    self.assertEqual(failed[3:], (None, None, None))
+                finally:
+                    os.close(descriptor)
+
     def test_source_generation_cleanup_rejects_root_swap_before_removal(self) -> None:
         with self.workspace._resolved_profile_operation(
             "default",

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2223,6 +2223,47 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual(recreated, source)
         self.assertEqual((recreated / "README").read_text(encoding="utf-8"), "client\n")
 
+    def test_source_generation_cleanup_rejects_root_swap_before_removal(self) -> None:
+        with self.workspace._resolved_profile_operation(
+            "default",
+            {"client"},
+            "build client",
+            materialize_clean_primaries=True,
+        ) as snapshot:
+            generation = snapshot.paths()["client"].parent
+        displaced = generation.with_name(f"{generation.name}-displaced")
+        real_remove = remove_owned_tree
+        swapped = False
+
+        def swap_before_remove(path: Path, **kwargs: object) -> None:
+            nonlocal swapped
+            if path == generation and not swapped:
+                swapped = True
+                generation.rename(displaced)
+                generation.mkdir()
+            real_remove(path, **kwargs)
+
+        with (
+            mock.patch(
+                "atrinik_workspace.cleanup.Cleanup._registered_worktree_paths",
+                return_value=(set(), False),
+            ),
+            mock.patch(
+                "atrinik_workspace.cleanup.remove_owned_tree",
+                side_effect=swap_before_remove,
+            ),
+        ):
+            applied = self.workspace.cleanup(["builds"], 0, [], True)
+        failed = next(
+            item
+            for item in applied["items"]
+            if item["kind"] == "source-generation"
+        )
+        self.assertEqual(failed["disposition"], "error")
+        self.assertIn("identity changed", failed["error"])
+        self.assertTrue(generation.is_dir())
+        self.assertTrue(displaced.is_dir())
+
     def test_source_generation_archive_extraction_rejects_unsafe_entries(self) -> None:
         def archive(name: str, entries: list[tuple[tarfile.TarInfo, bytes]]) -> Path:
             path = self.root / f"{name}.tar"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -62,6 +62,7 @@ from atrinik_workspace.workspace import (
     display_arguments,
     exclusive_lock,
     exclusive_layout_lock,
+    load_regular_json,
     shared_lock,
     shared_layout_lock,
     remove_owned_tree,
@@ -2136,7 +2137,9 @@ class WorkspaceTests(unittest.TestCase):
                     record["source_tree"],
                 )
 
-    def test_source_generation_git_tree_rejects_directory_open_replacement(self) -> None:
+    def test_source_generation_git_tree_rejects_directory_open_replacement(
+        self,
+    ) -> None:
         with self.workspace._resolved_profile_operation(
             "default",
             {"resources"},
@@ -2181,6 +2184,74 @@ class WorkspaceTests(unittest.TestCase):
                     record["source_tree"],
                 )
 
+    def test_source_generation_git_tree_rechecks_prior_leaf_identity(self) -> None:
+        with self.workspace._resolved_profile_operation(
+            "default",
+            {"resources"},
+            "build resources",
+            materialize_clean_primaries=True,
+        ) as snapshot:
+            source = snapshot.paths()["resources"]
+        record = load_json(
+            source.parent / workspace_module.SOURCE_GENERATION_METADATA
+        )
+        external = self.root / "retained-readme-link"
+        real_open = os.open
+        linked = False
+
+        def link_prior_leaf(
+            path: object, flags: int, *args: object, **kwargs: object
+        ) -> int:
+            nonlocal linked
+            if path == "paintings" and flags & os.O_DIRECTORY and not linked:
+                linked = True
+                os.link(source / "README", external)
+            return real_open(path, flags, *args, **kwargs)
+
+        with mock.patch(
+            "atrinik_workspace.workspace.os.open",
+            side_effect=link_prior_leaf,
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "changed while reading"):
+                self.workspace._validate_source_generation_git_tree(
+                    self.workspace.paths.repositories / "resources",
+                    source,
+                    record["source_tree"],
+                )
+
+    def test_source_generation_git_tree_rejects_mounted_source_root(self) -> None:
+        with self.workspace._resolved_profile_operation(
+            "default",
+            {"client"},
+            "build client",
+            materialize_clean_primaries=True,
+        ) as snapshot:
+            source = snapshot.paths()["client"]
+        record = load_json(
+            source.parent / workspace_module.SOURCE_GENERATION_METADATA
+        )
+        parent_identity = source.parent.stat()
+
+        def mount_identity(descriptor: int) -> int:
+            opened = os.fstat(descriptor)
+            return (
+                1
+                if (opened.st_dev, opened.st_ino)
+                == (parent_identity.st_dev, parent_identity.st_ino)
+                else 2
+            )
+
+        with mock.patch(
+            "atrinik_workspace.workspace._descriptor_mount_id",
+            side_effect=mount_identity,
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "root changed or is mounted"):
+                self.workspace._validate_source_generation_git_tree(
+                    self.workspace.paths.repositories / "client",
+                    source,
+                    record["source_tree"],
+                )
+
     def test_corrupt_source_generation_cleanup_recovers_preview_first(self) -> None:
         def resolve() -> Path:
             with self.workspace._resolved_profile_operation(
@@ -2203,7 +2274,7 @@ class WorkspaceTests(unittest.TestCase):
             for item in preview["items"]
             if item["kind"] == "source-generation"
         )
-        self.assertEqual(candidate["disposition"], "eligible")
+        self.assertEqual(candidate["disposition"], "eligible", candidate)
         self.assertEqual(candidate["reasons"], ["corrupt_source_generation"])
         self.assertTrue(generation.exists())
 
@@ -2263,6 +2334,53 @@ class WorkspaceTests(unittest.TestCase):
         self.assertIn("identity changed", failed["error"])
         self.assertTrue(generation.is_dir())
         self.assertTrue(displaced.is_dir())
+
+    def test_source_generation_cleanup_pins_root_during_validation(self) -> None:
+        with self.workspace._resolved_profile_operation(
+            "default",
+            {"client"},
+            "build client",
+            materialize_clean_primaries=True,
+        ) as snapshot:
+            generation = snapshot.paths()["client"].parent
+        replacement = generation.with_name(f"{generation.name}-replacement")
+        displaced = generation.with_name(f"{generation.name}-displaced")
+        shutil.copytree(generation, replacement, symlinks=True)
+        marker = generation / MANAGED_MARKER
+        generation.chmod(0o700)
+        marker.chmod(0o600)
+        atomic_json(
+            marker,
+            {"schema_version": 1, "purpose": "not-source-generation"},
+        )
+        real_load = load_regular_json
+        swapped = False
+
+        def swap_around_marker(path: Path, description: str, **kwargs: object) -> object:
+            nonlocal swapped
+            if description == "source generation ownership marker" and not swapped:
+                swapped = True
+                generation.rename(displaced)
+                replacement.rename(generation)
+                try:
+                    return real_load(path, description, **kwargs)
+                finally:
+                    generation.rename(replacement)
+                    displaced.rename(generation)
+            return real_load(path, description, **kwargs)
+
+        with mock.patch(
+            "atrinik_workspace.cleanup.load_regular_json",
+            side_effect=swap_around_marker,
+        ):
+            report = self.workspace.cleanup(["builds"], 0, [], False)
+        item = next(
+            row
+            for row in report["items"]
+            if row["kind"] == "source-generation"
+        )
+        self.assertEqual(item["disposition"], "protected")
+        self.assertIn("invalid_source_generation", item["reasons"])
 
     def test_source_generation_archive_extraction_rejects_unsafe_entries(self) -> None:
         def archive(name: str, entries: list[tuple[tarfile.TarInfo, bytes]]) -> Path:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2437,8 +2437,8 @@ class WorkspaceTests(unittest.TestCase):
             for row in report["items"]
             if row["kind"] == "source-generation"
         )
-        self.assertEqual(item["disposition"], "protected")
-        self.assertIn("invalid_source_generation", item["reasons"])
+        self.assertEqual(item["disposition"], "eligible")
+        self.assertEqual(item["reasons"], ["corrupt_source_generation"])
 
     def test_source_generation_publication_failure_leaves_no_partial_generation(self) -> None:
         with (

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2069,6 +2069,160 @@ class WorkspaceTests(unittest.TestCase):
         ):
             resolve()
 
+    def test_source_generation_git_tree_ignores_replacement_objects(self) -> None:
+        def resolve() -> Path:
+            with self.workspace._resolved_profile_operation(
+                "default",
+                {"client"},
+                "build client",
+                materialize_clean_primaries=True,
+            ) as snapshot:
+                return snapshot.paths()["client"]
+
+        source = resolve()
+        checkout = self.workspace.paths.repositories / "client"
+        original_tree = command("git", "rev-parse", "HEAD^{tree}", cwd=checkout)
+        readme = checkout / "README"
+        readme.write_text("replacement\n", encoding="utf-8")
+        command("git", "add", "README", cwd=checkout)
+        replacement_tree = command("git", "write-tree", cwd=checkout)
+        command("git", "restore", "--staged", "--worktree", "README", cwd=checkout)
+        command("git", "replace", original_tree, replacement_tree, cwd=checkout)
+
+        record = load_json(
+            source.parent / workspace_module.SOURCE_GENERATION_METADATA
+        )
+        self.workspace._validate_source_generation_git_tree(
+            checkout, source, record["source_tree"]
+        )
+        self.assertEqual((source / "README").read_text(encoding="utf-8"), "client\n")
+
+    def test_source_generation_git_tree_rejects_file_open_replacement(self) -> None:
+        with self.workspace._resolved_profile_operation(
+            "default",
+            {"client"},
+            "build client",
+            materialize_clean_primaries=True,
+        ) as snapshot:
+            source = snapshot.paths()["client"]
+        record = load_json(
+            source.parent / workspace_module.SOURCE_GENERATION_METADATA
+        )
+        source.chmod(0o700)
+        readme = source / "README"
+        external = self.root / "linked-readme"
+        shutil.copy2(readme, external)
+        real_open = os.open
+        replaced = False
+
+        def replace_before_open(
+            path: object, flags: int, *args: object, **kwargs: object
+        ) -> int:
+            nonlocal replaced
+            if path == "README" and kwargs.get("dir_fd") is not None and not replaced:
+                replaced = True
+                readme.unlink()
+                os.link(external, readme)
+            return real_open(path, flags, *args, **kwargs)
+
+        with mock.patch(
+            "atrinik_workspace.workspace.os.open",
+            side_effect=replace_before_open,
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "changed while reading"):
+                self.workspace._validate_source_generation_git_tree(
+                    self.workspace.paths.repositories / "client",
+                    source,
+                    record["source_tree"],
+                )
+
+    def test_source_generation_git_tree_rejects_directory_open_replacement(self) -> None:
+        with self.workspace._resolved_profile_operation(
+            "default",
+            {"resources"},
+            "build resources",
+            materialize_clean_primaries=True,
+        ) as snapshot:
+            source = snapshot.paths()["resources"]
+        record = load_json(
+            source.parent / workspace_module.SOURCE_GENERATION_METADATA
+        )
+        source.chmod(0o700)
+        external = self.root / "replacement-directory"
+        external.mkdir()
+        paintings = source / "paintings"
+        displaced = source / "displaced-paintings"
+        real_open = os.open
+        replaced = False
+
+        def replace_before_open(
+            path: object, flags: int, *args: object, **kwargs: object
+        ) -> int:
+            nonlocal replaced
+            if (
+                path == "paintings"
+                and flags & os.O_DIRECTORY
+                and kwargs.get("dir_fd") is not None
+                and not replaced
+            ):
+                replaced = True
+                paintings.rename(displaced)
+                paintings.symlink_to(external, target_is_directory=True)
+            return real_open(path, flags, *args, **kwargs)
+
+        with mock.patch(
+            "atrinik_workspace.workspace.os.open",
+            side_effect=replace_before_open,
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "cannot inspect immutable"):
+                self.workspace._validate_source_generation_git_tree(
+                    self.workspace.paths.repositories / "resources",
+                    source,
+                    record["source_tree"],
+                )
+
+    def test_corrupt_source_generation_cleanup_recovers_preview_first(self) -> None:
+        def resolve() -> Path:
+            with self.workspace._resolved_profile_operation(
+                "default",
+                {"client"},
+                "build client",
+                materialize_clean_primaries=True,
+            ) as snapshot:
+                return snapshot.paths()["client"]
+
+        source = resolve()
+        generation = source.parent
+        generation.chmod(0o700)
+        source.chmod(0o700)
+        (source / "README").unlink()
+
+        preview = self.workspace.cleanup(["builds"], 0, [], False)
+        candidate = next(
+            item
+            for item in preview["items"]
+            if item["kind"] == "source-generation"
+        )
+        self.assertEqual(candidate["disposition"], "eligible")
+        self.assertEqual(candidate["reasons"], ["corrupt_source_generation"])
+        self.assertTrue(generation.exists())
+
+        with mock.patch(
+            "atrinik_workspace.cleanup.Cleanup._registered_worktree_paths",
+            return_value=(set(), False),
+        ):
+            applied = self.workspace.cleanup(["builds"], 0, [], True)
+        removed = next(
+            item
+            for item in applied["items"]
+            if item["kind"] == "source-generation"
+        )
+        self.assertEqual(removed["disposition"], "removed")
+        self.assertFalse(generation.exists())
+        recreated = resolve()
+        self.assertEqual(recreated, source)
+        self.assertEqual((recreated / "README").read_text(encoding="utf-8"), "client\n")
+
     def test_source_generation_archive_extraction_rejects_unsafe_entries(self) -> None:
         def archive(name: str, entries: list[tuple[tarfile.TarInfo, bytes]]) -> Path:
             path = self.root / f"{name}.tar"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2130,7 +2130,7 @@ class WorkspaceTests(unittest.TestCase):
             "atrinik_workspace.workspace.os.open",
             side_effect=replace_before_open,
         ):
-            with self.assertRaisesRegex(WorkspaceError, "changed while reading"):
+            with self.assertRaisesRegex(WorkspaceError, "hard-linked|changed"):
                 self.workspace._validate_source_generation_git_tree(
                     self.workspace.paths.repositories / "client",
                     source,
@@ -2212,7 +2212,7 @@ class WorkspaceTests(unittest.TestCase):
             "atrinik_workspace.workspace.os.open",
             side_effect=link_prior_leaf,
         ):
-            with self.assertRaisesRegex(WorkspaceError, "changed while reading"):
+            with self.assertRaisesRegex(WorkspaceError, "hard-linked|changed"):
                 self.workspace._validate_source_generation_git_tree(
                     self.workspace.paths.repositories / "resources",
                     source,
@@ -2230,15 +2230,15 @@ class WorkspaceTests(unittest.TestCase):
         record = load_json(
             source.parent / workspace_module.SOURCE_GENERATION_METADATA
         )
-        parent_identity = source.parent.stat()
+        source_identity = source.stat()
 
         def mount_identity(descriptor: int) -> int:
             opened = os.fstat(descriptor)
             return (
-                1
+                2
                 if (opened.st_dev, opened.st_ino)
-                == (parent_identity.st_dev, parent_identity.st_ino)
-                else 2
+                == (source_identity.st_dev, source_identity.st_ino)
+                else 1
             )
 
         with mock.patch(
@@ -2251,6 +2251,87 @@ class WorkspaceTests(unittest.TestCase):
                     source,
                     record["source_tree"],
                 )
+
+    def test_source_generation_git_tree_rejects_generation_parent_swap(self) -> None:
+        with self.workspace._resolved_profile_operation(
+            "default",
+            {"client"},
+            "build client",
+            materialize_clean_primaries=True,
+        ) as snapshot:
+            source = snapshot.paths()["client"]
+        generation = source.parent
+        replacement = generation.with_name(f"{generation.name}-replacement")
+        displaced = generation.with_name(f"{generation.name}-displaced")
+        shutil.copytree(generation, replacement, symlinks=True)
+        record = load_json(generation / workspace_module.SOURCE_GENERATION_METADATA)
+        real_open = os.open
+        swapped = False
+
+        def swap_parent(
+            path: object, flags: int, *args: object, **kwargs: object
+        ) -> int:
+            nonlocal swapped
+            if path == "README" and kwargs.get("dir_fd") is not None and not swapped:
+                swapped = True
+                generation.rename(displaced)
+                replacement.rename(generation)
+            return real_open(path, flags, *args, **kwargs)
+
+        with mock.patch(
+            "atrinik_workspace.workspace.os.open", side_effect=swap_parent
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "changed while reading"):
+                self.workspace._validate_source_generation_git_tree(
+                    self.workspace.paths.repositories / "client",
+                    source,
+                    record["source_tree"],
+                )
+
+    def test_source_generation_git_tree_descriptor_use_is_depth_bounded(self) -> None:
+        checkout = self.workspace.paths.repositories / "client"
+        bulk = checkout / "bulk"
+        bulk.mkdir()
+        for index in range(64):
+            (bulk / f"entry-{index:03d}").write_text(
+                f"{index}\n", encoding="utf-8"
+            )
+        command("git", "add", "bulk", cwd=checkout)
+        command("git", "commit", "-m", "test: add bulk tree", cwd=checkout)
+        with self.workspace._resolved_profile_operation(
+            "default",
+            {"client"},
+            "build client",
+            materialize_clean_primaries=True,
+        ) as snapshot:
+            source = snapshot.paths()["client"]
+        record = load_json(
+            source.parent / workspace_module.SOURCE_GENERATION_METADATA
+        )
+        real_open = os.open
+        real_close = os.close
+        active: set[int] = set()
+        maximum = 0
+
+        def track_open(*args: object, **kwargs: object) -> int:
+            nonlocal maximum
+            descriptor = real_open(*args, **kwargs)
+            active.add(descriptor)
+            maximum = max(maximum, len(active))
+            return descriptor
+
+        def track_close(descriptor: int) -> None:
+            active.discard(descriptor)
+            real_close(descriptor)
+
+        with (
+            mock.patch("atrinik_workspace.workspace.os.open", side_effect=track_open),
+            mock.patch("atrinik_workspace.workspace.os.close", side_effect=track_close),
+        ):
+            self.workspace._validate_source_generation_git_tree(
+                checkout, source, record["source_tree"]
+            )
+        self.assertLess(maximum, 16)
 
     def test_corrupt_source_generation_cleanup_recovers_preview_first(self) -> None:
         def resolve() -> Path:
@@ -2328,7 +2409,7 @@ class WorkspaceTests(unittest.TestCase):
         failed = next(
             item
             for item in applied["items"]
-            if item["kind"] == "source-generation"
+            if item["path"] == str(generation)
         )
         self.assertEqual(failed["disposition"], "error")
         self.assertIn("identity changed", failed["error"])
@@ -2381,6 +2462,67 @@ class WorkspaceTests(unittest.TestCase):
         )
         self.assertEqual(item["disposition"], "protected")
         self.assertIn("invalid_source_generation", item["reasons"])
+
+    def test_source_generation_cleanup_rechecks_complete_corrupt_evidence(
+        self,
+    ) -> None:
+        with self.workspace._resolved_profile_operation(
+            "default",
+            {"client"},
+            "build client",
+            materialize_clean_primaries=True,
+        ) as snapshot:
+            source = snapshot.paths()["client"]
+        generation = source.parent
+        generation.chmod(0o700)
+        source.chmod(0o700)
+        external = self.root / "hardlink-evidence"
+        external.write_bytes(b"linked\n")
+        os.link(external, source / "A-hardlink")
+        later = source / "Z-later"
+        later.write_text("before\n", encoding="utf-8")
+        real_item = Cleanup._source_generation_item
+        calls = 0
+        evidence: list[object] = []
+
+        def mutate_after_revalidation(
+            cleaner: Cleanup,
+            path: Path,
+            checkout: str,
+            older_than_days: int,
+            **kwargs: object,
+        ) -> dict[str, object]:
+            nonlocal calls
+            result = real_item(
+                cleaner, path, checkout, older_than_days, **kwargs
+            )
+            if path == generation:
+                calls += 1
+                evidence.append(result.get("generation_evidence_sha256"))
+                if calls == 2:
+                    later.write_text("after\n", encoding="utf-8")
+            return result
+
+        with (
+            mock.patch(
+                "atrinik_workspace.cleanup.Cleanup._registered_worktree_paths",
+                return_value=(set(), False),
+            ),
+            mock.patch.object(
+                Cleanup,
+                "_source_generation_item",
+                autospec=True,
+                side_effect=mutate_after_revalidation,
+            ),
+        ):
+            applied = self.workspace.cleanup(["builds"], 0, [], True)
+        failed = next(
+            item
+            for item in applied["items"]
+            if item["kind"] == "source-generation"
+        )
+        self.assertEqual(failed["disposition"], "error", (failed, calls, evidence))
+        self.assertIn("changed before removal", failed["error"])
 
     def test_source_generation_archive_extraction_rejects_unsafe_entries(self) -> None:
         def archive(name: str, entries: list[tuple[tarfile.TarInfo, bytes]]) -> Path:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2035,6 +2035,40 @@ class WorkspaceTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "ownership is invalid"):
             self.workspace._source_generation_record(forged)
 
+    def test_source_generation_reuse_rejects_coherent_missing_git_entry(self) -> None:
+        def resolve() -> Path:
+            with self.workspace._resolved_profile_operation(
+                "default",
+                {"client"},
+                "build client",
+                materialize_clean_primaries=True,
+            ) as snapshot:
+                return snapshot.paths()["client"]
+
+        source = resolve()
+        generation = source.parent
+        metadata = generation / workspace_module.SOURCE_GENERATION_METADATA
+        source_mode = stat.S_IMODE(source.stat().st_mode)
+        generation.chmod(0o700)
+        source.chmod(0o700)
+        (source / "README").unlink()
+        source.chmod(source_mode)
+        record = load_json(metadata)
+        record["source_tree_sha256"] = _tree_digest(
+            source,
+            set(),
+            bounded_symlinks=True,
+            reject_hardlinks=True,
+        )
+        metadata.chmod(0o600)
+        atomic_json(metadata, record)
+        self.workspace._seal_runtime_generation(generation)
+
+        with self.assertRaisesRegex(
+            WorkspaceError, "does not match its recorded Git tree"
+        ):
+            resolve()
+
     def test_source_generation_archive_extraction_rejects_unsafe_entries(self) -> None:
         def archive(name: str, entries: list[tuple[tarfile.TarInfo, bytes]]) -> Path:
             path = self.root / f"{name}.tar"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2410,6 +2410,64 @@ class WorkspaceTests(unittest.TestCase):
         recreated = resolve()
         self.assertEqual((recreated / "README").read_text(encoding="utf-8"), "client\n")
 
+    def test_unreadable_source_generation_directories_recover_preview_first(
+        self,
+    ) -> None:
+        def resolve() -> Path:
+            with self.workspace._resolved_profile_operation(
+                "default",
+                {"client"},
+                "build client",
+                materialize_clean_primaries=True,
+            ) as snapshot:
+                return snapshot.paths()["client"]
+
+        for unreadable_root in (False, True):
+            with self.subTest(unreadable_root=unreadable_root):
+                source = resolve()
+                generation = source.parent
+                generation.chmod(0o700)
+                if unreadable_root:
+                    source.chmod(0o000)
+                else:
+                    source.chmod(0o700)
+                    nested = source / "nested"
+                    nested.mkdir()
+                    (nested / "file").write_text("corrupt\n", encoding="utf-8")
+                    nested.chmod(0o000)
+
+                preview = self.workspace.cleanup(["builds"], 0, [], False)
+                candidate = next(
+                    item
+                    for item in preview["items"]
+                    if item["path"] == str(generation)
+                )
+                self.assertEqual(candidate["disposition"], "eligible", candidate)
+                self.assertEqual(
+                    candidate["reasons"], ["corrupt_source_generation"]
+                )
+                self.assertIn(
+                    "Permission denied",
+                    candidate["content_error"],
+                )
+
+                with mock.patch(
+                    "atrinik_workspace.cleanup.Cleanup._registered_worktree_paths",
+                    return_value=(set(), False),
+                ):
+                    applied = self.workspace.cleanup(["builds"], 0, [], True)
+                removed = next(
+                    item
+                    for item in applied["items"]
+                    if item["path"] == str(generation)
+                )
+                self.assertEqual(removed["disposition"], "removed", removed)
+                recreated = resolve()
+                self.assertEqual(
+                    (recreated / "README").read_text(encoding="utf-8"),
+                    "client\n",
+                )
+
     def test_source_generation_cleanup_accepts_bounded_parent_symlink(self) -> None:
         checkout = self.workspace.paths.repositories / "client"
         (checkout / "targetdir").mkdir()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2375,6 +2375,64 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual(recreated, source)
         self.assertEqual((recreated / "README").read_text(encoding="utf-8"), "client\n")
 
+    def test_unreadable_source_generation_cleanup_recovers_preview_first(self) -> None:
+        def resolve() -> Path:
+            with self.workspace._resolved_profile_operation(
+                "default",
+                {"client"},
+                "build client",
+                materialize_clean_primaries=True,
+            ) as snapshot:
+                return snapshot.paths()["client"]
+
+        source = resolve()
+        generation = source.parent
+        generation.chmod(0o700)
+        source.chmod(0o700)
+        (source / "README").chmod(0o000)
+
+        preview = self.workspace.cleanup(["builds"], 0, [], False)
+        candidate = next(
+            item for item in preview["items"] if item["path"] == str(generation)
+        )
+        self.assertEqual(candidate["disposition"], "eligible", candidate)
+        self.assertEqual(candidate["reasons"], ["corrupt_source_generation"])
+
+        with mock.patch(
+            "atrinik_workspace.cleanup.Cleanup._registered_worktree_paths",
+            return_value=(set(), False),
+        ):
+            applied = self.workspace.cleanup(["builds"], 0, [], True)
+        removed = next(
+            item for item in applied["items"] if item["path"] == str(generation)
+        )
+        self.assertEqual(removed["disposition"], "removed")
+        recreated = resolve()
+        self.assertEqual((recreated / "README").read_text(encoding="utf-8"), "client\n")
+
+    def test_source_generation_cleanup_accepts_bounded_parent_symlink(self) -> None:
+        checkout = self.workspace.paths.repositories / "client"
+        (checkout / "targetdir").mkdir()
+        (checkout / "targetdir" / "file").write_text("target\n", encoding="utf-8")
+        (checkout / "sub").mkdir()
+        (checkout / "sub" / "linkdir").symlink_to("../targetdir")
+        command("git", "add", "targetdir", "sub", cwd=checkout)
+        command("git", "commit", "-m", "test: add bounded symlink", cwd=checkout)
+        with self.workspace._resolved_profile_operation(
+            "default",
+            {"client"},
+            "build client",
+            materialize_clean_primaries=True,
+        ) as snapshot:
+            generation = snapshot.paths()["client"].parent
+
+        preview = self.workspace.cleanup(["builds"], 0, [], False)
+        candidate = next(
+            item for item in preview["items"] if item["path"] == str(generation)
+        )
+        self.assertEqual(candidate["disposition"], "eligible", candidate)
+        self.assertEqual(candidate["reasons"], ["stale_source_generation"])
+
     def test_source_generation_cleanup_rejects_root_swap_before_removal(self) -> None:
         with self.workspace._resolved_profile_operation(
             "default",


### PR DESCRIPTION
## Summary

- prove every reused immutable source generation against its exact recorded Git tree, with replacement objects disabled
- reject missing, added, replaced, linked, mode-changed, mounted, or content-changed entries before selection
- keep ordinary builds read-only on corruption while making exact-owned corrupt generations recoverable through explicit preview-first cleanup
- revalidate complete cleanup evidence and root identity under the exclusive generation lock before bounded removal
- document the selection and recovery contracts and cover the original coherent-metadata/missing-file regression

Fixes #418

## Coordinates

- Base: `main` at `5d41fdd9a0e350596509c45e4a92a573eaa0e352`
- Head: `fix/source-generation-tree-verification-418` at `2ae5c6ee990254fa5450aa0f02da1a5c70d53e8b`
- Worktree: `/workspaces/atrinik/workspace/worktrees/atrinik/issue-418-source-tree`

## Validation

- unrestricted `python -m coverage run -m unittest discover -v` — 916 tests passed at the production head; the final test-only commit's focused regression also passed
- `python -m coverage report --show-missing` — 83% total coverage
- `python -m compileall -q atrinik atrinik_workspace tests` — passed
- `python -m atrinik_workspace.guidance_inventory --check` — passed
- `./atrinik manifest validate` — passed
- `./atrinik supply-chain validate` — passed
- `./atrinik cleanup --scope all --older-than 7 --dry-run --json` — passed
- `./atrinik cleanup --scope topologies --older-than 7 --dry-run --json` — passed
- `git diff --check` — passed
- latest-head GitHub Integration, CodeQL, and PR policy checks — passed
- Codecov patch coverage — 80.06% against a 77.93% target
- independent final whole-diff and cleanup-focused reviews — no ordinary actionable findings

## Verification

Runtime provisioning is not applicable: this changes wrapper-side immutable source selection and cleanup and is exercised with isolated temporary repositories.

To reproduce the original regression and recovery behavior:

```sh
cd /workspaces/atrinik/workspace/worktrees/atrinik/issue-418-source-tree
python -m unittest -v \
  tests.test_workspace.WorkspaceTests.test_source_generation_reuse_rejects_coherent_missing_git_entry \
  tests.test_workspace.WorkspaceTests.test_corrupt_source_generation_cleanup_recovers_preview_first \
  tests.test_workspace.WorkspaceTests.test_unreadable_source_generation_directories_recover_preview_first
```

Expected result: coherent metadata cannot make a missing tracked path reusable, and exact-owned content corruption is previewed, revalidated, explicitly removed, and recreated.

For an affected existing workspace, recovery remains explicit and preview-first:

```sh
./atrinik cleanup --scope builds --older-than 0 --dry-run --json
# Review the exact generation, then repeat the same scoped command with --apply.
```
