### PR TITLE
fix(delivery): live-prove target coordinate advances

### DIFF
--- a/.agents/skills/atrinik-issue-delivery/references/delivery-ledger.md
+++ b/.agents/skills/atrinik-issue-delivery/references/delivery-ledger.md
@@ -474,7 +474,18 @@ closing/migration. Target set, branches, initial commits, merge-base anchor,
 artifact slots/immutable intent, producer slot, and bound state are immutable;
 legal live-observation CAS may refresh a bound artifact's safety.
 Base or head advancement extends prior lineage; merge-base changes only with
-such an advance. Rewrites and retargets fail. Generic `cas` cannot perform any
+such an advance. Generic `cas` resolves exactly one advancing target to its
+single bound primitive or scope-produced worktree, pins its precommitted roots,
+Git authority, wrapper safety leases, and path identity without following
+links, and keeps that guard through the atomic replacement. Every appended
+base/head SHA must be a full exact commit present in that repository and a Git
+descendant of the immediately preceding lineage member. The helper recomputes
+`git merge-base` from the candidate current base/head and requires the exact
+candidate merge-base SHA. It repeats the live worktree and Git proof immediately
+before rename with lazy fetching disabled. Missing objects, abbreviations,
+guesses, rewrites, dirty/active/foreign worktrees, mutable authority, multiple
+target advances in one CAS, and retargets fail without publication. Generic
+`cas` cannot perform any
 part of an initial deferred primitive or scope bind; only the purpose-specific
 atomic binder may create the exact branch/worktree/resource candidate and its
 tagged crash receipt.
@@ -1285,7 +1296,9 @@ The values above illustrate shell shape only; copy actual values from the same
 `inspect` output. Never combine values from different observations. CAS locks,
 re-inventories, checks generation/digest/device/inode again immediately before
 atomic replace, and fsyncs. Before rename, all four expected identity values
-are mandatory concurrency guards. It also creates a durable hard-link receipt
+are mandatory concurrency guards. Target-coordinate changes additionally hold
+the live worktree/Git proof described above across this boundary. It also
+creates a durable hard-link receipt
 whose name encodes ledger, old generation/digest/device/inode, and candidate
 digest before rename:
 
@@ -1314,9 +1327,11 @@ use `--kind artifacts` or `--kind resources` only when deliberately checking
 that subset.
 
 For target advancement, first CAS-cancel pending ready/body/comment intent.
-Then refetch, prove descendant lineages, recompute merge base, CAS the new
-coordinates, and restart affected review, validation, and checks. Never encode a
-force-push/rebase/retarget as lineage.
+Then refetch exact full SHAs, append the descendant lineages, recompute merge
+base, and CAS the new coordinates. The helper independently repeats all Git
+proof at the publication boundary; caller-side inspection is not authority.
+Advance only one target per CAS, then restart affected review, validation, and
+checks. Never encode a force-push/rebase/retarget as lineage.
 
 ## Bind a created PR
 
@@ -1515,8 +1530,9 @@ bound, clearing digest and payload. Never cancel in-flight.
 
 ## Correct one proven target-head typo
 
-Ordinary CAS never rewrites lineage. If its caller nevertheless persisted one
-full-length but nonexistent target-head SHA, stop all delivery writes and retain
+Current ordinary CAS cannot publish an unproven target SHA. If a helper version
+without live target proof previously persisted one full-length but nonexistent
+target-head SHA, stop all delivery writes and retain
 the exact immediate-predecessor canonical ledger bytes. Use
 `correct-target-head` only when the bad generation differs from that predecessor
 solely by one target head advancement mirrored in exactly one bound branch and
@@ -1704,8 +1720,8 @@ stop for code-level recovery; never improvise file repair.
 | `create` stage only, including a durable short prefix | Rerun exact `create` with byte-identical candidate. It completes the deterministic stage. |
 | `create` target plus two-link stage | Rerun exact `create`; it proves identical inode/bytes and removes only the stage link. |
 | `create` target only | `inspect`; exact create retry is idempotent. Different bytes stop. |
