### PR TITLE
feat(cli): package Classic profiles for Windows review

### DIFF
--- a/README.md
+++ b/README.md
@@ -1152,6 +1152,44 @@ the explicit preview-first cleanup scope:
 Cleanup never stops a topology and never removes a live, busy, linked,
 malformed, registered, retained, promoted, or otherwise uncertain state.
 
+### Package a Classic review profile for Windows
+
+Create one portable ZIP when the client must be reviewed as a native Windows
+process rather than through the devcontainer display. The package cross-builds
+the selected Classic client and server, includes the profile's collected maps,
+generated client maps, resources, and sound, and snapshots one persistent
+server state with its accounts and player data:
+
+~~~sh
+./atrinik down REVIEW_TOPOLOGY
+./atrinik package windows \
+  --profile REVIEW_PROFILE \
+  --state REVIEW_STATE \
+  --output build/packages/review-windows.zip \
+  --json
+~~~
+
+The state must be stopped and must have been started at least once so its QUIC
+identity exists. To transfer a temporary topology's state, stop it with
+`--retain-state` and promote it to a new persistent name first. Packaging
+refuses a live or otherwise busy state, an incompatible profile/state pairing,
+an existing output file, or a non-Classic profile.
+
+Run the command inside the `windows-cross` devcontainer to use its installed
+toolchain directly. From the ordinary devcontainer or WSL2, the wrapper uses
+Docker and the digest-pinned image in
+`.devcontainer/windows-cross/devcontainer.json`. After the command succeeds,
+copy the ZIP to Windows, extract it, and double-click `run.bat`. The launcher
+starts the local packaged server on UDP port 1730 and pins the client to that
+server's copied certificate fingerprint. Use `--port PORT` when 1730 is not
+available on the Windows host.
+
+The output file is mode 0600 on the packaging host and the command reports its
+SHA-256 digest. Treat it as sensitive: `server/data` contains private player
+data, credentials, and the server private identity. Do not upload the ZIP to a
+public pull request, issue, CI artifact, or release. The wrapper never
+overwrites an existing ZIP.
+
 For a complete Classic profile, `up`, scenarios, and individual builds resolve
 one manifest-derived build-root selection across the `client`, `server`,
 `content`, `protocol`, `libatrinik`, `sound`, `resources`, and

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -315,6 +315,27 @@ def parser() -> argparse.ArgumentParser:
         help="disable automatic C/C++ compiler caching",
     )
 
+    package = commands.add_parser(
+        "package", help="package a resolved profile for another host"
+    )
+    package_commands = package.add_subparsers(
+        dest="package_command", required=True
+    )
+    package_windows = package_commands.add_parser(
+        "windows", help="build one portable Windows review topology ZIP"
+    )
+    mark(package_windows.add_argument("--profile", default="classic"), "profile")
+    mark(package_windows.add_argument("--state", default="default"), "state")
+    mark(
+        package_windows.add_argument(
+            "--port", type=int, default=1730,
+            help="local Windows server UDP port (default: 1730)",
+        ),
+        "none",
+    )
+    mark(package_windows.add_argument("--output", type=Path), "path")
+    package_windows.add_argument("--json", action="store_true")
+
     topology = commands.add_parser(
         "topology", help="inspect a resolved multi-component topology"
     )
@@ -998,6 +1019,22 @@ def main(arguments: list[str] | None = None) -> int:
                     use_ccache=not options.no_ccache,
                 )
             )
