### PR TITLE
fix(build): preserve writable Worker staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,8 +347,9 @@ installer. Copied root metadata is authenticated before the wrapper temporarily
 restores owner-only write access needed by dependency-install and source-view
 transactions; the source mode is reapplied before view publication. Sealed
 immutable source generations therefore cannot block staging writes. Worker
-checks receive the same temporary owner-only access for allowed generated
-outputs, and the sealed root mode is restored afterward. A second
+checks receive temporary full owner access with group and other write access
+disabled for allowed generated outputs, and the sealed root mode is restored
+afterward. A second
 input-identical build reuses that installation and an unchanged profile source
 view. Because enabled dependency lifecycle scripts can observe root files, the
 complete non-generated source digest participates in every dependency key and

--- a/README.md
+++ b/README.md
@@ -343,7 +343,12 @@ options fail closed; project
 `.npmrc` is supported through an authenticated copy. The hashed lifecycle-script
 environment and source
 metadata also participate in the key. `npm ci` remains the only
-installer. A second
+installer. Copied root metadata is authenticated before the wrapper temporarily
+restores owner-only write access needed by dependency-install and source-view
+transactions; the source mode is reapplied before view publication. Sealed
+immutable source generations therefore cannot block staging writes. Worker
+checks receive the same temporary owner-only access for allowed generated
+outputs, and the sealed root mode is restored afterward. A second
 input-identical build reuses that installation and an unchanged profile source
 view. Because enabled dependency lifecycle scripts can observe root files, the
 complete non-generated source digest participates in every dependency key and

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -1430,6 +1430,51 @@ def _copy_worker_source_metadata(source: Path, destination: Path) -> None:
     visit(source, destination, True)
 
 
