### PR TITLE
fix(workspace): support wrapper-self worktree inventory

### DIFF
--- a/.agents/skills/atrinik-issue-delivery/references/delivery-ledger.md
+++ b/.agents/skills/atrinik-issue-delivery/references/delivery-ledger.md
@@ -701,7 +701,8 @@ DELIVERY_OBSERVED_AT=2026-08-14T18:05:00Z
 git -C "$DELIVERY_WRAPPER_ROOT" worktree add -b docs/issue-419 \
   "$DELIVERY_WRAPPER_ROOT/workspace/worktrees/atrinik/issue-419" \
   aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-"$DELIVERY_WRAPPER_ROOT/atrinik" worktree list --json > "$DELIVERY_WORKTREE_LIST"
+"$DELIVERY_WRAPPER_ROOT/atrinik" worktree list --wrapper-self --json \
+  > "$DELIVERY_WORKTREE_LIST"
 python3 scripts/delivery_ledger.py worktree-observe \
   "$DELIVERY_REVIEW_ROOT" "$DELIVERY_LEDGER" worktree \
   "$DELIVERY_WORKTREE_LIST" "$DELIVERY_OBSERVED_AT" \
@@ -717,7 +718,10 @@ python3 scripts/delivery_ledger.py worktree-bind-cas \
 
 Raw Git has no canonical wrapper create output, so omitting `--create-output`
 and binding null `create_output`/producer `result_sha256` is the sole normal
-exception. Observation and atomic bind-CAS remain mandatory; generic `cas` and
+exception. The wrapper-self list command parses the complete NUL-delimited Git
+inventory, includes both primary and linked wrapper worktrees under physical
+checkout `atrinik`, and retains its JSON bytes without reconstructing managed
+paths. Observation and atomic bind-CAS remain mandatory; generic `cas` and
 caller-authored safety or candidate documents cannot bind this worktree.
 
 ## Create a fresh PR ledger

--- a/README.md
+++ b/README.md
@@ -712,8 +712,15 @@ List or remove managed worktrees:
 ~~~sh
 ./atrinik worktree list
 ./atrinik worktree list --json
+./atrinik worktree list --wrapper-self --json
 ./atrinik worktree remove content maps-pr
 ~~~
+
+The default list remains manifest-owned. `--wrapper-self` instead emits the
+complete parser-driven Git inventory for the wrapper repository, tagging both
+its primary and linked worktrees as physical checkout `atrinik`. It cannot be
+combined with component selectors; use its JSON bytes directly when a workflow
+needs retained wrapper-self inventory evidence.
 
 Removal refuses dirty worktrees. Each worktree is a full Git worktree of its
 physical repository, so a classic worktree contains all five classic source

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -169,6 +169,11 @@ def parser() -> argparse.ArgumentParser:
     mark(worktree_remove.add_argument("label"), "worktree")
     worktree_list = worktree_commands.add_parser("list")
     mark(worktree_list.add_argument("components", nargs="*"), "component")
