### PR TITLE
fix(agents): recover scope worktree head typos

### DIFF
--- a/.agents/skills/atrinik-issue-delivery/references/deep-review-checklist.md
+++ b/.agents/skills/atrinik-issue-delivery/references/deep-review-checklist.md
@@ -92,7 +92,9 @@ applicability; do not turn irrelevant categories into invented findings.
   source/report/snapshot/ledger/marker loss. Markdown is non-authoritative; no
   workflow may hand-roll state I/O.
 - For a helper-owned target-head typo correction, prove the exact predecessor
-  and hard-linked bad-generation inode, canonical explicit-recovery grant whose
+  and hard-linked bad-generation inode; the exact primitive request or active
+  scope binding, observation, owned references, and live scope/profile/topology
+  identity; canonical explicit-recovery grant whose
   objective binds the full source tuple/correction intent and exact ledger
   actor/repository/issue scope, exact no-lazy-fetch batch-check `missing` result
   for the full bad OID, live repository/branch/path, predecessor ancestry, recomputed merge

--- a/.agents/skills/atrinik-issue-delivery/references/delivery-ledger.md
+++ b/.agents/skills/atrinik-issue-delivery/references/delivery-ledger.md
@@ -1520,9 +1520,11 @@ full-length but nonexistent target-head SHA, stop all delivery writes and retain
 the exact immediate-predecessor canonical ledger bytes. Use
 `correct-target-head` only when the bad generation differs from that predecessor
 solely by one target head advancement mirrored in exactly one bound branch and
-one bound primitive worktree. Supply the bad generation's fresh four-part CAS
-identity, the nonexistent SHA, the exact live SHA, the predecessor file, and a
-canonical explicit-recovery authority/intent file.
+one bound worktree. The worktree must retain either its exact deferred primitive
+request or one exact `producer_resource_slot` naming a created, active scope.
+Supply the bad generation's fresh four-part CAS identity, the nonexistent SHA,
+the exact live SHA, the predecessor file, and a canonical explicit-recovery
+authority/intent file.
 
 That file has exactly `grant` and `intent`. `grant` is a normal
 `explicit-recovery` authority whose actor and complete repository/issue/PR
@@ -1538,9 +1540,21 @@ The helper rejects noncanonical bytes, a generic invocation or
 goal, any superset or changed actor/scope, and any objective/intent mismatch
 before writing.
 
+For a primitive worktree, the helper derives the managed path from the retained
+request and requires its repository and branch to equal the changed target. For
+a scope-produced worktree, it resolves the sole named scope resource and
+requires `created` state with an `active` lifecycle. It decodes the retained
+scope binding, revalidates the exact request/result and helper-owned observation,
+and requires the scope repository, branch, managed path, device/inode, common
+Git directory, profile, topology, state policy, commands, cleanup coordinates,
+generation, and owned references to remain exact. Missing, released, ambiguous,
+stale, or mismatched scope evidence fails before publication.
+
 The helper derives the correcting generation itself. It live-pins the recorded
-repository, branch, worktree path, roots, and Git authority; proves the actual
-commit exists, the predecessor is its ancestor, the bad commit does not exist,
+repository, branch, worktree path, roots, and Git authority. Scope recovery also
+pins the retained scope/profile/topology leases and reproves the live scope file
+and observation before each write boundary. The helper proves the actual commit
+exists, the predecessor is its ancestor, and the bad commit does not exist,
 by accepting only the exact `<full-oid> missing` response from a bounded
 `git cat-file --batch-check` with `GIT_NO_LAZY_FETCH=1`, so promisor objects
 cannot trigger a remote fetch, and the recorded merge base equals a fresh

--- a/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
+++ b/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
@@ -3796,6 +3796,7 @@ def _scope_binding_observation(
     *,
     live: bool,
     guard: _LiveWorktreeGuard | None = None,
+    live_request: Mapping[str, Any] | None = None,
 ) -> None:
     item = _exact(value, {"worktree_list", "safety_observation"}, context)
     worktree_request = _scope_worktree_request(request, repository)
