### PR TITLE
fix(workspace): publish resource owners atomically

### DIFF
--- a/README.md
+++ b/README.md
@@ -1219,11 +1219,14 @@ time, skips busy candidates, and journals completed actions in
 
 Waits longer than 10 seconds report the resource kind, stable coordinate, known
 owner operation, and supported recovery command without relying on a
-namespace-local PID. The wrapper fails closed when advisory shared locking or
-resource identity is unavailable. Active preparation leases are inherited by
-subprocesses. Build and startup hold profile, source, and build-root leases only
-until a sealed runtime generation is published. Foreground processes then
-retain the runtime-generation lease plus server state when applicable;
+namespace-local PID. Owner publication and stale-record reaping share a brief
+directory fence, so diagnostics cannot remove a newly visible record before
+its live-owner lock is established. The wrapper fails closed when advisory
+shared locking or resource identity is unavailable. Active preparation leases
+are inherited by subprocesses. Build and startup hold profile, source, and
+build-root leases only until a sealed runtime generation is published.
+Foreground processes then retain the runtime-generation lease plus server state
+when applicable;
 supervisors and guardians retain only runtime-generation, process-tree,
 server-state, and generation-specific port-reservation leases.
 

--- a/README.md
+++ b/README.md
@@ -1219,9 +1219,11 @@ time, skips busy candidates, and journals completed actions in
 
 Waits longer than 10 seconds report the resource kind, stable coordinate, known
 owner operation, and supported recovery command without relying on a
-namespace-local PID. Owner publication and stale-record reaping share a brief
-directory fence, so diagnostics cannot remove a newly visible record before
-its live-owner lock is established. The wrapper fails closed when advisory
+namespace-local PID. Owner records are written and locked in a private staging
+directory, then linked atomically into the diagnostic namespace; stale-record
+scans therefore never observe a new record before its live-owner lock is
+established. Legacy records are retained conservatively because their visible
+publication predates that invariant. The wrapper fails closed when advisory
 shared locking or resource identity is unavailable. Active preparation leases
 are inherited by subprocesses. Build and startup hold profile, source, and
 build-root leases only until a sealed runtime generation is published.

--- a/atrinik_workspace/locking.py
+++ b/atrinik_workspace/locking.py
@@ -217,6 +217,9 @@ def _lease_owner_summary(path: Path) -> str:
         owners_descriptor = os.open(
             owners.name, flags, dir_fd=parent_descriptor
         )
+        # Serialize enumeration/reaping with the short publication window in
+        # _resource_owner. A visible record is therefore already locked.
+        fcntl.flock(owners_descriptor, fcntl.LOCK_EX)
         paths = sorted(os.listdir(owners_descriptor))
     except (FileNotFoundError, NotADirectoryError, PermissionError, OSError, WorkspaceError):
         if owners_descriptor is not None:
@@ -649,6 +652,15 @@ def _resource_owner(
         raise WorkspaceError(
             f"cannot open resource lease owner directory {owners}: {error}"
         ) from error
+    try:
+        fcntl.flock(owner_descriptor, fcntl.LOCK_EX)
+    except OSError as error:
+        os.close(owner_descriptor)
+        os.close(parent_descriptor)
+        raise WorkspaceError(
+            f"cannot lock resource lease owner directory {owners}: {error}"
+        ) from error
+    publication_locked = True
     token = secrets.token_hex(16)
     metadata_path = owners / f"{token}.json"
     owner = f"{socket.gethostname()} uid={os.geteuid()} token={token}"
@@ -680,7 +692,15 @@ def _resource_owner(
             json.dump(value, stream, sort_keys=True)
             stream.write("\n")
             stream.flush()
-        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX)
+            fcntl.flock(owner_descriptor, fcntl.LOCK_UN)
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot publish resource lease owner metadata "
+                f"{metadata_path}: {error}"
+            ) from error
+        publication_locked = False
         with os.fdopen(os.dup(descriptor), "a+") as owner_lease:
             if inherit:
                 with inherit_lock_fds(owner_lease):