+    worktree_list.add_argument(
+        "--wrapper-self",
+        action="store_true",
+        help="list the wrapper repository's complete Git worktree inventory",
+    )
     worktree_list.add_argument("--json", action="store_true")
 
     scope = commands.add_parser(
@@ -786,18 +791,32 @@ def main(arguments: list[str] | None = None) -> int:
             elif options.worktree_command == "remove":
                 workspace.remove_worktree(options.component, options.label)
             else:
-                rows = workspace.list_worktrees(options.components)
-                if options.json:
-                    print(
-                        json.dumps(
-                            [
-                                {"component": component, **record}
-                                for component, record in rows
-                            ],
-                            indent=2,
-                            sort_keys=True,
-                        )
+                if options.wrapper_self and options.components:
+                    raise WorkspaceError(
+                        "--wrapper-self cannot be combined with component selectors"
                     )
+                rows = (
+                    workspace.list_wrapper_worktrees()
+                    if options.wrapper_self
+                    else workspace.list_worktrees(options.components)
+                )
+                if options.json:
+                    rendered = json.dumps(
+                        [
+                            {"component": component, **record}
+                            for component, record in rows
+                        ],
+                        indent=2,
+                        sort_keys=True,
+                    )
+                    if (
+                        options.wrapper_self
+                        and len(rendered.encode("utf-8")) + 1 > 512 * 1024
+                    ):
+                        raise WorkspaceError(
+                            "wrapper worktree inventory JSON exceeds the retained-evidence limit"
+                        )
+                    print(rendered)
                 else:
                     for component, record in rows:
                         branch = record.get("branch", "detached").removeprefix(

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -1666,6 +1666,89 @@ def _worktree_records(
     return records
 
 
+_WORKTREE_PORCELAIN_KEYS = {
+    "worktree",
+    "HEAD",
+    "branch",
+    "bare",
+    "detached",
+    "locked",
+    "prunable",
+}
+_WORKTREE_PORCELAIN_FLAGS = {"bare", "detached", "locked", "prunable"}
+_WORKTREE_INVENTORY_LIMIT = 1024 * 1024
+_WORKTREE_INVENTORY_ENTRIES = 4096
+_WORKTREE_HEAD_RE = re.compile(r"[0-9a-f]{40}")
+
+
+def _parse_worktree_porcelain(raw: bytes) -> list[dict[str, str]]:
+    """Parse one complete NUL-delimited Git worktree inventory."""
+
+    if len(raw) > _WORKTREE_INVENTORY_LIMIT:
+        raise WorkspaceError("wrapper worktree inventory output is not bounded")
+    if not raw.endswith(b"\0\0"):
+        raise WorkspaceError("wrapper worktree inventory is not NUL-delimited")
+    records: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    for index, token in enumerate(raw.split(b"\0")):
+        if not token:
+            if current:
+                if (
+                    not {"worktree", "HEAD"}.issubset(current)
+                    or ("branch" in current) == ("detached" in current)
+                    or "bare" in current
+                    or not _WORKTREE_HEAD_RE.fullmatch(current["HEAD"])
+                    or (
+                        "branch" in current
+                        and not current["branch"].startswith("refs/heads/")
+                    )
+                ):
+                    raise WorkspaceError(
+                        f"wrapper worktree inventory record {len(records)} is incomplete"
+                    )
+                records.append(current)
+                current = {}
+            continue
+        try:
+            line = token.decode("utf-8")
+        except UnicodeError as error:
+            raise WorkspaceError(
+                f"wrapper worktree inventory field {index} is not UTF-8"
+            ) from error
+        key, separator, value = line.partition(" ")
+        if (
+            key not in _WORKTREE_PORCELAIN_KEYS
+            or key in current
+            or (not separator and key not in _WORKTREE_PORCELAIN_FLAGS)
+            or any(
+                ord(character) < 32 or ord(character) == 127
+                for character in value
+            )
+        ):
+            raise WorkspaceError(
+                f"wrapper worktree inventory field {index} is malformed or ambiguous"
+            )
+        current[key] = value
+    if current or not records or len(records) > _WORKTREE_INVENTORY_ENTRIES:
+        raise WorkspaceError("wrapper worktree inventory is incomplete or oversized")
+    seen: set[str] = set()
+    for index, record in enumerate(records):
+        path = Path(record["worktree"])
+        if (
+            not path.is_absolute()
+            or str(path) != record["worktree"]
+            or os.path.normpath(record["worktree"]) != record["worktree"]
+        ):
+            raise WorkspaceError(
+                f"wrapper worktree inventory record {index} has a non-canonical path"
+            )
+        folded = record["worktree"].casefold()
+        if folded in seen:
+            raise WorkspaceError("wrapper worktree inventory contains an ambiguous path")
+        seen.add(folded)
+    return records
+
+
 def open_regular_file(
     path: Path, flags: int, description: str, mode: int = 0o600
 ) -> int:
@@ -2544,6 +2627,7 @@ class Workspace:
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     pass_fds=active_lock_fds(),
+                    timeout=30,
                 )
             except FileNotFoundError as error:
                 raise WorkspaceError("required command not found: git") from error
@@ -4960,6 +5044,45 @@ class Workspace:
                 for record in _worktree_records(repository, trace=False)
             )
         return result
+
+    def list_wrapper_worktrees(self) -> list[tuple[str, dict[str, str]]]:
+        """Return the complete wrapper common-Git-directory worktree inventory."""
+
+        request = self._lease_request(
+            "git-admin",
+            self._wrapper_git_admin_coordinate(),
+            "shared",
+            "list wrapper worktrees",
+        )
+        with self._resource_locks([request]):
+            try:
+                result = subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        str(self.paths.repository),
+                        "worktree",
+                        "list",
+                        "--porcelain",
+                        "-z",
+                    ],
+                    check=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    pass_fds=active_lock_fds(),
+                )
+            except FileNotFoundError as error:
+                raise WorkspaceError("required command not found: git") from error
+            except subprocess.CalledProcessError as error:
+                detail = error.stderr.decode("utf-8", errors="replace").strip()
+                suffix = f": {detail}" if detail else ""
+                raise WorkspaceError(f"cannot list wrapper worktrees{suffix}") from error
+            except subprocess.TimeoutExpired as error:
+                raise WorkspaceError("wrapper worktree inventory timed out") from error
+            return [
+                ("atrinik", record)
+                for record in _parse_worktree_porcelain(result.stdout)
+            ]
 
     def create_profile(self, name: str, source: str = "default") -> Path:
         self.paths.ensure()

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -18,6 +18,7 @@ import platform
 from pathlib import Path, PurePosixPath
 import re
 import secrets
