### PR TITLE
fix(package): stage clean primary Classic profiles for Windows

### DIFF
--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -13389,16 +13389,97 @@ class Workspace:
         staging: Path,
         build_root: Path,
         selected: dict[str, Path],
+        snapshot: ProfileResolutionSnapshot | None = None,
     ) -> None:
         source_exclusions = frozenset({".git", "build", MANAGED_MARKER})
-        classic_root = selected["client"].parent
-        if any(
-            selected[role].parent != classic_root
-            for role in ("server", "protocol", "libatrinik")
-        ):
-            raise WorkspaceError(
-                "Windows package Classic sources do not share one monorepo root"
-            )
+        classic_roles = ("client", "server", "protocol", "libatrinik")
+        classic_roots = {role: selected[role].parent for role in classic_roles}
+        if snapshot is None:
+            classic_root = classic_roots["client"]
+            if any(classic_roots[role] != classic_root for role in classic_roles):
+                raise WorkspaceError(
+                    "Windows package Classic sources do not share one monorepo root"
+                )
+        else:
+            profile = snapshot.profile()
+            stack = self.manifest.stack(profile["stack"])
+            states = snapshot.checkout_states()
+            identities: dict[str, tuple[str, str, str, str]] = {}
+            kinds: set[str] = set()
+            path_trees: dict[tuple[str, str, str], str] = {}
+            for role in classic_roles:
+                component = stack.providers[role]
+                state = states.get(component.checkout_name)
+                if state is None:
+                    raise WorkspaceError(
+                        f"Windows package Classic source identity is missing: {role}"
+                    )
+                generation = self._source_generation_record(selected[role])
+                if generation is not None:
+                    if generation["source"] != component.source:
+                        raise WorkspaceError(
+                            f"Windows package Classic source role is invalid: {role}"
+                        )
+                    identities[role] = (
+                        generation["checkout"],
+                        generation["repository"],
+                        generation["commit"],
+                        generation["tree"],
+                    )
+                    kinds.add("generation")
+                    continue
+
+                checkout = Path(state["path"])
+                expected = (
+                    checkout
+                    if component.source == "."
+                    else checkout.joinpath(*PurePosixPath(component.source).parts)
+                ).resolve()
+                if selected[role].resolve() != expected:
+                    raise WorkspaceError(
+                        f"Windows package Classic source path is invalid: {role}"
+                    )
+                commit = state.get("head")
+                if not isinstance(commit, str) or not re.fullmatch(
+                    r"[0-9a-f]{40,64}", commit
+                ):
+                    raise WorkspaceError(
+                        f"Windows package Classic source commit is invalid: {role}"
+                    )
+                tree_key = (component.checkout_name, component.repository, commit)
+                tree = path_trees.get(tree_key)
+                if tree is None:
+                    tree = git(
+                        checkout,
+                        "--no-replace-objects",
+                        "rev-parse",
+                        f"{commit}^{{tree}}",
+                        capture=True,
+                        trace=False,
+                    )
+                    if not re.fullmatch(r"[0-9a-f]{40,64}", tree):
+                        raise WorkspaceError(
+                            f"Windows package Classic source tree is invalid: {role}"
+                        )
+                    path_trees[tree_key] = tree
+                identities[role] = (
+                    component.checkout_name,
+                    component.repository,
+                    commit,
+                    tree,
+                )
+                kinds.add("path")
+
+            if len(kinds) != 1 or len(set(identities.values())) != 1:
+                raise WorkspaceError(
+                    "Windows package Classic sources do not share one "
+                    "checkout/repository/commit/tree identity"
+                )
+            if kinds == {"path"} and len(set(classic_roots.values())) != 1:
+                raise WorkspaceError(
+                    "Windows package Classic sources do not share one monorepo root"
+                )
+            classic_root = classic_roots["client"]
         self._copy_runtime_tree(
             classic_root / "cmake", staging / "cmake", source_exclusions
         )