+def _worker_owner_writable_mode(mode: int) -> int:
+    """Return a mode with owner access and no group or other write bits."""
+
+    return mode & ~(stat.S_IWGRP | stat.S_IWOTH) | stat.S_IRWXU
+
+
+def _make_worker_staging_owner_writable(staging: Path) -> None:
+    """Restore owner access after authenticating copied source metadata."""
+
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(
+            staging,
+            os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_NOFOLLOW", 0),
+        )
+        opened = os.fstat(descriptor)
+        visible = staging.stat(follow_symlinks=False)
+        if (
+            not stat.S_ISDIR(opened.st_mode)
+            or (opened.st_dev, opened.st_ino) != (visible.st_dev, visible.st_ino)
+            or opened.st_uid != os.geteuid()
+        ):
+            raise WorkspaceError(
+                f"Worker dependency staging root ownership is unsafe: {staging}"
+            )
+        os.fchmod(
+            descriptor,
+            _worker_owner_writable_mode(stat.S_IMODE(opened.st_mode)),
+        )
+        writable = os.fstat(descriptor)
+        if stat.S_IMODE(writable.st_mode) & stat.S_IRWXU != stat.S_IRWXU:
+            raise WorkspaceError(
+                f"Worker dependency staging root is not owner-writable: {staging}"
+            )
+    except WorkspaceError:
+        raise
+    except OSError as error:
+        raise WorkspaceError(
+            f"cannot make Worker dependency staging root writable {staging}: {error}"
+        ) from error
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
 def _copy_regular_file(
     source: Path,
     destination: Path,
@@ -8478,6 +8523,11 @@ class Workspace:
                     raise WorkspaceError(
                         "staged Worker lifecycle source does not match its cache key"
                     )
+                # Clean primary sources are immutable generations whose root
+                # has no write bits. Authenticate that copied mode first, then
+                # restore access only for the effective owner of this
+                # wrapper-created transaction so npm can create node_modules.
+                _make_worker_staging_owner_writable(staging)
                 if (staging / ".npmrc").exists():
                     (staging / ".npmrc").chmod(0o600)
                     if (
@@ -8695,6 +8745,7 @@ class Workspace:
                 raise WorkspaceError(
                     "staged Worker view source does not match its fingerprint"
                 )
+            _make_worker_staging_owner_writable(staging)
             shutil.copytree(dependencies, staging / "node_modules", symlinks=True)
             if (
                 _tree_digest(
@@ -8721,6 +8772,7 @@ class Workspace:
                 },
             )
             atomic_json(staging / WORKER_VIEW_METADATA, expected)
+            shutil.copystat(source, staging, follow_symlinks=False)
             replace_directory(
                 view,
                 staging,
@@ -8879,6 +8931,10 @@ class Workspace:
                 != dependency_metadata["node_modules_lock_sha256"]
             ):
                 raise WorkspaceError("Worker view controls are invalid before checks")
+            if opened_status.st_uid != os.geteuid():
+                raise WorkspaceError("Worker view ownership is unsafe before checks")
+            original_mode = stat.S_IMODE(opened_status.st_mode)
+            os.fchmod(descriptor, _worker_owner_writable_mode(original_mode))
             try:
                 run(
                     ["npm", "run", "check"],
@@ -8887,23 +8943,26 @@ class Workspace:
                 )
             finally:
                 try:
-                    current_status = view.lstat()
-                except OSError:
-                    current_status = None
-                if (
-                    current_status is not None
-                    and not view.is_symlink()
-                    and stat.S_ISDIR(current_status.st_mode)
-                    and (current_status.st_dev, current_status.st_ino)
-                    == (opened_status.st_dev, opened_status.st_ino)
-                ):
-                    for control_path in (marker_path, metadata_path):
-                        if control_path.is_symlink() or not control_path.is_dir():
-                            control_path.unlink(missing_ok=True)
-                        else:
-                            remove_owned_tree(control_path)
-                    atomic_json(marker_path, expected_marker)
-                    atomic_json(metadata_path, control_metadata)
+                    try:
+                        current_status = view.lstat()
+                    except OSError:
+                        current_status = None
+                    if (
+                        current_status is not None
+                        and not view.is_symlink()
+                        and stat.S_ISDIR(current_status.st_mode)
+                        and (current_status.st_dev, current_status.st_ino)
+                        == (opened_status.st_dev, opened_status.st_ino)
+                    ):
+                        for control_path in (marker_path, metadata_path):
+                            if control_path.is_symlink() or not control_path.is_dir():
+                                control_path.unlink(missing_ok=True)
+                            else:
+                                remove_owned_tree(control_path)
+                        atomic_json(marker_path, expected_marker)
+                        atomic_json(metadata_path, control_metadata)
+                finally:
+                    os.fchmod(descriptor, original_mode)
         finally:
             os.close(descriptor)
 

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -1453,7 +1453,7 @@ def _make_worker_staging_owner_writable(staging: Path) -> None:
             or opened.st_uid != os.geteuid()
         ):
             raise WorkspaceError(
-                f"Worker dependency staging root ownership is unsafe: {staging}"
+                f"Worker staging root ownership is unsafe: {staging}"
             )
         os.fchmod(
             descriptor,
@@ -1462,13 +1462,13 @@ def _make_worker_staging_owner_writable(staging: Path) -> None:
         writable = os.fstat(descriptor)
         if stat.S_IMODE(writable.st_mode) & stat.S_IRWXU != stat.S_IRWXU:
             raise WorkspaceError(
-                f"Worker dependency staging root is not owner-writable: {staging}"
+                f"Worker staging root is not owner-writable: {staging}"
             )
     except WorkspaceError:
         raise
     except OSError as error:
         raise WorkspaceError(
-            f"cannot make Worker dependency staging root writable {staging}: {error}"
+            f"cannot make Worker staging root writable {staging}: {error}"
         ) from error
     finally:
         if descriptor is not None:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -8525,8 +8525,8 @@ class Workspace:
                     )
                 # Clean primary sources are immutable generations whose root
                 # has no write bits. Authenticate that copied mode first, then
-                # restore access only for the effective owner of this
-                # wrapper-created transaction so npm can create node_modules.
+                # restore full effective-owner access while disabling group
+                # and other writes so npm can create node_modules.
                 _make_worker_staging_owner_writable(staging)
                 if (staging / ".npmrc").exists():
                     (staging / ".npmrc").chmod(0o600)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -442,11 +442,12 @@ are keyed; staging access times are normalized; and the
 staged source snapshot is authenticated before installation. A project `.npmrc`
 is a restrictive no-follow temporary copy that is removed before publication;
 after source authentication, dependency-install and source-view transaction
-roots restore read, write, and search access only for their effective owner so
+roots restore full effective-owner access while removing group and other write access so
 immutable source-generation modes cannot prevent `node_modules` staging; the
 source root mode is reapplied before view publication;
 the transaction marker is hidden during lifecycle execution and restored before
-publication. Worker checks similarly receive temporary owner-only root access
+publication. Worker checks similarly receive temporary full owner root access
+with group and other write access disabled
 for profile-local generated outputs, with the published source mode restored in
 their failure-safe control-repair path. Installed output containing the staging path is rejected as
 non-relocatable.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -441,8 +441,14 @@ is hashed. Copied modification times, filesystem flags, and extended metadata
 are keyed; staging access times are normalized; and the
 staged source snapshot is authenticated before installation. A project `.npmrc`
 is a restrictive no-follow temporary copy that is removed before publication;
+after source authentication, dependency-install and source-view transaction
+roots restore read, write, and search access only for their effective owner so
+immutable source-generation modes cannot prevent `node_modules` staging; the
+source root mode is reapplied before view publication;
 the transaction marker is hidden during lifecycle execution and restored before
-publication; installed output containing the staging path is rejected as
+publication. Worker checks similarly receive temporary owner-only root access
+for profile-local generated outputs, with the published source mode restored in
+their failure-safe control-repair path. Installed output containing the staging path is rejected as
 non-relocatable.
 A missing canonical entry recovers the newest structurally valid matching
 backup under the per-key lock before falling back to a new `npm ci`.

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -3290,6 +3290,40 @@ class WorkspaceTests(unittest.TestCase):
             self.workspace._worker_dependencies(source, {"PATH": "/bin"})
         self.assertEqual(installs, [])
 
+    def test_worker_staging_writable_failures_are_bounded(self) -> None:
+        staging = self.root / "worker-staging"
+        staging.mkdir(mode=0o700)
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.os.open",
+                side_effect=PermissionError(errno.EPERM, "simulated open denial"),
+            ),
+            self.assertRaisesRegex(
+                WorkspaceError, "cannot make Worker staging root writable"
+            ),
+        ):
+            workspace_module._make_worker_staging_owner_writable(staging)
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.os.fchmod",
+                side_effect=PermissionError(errno.EPERM, "simulated denial"),
+            ),
+            self.assertRaisesRegex(
+                WorkspaceError, "cannot make Worker staging root writable"
+            ),
+        ):
+            workspace_module._make_worker_staging_owner_writable(staging)
+
+        staging.chmod(0o500)
+        with (
+            mock.patch("atrinik_workspace.workspace.os.fchmod"),
+            self.assertRaisesRegex(WorkspaceError, "is not owner-writable"),
+        ):
+            workspace_module._make_worker_staging_owner_writable(staging)
+        staging.chmod(0o700)
+
     def test_worker_dependencies_reuse_exact_inputs_and_rebuild_corruption(self) -> None:
         source = self.make_worker_source()
         installs: list[Path] = []