+        elif options.command == "package":
+            summary = workspace.package_windows_profile(
+                options.profile,
+                options.state,
+                options.output,
+                port=options.port,
+            )
+            if options.json:
+                print(json.dumps(summary, indent=2, sort_keys=True))
+            else:
+                print(f"package\t{summary['path']}")
+                print(f"sha256\t{summary['sha256']}")
+                print(
+                    "sensitive\tcontains private server state, player data, "
+                    "and credentials"
+                )
         elif options.command == "topology":
             state = None if options.state_mode == "temporary" else options.state
             summary = workspace.topology_summary(

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -31,6 +31,7 @@ import tempfile
 import threading
 import time
 from typing import Any, Callable, Iterator, TextIO
+import zipfile
 
 from .launch_identity import CLIENT_LAUNCH_LABEL_ENV, client_launch_label
 from .content_migration import ContentMigration
@@ -289,6 +290,10 @@ class ProfileResolutionSnapshot:
 REGION_MAP_METADATA = ".atrinik-region-maps.json"
 REGION_MAP_SCHEMA_VERSION = 1
 EXPECTED_REGION_MAP = "incuna_-1"
+WINDOWS_PACKAGE_SCHEMA_VERSION = 1
+WINDOWS_PACKAGE_VERSION = "0.0.0"
+WINDOWS_PACKAGE_MAX_ENTRIES = 100_000
+WINDOWS_PACKAGE_MAX_BYTES = 8 * 1024 * 1024 * 1024
 
 
 class _InertScenarioError(WorkspaceError):
@@ -1129,6 +1134,59 @@ def _file_digest(path: Path, description: str) -> str:
     finally:
         if descriptor is not None:
             os.close(descriptor)
+
+
+def _tree_content_inventory(
+    root: Path, description: str
+) -> dict[str, tuple[int, str]]:
+    """Inventory exact regular-file paths and bytes while ignoring modes."""
+
+    entries: dict[str, tuple[int, str]] = {}
+    for directory, names, files in os.walk(root, followlinks=False):
+        names.sort()
+        files.sort()
+        current = Path(directory)
+        for name in names:
+            child = current / name
+            metadata = child.lstat()
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise WorkspaceError(
+                    f"{description} contains a linked or special directory: {child}"
+                )
+        for name in files:
+            child = current / name
+            metadata = child.lstat()
+            if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+                raise WorkspaceError(
+                    f"{description} contains a linked or special file: {child}"
+                )
+            entries[child.relative_to(root).as_posix()] = (
+                metadata.st_size,
+                _file_digest(child, description),
+            )
+    return entries
+
+
+def _tree_content_digest(root: Path, description: str) -> str:
+    """Hash exact regular-file paths and bytes while ignoring package modes."""
+
+    inventory = _tree_content_inventory(root, description)
+    return _tree_content_inventory_digest(inventory)
+
+
+def _tree_content_inventory_digest(
+    inventory: dict[str, tuple[int, str]],
+) -> str:
+    """Hash a previously validated content inventory."""
+
+    digest = hashlib.sha256()
+    for path, identity in sorted(inventory.items()):
+        encoded = json.dumps((path, *identity), separators=(",", ":")).encode(
+            "ascii"
+        )
+        digest.update(len(encoded).to_bytes(8, "big"))
+        digest.update(encoded)
+    return digest.hexdigest()
 
 
 def _tree_digest(
@@ -12084,6 +12142,612 @@ class Workspace:
             raise WorkspaceError("a topology must contain at least one service")
         return [service for service in TOPOLOGY_SERVICES if service in requested]
 
+    @staticmethod
+    def _portable_windows_package_members(
+        archive: zipfile.ZipFile, executable: str
+    ) -> tuple[PurePosixPath, list[tuple[zipfile.ZipInfo, PurePosixPath]]]:
+        infos = archive.infolist()
+        if not infos or len(infos) > WINDOWS_PACKAGE_MAX_ENTRIES:
+            raise WorkspaceError("portable Windows package entry count is invalid")
+        if sum(info.file_size for info in infos) > WINDOWS_PACKAGE_MAX_BYTES:
+            raise WorkspaceError("portable Windows package is too large")
+        members: list[tuple[zipfile.ZipInfo, PurePosixPath]] = []
+        names: set[str] = set()
+        executables: list[PurePosixPath] = []
+        for info in infos:
+            if info.flag_bits & 0x1:
+                raise WorkspaceError("portable Windows package is encrypted")
+            if "\\" in info.filename:
+                raise WorkspaceError(
+                    f"portable Windows package path is invalid: {info.filename}"
+                )
+            path = PurePosixPath(info.filename.rstrip("/"))
+            if (
+                not path.parts
+                or path.is_absolute()
+                or any(part in {"", ".", ".."} for part in path.parts)
+                or any(":" in part for part in path.parts)
+            ):
+                raise WorkspaceError(
+                    f"portable Windows package path is unsafe: {info.filename}"
+                )
+            folded = path.as_posix().casefold()
+            if folded in names:
+                raise WorkspaceError(
+                    f"portable Windows package path is duplicated: {info.filename}"
+                )
+            names.add(folded)
+            unix_mode = info.external_attr >> 16
+            file_type = stat.S_IFMT(unix_mode)
+            if file_type not in {0, stat.S_IFREG, stat.S_IFDIR}:
+                raise WorkspaceError(
+                    f"portable Windows package contains a special entry: {info.filename}"
+                )
+            if info.is_dir() and file_type == stat.S_IFREG:
+                raise WorkspaceError(
+                    f"portable Windows package directory is invalid: {info.filename}"
+                )
+            if not info.is_dir() and path.name.casefold() == executable.casefold():
+                executables.append(path)
+            members.append((info, path))
+        if len(executables) != 1:
+            raise WorkspaceError(
+                f"portable Windows package must contain exactly one {executable}"
+            )
+        root = executables[0].parent
+        return root, members
+
+    @classmethod
+    def _extract_portable_windows_package(
+        cls, archive_path: Path, destination: Path, executable: str
+    ) -> None:
+        try:
+            with zipfile.ZipFile(archive_path) as archive:
+                root, members = cls._portable_windows_package_members(
+                    archive, executable
+                )
+                destination.mkdir()
+                for info, path in members:
+                    if path == root or root not in path.parents:
+                        continue
+                    relative = path.relative_to(root)
+                    output = destination.joinpath(*relative.parts)
+                    if info.is_dir():
+                        output.mkdir(parents=True, exist_ok=True)
+                        continue
+                    output.parent.mkdir(parents=True, exist_ok=True)
+                    descriptor = os.open(
+                        output,
+                        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                        0o600,
+                    )
+                    try:
+                        with archive.open(info) as source:
+                            with os.fdopen(descriptor, "wb", closefd=False) as target:
+                                shutil.copyfileobj(source, target)
+                        mode = info.external_attr >> 16
+                        permissions = stat.S_IMODE(mode) if mode else 0o644
+                        os.fchmod(descriptor, permissions or 0o644)
+                    finally:
+                        os.close(descriptor)
+        except (OSError, zipfile.BadZipFile) as error:
+            raise WorkspaceError(
+                f"cannot extract portable Windows package {archive_path}: {error}"
+            ) from error
+        executable_path = destination / executable
+        if not executable_path.is_file() or executable_path.is_symlink():
+            raise WorkspaceError(
+                f"portable Windows package executable is missing: {executable_path}"
+            )
+
+    @staticmethod
+    def _windows_package_output(
+        builds: Path, profile_name: str, state_name: str, output: Path | None
+    ) -> Path:
+        selected = output or (
+            builds
+            / "packages"
+            / f"atrinik-{profile_name}-{state_name}-windows.zip"
+        )
+        selected = Path(os.path.abspath(selected.expanduser()))
+        if selected.suffix.lower() != ".zip":
+            raise WorkspaceError("Windows profile package output must end in .zip")
+        selected.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            parent = selected.parent.resolve(strict=True)
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot resolve Windows package output directory: {error}"
+            ) from error
+        selected = parent / selected.name
+        if selected.exists() or selected.is_symlink():
+            raise WorkspaceError(f"Windows profile package already exists: {selected}")
+        return selected
+
+    def _stage_windows_profile_sources(
+        self,
+        staging: Path,
+        build_root: Path,
+        selected: dict[str, Path],
+    ) -> None:
+        source_exclusions = frozenset({".git", "build", MANAGED_MARKER})
+        classic_root = selected["client"].parent
+        if any(
+            selected[role].parent != classic_root
+            for role in ("server", "protocol", "libatrinik")
+        ):
+            raise WorkspaceError(
+                "Windows package Classic sources do not share one monorepo root"
+            )
+        self._copy_runtime_tree(
+            classic_root / "cmake", staging / "cmake", source_exclusions
+        )
+        for document in ("LICENSE.md", "ATTRIBUTIONS.md"):
+            self._copy_runtime_regular_file(
+                classic_root / document, staging / document
+            )
+        for role in ("client", "server", "protocol", "libatrinik"):
+            exclusions = source_exclusions
+            if role == "client":
+                exclusions = frozenset({*exclusions, "sound"})
+            elif role == "server":
+                exclusions = frozenset({*exclusions, "resources", "runtime"})
+            self._copy_runtime_tree(
+                selected[role], staging / role, exclusions
+            )
+
+        # Materialized clean generations are sealed read-only. The package
+        # staging copies are private, so make them writable before adding the
+        # selected sound and collected server runtime overlays.
+        self._make_tree_owner_writable(staging)
+        metadata = load_json(build_root / BUILD_METADATA)
+        try:
+            sound = validate_sound_record(metadata.get("sound"))
+        except (AttributeError, WorkspaceError) as error:
+            raise WorkspaceError("profile build sound metadata is invalid") from error
+        self._copy_runtime_tree(
+            Path(sound["root"]), staging / "client" / "sound", source_exclusions
+        )
+        server = staging / "server"
+        (server / "runtime").mkdir()
+        self._copy_runtime_tree(
+            build_root / "runtime" / "content",
+            server / "runtime" / "content",
+        )
+        self._copy_runtime_tree(
+            build_root / "runtime" / "resources", server / "resources"
+        )
+        for private_input in (
+            staging / "client" / "data" / "discord-application-id",
+            server / "server-custom.cfg",
+        ):
+            if private_input.is_symlink() or (
+                private_input.exists() and not private_input.is_file()
+            ):
+                raise WorkspaceError(
+                    f"private Windows package input is invalid: {private_input}"
+                )
+            private_input.unlink(missing_ok=True)
+        self._make_tree_owner_writable(staging)
+        run(["git", "init", "--quiet"], cwd=staging)
+
+    def _snapshot_windows_profile_state(
+        self, state_fd: int, state: Path, destination: Path
+    ) -> str:
+        """Copy state through the descriptor that already holds its flock."""
+
+        self._copy_runtime_tree_from_descriptor(
+            state_fd, state, destination
+        )
+        return self._server_identity_fingerprint(destination)
+
+    def _windows_build_image(self) -> str:
+        config_path = self.paths.repository / ".devcontainer/windows-cross/devcontainer.json"
+        config = load_json(config_path)
+        image = config.get("image") if isinstance(config, dict) else None
+        if (
+            not isinstance(image, str)
+            or re.fullmatch(r"[^\s@]+@sha256:[0-9a-f]{64}", image) is None
+        ):
+            raise WorkspaceError(
+                f"pinned Windows build image is invalid: {config_path}"
+            )
+        return image
+
+    @staticmethod
+    def _local_windows_build_environment() -> dict[str, str] | None:
+        environment = os.environ.copy()
+        required = (
+            "MXE_TOOLCHAIN_FILE",
+            "MXE_RUNTIME_DIR",
+            "ATRINIK_WINDOWS_PYTHON_INCLUDE_DIR",
+            "ATRINIK_WINDOWS_PYTHON_LIBRARY",
+            "ATRINIK_WINDOWS_PYTHON_RUNTIME_DIR",
+        )
+        target = environment.get("MXE_TARGET", "x86_64-w64-mingw32.shared")
+        if shutil.which(f"{target}-cmake") is None or any(
+            not environment.get(name) or not Path(environment[name]).exists()
+            for name in required
+        ):
+            return None
+        environment["ATRINIK_PACKAGE_VERSION"] = WINDOWS_PACKAGE_VERSION
+        environment["ATRINIK_DISCORD_APPLICATION_ID_FILE"] = ""
+        return environment
+
+    def _build_windows_profile_archives(
+        self, staging: Path
+    ) -> tuple[Path, Path, dict[str, str]]:
+        packages = staging / "packages"
+        packages.mkdir()
+        local_environment = self._local_windows_build_environment()
+        if local_environment is not None:
+            local_environment["ATRINIK_PROFILE_SOUND_DIR"] = str(
+                staging / "client" / "sound"
+            )
+            local_environment["ATRINIK_PROFILE_CONTENT_DIR"] = str(
+                staging / "server" / "runtime" / "content"
+            )
+            local_environment["ATRINIK_PROFILE_RESOURCES_DIR"] = str(
+                staging / "server" / "resources"
+            )
+            for component in ("client", "server"):
+                run(
+                    [
+                        "bash",
+                        "tools/build-windows-package.sh",
+                        str(packages),
+                    ],
+                    cwd=staging / component,
+                    env=local_environment,
+                )
+            build = {"mode": "local", "image": ""}
+        else:
+            if shutil.which("docker") is None:
+                raise WorkspaceError(
+                    "Windows packaging requires either the windows-cross "
+                    "devcontainer toolchain or Docker"
+                )
+            image = self._windows_build_image()
+            script = staging / ".atrinik-build-windows.sh"
+            script.write_text(
+                "#!/usr/bin/env bash\n"
+                "set -euo pipefail\n"
+                "cd /workspace/client\n"
+                "bash tools/build-windows-package.sh /workspace/packages\n"
+                "cd /workspace/server\n"
+                "bash tools/build-windows-package.sh /workspace/packages\n",
+                encoding="utf-8",
+            )
+            script.chmod(0o700)
+            run(
+                [
+                    "docker",
+                    "run",
+                    "--rm",
+                    "--user",
+                    f"{os.getuid()}:{os.getgid()}",
+                    "--env",
+                    f"ATRINIK_PACKAGE_VERSION={WINDOWS_PACKAGE_VERSION}",
+                    "--env",
+                    "ATRINIK_DISCORD_APPLICATION_ID_FILE=",
+                    "--env",
+                    "ATRINIK_PROFILE_SOUND_DIR=/workspace/client/sound",
+                    "--env",
+                    "ATRINIK_PROFILE_CONTENT_DIR=/workspace/server/runtime/content",
+                    "--env",
+                    "ATRINIK_PROFILE_RESOURCES_DIR=/workspace/server/resources",
+                    "--volume",
+                    f"{staging}:/workspace",
+                    "--workdir",
+                    "/workspace",
+                    image,
+                    "bash",
+                    "/workspace/.atrinik-build-windows.sh",
+                ]
+            )
+            build = {"mode": "container", "image": image}
+
+        def one(pattern: str, label: str) -> Path:
+            matches = sorted(packages.glob(pattern))
+            if len(matches) != 1 or matches[0].is_symlink():
+                raise WorkspaceError(
+                    f"Windows {label} build produced {len(matches)} packages"
+                )
+            return matches[0]
+
+        client = one(
+            f"atrinik-classic-client-{WINDOWS_PACKAGE_VERSION}-windows-x86_64.zip",
+            "client",
+        )
+        server = one(
+            f"atrinik-classic-server-{WINDOWS_PACKAGE_VERSION}-windows-x86_64.zip",
+            "server",
+        )
+        return client, server, build
+
+    @staticmethod
+    def _write_windows_launch_files(
+        root: Path, profile_name: str, state_name: str, port: int, fingerprint: str
+    ) -> None:
+        launch = (
+            "@echo off\r\n"
+            "setlocal\r\n"
+            "cd /d \"%~dp0\"\r\n"
+            "start \"Atrinik Server\" /D \"%~dp0server\" cmd /k call "
+            f"server.bat --port_quic={port} --port_mapping=off --stun_server=off\r\n"
+            "timeout /t 2 /nobreak >nul\r\n"
+            "start \"Atrinik Client\" /D \"%~dp0client\" atrinik.exe "
+            f"--server=\"127.0.0.1 {port} {fingerprint}\" "
+            "--stun_server=off --nometa\r\n"
+        )
+        (root / "run.bat").write_bytes(launch.encode("ascii"))
+        readme = (
+            "Atrinik portable Windows review topology\r\n"
+            "==========================================\r\n\r\n"
+            f"Profile: {profile_name}\r\n"
+            f"Server state: {state_name}\r\n"
+            f"Local UDP port: {port}\r\n\r\n"
+            "Double-click run.bat. It starts the packaged server, waits briefly, "
+            "and starts the client pinned to that server identity. Close the "
+            "server console when finished.\r\n\r\n"
+            "SENSITIVE: server/data contains private player data, credentials, "
+            "and the server private identity. Do not publish or attach this ZIP "
+            "to a public issue or pull request.\r\n"
+        )
+        (root / "README.txt").write_bytes(readme.encode("utf-8"))
+
+    @staticmethod
+    def _archive_windows_profile(root: Path, output: Path) -> None:
+        entries: list[tuple[Path, str, os.stat_result]] = []
+        for directory, names, files in os.walk(root, followlinks=False):
+            names.sort()
+            files.sort()
+            current = Path(directory)
+            for name in (*names, *files):
+                path = current / name
+                metadata = path.lstat()
+                if stat.S_ISLNK(metadata.st_mode) or not (
+                    stat.S_ISDIR(metadata.st_mode) or stat.S_ISREG(metadata.st_mode)
+                ):
+                    raise WorkspaceError(
+                        f"Windows profile package contains a special entry: {path}"
+                    )
+                if stat.S_ISREG(metadata.st_mode) and metadata.st_nlink != 1:
+                    raise WorkspaceError(
+                        f"Windows profile package contains a hard-linked file: {path}"
+                    )
+                entries.append(
+                    (path, path.relative_to(root.parent).as_posix(), metadata)
+                )
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{output.name}.", suffix=".tmp", dir=output.parent
+        )
+        os.close(descriptor)
+        temporary = Path(temporary_name)
+        try:
+            with zipfile.ZipFile(
+                temporary, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=6
+            ) as archive:
+                for path, relative, metadata in entries:
+                    name = relative + ("/" if stat.S_ISDIR(metadata.st_mode) else "")
+                    info = zipfile.ZipInfo(name, (1980, 1, 1, 0, 0, 0))
+                    info.compress_type = zipfile.ZIP_DEFLATED
+                    info.create_system = 3
+                    info.external_attr = metadata.st_mode << 16
+                    if stat.S_ISDIR(metadata.st_mode):
+                        archive.writestr(info, b"")
+                        continue
+                    descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+                    try:
+                        opened = os.fstat(descriptor)
+                        if (
+                            (opened.st_dev, opened.st_ino)
+                            != (metadata.st_dev, metadata.st_ino)
+                            or opened.st_nlink != 1
+                        ):
+                            raise WorkspaceError(
+                                f"Windows profile package input changed: {path}"
+                            )
+                        with os.fdopen(descriptor, "rb", closefd=False) as source:
+                            with archive.open(info, "w") as target:
+                                shutil.copyfileobj(source, target)
+                        retained = os.fstat(descriptor)
+                        if Workspace._runtime_tree_identity(retained) != (
+                            Workspace._runtime_tree_identity(opened)
+                        ):
+                            raise WorkspaceError(
+                                f"Windows profile package input changed: {path}"
+                            )
+                    finally:
+                        os.close(descriptor)
+            temporary.chmod(0o600)
+            with temporary.open("rb") as stream:
+                os.fsync(stream.fileno())
+            rename_no_replace(temporary, output)
+        except BaseException:
+            temporary.unlink(missing_ok=True)
+            raise
+
+    def package_windows_profile(
+        self,
+        profile_name: str,
+        state_name: str,
+        output: Path | None = None,
+        *,
+        port: int = 1730,
+    ) -> dict[str, Any]:
+        self.paths.ensure()
+        self._validate_run_port(port)
+        validate_name(profile_name, "profile name")
+        validate_name(state_name, "state name")
+        self._require_classic_contracts(profile_name, {"client", "server"})
+        profile = self._load_profile(profile_name, require_file=False)
+        stack = self.manifest.stack(profile["stack"])
+        if stack.name != "classic":
+            raise WorkspaceError(
+                "portable Windows profile packages require the classic stack"
+            )
+        destination = self._windows_package_output(
+            self.paths.builds, profile_name, state_name, output
+        )
+        required = self._dependency_roles(profile, {"client", "server"})
+        targets = [role for role in ALL_BUILD_TARGETS if role in required]
+        with tempfile.TemporaryDirectory(
+            prefix=f"atrinik-{profile_name}-windows-"
+        ) as temporary_name:
+            staging = Path(temporary_name)
+            with self._resolved_profile_operation(
+                profile_name,
+                {"client", "server"},
+                f"package Windows profile {profile_name}",
+                materialize_clean_primaries=True,
+            ) as snapshot:
+                selected = snapshot.paths()
+                build_root = self._build_resolved(
+                    "windows-package", profile_name, False, targets, selected
+                )
+                resolved = self._topology_resolved_status(profile_name, selected)
+                providers = {
+                    role: stack.providers[role].name for role in sorted(required)
+                }
+                implementation = self._state_implementation(
+                    stack.name, providers, resolved
+                )
+                state_location = self._state_location(state_name)
+                with self._topology_state_lock(state_location) as state_lock:
+                    prepared = self.state_path(
+                        state_name,
+                        selected["server"],
+                        resolved_path=state_location,
+                        implementation=implementation,
+                        write_implementation=True,
+                        keep_descriptor=True,
+                    )
+                    assert isinstance(prepared, tuple)
+                    state, state_fd = prepared
+                    state_identity = {
+                        "device": os.fstat(state_fd).st_dev,
+                        "inode": os.fstat(state_fd).st_ino,
+                    }
+                    state_lock.bind(state_identity)
+                    try:
+                        fingerprint = self._snapshot_windows_profile_state(
+                            state_fd, state, staging / "state"
+                        )
+                    finally:
+                        os.close(state_fd)
+
+                with self._profile_build_lock(build_root, profile_name):
+                    (staging / "sources").mkdir()
+                    self._stage_windows_profile_sources(
+                        staging / "sources", build_root, selected
+                    )
+                    staged_server = staging / "sources" / "server"
+                    staged_runtime_paths = {
+                        "content_maps": staged_server
+                        / "runtime"
+                        / "content"
+                        / "maps",
+                        "content_lib": staged_server
+                        / "runtime"
+                        / "content"
+                        / "lib",
+                        "resources": staged_server / "resources",
+                    }
+                    expected_runtime_inventories = {
+                        name: _tree_content_inventory(
+                            path, f"staged profile runtime input {name}"
+                        )
+                        for name, path in staged_runtime_paths.items()
+                    }
+                    expected_runtime_digests = {
+                        name: _tree_content_inventory_digest(inventory)
+                        for name, inventory in expected_runtime_inventories.items()
+                    }
+                    build_metadata = load_json(build_root / BUILD_METADATA)
+
+            client_archive, server_archive, build = (
+                self._build_windows_profile_archives(staging / "sources")
+            )
+            package_root = staging / f"atrinik-{profile_name}-windows-review"
+            package_root.mkdir()
+            self._extract_portable_windows_package(
+                client_archive, package_root / "client", "atrinik.exe"
+            )
+            self._extract_portable_windows_package(
+                server_archive, package_root / "server", "atrinik-server.exe"
+            )
+            packaged_runtime_paths = {
+                "content_maps": package_root / "server" / "maps",
+                "content_lib": package_root / "server" / "lib",
+                "resources": package_root / "server" / "resources",
+            }
+            for name, path in packaged_runtime_paths.items():
+                actual_inventory = _tree_content_inventory(
+                    path, f"packaged profile runtime input {name}"
+                )
+                expected_inventory = expected_runtime_inventories[name]
+                if actual_inventory != expected_inventory:
+                    expected_paths = set(expected_inventory)
+                    actual_paths = set(actual_inventory)
+                    missing = sorted(expected_paths - actual_paths)
+                    extra = sorted(actual_paths - expected_paths)
+                    changed = sorted(
+                        candidate
+                        for candidate in expected_paths & actual_paths
+                        if expected_inventory[candidate]
+                        != actual_inventory[candidate]
+                    )
+                    raise WorkspaceError(
+                        "Windows server package changed the selected profile "
+                        f"runtime input {name}: missing={missing[:5]}, "
+                        f"extra={extra[:5]}, changed={changed[:5]}"
+                    )
+            (package_root / "server" / "data").parent.mkdir(exist_ok=True)
+            staging_state = staging / "state"
+            staging_state.replace(package_root / "server" / "data")
+            self._write_windows_launch_files(
+                package_root, profile_name, state_name, port, fingerprint
+            )
+            coordinates = build_metadata.get("coordinates", {})
+            public_coordinates = {
+                role: {
+                    key: value
+                    for key, value in coordinate.items()
+                    if key in {"component", "checkout", "repository", "branch", "source", "head"}
+                }
+                for role, coordinate in sorted(coordinates.items())
+                if isinstance(coordinate, dict)
+            }
+            atomic_json(
+                package_root / "manifest.json",
+                {
+                    "schema_version": WINDOWS_PACKAGE_SCHEMA_VERSION,
+                    "profile": profile_name,
+                    "state": state_name,
+                    "stack": stack.name,
+                    "port": port,
+                    "server_fingerprint": fingerprint,
+                    "contains_private_server_state": True,
+                    "build": build,
+                    "runtime_input_sha256": expected_runtime_digests,
+                    "components": public_coordinates,
+                },
+            )
+            self._archive_windows_profile(package_root, destination)
+
+        digest = _file_digest(destination, "Windows profile package")
+        return {
+            "schema_version": WINDOWS_PACKAGE_SCHEMA_VERSION,
+            "profile": profile_name,
+            "state": state_name,
+            "path": str(destination),
+            "sha256": digest,
+            "bytes": destination.stat().st_size,
+            "contains_private_server_state": True,
+            "build": build,
+        }
+
     def topology_summary(
         self,
         profile_name: str,
@@ -12700,6 +13364,77 @@ class Workspace:
             pinned_destination_parent_fd,
         )
         os.close(descriptor)
