### PR TITLE
test(delivery): exercise wrapper-self inventory binding

### DIFF
--- a/tests/test_delivery_ledger.py
+++ b/tests/test_delivery_ledger.py
@@ -372,12 +372,13 @@ def live_roots(base: Path, checkout: str) -> dict[str, object]:
     wrapper.mkdir(parents=True, exist_ok=True)
     workspace.mkdir(parents=True, exist_ok=True)
     shutil.copy2(ROOT / "components.json", wrapper / "components.json")
+    shutil.copy2(ROOT / "atrinik", wrapper / "atrinik")
     shutil.copytree(ROOT / "atrinik_workspace", wrapper / "atrinik_workspace")
     git_run(wrapper, "init", "--initial-branch=main")
     git_run(wrapper, "config", "user.name", "Delivery Test")
     git_run(wrapper, "config", "user.email", "delivery@example.invalid")
     git_run(wrapper, "remote", "add", "origin", "https://github.com/atrinik/atrinik.git")
-    git_run(wrapper, "add", "components.json", "atrinik_workspace")
+    git_run(wrapper, "add", "components.json", "atrinik", "atrinik_workspace")
     git_run(wrapper, "commit", "-m", "test wrapper")
     primary = wrapper if checkout == "atrinik" else wrapper / checkout
     if primary != wrapper:
@@ -505,8 +506,34 @@ def live_worktree_path(request: dict[str, object]) -> Path:
     return path
 
 
-def worktree_list_bytes(request: dict[str, object]) -> bytes:
+def worktree_list_bytes(
+    request: dict[str, object], *, use_wrapper_command: bool = True
+) -> bytes:
     live_worktree_path(request)
+    if request["physical_checkout"] == "atrinik" and use_wrapper_command:
+        wrapper = Path(request["roots"]["wrapper"]["path"])
+        result = subprocess.run(
+            [
+                str(wrapper / "atrinik"),
+                "worktree",
+                "list",
+                "--wrapper-self",
+                "--json",
+            ],
+            cwd=wrapper,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env={
+                **os.environ,
+                "ATRINIK_WORKSPACE_DIR": request["roots"]["workspace"]["path"],
+                "LC_ALL": "C",
+                "GIT_CONFIG_NOSYSTEM": "1",
+                "GIT_CONFIG_GLOBAL": "/dev/null",
+                "GIT_CONFIG_SYSTEM": "/dev/null",
+            },
+        )
+        return result.stdout
     primary = Path(request["roots"]["primary"]["path"])
     result = subprocess.run(
         ["git", "-C", str(primary), "worktree", "list", "--porcelain", "-z"],
@@ -4536,12 +4563,19 @@ class DeliveryLedgerTests(unittest.TestCase):
         listed = json.loads(worktree_list)
         for label, mutate in (
             ("missing", lambda rows: rows.pop()),
+            ("duplicate", lambda rows: rows.append(copy.deepcopy(rows[-1]))),
             ("advanced head", lambda rows: rows[-1].update(HEAD=SHA_B)),
             (
                 "detached",
                 lambda rows: (rows[-1].pop("branch"), rows[-1].update(detached="")),
             ),
             ("locked", lambda rows: rows[-1].update(locked="delivery")),
+            (
+                "prunable",
+                lambda rows: rows[-1].update(
+                    prunable="gitdir file points to non-existent location"
+                ),
+            ),
         ):
             with self.subTest(worktree_list=label):
                 changed = copy.deepcopy(listed)
@@ -5397,6 +5431,9 @@ class DeliveryLedgerTests(unittest.TestCase):
         )["primitive_request"]
         path = live_worktree_path(request)
         worktree_list = worktree_list_bytes(request)
+        listed = json.loads(worktree_list)
+        self.assertEqual(listed[-1]["component"], "atrinik")
+        self.assertEqual(listed[-1]["worktree"], str(path))
         observation = ledger.observe_primitive_worktree(
             document,
             "worktree",
@@ -7347,7 +7384,10 @@ class DeliveryLedgerTests(unittest.TestCase):
                     if slot["kind"] == "worktree"
                 )["primitive_request"]
                 live_worktree_path(request)