@@ -4361,6 +4395,22 @@ class WorkspaceTests(unittest.TestCase):
                 root, source, dependencies, "c" * 64, metadata
             )[1]
         )
+
+        displaced = sealed[0].with_name("metaserver-worker-displaced")
+
+        def displace_view(arguments: list[str], **kwargs: object) -> str:
+            self.assertEqual(arguments, ["npm", "run", "check"])
+            sealed[0].rename(displaced)
+            return ""
+
+        with mock.patch(
+            "atrinik_workspace.workspace.run", side_effect=displace_view
+        ):
+            self.workspace._run_worker_checks(
+                sealed[0], {}, "c" * 64, metadata
+            )
+        self.assertFalse(sealed[0].exists())
+        self.assertEqual(stat.S_IMODE(displaced.stat().st_mode), 0o555)
 
     def test_source_view_reconciles_links_copies_and_stale_entries_in_place(self) -> None:
         source = self.workspace.paths.repositories / "server"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -3234,6 +3234,62 @@ class WorkspaceTests(unittest.TestCase):
         ]
         self.assertEqual(entries, [])
 
+    def test_worker_dependency_reopens_sealed_restrictive_source_root(self) -> None:
+        source = self.make_worker_source()
+        source.chmod(0o700)
+        source.chmod(stat.S_IMODE(source.stat().st_mode) & ~0o222)
+        self.assertEqual(stat.S_IMODE(source.stat().st_mode), 0o500)
+        installs: list[Path] = []
+        versions = {"node": "v22.0.0", "npm": "11.0.0"}
+        runner = self.fake_worker_run(installs, versions, threading.Lock())
+
+        def writable_run(arguments: list[str], **kwargs: object) -> str:
+            if arguments == ["npm", "ci"]:
+                staging = kwargs["cwd"]
+                assert isinstance(staging, Path)
+                self.assertEqual(
+                    stat.S_IMODE(staging.stat().st_mode) & stat.S_IRWXU,
+                    stat.S_IRWXU,
+                )
+                self.assertEqual(
+                    stat.S_IMODE(staging.stat().st_mode)
+                    & (stat.S_IWGRP | stat.S_IWOTH),
+                    0,
+                )
+            return runner(arguments, **kwargs)
+
+        try:
+            with mock.patch(
+                "atrinik_workspace.workspace.run", side_effect=writable_run
+            ):
+                dependencies = self.workspace._worker_dependencies(
+                    source, {"PATH": "/bin"}
+                )
+        finally:
+            source.chmod(0o700)
+        self.assertEqual(len(installs), 1)
+        self.assertTrue(dependencies[0].is_dir())
+
+    def test_worker_dependency_rejects_foreign_owned_staging_root(self) -> None:
+        source = self.make_worker_source()
+        versions = {"node": "v22.0.0", "npm": "11.0.0"}
+        installs: list[Path] = []
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.run",
+                side_effect=self.fake_worker_run(
+                    installs, versions, threading.Lock()
+                ),
+            ),
+            mock.patch(
+                "atrinik_workspace.workspace.os.geteuid",
+                return_value=os.geteuid() + 1,
+            ),
+            self.assertRaisesRegex(WorkspaceError, "staging root ownership is unsafe"),
+        ):
+            self.workspace._worker_dependencies(source, {"PATH": "/bin"})
+        self.assertEqual(installs, [])
+
     def test_worker_dependencies_reuse_exact_inputs_and_rebuild_corruption(self) -> None:
         source = self.make_worker_source()
         installs: list[Path] = []
