### PR TITLE
feat(workspace): provision isolated agent development scopes

### DIFF
--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -41,12 +41,25 @@ clones.
 ./atrinik init [COMPONENT...]
 ./atrinik init --with classic
 ./atrinik sync [COMPONENT...]
+./atrinik scope create COMPONENT... --name REVIEW --from PROFILE --json
 ./atrinik worktree create COMPONENT LABEL --branch TYPE/TOPIC
 ```
 
 Sync only clean primaries; never replace, move, or remove dirty sources.
 Classic selectors create the full repository under
 `workspace/worktrees/classic/LABEL`. Commit and push in its owning worktree.
+Prefer atomic scopes for concurrent agents; generated names are
+collision-resistant, exact retries idempotent, and JSON commands secret-free.
+Temporary state is the default; persistent state is deliberate. Primitives
+remain supported. Release only with the freshly previewed plan digest:
+
+```sh
+./atrinik scope release REVIEW --dry-run --json
+./atrinik scope release REVIEW --apply --plan PLAN_SHA256 --json
+```
+
+Release never stops topologies or deletes persistent state. Unsafe or uncertain
+coordinates fail closed and retain their recovery journals.
 
 Reclaim review data only through preview-first cleanup:
 
@@ -59,15 +72,10 @@ Reclaim review data only through preview-first cleanup:
 
 Repeat a scoped command with `--apply` after review. Defaults cover
 worktrees/builds; caches and topology history are opt-in, and topologies are
-excluded from `all`. Reclaim only stopped, released, marker-owned records.
-Apply sound-cache before worktrees because each cache protects its worktree.
-Missing, replaced, invalid, busy, referenced, or unsafe targets fail closed.
-The sole historical-base exception is the frozen
-`atrinik/atrinik@main` `build/worktrees/` contract at
-`ee5ba2096c94bce0161629423d4962a966bc61d8`. Apply locks and revalidates each
-exact target with its reference-publication coordinates, journals completed
-actions, skips busy targets, and uses non-force Git while preserving refs,
-state, records, objects, reports, and unmarked paths.
+excluded from `all`. Reclaim only stopped, released, exact marker-owned records;
+unsafe or uncertain targets fail closed. Apply sound-cache before its worktree.
+See `README.md` and `docs/ARCHITECTURE.md` for historical wrapper-worktree proof
+and exact apply-time revalidation.
 
 ## Compose coherent sources
 
@@ -127,20 +135,14 @@ operations.
 
 ## Coordinate publication and policy
 
-- Use `atrinik-github-governance` for PR publication or policy; compare live and
-  desired state before authorized policy mutations.
-- PR titles use `type(optional-scope)!: concise description`; bodies use
-  renderable GitHub-Flavored Markdown and actual line breaks, never visible
-  literal `\n` separators. Give multi-section bodies by file or stdin; after
-  create/edit, verify remote rendering.
-- Keep physical repositories independently releasable; semantic-release owns
-  versions, tags, notes, and recovery. Never publish manually. Dependency
-  changes require `supply-chain/inventory.json` and a
-  complete-profile audit; overrides stay mandatory and only aggregate roots own
-  workflows/Dependabot.
-- Follow [`docs/PROVENANCE.md`](../../../docs/PROVENANCE.md) for grant-proven
-  Classic source reference, copy, migration/port, translation/adaptation, or
-  MIT relicensing. Fail temporal, authorship, or separability uncertainty closed.
+Use `atrinik-github-governance` for PRs or policy. PR titles use
+`type(optional-scope)!: concise description`; bodies require renderable
+GitHub-Flavored Markdown and actual line breaks, never visible literal `\n`
+separators. Feed multi-section bodies by file or standard input; after
+create/edit, verify the remote GitHub render.
+Semantic-release owns publication. Dependency changes update the inventory and
+audit a complete profile. Follow `docs/PROVENANCE.md` for Classic reuse and
+fail uncertainty closed.
 
 ## Maintain guidance
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,8 @@
 - Worktrees belong to physical checkouts. Selecting `classic`, a `classic-*`
   component, or one of its roles selects one root for all five; profiles append
   manifest source directories.
+- Prefer `scope create` for agents; use JSON handoff and
+  preview/apply release. Primitives remain.
 - Use wrapper commands and paths; never reconstruct managed paths. Give
   concurrent topologies distinct names, states, ports, and client config;
   prefer temporary state.
@@ -58,10 +60,10 @@
 - On touch, refresh existing Atrinik-owned copyright terminal years and blanket
   holders per `CONTRIBUTING.md`; preserve precise attribution.
 - MIT reuse follows `docs/PROVENANCE.md` and its canonical identity registry;
-  any rights, identity, temporal, authorship, or scope uncertainty fails closed.
-- Update `supply-chain/inventory.json` when dependency ownership or validation
-  changes. Keep Actions/images immutable, add no submodules, and audit a
-  complete profile. Only aggregate-root workflows and Dependabot are active.
+  rights, identity, temporal, authorship, or scope uncertainty fails closed.
+- Update `supply-chain/inventory.json` when dependency ownership/validation
+  changes. Keep Actions/images immutable, add no submodules, and audit a full
+  profile. Only aggregate-root workflows and Dependabot are active.
 - Commits and PR titles use `type(optional-scope)!: concise description`. PR
   bodies require renderable GitHub-Flavored Markdown and actual line breaks,
   never visible literal `\n` separators. Feed multi-section bodies by file or

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,13 @@ inheritance, reference-publication/removal races, and fail-closed diagnostics.
 Run the cleanup dry-run required by `AGENTS.md`; never use cleanup apply as
 validation.
 
+For development-scope changes, also cover distinct scopes sharing one physical
+checkout, same-name/label/branch races, every publication boundary, exact JSON
+handoff commands, state-policy opt-in, live-scope isolation, and hash-bound
+release refusal for dirty, detached, referenced, replaced, busy, retained, or
+ambiguous inputs. Scope release tests may apply only to temporary test-owned
+workspaces; repository validation remains preview-only.
+
 For CMake/cache changes, also repeat an unchanged build, exercise
 `--force-reconfigure` and `--no-ccache`, inspect `ccache --show-stats` when the
 command is installed, and preview shared-cache retention with

--- a/README.md
+++ b/README.md
@@ -601,6 +601,69 @@ that exact content lease. `build all` requests the union of every target's
 dependency closure and retains or snapshots every input without weakening
 coherence.
 
+## Agent development scopes
+
+Use one wrapper-owned development scope as the default entry point for
+concurrent agent work. Provisioning resolves every logical selector to its
+physical checkout, creates one full worktree per selected checkout, publishes
+one immutable derived profile, reserves a topology name and state policy, and
+publishes the completed scope record last:
+
+~~~sh
+./atrinik scope create classic-server --name issue-402 --from classic --json
+~~~
+
+Omit `--name` for a timestamped, collision-resistant `agent-*` name. A supplied
+name is stable: repeating the exact completed request returns the existing
+record, while a different component, label, branch, start point, topology, or
+state request fails without replacing it. Multiple Classic selectors still
+produce exactly one `classic` worktree containing all five `classic-*` source
+directories. Per-checkout coordinates can be selected deliberately:
+
+~~~sh
+./atrinik scope create classic-server content --name issue-402 \
+  --from classic \
+  --label classic=issue-402-classic \
+  --branch classic=feat/agent-development-scopes \
+  --start-point classic=origin/main \
+  --json
+~~~
+
+Automated scopes default to generation-owned temporary state. Persistent state
+is opt-in with `--state NAME` for an existing registered state or
+`--default-state` for the shared default. Provisioning does not start a
+topology or create persistent state.
+
+The secret-free JSON record under `workspace/scopes/<name>/scope.json` contains
+the scope name/generation/request digest; base profile and stack; requested
+logical components; every repository, checkout, label, branch, start point,
+commit, tree, path, and common-Git identity; the immutable profile name/path
+and digest; topology name/path; state ownership/lifecycle; and exact supported
+path, build, topology, log, shutdown, and release commands. Use those returned
+commands rather than reconstructing managed paths. `scope show` and `scope
+list` return the same validated records.
+
+Creation journals every worktree, profile-reference, profile, and completed
+record publication boundary. A failed transaction removes only exact newly
+created worktrees and profiles that remain clean, unchanged, and unreferenced;
+changed or uncertain inputs and the durable journal remain as explicit cleanup
+references for recovery.
+
+Scope release is explicit and hash-bound preview-first:
+
+~~~sh
+./atrinik scope release issue-402 --dry-run --json
+./atrinik scope release issue-402 --apply --plan PLAN_SHA256 --json
+~~~
+
+Apply recomputes the plan under the exact leases and refuses a stale plan,
+live or unreachable topology, retained generation, active lease, dirty,
+detached, replaced, ambiguously owned, or unexpectedly referenced worktree,
+changed profile, or uncertain build root. Named and default persistent state
+is always retained. Stopped topology history remains owned by the separate
+topology-cleanup lifecycle. The completed scope record and release journal are
+retained as recovery evidence.
+
 ## Checkout worktrees
 
 Create a branch and full-repository worktree from a checkout's remote default
@@ -632,7 +695,8 @@ List or remove managed worktrees:
 Removal refuses dirty worktrees. Each worktree is a full Git worktree of its
 physical repository, so a classic worktree contains all five classic source
 directories. Ordinary `git commit`, `git push`, and `gh pr create` work from
-inside it.
+inside it. These primitive commands remain supported for manual composition;
+prefer an atomic scope for concurrent automated development.
 
 ## Previewing and reclaiming stale workspace data
 

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -1666,6 +1666,7 @@ class Cleanup:
     def _references(self) -> tuple[dict[str, Any], set[str]]:
         references: dict[str, Any] = {
             "profiles": {},
+            "scopes": {},
             "scenarios": {},
             "topologies": {},
             "live_builds": {},
@@ -1675,6 +1676,7 @@ class Cleanup:
         errors: set[str] = set()
         collectors = (
             (self._profile_references, "profile_inventory_error"),
+            (self._scope_references, "scope_inventory_error"),
             (self._scenario_references, "scenario_inventory_error"),
             (self._topology_references, "topology_inventory_error"),
             (self._migration_references, "migration_inventory_error"),
@@ -1854,6 +1856,13 @@ class Cleanup:
                     self._add_reference(references["profiles"], selected, path.stem)
             except (OSError, WorkspaceError):
                 errors.add("profile_inventory_error")
+
+    def _scope_references(self, references: dict[str, Any], errors: set[str]) -> None:
+        try:
+            for name, path in self.workspace._scope_reference_records():
+                self._add_reference(references["scopes"], path, name)
+        except (OSError, RuntimeError, WorkspaceError):
+            errors.add("scope_inventory_error")
 
     def _scenario_references(self, references: dict[str, Any], errors: set[str]) -> None:
         if not self.paths.scenarios.is_dir() or self.paths.scenarios.is_symlink():
@@ -2295,6 +2304,7 @@ class Cleanup:
             item["reasons"].append("active_wrapper_view")
         reference_reasons = {
             "profiles": "profile_reference",
+            "scopes": "scope_reference",
             "scenarios": "scenario_reference",
             "topologies": "topology_reference",
             "migration": "migration_reference",

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -171,6 +171,68 @@ def parser() -> argparse.ArgumentParser:
     mark(worktree_list.add_argument("components", nargs="*"), "component")
     worktree_list.add_argument("--json", action="store_true")
 
+    scope = commands.add_parser(
+        "scope", help="provision and release isolated agent development scopes"
+    )
+    scope_commands = scope.add_subparsers(dest="scope_command", required=True)
+    scope_create = scope_commands.add_parser(
+        "create", help="atomically provision one complete development scope"
+    )
+    mark(scope_create.add_argument("components", nargs="+"), "component")
+    mark(scope_create.add_argument("--name"), "none")
+    mark(scope_create.add_argument("--from", dest="base_profile", default="default"), "profile")
+    mark(
+        scope_create.add_argument(
+            "--label", action="append", default=[], metavar="CHECKOUT=LABEL"
+        ),
+        "none",
+    )
+    mark(
+        scope_create.add_argument(
+            "--branch", action="append", default=[], metavar="CHECKOUT=BRANCH"
+        ),
+        "none",
+    )
+    mark(
+        scope_create.add_argument(
+            "--start-point", action="append", default=[], metavar="CHECKOUT=REF"
+        ),
+        "none",
+    )
+    mark(scope_create.add_argument("--topology"), "none")
+    scope_state = scope_create.add_mutually_exclusive_group()
+    scope_state.add_argument(
+        "--temporary-state",
+        dest="state_mode",
+        action="store_const",
+        const="temporary",
+        help="use generation-owned temporary state (default)",
+    )
+    mark(scope_state.add_argument("--state", dest="state_name"), "state")
+    scope_state.add_argument(
+        "--default-state",
+        dest="state_mode",
+        action="store_const",
+        const="default",
+        help="deliberately select shared persistent default state",
+    )
+    scope_create.set_defaults(state_mode="temporary")
+    scope_create.add_argument("--json", action="store_true")
+    scope_show = scope_commands.add_parser("show")
+    mark(scope_show.add_argument("name"), "scope")
+    scope_show.add_argument("--json", action="store_true")
+    scope_list = scope_commands.add_parser("list")
+    scope_list.add_argument("--json", action="store_true")
+    scope_release = scope_commands.add_parser(
+        "release", help="preview or apply exact scope release"
+    )
+    mark(scope_release.add_argument("name"), "scope")
+    scope_release_mode = scope_release.add_mutually_exclusive_group(required=True)
+    scope_release_mode.add_argument("--dry-run", action="store_true")
+    scope_release_mode.add_argument("--apply", action="store_true")
+    mark(scope_release.add_argument("--plan"), "none")
+    scope_release.add_argument("--json", action="store_true")
+
     cleanup = commands.add_parser(
         "cleanup", help="preview or reclaim stale workspace data"
     )
@@ -742,6 +804,56 @@ def main(arguments: list[str] | None = None) -> int:
                             "refs/heads/"
                         )
                         print(f"{component}\t{branch}\t{record['worktree']}")
+        elif options.command == "scope":
+            if options.scope_command == "create":
+                state_mode = "named" if options.state_name is not None else options.state_mode
+                result = workspace.scope_create(
+                    options.components,
+                    name=options.name,
+                    base_profile=options.base_profile,
+                    labels=options.label,
+                    branches=options.branch,
+                    start_points=options.start_point,
+                    topology=options.topology,
+                    state_mode=state_mode,
+                    state_name=options.state_name,
+                )
+            elif options.scope_command == "show":
+                result = workspace.scope_show(options.name)
+            elif options.scope_command == "list":
+                result = workspace.scope_list()
+            else:
+                if options.dry_run and options.plan is not None:
+                    raise WorkspaceError("--plan is accepted only with --apply")
+                result = workspace.scope_release(
+                    options.name,
+                    apply=options.apply,
+                    plan_sha256=options.plan,
+                )
+            if options.json:
+                print(json.dumps(result, indent=2, sort_keys=True))
+            elif isinstance(result, list):
+                for record in result:
+                    print(
+                        f"{record['name']}\t{record['status']}\t"
+                        f"{record['profile']['name']}\t{record['topology']['name']}"
+                    )
+            elif options.scope_command == "release":
+                print(f"scope\t{result['scope']}\t{result['mode']}")
+                print(f"plan\t{result['plan_sha256']}")
+                for item in result["items"]:
+                    print(
+                        f"{item['disposition']}\t{item['kind']}\t"
+                        f"{item.get('path') or '-'}\t{','.join(item['reasons'])}"
+                    )
+            else:
+                print(f"scope\t{result['name']}\t{result['generation']}")
+                print(f"profile\t{result['profile']['name']}\t{result['profile']['path']}")
+                print(f"topology\t{result['topology']['name']}\t{result['topology']['path']}")
+                for row in result["worktrees"]:
+                    print(
+                        f"worktree\t{row['checkout']}\t{row['branch']}\t{row['path']}"
+                    )
         elif options.command == "cleanup":
             report = workspace.cleanup(
                 options.scope,

--- a/atrinik_workspace/completion.py
+++ b/atrinik_workspace/completion.py
@@ -357,7 +357,44 @@ def _dynamic_candidates(
         return _scenario_names(manifest, paths)
     if kind == "topology":
         return _topology_names(manifest, paths)
+    if kind == "scope":
+        return _scope_names(paths)
     return []
+
+
+def _scope_names(paths: Paths | None) -> list[str]:
+    if paths is None:
+        return []
+    root = _workspace_descriptor(paths)
+    if root is None:
+        return []
+    scopes = _directory_descriptor("scopes", dir_fd=root)
+    try:
+        if scopes is None:
+            return []
+        names: list[str] = []
+        for name in _entry_names(scopes, file_type="directory"):
+            if not _valid_name(name):
+                continue
+            scope = _directory_descriptor(name, dir_fd=scopes)
+            if scope is None:
+                continue
+            try:
+                value = _json_at(scope, "scope.json", _MAX_RECORD_BYTES)
+                if (
+                    isinstance(value, dict)
+                    and value.get("schema_version") == 1
+                    and value.get("status") == "complete"
+                    and value.get("name") == name
+                ):
+                    names.append(name)
+            finally:
+                os.close(scope)
+        return names
+    finally:
+        if scopes is not None:
+            os.close(scopes)
+        os.close(root)
 
 
 def _manifest(repository: Path) -> Manifest | None:

--- a/atrinik_workspace/model.py
+++ b/atrinik_workspace/model.py
@@ -1180,6 +1180,7 @@ class Paths:
     workspace: Path
     repositories: Path
     worktrees: Path
+    scopes: Path
     profiles: Path
     builds: Path
     topologies: Path
@@ -1205,6 +1206,7 @@ class Paths:
             workspace=workspace,
             repositories=repository,
             worktrees=workspace / "worktrees",
+            scopes=workspace / "scopes",
             profiles=workspace / "profiles",
             builds=workspace / "build",
             topologies=workspace / "topologies",
@@ -1316,6 +1318,7 @@ class Paths:
                         )
                 for directory in (
                     self.worktrees,
+                    self.scopes,
                     self.profiles,
                     self.builds,
                     self.topologies,

--- a/atrinik_workspace/scopes.py
+++ b/atrinik_workspace/scopes.py
@@ -1,0 +1,1517 @@
+from __future__ import annotations
+
+import copy
+from contextlib import ExitStack
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import secrets
+from typing import Any, TYPE_CHECKING
+
+from .locking import LockBusyError, exclusive_lock
+from .model import (
+    AtomicJsonCommitUncertain,
+    MANAGED_MARKER,
+    WorkspaceError,
+    durable_atomic_json,
+    validate_name,
+)
+from .workspace import load_regular_json
+
+if TYPE_CHECKING:
+    from .workspace import Workspace
+
+
+SCOPE_SCHEMA_VERSION = 1
+SCOPE_RESERVATION_SCHEMA_VERSION = 1
+SCOPE_JOURNAL_SCHEMA_VERSION = 1
+SCOPE_RELEASE_SCHEMA_VERSION = 1
+SCOPE_FAILURE_BOUNDARIES_ENV = "ATRINIK_SCOPE_FAIL_AFTER"
+_HEX40 = re.compile(r"[0-9a-f]{40}")
+_HEX64 = re.compile(r"[0-9a-f]{64}")
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while block := stream.read(1024 * 1024):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _mapping(values: list[str], context: str) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for raw in values:
+        key, separator, value = raw.partition("=")
+        if not separator or not key or not value:
+            raise WorkspaceError(f"{context} must use CHECKOUT=VALUE")
+        validate_name(key, f"{context} checkout")
+        if key in result:
+            raise WorkspaceError(f"{context} repeats checkout: {key}")
+        result[key] = value
+    return result
+
+
+class ScopeLifecycle:
+    def __init__(self, workspace: Workspace):
+        self.workspace = workspace
+        self.paths = workspace.paths
+
+    @property
+    def root(self) -> Path:
+        return self.paths.scopes
+
+    def _scope_root(self, name: str) -> Path:
+        validate_name(name, "scope name")
+        return self.root / name
+
+    def _record_path(self, name: str) -> Path:
+        return self._scope_root(name) / "scope.json"
+
+    def _journal_path(self, name: str) -> Path:
+        return self._scope_root(name) / "creation-journal.json"
+
+    def _reservation_path(self, name: str) -> Path:
+        return self._scope_root(name) / "reservation.json"
+
+    def _release_path(self, name: str) -> Path:
+        return self._scope_root(name) / "release-journal.json"
+
+    @staticmethod
+    def generated_name() -> str:
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+        return f"agent-{stamp}-{secrets.token_hex(6)}"
+
+    def create(
+        self,
+        components: list[str],
+        *,
+        name: str | None = None,
+        base_profile: str = "default",
+        labels: list[str] | None = None,
+        branches: list[str] | None = None,
+        start_points: list[str] | None = None,
+        topology: str | None = None,
+        state_mode: str = "temporary",
+        state_name: str | None = None,
+    ) -> dict[str, Any]:
+        self.paths.ensure()
+        scope_name = name or self.generated_name()
+        validate_name(scope_name, "scope name")
+        if not components:
+            raise WorkspaceError("scope creation requires at least one component")
+        label_overrides = _mapping(labels or [], "scope label")
+        branch_overrides = _mapping(branches or [], "scope branch")
+        start_overrides = _mapping(start_points or [], "scope start point")
+        if name is not None and (
+            self._scope_root(scope_name).exists()
+            or self._scope_root(scope_name).is_symlink()
+        ):
+            return self._retry_existing(
+                scope_name,
+                components,
+                base_profile,
+                label_overrides,
+                branch_overrides,
+                start_overrides,
+                topology,
+                state_mode,
+                state_name,
+            )
+        request = self._preflight_request(
+            scope_name,
+            components,
+            base_profile,
+            label_overrides,
+            branch_overrides,
+            start_overrides,
+            topology,
+            state_mode,
+            state_name,
+        )
+        digest = _canonical_sha256(request)
+        existing = self._existing_exact(scope_name, digest)
+        if existing is not None:
+            return existing
+
+        requests = self._creation_leases(request)
+        scope_request = requests[0]
+        scope_entered = False
+        try:
+            with self.workspace._resource_locks(
+                [scope_request], nonblocking=True, include_wrapper=False
+            ):
+                scope_entered = True
+                with self.workspace._resource_locks(requests[1:]):
+                    existing = self._existing_exact(scope_name, digest)
+                    if existing is not None:
+                        return existing
+                    request = self._preflight_request(
+                        scope_name,
+                        components,
+                        base_profile,
+                        label_overrides,
+                        branch_overrides,
+                        start_overrides,
+                        topology,
+                        state_mode,
+                        state_name,
+                    )
+                    if _canonical_sha256(request) != digest:
+                        raise WorkspaceError("scope coordinates changed during preflight; retry")
+                    return self._create_locked(request, digest)
+        except LockBusyError as error:
+            if scope_entered:
+                raise WorkspaceError(
+                    f"scope resources remained busy while provisioning: {scope_name}; retry after the exact operation finishes"
+                ) from error
+            raise WorkspaceError(
+                f"scope coordinates are already in use: {scope_name}; inspect the exact scope, profile, topology, and worktree coordinates"
+            ) from error
+
+    def _retry_existing(
+        self,
+        name: str,
+        components: list[str],
+        base_profile: str,
+        labels: dict[str, str],
+        branches: dict[str, str],
+        start_points: dict[str, str],
+        topology: str | None,
+        state_mode: str,
+        state_name: str | None,
+    ) -> dict[str, Any]:
+        record_path = self._record_path(name)
+        if record_path.is_symlink() or not record_path.is_file():
+            raise WorkspaceError(
+                f"scope creation is incomplete: {name}; preserve and inspect {self._journal_path(name)}"
+            )
+        record = self._load_record(name)
+        self._require_unreleased(record)
+        expected_topology = topology or f"scope-{name}"
+        expected_state_name = (
+            None if state_mode == "temporary" else "default" if state_mode == "default" else state_name
+        )
+        rows = {row["checkout"]: row for row in record["worktrees"]}
+        expected_rows = {
+            checkout: {
+                "label": labels.get(checkout, record["profile"]["name"]),
+                "branch": branches.get(checkout, f"scope/{name}/{checkout}"),
+                "start_point": start_points.get(
+                    checkout,
+                    f"refs/heads/{self.workspace.manifest.by_checkout[checkout].branch}",
+                ),
+            }
+            for checkout in rows
+        }
+        conflicts = (
+            record["base_profile"] != base_profile
+            or record["requested_components"] != sorted(set(components))
+            or record["topology"]["name"] != expected_topology
+            or record["state_policy"]["mode"] != state_mode
+            or record["state_policy"]["name"] != expected_state_name
+            or set(labels) - set(rows)
+            or set(branches) - set(rows)
+            or set(start_points) - set(rows)
+            or any(
+                rows[checkout][coordinate] != expected
+                for checkout, coordinates in expected_rows.items()
+                for coordinate, expected in coordinates.items()
+            )
+        )
+        if conflicts:
+            raise WorkspaceError(
+                f"scope name is already bound to different coordinates: {name}"
+            )
+        return record
+
+    def _preflight_request(
+        self,
+        name: str,
+        components: list[str],
+        base_profile: str,
+        labels: dict[str, str],
+        branches: dict[str, str],
+        start_points: dict[str, str],
+        topology: str | None,
+        state_mode: str,
+        state_name: str | None,
+    ) -> dict[str, Any]:
+        from .workspace import git, run
+
+        validate_name(base_profile, "scope base profile")
+        base = self.workspace._load_profile_file(base_profile, require_file=False)
+        stack = self.workspace.manifest.stack(base["stack"])
+        selected: dict[str, set[str]] = {}
+        requested: list[str] = []
+        for selector in components:
+            requested.append(selector)
+            resolved = self.workspace._profile_components(base, selector)
+            for component in resolved:
+                selected.setdefault(component.checkout_name, set()).add(component.name)
+        unknown_overrides = (set(labels) | set(branches) | set(start_points)) - set(selected)
+        if unknown_overrides:
+            raise WorkspaceError(
+                "scope override names unselected checkouts: "
+                + ", ".join(sorted(unknown_overrides))
+            )
+
+        profile_name = f"scope-{name}"
+        topology_name = topology or profile_name
+        validate_name(profile_name, "scope profile name")
+        validate_name(topology_name, "scope topology name")
+        if profile_name in self.workspace.manifest.stacks:
+            raise WorkspaceError(f"scope profile collides with built-in profile: {profile_name}")
+        profile_path = self.paths.profiles / f"{profile_name}.json"
+        topology_path = self.paths.topologies / topology_name
+        if profile_path.exists() or profile_path.is_symlink():
+            raise WorkspaceError(f"scope profile already exists: {profile_name}")
+        if topology_path.exists() or topology_path.is_symlink():
+            raise WorkspaceError(f"scope topology namespace already exists: {topology_name}")
+
+        if state_mode not in {"temporary", "named", "default"}:
+            raise WorkspaceError(f"invalid scope state mode: {state_mode}")
+        if state_mode == "temporary":
+            if state_name is not None:
+                raise WorkspaceError("temporary scope state does not accept a state name")
+            policy = {
+                "mode": "temporary",
+                "name": None,
+                "ownership": "topology-generation",
+                "lifecycle": "remove-on-clean-stop",
+            }
+        elif state_mode == "default":
+            if state_name is not None:
+                raise WorkspaceError("default scope state does not accept a state name")
+            policy = {
+                "mode": "default",
+                "name": "default",
+                "ownership": "persistent-shared",
+                "lifecycle": "never-remove-with-scope",
+            }
+        else:
+            if state_name is None:
+                raise WorkspaceError("named scope state requires --state NAME")
+            validate_name(state_name, "scope state name")
+            if state_name == "default":
+                raise WorkspaceError("use --default-state to select shared default state")
+            states = self.workspace.list_states()
+            if state_name not in states:
+                raise WorkspaceError(f"registered state does not exist: {state_name}")
+            policy = {
+                "mode": "named",
+                "name": state_name,
+                "ownership": "persistent-registered",
+                "lifecycle": "never-remove-with-scope",
+            }
+
+        rows: list[dict[str, Any]] = []
+        for checkout_name in sorted(selected):
+            checkout = self.workspace.manifest.by_checkout[checkout_name]
+            repository = self.workspace._primary_path(checkout)
+            if repository.is_symlink() or not repository.is_dir():
+                raise WorkspaceError(
+                    f"scope checkout is not initialized: {checkout_name}: {repository}"
+                )
+            self.workspace._validate_primary_checkout(checkout, repository, trace=False)
+            remote = self.workspace._canonical_remote(checkout, repository)
+            label = labels.get(checkout_name, profile_name)
+            validate_name(label, f"scope worktree label for {checkout_name}")
+            branch = branches.get(checkout_name, f"scope/{name}/{checkout_name}")
+            run(["git", "check-ref-format", "--branch", branch], capture=True, trace=False)
+            point = start_points.get(checkout_name, f"refs/heads/{checkout.branch}")
+            if point.startswith("-"):
+                raise WorkspaceError("scope start point must not begin with '-'")
+            commit = git(
+                repository,
+                "rev-parse",
+                "--verify",
+                "--end-of-options",
+                f"{point}^{{commit}}",
+                capture=True,
+                trace=False,
+            )
+            tree = git(
+                repository,
+                "rev-parse",
+                "--verify",
+                "--end-of-options",
+                f"{commit}^{{tree}}",
+                capture=True,
+                trace=False,
+            )
+            if not _HEX40.fullmatch(commit) or not _HEX40.fullmatch(tree):
+                raise WorkspaceError(f"scope start point is not an exact Git commit: {point}")
+            destination = self.paths.worktrees / checkout_name / label
+            if destination.exists() or destination.is_symlink():
+                raise WorkspaceError(f"scope worktree path already exists: {destination}")
+            rows.append(
+                {
+                    "checkout": checkout_name,
+                    "repository": checkout.repository,
+                    "logical_components": sorted(selected[checkout_name]),
+                    "label": label,
+                    "branch": branch,
+                    "start_point": point,
+                    "commit": commit,
+                    "tree": tree,
+                    "path": str(destination),
+                    "primary_path": str(repository),
+                }
+            )
+        # The branch absence check must not use git(), whose non-zero result is
+        # exceptional. Keep it last so every other coordinate has been proven.
+        import subprocess
+
+        for row in rows:
+            completed = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    row["primary_path"],
+                    "show-ref",
+                    "--verify",
+                    "--quiet",
+                    f"refs/heads/{row['branch']}",
+                ],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            if completed.returncode == 0:
+                raise WorkspaceError(
+                    f"scope branch already exists: {row['checkout']}:{row['branch']}"
+                )
+            if completed.returncode != 1:
+                raise WorkspaceError(
+                    f"cannot preflight scope branch: {row['checkout']}:{row['branch']}"
+                )
+
+        return {
+            "name": name,
+            "base_profile": base_profile,
+            "stack": stack.name,
+            "requested_components": sorted(set(requested)),
+            "profile": {"name": profile_name, "path": str(profile_path)},
+            "topology": {"name": topology_name, "path": str(topology_path)},
+            "state_policy": policy,
+            "worktrees": rows,
+        }
+
+    def _creation_leases(self, request: dict[str, Any]) -> list[Any]:
+        requests = [
+            self.workspace._lease_request(
+                "registry", f"scope:{request['name']}", "exclusive", f"provision scope {request['name']}"
+            ),
+            self.workspace._lease_request(
+                "profile", request["profile"]["name"], "exclusive", f"provision scope {request['name']}"
+            ),
+            self.workspace._lease_request(
+                "topology", request["topology"]["name"], "exclusive", f"reserve scope {request['name']} topology"
+            ),
+        ]
+        if request["base_profile"] != request["profile"]["name"]:
+            requests.append(
+                self.workspace._lease_request(
+                    "profile",
+                    request["base_profile"],
+                    "shared",
+                    f"copy base profile for scope {request['name']}",
+                )
+            )
+        policy = request["state_policy"]
+        if policy["mode"] != "temporary":
+            requests.append(
+                self.workspace._lease_request(
+                    "state", policy["name"], "shared", f"reserve scope {request['name']} state policy"
+                )
+            )
+        for row in request["worktrees"]:
+            checkout = self.workspace.manifest.by_checkout[row["checkout"]]
+            primary = Path(row["primary_path"])
+            destination = Path(row["path"])
+            requests.extend(
+                [
+                    self.workspace._lease_request(
+                        "git-admin",
+                        self.workspace._git_admin_coordinate(checkout, primary),
+                        "exclusive",
+                        f"provision scope {request['name']} worktree",
+                    ),
+                    self.workspace._lease_request(
+                        "source",
+                        self.workspace._source_coordinate(checkout.name, destination),
+                        "exclusive",
+                        f"provision scope {request['name']} worktree",
+                    ),
+                ]
+            )
+        return requests
+
+    def _existing_exact(self, name: str, digest: str) -> dict[str, Any] | None:
+        root = self._scope_root(name)
+        if not root.exists() and not root.is_symlink():
+            return None
+        if root.is_symlink() or not root.is_dir():
+            raise WorkspaceError(f"scope reservation is unsafe: {name}")
+        record_path = self._record_path(name)
+        if record_path.is_file() and not record_path.is_symlink():
+            record = self._load_record(name)
+            self._require_unreleased(record)
+            if record["request_sha256"] == digest:
+                return record
+            raise WorkspaceError(f"scope name is already bound to different coordinates: {name}")
+        reservation_path = self._reservation_path(name)
+        if not reservation_path.is_file() or reservation_path.is_symlink():
+            raise WorkspaceError(f"scope reservation is incomplete or unsafe: {name}")
+        reservation = load_regular_json(reservation_path, f"scope reservation {name}")
+        if reservation.get("request_sha256") != digest:
+            raise WorkspaceError(f"scope name is already reserved for different coordinates: {name}")
+        raise WorkspaceError(
+            f"scope creation is incomplete: {name}; preserve and inspect {self._journal_path(name)}"
+        )
+
+    def _create_locked(self, request: dict[str, Any], digest: str) -> dict[str, Any]:
+        from .workspace import PROFILE_SCHEMA_VERSION, git
+
+        name = request["name"]
+        root = self._scope_root(name)
+        try:
+            root.mkdir(mode=0o700)
+        except FileExistsError as error:
+            raise WorkspaceError(f"scope name was concurrently reserved: {name}") from error
+        generation = secrets.token_hex(16)
+        reservation = {
+            "schema_version": SCOPE_RESERVATION_SCHEMA_VERSION,
+            "name": name,
+            "generation": generation,
+            "request_sha256": digest,
+            "reserved_at": _now(),
+        }
+        journal: dict[str, Any] = {
+            "schema_version": SCOPE_JOURNAL_SCHEMA_VERSION,
+            "name": name,
+            "generation": generation,
+            "request_sha256": digest,
+            "status": "creating",
+            "updated_at": reservation["reserved_at"],
+            "boundaries": [],
+            "worktrees": [
+                {
+                    **copy.deepcopy(row),
+                    "status": "planned",
+                    "common_git_dir": None,
+                    "path_device": None,
+                    "path_inode": None,
+                }
+                for row in request["worktrees"]
+            ],
+            "profile": {
+                **request["profile"],
+                "status": "planned",
+                "sha256": None,
+                "path_device": None,
+                "path_inode": None,
+            },
+            "rollback": [],
+            "error": None,
+        }
+        durable_atomic_json(self._reservation_path(name), reservation)
+        durable_atomic_json(self._journal_path(name), journal)
+        profile_created = False
+        profile_reference_created = False
+        final_published = False
+        publication_uncertain = False
+        try:
+            self._boundary(journal, "reservation")
+            for index, row in enumerate(request["worktrees"]):
+                path = self.workspace._create_worktree(
+                    row["checkout"],
+                    row["label"],
+                    row["branch"],
+                    row["commit"],
+                    False,
+                    announce=False,
+                )
+                checkout = self.workspace.manifest.by_checkout[row["checkout"]]
+                self.workspace._validate_checkout(checkout, path, trace=False)
+                if git(path, "rev-parse", "HEAD", capture=True, trace=False) != row["commit"]:
+                    raise WorkspaceError(f"scope worktree head changed during creation: {path}")
+                common = str(self.workspace._git_common_directory(path, trace=False))
+                identity = path.stat(follow_symlinks=False)
+                journal["worktrees"][index].update(
+                    {
+                        "status": "created",
+                        "common_git_dir": common,
+                        "path_device": identity.st_dev,
+                        "path_inode": identity.st_ino,
+                    }
+                )
+                self._write_journal(journal)
+                self._boundary(journal, f"worktree:{row['checkout']}")
+
+            base = self.workspace._load_profile_file(
+                request["base_profile"], require_file=False
+            )
+            profile = {
+                "schema_version": PROFILE_SCHEMA_VERSION,
+                "name": request["profile"]["name"],
+                "stack": base["stack"],
+                "sound_mode": base["sound_mode"],
+                "sound_release": copy.deepcopy(base["sound_release"]),
+                "components": copy.deepcopy(base["components"]),
+            }
+            for row in request["worktrees"]:
+                for component in self.workspace.manifest.stack(profile["stack"]).components:
+                    if component.checkout_name == row["checkout"]:
+                        profile["components"][component.name] = {
+                            "kind": "worktree",
+                            "value": row["label"],
+                        }
+            profile_path = Path(request["profile"]["path"])
+            self.workspace._publish_profile_references(profile["name"], profile)
+            profile_reference_created = True
+            journal["profile"]["status"] = "reference-published"
+            self._write_journal(journal)
+            self._boundary(journal, "profile-reference")
+            try:
+                durable_atomic_json(profile_path, profile)
+            except AtomicJsonCommitUncertain:
+                publication_uncertain = True
+                journal["profile"]["status"] = "preserved-uncertain"
+                self._write_journal(journal)
+                raise
+            except BaseException:
+                self.workspace._remove_physical_reference(profile_path)
+                raise
+            profile_created = True
+            profile_identity = profile_path.stat(follow_symlinks=False)
+            journal["profile"].update(
+                {
+                    "status": "created",
+                    "sha256": _file_sha256(profile_path),
+                    "path_device": profile_identity.st_dev,
+                    "path_inode": profile_identity.st_ino,
+                }
+            )
+            self._write_journal(journal)
+            self._boundary(journal, "profile")
+
+            worktrees = []
+            for row in journal["worktrees"]:
+                worktrees.append(
+                    {
+                        key: row[key]
+                        for key in (
+                            "checkout",
+                            "repository",
+                            "logical_components",
+                            "label",
+                            "branch",
+                            "start_point",
+                            "commit",
+                            "tree",
+                            "path",
+                            "primary_path",
+                            "common_git_dir",
+                            "path_device",
+                            "path_inode",
+                        )
+                    }
+                    | {"created_by_scope": True}
+                )
+            record = self._record(
+                request,
+                digest,
+                generation,
+                reservation["reserved_at"],
+                worktrees,
+                journal["profile"]["sha256"],
+                journal["profile"]["path_device"],
+                journal["profile"]["path_inode"],
+            )
+            self._validate_record(record, name)
+            try:
+                durable_atomic_json(self._record_path(name), record)
+            except AtomicJsonCommitUncertain:
+                publication_uncertain = True
+                raise
+            final_published = True
+            journal["status"] = "complete"
+            journal["updated_at"] = _now()
+            journal["boundaries"].append("scope")
+            self._write_journal(journal)
+            self._maybe_fail("scope")
+            return record
+        except BaseException as error:
+            if final_published:
+                journal["status"] = "complete"
+                journal["error"] = f"{type(error).__name__}: {error}"
+                journal["updated_at"] = _now()
+                self._write_journal(journal)
+                raise
+            if publication_uncertain:
+                journal["status"] = "recovery-required"
+                journal["error"] = f"{type(error).__name__}: {error}"
+                journal["updated_at"] = _now()
+                self._write_journal(journal)
+                raise WorkspaceError(
+                    f"scope creation publication is uncertain; all inputs were preserved in {self._journal_path(name)}: {error}"
+                ) from error
+            journal["status"] = "rolling-back"
+            journal["error"] = f"{type(error).__name__}: {error}"
+            self._write_journal(journal)
+            uncertain = self._rollback_creation(
+                journal, profile_created, profile_reference_created
+            )
+            journal["status"] = "recovery-required" if uncertain else "rolled-back"
+            journal["updated_at"] = _now()
+            self._write_journal(journal)
+            if uncertain:
+                raise WorkspaceError(
+                    f"scope creation failed and recovery inputs were preserved in {self._journal_path(name)}: {error}"
+                ) from error
+            raise
+
+    def _boundary(self, journal: dict[str, Any], name: str) -> None:
+        journal["boundaries"].append(name)
+        journal["updated_at"] = _now()
+        self._write_journal(journal)
+        self._maybe_fail(name)
+
+    @staticmethod
+    def _maybe_fail(boundary: str) -> None:
+        if os.environ.get(SCOPE_FAILURE_BOUNDARIES_ENV) == boundary:
+            raise WorkspaceError(f"injected scope failure after publication boundary: {boundary}")
+
+    def _write_journal(self, journal: dict[str, Any]) -> None:
+        durable_atomic_json(self._journal_path(journal["name"]), journal)
+
+    def _rollback_creation(
+        self,
+        journal: dict[str, Any],
+        profile_created: bool,
+        profile_reference_created: bool,
+    ) -> bool:
+        from .workspace import git
+
+        uncertain = False
+        profile = journal["profile"]
+        profile_path = Path(profile["path"])
+        if profile_created:
+            try:
+                if (
+                    profile_path.is_file()
+                    and not profile_path.is_symlink()
+                    and _file_sha256(profile_path) == profile["sha256"]
+                    and (
+                        profile_path.stat(follow_symlinks=False).st_dev,
+                        profile_path.stat(follow_symlinks=False).st_ino,
+                    )
+                    == (profile["path_device"], profile["path_inode"])
+                ):
+                    profile_path.unlink()
+                    self.workspace._remove_physical_reference(profile_path)
+                    journal["rollback"].append("profile")
+                    profile["status"] = "rolled-back"
+                else:
+                    uncertain = True
+                    profile["status"] = "preserved-changed"
+            except BaseException as rollback_error:
+                uncertain = True
+                profile["status"] = "preserved-uncertain"
+                journal["rollback"].append(f"profile-error:{rollback_error}")
+            self._write_journal(journal)
+        elif profile_reference_created:
+            try:
+                self.workspace._remove_physical_reference(profile_path)
+                journal["rollback"].append("profile-reference")
+                profile["status"] = "rolled-back"
+            except BaseException as rollback_error:
+                uncertain = True
+                profile["status"] = "preserved-uncertain"
+                journal["rollback"].append(
+                    f"profile-reference-error:{rollback_error}"
+                )
+            self._write_journal(journal)
+        for row in reversed(journal["worktrees"]):
+            if row["status"] != "created":
+                continue
+            path = Path(row["path"])
+            try:
+                exact = (
+                    path.is_dir()
+                    and not path.is_symlink()
+                    and (path.stat(follow_symlinks=False).st_dev, path.stat(follow_symlinks=False).st_ino)
+                    == (row["path_device"], row["path_inode"])
+                    and self.workspace._git_common_directory(path, trace=False)
+                    == Path(row["common_git_dir"])
+                    and git(path, "rev-parse", "HEAD", capture=True, trace=False)
+                    == row["commit"]
+                    and git(path, "branch", "--show-current", capture=True, trace=False)
+                    == row["branch"]
+                    and not [
+                        reference
+                        for reference in self.workspace._source_references(path)
+                        if reference != f"scope:{journal['name']}"
+                    ]
+                )
+                from .workspace import _is_clean
+
+                if not exact or not _is_clean(path):
+                    uncertain = True
+                    row["status"] = "preserved-changed"
+                    continue
+                checkout = self.workspace.manifest.by_checkout[row["checkout"]]
+                primary = Path(row["primary_path"])
+                git(primary, "worktree", "remove", str(path), trace=False)
+                git(primary, "branch", "-d", row["branch"], trace=False)
+                row["status"] = "rolled-back"
+                journal["rollback"].append(f"worktree:{row['checkout']}")
+            except BaseException as rollback_error:
+                uncertain = True
+                row["status"] = "preserved-uncertain"
+                journal["rollback"].append(
+                    f"worktree-error:{row['checkout']}:{rollback_error}"
+                )
+            self._write_journal(journal)
+        return uncertain
+
+    def _record(
+        self,
+        request: dict[str, Any],
+        digest: str,
+        generation: str,
+        created_at: str,
+        worktrees: list[dict[str, Any]],
+        profile_sha256: str,
+        profile_device: int,
+        profile_inode: int,
+    ) -> dict[str, Any]:
+        profile = request["profile"]["name"]
+        topology = request["topology"]["name"]
+        state = request["state_policy"]
+        state_args = (
+            ["--temporary-state"]
+            if state["mode"] == "temporary"
+            else ["--default-state"]
+            if state["mode"] == "default"
+            else ["--state", state["name"]]
+        )
+        quote = lambda values: " ".join(values)
+        stack = self.workspace.manifest.stack(request["stack"])
+        build_commands = {
+            component.name: f"./atrinik build {component.name} --profile {profile} --test"
+            for component in stack.components
+            if self.workspace.manifest.effective_build(stack.name, component) != "none"
+        }
+        path_commands = {
+            component.name: f"./atrinik path {component.name} --profile {profile}"
+            for component in stack.components
+        }
+        return {
+            "schema_version": SCOPE_SCHEMA_VERSION,
+            "status": "complete",
+            "name": request["name"],
+            "generation": generation,
+            "request_sha256": digest,
+            "created_at": created_at,
+            "base_profile": request["base_profile"],
+            "stack": request["stack"],
+            "requested_components": request["requested_components"],
+            "worktrees": worktrees,
+            "profile": {
+                **request["profile"],
+                "sha256": profile_sha256,
+                "path_device": profile_device,
+                "path_inode": profile_inode,
+                "immutable": True,
+            },
+            "topology": request["topology"],
+            "state_policy": state,
+            "commands": {
+                "paths": path_commands,
+                "builds": build_commands,
+                "topology_show": quote(
+                    ["./atrinik", "topology", "show", profile, *state_args, "--json"]
+                ),
+                "up": quote(
+                    ["./atrinik", "up", "--name", topology, "--profile", profile, *state_args, "--json"]
+                ),
+                "ps": f"./atrinik ps {topology} --json",
+                "logs": {
+                    service: f"./atrinik logs {topology} {service} --tail 100"
+                    for service in ("server", "client")
+                },
+                "down": f"./atrinik down {topology} --json",
+                "release_preview": f"./atrinik scope release {request['name']} --dry-run --json",
+                "release_apply": f"./atrinik scope release {request['name']} --apply --plan PLAN_SHA256 --json",
+            },
+            "cleanup": {
+                "policy": "explicit-preview-first",
+                "journal": str(self._journal_path(request["name"])),
+                "release_journal": str(self._release_path(request["name"])),
+            },
+        }
+
+    def show(self, name: str) -> dict[str, Any]:
+        return self._load_record(name)
+
+    def list(self) -> list[dict[str, Any]]:
+        if not self.root.exists():
+            return []
+        if self.root.is_symlink() or not self.root.is_dir():
+            raise WorkspaceError(f"scope registry is unsafe: {self.root}")
+        records = []
+        for entry in sorted(self.root.iterdir()):
+            if entry.is_dir() and not entry.is_symlink() and (entry / "scope.json").is_file():
+                records.append(self._load_record(entry.name))
+        return records
+
+    def _load_record(self, name: str) -> dict[str, Any]:
+        path = self._record_path(name)
+        if path.is_symlink() or not path.is_file():
+            raise WorkspaceError(f"completed scope does not exist: {name}")
+        value = load_regular_json(path, f"scope {name}")
+        self._validate_record(value, name)
+        return value
+
+    def _validate_record(self, value: Any, name: str) -> None:
+        if not isinstance(value, dict):
+            raise WorkspaceError(f"scope record is invalid: {name}")
+        expected = {
+            "schema_version", "status", "name", "generation", "request_sha256",
+            "created_at", "base_profile", "stack", "requested_components",
+            "worktrees", "profile", "topology", "state_policy", "commands", "cleanup",
+        }
+        if set(value) != expected or value.get("schema_version") != SCOPE_SCHEMA_VERSION:
+            raise WorkspaceError(f"scope record schema is invalid: {name}")
+        if value.get("status") != "complete" or value.get("name") != name:
+            raise WorkspaceError(f"scope record identity is invalid: {name}")
+        if not isinstance(value.get("generation"), str) or not re.fullmatch(
+            r"[0-9a-f]{32}", value["generation"]
+        ):
+            raise WorkspaceError(f"scope generation is invalid: {name}")
+        if not isinstance(value.get("request_sha256"), str) or not _HEX64.fullmatch(
+            value["request_sha256"]
+        ):
+            raise WorkspaceError(f"scope request identity is invalid: {name}")
+        if value.get("stack") not in self.workspace.manifest.stacks:
+            raise WorkspaceError(f"scope stack is invalid: {name}")
+        if not isinstance(value.get("created_at"), str) or not value["created_at"]:
+            raise WorkspaceError(f"scope creation time is invalid: {name}")
+        if not isinstance(value.get("base_profile"), str):
+            raise WorkspaceError(f"scope base profile is invalid: {name}")
+        if (
+            not isinstance(value.get("requested_components"), list)
+            or not value["requested_components"]
+            or value["requested_components"] != sorted(set(value["requested_components"]))
+            or not all(isinstance(item, str) and item for item in value["requested_components"])
+        ):
+            raise WorkspaceError(f"scope requested components are invalid: {name}")
+        worktrees = value.get("worktrees")
+        if not isinstance(worktrees, list) or not worktrees:
+            raise WorkspaceError(f"scope worktrees are invalid: {name}")
+        seen: set[str] = set()
+        for row in worktrees:
+            expected_worktree = {
+                "checkout", "repository", "logical_components", "label", "branch",
+                "start_point", "commit", "tree", "path", "primary_path",
+                "common_git_dir", "path_device", "path_inode", "created_by_scope",
+            }
+            if (
+                not isinstance(row, dict)
+                or set(row) != expected_worktree
+                or row.get("checkout") in seen
+                or row.get("created_by_scope") is not True
+            ):
+                raise WorkspaceError(f"scope worktree record is invalid: {name}")
+            checkout = row.get("checkout")
+            if checkout not in self.workspace.manifest.by_checkout:
+                raise WorkspaceError(f"scope worktree checkout is invalid: {name}")
+            seen.add(checkout)
+            if row.get("repository") != self.workspace.manifest.by_checkout[checkout].repository:
+                raise WorkspaceError(f"scope worktree repository is invalid: {name}")
+            if not all(isinstance(row.get(key), str) and row[key] for key in (
+                "label", "branch", "start_point", "commit", "tree", "path",
+                "primary_path", "common_git_dir",
+            )) or not _HEX40.fullmatch(row["commit"]) or not _HEX40.fullmatch(row["tree"]):
+                raise WorkspaceError(f"scope worktree coordinates are invalid: {name}")
+            if not all(type(row.get(key)) is int and row[key] >= 0 for key in ("path_device", "path_inode")):
+                raise WorkspaceError(f"scope worktree path identity is invalid: {name}")
+            expected_components = sorted(
+                component.name
+                for component in self.workspace.manifest.stacks[value["stack"]].components
+                if component.checkout_name == checkout
+            )
+            if row.get("logical_components") != expected_components:
+                raise WorkspaceError(f"scope logical checkout coverage is invalid: {name}")
+            expected_path = self.paths.worktrees / checkout / row["label"]
+            if Path(row["path"]) != expected_path:
+                raise WorkspaceError(f"scope worktree path is invalid: {name}")
+            if Path(row["primary_path"]) != self.workspace._primary_path(
+                self.workspace.manifest.by_checkout[checkout]
+            ):
+                raise WorkspaceError(f"scope primary checkout path is invalid: {name}")
+        profile = value.get("profile")
+        topology = value.get("topology")
+        policy = value.get("state_policy")
+        if not isinstance(profile, dict) or set(profile) != {
+            "name", "path", "sha256", "path_device", "path_inode", "immutable",
+        }:
+            raise WorkspaceError(f"scope profile record is invalid: {name}")
+        if profile.get("path") != str(self.paths.profiles / f"{profile.get('name')}.json"):
+            raise WorkspaceError(f"scope profile path is invalid: {name}")
+        if profile.get("name") != f"scope-{name}":
+            raise WorkspaceError(f"scope profile name is invalid: {name}")
+        if profile.get("immutable") is not True or not _HEX64.fullmatch(str(profile.get("sha256"))):
+            raise WorkspaceError(f"scope profile identity is invalid: {name}")
+        if not all(
+            type(profile.get(key)) is int and profile[key] >= 0
+            for key in ("path_device", "path_inode")
+        ):
+            raise WorkspaceError(f"scope profile path identity is invalid: {name}")
+        if (
+            not isinstance(topology, dict)
+            or set(topology) != {"name", "path"}
+            or not isinstance(topology.get("name"), str)
+            or topology.get("path") != str(self.paths.topologies / topology["name"])
+        ):
+            raise WorkspaceError(f"scope topology record is invalid: {name}")
+        if (
+            not isinstance(policy, dict)
+            or set(policy) != {"mode", "name", "ownership", "lifecycle"}
+            or policy.get("mode") not in {"temporary", "named", "default"}
+        ):
+            raise WorkspaceError(f"scope state policy is invalid: {name}")
+        if (
+            (policy["mode"] == "temporary" and policy["name"] is not None)
+            or (policy["mode"] == "default" and policy["name"] != "default")
+            or (policy["mode"] == "named" and not isinstance(policy["name"], str))
+        ):
+            raise WorkspaceError(f"scope state identity is invalid: {name}")
+        commands = value.get("commands")
+        if not isinstance(commands, dict) or set(commands) != {
+            "paths", "builds", "topology_show", "up", "ps", "logs", "down",
+            "release_preview", "release_apply",
+        }:
+            raise WorkspaceError(f"scope commands are invalid: {name}")
+        if not all(
+            isinstance(commands.get(key), str) and commands[key]
+            for key in (
+                "topology_show", "up", "ps", "down", "release_preview", "release_apply"
+            )
+        ):
+            raise WorkspaceError(f"scope command coordinates are invalid: {name}")
+        if (
+            not isinstance(commands.get("paths"), dict)
+            or not isinstance(commands.get("builds"), dict)
+            or not isinstance(commands.get("logs"), dict)
+            or set(commands["logs"]) != {"client", "server"}
+            or not all(isinstance(item, str) and item for item in commands["paths"].values())
+            or not all(isinstance(item, str) and item for item in commands["builds"].values())
+            or not all(isinstance(item, str) and item for item in commands["logs"].values())
+        ):
+            raise WorkspaceError(f"scope command maps are invalid: {name}")
+        cleanup = value.get("cleanup")
+        if (
+            not isinstance(cleanup, dict)
+            or set(cleanup) != {"policy", "journal", "release_journal"}
+            or cleanup.get("policy") != "explicit-preview-first"
+            or cleanup.get("journal") != str(self._journal_path(name))
+            or cleanup.get("release_journal") != str(self._release_path(name))
+        ):
+            raise WorkspaceError(f"scope cleanup coordinates are invalid: {name}")
+        request = {
+            "name": value["name"],
+            "base_profile": value["base_profile"],
+            "stack": value["stack"],
+            "requested_components": value["requested_components"],
+            "profile": {"name": profile["name"], "path": profile["path"]},
+            "topology": topology,
+            "state_policy": policy,
+            "worktrees": [
+                {
+                    key: row[key]
+                    for key in (
+                        "checkout", "repository", "logical_components", "label", "branch",
+                        "start_point", "commit", "tree", "path", "primary_path",
+                    )
+                }
+                for row in worktrees
+            ],
+        }
+        if _canonical_sha256(request) != value["request_sha256"]:
+            raise WorkspaceError(f"scope request digest is invalid: {name}")
+        canonical = self._record(
+            request,
+            value["request_sha256"],
+            value["generation"],
+            value["created_at"],
+            worktrees,
+            profile["sha256"],
+            profile["path_device"],
+            profile["path_inode"],
+        )
+        if value["commands"] != canonical["commands"]:
+            raise WorkspaceError(f"scope commands do not match exact coordinates: {name}")
+        if value["cleanup"] != canonical["cleanup"]:
+            raise WorkspaceError(f"scope cleanup does not match exact coordinates: {name}")
+
+        def forbidden_key(candidate: Any) -> bool:
+            if isinstance(candidate, dict):
+                return any(
+                    re.search(r"password|credential|secret|token", str(key), re.IGNORECASE)
+                    or forbidden_key(item)
+                    for key, item in candidate.items()
+                )
+            if isinstance(candidate, list):
+                return any(forbidden_key(item) for item in candidate)
+            return False
+
+        if forbidden_key(value):
+            raise WorkspaceError(f"scope record contains forbidden secret-shaped fields: {name}")
+
+    def profile_owner(self, profile_name: str) -> str | None:
+        for record in self.list():
+            if record["profile"]["name"] == profile_name:
+                return record["name"]
+        if not self.root.exists() or self.root.is_symlink() or not self.root.is_dir():
+            return None
+        for directory in sorted(self.root.iterdir()):
+            if directory.is_symlink() or not directory.is_dir():
+                continue
+            if profile_name == f"scope-{directory.name}":
+                return directory.name
+        return None
+
+    def topology_owner(self, topology_name: str) -> dict[str, Any] | None:
+        for record in self.list():
+            if record["topology"]["name"] == topology_name:
+                return record
+        return None
+
+    def _require_unreleased(self, record: dict[str, Any]) -> None:
+        path = self._release_path(record["name"])
+        if not path.exists() and not path.is_symlink():
+            return
+        if path.is_symlink() or not path.is_file():
+            raise WorkspaceError(
+                f"scope release evidence is unsafe: {record['name']}"
+            )
+        journal = load_regular_json(path, f"scope release {record['name']}")
+        if (
+            not isinstance(journal, dict)
+            or journal.get("schema_version") != SCOPE_RELEASE_SCHEMA_VERSION
+            or journal.get("scope") != record["name"]
+            or journal.get("generation") != record["generation"]
+        ):
+            raise WorkspaceError(
+                f"scope release evidence is invalid: {record['name']}"
+            )
+        raise WorkspaceError(
+            f"scope release has started; choose a new scope name: {record['name']}"
+        )
+
+    def release(
+        self, name: str, *, apply: bool, plan_sha256: str | None = None
+    ) -> dict[str, Any]:
+        record = self._load_record(name)
+        requests = self._release_leases(record)
+        try:
+            with ExitStack() as locks:
+                for root in self._candidate_build_roots(record["profile"]["name"]):
+                    locks.enter_context(
+                        exclusive_lock(
+                            self.paths.builds / "locks" / f"{root.name}.lock",
+                            f"scope release build {root.name}",
+                            nonblocking=True,
+                        )
+                    )
+                with self.workspace._resource_locks(requests, nonblocking=True):
+                    plan = self._release_plan(record)
+                    if not apply:
+                        return plan
+                    if plan_sha256 is None or not _HEX64.fullmatch(plan_sha256):
+                        raise WorkspaceError("scope release apply requires the exact --plan SHA256 from dry-run")
+                    if plan_sha256 != plan["plan_sha256"]:
+                        raise WorkspaceError("scope release coordinates changed since preview; preview again")
+                    blockers = [item for item in plan["items"] if item["disposition"] == "protected"]
+                    if blockers:
+                        raise WorkspaceError(
+                            "scope release is protected: "
+                            + "; ".join(
+                                f"{item['kind']}:{','.join(item['reasons'])}" for item in blockers
+                            )
+                        )
+                    return self._apply_release(record, plan)
+        except LockBusyError as error:
+            raise WorkspaceError(
+                f"scope release refused active resource leases: {name}"
+            ) from error
+
+    def _candidate_build_roots(self, profile_name: str) -> list[Path]:
+        parent = self.paths.builds / "profiles"
+        if not parent.is_dir() or parent.is_symlink():
+            return []
+        return sorted(parent.glob(f"{profile_name}-*"))
+
+    def _release_leases(self, record: dict[str, Any]) -> list[Any]:
+        requests = [
+            self.workspace._lease_request(
+                "registry", f"scope:{record['name']}", "exclusive", f"release scope {record['name']}"
+            ),
+            self.workspace._lease_request(
+                "registry", "physical-references", "exclusive", f"release scope {record['name']}"
+            ),
+            self.workspace._lease_request(
+                "profile", record["profile"]["name"], "exclusive", f"release scope {record['name']}"
+            ),
+            self.workspace._lease_request(
+                "topology", record["topology"]["name"], "exclusive", f"release scope {record['name']}"
+            ),
+        ]
+        for row in record["worktrees"]:
+            checkout = self.workspace.manifest.by_checkout[row["checkout"]]
+            requests.extend(
+                [
+                    self.workspace._lease_request(
+                        "git-admin",
+                        self.workspace._git_admin_coordinate(checkout, Path(row["primary_path"])),
+                        "exclusive",
+                        f"release scope {record['name']}",
+                    ),
+                    self.workspace._lease_request(
+                        "source",
+                        self.workspace._source_coordinate(checkout.name, Path(row["path"])),
+                        "exclusive",
+                        f"release scope {record['name']}",
+                    ),
+                ]
+            )
+        return requests
+
+    def _release_plan(self, record: dict[str, Any]) -> dict[str, Any]:
+        from .workspace import BUILD_METADATA, _is_clean, git
+
+        items: list[dict[str, Any]] = []
+        topology_path = Path(record["topology"]["path"])
+        if topology_path.exists() or topology_path.is_symlink():
+            try:
+                status = self.workspace.topology_status(record["topology"]["name"])
+                supervisor_liveness = status.get("supervisor", {}).get("liveness")
+                unreachable = supervisor_liveness == "unreachable"
+                running = supervisor_liveness == "live" or any(
+                    service.get("status") == "running" or service.get("running") is True
+                    for service in status.get("services", {}).values()
+                )
+                observation = status.get("observation", {})
+                retained = any(
+                    observation.get(key) == "retained"
+                    for key in ("process_tree_lease", "runtime_bundle_lease")
+                )
+                state_policy = status.get("state_policy", {})
+                retained_state = (
+                    isinstance(state_policy, dict)
+                    and state_policy.get("mode") == "temporary"
+                    and state_policy.get("lifecycle") == "retained"
+                )
+                if unreachable:
+                    reasons = ["unreachable_topology"]
+                elif running:
+                    reasons = ["live_topology"]
+                elif retained or retained_state:
+                    reasons = ["retained_generation"]
+                else:
+                    reasons = ["stopped_topology_history_retained"]
+                disposition = (
+                    "protected" if running or unreachable or retained or retained_state else "retained"
+                )
+            except (OSError, WorkspaceError) as error:
+                reasons = [f"unreachable_topology:{error}"]
+                disposition = "protected"
+            items.append(
+                {"kind": "topology", "path": str(topology_path), "disposition": disposition, "reasons": reasons}
+            )
+        else:
+            items.append(
+                {"kind": "topology", "path": str(topology_path), "disposition": "absent", "reasons": ["not_created"]}
+            )
+
+        policy = record["state_policy"]
+        items.append(
+            {
+                "kind": "state",
+                "path": None,
+                "disposition": "retained" if policy["mode"] != "temporary" else "absent",
+                "reasons": [
+                    "persistent_state_never_removed"
+                    if policy["mode"] != "temporary"
+                    else "generation_owned_state_removed_on_clean_stop"
+                ],
+            }
+        )
+
+        build_roots = self._candidate_build_roots(record["profile"]["name"])
+        for root in build_roots:
+            reasons: list[str] = []
+            marker = root / MANAGED_MARKER
+            metadata_path = root / BUILD_METADATA
+            marker_sha256: str | None = None
+            metadata_sha256: str | None = None
+            if root.is_symlink() or not root.is_dir() or not marker.is_file() or marker.is_symlink():
+                reasons.append("uncertain_build_ownership")
+            else:
+                try:
+                    metadata = load_regular_json(metadata_path, "scope build metadata")
+                    marker_value = load_regular_json(marker, "scope build marker")
+                    if (
+                        not isinstance(metadata, dict)
+                        or metadata.get("profile") != record["profile"]["name"]
+                        or not isinstance(metadata.get("key"), str)
+                        or root.name != f"{record['profile']['name']}-{metadata['key']}"
+                        or marker_value
+                        != {
+                            "schema_version": 1,
+                            "purpose": f"profile:{record['profile']['name']}:{metadata['key']}",
+                        }
+                    ):
+                        reasons.append("uncertain_build_ownership")
+                    else:
+                        metadata_sha256 = _file_sha256(metadata_path)
+                        marker_sha256 = _file_sha256(marker)
+                except (OSError, WorkspaceError):
+                    reasons.append("uncertain_build_ownership")
+            disposition = "protected" if reasons else "eligible"
+            identity = root.stat(follow_symlinks=False) if disposition == "eligible" else None
+            items.append(
+                {
+                    "kind": "build",
+                    "path": str(root),
+                    "device": identity.st_dev if identity is not None else None,
+                    "inode": identity.st_ino if identity is not None else None,
+                    "metadata_sha256": metadata_sha256,
+                    "marker_sha256": marker_sha256,
+                    "disposition": disposition,
+                    "reasons": reasons or ["scope_profile_build"],
+                }
+            )
+
+        profile_path = Path(record["profile"]["path"])
+        profile_reasons: list[str] = []
+        if profile_path.exists() or profile_path.is_symlink():
+            if profile_path.is_symlink() or not profile_path.is_file():
+                profile_reasons.append("replaced_profile")
+            elif _file_sha256(profile_path) != record["profile"]["sha256"]:
+                profile_reasons.append("changed_profile")
+            else:
+                profile_identity = profile_path.stat(follow_symlinks=False)
+                if (
+                    profile_identity.st_dev,
+                    profile_identity.st_ino,
+                ) != (
+                    record["profile"]["path_device"],
+                    record["profile"]["path_inode"],
+                ):
+                    profile_reasons.append("replaced_profile")
+            disposition = "protected" if profile_reasons else "eligible"
+        else:
+            disposition = "absent"
+            profile_reasons.append("already_removed")
+        items.append(
+            {"kind": "profile", "path": str(profile_path), "disposition": disposition, "reasons": profile_reasons or ["scope_owned"]}
+        )
+
+        for row in record["worktrees"]:
+            path = Path(row["path"])
+            reasons: list[str] = []
+            if path.exists() or path.is_symlink():
+                if path.is_symlink() or not path.is_dir():
+                    reasons.append("replaced_path")
+                else:
+                    try:
+                        identity = path.stat(follow_symlinks=False)
+                        if (identity.st_dev, identity.st_ino) != (
+                            row["path_device"], row["path_inode"]
+                        ):
+                            reasons.append("replaced_path")
+                        if self.workspace._git_common_directory(path, trace=False) != Path(row["common_git_dir"]):
+                            reasons.append("changed_common_git_identity")
+                        if git(path, "rev-parse", "HEAD", capture=True, trace=False) != row["commit"]:
+                            reasons.append("changed_head")
+                        branch = git(path, "branch", "--show-current", capture=True, trace=False)
+                        if branch != row["branch"]:
+                            reasons.append("detached_or_changed_branch")
+                        if not _is_clean(path):
+                            reasons.append("dirty_worktree")
+                        references = self.workspace._source_references(path)
+                        unexpected = [
+                            reference
+                            for reference in references
+                            if reference != f"profile:{record['profile']['name']}"
+                            and reference != record["profile"]["name"]
+                            and reference != f"scope:{record['name']}"
+                        ]
+                        if unexpected:
+                            reasons.append("unexpected_references:" + ",".join(unexpected))
+                    except (OSError, WorkspaceError) as error:
+                        reasons.append(f"ambiguous_git_state:{error}")
+                disposition = "protected" if reasons else "eligible"
+            else:
+                disposition = "absent"
+                reasons.append("already_removed")
+            items.append(
+                {"kind": "worktree", "checkout": row["checkout"], "path": str(path), "disposition": disposition, "reasons": reasons or ["scope_owned_clean_exact"]}
+            )
+
+        identity = {
+            "schema_version": SCOPE_RELEASE_SCHEMA_VERSION,
+            "scope": record["name"],
+            "generation": record["generation"],
+            "items": items,
+        }
+        return {
+            **identity,
+            "mode": "dry-run",
+            "plan_sha256": _canonical_sha256(identity),
+            "can_apply": not any(item["disposition"] == "protected" for item in items),
+        }
+
+    def _apply_release(self, record: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
+        from .workspace import BUILD_METADATA, git, remove_owned_tree
+
+        completed: list[str] = []
+        release_path = self._release_path(record["name"])
+        if release_path.exists() or release_path.is_symlink():
+            if release_path.is_symlink() or not release_path.is_file():
+                raise WorkspaceError("scope release journal is unsafe")
+            previous = load_regular_json(release_path, f"scope release {record['name']}")
+            if (
+                not isinstance(previous, dict)
+                or previous.get("schema_version") != SCOPE_RELEASE_SCHEMA_VERSION
+                or previous.get("scope") != record["name"]
+                or previous.get("generation") != record["generation"]
+                or not isinstance(previous.get("completed"), list)
+                or not all(isinstance(item, str) for item in previous["completed"])
+            ):
+                raise WorkspaceError("scope release journal is invalid")
+            completed = list(dict.fromkeys(previous["completed"]))
+        journal: dict[str, Any] = {
+            "schema_version": SCOPE_RELEASE_SCHEMA_VERSION,
+            "scope": record["name"],
+            "generation": record["generation"],
+            "plan_sha256": plan["plan_sha256"],
+            "status": "applying",
+            "completed": completed,
+            "updated_at": _now(),
+        }
+        durable_atomic_json(self._release_path(record["name"]), journal)
+        for item in plan["items"]:
+            if item["kind"] != "build" or item["disposition"] != "eligible":
+                continue
+            root = Path(item["path"])
+            metadata_path = root / BUILD_METADATA
+            marker_path = root / MANAGED_MARKER
+            if (
+                metadata_path.is_symlink()
+                or not metadata_path.is_file()
+                or marker_path.is_symlink()
+                or not marker_path.is_file()
+                or _file_sha256(metadata_path) != item["metadata_sha256"]
+                or _file_sha256(marker_path) != item["marker_sha256"]
+            ):
+                raise WorkspaceError(
+                    f"scope build ownership changed during release: {root}"
+                )
+            remove_owned_tree(
+                root,
+                expected_identity={"device": item["device"], "inode": item["inode"]},
+            )
+            action = f"build:{item['path']}"
+            if action not in journal["completed"]:
+                journal["completed"].append(action)
+            journal["updated_at"] = _now()
+            durable_atomic_json(self._release_path(record["name"]), journal)
+
+        profile_path = Path(record["profile"]["path"])
+        if any(item["kind"] == "profile" and item["disposition"] == "eligible" for item in plan["items"]):
+            if (
+                profile_path.is_symlink()
+                or not profile_path.is_file()
+                or _file_sha256(profile_path) != record["profile"]["sha256"]
+                or (
+                    profile_path.stat(follow_symlinks=False).st_dev,
+                    profile_path.stat(follow_symlinks=False).st_ino,
+                )
+                != (
+                    record["profile"]["path_device"],
+                    record["profile"]["path_inode"],
+                )
+            ):
+                raise WorkspaceError("scope profile changed during release")
+            profile_path.unlink()
+            self.workspace._remove_physical_reference(profile_path)
+            if "profile" not in journal["completed"]:
+                journal["completed"].append("profile")
+            journal["updated_at"] = _now()
+            durable_atomic_json(self._release_path(record["name"]), journal)
+
+        by_checkout = {
+            item["checkout"]: item
+            for item in plan["items"]
+            if item["kind"] == "worktree"
+        }
+        for row in reversed(record["worktrees"]):
+            item = by_checkout[row["checkout"]]
+            if item["disposition"] != "eligible":
+                continue
+            path = Path(row["path"])
+            if path.is_symlink() or not path.is_dir():
+                raise WorkspaceError(f"scope worktree changed during release: {path}")
+            identity = path.stat(follow_symlinks=False)
+            if (
+                (identity.st_dev, identity.st_ino)
+                != (row["path_device"], row["path_inode"])
+                or self.workspace._git_common_directory(path, trace=False)
+                != Path(row["common_git_dir"])
+                or git(path, "rev-parse", "HEAD", capture=True, trace=False)
+                != row["commit"]
+                or git(path, "branch", "--show-current", capture=True, trace=False)
+                != row["branch"]
+            ):
+                raise WorkspaceError(f"scope worktree changed during release: {path}")
+            from .workspace import _is_clean
+
+            if not _is_clean(path):
+                raise WorkspaceError(f"scope worktree became dirty during release: {path}")
+            if [
+                reference
+                for reference in self.workspace._source_references(path)
+                if reference != f"scope:{record['name']}"
+            ]:
+                raise WorkspaceError(f"scope worktree became referenced during release: {path}")
+            primary = Path(row["primary_path"])
+            git(primary, "worktree", "remove", str(path), trace=False)
+            git(primary, "branch", "-d", row["branch"], trace=False)
+            action = f"worktree:{row['checkout']}"
+            if action not in journal["completed"]:
+                journal["completed"].append(action)
+            journal["updated_at"] = _now()
+            durable_atomic_json(self._release_path(record["name"]), journal)
+        journal["status"] = "complete"
+        journal["updated_at"] = _now()
+        durable_atomic_json(self._release_path(record["name"]), journal)
+        return {**plan, "mode": "apply", "released": True, "journal": str(self._release_path(record["name"]))}

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -1757,6 +1757,62 @@ class Workspace:
             self._wrapper_lease = None
             wrapper_lease.__exit__(None, None, None)
 
+    def scope_create(
+        self,
+        components: list[str],
+        *,
+        name: str | None = None,
+        base_profile: str = "default",
+        labels: list[str] | None = None,
+        branches: list[str] | None = None,
+        start_points: list[str] | None = None,
+        topology: str | None = None,
+        state_mode: str = "temporary",
+        state_name: str | None = None,
+    ) -> dict[str, Any]:
+        from .scopes import ScopeLifecycle
+
+        return ScopeLifecycle(self).create(
+            components,
+            name=name,
+            base_profile=base_profile,
+            labels=labels,
+            branches=branches,
+            start_points=start_points,
+            topology=topology,
+            state_mode=state_mode,
+            state_name=state_name,
+        )
+
+    def scope_show(self, name: str) -> dict[str, Any]:
+        from .scopes import ScopeLifecycle
+
+        return ScopeLifecycle(self).show(name)
+
+    def scope_list(self) -> list[dict[str, Any]]:
+        from .scopes import ScopeLifecycle
+
+        return ScopeLifecycle(self).list()
+
+    def scope_release(
+        self, name: str, *, apply: bool, plan_sha256: str | None = None
+    ) -> dict[str, Any]:
+        from .scopes import ScopeLifecycle
+
+        return ScopeLifecycle(self).release(
+            name, apply=apply, plan_sha256=plan_sha256
+        )
+
+    def _scope_profile_owner(self, name: str) -> str | None:
+        from .scopes import ScopeLifecycle
+
+        return ScopeLifecycle(self).profile_owner(name)
+
+    def _scope_topology_owner(self, name: str) -> dict[str, Any] | None:
+        from .scopes import ScopeLifecycle
+
+        return ScopeLifecycle(self).topology_owner(name)
+
     def __del__(self) -> None:
         try:
             self.close()
@@ -1965,6 +2021,7 @@ class Workspace:
         requests: list[LeaseRequest] | tuple[LeaseRequest, ...],
         *,
         nonblocking: bool = False,
+        include_wrapper: bool = True,
     ) -> Iterator[tuple[TextIO, ...]]:
         """Acquire exact leases beneath the shared migration barrier."""
 
@@ -1974,7 +2031,9 @@ class Workspace:
             "shared",
             "use wrapper worktree",
         )
-        protected_requests = (*requests, wrapper_request)
+        protected_requests = (
+            (*requests, wrapper_request) if include_wrapper else tuple(requests)
+        )
         with shared_maintenance_lock(
             self._lease_namespace / "repository-layout.lock"
         ):
@@ -3356,6 +3415,8 @@ class Workspace:
         start_point: str | None,
         existing: bool,
         stable_destination: Path | None = None,
+        *,
+        announce: bool = True,
     ) -> Path:
         self.paths.ensure()
         validate_name(label, "worktree label")
@@ -3416,7 +3477,8 @@ class Workspace:
                         f"be rolled back: {rollback_error}"
                     ) from error
             raise
-        print(reported_destination)
+        if announce:
+            print(reported_destination)
         return reported_destination
 
     def remove_worktree(self, component_name: str, label: str) -> None:
@@ -3633,7 +3695,7 @@ class Workspace:
         """Return exact persisted references while the caller holds source exclusive."""
 
         target = source_root.resolve()
-        references: list[str] = []
+        references: list[str] = self._scope_source_references(target)
         for record in self._physical_reference_records():
             if (
                 not isinstance(record, dict)
@@ -3703,6 +3765,105 @@ class Workspace:
                         break
         return sorted(set(references))
 
+    def _scope_source_references(self, target: Path) -> list[str]:
+        """Keep complete or recoverable scope inputs visible to cleanup."""
+
+        return [
+            f"scope:{name}"
+            for name, path in self._scope_reference_records()
+            if path.resolve(strict=False) == target
+        ]
+
+    def _scope_reference_records(self) -> list[tuple[str, Path]]:
+        """Return exact source paths retained by complete or recoverable scopes."""
+
+        from .scopes import (
+            SCOPE_JOURNAL_SCHEMA_VERSION,
+            SCOPE_RELEASE_SCHEMA_VERSION,
+            ScopeLifecycle,
+        )
+
+        root = self.paths.scopes
+        if not root.exists():
+            return []
+        if root.is_symlink() or not root.is_dir():
+            raise WorkspaceError(f"cannot prove scope references: {root}")
+        references: list[tuple[str, Path]] = []
+        lifecycle = ScopeLifecycle(self)
+        for directory in sorted(root.iterdir()):
+            if (
+                directory.name.startswith(".")
+                or directory.is_symlink()
+                or not directory.is_dir()
+            ):
+                raise WorkspaceError(
+                    f"cannot prove scope reference directory: {directory}"
+                )
+            record_path = directory / "scope.json"
+            journal_path = directory / "creation-journal.json"
+            release_path = directory / "release-journal.json"
+            completed: set[str] = set()
+            if release_path.exists() or release_path.is_symlink():
+                release = load_regular_json(
+                    release_path, f"scope release {directory.name}"
+                )
+                if (
+                    not isinstance(release, dict)
+                    or release.get("schema_version")
+                    != SCOPE_RELEASE_SCHEMA_VERSION
+                    or release.get("scope") != directory.name
+                    or not isinstance(release.get("completed"), list)
+                    or not all(
+                        isinstance(item, str) for item in release["completed"]
+                    )
+                ):
+                    raise WorkspaceError(
+                        f"cannot prove scope release references: {release_path}"
+                    )
+                completed = set(release["completed"])
+            if record_path.exists() or record_path.is_symlink():
+                record = lifecycle._load_record(directory.name)
+                rows = [
+                    row
+                    for row in record["worktrees"]
+                    if f"worktree:{row['checkout']}" not in completed
+                ]
+            elif journal_path.exists() or journal_path.is_symlink():
+                journal = load_regular_json(
+                    journal_path, f"scope creation journal {directory.name}"
+                )
+                if (
+                    not isinstance(journal, dict)
+                    or journal.get("schema_version")
+                    != SCOPE_JOURNAL_SCHEMA_VERSION
+                    or journal.get("name") != directory.name
+                    or not isinstance(journal.get("worktrees"), list)
+                ):
+                    raise WorkspaceError(
+                        f"cannot prove scope creation references: {journal_path}"
+                    )
+                rows = [
+                    row
+                    for row in journal["worktrees"]
+                    if isinstance(row, dict)
+                    and row.get("status")
+                    in {"created", "preserved-changed", "preserved-uncertain"}
+                ]
+                if any(
+                    not isinstance(row, dict)
+                    or not isinstance(row.get("path"), str)
+                    for row in journal["worktrees"]
+                ):
+                    raise WorkspaceError(
+                        f"cannot prove scope creation references: {journal_path}"
+                    )
+            else:
+                continue
+            references.extend(
+                (directory.name, Path(row["path"])) for row in rows
+            )
+        return references
+
     def list_worktrees(self, names: list[str] | None = None) -> list[tuple[str, dict[str, str]]]:
         self.paths.ensure()
         result: list[tuple[str, dict[str, str]]] = []
@@ -3726,6 +3887,11 @@ class Workspace:
         self.paths.ensure()
         validate_name(name, "profile name")
         validate_name(source, "profile name")
+        scope_owner = self._scope_profile_owner(name)
+        if scope_owner is not None:
+            raise WorkspaceError(
+                f"profile name is reserved by scope {scope_owner}: {name}"
+            )
         requests = [
             self._lease_request(
                 "profile", name, "exclusive", f"create profile {name}"
@@ -3807,6 +3973,11 @@ class Workspace:
     ) -> None:
         self.paths.ensure()
         validate_name(name, "profile name")
+        scope_owner = self._scope_profile_owner(name)
+        if scope_owner is not None:
+            raise WorkspaceError(
+                f"profile is immutable while owned by scope {scope_owner}: {name}"
+            )
         profile_request = self._lease_request(
             "profile", name, "exclusive", f"update profile {name}"
         )
@@ -4427,6 +4598,11 @@ class Workspace:
         release_coordinates: dict[str, Any] | None = None,
     ) -> None:
         self.paths.ensure()
+        scope_owner = self._scope_profile_owner(name)
+        if scope_owner is not None:
+            raise WorkspaceError(
+                f"profile is immutable while owned by scope {scope_owner}: {name}"
+            )
         with self._resource_locks(
             [
                 self._lease_request(
@@ -13744,6 +13920,23 @@ class Workspace:
     ) -> dict[str, Any]:
         self.paths.ensure()
         selected_services = self._topology_services(services)
+        normalized_mode, normalized_state = self._normalize_topology_state_request(
+            state_mode, state_name, selected_services
+        )
+        scope = self._scope_topology_owner(name)
+        if scope is not None:
+            policy = scope["state_policy"]
+            if (
+                profile_name != scope["profile"]["name"]
+                or "server" in selected_services
+                and (
+                    normalized_mode != policy["mode"]
+                    or normalized_state != policy["name"]
+                )
+            ):
+                raise WorkspaceError(
+                    f"topology name is reserved by scope {scope['name']} with exact profile and state coordinates: {name}"
+                )
         with self._resolved_profile_operation(
             profile_name,
             set(selected_services),
@@ -13759,10 +13952,10 @@ class Workspace:
                 return self._topology_up(
                     name,
                     profile_name,
-                    state_name,
+                    normalized_state,
                     services,
                     port,
-                    state_mode,
+                    normalized_mode,
                 )
 
     def _topology_resolved_status(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -131,6 +131,7 @@ so an absent opt-in checkout is not mistaken for a broken default workspace.
   <checkout-destination>/           primary independent Git checkouts
 workspace/
   worktrees/<checkout>/<label>/      physical-checkout Git worktrees
+  scopes/<name>/                     durable development-scope records/journals
   profiles/<name>.json               logical component -> checkout selectors
   build/profiles/<name>-<key>/       isolated sources, builds, and runtime
   build/source-generations/<checkout>/<key>/ immutable primary exports
@@ -188,6 +189,38 @@ exact physical checkouts through either checkout or logical-component
 identities. One checkout is synchronized only once. A missing optional
 repository is reported and skipped rather than cloned as a synchronization
 side effect.
+
+Agent development scopes compose existing physical repository, profile,
+topology, state, and lease contracts without introducing a second path model.
+The transaction preflights its stable or collision-resistant generated name,
+base profile, deduplicated physical checkouts, labels, branches and exact start
+commits, destination paths, immutable profile, topology namespace, and state
+policy before reserving the name. It takes the name reservation first, then
+acquires profile, Git-admin, source, topology, and state coordinates in the
+global lease order. Distinct names may overlap except for bounded Git-admin
+publication on one physical checkout; identical names or explicit branch/path
+coordinates have one creator.
+
+`reservation.json` and `creation-journal.json` are durable before the first
+resource publication. Each full worktree, profile-reference, immutable profile,
+and completed-record publication is journaled in order. The schema-validated
+`scope.json` is last, so readers cannot observe a completed scope backed by a
+partial profile. Exact completed retries return that record. Conflicting or
+incomplete reservations never overwrite their existing evidence. Rollback
+requires the recorded path, common-Git directory, branch, commit, cleanliness,
+and reference set to remain exact; any uncertainty converts the journal to
+recovery-required. Complete and recoverable scope journals contribute exact
+cleanup references until release journals prove each worktree removed.
+
+Release computes a canonical SHA-256 plan over the completed scope generation
+and every observed topology, state, build, profile, worktree, and reference
+disposition. Apply requires that preview digest and recomputes it under the
+same exact leases. Dependency-ordered removal journals each completed action.
+Persistent named/default state and stopped topology history are retained, and
+live/unreachable topologies, retained runtime or temporary-state generations,
+busy resources, changed identities, dirty/detached Git state, replacement,
+unexpected references, and uncertain ownership fail closed. The completed
+scope and release journal remain durable evidence after release.
 
 ## Cleanup inventory and retention
 
@@ -489,6 +522,12 @@ identity. Resolution verifies that every selected root is a Git worktree whose
 checkouts additionally require the manifest branch; feature-worktree and
 explicit-path selectors may use review branches. Only after validation does
 resolution append the logical component's declared source path.
+
+A scope-owned saved profile uses the same schema and resolution path but is
+immutable for the scope lifetime. Its exact bytes are hashed into the scope
+record, and primitive profile mutation refuses the owner. This keeps the JSON
+handoff's path/build/topology commands stable while preserving ordinary mutable
+saved profiles for manual workflows.
 
 Worktrees are always full physical repositories and are keyed by checkout, so
 every classic worktree lives below `workspace/worktrees/classic/<label>` and

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,131 @@ from atrinik_workspace.model import WorkspaceError
 
 
 class ParserTests(unittest.TestCase):
+    def test_scope_human_output_reports_exact_coordinates(self) -> None:
+        record = {
+            "name": "review",
+            "generation": "generation-1",
+            "status": "complete",
+            "profile": {"name": "scope-review", "path": "/profiles/scope-review.json"},
+            "topology": {"name": "scope-review", "path": "/topologies/scope-review"},
+            "worktrees": [
+                {
+                    "checkout": "client",
+                    "branch": "scope/review/client",
+                    "path": "/worktrees/client/scope-review",
+                }
+            ],
+        }
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.scope_create.return_value = record
+            with mock.patch("builtins.print") as output:
+                result = main(["scope", "create", "client", "--name", "review"])
+
+        self.assertEqual(result, 0)
+        self.assertEqual(
+            [call.args[0] for call in output.call_args_list],
+            [
+                "scope\treview\tgeneration-1",
+                "profile\tscope-review\t/profiles/scope-review.json",
+                "topology\tscope-review\t/topologies/scope-review",
+                "worktree\tclient\tscope/review/client\t/worktrees/client/scope-review",
+            ],
+        )
+
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.scope_list.return_value = [record]
+            with mock.patch("builtins.print") as output:
+                result = main(["scope", "list"])
+        self.assertEqual(result, 0)
+        output.assert_called_once_with("review\tcomplete\tscope-review\tscope-review")
+
+    def test_scope_release_human_output_and_preview_guard(self) -> None:
+        release = {
+            "scope": "review",
+            "mode": "dry-run",
+            "plan_sha256": "a" * 64,
+            "items": [
+                {
+                    "disposition": "candidate",
+                    "kind": "profile",
+                    "path": "/profiles/scope-review.json",
+                    "reasons": [],
+                },
+                {
+                    "disposition": "protected",
+                    "kind": "state",
+                    "path": None,
+                    "reasons": ["persistent state"],
+                },
+            ],
+        }
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.scope_release.return_value = release
+            with mock.patch("builtins.print") as output:
+                result = main(["scope", "release", "review", "--dry-run"])
+
+        self.assertEqual(result, 0)
+        self.assertEqual(
+            [call.args[0] for call in output.call_args_list],
+            [
+                "scope\treview\tdry-run",
+                f"plan\t{'a' * 64}",
+                "candidate\tprofile\t/profiles/scope-review.json\t",
+                "protected\tstate\t-\tpersistent state",
+            ],
+        )
+        with mock.patch("atrinik_workspace.cli.Workspace"):
+            with mock.patch("sys.stderr"):
+                result = main(
+                    ["scope", "release", "review", "--dry-run", "--plan", "a" * 64]
+                )
+        self.assertEqual(result, 1)
+
+    def test_scope_create_dispatches_exact_coordinates_as_json(self) -> None:
+        record = {"schema_version": 1, "name": "review", "status": "complete"}
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.scope_create.return_value = record
+            with mock.patch("builtins.print") as output:
+                result = main(
+                    [
+                        "scope", "create", "classic-server", "content",
+                        "--name", "review", "--from", "classic",
+                        "--branch", "classic=feat/review", "--state", "shared",
+                        "--json",
+                    ]
+                )
+        self.assertEqual(result, 0)
+        workspace_type.return_value.scope_create.assert_called_once_with(
+            ["classic-server", "content"],
+            name="review",
+            base_profile="classic",
+            labels=[],
+            branches=["classic=feat/review"],
+            start_points=[],
+            topology=None,
+            state_mode="named",
+            state_name="shared",
+        )
+        self.assertEqual(json.loads(output.call_args.args[0]), record)
+
+    def test_scope_release_requires_preview_mode_and_forwards_plan(self) -> None:
+        options = parser().parse_args(
+            ["scope", "release", "review", "--apply", "--plan", "a" * 64]
+        )
+        self.assertTrue(options.apply)
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.scope_release.return_value = {
+                "scope": "review", "mode": "apply", "plan_sha256": "a" * 64,
+                "items": [],
+            }
+            result = main(
+                ["scope", "release", "review", "--apply", "--plan", "a" * 64, "--json"]
+            )
+        self.assertEqual(result, 0)
+        workspace_type.return_value.scope_release.assert_called_once_with(
+            "review", apply=True, plan_sha256="a" * 64
+        )
+
     def test_cleanup_accepts_the_explicit_topologies_scope(self) -> None:
         options = parser().parse_args(["cleanup", "--scope", "topologies"])
         self.assertEqual(options.scope, ["topologies"])

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -108,10 +108,15 @@ class CompletionTests(unittest.TestCase):
         self.assertEqual(mode, "candidates")
         self.assertIn("completion", values)
         self.assertIn("worktree", values)
+        self.assertIn("scope", values)
 
         self.assertEqual(
             self.candidates("worktree", ""),
             ("candidates", ["create", "list", "remove"]),
+        )
+        self.assertEqual(
+            self.candidates("scope", ""),
+            ("candidates", ["create", "list", "release", "show"]),
         )
         self.assertEqual(
             self.candidates("topology", "show", "default", "--service", "s"),
@@ -128,6 +133,20 @@ class CompletionTests(unittest.TestCase):
         mode, values = self.candidates("logs", "default", "server", "--f")
         self.assertEqual(mode, "candidates")
         self.assertEqual(values, ["--follow"])
+
+    def test_completed_scope_names_refresh_without_loading_workspace(self) -> None:
+        self.write_json(
+            self.workspace / "scopes" / "review" / "scope.json",
+            {"schema_version": 1, "status": "complete", "name": "review"},
+        )
+        self.write_json(
+            self.workspace / "scopes" / "partial" / "scope.json",
+            {"schema_version": 1, "status": "creating", "name": "partial"},
+        )
+        self.assertEqual(
+            self.candidates("scope", "show", ""),
+            ("candidates", ["review"]),
+        )
 
     def test_consumed_and_mutually_exclusive_options_are_suppressed(self) -> None:
         mode, values = self.candidates("cleanup", "--dry-run", "--", "")

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -1,0 +1,872 @@
+from __future__ import annotations
+
+import copy
+import json
+import os
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import tempfile
+import threading
+import unittest
+from unittest import mock
+
+from atrinik_workspace.model import AtomicJsonCommitUncertain, MANAGED_MARKER, WorkspaceError
+from atrinik_workspace.cli import main
+from atrinik_workspace.cleanup import Cleanup
+import atrinik_workspace.scopes as scopes_module
+from atrinik_workspace.scopes import SCOPE_FAILURE_BOUNDARIES_ENV
+from atrinik_workspace.scopes import ScopeLifecycle
+from atrinik_workspace.workspace import BUILD_METADATA, Workspace
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def command(*arguments: str, cwd: Path) -> str:
+    completed = subprocess.run(
+        list(arguments), cwd=cwd, check=True, capture_output=True, text=True
+    )
+    return completed.stdout.strip()
+
+
+class ScopeLifecycleTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.wrapper = self.root / "wrapper"
+        self.wrapper.mkdir()
+        shutil.copy2(ROOT / "components.json", self.wrapper / "components.json")
+        self.workspace_directory = self.root / "workspace"
+        self.environment = mock.patch.dict(
+            os.environ, {"ATRINIK_WORKSPACE_DIR": str(self.workspace_directory)}
+        )
+        self.environment.start()
+        self.remote_matcher = mock.patch(
+            "atrinik_workspace.workspace._remote_matches", return_value=True
+        )
+        self.remote_matcher.start()
+        self.workspace = Workspace(self.wrapper)
+        self.workspace.paths.ensure()
+
+    def tearDown(self) -> None:
+        self.workspace.close()
+        self.remote_matcher.stop()
+        self.environment.stop()
+        self.temporary.cleanup()
+
+    def make_checkout(self, checkout_name: str) -> Path:
+        checkout = self.workspace.manifest.by_checkout[checkout_name]
+        origin = self.root / "origins" / f"{checkout_name}.git"
+        origin.parent.mkdir(exist_ok=True)
+        command("git", "init", "--bare", str(origin), cwd=self.root)
+        seed = self.root / "seeds" / checkout_name
+        seed.mkdir(parents=True)
+        command("git", "init", "-b", checkout.branch, cwd=seed)
+        command("git", "config", "user.name", "Tests", cwd=seed)
+        command("git", "config", "user.email", "tests@example.invalid", cwd=seed)
+        (seed / "README").write_text(f"{checkout_name}\n", encoding="utf-8")
+        for component in self.workspace.manifest.components:
+            if component.checkout_name != checkout_name or component.source == ".":
+                continue
+            (seed / component.source).mkdir(parents=True, exist_ok=True)
+            (seed / component.source / ".keep").write_text("\n", encoding="utf-8")
+        command("git", "add", ".", cwd=seed)
+        command("git", "commit", "-m", "feat: seed", cwd=seed)
+        command("git", "remote", "add", "origin", str(origin), cwd=seed)
+        command("git", "push", "-u", "origin", checkout.branch, cwd=seed)
+        command("git", "symbolic-ref", "HEAD", f"refs/heads/{checkout.branch}", cwd=origin)
+        destination = self.wrapper / checkout.path
+        command("git", "clone", str(origin), str(destination), cwd=self.root)
+        return destination
+
+    def test_completed_retry_is_exact_and_conflicts_do_not_overwrite(self) -> None:
+        self.make_checkout("client")
+        first = self.workspace.scope_create(["client"], name="retry")
+        retried = self.workspace.scope_create(["client"], name="retry")
+        self.assertEqual(retried, first)
+        with self.assertRaisesRegex(WorkspaceError, "different coordinates"):
+            self.workspace.scope_create(
+                ["client"], name="retry", branches=["client=feat/conflict"]
+            )
+        self.assertEqual(self.workspace.scope_show("retry"), first)
+
+        custom = self.workspace.scope_create(
+            ["client"],
+            name="custom-retry",
+            labels=["client=custom-label"],
+            branches=["client=feat/custom-retry"],
+            start_points=["client=refs/heads/main"],
+        )
+        self.assertEqual(
+            self.workspace.scope_create(
+                ["client"],
+                name="custom-retry",
+                labels=["client=custom-label"],
+                branches=["client=feat/custom-retry"],
+                start_points=["client=refs/heads/main"],
+            ),
+            custom,
+        )
+        with self.assertRaisesRegex(WorkspaceError, "different coordinates"):
+            self.workspace.scope_create(["client"], name="custom-retry")
+
+    def test_invalid_requests_fail_before_publication(self) -> None:
+        with self.assertRaisesRegex(WorkspaceError, "at least one component"):
+            self.workspace.scope_create([], name="empty")
+        with self.assertRaisesRegex(WorkspaceError, "CHECKOUT=VALUE"):
+            self.workspace.scope_create(["client"], name="bad-map", labels=["client"])
+        with self.assertRaisesRegex(WorkspaceError, "repeats checkout"):
+            self.workspace.scope_create(
+                ["client"], name="duplicate-map", labels=["client=a", "client=b"]
+            )
+        with self.assertRaisesRegex(WorkspaceError, "not initialized"):
+            self.workspace.scope_create(["client"], name="uninitialized")
+
+        checkout = self.make_checkout("client")
+        lifecycle = ScopeLifecycle(self.workspace)
+
+        def preflight(name: str, **overrides: object) -> dict[str, object]:
+            arguments = {
+                "name": name,
+                "components": ["client"],
+                "base_profile": "default",
+                "labels": {},
+                "branches": {},
+                "start_points": {},
+                "topology": None,
+                "state_mode": "temporary",
+                "state_name": None,
+            }
+            arguments.update(overrides)
+            return lifecycle._preflight_request(**arguments)
+
+        failures = [
+            ("unknown-override", {"labels": {"sound": "review"}}, "unselected"),
+            ("bad-mode", {"state_mode": "other"}, "invalid scope state mode"),
+            ("temporary-name", {"state_name": "named"}, "does not accept"),
+            (
+                "default-name",
+                {"state_mode": "default", "state_name": "named"},
+                "does not accept",
+            ),
+            ("named-missing", {"state_mode": "named"}, "requires --state"),
+            (
+                "named-default",
+                {"state_mode": "named", "state_name": "default"},
+                "--default-state",
+            ),
+            (
+                "named-absent",
+                {"state_mode": "named", "state_name": "absent"},
+                "does not exist",
+            ),
+            ("bad-start", {"start_points": {"client": "-option"}}, "must not begin"),
+        ]
+        for name, overrides, message in failures:
+            with self.subTest(name=name), self.assertRaisesRegex(WorkspaceError, message):
+                preflight(name, **overrides)
+
+        profile = self.workspace_directory / "profiles" / "scope-profile-exists.json"
+        profile.write_text("{}", encoding="utf-8")
+        with self.assertRaisesRegex(WorkspaceError, "profile already exists"):
+            preflight("profile-exists")
+        topology = self.workspace_directory / "topologies" / "occupied"
+        topology.mkdir(parents=True)
+        with self.assertRaisesRegex(WorkspaceError, "topology namespace"):
+            preflight("topology-exists", topology="occupied")
+        destination = self.workspace_directory / "worktrees" / "client" / "occupied"
+        destination.mkdir(parents=True)
+        with self.assertRaisesRegex(WorkspaceError, "worktree path"):
+            preflight("path-exists", labels={"client": "occupied"})
+        command("git", "branch", "scope/branch-exists/client", cwd=checkout)
+        with self.assertRaisesRegex(WorkspaceError, "branch already exists"):
+            preflight("branch-exists")
+        real_run = subprocess.run
+
+        def fail_show_ref(arguments: list[str], **keywords: object) -> object:
+            if "show-ref" in arguments:
+                return mock.Mock(returncode=2)
+            return real_run(arguments, **keywords)
+
+        with mock.patch("subprocess.run", side_effect=fail_show_ref):
+            with self.assertRaisesRegex(WorkspaceError, "cannot preflight scope branch"):
+                preflight("branch-error")
+
+    def test_scope_record_schema_rejects_each_identity_family(self) -> None:
+        self.make_checkout("client")
+        record = self.workspace.scope_create(["client"], name="schema")
+        lifecycle = ScopeLifecycle(self.workspace)
+
+        def rejected(candidate: object, message: str) -> None:
+            with self.assertRaisesRegex(WorkspaceError, message):
+                lifecycle._validate_record(candidate, "schema")
+
+        rejected([], "record is invalid")
+        mutations: list[tuple[tuple[object, ...], object, str]] = [
+            (("extra",), True, "schema"),
+            (("status",), "creating", "identity"),
+            (("generation",), "bad", "generation"),
+            (("request_sha256",), "bad", "request identity"),
+            (("stack",), "missing", "stack"),
+            (("created_at",), "", "creation time"),
+            (("base_profile",), 1, "base profile"),
+            (("requested_components",), [], "requested components"),
+            (("worktrees",), [], "worktrees"),
+            (("worktrees", 0, "extra"), True, "worktree record"),
+            (("worktrees", 0, "checkout"), "missing", "checkout"),
+            (("worktrees", 0, "repository"), "other/repository", "repository"),
+            (("worktrees", 0, "label"), "", "coordinates"),
+            (("worktrees", 0, "path_device"), -1, "path identity"),
+            (("worktrees", 0, "logical_components"), [], "coverage"),
+            (("worktrees", 0, "path"), "/tmp/replaced", "worktree path"),
+            (("worktrees", 0, "primary_path"), "/tmp/replaced", "primary checkout"),
+            (("profile", "extra"), True, "profile record"),
+            (("profile", "path"), "/tmp/replaced", "profile path"),
+            (("profile", "name"), "other", "profile path"),
+            (("profile", "immutable"), False, "profile identity"),
+            (("profile", "path_inode"), -1, "profile path identity"),
+            (("topology", "path"), "/tmp/replaced", "topology"),
+            (("state_policy", "mode"), "other", "state policy"),
+            (("state_policy", "name"), "unexpected", "state identity"),
+            (("commands", "extra"), True, "commands are invalid"),
+            (("commands", "up"), "", "command coordinates"),
+            (("commands", "paths"), [], "command maps"),
+            (("cleanup", "policy"), "other", "cleanup coordinates"),
+        ]
+        for path, value, message in mutations:
+            candidate = copy.deepcopy(record)
+            target = candidate
+            for key in path[:-1]:
+                target = target[key]  # type: ignore[index]
+            target[path[-1]] = value  # type: ignore[index]
+            with self.subTest(path=path):
+                rejected(candidate, message)
+
+        digest_mismatch = copy.deepcopy(record)
+        digest_mismatch["base_profile"] = "classic"
+        rejected(digest_mismatch, "request digest")
+
+    def test_distinct_scopes_use_different_worktrees_of_one_checkout(self) -> None:
+        self.make_checkout("client")
+        first = self.workspace.scope_create(["client"], name="first")
+        second = self.workspace.scope_create(["client"], name="second")
+        self.assertNotEqual(first["worktrees"][0]["path"], second["worktrees"][0]["path"])
+        self.assertNotEqual(first["worktrees"][0]["branch"], second["worktrees"][0]["branch"])
+        self.assertEqual(first["worktrees"][0]["common_git_dir"], second["worktrees"][0]["common_git_dir"])
+
+    def test_concurrent_distinct_scopes_progress_on_one_physical_checkout(self) -> None:
+        self.make_checkout("client")
+        checkout = self.workspace.manifest.by_checkout["client"]
+        git_request = self.workspace._lease_request(
+            "git-admin",
+            self.workspace._git_admin_coordinate(
+                checkout, self.workspace._primary_path(checkout)
+            ),
+            "exclusive",
+            "hold shared checkout publication",
+        )
+        preflight_barrier = threading.Barrier(2)
+        preflights_complete = threading.Event()
+        first_preflights: set[int] = set()
+        first_preflights_lock = threading.Lock()
+        original_preflight = ScopeLifecycle._preflight_request
+
+        def synchronized_preflight(
+            lifecycle: ScopeLifecycle, *arguments: object, **keywords: object
+        ) -> dict[str, object]:
+            result = original_preflight(lifecycle, *arguments, **keywords)
+            thread = threading.get_ident()
+            with first_preflights_lock:
+                first = thread not in first_preflights
+                first_preflights.add(thread)
+                if len(first_preflights) == 2:
+                    preflights_complete.set()
+            if first:
+                preflight_barrier.wait(timeout=5)
+            return result
+
+        def create(name: str) -> dict[str, object]:
+            workspace = Workspace(self.wrapper)
+            try:
+                return workspace.scope_create(["client"], name=name)
+            finally:
+                workspace.close()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            with self.workspace._resource_locks([git_request]), mock.patch.object(
+                ScopeLifecycle,
+                "_preflight_request",
+                synchronized_preflight,
+            ):
+                first = executor.submit(create, "parallel-a")
+                second = executor.submit(create, "parallel-b")
+                self.assertTrue(preflights_complete.wait(timeout=5))
+            records = [first.result(timeout=10), second.result(timeout=10)]
+        self.assertEqual({record["name"] for record in records}, {"parallel-a", "parallel-b"})
+        self.assertEqual(len({record["worktrees"][0]["path"] for record in records}), 2)
+
+    def test_distinct_scope_profiles_build_concurrently_from_returned_coordinates(self) -> None:
+        self.make_checkout("sound")
+        first = self.workspace.scope_create(["sound"], name="build-a")
+        second = self.workspace.scope_create(["sound"], name="build-b")
+        barrier = threading.Barrier(2)
+        observed: dict[str, str] = {}
+
+        def build_resolved(
+            workspace: Workspace,
+            target: str,
+            profile: str,
+            tests: bool,
+            targets: list[str],
+            selected: dict[str, Path],
+            **_options: object,
+        ) -> Path:
+            self.assertEqual(target, "sound")
+            self.assertTrue(tests)
+            self.assertEqual(targets, ["sound"])
+            observed[profile] = str(selected["sound"])
+            barrier.wait(timeout=5)
+            return workspace.paths.builds / profile
+
+        def build(record: dict[str, object]) -> Path:
+            workspace = Workspace(self.wrapper)
+            try:
+                return workspace.build("sound", record["profile"]["name"], True)
+            finally:
+                workspace.close()
+
+        with mock.patch.object(Workspace, "_build_resolved", build_resolved):
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                results = [
+                    future.result(timeout=10)
+                    for future in (executor.submit(build, first), executor.submit(build, second))
+                ]
+        self.assertEqual(len(set(results)), 2)
+        self.assertEqual(
+            observed[first["profile"]["name"]],
+            first["worktrees"][0]["path"],
+        )
+        self.assertEqual(
+            observed[second["profile"]["name"]],
+            second["worktrees"][0]["path"],
+        )
+
+    def test_same_scope_race_has_one_winner_and_no_unowned_partial(self) -> None:
+        self.make_checkout("client")
+
+        def create() -> tuple[str, object]:
+            workspace = Workspace(self.wrapper)
+            try:
+                return "winner", workspace.scope_create(["client"], name="race")
+            except WorkspaceError as error:
+                return "loser", str(error)
+            finally:
+                workspace.close()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            outcomes = [future.result(timeout=10) for future in (executor.submit(create), executor.submit(create))]
+        self.assertEqual([kind for kind, _value in outcomes].count("winner"), 1)
+        self.assertEqual([kind for kind, _value in outcomes].count("loser"), 1)
+        record = self.workspace.scope_show("race")
+        self.assertTrue(Path(record["profile"]["path"]).is_file())
+        self.assertTrue(Path(record["worktrees"][0]["path"]).is_dir())
+
+    def test_same_explicit_label_and_branch_race_has_one_complete_winner(self) -> None:
+        self.make_checkout("client")
+
+        def create(name: str) -> tuple[str, object]:
+            workspace = Workspace(self.wrapper)
+            try:
+                return "winner", workspace.scope_create(
+                    ["client"],
+                    name=name,
+                    labels=["client=shared-coordinate"],
+                    branches=["client=feat/shared-coordinate"],
+                )
+            except WorkspaceError as error:
+                return "loser", str(error)
+            finally:
+                workspace.close()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            outcomes = [
+                future.result(timeout=10)
+                for future in (
+                    executor.submit(create, "coordinate-a"),
+                    executor.submit(create, "coordinate-b"),
+                )
+            ]
+        self.assertEqual([kind for kind, _value in outcomes].count("winner"), 1)
+        self.assertEqual([kind for kind, _value in outcomes].count("loser"), 1)
+        complete = [
+            path
+            for path in (self.workspace_directory / "scopes").glob("*/scope.json")
+        ]
+        self.assertEqual(len(complete), 1)
+
+    def test_classic_selectors_publish_one_complete_physical_worktree(self) -> None:
+        self.make_checkout("classic")
+        record = self.workspace.scope_create(
+            ["classic-client", "classic-server"], name="classic-agent", base_profile="classic"
+        )
+        self.assertEqual(len(record["worktrees"]), 1)
+        self.assertEqual(record["worktrees"][0]["checkout"], "classic")
+        self.assertEqual(
+            set(record["worktrees"][0]["logical_components"]),
+            {
+                "classic-client", "classic-server", "classic-protocol",
+                "classic-libatrinik", "classic-editor",
+            },
+        )
+
+    def test_json_handoff_contains_supported_exact_commands_without_secrets(self) -> None:
+        checkout = self.make_checkout("client")
+        record = self.workspace.scope_create(["client"], name="handoff")
+        serialized = json.dumps(record, sort_keys=True)
+        self.assertNotRegex(serialized.lower(), r"password|credential|secret|token")
+        self.assertEqual(
+            self.workspace.component_path("client", record["profile"]["name"]),
+            Path(record["worktrees"][0]["path"]),
+        )
+        self.assertNotIn("client", record["commands"]["builds"])
+        self.assertTrue(record["commands"]["builds"])
+        self.assertTrue(
+            all("--profile scope-handoff --test" in value for value in record["commands"]["builds"].values())
+        )
+        self.assertIn("--temporary-state", record["commands"]["up"])
+        self.assertEqual(record["state_policy"]["mode"], "temporary")
+        self.assertNotEqual(checkout, Path(record["worktrees"][0]["path"]))
+
+        build_command = next(iter(record["commands"]["builds"].values()))
+        build_arguments = shlex.split(build_command)[1:]
+        up_arguments = shlex.split(record["commands"]["up"])[1:]
+        down_arguments = shlex.split(record["commands"]["down"])[1:]
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            cli_workspace = workspace_type.return_value
+            cli_workspace.build.return_value = self.root / "build-result"
+            cli_workspace.topology_up.return_value = {"ready": True}
+            cli_workspace.topology_down.return_value = {"stopped_at": "now"}
+            with mock.patch("builtins.print"):
+                self.assertEqual(main(build_arguments), 0)
+                self.assertEqual(main(up_arguments), 0)
+                self.assertEqual(main(down_arguments), 0)
+        build_target = build_arguments[1]
+        cli_workspace.build.assert_called_once_with(
+            build_target,
+            record["profile"]["name"],
+            True,
+            force_reconfigure=False,
+            use_ccache=True,
+        )
+        cli_workspace.topology_up.assert_called_once_with(
+            record["topology"]["name"],
+            record["profile"]["name"],
+            None,
+            None,
+            None,
+            state_mode="temporary",
+        )
+        cli_workspace.topology_down.assert_called_once_with(
+            record["topology"]["name"]
+        )
+
+    def test_completed_record_rejects_edited_handoff_commands(self) -> None:
+        self.make_checkout("client")
+        record = self.workspace.scope_create(["client"], name="edited-command")
+        record["commands"]["up"] = "./unexpected-command"
+        record_path = (
+            self.workspace_directory / "scopes" / "edited-command" / "scope.json"
+        )
+        record_path.write_text(json.dumps(record), encoding="utf-8")
+        with self.assertRaisesRegex(WorkspaceError, "exact coordinates"):
+            self.workspace.scope_show("edited-command")
+
+    def test_failure_after_each_publication_boundary_is_journaled(self) -> None:
+        self.make_checkout("client")
+        for index, boundary in enumerate(
+            ("reservation", "worktree:client", "profile-reference", "profile", "scope")
+        ):
+            name = f"failure-{index}"
+            with self.subTest(boundary=boundary), mock.patch.dict(
+                os.environ, {SCOPE_FAILURE_BOUNDARIES_ENV: boundary}
+            ):
+                with self.assertRaisesRegex(WorkspaceError, "injected scope failure"):
+                    self.workspace.scope_create(["client"], name=name)
+            journal = json.loads(
+                (self.workspace_directory / "scopes" / name / "creation-journal.json").read_text(encoding="utf-8")
+            )
+            self.assertIn(journal["status"], {"rolled-back", "complete"})
+            record = self.workspace_directory / "scopes" / name / "scope.json"
+            self.assertEqual(record.is_file(), boundary == "scope")
+            worktree = self.workspace_directory / "worktrees" / "client" / f"scope-{name}"
+            self.assertEqual(worktree.is_dir(), boundary == "scope")
+            if boundary == "profile-reference":
+                self.assertIn("profile-reference", journal["rollback"])
+
+    def test_uncertain_profile_publication_preserves_every_input(self) -> None:
+        self.make_checkout("client")
+        original = scopes_module.durable_atomic_json
+        profile = self.workspace_directory / "profiles" / "scope-profile-uncertain.json"
+        injected = False
+
+        def uncertain(path: Path, value: object) -> None:
+            nonlocal injected
+            original(path, value)
+            if path == profile and not injected:
+                injected = True
+                raise AtomicJsonCommitUncertain("injected profile fsync uncertainty")
+
+        with mock.patch.object(scopes_module, "durable_atomic_json", side_effect=uncertain):
+            with self.assertRaisesRegex(WorkspaceError, "publication is uncertain"):
+                self.workspace.scope_create(["client"], name="profile-uncertain")
+        worktree = self.workspace_directory / "worktrees" / "client" / "scope-profile-uncertain"
+        journal = json.loads(
+            (
+                self.workspace_directory
+                / "scopes"
+                / "profile-uncertain"
+                / "creation-journal.json"
+            ).read_text(encoding="utf-8")
+        )
+        self.assertEqual(journal["status"], "recovery-required")
+        self.assertTrue(profile.is_file())
+        self.assertTrue(worktree.is_dir())
+        with self.assertRaisesRegex(WorkspaceError, "immutable"):
+            self.workspace.set_profile("scope-profile-uncertain", "client", "primary")
+
+    def test_uncertain_completed_record_preserves_and_remains_readable(self) -> None:
+        self.make_checkout("client")
+        original = scopes_module.durable_atomic_json
+        record_path = self.workspace_directory / "scopes" / "record-uncertain" / "scope.json"
+        injected = False
+
+        def uncertain(path: Path, value: object) -> None:
+            nonlocal injected
+            original(path, value)
+            if path == record_path and not injected:
+                injected = True
+                raise AtomicJsonCommitUncertain("injected record fsync uncertainty")
+
+        with mock.patch.object(scopes_module, "durable_atomic_json", side_effect=uncertain):
+            with self.assertRaisesRegex(WorkspaceError, "publication is uncertain"):
+                self.workspace.scope_create(["client"], name="record-uncertain")
+        record = self.workspace.scope_show("record-uncertain")
+        self.assertEqual(record["status"], "complete")
+        self.assertTrue(Path(record["worktrees"][0]["path"]).is_dir())
+        journal = json.loads(
+            (
+                self.workspace_directory
+                / "scopes"
+                / "record-uncertain"
+                / "creation-journal.json"
+            ).read_text(encoding="utf-8")
+        )
+        self.assertEqual(journal["status"], "recovery-required")
+
+    def test_recoverable_creation_journal_protects_changed_worktree_from_cleanup(self) -> None:
+        self.make_checkout("client")
+        path = self.workspace_directory / "worktrees" / "client" / "scope-recoverable"
+
+        def fail_after_dirtying(boundary: str) -> None:
+            if boundary != "worktree:client":
+                return
+            (path / "recovery-input").write_text("preserve\n", encoding="utf-8")
+            raise WorkspaceError("injected changed recovery input")
+
+        with mock.patch.object(
+            ScopeLifecycle, "_maybe_fail", side_effect=fail_after_dirtying
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "recovery inputs were preserved"):
+                self.workspace.scope_create(["client"], name="recoverable")
+        journal = json.loads(
+            (
+                self.workspace_directory
+                / "scopes"
+                / "recoverable"
+                / "creation-journal.json"
+            ).read_text(encoding="utf-8")
+        )
+        self.assertEqual(journal["status"], "recovery-required")
+        self.assertIn(
+            "scope:recoverable", self.workspace._source_references(path)
+        )
+        references, errors = Cleanup(self.workspace)._references()
+        self.assertFalse(errors)
+        self.assertEqual(
+            references["scopes"][path.resolve()], ["recoverable"]
+        )
+
+    def test_release_is_preview_bound_and_protects_dirty_worktree(self) -> None:
+        self.make_checkout("client")
+        record = self.workspace.scope_create(["client"], name="release")
+        preview = self.workspace.scope_release("release", apply=False)
+        self.assertTrue(preview["can_apply"])
+        with self.assertRaisesRegex(WorkspaceError, "requires the exact --plan"):
+            self.workspace.scope_release("release", apply=True)
+        worktree = Path(record["worktrees"][0]["path"])
+        (worktree / "dirty").write_text("changed\n", encoding="utf-8")
+        changed = self.workspace.scope_release("release", apply=False)
+        self.assertFalse(changed["can_apply"])
+        self.assertIn(
+            "dirty_worktree",
+            next(item for item in changed["items"] if item["kind"] == "worktree")["reasons"],
+        )
+        with self.assertRaisesRegex(WorkspaceError, "changed since preview"):
+            self.workspace.scope_release(
+                "release", apply=True, plan_sha256=preview["plan_sha256"]
+            )
+
+    def test_clean_release_removes_profile_and_worktree_but_retains_record(self) -> None:
+        self.make_checkout("client")
+        record = self.workspace.scope_create(["client"], name="clean-release")
+        preview = self.workspace.scope_release("clean-release", apply=False)
+        result = self.workspace.scope_release(
+            "clean-release", apply=True, plan_sha256=preview["plan_sha256"]
+        )
+        self.assertTrue(result["released"])
+        self.assertFalse(Path(record["profile"]["path"]).exists())
+        self.assertFalse(Path(record["worktrees"][0]["path"]).exists())
+        self.assertEqual(self.workspace.scope_show("clean-release"), record)
+        with self.assertRaisesRegex(WorkspaceError, "release has started"):
+            self.workspace.scope_create(["client"], name="clean-release")
+
+    def test_resumed_release_preserves_prior_completed_actions(self) -> None:
+        self.make_checkout("client")
+        record = self.workspace.scope_create(["client"], name="resume-release")
+        preview = self.workspace.scope_release("resume-release", apply=False)
+        release_path = (
+            self.workspace_directory
+            / "scopes"
+            / "resume-release"
+            / "release-journal.json"
+        )
+        scopes_module.durable_atomic_json(
+            release_path,
+            {
+                "schema_version": 1,
+                "scope": "resume-release",
+                "generation": record["generation"],
+                "plan_sha256": "0" * 64,
+                "status": "applying",
+                "completed": ["build:/already-removed"],
+                "updated_at": "2026-08-14T00:00:00Z",
+            },
+        )
+        self.workspace.scope_release(
+            "resume-release", apply=True, plan_sha256=preview["plan_sha256"]
+        )
+        journal = json.loads(release_path.read_text(encoding="utf-8"))
+        self.assertIn("build:/already-removed", journal["completed"])
+        self.assertIn("profile", journal["completed"])
+        self.assertIn("worktree:client", journal["completed"])
+
+    def test_release_removes_only_exact_scope_build_ownership(self) -> None:
+        self.make_checkout("client")
+        record = self.workspace.scope_create(["client"], name="build-release")
+        key = "a" * 64
+        root = (
+            self.workspace.paths.builds
+            / "profiles"
+            / f"{record['profile']['name']}-{key}"
+        )
+        root.mkdir(parents=True)
+        (root / BUILD_METADATA).write_text(
+            json.dumps({"profile": record["profile"]["name"], "key": key}),
+            encoding="utf-8",
+        )
+        (root / MANAGED_MARKER).write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "purpose": f"profile:{record['profile']['name']}:{key}",
+                }
+            ),
+            encoding="utf-8",
+        )
+        preview = self.workspace.scope_release("build-release", apply=False)
+        build = next(item for item in preview["items"] if item["kind"] == "build")
+        self.assertEqual(build["disposition"], "eligible")
+        self.assertRegex(build["metadata_sha256"], r"^[0-9a-f]{64}$")
+        result = self.workspace.scope_release(
+            "build-release", apply=True, plan_sha256=preview["plan_sha256"]
+        )
+        self.assertTrue(result["released"])
+        self.assertFalse(root.exists())
+
+    def test_scope_profile_is_immutable(self) -> None:
+        self.make_checkout("client")
+        record = self.workspace.scope_create(["client"], name="immutable")
+        with self.assertRaisesRegex(WorkspaceError, "immutable"):
+            self.workspace.set_profile(record["profile"]["name"], "client", "primary")
+
+    def test_release_refuses_identical_profile_path_replacement(self) -> None:
+        self.make_checkout("client")
+        record = self.workspace.scope_create(["client"], name="replaced-profile")
+        profile = Path(record["profile"]["path"])
+        content = profile.read_bytes()
+        profile.unlink()
+        profile.write_bytes(content)
+        preview = self.workspace.scope_release("replaced-profile", apply=False)
+        item = next(item for item in preview["items"] if item["kind"] == "profile")
+        self.assertEqual(item["disposition"], "protected")
+        self.assertIn("replaced_profile", item["reasons"])
+
+    def test_release_protects_live_referenced_detached_and_replaced_inputs(self) -> None:
+        self.make_checkout("client")
+
+        live = self.workspace.scope_create(["client"], name="live")
+        Path(live["topology"]["path"]).mkdir()
+        with mock.patch.object(
+            self.workspace,
+            "topology_status",
+            return_value={
+                "supervisor": {"running": True, "liveness": "live"},
+                "services": {},
+                "observation": {},
+            },
+        ):
+            preview = self.workspace.scope_release("live", apply=False)
+        self.assertIn(
+            "live_topology",
+            next(item for item in preview["items"] if item["kind"] == "topology")["reasons"],
+        )
+
+        referenced = self.workspace.scope_create(["client"], name="referenced")
+        self.workspace.create_profile("outside-reference")
+        self.workspace.set_profile(
+            "outside-reference",
+            "client",
+            "worktree",
+            referenced["worktrees"][0]["label"],
+        )
+        preview = self.workspace.scope_release("referenced", apply=False)
+        reasons = next(item for item in preview["items"] if item["kind"] == "worktree")["reasons"]
+        self.assertTrue(any(reason.startswith("unexpected_references:") for reason in reasons))
+
+        detached = self.workspace.scope_create(["client"], name="detached")
+        command("git", "checkout", "--detach", cwd=Path(detached["worktrees"][0]["path"]))
+        preview = self.workspace.scope_release("detached", apply=False)
+        self.assertIn(
+            "detached_or_changed_branch",
+            next(item for item in preview["items"] if item["kind"] == "worktree")["reasons"],
+        )
+
+        replaced = self.workspace.scope_create(["client"], name="replaced")
+        path = Path(replaced["worktrees"][0]["path"])
+        moved = path.with_name("moved-replaced")
+        path.rename(moved)
+        path.mkdir()
+        preview = self.workspace.scope_release("replaced", apply=False)
+        self.assertIn(
+            "replaced_path",
+            next(item for item in preview["items"] if item["kind"] == "worktree")["reasons"],
+        )
+
+    def test_release_refuses_unreachable_retained_and_active_coordinates(self) -> None:
+        self.make_checkout("client")
+        unreachable = self.workspace.scope_create(["client"], name="unreachable")
+        Path(unreachable["topology"]["path"]).mkdir()
+        with mock.patch.object(
+            self.workspace,
+            "topology_status",
+            return_value={
+                "supervisor": {"running": True, "liveness": "unreachable"},
+                "services": {},
+                "observation": {"process_tree_lease": "retained"},
+            },
+        ):
+            preview = self.workspace.scope_release("unreachable", apply=False)
+        self.assertIn(
+            "unreachable_topology",
+            next(item for item in preview["items"] if item["kind"] == "topology")["reasons"],
+        )
+
+        retained = self.workspace.scope_create(["client"], name="retained")
+        Path(retained["topology"]["path"]).mkdir()
+        with mock.patch.object(
+            self.workspace,
+            "topology_status",
+            return_value={
+                "supervisor": {"running": False, "liveness": "exited"},
+                "services": {},
+                "observation": {"runtime_bundle_lease": "retained"},
+            },
+        ):
+            preview = self.workspace.scope_release("retained", apply=False)
+        self.assertIn(
+            "retained_generation",
+            next(item for item in preview["items"] if item["kind"] == "topology")["reasons"],
+        )
+
+        busy = self.workspace.scope_create(["client"], name="busy")
+        row = busy["worktrees"][0]
+        request = self.workspace._lease_request(
+            "source",
+            self.workspace._source_coordinate(row["checkout"], Path(row["path"])),
+            "shared",
+            "hold scope source",
+        )
+        with self.workspace._resource_locks([request]):
+            with self.assertRaisesRegex(WorkspaceError, "active resource leases"):
+                self.workspace.scope_release("busy", apply=False)
+
+    def test_scope_topology_namespace_requires_recorded_profile_and_state(self) -> None:
+        self.make_checkout("client")
+        record = self.workspace.scope_create(["client"], name="reserved-topology")
+        with self.assertRaisesRegex(WorkspaceError, "reserved by scope"):
+            self.workspace.topology_up(
+                record["topology"]["name"],
+                "default",
+                None,
+                ["server"],
+                state_mode="temporary",
+            )
+
+    def test_persistent_scope_state_is_deliberate_and_never_released(self) -> None:
+        self.make_checkout("client")
+        state = self.root / "persistent-state"
+        state.mkdir()
+        for name in ("bans", "motd"):
+            (state / name).write_text("", encoding="utf-8")
+        for name in ("keys", "unique-items"):
+            (state / name).mkdir()
+        self.workspace.state_add("shared", state)
+        named = self.workspace.scope_create(
+            ["client"], name="named-state", state_mode="named", state_name="shared"
+        )
+        preview = self.workspace.scope_release("named-state", apply=False)
+        state_item = next(item for item in preview["items"] if item["kind"] == "state")
+        self.assertEqual(state_item["disposition"], "retained")
+        self.assertEqual(named["state_policy"]["lifecycle"], "never-remove-with-scope")
+
+        default = self.workspace.scope_create(
+            ["client"], name="default-state", state_mode="default"
+        )
+        self.assertEqual(default["state_policy"]["mode"], "default")
+        self.assertIn("--default-state", default["commands"]["up"])
+
+    def test_live_scope_a_does_not_block_scope_b_release(self) -> None:
+        self.make_checkout("client")
+        scope_a = self.workspace.scope_create(["client"], name="scope-a")
+        Path(scope_a["topology"]["path"]).mkdir()
+        scope_b = self.workspace.scope_create(["client"], name="scope-b")
+        live_a = self.workspace._lease_request(
+            "topology", scope_a["topology"]["name"], "exclusive", "test live scope A"
+        )
+        with self.workspace._resource_locks([live_a]):
+            preview = self.workspace.scope_release("scope-b", apply=False)
+            released = self.workspace.scope_release(
+                "scope-b", apply=True, plan_sha256=preview["plan_sha256"]
+            )
+        self.assertTrue(released["released"])
+        self.assertTrue(Path(scope_a["worktrees"][0]["path"]).is_dir())
+        self.assertTrue(Path(scope_a["profile"]["path"]).is_file())
+        self.assertTrue(Path(scope_a["topology"]["path"]).is_dir())
+        self.assertFalse(Path(scope_b["worktrees"][0]["path"]).exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #402

## Summary

- add atomic wrapper-native `scope create/show/list/release` lifecycle commands with stable supplied names and collision-resistant generated names
- resolve logical selections to full physical checkouts, including exactly one complete worktree for all five `classic-*` components
- preflight and lease names, branches, labels, profiles, topology namespaces, and state policies before mutation
- publish durable creation/release journals, exact secret-free JSON handoffs, immutable profiles, and the completed scope record last
- make exact completed retries idempotent, preserve uncertain recovery inputs, and require hash-bound preview/apply release with strict live/dirty/replaced/referenced/busy refusal
- keep primitive worktree, profile, build, topology, and cleanup commands supported

## Development coordinates

- base: `origin/main@66a03f8317bcc9a6bb95fe219407ec07e804d66e`
- head: `feat/agent-development-scopes@5f557c8fd3b55896b261eaa4b1b0df9f8d8d9805`
- wrapper-managed worktree: `/workspaces/atrinik/workspace/worktrees/atrinik/issue-402`
- verification scope: `issue-402-verification`
- verification profile: `scope-issue-402-verification`
- verification topology: `scope-issue-402-verification`
- verification state: generation-owned `temporary` state (`name: null`, removed on proven clean stop)

No persistent verification scope was allocated while implementing its own lifecycle. On an initialized Classic workspace, the exact provisioning command is:

```sh
./atrinik scope create classic-server --name issue-402-verification --from classic --json
```

The returned record is the source of truth for every exact worktree path, checkout/label/branch/commit/tree/common-Git identity, immutable profile path/hash/inode, topology path, state policy, and supported path/build/up/ps/log/down/release command. Classic returns one `classic` physical worktree covering `classic-client`, `classic-server`, `classic-protocol`, `classic-libatrinik`, and `classic-editor`.

## Validation

- `python -m coverage run -m unittest discover -v`: 901 passed in 346.144s
- `python -m coverage report --show-missing`: 83% total coverage
- `python -m compileall -q atrinik atrinik_workspace tests`
- `python -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`: 20 components
- `./atrinik supply-chain validate`: 110 dependencies
- `python -m atrinik_workspace.mcp_contract validate`: 18 adversarial cases, 9 capabilities, 2 schemas, 6 workloads
- `./atrinik provenance validate`: 2 records, 0 references
- workspace skill validator: pass
- `./atrinik cleanup --scope all --older-than 7 --dry-run --json`: 309 protected, 0 candidates, 0 errors
- `./atrinik cleanup --scope topologies --older-than 7 --dry-run --json`: 0 items, 0 errors
- `git diff --check`

## Manual lifecycle

1. Provision with the command above and use only the commands and paths returned in JSON.
2. Build through the returned `commands.builds` coordinate.
3. Start with `commands.up`, inspect with `commands.ps`/`commands.logs`, and stop with `commands.down`.
4. Preview with `commands.release_preview`.
5. Substitute the returned `plan_sha256` into `commands.release_apply` and apply only if every item remains eligible or intentionally retained.

Named/default persistent state is deliberate and never deleted by scope release. Stopped topology history remains under the separate topology cleanup lifecycle.