-                listing = worktree_list_bytes(request)
+                # This test deliberately poisons the wrapper package before the
+                # ledger proves it safe, so invoking that wrapper here would
+                # defeat the trust-before-exec property under test.
+                listing = worktree_list_bytes(request, use_wrapper_command=False)
                 with self.assertRaisesRegex(
                     ledger.LedgerError,
                     "wrapper authority package.*(writable|regular|directory)",

--- a/tests/test_delivery_ledger.py
+++ b/tests/test_delivery_ledger.py
@@ -512,6 +512,9 @@ def worktree_list_bytes(
     live_worktree_path(request)
     if request["physical_checkout"] == "atrinik" and use_wrapper_command:
         wrapper = Path(request["roots"]["wrapper"]["path"])
+        # Capture post-trust producer behavior from the known-good copied
+        # wrapper without inheriting CI secrets or Python/Git selector controls.
+        # Trust-before-import adversaries use retained raw evidence below.
         result = subprocess.run(
             [
                 str(wrapper / "atrinik"),
@@ -525,12 +528,12 @@ def worktree_list_bytes(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env={
-                **os.environ,
                 "ATRINIK_WORKSPACE_DIR": request["roots"]["workspace"]["path"],
-                "LC_ALL": "C",
                 "GIT_CONFIG_NOSYSTEM": "1",
                 "GIT_CONFIG_GLOBAL": "/dev/null",
                 "GIT_CONFIG_SYSTEM": "/dev/null",
+                "LC_ALL": "C",
+                "PATH": os.defpath,
             },
         )
         return result.stdout

--- a/tests/test_delivery_ledger.py
+++ b/tests/test_delivery_ledger.py
@@ -517,6 +517,8 @@ def worktree_list_bytes(
         # Trust-before-import adversaries use retained raw evidence below.
         result = subprocess.run(
             [
+                sys.executable,
+                "-B",
                 str(wrapper / "atrinik"),
                 "worktree",
                 "list",

--- a/tests/test_delivery_ledger.py
+++ b/tests/test_delivery_ledger.py
@@ -512,6 +512,9 @@ def worktree_list_bytes(
     live_worktree_path(request)
     if request["physical_checkout"] == "atrinik" and use_wrapper_command:
         wrapper = Path(request["roots"]["wrapper"]["path"])
+        git_executable = shutil.which("git")
+        if git_executable is None:  # pragma: no cover - test prerequisite
+            raise RuntimeError("git executable is unavailable")
         # Capture post-trust producer behavior from the known-good copied
         # wrapper without inheriting CI secrets or Python/Git selector controls.
         # Trust-before-import adversaries use retained raw evidence below.
@@ -535,7 +538,7 @@ def worktree_list_bytes(
                 "GIT_CONFIG_GLOBAL": "/dev/null",
                 "GIT_CONFIG_SYSTEM": "/dev/null",
                 "LC_ALL": "C",
-                "PATH": os.defpath,
+                "PATH": str(Path(git_executable).resolve().parent),
             },
         )
         return result.stdout

--- a/tests/test_delivery_ledger.py
+++ b/tests/test_delivery_ledger.py
@@ -538,7 +538,7 @@ def worktree_list_bytes(
                 "GIT_CONFIG_GLOBAL": "/dev/null",
                 "GIT_CONFIG_SYSTEM": "/dev/null",
                 "LC_ALL": "C",
-                "PATH": str(Path(git_executable).resolve().parent),
+                "PATH": str(Path(git_executable).absolute().parent),
             },
         )
         return result.stdout


### PR DESCRIPTION
Closes #442

## Summary

- expose wrapper-self worktrees through a supported parser-driven inventory path
- preserve the existing manifest-owned `worktree list --json` contract by making wrapper inclusion explicit
- exercise real wrapper output through helper observation and atomic bind-CAS, including fail-closed edge cases

## Validation

Pending implementation and final-head review.

<!-- atrinik-delivery:body:b3b18c1165bbdb6afd9a5b6ee512913309b9203363ba0003675c8f047e36f9c1:start -->
## Delivery validation

- Full repository suite: 1,094 tests passed; coverage report 83%.
- Manifest, supply-chain, compileall, guidance-inventory, and diff-hygiene checks passed.
- Independent final acceptance, security/authority, and test-quality reviews found zero actionable issues.
- GitHub Integration, CodeQL, PR-title policy, and Codecov patch checks passed on `e7cb13e22977968d927017c2979572d9e116db2c`.
- Runtime verification is not applicable because this is test-only delivery coverage.

<!-- atrinik-delivery:body:b3b18c1165bbdb6afd9a5b6ee512913309b9203363ba0003675c8f047e36f9c1:end -->