+import selectors
 import shlex
 import shutil
 import signal
@@ -1677,8 +1678,91 @@ _WORKTREE_PORCELAIN_KEYS = {
 }
 _WORKTREE_PORCELAIN_FLAGS = {"bare", "detached", "locked", "prunable"}
 _WORKTREE_INVENTORY_LIMIT = 1024 * 1024
+_WORKTREE_INVENTORY_ERROR_LIMIT = 64 * 1024
 _WORKTREE_INVENTORY_ENTRIES = 4096
+_WORKTREE_INVENTORY_TIMEOUT = 30.0
 _WORKTREE_HEAD_RE = re.compile(r"[0-9a-f]{40}")
+
+
+def _run_wrapper_worktree_inventory(
+    repository: Path, pass_fds: tuple[int, ...]
+) -> bytes:
+    """Capture one Git worktree inventory with live byte and time bounds."""
+
+    try:
+        process = subprocess.Popen(
+            [
+                "git",
+                "-C",
+                str(repository),
+                "worktree",
+                "list",
+                "--porcelain",
+                "-z",
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            pass_fds=pass_fds,
+        )
+    except FileNotFoundError as error:
+        raise WorkspaceError("required command not found: git") from error
+    except OSError as error:
+        raise WorkspaceError(f"cannot list wrapper worktrees: {error}") from error
+    if process.stdout is None or process.stderr is None:  # pragma: no cover
+        process.kill()
+        process.wait()
+        raise WorkspaceError("cannot list wrapper worktrees: Git pipes are unavailable")
+    stdout_fd = process.stdout.fileno()
+    stderr_fd = process.stderr.fileno()
+    output = {stdout_fd: bytearray(), stderr_fd: bytearray()}
+    limits = {
+        stdout_fd: _WORKTREE_INVENTORY_LIMIT,
+        stderr_fd: _WORKTREE_INVENTORY_ERROR_LIMIT,
+    }
+    selector = selectors.DefaultSelector()
+    selector.register(process.stdout, selectors.EVENT_READ)
+    selector.register(process.stderr, selectors.EVENT_READ)
+    deadline = time.monotonic() + _WORKTREE_INVENTORY_TIMEOUT
+    try:
+        while selector.get_map():
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise WorkspaceError("wrapper worktree inventory timed out")
+            events = selector.select(remaining)
+            if not events:
+                raise WorkspaceError("wrapper worktree inventory timed out")
+            for key, _ in events:
+                chunk = os.read(key.fd, 65536)
+                if not chunk:
+                    selector.unregister(key.fileobj)
+                    continue
+                output[key.fd].extend(chunk)
+                if len(output[key.fd]) > limits[key.fd]:
+                    raise WorkspaceError(
+                        "wrapper worktree inventory output is not bounded"
+                    )
+        remaining = max(0.001, deadline - time.monotonic())
+        returncode = process.wait(timeout=remaining)
+    except (WorkspaceError, subprocess.TimeoutExpired) as error:
+        process.kill()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass
+        if isinstance(error, WorkspaceError):
+            raise
+        raise WorkspaceError("wrapper worktree inventory timed out") from error
+    finally:
+        selector.close()
+        process.stdout.close()
+        process.stderr.close()
+    stderr = bytes(output[stderr_fd])
+    if returncode:
+        detail = stderr.decode("utf-8", errors="replace").strip()
+        suffix = f": {detail}" if detail else ""
+        raise WorkspaceError(f"cannot list wrapper worktrees{suffix}")
+    return bytes(output[stdout_fd])
 
 
 def _parse_worktree_porcelain(raw: bytes) -> list[dict[str, str]]:
@@ -1720,6 +1804,7 @@ def _parse_worktree_porcelain(raw: bytes) -> list[dict[str, str]]:
             key not in _WORKTREE_PORCELAIN_KEYS
             or key in current
             or (not separator and key not in _WORKTREE_PORCELAIN_FLAGS)
+            or (separator and key in {"bare", "detached"})
             or any(
                 ord(character) < 32 or ord(character) == 127
                 for character in value
@@ -1736,6 +1821,7 @@ def _parse_worktree_porcelain(raw: bytes) -> list[dict[str, str]]:
         path = Path(record["worktree"])
         if (
             not path.is_absolute()
+            or record["worktree"] == "/"
             or str(path) != record["worktree"]
             or os.path.normpath(record["worktree"]) != record["worktree"]
         ):
@@ -5055,33 +5141,13 @@ class Workspace:
             "list wrapper worktrees",
         )
         with self._resource_locks([request]):
-            try:
-                result = subprocess.run(
-                    [
-                        "git",
-                        "-C",
-                        str(self.paths.repository),
-                        "worktree",
-                        "list",
-                        "--porcelain",
-                        "-z",
-                    ],
-                    check=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    pass_fds=active_lock_fds(),
-                )
-            except FileNotFoundError as error:
-                raise WorkspaceError("required command not found: git") from error
-            except subprocess.CalledProcessError as error:
-                detail = error.stderr.decode("utf-8", errors="replace").strip()
-                suffix = f": {detail}" if detail else ""
-                raise WorkspaceError(f"cannot list wrapper worktrees{suffix}") from error
-            except subprocess.TimeoutExpired as error:
-                raise WorkspaceError("wrapper worktree inventory timed out") from error
             return [
                 ("atrinik", record)
-                for record in _parse_worktree_porcelain(result.stdout)
+                for record in _parse_worktree_porcelain(
+                    _run_wrapper_worktree_inventory(
+                        self.paths.repository, active_lock_fds()
+                    )
+                )
             ]
 
     def create_profile(self, name: str, source: str = "default") -> Path:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -345,6 +345,11 @@ historical wrapper worktrees are recognized only as direct children of the
 top-level `build/worktrees/` namespace. Common-Git-directory and canonical
 repository identity, named/unlocked state, absence of in-progress Git
 operations, and ordinary tracked/untracked cleanliness are mandatory. Saved
+`worktree list --wrapper-self --json` acquires the wrapper common-Git-directory
+lease and parses NUL-delimited porcelain into the same bounded row schema used
+by manifest worktree inventories. It rejects incomplete, duplicate, case-alias,
+noncanonical, non-UTF-8, and control-bearing records before emitting retained
+evidence; the ordinary component-list path is unchanged. Saved
 profile selectors of kind `worktree`, absolute `path`, or migration-only
 `migrated-worktree`; retained scenario coordinates; live topology coordinates;
 and every original/destination/composite migration path protect exact

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -344,7 +344,7 @@ only when Git registers them directly under `workspace/worktrees/atrinik/`;
 historical wrapper worktrees are recognized only as direct children of the
 top-level `build/worktrees/` namespace. Common-Git-directory and canonical
 repository identity, named/unlocked state, absence of in-progress Git
-operations, and ordinary tracked/untracked cleanliness are mandatory. Saved
+operations, and ordinary tracked/untracked cleanliness are mandatory. The
 `worktree list --wrapper-self --json` acquires the wrapper common-Git-directory
 lease and parses NUL-delimited porcelain into the same bounded row schema used
 by manifest worktree inventories. It rejects incomplete, duplicate, case-alias,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -782,6 +782,77 @@ class ParserTests(unittest.TestCase):
         workspace_type.return_value.repository_status.assert_called_once_with(["client"])
         self.assertEqual(json.loads(output.call_args.args[0]), rows)
 
+    def test_worktree_list_wrapper_self_emits_complete_json_rows(self) -> None:
+        rows = [
+            (
+                "atrinik",
+                {
+                    "worktree": "/workspace/atrinik",
+                    "HEAD": "a" * 40,
+                    "branch": "refs/heads/main",
+                },
+            ),
+            (
+                "atrinik",
+                {
+                    "worktree": "/workspace/atrinik/linked worktree",
+                    "HEAD": "b" * 40,
+                    "detached": "",
+                    "locked": "inspection",
+                },
+            ),
+        ]
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.list_wrapper_worktrees.return_value = rows
+            with mock.patch("builtins.print") as output:
+                result = main(["worktree", "list", "--wrapper-self", "--json"])
+
+        self.assertEqual(result, 0)
+        workspace_type.return_value.list_wrapper_worktrees.assert_called_once_with()
+        workspace_type.return_value.list_worktrees.assert_not_called()
+        self.assertEqual(
+            json.loads(output.call_args.args[0]),
+            [{"component": component, **record} for component, record in rows],
+        )
+
+    def test_worktree_list_manifest_mode_remains_unchanged(self) -> None:
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.list_worktrees.return_value = []
+            result = main(["worktree", "list", "client", "--json"])
+
+        self.assertEqual(result, 0)
+        workspace_type.return_value.list_worktrees.assert_called_once_with(["client"])
+        workspace_type.return_value.list_wrapper_worktrees.assert_not_called()
+
+    def test_worktree_list_wrapper_self_rejects_component_selectors(self) -> None:
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            with mock.patch("sys.stderr"):
+                result = main(
+                    ["worktree", "list", "client", "--wrapper-self", "--json"]
+                )
+
+        self.assertEqual(result, 1)
+        workspace_type.return_value.list_wrapper_worktrees.assert_not_called()
+        workspace_type.return_value.list_worktrees.assert_not_called()
+
+    def test_worktree_list_wrapper_self_bounds_retained_json(self) -> None:
+        rows = [
+            (
+                "atrinik",
+                {
+                    "worktree": "/workspace/" + "x" * (512 * 1024),
+                    "HEAD": "a" * 40,
+                    "branch": "refs/heads/main",
+                },
+            )
+        ]
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.list_wrapper_worktrees.return_value = rows
+            with mock.patch("sys.stderr"):
+                result = main(["worktree", "list", "--wrapper-self", "--json"])
+
+        self.assertEqual(result, 1)
+
     def test_profile_create_can_clone_another_profile(self) -> None:
         with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
             result = main(["profile", "create", "copy", "--from", "review"])

--- a/tests/test_delivery_ledger.py
+++ b/tests/test_delivery_ledger.py
@@ -16,6 +16,7 @@ import unittest
 from unittest import mock
 
 from atrinik_workspace.model import Manifest
+from atrinik_workspace.workspace import _parse_worktree_porcelain
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -506,19 +507,24 @@ def live_worktree_path(request: dict[str, object]) -> Path:
 
 def worktree_list_bytes(request: dict[str, object]) -> bytes:
     live_worktree_path(request)
-    output = git_run(
-        Path(request["roots"]["primary"]["path"]),
-        "worktree",
-        "list",
-        "--porcelain",
-    ).stdout
-    rows: list[dict[str, str]] = []
-    for record in output.strip().split("\n\n"):
-        parsed: dict[str, str] = {"component": request["physical_checkout"]}
-        for line in record.splitlines():
-            key, _, value = line.partition(" ")
-            parsed[key] = value
-        rows.append(parsed)
+    primary = Path(request["roots"]["primary"]["path"])
+    result = subprocess.run(
+        ["git", "-C", str(primary), "worktree", "list", "--porcelain", "-z"],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env={
+            **os.environ,
+            "LC_ALL": "C",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+        },
+    )
+    rows = [
+        {"component": request["physical_checkout"], **record}
+        for record in _parse_worktree_porcelain(result.stdout)
+    ]
     return (json.dumps(rows, sort_keys=True) + "\n").encode()
 
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -59,6 +59,7 @@ from atrinik_workspace.workspace import (
     Workspace,
     _copy_regular_file as real_copy_regular_file,
     _copy_worker_source as real_copy_worker_source,
+    _parse_worktree_porcelain,
     _tree_digest,
     _remote_matches as real_remote_matches,
     display_arguments,
@@ -1485,6 +1486,68 @@ class WorkspaceTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "dirty primary"):
             self.workspace.sync(["client"], "none")
         self.assertTrue((checkout / "dirty").is_file())
+
+    def test_wrapper_worktree_porcelain_preserves_complete_safe_records(self) -> None:
+        raw = (
+            b"worktree /repo with spaces+plus_underscore\0"
+            b"HEAD " + b"a" * 40 + b"\0"
+            b"branch refs/heads/feat/safe+branch_name\0"
+            b"locked maintenance window\0\0"
+            b"worktree /repo/linked@safe\0"
+            b"HEAD " + b"b" * 40 + b"\0"
+            b"detached\0"
+            b"prunable gitdir file points to non-existent location\0\0"
+        )
+
+        self.assertEqual(
+            _parse_worktree_porcelain(raw),
+            [
+                {
+                    "worktree": "/repo with spaces+plus_underscore",
+                    "HEAD": "a" * 40,
+                    "branch": "refs/heads/feat/safe+branch_name",
+                    "locked": "maintenance window",
+                },
+                {
+                    "worktree": "/repo/linked@safe",
+                    "HEAD": "b" * 40,
+                    "detached": "",
+                    "prunable": "gitdir file points to non-existent location",
+                },
+            ],
+        )
+
+    def test_wrapper_worktree_porcelain_rejects_malformed_or_ambiguous_rows(self) -> None:
+        valid = (
+            b"worktree /repo\0HEAD " + b"a" * 40
+            + b"\0branch refs/heads/main\0\0"
+        )
+        invalid = {
+            "not delimited": valid[:-1],
+            "unknown field": valid.replace(b"branch ", b"unknown "),
+            "duplicate field": valid.replace(
+                b"HEAD " + b"a" * 40,
+                b"HEAD " + b"a" * 40 + b"\0HEAD " + b"b" * 40,
+            ),
+            "missing head": valid.replace(b"HEAD " + b"a" * 40 + b"\0", b""),
+            "invalid head": valid.replace(b"a" * 40, b"not-a-commit"),
+            "non-head branch": valid.replace(
+                b"refs/heads/main", b"refs/remotes/origin/main"
+            ),
+            "branch and detached": valid.replace(
+                b"branch refs/heads/main", b"branch refs/heads/main\0detached"
+            ),
+            "invalid utf8": valid.replace(b"/repo", b"/repo\xff"),
+            "control in path": valid.replace(b"/repo", b"/repo\nunsafe"),
+            "noncanonical path": valid.replace(b"/repo", b"/repo/../other"),
+            "case alias": valid + valid.replace(b"/repo", b"/REPO"),
+        }
+        for name, raw in invalid.items():
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(
+                    WorkspaceError, "worktree inventory"
+                ):
+                    _parse_worktree_porcelain(raw)
 
     def test_worktree_sync_excludes_protected_paths_before_dirty_check(self) -> None:
         repository = self.workspace.paths.repositories / "content"
@@ -11665,6 +11728,56 @@ class WorkspaceTests(unittest.TestCase):
         finally:
             shutil.rmtree(namespace)
             detached.rename(namespace)
+
+    def test_wrapper_worktree_inventory_lists_primary_and_linked_rows(self) -> None:
+        self.workspace.close()
+        command("git", "init", "-b", "main", cwd=self.wrapper)
+        command("git", "config", "user.name", "Tests", cwd=self.wrapper)
+        command(
+            "git", "config", "user.email", "tests@example.invalid", cwd=self.wrapper
+        )
+        command("git", "add", "components.json", cwd=self.wrapper)
+        command("git", "commit", "-m", "feat: seed wrapper", cwd=self.wrapper)
+        linked_root = self.root / "linked wrapper+safe"
+        command(
+            "git",
+            "worktree",
+            "add",
+            "-b",
+            "test/linked+wrapper_safe",
+            str(linked_root),
+            cwd=self.wrapper,
+        )
+        command(
+            "git",
+            "worktree",
+            "lock",
+            "--reason",
+            "delivery evidence",
+            str(linked_root),
+            cwd=self.wrapper,
+        )
+        self.workspace = Workspace(self.wrapper)
+
+        rows = self.workspace.list_wrapper_worktrees()
+
+        self.assertEqual(
+            [component for component, _ in rows], ["atrinik", "atrinik"]
+        )
+        self.assertEqual(
+            [record["worktree"] for _, record in rows],
+            [str(self.wrapper), str(linked_root)],
+        )
+        self.assertEqual(rows[0][1]["branch"], "refs/heads/main")
+        self.assertEqual(
+            rows[1][1],
+            {
+                "worktree": str(linked_root),
+                "HEAD": rows[1][1]["HEAD"],
+                "branch": "refs/heads/test/linked+wrapper_safe",
+                "locked": "delivery evidence",
+            },
+        )
 
     def test_git_checkout_common_namespace_resolution_fails_closed(self) -> None:
         (self.wrapper / ".git").mkdir()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1537,9 +1537,13 @@ class WorkspaceTests(unittest.TestCase):
             "branch and detached": valid.replace(
                 b"branch refs/heads/main", b"branch refs/heads/main\0detached"
             ),
+            "valued detached flag": valid.replace(
+                b"branch refs/heads/main", b"detached unexpected"
+            ),
             "invalid utf8": valid.replace(b"/repo", b"/repo\xff"),
             "control in path": valid.replace(b"/repo", b"/repo\nunsafe"),
             "noncanonical path": valid.replace(b"/repo", b"/repo/../other"),
+            "root path": valid.replace(b"/repo", b"/"),
             "case alias": valid + valid.replace(b"/repo", b"/REPO"),
         }
         for name, raw in invalid.items():