-| CAS stage before rename, including a durable short prefix | Rerun exact `cas` with identical replacement and original four-part expected tuple. |
-| CAS target already replaced with its two-link update receipt | Rerun exact CAS with identical replacement and four-part predecessor tuple; the receipt name preserves generation/digest/device/inode and its shared inode proves the installed candidate. The helper removes the receipt. |
+| CAS stage before rename, including a durable short prefix | Rerun exact `cas` with identical replacement and original four-part expected tuple. A target-coordinate candidate must still pass the complete live Git/worktree proof before publication. |
+| CAS target already replaced with its two-link update receipt | Rerun exact CAS with identical replacement and four-part predecessor tuple; the receipt name preserves generation/digest/device/inode and its shared inode proves the installed candidate passed the pre-rename proof. The helper removes the receipt without requiring the branch to remain frozen after publication. |
 | Atomic worktree/scope bind interrupted at either CAS boundary | Rerun the identical `worktree-bind-cas` or `scope-bind-cas` with the same retained inputs and original four-part predecessor tuple, never generic `cas`. The helper freshly reproves live state before replacement and before accepting an installed post-rename receipt; drift preserves evidence and stops. |
 | Migration operation-digest plan/snapshot/report/prepared/ledger/complete boundary | Rerun exact `migrate` with identical null-migration candidate, kind, direct source name, and original source identity/digest. A different candidate or source cannot reuse even a short planned-stage prefix. |
 | Complete migration | `inventory` and `inspect`; require source/snapshot/marker/ledger coherence and no pending stage. |

--- a/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
+++ b/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
@@ -8997,7 +8997,144 @@ def _comment_transition(before: Mapping[str, Any], after: Mapping[str, Any]) -> 
     raise LedgerError("invalid delivery comment transition")
 
 