@@ -13760,7 +13841,7 @@ class Workspace:
                 with self._profile_build_lock(build_root, profile_name):
                     (staging / "sources").mkdir()
                     self._stage_windows_profile_sources(
-                        staging / "sources", build_root, selected
+                        staging / "sources", build_root, selected, snapshot
                     )
                     staged_server = staging / "sources" / "server"
                     staged_runtime_paths = {

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -20744,6 +20744,105 @@ class WorkspaceTests(unittest.TestCase):
                 self.root / "staging", self.root / "build", selected, snapshot
             )
 
+    def test_windows_source_staging_rejects_invalid_classic_coordinates(self) -> None:
+        self.workspace.manifest = Manifest.load(
+            Path(__file__).parents[1] / "components.json"
+        )
+        profile = self.workspace._load_profile("classic", require_file=False)
+        classic_root = self.root / "classic"
+        selected = {
+            role: classic_root / role
+            for role in ("client", "server", "protocol", "libatrinik")
+        }
+        for path in selected.values():
+            path.mkdir(parents=True)
+
+        def snapshot(states: dict[str, object]) -> workspace_module.ProfileResolutionSnapshot:
+            return workspace_module.ProfileResolutionSnapshot(
+                "classic",
+                "d" * 64,
+                json.dumps(profile, sort_keys=True, separators=(",", ":")),
+                tuple((role, str(path)) for role, path in sorted(selected.items())),
+                json.dumps(states, sort_keys=True, separators=(",", ":")),
+            )
+
+        with self.assertRaisesRegex(WorkspaceError, "identity is missing: client"):
+            self.workspace._stage_windows_profile_sources(
+                self.root / "missing-state",
+                self.root / "build",
+                selected,
+                snapshot({}),
+            )
+
+        state = {
+            "classic": {
+                "path": str(classic_root),
+                "head": "a" * 40,
+                "dirty": False,
+            }
+        }
+        component = self.workspace.manifest.stack("classic").providers["client"]
+        wrong_role = {
+            "checkout": "classic",
+            "repository": "atrinik/classic",
+            "commit": "a" * 40,
+            "tree": "b" * 40,
+            "source": component.source + "-other",
+        }
+        with (
+            mock.patch.object(
+                self.workspace,
+                "_source_generation_record",
+                side_effect=lambda path: wrong_role if path == selected["client"] else None,
+            ),
+            self.assertRaisesRegex(WorkspaceError, "source role is invalid: client"),
+        ):
+            self.workspace._stage_windows_profile_sources(
+                self.root / "wrong-role",
+                self.root / "build",
+                selected,
+                snapshot(state),
+            )
+
+        invalid_path = dict(selected)
+        invalid_path["client"] = self.root / "other-client"
+        with self.assertRaisesRegex(WorkspaceError, "source path is invalid: client"):
+            self.workspace._stage_windows_profile_sources(
+                self.root / "wrong-path",
+                self.root / "build",
+                invalid_path,
+                snapshot(state),
+            )
+
+        invalid_head = {"classic": {**state["classic"], "head": "not-a-commit"}}
+        with self.assertRaisesRegex(WorkspaceError, "source commit is invalid: client"):
+            self.workspace._stage_windows_profile_sources(
+                self.root / "wrong-commit",
+                self.root / "build",
+                selected,
+                snapshot(invalid_head),
+            )
+
+        with (
+            mock.patch("atrinik_workspace.workspace.git", return_value="not-a-tree"),
+            self.assertRaisesRegex(WorkspaceError, "source tree is invalid: client"),
+        ):
+            self.workspace._stage_windows_profile_sources(
+                self.root / "wrong-tree",
+                self.root / "build",
+                selected,
+                snapshot(state),
+            )
+
+        mismatched_parents = dict(selected)
+        mismatched_parents["server"] = self.root / "other" / "server"
+        with self.assertRaisesRegex(WorkspaceError, "do not share one monorepo root"):
+            self.workspace._stage_windows_profile_sources(
+                self.root / "wrong-parent",
+                self.root / "build",
+                mismatched_parents,
+            )
+
     def test_windows_state_snapshot_reuses_existing_physical_lock(self) -> None:
         server = self.workspace.paths.repositories / "server"
         prepared = self.workspace.state_path(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import contextmanager, ExitStack, redirect_stderr
+from contextlib import contextmanager, ExitStack, nullcontext, redirect_stderr
 import ctypes
 import errno
 import fcntl
@@ -20408,6 +20408,9 @@ class WorkspaceTests(unittest.TestCase):
         self.assertIn("private player data", readme)
 
     def test_windows_source_staging_overlays_read_only_generations(self) -> None:
+        self.workspace.manifest = Manifest.load(
+            Path(__file__).parents[1] / "components.json"
+        )
         selected: dict[str, Path] = {}
         classic_root = self.root / "sealed-classic"
         (classic_root / "cmake").mkdir(parents=True)
@@ -20420,8 +20423,17 @@ class WorkspaceTests(unittest.TestCase):
             source = classic_root / role
             source.mkdir()
             (source / "source.txt").write_text(role, encoding="utf-8")
-            source.chmod(0o555)
             selected[role] = source
+        command("git", "init", "-b", "main", cwd=classic_root)
+        command("git", "config", "user.name", "Tests", cwd=classic_root)
+        command(
+            "git", "config", "user.email", "tests@example.invalid", cwd=classic_root
+        )
+        command("git", "add", ".", cwd=classic_root)
+        command("git", "commit", "-m", "test: seed Classic staging", cwd=classic_root)
+        commit = command("git", "rev-parse", "HEAD", cwd=classic_root)
+        for role in ("client", "server", "protocol", "libatrinik"):
+            selected[role].chmod(0o555)
         (classic_root / "cmake").chmod(0o555)
         classic_root.chmod(0o555)
 
@@ -20456,13 +20468,30 @@ class WorkspaceTests(unittest.TestCase):
         )
         staging = self.root / "windows-sources"
         staging.mkdir()