@@ -3810,13 +3811,22 @@ def _scope_binding_observation(
         "scope",
         scope_digest,
         f"{context}.safety_observation",
-        live=live,
+        live=live and live_request is None,
         expected_tree=row["tree"],
         expected_common_git_dir=row["common_git_dir"],
         guard=guard,
         allowed_references=_scope_owned_references(request),
         scope_record=scope_record,
     )
+    if live_request is not None:
+        if not live or guard is None:
+            raise LedgerError(f"{context} correction live proof is incomplete")
+        if guard.request != live_request or guard.path != path:
+            raise LedgerError(f"{context} correction worktree guard differs")
+        proof = guard.prove()
+        _verify_live_observation(observation, proof, context)
+        if proof["common_git_dir"] != row["common_git_dir"]:
+            raise LedgerError(f"{context} common Git directory differs from scope result")
     if (observation["path_device"], observation["path_inode"]) != (
         row["path_device"],
         row["path_inode"],
@@ -7017,7 +7027,12 @@ def _head_correction_document(
     *,
     bad_head: str,
     actual_head: str,
-) -> tuple[dict[str, Any], dict[str, Any], Mapping[str, Any]]:
+) -> tuple[
+    dict[str, Any],
+    dict[str, Any],
+    Mapping[str, Any],
+    Mapping[str, Any] | None,
+]:
     """Build the sole permitted correction of one mistyped target advancement."""
 
     predecessor_raw = canonical_bytes(predecessor)
@@ -7103,10 +7118,70 @@ def _head_correction_document(
     worktree_slot = next(slot for slot in changed_artifacts if slot["kind"] == "worktree")
     worktree = worktree_slot["current"]["path"]
     request = worktree_slot.get("primitive_request")
-    if request is None or worktree != _expected_worktree_path(request):
-        raise LedgerError("head correction lacks one exact primitive worktree request")
-    if request["repository"] != before_target["repository"] or request["branch"] != key[1]:
-        raise LedgerError("head correction worktree request differs from its target")
+    scope_proof = None
+    if request is not None:
+        if worktree != _expected_worktree_path(request):
+            raise LedgerError("head correction lacks one exact primitive worktree request")
+        if (
+            request["repository"] != before_target["repository"]
+            or request["branch"] != key[1]
+        ):
+            raise LedgerError("head correction worktree request differs from its target")
+    else:
+        producer_slot = worktree_slot.get("producer_resource_slot")
+        scopes = [
+            resource
+            for resource in erroneous["resources"]
+            if resource["slot_id"] == producer_slot
+        ]
+        if len(scopes) != 1 or scopes[0]["kind"] != "scope":
+            raise LedgerError("head correction lacks one exact scope producer")
+        scope = scopes[0]
+        current = scope["current"]
+        if (
+            scope["state"] != "created"
+            or current is None
+            or current["lifecycle"] != "active"
+        ):
+            raise LedgerError("head correction scope producer is not active")
+        scope_repository = scope["immutable"]["repository"]
+        if scope_repository != before_target["repository"]:
+            raise LedgerError("head correction scope repository differs from its target")
+        binding_raw = _retained_result(
+            current["binding"], "head correction scope binding"
+        )
+        scope_record, scope_row = _scope_show_record(
+            binding_raw,
+            scope["request"],
+            scope_repository,
+            "head correction scope binding",
+        )
+        binding_digest = byte_digest(binding_raw)
+        _scope_binding_observation(
+            current["observation"],
+            scope["request"],
+            scope_repository,
+            scope_row,
+            binding_digest,
+            scope_record,
+            "head correction scope observation",
+            live=False,
+        )
+        request = _scope_worktree_request(scope["request"], scope_repository)
+        if (
+            worktree != scope_row["path"]
+            or worktree != _expected_worktree_path(request)
+            or request["branch"] != key[1]
+        ):
+            raise LedgerError("head correction scope worktree differs from its target")
+        scope_proof = {
+            "request": scope["request"],
+            "repository": scope_repository,
+            "row": scope_row,
+            "binding_digest": binding_digest,
+            "record": scope_record,
+            "observation": current["observation"],
+        }
     corrected = copy.deepcopy(erroneous)
     corrected["generation"] += 1
     corrected["previous_byte_digest"] = erroneous_digest
@@ -7136,7 +7211,7 @@ def _head_correction_document(
     }
     live_request = copy.deepcopy(request)
     live_request["expected_head_sha"] = actual_head
-    return corrected, metadata, live_request
+    return corrected, metadata, live_request, scope_proof
 
 
 def _inventory_locked(directory: int) -> Inventory:
@@ -7492,7 +7567,7 @@ def _inventory_locked(directory: int) -> Inventory:
                     }
                 ):
                     raise LedgerError(f"head-correction source identity changed: {target}")