-def cas(
+def _target_advancement(
+    old: Mapping[str, Any], new: Mapping[str, Any]
+) -> tuple[Mapping[str, Any], Mapping[str, Any]] | None:
+    """Return the one target whose persisted Git coordinates advance."""
+
+    old_targets = {
+        (row["repository"]["node_id"], row["head"]["branch"]): row
+        for row in old["targets"]
+    }
+    changed = []
+    for after in new["targets"]:
+        key = (after["repository"]["node_id"], after["head"]["branch"])
+        before = old_targets.get(key)
+        if before is not None and any(
+            before[field]["current_sha"] != after[field]["current_sha"]
+            for field in ("base", "head", "merge_base")
+        ):
+            changed.append((before, after))
+    if len(changed) > 1:
+        raise LedgerError(
+            "one CAS may advance target coordinates for only one repository"
+        )
+    return changed[0] if changed else None
+
+
+def _target_worktree_proof(
+    document: Mapping[str, Any], target: Mapping[str, Any]
+) -> tuple[dict[str, Any], str, frozenset[str], Mapping[str, Any] | None]:
+    """Resolve one bound target to its immutable live-worktree authority."""
+
+    coordinate = (target["repository"]["node_id"], target["head"]["branch"])
+    matches = [
+        slot
+        for slot in document["artifacts"]
+        if slot["kind"] == "worktree"
+        and slot["state"] != "planned"
+        and (
+            slot["immutable"]["repository"]["node_id"],
+            slot["immutable"]["branch"],
+        )
+        == coordinate
+    ]
+    if len(matches) != 1:
+        raise LedgerError(
+            "target advancement requires exactly one bound authoritative worktree"
+        )
+    worktree = matches[0]
+    current = worktree.get("current")
+    path = None if current is None else current.get("path")
+    if not isinstance(path, str):
+        raise LedgerError("target advancement worktree has no bound live path")
+    request = worktree.get("primitive_request")
+    allowed_references: frozenset[str] = frozenset()
+    scope_record = None
+    if request is not None:
+        live_request = copy.deepcopy(request)
+    else:
+        producer = worktree.get("producer_resource_slot")
+        resources = [
+            resource
+            for resource in document["resources"]
+            if resource["slot_id"] == producer and resource["kind"] == "scope"
+        ]
+        if len(resources) != 1 or resources[0].get("current") is None:
+            raise LedgerError(
+                "target advancement lacks retained primitive or scope authority"
+            )
+        scope = resources[0]
+        scope_request = scope["request"]
+        live_request = _scope_worktree_request(
+            scope_request, target["repository"]
+        )
+        scope_raw = _retained_result(
+            scope["current"]["binding"],
+            "target advancement scope binding",
+        )
+        scope_record, _ = _scope_show_record(
+            scope_raw,
+            scope_request,
+            target["repository"],
+            "target advancement scope binding",
+        )
+        allowed_references = _scope_owned_references(scope_request)
+    live_request["expected_head_sha"] = target["head"]["current_sha"]
+    return live_request, path, allowed_references, scope_record
+
+
+def _prove_target_advancement(
+    guard: _LiveWorktreeGuard,
+    before: Mapping[str, Any],
+    after: Mapping[str, Any],
+) -> None:
+    """Live-prove exact commits, append ancestry, and the recomputed merge base."""
+
+    guard.prove()
+    worktree = guard.descriptors["worktree"]
+    for field in ("base", "head"):
+        prior = before[field]["lineage"][-1]
+        appended = after[field]["lineage"][len(before[field]["lineage"]) :]
+        for commit in appended:
+            _git(
+                worktree,
+                ("cat-file", "-e", f"{commit}^{{commit}}"),
+                f"target {field} commit {commit}",
+            )
+            status, _ = _git(
+                worktree,
+                ("merge-base", "--is-ancestor", prior, commit),
+                f"target {field} ancestry {prior}..{commit}",
+                accepted={0, 1},
+            )
+            if status != 0:
+                raise LedgerError(
+                    f"target {field} commit {commit} does not descend from {prior}"
+                )
+            prior = commit
+    _, merge_base_raw = _git(
+        worktree,
+        (
+            "merge-base",
+            after["base"]["current_sha"],
+            after["head"]["current_sha"],
+        ),
+        "target advancement merge base",
+    )
+    observed_merge_base = _one_git_line(
+        merge_base_raw, "target advancement merge base"
+    )
+    if observed_merge_base != after["merge_base"]["current_sha"]:
+        raise LedgerError(
+            "target merge-base coordinate does not match live Git: "
+            f"expected {after['merge_base']['current_sha']}, "
+            f"observed {observed_merge_base}"
+        )
+    guard.prove()
+
+
+def _cas_install(
     root: Path | str,
     name: str,
     document: Mapping[str, Any],
@@ -9208,6 +9345,99 @@ def cas(
                 raise LedgerError("installed CAS lost its predecessor proof")
             _unlink_exact(directory, proof, proof_visible)
             return installed
+
+
+def cas(
+    root: Path | str,
+    name: str,
+    document: Mapping[str, Any],
+    *,
+    expected_generation: int,
+    expected_digest: str,
+    expected_device: int,
+    expected_inode: int,
+    failpoint: Failpoint = None,
+    _precommit: Callable[[], None] | None = None,
+    _binding_capability: _AtomicBindingCapability | None = None,
+) -> Snapshot:
+    """CAS a ledger, live-proving every newly persisted Git coordinate."""
+
+    name = _direct_name(name)
+    prepared = prepare(document)
+    current = inspect(root, name)
+    raw = canonical_bytes(prepared)
+    # A hard-linked post-rename receipt can exist only after this exact
+    # candidate already passed its live proof immediately before publication.
+    # Resume receipt cleanup without requiring the branch to remain frozen.
+    if (
+        current.raw == raw
+        and prepared["generation"] == expected_generation + 1
+        and prepared["previous_byte_digest"] == expected_digest
+    ):
+        return _cas_install(
+            root,
+            name,
+            prepared,
+            expected_generation=expected_generation,
+            expected_digest=expected_digest,
+            expected_device=expected_device,
+            expected_inode=expected_inode,
+            failpoint=failpoint,
+            _precommit=_precommit,
+            _binding_capability=_binding_capability,
+        )
+    advancement = _target_advancement(current.document, prepared)
+    if advancement is None:
+        return _cas_install(
+            root,
+            name,
+            prepared,
+            expected_generation=expected_generation,
+            expected_digest=expected_digest,
+            expected_device=expected_device,
+            expected_inode=expected_inode,
+            failpoint=failpoint,
+            _precommit=_precommit,
+            _binding_capability=_binding_capability,
+        )
+    # Reject malformed transitions before consulting any mutable external Git
+    # authority.  The locked installation repeats this check against the exact
+    # predecessor bytes immediately before staging.
+    _transition(
+        current.document,
+        prepared,
+        current.digest,
+        _binding_capability=_binding_capability,
+    )
+    before, after = advancement
+    request, path, references, scope_record = _target_worktree_proof(
+        current.document, after
+    )
+    with _pinned_live_worktree(
+        request,
+        path,
+        "target advancement",
+        allowed_references=references,
+        scope_record=scope_record,
+    ) as guard:
+        def prove_before_publish() -> None:
+            if _precommit is not None:
+                _precommit()
+            _prove_target_advancement(guard, before, after)
+
+        prove_before_publish()
+        return _cas_install(
+            root,
+            name,
+            prepared,
+            expected_generation=expected_generation,
+            expected_digest=expected_digest,
+            expected_device=expected_device,
+            expected_inode=expected_inode,
+            failpoint=failpoint,
+            _precommit=prove_before_publish,
+            _binding_capability=_binding_capability,
+        )
 
 
 def correct_target_head(

--- a/tests/test_delivery_ledger.py
+++ b/tests/test_delivery_ledger.py
@@ -1498,7 +1498,7 @@ class DeliveryLedgerTests(unittest.TestCase):
             with self.subTest(failpoint=failpoint), tempfile.TemporaryDirectory() as temporary:
                 root = Path(temporary)
                 initial = ledger.create(root, issue_ledger())
-                update = replacement(initial)
+                update = next_generation(initial)
                 arguments = {
                     "expected_generation": initial.document["generation"],
                     "expected_digest": initial.digest,
@@ -1521,9 +1521,9 @@ class DeliveryLedgerTests(unittest.TestCase):
                         )
                 current = ledger.cas(root, initial.name, update, **arguments)
                 self.assertEqual(current.document["generation"], 2)
-                self.assertEqual(current.document["targets"][0]["head"]["current_sha"], SHA_B)
+                self.assertEqual(current.document["targets"][0]["head"]["current_sha"], SHA_A)
                 with self.assertRaisesRegex(ledger.LedgerError, "stale CAS"):
-                    other = replacement(current, head=SHA_C)
+                    other = next_generation(current)
                     ledger.cas(
                         root,
                         current.name,
@@ -1768,31 +1768,20 @@ class DeliveryLedgerTests(unittest.TestCase):
             root = Path(temporary)
             initial = ledger.create(root, issue_ledger())
             descendant = replacement(initial)
-            advanced = ledger.cas(
-                root,
-                initial.name,
-                descendant,
-                expected_generation=1,
-                expected_digest=initial.digest,
-                expected_device=initial.device,
-                expected_inode=initial.inode,
-            )
-            rewritten = copy.deepcopy(advanced.document)
-            rewritten["generation"] = 3
-            rewritten["previous_byte_digest"] = advanced.digest
-            rewritten["history"].append(advanced.digest)
+            with self.assertRaisesRegex(
+                ledger.LedgerError, "bound authoritative worktree"
+            ):
+                ledger.cas(root, initial.name, descendant, **cas_arguments(initial))
+            rewritten = copy.deepcopy(descendant)
             rewritten["targets"][0]["head"].update(
-                current_sha=SHA_C, lineage=[SHA_A, SHA_C]
+                current_sha=SHA_C, lineage=[SHA_C]
             )
-            with self.assertRaisesRegex(ledger.LedgerError, "rewritten"):
+            with self.assertRaisesRegex(ledger.LedgerError, "must connect"):
                 ledger.cas(
                     root,
-                    advanced.name,
+                    initial.name,
                     rewritten,
-                    expected_generation=2,
-                    expected_digest=advanced.digest,
-                    expected_device=advanced.device,
-                    expected_inode=advanced.inode,
+                    **cas_arguments(initial),
                 )
             process = subprocess.run(
                 [sys.executable, "-B", str(SCRIPT), "inventory", str(root)],
@@ -2040,13 +2029,16 @@ class DeliveryLedgerTests(unittest.TestCase):
                 current_sha=SHA_C, lineage=[SHA_A, SHA_C]
             )
             advanced["targets"][0]["merge_base"]["current_sha"] = SHA_B
-            current = ledger.cas(root, initial.name, advanced, **cas_arguments(initial))
-            rewritten = next_generation(current)
+            with self.assertRaisesRegex(
+                ledger.LedgerError, "bound authoritative worktree"
+            ):
+                ledger.cas(root, initial.name, advanced, **cas_arguments(initial))
+            rewritten = next_generation(initial)
             rewritten["targets"][0]["base"].update(
-                current_sha="d" * 40, lineage=[SHA_A, "d" * 40]
+                current_sha="d" * 40, lineage=["d" * 40]
             )
-            with self.assertRaisesRegex(ledger.LedgerError, "base lineage was rewritten"):
-                ledger.cas(root, current.name, rewritten, **cas_arguments(current))
+            with self.assertRaisesRegex(ledger.LedgerError, "must connect"):
+                ledger.cas(root, initial.name, rewritten, **cas_arguments(initial))
 
         invalid_head = pr_ledger(
             423,
@@ -2189,9 +2181,11 @@ class DeliveryLedgerTests(unittest.TestCase):
                 ).name,
                 migrated.name,
             )
-            second = ledger.cas(root, migrated.name, replacement(migrated), **cas_arguments(migrated))
+            second = ledger.cas(
+                root, migrated.name, next_generation(migrated), **cas_arguments(migrated)
+            )
             self.assertEqual(len(ledger.inventory(root).ledgers), 1)
-            third_document = replacement(second, head=SHA_C)
+            third_document = next_generation(second)
             third = ledger.cas(root, second.name, third_document, **cas_arguments(second))
             self.assertEqual(third.document["history"][0], migrated.digest)
 
@@ -2751,8 +2745,19 @@ class DeliveryLedgerTests(unittest.TestCase):
     def test_18_cross_process_cas_race_has_one_winner_and_no_debris(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
-            initial = ledger.create(root, issue_ledger())
-            replacements = [replacement(initial, head=SHA_B), replacement(initial, head=SHA_C)]
+            initial = ledger.create(
+                root,
+                pr_ledger(
+                    453,
+                    pr_node="P_cas_race",
+                    branch="fix/cas-race",
+                    worktree="/workspace/worktrees/cas-race",
+                ),
+            )
+            unchanged = next_generation(initial)
+            ready_intent = next_generation(initial)
+            ready_intent["selected_prs"][0]["draft_intent"] = "ready"
+            replacements = [unchanged, ready_intent]
             processes: list[subprocess.Popen[str]] = []
             for index, candidate in enumerate(replacements):
                 input_path = root / f"cas-{index}.json"
@@ -3152,12 +3157,16 @@ class DeliveryLedgerTests(unittest.TestCase):
             for slot in refreshed_document["artifacts"]:
                 if slot["state"] != "planned":
                     slot["current"]["head_sha"] = SHA_B
-            refreshed = ledger.cas(
-                root,
-                cancelled_snapshot.name,
-                refreshed_document,
-                **cas_arguments(cancelled_snapshot),
-            )
+            with self.assertRaisesRegex(
+                ledger.LedgerError, "bound authoritative worktree"
+            ):
+                ledger.cas(
+                    root,
+                    cancelled_snapshot.name,
+                    refreshed_document,
+                    **cas_arguments(cancelled_snapshot),
+                )
+            refreshed = cancelled_snapshot
             replan = next_generation(refreshed)
             replan["selected_prs"][0]["body"] = plan["body"]
             replanned = ledger.cas(
@@ -3580,7 +3589,18 @@ class DeliveryLedgerTests(unittest.TestCase):
             self.assertEqual(created.raw, raw)
             self.assertEqual(ledger.inventory(root).pending, ())
 
-            update = replacement(created, head=SHA_B)
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            document = pr_ledger(
+                453,
+                pr_node="P_stage_resume",
+                branch="fix/stage-resume",
+                worktree="/workspace/worktrees/stage-resume",
+            )
+            created = ledger.create(root, document)
+            self.assertEqual(ledger.inventory(root).pending, ())
+
+            update = next_generation(created)
             update_raw = ledger.canonical_bytes(update)
             update_stage = root / (
                 f".{created.name}.update-g2-from-{created.digest}-"
@@ -3588,7 +3608,8 @@ class DeliveryLedgerTests(unittest.TestCase):
             )
             update_stage.write_bytes(update_raw[:1])
             os.chmod(update_stage, 0o600)
-            other = replacement(created, head=SHA_C)
+            other = next_generation(created)
+            other["selected_prs"][0]["draft_intent"] = "ready"
             before = directory_snapshot(root)
             with self.assertRaisesRegex(ledger.LedgerError, "pending"):
                 ledger.cas(root, created.name, other, **cas_arguments(created))
@@ -6447,6 +6468,41 @@ class DeliveryLedgerTests(unittest.TestCase):
         finally:
             hidden_profile.rename(profile_path)
 
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            initial = ledger.create(root, document)
+            ledger.bind_scope_cas(
+                root,
+                initial.name,
+                "scope",
+                scope_show,
+                worktree_list,
+                safety,
+                **cas_arguments(initial),
+            )
+            bound = ledger.inspect(root, initial.name)
+            live = live_worktree_path(request)
+            (live / "scope-advance.txt").write_text(
+                "scope advance\n", encoding="utf-8"
+            )
+            git_run(live, "add", "scope-advance.txt")
+            git_run(live, "commit", "-m", "advance scope target")
+            head = git_run(live, "rev-parse", "HEAD").stdout.strip()
+            candidate = next_generation(bound)
+            target_head = candidate["targets"][0]["head"]
+            target_head["current_sha"] = head
+            target_head["lineage"].append(head)
+            for slot in candidate["artifacts"]:
+                if slot["kind"] in {"branch", "worktree"}:
+                    slot["current"]["head_sha"] = head
+            advanced = ledger.cas(
+                root, bound.name, candidate, **cas_arguments(bound)
+            )
+            self.assertEqual(
+                advanced.document["targets"][0]["head"]["current_sha"], head
+            )
+            self.assertEqual(ledger.inventory(root).pending, ())
+
     def test_38_cli_fifo_and_unsafe_adopted_pr_are_zero_write(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -8447,7 +8503,185 @@ class DeliveryLedgerTests(unittest.TestCase):
                 "atrinik-atrinik-issue-329.md.ledger.json",
             )
 
-    def test_48_exact_target_head_correction_is_audited_and_resumable(self) -> None:
+    def test_48_target_advancement_is_live_proven_and_crash_safe(self) -> None:
+        roots = live_roots(self.live_base / "target-advancement", "atrinik")
+        initial_head = git_head(roots)
+        branch = "fix/target-advancement"
+        label = "target-advancement"
+        worktree_path = str(
+            Path(roots["workspace"]["path"]) / "worktrees" / "atrinik" / label
+        )
+        document = issue_ledger(
+            number=453,
+            issue_node="I_target_advancement",
+            branch=branch,
+            worktree=worktree_path,
+        )
+        replace_sha(document, SHA_A, initial_head)
+        worktree = next(
+            slot for slot in document["artifacts"] if slot["kind"] == "worktree"
+        )
+        worktree["primitive_request"]["roots"] = copy.deepcopy(roots)
+        live = live_worktree_path(worktree["primitive_request"])
+
+        def advance_head(snapshot: object, head: str) -> dict[str, object]:
+            candidate = next_generation(snapshot)
+            target_head = candidate["targets"][0]["head"]
+            target_head["current_sha"] = head
+            target_head["lineage"].append(head)
+            for slot in candidate["artifacts"]:
+                if slot["kind"] in {"branch", "worktree"}:
+                    slot["current"]["head_sha"] = head
+            return candidate
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            created = ledger.create(root, document)
+            worktree_list = worktree_list_bytes(worktree["primitive_request"])
+            safety = safety_observation_bytes(
+                worktree["primitive_request"],
+                worktree_list,
+                producer_kind="primitive",
+                producer_digest=None,
+            )
+            ledger.bind_worktree_cas(
+                root,
+                created.name,
+                "worktree",
+                worktree_list,
+                safety,
+                **cas_arguments(created),
+            )
+            current = ledger.inspect(root, created.name)
+
+            (live / "first.txt").write_text("first\n", encoding="utf-8")
+            git_run(live, "add", "first.txt")
+            git_run(live, "commit", "-m", "first target advancement")
+            first_head = git_run(live, "rev-parse", "HEAD").stdout.strip()
+            first_candidate = advance_head(current, first_head)
+            current = ledger.cas(
+                root, current.name, first_candidate, **cas_arguments(current)
+            )
+            self.assertEqual(
+                current.document["targets"][0]["head"]["current_sha"], first_head
+            )
+            self.assertEqual(ledger.inventory(root).pending, ())
+
+            primary = Path(roots["primary"]["path"])
+            (primary / "base.txt").write_text("base\n", encoding="utf-8")
+            git_run(primary, "add", "base.txt")
+            git_run(primary, "commit", "-m", "advance target base")
+            base_head = git_run(primary, "rev-parse", "HEAD").stdout.strip()
+            base_candidate = next_generation(current)
+            target_base = base_candidate["targets"][0]["base"]
+            target_base["current_sha"] = base_head
+            target_base["lineage"].append(base_head)
+            current = ledger.cas(
+                root, current.name, base_candidate, **cas_arguments(current)
+            )
+            self.assertEqual(
+                current.document["targets"][0]["base"]["current_sha"], base_head
+            )
+
+            latest_head = first_head
+            for index, failpoint in enumerate(("cas:staged", "cas:proofed")):
+                filename = f"proof-{index}.txt"
+                (live / filename).write_text(f"proof {index}\n", encoding="utf-8")
+                git_run(live, "add", filename)
+                git_run(live, "commit", "-m", f"target proof {failpoint}")
+                latest_head = git_run(live, "rev-parse", "HEAD").stdout.strip()
+                candidate = advance_head(current, latest_head)
+                with self.assertRaises(ledger.InjectedCrash):
+                    ledger.cas(
+                        root,
+                        current.name,
+                        candidate,
+                        failpoint=failpoint,
+                        **cas_arguments(current),
+                    )
+                current = ledger.cas(
+                    root, current.name, candidate, **cas_arguments(current)
+                )
+                self.assertEqual(ledger.inventory(root).pending, ())
+
+            missing_base = next_generation(current)
+            missing_base["targets"][0]["base"]["current_sha"] = "f" * 40
+            missing_base["targets"][0]["base"]["lineage"].append("f" * 40)
+            before = directory_snapshot(root)
+            with self.assertRaisesRegex(ledger.LedgerError, "target base commit"):
+                ledger.cas(root, current.name, missing_base, **cas_arguments(current))
+            self.assertEqual(directory_snapshot(root), before)
+
+            abbreviated = advance_head(current, latest_head[:12])
+            with self.assertRaisesRegex(ledger.LedgerError, "current_sha is invalid"):
+                ledger.prepare(abbreviated)
+
+            git_run(live, "reset", "--hard", initial_head)
+            (live / "sibling.txt").write_text("sibling\n", encoding="utf-8")
+            git_run(live, "add", "sibling.txt")
+            git_run(live, "commit", "-m", "non-descendant target")
+            sibling_head = git_run(live, "rev-parse", "HEAD").stdout.strip()
+            sibling_candidate = advance_head(current, sibling_head)
+            before = directory_snapshot(root)
+            with self.assertRaisesRegex(ledger.LedgerError, "does not descend"):
+                ledger.cas(
+                    root, current.name, sibling_candidate, **cas_arguments(current)
+                )
+            self.assertEqual(directory_snapshot(root), before)
+
+            git_run(live, "reset", "--hard", latest_head)
+            (live / "second.txt").write_text("second\n", encoding="utf-8")
+            git_run(live, "add", "second.txt")
+            git_run(live, "commit", "-m", "second target advancement")
+            second_head = git_run(live, "rev-parse", "HEAD").stdout.strip()
+            wrong_merge_base = advance_head(current, second_head)
+            wrong_merge_base["targets"][0]["merge_base"]["current_sha"] = second_head
+            before = directory_snapshot(root)
+            with self.assertRaisesRegex(ledger.LedgerError, "merge-base coordinate"):
+                ledger.cas(
+                    root, current.name, wrong_merge_base, **cas_arguments(current)
+                )
+            self.assertEqual(directory_snapshot(root), before)
+
+            second_candidate = advance_head(current, second_head)
+            with self.assertRaises(ledger.InjectedCrash):
+                ledger.cas(
+                    root,
+                    current.name,
+                    second_candidate,
+                    failpoint="cas:renamed",
+                    **cas_arguments(current),
+                )
+            installed = ledger.inspect(root, current.name)
+            self.assertEqual(
+                installed.document["targets"][0]["head"]["current_sha"], second_head
+            )
+            (live / "third.txt").write_text("third\n", encoding="utf-8")
+            git_run(live, "add", "third.txt")
+            git_run(live, "commit", "-m", "post-crash target advancement")
+            third_head = git_run(live, "rev-parse", "HEAD").stdout.strip()
+            resumed = ledger.cas(
+                root, current.name, second_candidate, **cas_arguments(current)
+            )
+            self.assertEqual(resumed.digest, installed.digest)
+            self.assertEqual(ledger.inventory(root).pending, ())
+            third_candidate = advance_head(resumed, third_head)
+            with self.assertRaises(ledger.InjectedCrash):
+                ledger.cas(
+                    root,
+                    resumed.name,
+                    third_candidate,
+                    failpoint="cas:installed",
+                    **cas_arguments(resumed),
+                )
+            final = ledger.cas(
+                root, resumed.name, third_candidate, **cas_arguments(resumed)
+            )
+            self.assertEqual(
+                final.document["targets"][0]["head"]["current_sha"], third_head
+            )
+
+    def test_49_exact_target_head_correction_is_audited_and_resumable(self) -> None:
         bad_head = "f0f8d7493278dc691710056c79d0d63f1d802488"
 
         def incident(
@@ -8511,7 +8745,10 @@ class DeliveryLedgerTests(unittest.TestCase):
             for slot in erroneous_document["artifacts"]:
                 if slot["kind"] in {"branch", "worktree"}:
                     slot["current"]["head_sha"] = incident_bad_head
-            erroneous = ledger.cas(
+            # Model exact bytes published by the pre-fix generic CAS.  The
+            # public CAS must now reject this nonexistent coordinate; recovery
+            # still needs a faithful historical incident fixture.
+            erroneous = ledger._cas_install(
                 root,
                 predecessor.name,
                 erroneous_document,


### PR DESCRIPTION
Closes #453

## Summary

- live-prove every delivery-ledger target advancement against exact local Git history
- reject nonexistent, abbreviated, guessed, or rewritten target coordinates before publication
- recompute and verify merge-base coordinates while preserving crash-safe typo recovery provenance

## Validation

Pending implementation and final-head review.

<!-- atrinik-delivery:body:ec2b5f1c5366911ffd17fae5aa647f35ad708c0b5536f4bdf25bfcc6661a4726:start -->
## Delivery status

The pending note above is superseded by final-head validation on `890163e4d3f5e4ce435d5798d63f547f15d64b41`.

- `python3 -m coverage run -m unittest discover -v`: 1,100 tests passed
- `python3 -m coverage report --show-missing`: 84% aggregate coverage
- compile, guidance inventory, skill validation, manifest, supply-chain, and whitespace gates passed
- two complete whole-diff review cycles finished with no known actionable findings

Runtime verification is not applicable because this changes offline delivery-ledger tooling, tests, and operator guidance.

<!-- atrinik-delivery:body:ec2b5f1c5366911ffd17fae5aa647f35ad708c0b5536f4bdf25bfcc6661a4726:end -->