+
+    def _copy_runtime_tree_from_descriptor(
+        self,
+        source_fd: int,
+        source_display: Path,
+        destination: Path,
+        exclusions: frozenset[str] = frozenset(),
+    ) -> None:
+        source_before = os.fstat(source_fd)
+        if not stat.S_ISDIR(source_before.st_mode):
+            raise WorkspaceError(
+                f"runtime publication input is not a directory: {source_display}"
+            )
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        destination_parent_before = destination.parent.stat(
+            follow_symlinks=False
+        )
+        destination_parent_fd: int | None = None
+        destination_fd: int | None = None
+        try:
+            destination_parent_fd = os.open(destination.parent, flags)
+            if self._runtime_tree_identity(os.fstat(destination_parent_fd)) != (
+                self._runtime_tree_identity(destination_parent_before)
+            ):
+                raise WorkspaceError(
+                    "runtime staging directory changed before descriptor copy: "
+                    f"{destination.parent}"
+                )
+            try:
+                os.mkdir(
+                    destination.name,
+                    stat.S_IMODE(source_before.st_mode) | 0o700,
+                    dir_fd=destination_parent_fd,
+                )
+                destination_fd = os.open(
+                    destination.name, flags, dir_fd=destination_parent_fd
+                )
+            except OSError as error:
+                raise WorkspaceError(
+                    "runtime staging destination changed during descriptor copy: "
+                    f"{destination}: {error}"
+                ) from error
+            self._copy_topology_runtime_directory(
+                source_fd,
+                source_display,
+                destination_fd,
+                destination,
+                exclusions,
+            )
+            if self._runtime_tree_identity(os.fstat(source_fd)) != (
+                self._runtime_tree_identity(source_before)
+            ):
+                raise WorkspaceError(
+                    f"runtime publication input changed during copy: {source_display}"
+                )
+            destination_parent_after = os.fstat(destination_parent_fd)
+            if (
+                destination_parent_after.st_dev
+                != destination_parent_before.st_dev
+                or destination_parent_after.st_ino
+                != destination_parent_before.st_ino
+            ):
+                raise WorkspaceError(
+                    "runtime staging directory changed during descriptor copy: "
+                    f"{destination.parent}"
+                )
+        finally:
+            if destination_fd is not None:
+                os.close(destination_fd)
+            if destination_parent_fd is not None:
+                os.close(destination_parent_fd)
 
     def _copy_runtime_regular_file(self, source: Path, destination: Path) -> None:
         flags = os.O_RDONLY | os.O_NOFOLLOW

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -745,6 +745,47 @@ worldmaker. Roles outside that target closure do not invalidate that cache. It
 is reusable only for clean input checkouts with an exact metadata
 match; dirty inputs deliberately regenerate.
 