@@ -1548,6 +1552,58 @@ class WorkspaceTests(unittest.TestCase):
                     WorkspaceError, "worktree inventory"
                 ):
                     _parse_worktree_porcelain(raw)
+
+    def test_wrapper_worktree_porcelain_rejects_byte_and_record_overflow(self) -> None:
+        record = (
+            b"worktree /repo\0HEAD " + b"a" * 40
+            + b"\0branch refs/heads/main\0\0"
+        )
+
+        with self.assertRaisesRegex(WorkspaceError, "not bounded"):
+            _parse_worktree_porcelain(
+                record + b"x" * workspace_module._WORKTREE_INVENTORY_LIMIT
+            )
+        with self.assertRaisesRegex(WorkspaceError, "oversized"):
+            _parse_worktree_porcelain(record * 4097)
+
+    def test_wrapper_worktree_capture_enforces_live_byte_bound(self) -> None:
+        real_popen = subprocess.Popen
+
+        def oversized(*_arguments: object, **keywords: object) -> subprocess.Popen[bytes]:
+            return real_popen(
+                [
+                    sys.executable,
+                    "-c",
+                    "import sys; sys.stdout.buffer.write(b'x' * (1024 * 1024 + 1))",
+                ],
+                **keywords,
+            )
+
+        with mock.patch(
+            "atrinik_workspace.workspace.subprocess.Popen", side_effect=oversized
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "not bounded"):
+                workspace_module._run_wrapper_worktree_inventory(self.wrapper, ())
+
+    def test_wrapper_worktree_capture_enforces_live_timeout(self) -> None:
+        real_popen = subprocess.Popen
+
+        def stalled(*_arguments: object, **keywords: object) -> subprocess.Popen[bytes]:
+            return real_popen(
+                [sys.executable, "-c", "import time; time.sleep(60)"],
+                **keywords,
+            )
+
+        with (
+            mock.patch(
+                "atrinik_workspace.workspace.subprocess.Popen", side_effect=stalled
+            ),
+            mock.patch.object(
+                workspace_module, "_WORKTREE_INVENTORY_TIMEOUT", 0.05
+            ),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "timed out"):
+                workspace_module._run_wrapper_worktree_inventory(self.wrapper, ())
 
     def test_worktree_sync_excludes_protected_paths_before_dirty_check(self) -> None:
         repository = self.workspace.paths.repositories / "content"


### PR DESCRIPTION
Closes #441

## Summary

- add a parser-driven wrapper-self worktree inventory mode
- preserve manifest-owned worktree listing behavior
- cover linked, detached, locked, prunable, unusual, malformed, and ambiguous records

## Validation

Pending implementation and final-head review.

<!-- atrinik-delivery:body:c7975f7ae3c6a43e1ed7476ff7d50dfe6e65b85c46d460abbc8d74bb32d72dd0:start -->
## Delivery status

Complete; this supersedes the initial pending-validation note above.

- Added `worktree list --wrapper-self --json` with shared Git-admin locking, NUL-delimited parsing, and live output/time bounds.
- Preserved manifest-owned worktree listing and integrated the production parser into delivery-ledger tests.
- Covered primary, linked, detached, locked, prunable, unusual, malformed, ambiguous, oversized, and timed-out inventories.
- Final validation: 1,028 tests passed under coverage (83%); compile, guidance, skill, manifest, supply-chain, and diff checks passed.
- Whole-diff review completed with no remaining actionable findings.

<!-- atrinik-delivery:body:c7975f7ae3c6a43e1ed7476ff7d50dfe6e65b85c46d460abbc8d74bb32d72dd0:end -->