### PR TITLE
fix(runtime): release retained topology leases before process-tree publication

### DIFF
--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -735,19 +735,12 @@ def supervise(
                     control_path.unlink()
             except FileNotFoundError:
                 pass
-        # On orderly shutdown stop being a lease holder before telling the
-        # guardian to perform its final exact-holder sweep. On a crash the
-        # kernel closes this descriptor before pipe EOF instead.
+        # On orderly shutdown leave the guardian as the sole lease holder
+        # before telling it to perform its final exact-holder sweep. On a
+        # crash the kernel closes these descriptors before pipe EOF instead.
         if process_tree_fd is not None:
             os.close(process_tree_fd)
             process_tree_fd = None
-        if guardian_write_fd is not None:
-            os.close(guardian_write_fd)
-        if guardian_pid is not None:
-            try:
-                os.waitpid(guardian_pid, 0)
-            except ChildProcessError:
-                pass
         if lock_fd is not None:
             os.close(lock_fd)
         if layout_lock_fd is not None:
@@ -764,6 +757,13 @@ def supervise(
             os.close(state_output_fd)
         if physical_state_lock_fd is not None:
             os.close(physical_state_lock_fd)
+        if guardian_write_fd is not None:
+            os.close(guardian_write_fd)
+        if guardian_pid is not None:
+            try:
+                os.waitpid(guardian_pid, 0)
+            except ChildProcessError:
+                pass
     return 0
 
 

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -388,10 +388,10 @@ def _guardian(
         time.sleep(0.05)
     while holders_exist(process_tree_fd, exclude=excluded):
         time.sleep(0.5)
-    os.close(process_tree_fd)
     for descriptor in retained_fds:
         if descriptor is not None:
             os.close(descriptor)
+    os.close(process_tree_fd)
 
 
 def _start_guardian(

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -735,12 +735,9 @@ def supervise(
                     control_path.unlink()
             except FileNotFoundError:
                 pass
-        # On orderly shutdown leave the guardian as the sole lease holder
-        # before telling it to perform its final exact-holder sweep. On a
-        # crash the kernel closes these descriptors before pipe EOF instead.
-        if process_tree_fd is not None:
-            os.close(process_tree_fd)
-            process_tree_fd = None
+        # Release resource leases before the process-tree publication barrier.
+        # When startup reached the guardian, its duplicate descriptors keep the
+        # topology protected until pipe EOF triggers the same ordered release.
         if lock_fd is not None:
             os.close(lock_fd)
         if layout_lock_fd is not None:
@@ -757,6 +754,9 @@ def supervise(
             os.close(state_output_fd)
         if physical_state_lock_fd is not None:
             os.close(physical_state_lock_fd)
+        if process_tree_fd is not None:
+            os.close(process_tree_fd)
+            process_tree_fd = None
         if guardian_write_fd is not None:
             os.close(guardian_write_fd)
         if guardian_pid is not None:
@@ -821,11 +821,6 @@ def main() -> int:
                 os.close(options.build_lock_fd)
             except OSError:
                 pass
-        if options.process_tree_fd is not None:
-            try:
-                os.close(options.process_tree_fd)
-            except OSError:
-                pass
         if options.port_reservation_fd is not None:
             try:
                 os.close(options.port_reservation_fd)
@@ -849,6 +844,11 @@ def main() -> int:
         if options.physical_state_lock_fd is not None:
             try:
                 os.close(options.physical_state_lock_fd)
+            except OSError:
+                pass
+        if options.process_tree_fd is not None:
+            try:
+                os.close(options.process_tree_fd)
             except OSError:
                 pass
         return 1

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -732,9 +732,9 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                 )
             self.assertEqual(popen.call_args.kwargs["pass_fds"], (4, 7, 8))
             guardian.assert_called_once_with(4, 5, 3, 6, 7, 8, 9)
-            self.assertTrue(
-                {3, 4, 5, 6, 7, 8, 9, 99}
-                <= {call.args[0] for call in close.call_args_list}
+            self.assertEqual(
+                [call.args[0] for call in close.call_args_list[-8:]],
+                [4, 3, 5, 6, 7, 8, 9, 99],
             )
 
     def test_main_daemon_parent_returns_without_supervising(self) -> None:

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -770,7 +770,11 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                 mock.patch.object(supervisor_module.threading, "Thread"),
                 mock.patch.object(supervisor_module, "terminate", return_value=True),
                 mock.patch.object(supervisor_module.os, "close") as close,
-                mock.patch.object(supervisor_module.os, "waitpid") as waitpid,
+                mock.patch.object(
+                    supervisor_module.os,
+                    "waitpid",
+                    side_effect=ChildProcessError,
+                ) as waitpid,
             ):
                 self.assertEqual(
                     supervise(
@@ -833,6 +837,10 @@ class ServerReadinessCaptureTests(unittest.TestCase):
             self.assertEqual(supervisor_module.main(), 1)
 
     def test_main_closes_every_current_lease_after_startup_failure(self) -> None:
+        def close_descriptor(descriptor: int) -> None:
+            if descriptor == 6:
+                raise OSError("process-tree descriptor already closed")
+
         arguments = [
             "atrinik-supervisor",
             "--spec",
@@ -864,7 +872,9 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                 side_effect=RuntimeError("invalid runtime"),
             ),
             mock.patch.object(supervisor_module, "atomic_status"),
-            mock.patch.object(supervisor_module.os, "close") as close,
+            mock.patch.object(
+                supervisor_module.os, "close", side_effect=close_descriptor
+            ) as close,
             mock.patch.object(sys, "stderr"),
         ):
             self.assertEqual(supervisor_module.main(), 1)

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -640,6 +640,62 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                 <= {call.args[0] for call in close.call_args_list}
             )
 
+    def test_guardian_startup_failure_preserves_tree_barrier_order(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            spec_path = root / "spec.json"
+            spec_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 3,
+                        "name": "guardian-failure",
+                        "profile": "classic",
+                        "dependencies": [],
+                        "state": str(root / "state"),
+                        "state_policy": {"mode": "named"},
+                        "build_root": "/tmp/build",
+                        "resolved": {},
+                        "endpoint": None,
+                        "runtime": {"generation": "a" * 64},
+                        "services": {},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with (
+                mock.patch.object(
+                    supervisor_module, "process_start_time", return_value="1"
+                ),
+                mock.patch.object(supervisor_module, "_validate_port_reservation"),
+                mock.patch.object(
+                    supervisor_module,
+                    "_start_guardian",
+                    side_effect=OSError("fork failed"),
+                ),
+                mock.patch.object(supervisor_module, "terminate"),
+                mock.patch.object(supervisor_module.os, "close") as close,
+            ):
+                self.assertEqual(
+                    supervise(
+                        spec_path,
+                        3,
+                        None,
+                        None,
+                        4,
+                        5,
+                        6,
+                        7,
+                        8,
+                        9,
+                    ),
+                    1,
+                )
+
+            self.assertEqual(
+                [call.args[0] for call in close.call_args_list[-7:]],
+                [3, 5, 6, 7, 8, 9, 4],
+            )
+
     def test_server_launch_inherits_exact_state_descriptors(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -692,7 +748,7 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                 mock.patch.object(supervisor_module, "_validate_port_reservation"),
                 mock.patch.object(supervisor_module, "_require_server_port_available"),
                 mock.patch.object(
-                    supervisor_module, "_start_guardian", return_value=(None, 99)
+                    supervisor_module, "_start_guardian", return_value=(4321, 99)
                 ) as guardian,
                 mock.patch.object(
                     supervisor_module, "_open_control", return_value=control
@@ -714,6 +770,7 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                 mock.patch.object(supervisor_module.threading, "Thread"),
                 mock.patch.object(supervisor_module, "terminate", return_value=True),
                 mock.patch.object(supervisor_module.os, "close") as close,
+                mock.patch.object(supervisor_module.os, "waitpid") as waitpid,
             ):
                 self.assertEqual(
                     supervise(
@@ -732,9 +789,10 @@ class ServerReadinessCaptureTests(unittest.TestCase):
                 )
             self.assertEqual(popen.call_args.kwargs["pass_fds"], (4, 7, 8))
             guardian.assert_called_once_with(4, 5, 3, 6, 7, 8, 9)
+            waitpid.assert_called_once_with(4321, 0)
             self.assertEqual(
                 [call.args[0] for call in close.call_args_list[-8:]],
-                [4, 3, 5, 6, 7, 8, 9, 99],
+                [3, 5, 6, 7, 8, 9, 4, 99],
             )
 
     def test_main_daemon_parent_returns_without_supervising(self) -> None:
@@ -811,7 +869,8 @@ class ServerReadinessCaptureTests(unittest.TestCase):
         ):
             self.assertEqual(supervisor_module.main(), 1)
         self.assertEqual(
-            {call.args[0] for call in close.call_args_list}, set(range(3, 12))
+            [call.args[0] for call in close.call_args_list],
+            [3, 4, 5, 7, 8, 9, 10, 11, 6],
         )
 
 

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -562,6 +562,26 @@ class ServerReadinessCaptureTests(unittest.TestCase):
         )
         close.assert_called_once_with(9)
 
+    def test_guardian_releases_retained_leases_before_tree_barrier(self) -> None:
+        with (
+            mock.patch.object(supervisor_module.os, "read", return_value=b""),
+            mock.patch.object(supervisor_module.os, "getpid", return_value=1234),
+            mock.patch.object(supervisor_module.os, "close") as close,
+            mock.patch.object(supervisor_module, "signal_holders"),
+            mock.patch.object(
+                supervisor_module, "holders_exist", return_value=False
+            ),
+            mock.patch.object(
+                supervisor_module.time, "monotonic", side_effect=[0, 11, 11, 14]
+            ),
+        ):
+            supervisor_module._guardian(10, 20, (30, None, 40))
+
+        self.assertEqual(
+            [call.args[0] for call in close.call_args_list],
+            [10, 30, 40, 20],
+        )
+
     def test_current_supervisor_orderly_stop_closes_exact_leases(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)


### PR DESCRIPTION
Closes #438

## Summary

- release guardian-retained topology resource leases before publishing process-tree lease release
- add deterministic unit coverage for descriptor close ordering
- retain end-to-end temporary-state lifecycle coverage

## Validation

- pending

<!-- atrinik-delivery:body:d7896983390c725ccc93e78fd7d11cdbf31a16259b534d593b1611076cd45cc4:start -->
## Final validation

The initial pending marker is resolved.

- full suite: 1,051 tests passed; total coverage 84%
- focused supervisor module: 24 tests passed
- race-sensitive temporary-state lifecycle: five consecutive passes plus the final full-suite pass
- compileall, guidance inventory, manifest, supply-chain, and diff checks passed
- fresh whole-diff review at `243e0b319f4318b1294ed62536342b65edec9594`: zero actionable findings
- latest-head integration, CodeQL, PR-title, and Codecov patch checks passed

<!-- atrinik-delivery:body:d7896983390c725ccc93e78fd7d11cdbf31a16259b534d593b1611076cd45cc4:end -->