+## Portable Windows profile packages
+
+`package windows` is a private review handoff, not a release publisher. It
+resolves and leases one exact Classic client/server dependency closure,
+materializes clean primary generations, and reuses the normal wrapper build to
+collect Classic-target content, resources, sound, and generated region maps.
+It then copies only those selected inputs into private temporary staging and
+runs the existing Classic client and server portable-package builders. The
+installed `windows-cross` toolchain is preferred; otherwise the command reads
+the digest-pinned image identity from the devcontainer composition and invokes
+that image through Docker. The two paths use the same package scripts and
+`0.0.0` non-release version, so this command cannot mint a release version or
+asset. Explicit, path-bounded package-script inputs preserve the profile's
+staged sound, content, and resources instead of resolving component release
+locks. Before publication, tree digests prove the packaged maps, content
+library, and resources still match those staged profile inputs.
+
+The selected persistent state is admitted through the ordinary path and
+physical-identity leases plus a nonblocking directory lock. A live topology,
+uncertain owner, incompatible implementation marker, link, special entry, or
+missing server certificate fails closed. The
+descriptor-pinned copy completes before releasing the state, so later server
+activity cannot alter the snapshot. State is acquired before the profile-build
+reader, preserving the global lease order.
+
+Generated client/server ZIPs are parsed without general-purpose extraction.
+Entry counts and expanded bytes are bounded; absolute, traversal, encrypted,
+duplicate-case, linked, special, and missing/duplicate executable layouts are
+rejected. Only the executable's runtime subtree is extracted, so unrelated
+CPack build metadata is ignored. Assembly emits only `client/`, `server/`, copied
+`server/data/`, a coordinate manifest, instructions, and a loopback launcher
+whose client argument pins the copied server fingerprint. Final archive input
+must be a regular single-link tree. ZIP metadata is normalized, output is
+streamed to a same-directory temporary file, mode 0600, and published with a
+no-replace rename. The returned SHA-256 covers the completed archive.
+
+Because the state contains player credentials and the QUIC private identity,
+the resulting archive is always classified as sensitive. It is intentionally
+outside release, CI artifact, cleanup, and public-upload contracts; operators
+choose its destination and remove it explicitly after the review.
+
 ## Runtime and state
 
 For the currently runnable classic profile, server launch preparation assembles

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -481,6 +481,42 @@ class ParserTests(unittest.TestCase):
             use_ccache=False,
         )
 