@@ -688,6 +708,11 @@ def _resource_owner(
             else:
                 yield
     finally:
+        if publication_locked:
+            try:
+                fcntl.flock(owner_descriptor, fcntl.LOCK_UN)
+            except OSError:
+                pass
         os.close(descriptor)
         cleanup_descriptor: int | None = None
         try:

--- a/atrinik_workspace/locking.py
+++ b/atrinik_workspace/locking.py
@@ -23,7 +23,7 @@ from .model import WorkspaceError
 LAYOUT_WRITER_INTENT_SUFFIX = ".writer-intent"
 LAYOUT_WRITER_PENDING_SUFFIX = ".writer-pending"
 LOCK_WAIT_DIAGNOSTIC_SECONDS = 10.0
-RESOURCE_LEASE_SCHEMA_VERSION = 1
+RESOURCE_LEASE_SCHEMA_VERSION = 2
 RESOURCE_KIND_ORDER = {
     "maintenance": 0,
     "registry": 10,
@@ -201,6 +201,54 @@ def _advisory_lock(
         yield lock
 
 
+def _reap_staged_resource_owners(
+    owners_descriptor: int,
+    owners: Path,
+) -> None:
+    staging_descriptor: int | None = None
+    try:
+        staging_descriptor = _open_or_create_directory_at(
+            owners_descriptor, ".pending", owners / ".pending"
+        )
+        fcntl.flock(
+            staging_descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB
+        )
+        metadata_names = sorted(os.listdir(staging_descriptor))
+        for metadata_name in metadata_names:
+            descriptor: int | None = None
+            try:
+                flags = os.O_RDWR | os.O_CLOEXEC
+                if hasattr(os, "O_NOFOLLOW"):
+                    flags |= os.O_NOFOLLOW
+                descriptor = os.open(
+                    metadata_name, flags, dir_fd=staging_descriptor
+                )
+                opened = os.fstat(descriptor)
+                visible = os.stat(
+                    metadata_name,
+                    dir_fd=staging_descriptor,
+                    follow_symlinks=False,
+                )
+                if (
+                    not stat.S_ISREG(visible.st_mode)
+                    or (opened.st_dev, opened.st_ino)
+                    != (visible.st_dev, visible.st_ino)
+                ):
+                    continue
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                os.unlink(metadata_name, dir_fd=staging_descriptor)
+            except (FileNotFoundError, BlockingIOError, OSError):
+                continue
+            finally:
+                if descriptor is not None:
+                    os.close(descriptor)
+    except (OSError, WorkspaceError):
+        pass
+    finally:
+        if staging_descriptor is not None:
+            os.close(staging_descriptor)
+
+
 def _lease_owner_summary(path: Path) -> str:
     owners = path.with_name(f"{path.name}.owners")
     parent_descriptor: int | None = None
@@ -217,9 +265,7 @@ def _lease_owner_summary(path: Path) -> str:
         owners_descriptor = os.open(
             owners.name, flags, dir_fd=parent_descriptor
         )
-        # Serialize enumeration/reaping with the short publication window in
-        # _resource_owner. A visible record is therefore already locked.
-        fcntl.flock(owners_descriptor, fcntl.LOCK_EX)
+        _reap_staged_resource_owners(owners_descriptor, owners)
         paths = sorted(os.listdir(owners_descriptor))
     except (FileNotFoundError, NotADirectoryError, PermissionError, OSError, WorkspaceError):
         if owners_descriptor is not None:
@@ -229,6 +275,8 @@ def _lease_owner_summary(path: Path) -> str:
         return "owner metadata unavailable"
     descriptions: list[str] = []
     for metadata_name in paths:
+        if not metadata_name.endswith(".json"):
+            continue
         descriptor: int | None = None
         try:
             flags = os.O_RDWR | os.O_CLOEXEC
@@ -248,32 +296,42 @@ def _lease_owner_summary(path: Path) -> str:
                 or (opened.st_dev, opened.st_ino)
                 != (visible.st_dev, visible.st_ino)
             ):
+                os.close(descriptor)
+                descriptor = None
                 continue
+            with os.fdopen(os.dup(descriptor), encoding="utf-8") as stream:
+                value = json.load(stream)
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            if descriptor is not None:
+                os.close(descriptor)
+            continue
+        if not isinstance(value, dict):
+            os.close(descriptor)
+            continue
+        schema_version = value.get("schema_version")
+        if schema_version == RESOURCE_LEASE_SCHEMA_VERSION:
             try:
                 fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
             except BlockingIOError:
                 pass
+            except OSError:
+                os.close(descriptor)
+                continue
             else:
                 os.close(descriptor)
                 descriptor = None
-                os.unlink(metadata_name, dir_fd=owners_descriptor)
+                try:
+                    os.unlink(metadata_name, dir_fd=owners_descriptor)
+                except OSError:
+                    continue
                 continue
-            with os.fdopen(descriptor, encoding="utf-8") as stream:
-                descriptor = None
-                value = json.load(stream)
-        except (OSError, UnicodeError, json.JSONDecodeError):
-            continue
-        finally:
-            if descriptor is not None:
-                os.close(descriptor)
-        if not isinstance(value, dict):
-            continue
         operation = value.get("operation")
         owner = value.get("owner")
         mode = value.get("mode")
         if all(isinstance(item, str) and item for item in (operation, owner, mode)):
             if len(descriptions) < 8:
                 descriptions.append(f"{mode} {operation} by {owner}")
+        os.close(descriptor)
     os.close(owners_descriptor)
     os.close(parent_descriptor)
     return "; ".join(descriptions) if descriptions else "owner metadata unavailable"
@@ -652,15 +710,23 @@ def _resource_owner(
         raise WorkspaceError(
             f"cannot open resource lease owner directory {owners}: {error}"
         ) from error
+    staging_descriptor: int | None = None
     try:
-        fcntl.flock(owner_descriptor, fcntl.LOCK_EX)
-    except OSError as error:
+        staging_descriptor = _open_or_create_directory_at(
+            owner_descriptor, ".pending", owners / ".pending"
+        )
+        fcntl.flock(staging_descriptor, fcntl.LOCK_EX)
+    except (OSError, WorkspaceError) as error:
+        if staging_descriptor is not None:
+            os.close(staging_descriptor)
         os.close(owner_descriptor)
         os.close(parent_descriptor)
         raise WorkspaceError(
-            f"cannot lock resource lease owner directory {owners}: {error}"
+            f"cannot open resource lease owner staging directory "
+            f"{owners / '.pending'}: {error}"
         ) from error
     publication_locked = True
+    published = False
     token = secrets.token_hex(16)
     metadata_path = owners / f"{token}.json"
     owner = f"{socket.gethostname()} uid={os.geteuid()} token={token}"
@@ -679,9 +745,10 @@ def _resource_owner(
         flags |= os.O_NOFOLLOW
     try:
         descriptor = os.open(
-            metadata_path.name, flags, 0o600, dir_fd=owner_descriptor
+            metadata_path.name, flags, 0o600, dir_fd=staging_descriptor
         )
     except OSError:
+        os.close(staging_descriptor)
         os.close(owner_descriptor)
         os.close(parent_descriptor)
         raise WorkspaceError(
@@ -694,7 +761,16 @@ def _resource_owner(
             stream.flush()
         try:
             fcntl.flock(descriptor, fcntl.LOCK_EX)
-            fcntl.flock(owner_descriptor, fcntl.LOCK_UN)
+            os.link(
+                metadata_path.name,
+                metadata_path.name,
+                src_dir_fd=staging_descriptor,
+                dst_dir_fd=owner_descriptor,
+                follow_symlinks=False,
+            )
+            published = True
+            os.unlink(metadata_path.name, dir_fd=staging_descriptor)
+            fcntl.flock(staging_descriptor, fcntl.LOCK_UN)
         except OSError as error:
             raise WorkspaceError(
                 f"cannot publish resource lease owner metadata "
@@ -710,7 +786,7 @@ def _resource_owner(
     finally:
         if publication_locked:
             try:
-                fcntl.flock(owner_descriptor, fcntl.LOCK_UN)
+                fcntl.flock(staging_descriptor, fcntl.LOCK_UN)
             except OSError:
                 pass
         os.close(descriptor)
@@ -719,15 +795,16 @@ def _resource_owner(
             cleanup_flags = os.O_RDWR | os.O_CLOEXEC
             if hasattr(os, "O_NOFOLLOW"):
                 cleanup_flags |= os.O_NOFOLLOW
-            cleanup_descriptor = os.open(
-                metadata_path.name,
-                cleanup_flags,
-                dir_fd=owner_descriptor,
-            )
-            fcntl.flock(
-                cleanup_descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB
-            )
-            os.unlink(metadata_path.name, dir_fd=owner_descriptor)
+            if published:
+                cleanup_descriptor = os.open(
+                    metadata_path.name,
+                    cleanup_flags,
+                    dir_fd=owner_descriptor,
+                )
+                fcntl.flock(
+                    cleanup_descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB
+                )
+                os.unlink(metadata_path.name, dir_fd=owner_descriptor)
         except (FileNotFoundError, BlockingIOError, OSError):
             # An inherited descriptor deliberately keeps the owner record live;
             # a later diagnostic scan reaps it after the child exits.
@@ -735,6 +812,11 @@ def _resource_owner(
         finally:
             if cleanup_descriptor is not None:
                 os.close(cleanup_descriptor)
+            try:
+                os.unlink(metadata_path.name, dir_fd=staging_descriptor)
+            except OSError:
+                pass
+            os.close(staging_descriptor)
             os.close(owner_descriptor)
             os.close(parent_descriptor)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -240,7 +240,10 @@ scenario, state, build-root, and cache requests are deduplicated and sorted.
 Multi-source writers retry all-or-none, releasing earlier coordinates before
 waiting on a busy later source. A queued writer precedes later readers only for
 that coordinate, and waits longer than 10 seconds report its owner operation
-and supported recovery action.
+and supported recovery action. Owner records become diagnostically visible
+under a directory publication fence that remains held until the record itself
+is locked; stale-record scans take the same fence before reaping unlocked
+metadata.
 
 Profile consumers lock the profile, derive the requested operation's transitive
 provider closure, acquire only those exact sources, revalidate, and capture

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -240,10 +240,11 @@ scenario, state, build-root, and cache requests are deduplicated and sorted.
 Multi-source writers retry all-or-none, releasing earlier coordinates before
 waiting on a busy later source. A queued writer precedes later readers only for
 that coordinate, and waits longer than 10 seconds report its owner operation
-and supported recovery action. Owner records become diagnostically visible
-under a directory publication fence that remains held until the record itself
-is locked; stale-record scans take the same fence before reaping unlocked
-metadata.
+and supported recovery action. Owner records are fully written and locked in a
+private staging directory before an atomic hard-link makes them diagnostically
+visible. Stale-record scans reap current-schema records only after the owner
+lock is released; legacy records remain untouched because their publication
+protocol did not guarantee that every visible record was already locked.
 
 Profile consumers lock the profile, derive the requested operation's transitive
 provider closure, acquire only those exact sources, revalidate, and capture

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -10658,7 +10658,7 @@ class WorkspaceTests(unittest.TestCase):
             "inspect review",
             "remove the unsafe lease namespace",
         )
-        for level in ("kind", "owners"):
+        for level in ("kind", "owners", "pending"):
             with self.subTest(level=level):
                 root = self.root / f"lease-{level}"
                 kind = root / "leases" / "source"
@@ -10672,9 +10672,14 @@ class WorkspaceTests(unittest.TestCase):
                     lock = resource_lock_path(
                         root, request.kind, request.coordinate
                     )
-                    lock.with_name(f"{lock.name}.owners").symlink_to(
-                        external, target_is_directory=True
-                    )
+                    owners = lock.with_name(f"{lock.name}.owners")
+                    if level == "owners":
+                        owners.symlink_to(external, target_is_directory=True)
+                    else:
+                        owners.mkdir()
+                        (owners / ".pending").symlink_to(
+                            external, target_is_directory=True
+                        )
 
                 with self.assertRaisesRegex(
                     WorkspaceError, "directory is unsafe|cannot open.*directory"
@@ -10699,7 +10704,31 @@ class WorkspaceTests(unittest.TestCase):
             self.workspace.paths.workspace, request.kind, request.coordinate
         )
         owners = lock.with_name(f"{lock.name}.owners")
-        self.assertEqual(list(owners.iterdir()), [])
+        self.assertEqual(list(owners.glob("*.json")), [])
+        self.assertEqual(list((owners / ".pending").iterdir()), [])
+
+    def test_resource_owner_scan_reaps_interrupted_staging(self) -> None:
+        request = LeaseRequest(
+            "source",
+            "client:/worktrees/review",
+            "shared",
+            "inspect review",
+            "wait for review",
+        )
+        with resource_locks(self.workspace.paths.workspace, [request]):
+            pass
+        lock = resource_lock_path(
+            self.workspace.paths.workspace, request.kind, request.coordinate
+        )
+        staging = lock.with_name(f"{lock.name}.owners") / ".pending"
+        interrupted = staging / "interrupted.json"
+        interrupted.write_text("{}\n", encoding="utf-8")
+
+        self.assertEqual(
+            locking_module._lease_owner_summary(lock),
+            "owner metadata unavailable",
+        )
+        self.assertFalse(interrupted.exists())
 
     def test_resource_owner_publication_is_atomic_with_diagnostic_scan(self) -> None:
         request = LeaseRequest(
@@ -10763,22 +10792,22 @@ class WorkspaceTests(unittest.TestCase):
             publisher = threading.Thread(target=publish_owner)
             publisher.start()
             self.assertTrue(publication_visible.wait(2))
-            self.assertEqual(len(list(owners.iterdir())), 1)
+            self.assertEqual(list(owners.glob("*.json")), [])
 
             scanner = threading.Thread(
                 target=scan_owner, name="owner-summary-scan"
             )
             scanner.start()
             self.assertTrue(scan_attempted.wait(2))
-            self.assertFalse(scan_completed.wait(0.1))
+            self.assertTrue(scan_completed.wait(2))
+            summary = results.get_nowait()
+            self.assertEqual(summary, "owner metadata unavailable")
 
             continue_publication.set()
             self.assertTrue(lease_entered.wait(2))
-            self.assertTrue(scan_completed.wait(2))
-            summary = results.get_nowait()
-            self.assertIsInstance(summary, str)
+            summary = locking_module._lease_owner_summary(lock)
             self.assertIn("shared inspect review by", summary)
-            self.assertEqual(len(list(owners.iterdir())), 1)
+            self.assertEqual(len(list(owners.glob("*.json"))), 1)
 
             release_lease.set()
             publisher.join(2)
@@ -10787,7 +10816,160 @@ class WorkspaceTests(unittest.TestCase):
         self.assertFalse(publisher.is_alive())
         self.assertFalse(scanner.is_alive())
         self.assertIsNone(results.get_nowait())
-        self.assertEqual(list(owners.iterdir()), [])
+        self.assertEqual(list(owners.glob("*.json")), [])
+        self.assertEqual(list((owners / ".pending").iterdir()), [])
+
+    def test_new_resource_owner_is_atomic_for_legacy_diagnostic_scan(self) -> None:
+        request = LeaseRequest(
+            "source",
+            "client:/worktrees/review",
+            "shared",
+            "inspect review",
+            "wait for review",
+        )
+        lock = resource_lock_path(
+            self.workspace.paths.workspace, request.kind, request.coordinate
+        )
+        owners = lock.with_name(f"{lock.name}.owners")
+        publication_staged = threading.Event()
+        continue_publication = threading.Event()
+        lease_entered = threading.Event()
+        release_lease = threading.Event()
+        results: queue.Queue[object] = queue.Queue()
+        real_dump = locking_module.json.dump
+
+        def pause_staged_publication(*args: object, **kwargs: object) -> None:
+            real_dump(*args, **kwargs)
+            publication_staged.set()
+            if not continue_publication.wait(5):
+                raise TimeoutError("owner publication was not released")
+
+        def publish_owner() -> None:
+            try:
+                with resource_locks(self.workspace.paths.workspace, [request]):
+                    lease_entered.set()
+                    if not release_lease.wait(5):
+                        raise TimeoutError("resource lease was not released")
+                results.put(None)
+            except BaseException as error:
+                results.put(error)
+
+        def legacy_scan() -> list[str]:
+            visible: list[str] = []
+            owner_descriptor = os.open(
+                owners, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC
+            )
+            try:
+                for metadata_name in sorted(os.listdir(owner_descriptor)):
+                    descriptor: int | None = None
+                    try:
+                        descriptor = os.open(
+                            metadata_name,
+                            os.O_RDWR | os.O_CLOEXEC,
+                            dir_fd=owner_descriptor,
+                        )
+                        fcntl.flock(
+                            descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB
+                        )
+                        visible.append(metadata_name)
+                    except OSError:
+                        continue
+                    finally:
+                        if descriptor is not None:
+                            os.close(descriptor)
+            finally:
+                os.close(owner_descriptor)
+            return visible
+
+        with mock.patch.object(
+            locking_module.json, "dump", side_effect=pause_staged_publication
+        ):
+            publisher = threading.Thread(target=publish_owner)
+            publisher.start()
+            self.assertTrue(publication_staged.wait(2))
+            self.assertEqual(legacy_scan(), [])
+            self.assertEqual(list(owners.glob("*.json")), [])
+
+            continue_publication.set()
+            self.assertTrue(lease_entered.wait(2))
+            self.assertEqual(len(list(owners.glob("*.json"))), 1)
+            self.assertEqual(legacy_scan(), [])
+            self.assertEqual(len(list(owners.glob("*.json"))), 1)
+            release_lease.set()
+            publisher.join(2)
+
+        self.assertFalse(publisher.is_alive())
+        self.assertIsNone(results.get_nowait())
+
+    def test_legacy_resource_owner_survives_new_diagnostic_scan(self) -> None:
+        request = LeaseRequest(
+            "source",
+            "client:/worktrees/review",
+            "shared",
+            "inspect legacy review",
+            "wait for review",
+        )
+        lock = resource_lock_path(
+            self.workspace.paths.workspace, request.kind, request.coordinate
+        )
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        owners = lock.with_name(f"{lock.name}.owners")
+        owners.mkdir()
+        metadata = owners / "legacy.json"
+        publication_visible = threading.Event()
+        continue_publication = threading.Event()
+        owner_locked = threading.Event()
+        release_owner = threading.Event()
+        results: queue.Queue[object] = queue.Queue()
+
+        def legacy_publish() -> None:
+            descriptor = os.open(
+                metadata, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600
+            )
+            try:
+                with os.fdopen(
+                    descriptor, "w+", encoding="utf-8", closefd=False
+                ) as stream:
+                    json.dump(
+                        {
+                            "schema_version": 1,
+                            "mode": request.mode,
+                            "operation": request.operation,
+                            "owner": "legacy wrapper",
+                        },
+                        stream,
+                    )
+                    stream.flush()
+                publication_visible.set()
+                if not continue_publication.wait(5):
+                    raise TimeoutError("legacy publication was not released")
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                owner_locked.set()
+                if not release_owner.wait(5):
+                    raise TimeoutError("legacy owner was not released")
+                results.put(None)
+            except BaseException as error:
+                results.put(error)
+            finally:
+                os.close(descriptor)
+                metadata.unlink(missing_ok=True)
+
+        publisher = threading.Thread(target=legacy_publish)
+        publisher.start()
+        self.assertTrue(publication_visible.wait(2))
+
+        summary = locking_module._lease_owner_summary(lock)
+        self.assertIn("shared inspect legacy review by legacy wrapper", summary)
+        self.assertTrue(metadata.exists())
+
+        continue_publication.set()
+        self.assertTrue(owner_locked.wait(2))
+        self.assertTrue(metadata.exists())
+        release_owner.set()
+        publisher.join(2)
+
+        self.assertFalse(publisher.is_alive())
+        self.assertIsNone(results.get_nowait())
 
     def test_resource_owner_metadata_survives_inherited_child(self) -> None:
         request = LeaseRequest(
@@ -10807,11 +10989,12 @@ class WorkspaceTests(unittest.TestCase):
                 pass_fds=active_lock_fds(),
             )
         owners = lock.with_name(f"{lock.name}.owners")
-        self.assertEqual(len(list(owners.iterdir())), 1)
+        self.assertEqual(len(list(owners.glob("*.json"))), 1)
         child.terminate()
         child.wait(timeout=5)
         locking_module._lease_owner_summary(lock)
-        self.assertEqual(list(owners.iterdir()), [])
+        self.assertEqual(list(owners.glob("*.json")), [])
+        self.assertEqual(list((owners / ".pending").iterdir()), [])
 
     def test_relocated_workspace_roots_share_physical_lease_namespace(self) -> None:
         alternate_root = self.root / "alternate-workspace"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -10701,6 +10701,94 @@ class WorkspaceTests(unittest.TestCase):
         owners = lock.with_name(f"{lock.name}.owners")
         self.assertEqual(list(owners.iterdir()), [])
 
+    def test_resource_owner_publication_is_atomic_with_diagnostic_scan(self) -> None:
+        request = LeaseRequest(
+            "source",
+            "client:/worktrees/review",
+            "shared",
+            "inspect review",
+            "wait for review",
+        )
+        lock = resource_lock_path(
+            self.workspace.paths.workspace, request.kind, request.coordinate
+        )
+        owners = lock.with_name(f"{lock.name}.owners")
+        publication_visible = threading.Event()
+        continue_publication = threading.Event()
+        lease_entered = threading.Event()
+        release_lease = threading.Event()
+        scan_attempted = threading.Event()
+        scan_completed = threading.Event()
+        results: queue.Queue[object] = queue.Queue()
+        real_dump = locking_module.json.dump
+        real_flock = locking_module.fcntl.flock
+
+        def pause_visible_publication(*args: object, **kwargs: object) -> None:
+            real_dump(*args, **kwargs)
+            publication_visible.set()
+            if not continue_publication.wait(5):
+                raise TimeoutError("owner publication was not released")
+
+        def publish_owner() -> None:
+            try:
+                with resource_locks(self.workspace.paths.workspace, [request]):
+                    lease_entered.set()
+                    if not release_lease.wait(5):
+                        raise TimeoutError("resource lease was not released")
+                results.put(None)
+            except BaseException as error:
+                results.put(error)
+
+        def scan_owner() -> None:
+            try:
+                results.put(locking_module._lease_owner_summary(lock))
+            except BaseException as error:
+                results.put(error)
+            finally:
+                scan_completed.set()
+
+        def observe_scan_flock(descriptor: object, operation: int) -> None:
+            if threading.current_thread().name == "owner-summary-scan":
+                scan_attempted.set()
+            real_flock(descriptor, operation)
+
+        with (
+            mock.patch.object(
+                locking_module.json, "dump", side_effect=pause_visible_publication
+            ),
+            mock.patch.object(
+                locking_module.fcntl, "flock", side_effect=observe_scan_flock
+            ),
+        ):
+            publisher = threading.Thread(target=publish_owner)
+            publisher.start()
+            self.assertTrue(publication_visible.wait(2))
+            self.assertEqual(len(list(owners.iterdir())), 1)
+
+            scanner = threading.Thread(
+                target=scan_owner, name="owner-summary-scan"
+            )
+            scanner.start()
+            self.assertTrue(scan_attempted.wait(2))
+            self.assertFalse(scan_completed.wait(0.1))
+
+            continue_publication.set()
+            self.assertTrue(lease_entered.wait(2))
+            self.assertTrue(scan_completed.wait(2))
+            summary = results.get_nowait()
+            self.assertIsInstance(summary, str)
+            self.assertIn("shared inspect review by", summary)
+            self.assertEqual(len(list(owners.iterdir())), 1)
+
+            release_lease.set()
+            publisher.join(2)
+            scanner.join(2)
+
+        self.assertFalse(publisher.is_alive())
+        self.assertFalse(scanner.is_alive())
+        self.assertIsNone(results.get_nowait())
+        self.assertEqual(list(owners.iterdir()), [])
+
     def test_resource_owner_metadata_survives_inherited_child(self) -> None:
         request = LeaseRequest(
             "source",


### PR DESCRIPTION
## Summary

- write and lock resource-owner metadata in private staging before atomically linking it into the diagnostic namespace
- preserve mixed-wrapper safety by versioning the publication protocol and retaining legacy records conservatively
- keep interrupted-staging cleanup nonblocking so paused publishers cannot stall diagnostics or cleanup
- add deterministic current/current and both-direction legacy/current rendezvous regressions plus interruption and symlink coverage
- document the atomic owner-diagnostic handoff in operator and architecture guidance

## Coordinates

- Base: `main` at `148dccbbf1cebde484f2dc91a4d4e38e3c9e58dd`
- Head branch: `fix/resource-owner-publication-430`
- Final head: `7f5bef5a19f19c2c00d6783071a4b6e982ade0e7`
- Worktree: `/workspaces/atrinik/workspace/worktrees/atrinik/issue-430-resource-owner-publication`

## Validation

- `.venv/bin/python -m coverage run -m unittest discover -v` — 924 tests passed in 417.345s
- `.venv/bin/python -m coverage report --show-missing` — 83% total coverage
- focused owner-publication, mixed-revision, cleanup, symlink, namespace, and fairness tests
- `.venv/bin/python -m compileall -q atrinik atrinik_workspace tests`
- `.venv/bin/python -m atrinik_workspace.guidance_inventory --check`
- `.venv/bin/python -m atrinik_workspace.mcp_contract validate`
- `./atrinik manifest validate`
- `./atrinik provenance validate`
- `./atrinik supply-chain validate`
- `./atrinik cleanup --scope all --older-than 7 --dry-run --json`
- `./atrinik cleanup --scope topologies --older-than 7 --dry-run --json`
- `git diff --check`

## Verification

Runtime provisioning is not applicable: this change affects wrapper advisory-lock owner metadata, not a build or game service. Deterministic tests pause at the staging and legacy visible-before-lock boundaries, prove staging stays invisible without blocking diagnostics, verify both mixed-wrapper directions, confirm published live owners remain diagnosable, and cover normal, inherited, and interrupted cleanup.

Closes #430