+        profile = self.workspace._load_profile("classic", require_file=False)
+        snapshot = workspace_module.ProfileResolutionSnapshot(
+            "classic",
+            "c" * 64,
+            json.dumps(profile, sort_keys=True, separators=(",", ":")),
+            tuple((role, str(path)) for role, path in sorted(selected.items())),
+            json.dumps(
+                {
+                    "classic": {
+                        "path": str(classic_root),
+                        "head": commit,
+                        "dirty": False,
+                    }
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        )
 
-        with mock.patch("atrinik_workspace.workspace.run") as execute:
-            self.workspace._stage_windows_profile_sources(
-                staging, build_root, selected
-            )
+        self.workspace._stage_windows_profile_sources(
+            staging, build_root, selected, snapshot
+        )
 
-        execute.assert_called_once_with(["git", "init", "--quiet"], cwd=staging)
+        self.assertTrue((staging / ".git").is_dir())
         self.assertEqual(
             (staging / "cmake" / "AtrinikVersion.cmake").read_text(
                 encoding="utf-8"
@@ -20487,6 +20516,233 @@ class WorkspaceTests(unittest.TestCase):
             .read_text(encoding="utf-8"),
             "resource",
         )
+
+    def test_windows_profile_packages_role_specific_classic_generations(self) -> None:
+        self.workspace.manifest = Manifest.load(
+            Path(__file__).parents[1] / "components.json"
+        )
+        profile = self.workspace._load_profile("classic", require_file=False)
+        commit = "a" * 40
+        tree = "b" * 40
+        selected: dict[str, Path] = {}
+        records: dict[Path, dict[str, object]] = {}
+        for role in ("client", "server", "protocol", "libatrinik"):
+            generation = self.root / f"generation-{role}"
+            source = generation / "source"
+            source.mkdir(parents=True)
+            (source / "source.txt").write_text(role, encoding="utf-8")
+            selected[role] = source
+            component = self.workspace.manifest.stack("classic").providers[role]
+            records[source] = {
+                "checkout": "classic",
+                "repository": "atrinik/classic",
+                "commit": commit,
+                "tree": tree,
+                "source": component.source,
+            }
+        client_root = selected["client"].parent
+        (client_root / "cmake").mkdir()
+        (client_root / "cmake" / "AtrinikVersion.cmake").write_text(
+            "version", encoding="utf-8"
+        )
+        for document in ("LICENSE.md", "ATTRIBUTIONS.md"):
+            (client_root / document).write_text(document, encoding="utf-8")
+        for role in ("sound", "content", "resources"):
+            selected[role] = self.root / role
+            selected[role].mkdir()
+
+        snapshot = workspace_module.ProfileResolutionSnapshot(
+            "classic",
+            "c" * 64,
+            json.dumps(profile, sort_keys=True, separators=(",", ":")),
+            tuple((role, str(path)) for role, path in sorted(selected.items())),
+            json.dumps(
+                {
+                    "classic": {
+                        "path": str(self.root / "classic"),
+                        "head": commit,
+                        "dirty": False,
+                    }
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        )
+        build_root = self.root / "windows-build"
+        for path in (
+            build_root / "runtime" / "content" / "maps",
+            build_root / "runtime" / "content" / "lib",
+            build_root / "runtime" / "resources",
+        ):
+            path.mkdir(parents=True)
+            (path / "input.txt").write_text(path.name, encoding="utf-8")
+        atomic_json(
+            build_root / workspace_module.BUILD_METADATA,
+            {
+                "sound": {
+                    "mode": "source",
+                    "root": str(selected["sound"]),
+                    "source_commit": "d" * 40,
+                    "source_tree": "e" * 40,
+                    "source_clean": True,
+                },
+                "coordinates": {},
+            },
+        )
+        state = self.root / "state"
+        state.mkdir()
+        output = self.root / "packages" / "classic.zip"
+        archive_reached = mock.Mock()
+        staged_sources: list[Path] = []
+
+        def snapshot_state(_fd: int, _state: Path, destination: Path) -> str:
+            destination.mkdir()
+            (destination / "player.dat").write_text("state", encoding="utf-8")
+            return "f" * 64
+
+        def build_archives(staging: Path) -> tuple[Path, Path, dict[str, str]]:
+            staged_sources.append(staging)
+            self.assertEqual(
+                (staging / "client" / "source.txt").read_text(encoding="utf-8"),
+                "client",
+            )
+            self.assertEqual(
+                (staging / "server" / "source.txt").read_text(encoding="utf-8"),
+                "server",
+            )
+            client = self.root / "client.zip"
+            server = self.root / "server.zip"
+            client.write_bytes(b"client")
+            server.write_bytes(b"server")
+            return client, server, {"mode": "test", "image": ""}
+
+        def extract(_archive: Path, destination: Path, executable: str) -> None:
+            destination.mkdir()
+            (destination / executable).write_bytes(b"executable")
+            if executable == "atrinik-server.exe":
+                staged = staged_sources[0] / "server"
+                shutil.copytree(
+                    staged / "runtime" / "content" / "maps",
+                    destination / "maps",
+                )
+                shutil.copytree(
+                    staged / "runtime" / "content" / "lib",
+                    destination / "lib",
+                )
+                shutil.copytree(staged / "resources", destination / "resources")
+
+        def archive(_root: Path, destination: Path) -> None:
+            archive_reached()
+            destination.write_bytes(b"package")
+
+        state_fd = os.open(state, os.O_RDONLY | os.O_DIRECTORY)
+        state_lock = mock.Mock()
+        with (
+            mock.patch.object(self.workspace, "_require_classic_contracts"),
+            mock.patch.object(
+                self.workspace,
+                "_resolved_profile_operation",
+                return_value=nullcontext(snapshot),
+            ),
+            mock.patch.object(
+                self.workspace, "_build_resolved", return_value=build_root
+            ),
+            mock.patch.object(
+                self.workspace, "_topology_resolved_status", return_value={}
+            ),
+            mock.patch.object(
+                self.workspace, "_state_implementation", return_value={}
+            ),
+            mock.patch.object(self.workspace, "_state_location", return_value=state),
+            mock.patch.object(
+                self.workspace,
+                "_topology_state_lock",
+                return_value=nullcontext(state_lock),
+            ),
+            mock.patch.object(
+                self.workspace, "state_path", return_value=(state, state_fd)
+            ),
+            mock.patch.object(
+                self.workspace,
+                "_snapshot_windows_profile_state",
+                side_effect=snapshot_state,
+            ),
+            mock.patch.object(
+                self.workspace,
+                "_profile_build_lock",
+                return_value=nullcontext(),
+            ),
+            mock.patch.object(
+                self.workspace,
+                "_source_generation_record",
+                side_effect=lambda path: records.get(path),
+            ),
+            mock.patch.object(
+                self.workspace,
+                "_build_windows_profile_archives",
+                side_effect=build_archives,
+            ),
+            mock.patch.object(
+                self.workspace,
+                "_extract_portable_windows_package",
+                side_effect=extract,
+            ),
+            mock.patch.object(
+                self.workspace, "_archive_windows_profile", side_effect=archive
+            ),
+        ):
+            result = self.workspace.package_windows_profile(
+                "classic", "default", output
+            )
+
+        archive_reached.assert_called_once_with()
+        state_lock.bind.assert_called_once()
+        self.assertEqual(result["path"], str(output))
+
+    def test_windows_source_staging_rejects_mixed_generation_identity(self) -> None:
+        self.workspace.manifest = Manifest.load(
+            Path(__file__).parents[1] / "components.json"
+        )
+        profile = self.workspace._load_profile("classic", require_file=False)
+        selected: dict[str, Path] = {}
+        records: dict[Path, dict[str, object]] = {}
+        for index, role in enumerate(("client", "server", "protocol", "libatrinik")):
+            source = self.root / f"generation-{role}" / "source"
+            source.mkdir(parents=True)
+            selected[role] = source
+            component = self.workspace.manifest.stack("classic").providers[role]
+            records[source] = {
+                "checkout": "classic",
+                "repository": "atrinik/classic",
+                "commit": ("a" if index != 1 else "c") * 40,
+                "tree": "b" * 40,
+                "source": component.source,
+            }
+        snapshot = workspace_module.ProfileResolutionSnapshot(
+            "classic",
+            "d" * 64,
+            json.dumps(profile, sort_keys=True, separators=(",", ":")),
+            tuple((role, str(path)) for role, path in sorted(selected.items())),
+            json.dumps(
+                {"classic": {"path": str(self.root / "classic"), "head": "a" * 40}},
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        )
+
+        with (
+            mock.patch.object(
+                self.workspace,
+                "_source_generation_record",
+                side_effect=lambda path: records[path],
+            ),
+            self.assertRaisesRegex(
+                WorkspaceError, "checkout/repository/commit/tree identity"
+            ),
+        ):
+            self.workspace._stage_windows_profile_sources(
+                self.root / "staging", self.root / "build", selected, snapshot
+            )
 
     def test_windows_state_snapshot_reuses_existing_physical_lock(self) -> None:
         server = self.workspace.paths.repositories / "server"


### PR DESCRIPTION
Closes #449

## Summary

- stage coherent Classic clean-primary source generations by checkout, repository, commit, and tree identity
- preserve immutable-generation and source-lease guarantees while rejecting genuinely mixed Classic inputs
- cover the clean-primary package handoff, path-backed profiles, and mismatch failures

## Validation

Final-head validation and the exact manual verification recipe will be recorded before this draft is marked ready.

<!-- atrinik-delivery:body:574ffd2b866bb3733a2b823f71b06839377b0d238f2117fd37f65d8344df96a9:start -->
## Final delivery

### Validation

- `python3 -m coverage run -m unittest discover -v` — 1,097 tests passed in 441.916 seconds at final head `6353b9cc`; total coverage 84%
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `git diff --check`
- latest-head GitHub Integration, CodeQL, PR-title, and Codecov patch checks passed; patch coverage is 93.33%

### Manual verification

The final PR code was loaded over the shared wrapper root and used to run `package windows --profile classic-test --state default` against clean primary Classic inputs. It produced a valid private ZIP (`0600`, 292,528,417 bytes, SHA-256 `8f286e74a71de357c8bb2d6e45ccb5734ed886295d265682210e62c795751acb`) and left zero running topologies. The archive remains local because it contains private server state, player data, and credentials.

Whole-diff review converged with no remaining actionable findings. The initial patch-coverage finding was resolved by adding invalid-coordinate coverage; no follow-up issue is needed.

<!-- atrinik-delivery:body:574ffd2b866bb3733a2b823f71b06839377b0d238f2117fd37f65d8344df96a9:end -->