+    def test_windows_package_dispatches_profile_state_port_and_output(self) -> None:
+        summary = {
+            "schema_version": 1,
+            "profile": "review",
+            "state": "scenario-review",
+            "path": "/tmp/review.zip",
+            "sha256": "a" * 64,
+            "bytes": 123,
+            "contains_private_server_state": True,
+            "build": {"mode": "container", "image": "example@sha256:" + "b" * 64},
+        }
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.package_windows_profile.return_value = summary
+            with mock.patch("builtins.print") as output:
+                result = main(
+                    [
+                        "package",
+                        "windows",
+                        "--profile",
+                        "review",
+                        "--state",
+                        "scenario-review",
+                        "--port",
+                        "1731",
+                        "--output",
+                        "/tmp/review.zip",
+                        "--json",
+                    ]
+                )
+
+        self.assertEqual(result, 0)
+        workspace_type.return_value.package_windows_profile.assert_called_once_with(
+            "review", "scenario-review", Path("/tmp/review.zip"), port=1731
+        )
+        self.assertEqual(json.loads(output.call_args.args[0]), summary)
+
     def test_classic_cohort_option_rejects_abbreviated_spelling(self) -> None:
         for command in ("init", "sync"):
             with self.subTest(command=command):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -25,6 +25,7 @@ import tempfile
 import threading
 import time
 import unittest