@@ -4227,6 +4283,44 @@ class WorkspaceTests(unittest.TestCase):
             "export const value = 2;\n",
         )
         self.assertFalse((changed[0] / "node_modules" / "alpha" / "local").exists())
+
+        source.chmod(0o555)
+        self.addCleanup(source.chmod, 0o700)
+        metadata["inputs"]["lifecycle_source_sha256"] = _tree_digest(
+            source,
+            WORKER_SOURCE_EXCLUSIONS,
+            reject_symlinks=True,
+            copied_metadata=True,
+        )
+        sealed = self.workspace._worker_view(
+            root, source, dependencies, "c" * 64, metadata
+        )
+        self.assertFalse(sealed[1])
+        self.assertEqual(stat.S_IMODE(sealed[0].stat().st_mode), 0o555)
+
+        def generate_types(arguments: list[str], **kwargs: object) -> str:
+            self.assertEqual(arguments, ["npm", "run", "check"])
+            view = kwargs["cwd"]
+            assert isinstance(view, Path)
+            mode = stat.S_IMODE(view.stat().st_mode)
+            self.assertEqual(mode & stat.S_IRWXU, stat.S_IRWXU)
+            self.assertEqual(mode & (stat.S_IWGRP | stat.S_IWOTH), 0)
+            (view / "worker-runtime.d.ts").write_text(
+                "generated\n", encoding="utf-8"
+            )
+            return ""
+
+        with mock.patch(
+            "atrinik_workspace.workspace.run", side_effect=generate_types
+        ):
+            self.workspace._run_worker_checks(
+                sealed[0], {}, "c" * 64, metadata
+            )
+        self.assertEqual(stat.S_IMODE(sealed[0].stat().st_mode), 0o555)
+        self.workspace._reconcile_worker_view_after_checks(
+            source, sealed[0], "c" * 64, metadata
+        )
+
     def test_source_view_reconciles_links_copies_and_stale_entries_in_place(self) -> None:
         source = self.workspace.paths.repositories / "server"
         copied_source = source / "install_data"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -4316,8 +4316,7 @@ class WorkspaceTests(unittest.TestCase):
             view = kwargs["cwd"]
             assert isinstance(view, Path)
             mode = stat.S_IMODE(view.stat().st_mode)