-                _, metadata, _ = _head_correction_document(
+                _, metadata, _, _ = _head_correction_document(
                     predecessor,
                     erroneous,
                     source_digest,
@@ -7521,7 +7596,7 @@ def _inventory_locked(directory: int) -> Inventory:
         erroneous = validate(_decode(erroneous_raw, erroneous_name))
         if erroneous_raw != canonical_bytes(erroneous) or byte_digest(erroneous_raw) != source_digest:
             raise LedgerError(f"head-correction erroneous snapshot mismatch: {target}")
-        corrected, metadata, _ = _head_correction_document(
+        corrected, metadata, _, _ = _head_correction_document(
             predecessor,
             erroneous,
             source_digest,
@@ -9264,7 +9339,7 @@ def correct_target_head(
     erroneous = validate(_decode(erroneous_raw, "head-correction erroneous bytes"))
     if byte_digest(erroneous_raw) != expected_digest:
         raise LedgerError("head-correction erroneous snapshot differs from expected digest")
-    corrected, metadata, live_request = _head_correction_document(
+    corrected, metadata, live_request, scope_proof = _head_correction_document(
         predecessor,
         erroneous,
         expected_digest,
@@ -9296,10 +9371,31 @@ def correct_target_head(
     )
 
     with _pinned_live_worktree(
-        live_request, metadata["worktree"], "target-head correction"
+        live_request,
+        metadata["worktree"],
+        "target-head correction",
+        allowed_references=(
+            ()
+            if scope_proof is None
+            else _scope_owned_references(scope_proof["request"])
+        ),
+        scope_record=None if scope_proof is None else scope_proof["record"],
     ) as guard:
         def prove_live() -> None:
             guard.prove()
+            if scope_proof is not None:
+                _scope_binding_observation(
+                    scope_proof["observation"],
+                    scope_proof["request"],
+                    scope_proof["repository"],
+                    scope_proof["row"],
+                    scope_proof["binding_digest"],
+                    scope_proof["record"],
+                    "target-head correction scope observation",
+                    live=True,
+                    guard=guard,
+                    live_request=live_request,
+                )
             worktree = guard.descriptors["worktree"]
             _git(
                 worktree,

--- a/tests/test_delivery_ledger.py
+++ b/tests/test_delivery_ledger.py
@@ -8451,15 +8451,20 @@ class DeliveryLedgerTests(unittest.TestCase):
         bad_head = "f0f8d7493278dc691710056c79d0d63f1d802488"
 
         def incident(
-            root: Path, label: str, *, bad_kind: str = "missing"
+            root: Path,
+            label: str,
+            *,
+            bad_kind: str = "missing",
+            producer: str = "primitive",
         ) -> tuple[object, object, str, str, Path]:
-            roots = live_roots(self.live_base / label, "atrinik")
+            checkout = "client" if producer == "scope" else "atrinik"
+            roots = live_roots(self.live_base / label, checkout)
             base = git_head(roots)
             branch = f"fix/{label}"
             worktree_path = str(
                 Path(roots["workspace"]["path"])
                 / "worktrees"
-                / "atrinik"
+                / checkout
                 / label
             )
             document = issue_ledger(
@@ -8472,24 +8477,61 @@ class DeliveryLedgerTests(unittest.TestCase):
             worktree = next(
                 slot for slot in document["artifacts"] if slot["kind"] == "worktree"
             )
-            worktree["primitive_request"]["roots"] = copy.deepcopy(roots)
-            live = live_worktree_path(worktree["primitive_request"])
+            request = worktree["primitive_request"]
+            request["roots"] = copy.deepcopy(roots)
+            if producer == "scope":
+                request = scope_request(
+                    name=f"{label}-scope",
+                    component="client",
+                    checkout="client",
+                    label=label,
+                    branch=branch,
+                    start_sha=base,
+                    roots=roots,
+                )
+                document["resources"] = [scope_resource(request)]
+                worktree["primitive_request"] = None
+                worktree["producer_resource_slot"] = "scope"
+                retarget_repository(document, repository("client", "R_client"))
+            live = live_worktree_path(request)
             first = ledger.create(root, document)
-            worktree_list = worktree_list_bytes(worktree["primitive_request"])
-            safety = safety_observation_bytes(
-                worktree["primitive_request"],
-                worktree_list,
-                producer_kind="primitive",
-                producer_digest=None,
-            )
-            ledger.bind_worktree_cas(
-                root,
-                first.name,
-                "worktree",
-                worktree_list,
-                safety,
-                **cas_arguments(first),
-            )
+            worktree_list = worktree_list_bytes(request)
+            if producer == "scope":
+                scope_show = scope_show_bytes(
+                    request, repository_name="atrinik/client"
+                )
+                install_scope_references(request, scope_show)
+                safety = safety_observation_bytes(
+                    request,
+                    worktree_list,
+                    producer_kind="scope",
+                    producer_digest=ledger.byte_digest(scope_show),
+                    repository_value=repository("client", "R_client"),
+                )
+                ledger.bind_scope_cas(
+                    root,
+                    first.name,
+                    "scope",
+                    scope_show,
+                    worktree_list,
+                    safety,
+                    **cas_arguments(first),
+                )
+            else:
+                safety = safety_observation_bytes(
+                    request,
+                    worktree_list,
+                    producer_kind="primitive",
+                    producer_digest=None,
+                )
+                ledger.bind_worktree_cas(
+                    root,
+                    first.name,
+                    "worktree",
+                    worktree_list,
+                    safety,
+                    **cas_arguments(first),
+                )
             predecessor = ledger.inspect(root, first.name)
             (live / "correction.txt").write_text("actual\n", encoding="utf-8")
             git_run(live, "add", "correction.txt")
@@ -8527,33 +8569,50 @@ class DeliveryLedgerTests(unittest.TestCase):
             "correct-target-head:renamed",
             "correct-target-head:installed",
         )
-        for index, failpoint in enumerate(failpoints):
-            with self.subTest(failpoint=failpoint), tempfile.TemporaryDirectory() as temporary:
-                root = Path(temporary)
-                predecessor, erroneous, actual, incident_bad, _ = incident(
-                    root, f"correction-{index}"
-                )
-                arguments = {
-                    **cas_arguments(erroneous),
-                    "bad_head": incident_bad,
-                    "actual_head": actual,
-                }
-                recovery = head_correction_recovery(
-                    predecessor, erroneous, actual, incident_bad
-                )
-                with self.assertRaises(ledger.InjectedCrash):
-                    ledger.correct_target_head(
-                        root,
-                        erroneous.name,
-                        predecessor.raw,
-                        recovery,
-                        failpoint=failpoint,
-                        **arguments,
+        for producer in ("primitive", "scope"):
+            for index, failpoint in enumerate(failpoints):
+                with self.subTest(
+                    producer=producer, failpoint=failpoint
+                ), tempfile.TemporaryDirectory() as temporary:
+                    root = Path(temporary)
+                    predecessor, erroneous, actual, incident_bad, _ = incident(
+                        root, f"correction-{producer}-{index}", producer=producer
                     )
-                if failpoint == "correct-target-head:renamed":
-                    with mock.patch.object(
-                        ledger, "_fsync", wraps=ledger._fsync
-                    ) as fsync:
+                    arguments = {
+                        **cas_arguments(erroneous),
+                        "bad_head": incident_bad,
+                        "actual_head": actual,
+                    }
+                    recovery = head_correction_recovery(
+                        predecessor, erroneous, actual, incident_bad
+                    )
+                    with self.assertRaises(ledger.InjectedCrash):
+                        ledger.correct_target_head(
+                            root,
+                            erroneous.name,
+                            predecessor.raw,
+                            recovery,
+                            failpoint=failpoint,
+                            **arguments,
+                        )
+                    if failpoint == "correct-target-head:renamed":
+                        with mock.patch.object(
+                            ledger, "_fsync", wraps=ledger._fsync
+                        ) as fsync:
+                            corrected = ledger.correct_target_head(
+                                root,
+                                erroneous.name,
+                                predecessor.raw,
+                                recovery,
+                                **arguments,
+                            )
+                        self.assertTrue(
+                            any(
+                                "resuming correction" in call.args[1]
+                                for call in fsync.call_args_list
+                            )
+                        )
+                    else:
                         corrected = ledger.correct_target_head(
                             root,
                             erroneous.name,
@@ -8561,44 +8620,175 @@ class DeliveryLedgerTests(unittest.TestCase):
                             recovery,
                             **arguments,
                         )
-                    self.assertTrue(
-                        any(
-                            "resuming correction" in call.args[1]
-                            for call in fsync.call_args_list
-                        )
+                    self.assertEqual(
+                        corrected.document["generation"],
+                        erroneous.document["generation"] + 1,
                     )
-                else:
-                    corrected = ledger.correct_target_head(
-                        root,
-                        erroneous.name,
-                        predecessor.raw,
-                        recovery,
-                        **arguments,
+                    self.assertEqual(
+                        corrected.document["history"][-1], erroneous.digest
                     )
-                self.assertEqual(
-                    corrected.document["generation"],
-                    erroneous.document["generation"] + 1,
-                )
-                self.assertEqual(corrected.document["history"][-1], erroneous.digest)
-                self.assertEqual(corrected.document["targets"][0]["head"]["current_sha"], actual)
-                self.assertEqual(
-                    corrected.document["targets"][0]["head"]["lineage"],
-                    [
-                        *predecessor.document["targets"][0]["head"]["lineage"],
+                    self.assertEqual(
+                        corrected.document["targets"][0]["head"]["current_sha"],
                         actual,
-                    ],
+                    )
+                    self.assertEqual(
+                        corrected.document["targets"][0]["head"]["lineage"],
+                        [
+                            *predecessor.document["targets"][0]["head"]["lineage"],
+                            actual,
+                        ],
+                    )
+                    self.assertEqual(ledger.inventory(root).pending, ())
+                    self.assertEqual(
+                        ledger.correct_target_head(
+                            root,
+                            erroneous.name,
+                            predecessor.raw,
+                            recovery,
+                            **arguments,
+                        ).digest,
+                        corrected.digest,
+                    )
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            predecessor, erroneous, actual, incident_bad, _ = incident(
+                root, "correction-scope-controls", producer="scope"
+            )
+
+            def scope_resource_of(document: dict[str, object]) -> dict[str, object]:
+                return next(
+                    resource
+                    for resource in document["resources"]
+                    if resource["slot_id"] == "scope"
                 )
-                self.assertEqual(ledger.inventory(root).pending, ())
-                self.assertEqual(
-                    ledger.correct_target_head(
-                        root,
-                        erroneous.name,
-                        predecessor.raw,
-                        recovery,
-                        **arguments,
-                    ).digest,
-                    corrected.digest,
+
+            def scope_worktree_of(document: dict[str, object]) -> dict[str, object]:
+                return next(
+                    artifact
+                    for artifact in document["artifacts"]
+                    if artifact["kind"] == "worktree"
                 )
+
+            def alter_both(expected: str, mutation: object) -> None:
+                before = copy.deepcopy(predecessor.document)
+                after = copy.deepcopy(erroneous.document)
+                assert callable(mutation)
+                mutation(before)
+                mutation(after)
+                before_digest = ledger.byte_digest(ledger.canonical_bytes(before))
+                after["previous_byte_digest"] = before_digest
+                after["history"] = [*before["history"], before_digest]
+                after_digest = ledger.byte_digest(ledger.canonical_bytes(after))
+                with self.assertRaises(ledger.LedgerError) as rejected:
+                    ledger._head_correction_document(
+                        before,
+                        after,
+                        after_digest,
+                        bad_head=incident_bad,
+                        actual_head=actual,
+                    )
+                self.assertNotIn(
+                    "exact immediate predecessor", str(rejected.exception)
+                )
+                self.assertIn(expected, str(rejected.exception))
+
+            scope_controls = (
+                (
+                    "missing producer",
+                    "one exact scope producer",
+                    lambda document: scope_worktree_of(document).__setitem__(
+                        "producer_resource_slot", None
+                    ),
+                ),
+                (
+                    "non-scope producer",
+                    "one exact scope producer",
+                    lambda document: scope_resource_of(document).__setitem__(
+                        "kind", "profile"
+                    ),
+                ),
+                (
+                    "inactive producer",
+                    "scope producer is not active",
+                    lambda document: scope_resource_of(document)["current"].__setitem__(
+                        "lifecycle", "released"
+                    ),
+                ),
+                (
+                    "repository",
+                    "scope repository differs from its target",
+                    lambda document: scope_resource_of(document)["immutable"][
+                        "repository"
+                    ].__setitem__("node_id", "R_other"),
+                ),
+                (
+                    "branch",
+                    "worktree row differs from exact scope request",
+                    lambda document: scope_resource_of(document)["request"].__setitem__(
+                        "branch", "fix/other"
+                    ),
+                ),
+                (
+                    "head",
+                    "worktree row differs from exact scope request",
+                    lambda document: scope_resource_of(document)["request"].__setitem__(
+                        "start_sha", SHA_C
+                    ),
+                ),
+                (
+                    "path",
+                    "scope worktree differs from its target",
+                    lambda document: scope_worktree_of(document)["current"].__setitem__(
+                        "path", "/wrong/worktree"
+                    ),
+                ),
+                (
+                    "binding evidence",
+                    "digest does not match retained bytes",
+                    lambda document: scope_resource_of(document)["current"][
+                        "binding"
+                    ].__setitem__("sha256", "0" * 64),
+                ),
+                (
+                    "observation evidence",
+                    "digest does not match retained bytes",
+                    lambda document: scope_resource_of(document)["current"][
+                        "observation"
+                    ]["safety_observation"].__setitem__("sha256", "0" * 64),
+                ),
+            )
+            for label, expected, mutation in scope_controls:
+                with self.subTest(scope_control=label):
+                    alter_both(expected, mutation)
+
+            scope = scope_resource_of(erroneous.document)
+            scope_file = (
+                Path(scope["request"]["roots"]["workspace"]["path"])
+                / "scopes"
+                / scope["request"]["name"]
+                / "scope.json"
+            )
+            retained_scope = scope_file.read_bytes()
+            drifted_scope = json.loads(retained_scope)
+            drifted_scope["generation"] = "2" * 32
+            scope_file.write_bytes(json_bytes(drifted_scope))
+            recovery = head_correction_recovery(
+                predecessor, erroneous, actual, incident_bad
+            )
+            before = directory_snapshot(root)
+            with self.assertRaisesRegex(ledger.LedgerError, "scope file differs"):
+                ledger.correct_target_head(
+                    root,
+                    erroneous.name,
+                    predecessor.raw,
+                    recovery,
+                    **cas_arguments(erroneous),
+                    bad_head=incident_bad,
+                    actual_head=actual,
+                )
+            self.assertEqual(directory_snapshot(root), before)
+            scope_file.write_bytes(retained_scope)
 
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)


### PR DESCRIPTION
Closes #457

## Summary

- support audited target-head correction for scope-produced worktrees
- reject stale, inactive, mismatched, or ambiguous scope recovery evidence
- document and test primitive and scope recovery paths

## Validation

Pending implementation and final-head validation.

<!-- atrinik-delivery:body:54816cae6d8df79e0903005c4f4430ed7da0841ab3450c17acaceb3865041983:start -->
## Delivery validation

The pending note above is superseded by this final-head validation:

- 1,100 workspace tests pass at `e33cce7f00a7f7c612900c3bf5ca82b185a89211`
- aggregate coverage: 84%
- compileall, guidance inventory, manifest, supply-chain, skill, and whitespace checks pass
- two independent final whole-diff reviews found zero actionable findings

<!-- atrinik-delivery:body:54816cae6d8df79e0903005c4f4430ed7da0841ab3450c17acaceb3865041983:end -->