+import zipfile
 from dataclasses import replace
 from unittest import mock
 
@@ -17265,6 +17266,277 @@ class WorkspaceTests(unittest.TestCase):
                 if time.monotonic() >= deadline:
                     self.fail("cleanup child did not release the layout lease")
                 time.sleep(0.05)
+
+    def test_portable_windows_package_extraction_is_rooted_at_executable(self) -> None:
+        archive = self.root / "client.zip"
+        executable = zipfile.ZipInfo("package/atrinik.exe")
+        executable.create_system = 3
+        executable.external_attr = (stat.S_IFREG | 0o755) << 16
+        with zipfile.ZipFile(archive, "w") as output:
+            output.writestr(executable, b"client")
+            output.writestr("package/data/settings.txt", b"settings")
+            output.writestr("lib/pkgconfig/build-only.pc", b"metadata")
+
+        destination = self.root / "portable-client"
+        self.workspace._extract_portable_windows_package(
+            archive, destination, "atrinik.exe"
+        )
+
+        self.assertEqual((destination / "atrinik.exe").read_bytes(), b"client")
+        self.assertEqual(
+            (destination / "data" / "settings.txt").read_bytes(), b"settings"
+        )
+        self.assertFalse((destination / "package").exists())
+        self.assertFalse((destination / "lib").exists())
+
+    def test_portable_windows_package_rejects_unsafe_or_linked_entries(self) -> None:
+        cases: list[tuple[str, zipfile.ZipInfo, str]] = []
+        traversal = zipfile.ZipInfo("../escape")
+        cases.append(("traversal", traversal, "unsafe"))
+        linked = zipfile.ZipInfo("package/link")
+        linked.create_system = 3
+        linked.external_attr = (stat.S_IFLNK | 0o777) << 16
+        cases.append(("link", linked, "special entry"))
+        duplicate = zipfile.ZipInfo("PACKAGE/ATRINIK.EXE")
+        cases.append(("case duplicate", duplicate, "duplicated"))
+        for label, invalid, message in cases:
+            with self.subTest(label=label):
+                archive = self.root / f"invalid-{label.replace(' ', '-')}.zip"
+                with zipfile.ZipFile(archive, "w") as output:
+                    output.writestr("package/atrinik.exe", b"client")
+                    output.writestr(invalid, b"invalid")
+                with self.assertRaisesRegex(WorkspaceError, message):
+                    self.workspace._extract_portable_windows_package(
+                        archive, self.root / f"output-{label}", "atrinik.exe"
+                    )
+
+    def test_windows_profile_archive_is_deterministic_and_private(self) -> None:
+        root = self.root / "atrinik-review-windows"
+        (root / "server" / "data" / "players").mkdir(parents=True)
+        (root / "run.bat").write_bytes(b"run\r\n")
+        player = root / "server" / "data" / "players" / "player.dat"
+        player.write_bytes(b"private player")
+        first = self.root / "first.zip"
+        second = self.root / "second.zip"
+
+        self.workspace._archive_windows_profile(root, first)
+        self.workspace._archive_windows_profile(root, second)
+
+        self.assertEqual(first.read_bytes(), second.read_bytes())
+        self.assertEqual(stat.S_IMODE(first.stat().st_mode), 0o600)
+        with zipfile.ZipFile(first) as archive:
+            self.assertIn(
+                "atrinik-review-windows/server/data/players/player.dat",
+                archive.namelist(),
+            )
+            self.assertEqual(
+                archive.read(
+                    "atrinik-review-windows/server/data/players/player.dat"
+                ),
+                b"private player",
+            )
+
+    def test_windows_runtime_content_digest_ignores_modes_not_bytes(self) -> None:
+        first = self.root / "runtime-first"
+        second = self.root / "runtime-second"
+        (first / "maps").mkdir(parents=True)
+        (second / "maps").mkdir(parents=True)
+        (first / "maps" / "review-map").write_bytes(b"profile map")
+        (second / "maps" / "review-map").write_bytes(b"profile map")
+        (first / "maps").chmod(0o555)
+        (first / "maps" / "review-map").chmod(0o444)
+        (second / "maps").chmod(0o755)
+        (second / "maps" / "review-map").chmod(0o644)
+
+        expected = workspace_module._tree_content_digest(first, "first runtime")
+        self.assertEqual(
+            expected,
+            workspace_module._tree_content_digest(second, "second runtime"),
+        )
+        (second / "maps" / "review-map").write_bytes(b"release map")
+        self.assertNotEqual(
+            expected,
+            workspace_module._tree_content_digest(second, "second runtime"),
+        )
+
+    def test_windows_launch_files_pin_local_server_identity_and_warn(self) -> None:
+        root = self.root / "launch"
+        root.mkdir()
+        fingerprint = "a" * 64
+        self.workspace._write_windows_launch_files(
+            root, "review", "scenario-review", 1731, fingerprint
+        )
+
+        launch = (root / "run.bat").read_text(encoding="ascii")
+        readme = (root / "README.txt").read_text(encoding="utf-8")
+        self.assertIn("--port_quic=1731", launch)
+        self.assertIn(f"127.0.0.1 1731 {fingerprint}", launch)
+        self.assertIn("--stun_server=off --nometa", launch)
+        self.assertIn("SENSITIVE", readme)
+        self.assertIn("private player data", readme)
+
+    def test_windows_source_staging_overlays_read_only_generations(self) -> None:
+        selected: dict[str, Path] = {}
+        classic_root = self.root / "sealed-classic"
+        (classic_root / "cmake").mkdir(parents=True)
+        (classic_root / "cmake" / "AtrinikVersion.cmake").write_text(
+            "version", encoding="utf-8"
+        )
+        for document in ("LICENSE.md", "ATTRIBUTIONS.md"):
+            (classic_root / document).write_text(document, encoding="utf-8")
+        for role in ("client", "server", "protocol", "libatrinik"):
+            source = classic_root / role
+            source.mkdir()
+            (source / "source.txt").write_text(role, encoding="utf-8")
+            source.chmod(0o555)
+            selected[role] = source
+        (classic_root / "cmake").chmod(0o555)
+        classic_root.chmod(0o555)
+
+        sound = self.root / "sealed-sound"
+        sound.mkdir()
+        (sound / "review.ogg").write_bytes(b"sound")
+        sound.chmod(0o555)
+        build_root = self.root / "windows-build"
+        (build_root / "runtime" / "content" / "maps").mkdir(parents=True)
+        (build_root / "runtime" / "content" / "lib").mkdir()
+        (build_root / "runtime" / "resources").mkdir()
+        (build_root / "runtime" / "content" / "maps" / "map.txt").write_text(
+            "map", encoding="utf-8"
+        )
+        (build_root / "runtime" / "content" / "lib" / "script.py").write_text(
+            "script", encoding="utf-8"
+        )
+        (build_root / "runtime" / "resources" / "resource.txt").write_text(
+            "resource", encoding="utf-8"
+        )
+        atomic_json(
+            build_root / workspace_module.BUILD_METADATA,
+            {
+                "sound": {
+                    "mode": "source",
+                    "root": str(sound),
+                    "source_commit": "a" * 40,
+                    "source_tree": "b" * 40,
+                    "source_clean": True,
+                }
+            },
+        )
+        staging = self.root / "windows-sources"
+        staging.mkdir()
+
+        with mock.patch("atrinik_workspace.workspace.run") as execute:
+            self.workspace._stage_windows_profile_sources(
+                staging, build_root, selected
+            )
+
+        execute.assert_called_once_with(["git", "init", "--quiet"], cwd=staging)
+        self.assertEqual(
+            (staging / "cmake" / "AtrinikVersion.cmake").read_text(
+                encoding="utf-8"
+            ),
+            "version",
+        )
+        self.assertEqual(
+            (staging / "LICENSE.md").read_text(encoding="utf-8"),
+            "LICENSE.md",
+        )
+        self.assertEqual(
+            (staging / "client" / "sound" / "review.ogg").read_bytes(),
+            b"sound",
+        )
+        self.assertEqual(
+            (staging / "server" / "runtime" / "content" / "maps" / "map.txt")
+            .read_text(encoding="utf-8"),
+            "map",
+        )
+        self.assertEqual(
+            (staging / "server" / "resources" / "resource.txt")
+            .read_text(encoding="utf-8"),
+            "resource",
+        )
+
+    def test_windows_state_snapshot_reuses_existing_physical_lock(self) -> None:
+        server = self.workspace.paths.repositories / "server"
+        prepared = self.workspace.state_path(
+            "default", server, keep_descriptor=True
+        )
+        self.assertIsInstance(prepared, tuple)
+        state, state_fd = prepared
+        identity = os.fstat(state_fd)
+        (state / "accounts").mkdir()
+        (state / "accounts" / "review.player").write_text(
+            "player\n", encoding="utf-8"
+        )
+        (state / "quic-identity.pem").write_text(
+            "-----BEGIN PRIVATE KEY-----\nignored\n-----END PRIVATE KEY-----\n"
+            "-----BEGIN CERTIFICATE-----\nAQID\n-----END CERTIFICATE-----\n",
+            encoding="ascii",
+        )
+        try:
+            with self.assertRaisesRegex(WorkspaceError, "already in use"):
+                self.workspace._lock_state_directory_mutation(
+                    state,
+                    {"device": identity.st_dev, "inode": identity.st_ino},
+                    "server state",
+                )
+            fingerprint = self.workspace._snapshot_windows_profile_state(
+                state_fd, state, self.root / "state-snapshot"
+            )
+        finally:
+            os.close(state_fd)
+
+        self.assertEqual(
+            fingerprint,
+            "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
+        )
+        self.assertEqual(
+            (self.root / "state-snapshot" / "accounts" / "review.player")
+            .read_text(encoding="utf-8"),
+            "player\n",
+        )
+
+    def test_windows_cross_build_uses_pinned_container_and_exact_outputs(self) -> None:
+        staging = self.root / "windows-sources"
+        staging.mkdir()
+        image = "ghcr.io/atrinik/windows-build:1@sha256:" + "a" * 64
+
+        def synthetic_build(arguments: list[str], **_kwargs: object) -> str:
+            packages = staging / "packages"
+            for component in ("client", "server"):
+                (packages / (
+                    f"atrinik-classic-{component}-0.0.0-windows-x86_64.zip"
+                )).write_bytes(component.encode())
+            self.assertEqual(arguments[0:2], ["docker", "run"])
+            self.assertIn(image, arguments)
+            self.assertIn(
+                "ATRINIK_PROFILE_SOUND_DIR=/workspace/client/sound", arguments
+            )
+            self.assertIn(
+                "ATRINIK_PROFILE_CONTENT_DIR=/workspace/server/runtime/content",
+                arguments,
+            )
+            self.assertIn(
+                "ATRINIK_PROFILE_RESOURCES_DIR=/workspace/server/resources",
+                arguments,
+            )
+            return ""
+
+        with (
+            mock.patch.object(
+                self.workspace, "_local_windows_build_environment", return_value=None
+            ),
+            mock.patch.object(self.workspace, "_windows_build_image", return_value=image),
+            mock.patch("atrinik_workspace.workspace.shutil.which", return_value="/usr/bin/docker"),
+            mock.patch("atrinik_workspace.workspace.run", side_effect=synthetic_build),
+        ):
+            client, server, build = self.workspace._build_windows_profile_archives(
+                staging
+            )
+
+        self.assertEqual(client.name, "atrinik-classic-client-0.0.0-windows-x86_64.zip")
+        self.assertEqual(server.name, "atrinik-classic-server-0.0.0-windows-x86_64.zip")
+        self.assertEqual(build, {"mode": "container", "image": image})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add `atrinik package windows` for producing one portable native Windows review ZIP from a resolved Classic profile
- snapshot a stopped persistent server state, including accounts, player data, credentials, and server identity
- package the selected maps, generated client maps, content library, resources, and sound rather than release-locked substitutes
- validate archive structure and exact runtime input inventories before atomic publication
- generate a loopback `run.bat`, fingerprint-pinned client configuration, manifest, and sensitive-data warning

## Dependency

- Depends on atrinik/classic#331.

## Validation

- all new CLI, staging, state-lock, archive-safety, deterministic-output, and cross-build unit tests passed
- full local discovery: 1,034 root tests passed; the six guidance/MCP checks affected by an unrelated untracked local skill passed from a clean detached worktree
- clean-worktree guidance budget, MCP contract, compile, manifest, provenance, and supply-chain validation passed
- end-to-end package: `./atrinik package windows --profile pr-198-classic2 --state default --output build/packages/review-windows-pr198.zip`
- packaged PR map, collected runtime map, and profile worktree map matched at SHA-256 `e69592a67d553738b4c03ad9d609ebebb96ef8cfbe63d7520678a60d0e1448f8`
- `git diff --check`

## Security

The generated ZIP is deliberately local-only and mode `0600`. It contains private player state, credentials, and the server private identity, and must not be published as a PR, CI, or release artifact.