-            self.assertEqual(mode & stat.S_IRWXU, stat.S_IRWXU)
-            self.assertEqual(mode & (stat.S_IWGRP | stat.S_IWOTH), 0)
+            self.assertEqual(mode, 0o755)
             (view / "worker-runtime.d.ts").write_text(
                 "generated\n", encoding="utf-8"
             )

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -4298,6 +4298,19 @@ class WorkspaceTests(unittest.TestCase):
         self.assertFalse(sealed[1])
         self.assertEqual(stat.S_IMODE(sealed[0].stat().st_mode), 0o555)
 
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.os.geteuid",
+                return_value=os.geteuid() + 1,
+            ),
+            self.assertRaisesRegex(
+                WorkspaceError, "Worker staging root ownership is unsafe"
+            ),
+        ):
+            self.workspace._worker_view(
+                root, source, dependencies, "d" * 64, metadata
+            )
+
         def generate_types(arguments: list[str], **kwargs: object) -> str:
             self.assertEqual(arguments, ["npm", "run", "check"])
             view = kwargs["cwd"]
@@ -4319,6 +4332,35 @@ class WorkspaceTests(unittest.TestCase):
         self.assertEqual(stat.S_IMODE(sealed[0].stat().st_mode), 0o555)
         self.workspace._reconcile_worker_view_after_checks(
             source, sealed[0], "c" * 64, metadata
+        )
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.os.geteuid",
+                return_value=os.geteuid() + 1,
+            ),
+            self.assertRaisesRegex(WorkspaceError, "view ownership is unsafe"),
+        ):
+            self.workspace._run_worker_checks(
+                sealed[0], {}, "c" * 64, metadata
+            )
+        self.assertEqual(stat.S_IMODE(sealed[0].stat().st_mode), 0o555)
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.run",
+                side_effect=WorkspaceError("simulated check failure"),
+            ),
+            self.assertRaisesRegex(WorkspaceError, "simulated check failure"),
+        ):
+            self.workspace._run_worker_checks(
+                sealed[0], {}, "c" * 64, metadata
+            )
+        self.assertEqual(stat.S_IMODE(sealed[0].stat().st_mode), 0o555)
+        self.assertTrue(
+            self.workspace._worker_view(
+                root, source, dependencies, "c" * 64, metadata
+            )[1]
         )
 
     def test_source_view_reconciles_links_copies_and_stale_entries_in_place(self) -> None:


### PR DESCRIPTION
## Summary

- authenticate copied Worker source metadata before reopening wrapper-owned staging roots
- grant temporary full owner access while disabling group/other writes for dependency installation, source-view staging, and generated Worker checks
- restore sealed source modes before view publication and after checks, including failure paths
- document the mode-transition contract and cover restrictive `0700` sources, foreign ownership, exact temporary modes, source views, and failed checks

Fixes #425

## Coordinates

- Base: `main` at `5d41fdd9a0e350596509c45e4a92a573eaa0e352`
- Head: `fix/worker-dependency-staging-permissions` at `0ef92d3f747aad4b4d8fd08bc20bef8fc781c6f4`
- Worktree: `/workspaces/atrinik/workspace/worktrees/atrinik/issue-425-worker-staging`
- Commits:
  - `f7bebe44c fix(build): preserve writable Worker staging`
  - `883ac5712 test(build): cover Worker staging recovery`
  - `21fa713dc docs(build): clarify Worker staging permissions`
  - `828f08d3b docs(build): align Worker permission wording`
  - `e2e0a5336 test(build): assert preserved Worker read modes`
  - `0ef92d3f7 test(build): cover Worker staging error paths`

## Validation

- complete repository suite — 904 passed in 345.924s; 83% coverage
- focused Worker dependency, source-view, ownership, failure-restoration, cache, publication, recovery, and cleanup tests — passed
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `python3 -m atrinik_workspace.mcp_contract validate`
- `./atrinik manifest validate`
- `./atrinik provenance validate`
- `./atrinik supply-chain validate`
- `git diff --check`
- two fresh independent final whole-diff reviews — zero known actionable findings
- final-head Classic-profile `metaserver-worker` build and repeat — passed dependency/view reuse, type generation/checks, 443 Vitest tests, 72 admin tests, deployment dry-runs, and service-binding tests

## Verification

Runtime playtesting is not applicable because this changes wrapper build orchestration rather than game-server behavior. From an aggregate workspace checkout of this branch:

```sh
./atrinik profile show classic --json
./atrinik build metaserver-worker --profile classic --test
./atrinik build metaserver-worker --profile classic --test
```

The first command must resolve the Classic profile. The first build must proceed through dependency installation, Worker view preparation, and the complete Worker check suite. The repeat must reuse the validated dependency installation and Worker view while still passing all checks. No topology, scenario, credentials, server/client data, or persistent state is required.
