### PR TITLE
fix(delivery): preserve active evidence across transitions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,12 @@ inheritance, reference-publication/removal races, and fail-closed diagnostics.
 Run the cleanup dry-run required by `AGENTS.md`; never use cleanup apply as
 validation.
 
+Cleanup or repository-layout changes must also cover active issue-delivery
+evidence: an active ledger protects its review root, report, lock, and
+worktree; missing or unsupported evidence fails closed; and repository
+migration refuses active ledgers without mutating them. Recovery tests must
+prove that the wrapper does not synthesize missing ledger bytes or authority.
+
 For development-scope changes, also cover distinct scopes sharing one physical
 checkout, same-name/label/branch races, every publication boundary, exact JSON
 handoff commands, state-policy opt-in, live-scope isolation, and hash-bound

--- a/README.md
+++ b/README.md
@@ -831,6 +831,17 @@ worktree dirty, but its paths and allocated bytes are reported because
 `git worktree remove` will reclaim it. Apply uses only ordinary non-force
 worktree removal and preserves local and remote branch refs and Git objects.
 
+Active issue-delivery evidence is a separate protected ownership boundary.
+When `build/reviews` exists, cleanup inventories it through the canonical
+delivery-ledger helper and protects the review root, every active ledger's
+report and lock, and each ledger-owned worktree. Missing reports or locks,
+unsupported helper output, and unrecognized inventory errors protect the
+complete cleanup plan; the wrapper never recreates missing evidence. The
+repository migration preview and apply paths use the same inventory and refuse
+while any active ledger exists. Recovery therefore requires the authenticated
+delivery authority and exact preserved bytes; a fresh ledger, timestamp,
+branch, worktree, or issue assignment cannot substitute for lost evidence.
+
 Profile builds are eligible only as direct
 `workspace/build/profiles/<profile>-<key>` children with an exact regular
 ownership marker. Each build use atomically refreshes strict metadata with its

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Iterable, Iterator
 
 from .locking import LockBusyError, active_lock_fds
 from .content_migration import CONTENT_MIGRATION_PENDING, CONTENT_MIGRATION_RECORD
+from .delivery import inventory_active_delivery_evidence
 from .migration import MIGRATION_PENDING, MIGRATION_RECORD, OPERATION_PATHS
 from .model import (
     MANAGED_MARKER,
@@ -1387,6 +1388,7 @@ def _base_item(kind: str, owner: str, repository: str, path: Path) -> dict[str, 
             "topologies": [],
             "migration": [],
             "retention": [],
+            "delivery": [],
         },
     }
 
@@ -2433,6 +2435,7 @@ class Cleanup:
                 "live_builds": {},
                 "migration": {},
                 "retention": {},
+                "delivery": {},
             }
             reference_errors: set[str] = set()
         else:
@@ -2467,7 +2470,7 @@ class Cleanup:
                     reference_errors,
                 )
             )
-            items.extend(self._unmanaged_builds(registered))
+            items.extend(self._unmanaged_builds(registered, references))
         if "temporary-states" in scopes and names is None:
             items.extend(self._temporary_states(older_than_days))
         if "npm-cache" in scopes:
@@ -3302,6 +3305,7 @@ class Cleanup:
             "live_builds": {},
             "migration": {},
             "retention": {},
+            "delivery": {},
         }
         errors: set[str] = set()
         collectors = (
@@ -3311,6 +3315,7 @@ class Cleanup:
             (self._topology_references, "topology_inventory_error"),
             (self._migration_references, "migration_inventory_error"),
             (self._retention_references, "retention_inventory_error"),
+            (self._delivery_references, "delivery_inventory_error"),
         )
         for collector, reason in collectors:
             try:
@@ -3813,6 +3818,12 @@ class Cleanup:
         except (OSError, WorkspaceError):
             errors.add("retention_inventory_error")
 
+    def _delivery_references(self, references: dict[str, Any], errors: set[str]) -> None:
+        evidence = inventory_active_delivery_evidence(self.paths.repository)
+        for path, ledgers in evidence.references.items():
+            for ledger in ledgers:
+                self._add_reference(references["delivery"], path, ledger)
+
     def _worktrees(
         self,
         names: set[str] | None,
@@ -3938,6 +3949,7 @@ class Cleanup:
             "scenarios": "scenario_reference",
             "topologies": "topology_reference",
             "migration": "migration_reference",
+            "delivery": "delivery_reference",
         }
         for category, reference_reason in reference_reasons.items():
             values = references[category].get(normalized, [])
@@ -5623,7 +5635,9 @@ class Cleanup:
         except OSError as error:
             return False, str(error), None
 
-    def _unmanaged_builds(self, registered: set[Path]) -> list[dict[str, Any]]:
+    def _unmanaged_builds(
+        self, registered: set[Path], references: dict[str, Any]
+    ) -> list[dict[str, Any]]:
         items: list[dict[str, Any]] = []
         roots: list[tuple[Path, list[Path]]] = []
         top = self._wrapper_primary / "build"
@@ -5673,6 +5687,13 @@ class Cleanup:
                 max(0, int((self.now - observed).total_seconds())) if observed else None
             )
             item["reasons"] = ["unmanaged_build"]
+            delivery_references: set[str] = set()
+            for protected, values in references["delivery"].items():
+                if _path_relation(path, protected):
+                    delivery_references.update(values)
+            if delivery_references:
+                item["references"]["delivery"] = sorted(delivery_references)
+                item["reasons"].append("delivery_reference")
             if error:
                 item["reasons"].append("filesystem_traversal_error")
                 item["error"] = error

--- a/atrinik_workspace/delivery.py
+++ b/atrinik_workspace/delivery.py
@@ -1,0 +1,220 @@
+"""Read-only protection for active issue-delivery evidence.
+
+The delivery-ledger helper owns the ledger schema and its trust boundary.  The
+wrapper only projects the helper's bounded inventory into path references for
+cleanup and repository-layout transitions; it never parses or rewrites ledger
+bytes itself.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any
+
+from .locking import active_lock_fds
+from .model import WorkspaceError
+
+
+_INVENTORY_LIMIT = 32 * 1024 * 1024
+_INVENTORY_TIMEOUT_SECONDS = 30
+_LEDGER_SUFFIX = ".md.ledger.json"
+_HELPER_RELATIVE = Path(
+    ".agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py"
+)
+
+
+@dataclass(frozen=True)
+class ActiveDeliveryEvidence:
+    """The exact paths reserved by active delivery ledgers."""
+
+    review_root: Path
+    references: dict[Path, tuple[str, ...]]
+    ledgers: tuple[str, ...]
+    transition_blockers: tuple[str, ...]
+
+
+def _regular_path(path: Path, context: str) -> None:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError as error:
+        raise WorkspaceError(f"{context} is missing: {path}") from error
+    except OSError as error:
+        raise WorkspaceError(f"cannot inspect {context}: {path}: {error}") from error
+    if not path.is_file() or path.is_symlink():
+        raise WorkspaceError(f"{context} is not a regular file: {path}")
+    if metadata.st_uid != os.geteuid():
+        raise WorkspaceError(f"{context} is not owned by the current user: {path}")
+
+
+def _absolute_path(value: Any, context: str) -> Path:
+    if not isinstance(value, str) or not value:
+        raise WorkspaceError(f"{context} is not an absolute path")
+    path = Path(value)
+    if not path.is_absolute() or "\x00" in value:
+        raise WorkspaceError(f"{context} is not an absolute path")
+    try:
+        return path.resolve(strict=False)
+    except (OSError, RuntimeError) as error:
+        raise WorkspaceError(f"cannot resolve {context}: {path}: {error}") from error
+
+
+def _add_reference(
+    references: dict[Path, list[str]], path: Path, ledger: str
+) -> None:
+    references.setdefault(path, []).append(ledger)
+
+
+def inventory_active_delivery_evidence(wrapper_root: Path) -> ActiveDeliveryEvidence:
+    """Inventory active delivery evidence without mutating any ledger bytes.
+
+    An absent review root means that this wrapper has no delivery evidence to
+    protect.  Once the root exists, every active ledger must retain its
+    canonical report and lock.  Any helper, schema, or evidence failure is
+    raised so callers can preserve all candidate cleanup/migration targets.
+    """
+
+    root = Path(wrapper_root).resolve()
+    review_root = root / "build" / "reviews"
+    if not review_root.exists() and not review_root.is_symlink():
+        return ActiveDeliveryEvidence(review_root, {}, (), ())
+    if review_root.is_symlink() or not review_root.is_dir():
+        raise WorkspaceError(f"delivery review root is not a regular directory: {review_root}")
+
+    helper = root / _HELPER_RELATIVE
+    _regular_path(helper, "delivery-ledger helper")
+    try:
+        result = subprocess.run(
+            [sys.executable, "-B", str(helper), "inventory", str(review_root)],
+            cwd=root,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_INVENTORY_TIMEOUT_SECONDS,
+            pass_fds=active_lock_fds(),
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise WorkspaceError(f"delivery-ledger inventory failed: {error}") from error
+    if (
+        len(result.stdout.encode()) > _INVENTORY_LIMIT
+        or len(result.stderr.encode()) > _INVENTORY_LIMIT
+    ):
+        raise WorkspaceError("delivery-ledger inventory exceeded its output limit")
+    if result.returncode:
+        detail = result.stderr.strip()
+        suffix = f": {detail}" if detail else ""
+        raise WorkspaceError(
+            f"delivery-ledger inventory failed ({result.returncode}){suffix}"
+        )
+    try:
+        inventory = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise WorkspaceError("delivery-ledger inventory was not valid JSON") from error
+    if not isinstance(inventory, dict) or inventory.get("schema_version") != 1:
+        raise WorkspaceError("delivery-ledger inventory schema is unsupported")
+    ledgers = inventory.get("ledgers")
+    if not isinstance(ledgers, list):
+        raise WorkspaceError("delivery-ledger inventory ledgers are invalid")
+
+    references: dict[Path, list[str]] = {}
+    active_names: list[str] = []
+    for index, snapshot in enumerate(ledgers):
+        context = f"delivery-ledger inventory ledgers[{index}]"
+        if not isinstance(snapshot, dict):
+            raise WorkspaceError(f"{context} is invalid")
+        name = snapshot.get("name")
+        document = snapshot.get("document")
+        if (
+            not isinstance(name, str)
+            or not name.endswith(_LEDGER_SUFFIX)
+            or Path(name).name != name
+            or not isinstance(document, dict)
+        ):
+            raise WorkspaceError(f"{context} is invalid")
+        ledger_path = review_root / name
+        report_path = review_root / name.removesuffix(".ledger.json")
+        lock_path = review_root / f".{name}.lock"
+        for path, label in (
+            (ledger_path, "active delivery ledger"),
+            (report_path, "active delivery report"),
+            (lock_path, "active delivery lock"),
+        ):
+            _regular_path(path, f"{label} for {name}")
+        _add_reference(references, review_root, name)
+        _add_reference(references, ledger_path.resolve(), name)
+        _add_reference(references, report_path.resolve(), name)
+        _add_reference(references, lock_path.resolve(), name)
+        artifacts = document.get("artifacts")
+        if not isinstance(artifacts, list):
+            raise WorkspaceError(f"{context}.document.artifacts is invalid")
+        for artifact_index, artifact in enumerate(artifacts):
+            if not isinstance(artifact, dict) or artifact.get("kind") != "worktree":
+                continue
+            current = artifact.get("current")
+            if current is None:
+                request = artifact.get("primitive_request")
+                if isinstance(request, dict):
+                    roots = request.get("roots")
+                    if isinstance(roots, dict):
+                        workspace_path = roots.get("workspace", {}).get("path")
+                        checkout = request.get("physical_checkout")
+                        label = request.get("label")
+                        if (
+                            isinstance(workspace_path, str)
+                            and isinstance(checkout, str)
+                            and isinstance(label, str)
+                        ):
+                            planned = _absolute_path(
+                                str(Path(workspace_path) / "worktrees" / checkout / label),
+                                f"{context}.document.artifacts[{artifact_index}].primitive_request.path",
+                            )
+                            _add_reference(references, planned, name)
+                continue
+            if not isinstance(current, dict):
+                raise WorkspaceError(
+                    f"{context}.document.artifacts[{artifact_index}].current is invalid"
+                )
+            path = _absolute_path(
+                current.get("path"),
+                f"{context}.document.artifacts[{artifact_index}].current.path",
+            )
+            _add_reference(references, path, name)
+        active_names.append(name)
+
+    preserved_labels: list[str] = [*active_names]
+    transition_blockers: list[str] = [*active_names]
+    for field, prefix in (
+        ("pending", "pending"),
+        ("legacy_reports", "legacy"),
+        ("releases", "release"),
+        ("archives", "archive"),
+        ("reclaims", "reclaim"),
+        ("historical_ledgers", "historical"),
+    ):
+        rows = inventory.get(field)
+        if not isinstance(rows, list):
+            raise WorkspaceError(f"delivery-ledger inventory {field} is invalid")
+        for row in rows:
+            if not isinstance(row, dict):
+                raise WorkspaceError(f"delivery-ledger inventory {field} contains invalid evidence")
+            identity = row.get("name") or row.get("target") or row.get("ledger_name")
+            if not isinstance(identity, str) or not identity:
+                raise WorkspaceError(f"delivery-ledger inventory {field} lacks an identity")
+            label = f"{prefix}:{identity}"
+            preserved_labels.append(label)
+            if prefix == "pending":
+                transition_blockers.append(label)
+    if preserved_labels:
+        for label in preserved_labels:
+            _add_reference(references, review_root.resolve(), label)
+
+    return ActiveDeliveryEvidence(
+        review_root.resolve(),
+        {path: tuple(sorted(set(values))) for path, values in references.items()},
+        tuple(sorted(active_names)),
+        tuple(sorted(set(transition_blockers))),
+    )

--- a/atrinik_workspace/migration.py
+++ b/atrinik_workspace/migration.py
@@ -18,6 +18,7 @@ import tempfile
 from typing import Any, Callable, Iterable
 
 from .locking import LockBusyError, active_lock_fds, exclusive_layout_lock
+from .delivery import inventory_active_delivery_evidence
 from .model import (
     AtomicJsonCommitUncertain,
     JsonUnlinkCommitUncertain,
@@ -540,6 +541,26 @@ class RepositoryMigration:
 
     def _inspect(self) -> _Inspection:
         refusals: list[dict[str, str]] = []
+        try:
+            delivery = inventory_active_delivery_evidence(self.repository_root)
+        except WorkspaceError as error:
+            refusals.append(
+                self._refusal(
+                    "delivery_inventory_error",
+                    f"active delivery evidence could not be inspected: {error}",
+                    "preserve the review root and repair only the exact delivery evidence",
+                )
+            )
+        else:
+            if delivery.transition_blockers:
+                refusals.append(
+                    self._refusal(
+                        "active_delivery",
+                        "repository migration is blocked by active delivery evidence: "
+                        + ", ".join(delivery.transition_blockers),
+                        "complete the delivery lifecycle or use its explicit recovery protocol",
+                    )
+                )
         classic, classic_row, classic_refusals = self._inspect_classic()
         refusals.extend(classic_refusals)
         sources: list[_Source] = []

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -502,6 +502,23 @@ graft metadata can rewrite the ancestry proof. Missing, mismatched,
 unavailable, or ambiguous evidence protects the target. Apply reruns this API
 and local Git proof immediately before removal.
 
+Active issue-delivery evidence is a wrapper-level ownership boundary in
+addition to the helper's terminal lifecycle. When the canonical
+`build/reviews` root exists, cleanup invokes the trusted bounded helper
+inventory and projects every active ledger's review root, JSON sidecar,
+canonical report, persistent lock, and current worktree into its reference
+graph. A missing report or lock, unsupported helper result, malformed ledger,
+or any other inventory uncertainty makes the complete cleanup plan fail closed;
+the wrapper does not recreate or timestamp missing bytes. Unmanaged build
+discovery therefore cannot reclaim `build/reviews`, and a prunable Git
+worktree registration remains protected by the ledger's exact path reference.
+Repository migration uses the same barrier and refuses both preview and apply
+while active ledgers exist, so workspace-layout changes cannot move or lose
+their evidence. Recovery is authenticated and exact: only the delivery
+authority may continue a preserved ledger or explicitly recover a historical
+generation, and no reconstructed branch, worktree, timestamp, or issue state
+can stand in for missing authority.
+
 Worktree status is inspected with `--ignore-submodules=none`. A populated
 submodule protects the worktree even when its visible files are clean because
 per-worktree Git directories can retain private refs, reflogs, and objects. A

--- a/tests/test_delivery.py
+++ b/tests/test_delivery.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+import tempfile
+import unittest
+from unittest import mock
+
+from atrinik_workspace.cleanup import Cleanup
+from atrinik_workspace.delivery import (
+    ActiveDeliveryEvidence,
+    inventory_active_delivery_evidence,
+)
+from atrinik_workspace.migration import RepositoryMigration
+from atrinik_workspace.model import WorkspaceError
+
+
+class DeliveryEvidenceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.review_root = self.root / "build" / "reviews"
+        self.review_root.mkdir(parents=True)
+        self.helper = (
+            self.root
+            / ".agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py"
+        )
+        self.helper.parent.mkdir(parents=True)
+        self.helper.write_text("trusted helper\n", encoding="utf-8")
+        self.name = "atrinik-atrinik-issue-471.md.ledger.json"
+        for filename in (
+            self.name,
+            self.name.removesuffix(".ledger.json"),
+            f".{self.name}.lock",
+        ):
+            (self.review_root / filename).write_text("evidence\n", encoding="utf-8")
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def inventory_output(self, worktree: Path) -> str:
+        document = {
+            "artifacts": [
+                {"kind": "worktree", "current": {"path": str(worktree)}}
+            ]
+        }
+        return json.dumps(
+            {
+                "schema_version": 1,
+                "ledgers": [{"name": self.name, "document": document}],
+                "pending": [],
+                "legacy_reports": [],
+                "releases": [],
+                "archives": [],
+                "reclaims": [],
+                "historical_ledgers": [],
+            }
+        )
+
+    def test_projects_active_evidence_and_worktree(self) -> None:
+        worktree = self.root / "workspace" / "worktrees" / "active"
+        completed = SimpleNamespace(
+            returncode=0, stdout=self.inventory_output(worktree), stderr=""
+        )
+        with mock.patch(
+            "atrinik_workspace.delivery.subprocess.run", return_value=completed
+        ) as invoke:
+            evidence = inventory_active_delivery_evidence(self.root)
+
+        self.assertEqual(evidence.ledgers, (self.name,))
+        self.assertEqual(evidence.references[worktree.resolve()], (self.name,))
+        self.assertIn(self.review_root.resolve(), evidence.references)
+        self.assertEqual(invoke.call_args.args[0][3], "inventory")
+        self.assertEqual(invoke.call_args.kwargs["timeout"], 30)
+
+    def test_missing_report_fails_closed(self) -> None:
+        (self.review_root / self.name.removesuffix(".ledger.json")).unlink()
+        completed = SimpleNamespace(
+            returncode=0, stdout=self.inventory_output(self.root), stderr=""
+        )
+        with mock.patch(
+            "atrinik_workspace.delivery.subprocess.run", return_value=completed
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "active delivery report"):
+                inventory_active_delivery_evidence(self.root)
+
+    def test_projects_planned_worktree_request(self) -> None:
+        worktree = self.root / "workspace" / "worktrees" / "atrinik" / "planned"
+        document = {
+            "artifacts": [
+                {
+                    "kind": "worktree",
+                    "current": None,
+                    "primitive_request": {
+                        "roots": {"workspace": {"path": str(self.root / "workspace")}},
+                        "physical_checkout": "atrinik",
+                        "label": "planned",
+                    },
+                }
+            ]
+        }
+        output = {
+            "schema_version": 1,
+            "ledgers": [{"name": self.name, "document": document}],
+            "pending": [],
+            "legacy_reports": [],
+            "releases": [],
+            "archives": [],
+            "reclaims": [],
+            "historical_ledgers": [],
+        }
+        completed = SimpleNamespace(returncode=0, stdout=json.dumps(output), stderr="")
+        with mock.patch(
+            "atrinik_workspace.delivery.subprocess.run", return_value=completed
+        ):
+            evidence = inventory_active_delivery_evidence(self.root)
+
+        self.assertEqual(evidence.references[worktree.resolve()], (self.name,))
+
+    def test_invalid_helper_inventory_fails_closed(self) -> None:
+        completed = SimpleNamespace(returncode=2, stdout="", stderr="old schema")
+        with mock.patch(
+            "atrinik_workspace.delivery.subprocess.run", return_value=completed
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "old schema"):
+                inventory_active_delivery_evidence(self.root)
+
+    def test_unmanaged_review_root_is_protected(self) -> None:
+        paths = SimpleNamespace(
+            repository=self.root,
+            builds=self.root / "workspace" / "build",
+        )
+        paths.builds.mkdir(parents=True)
+        cleanup = Cleanup.__new__(Cleanup)
+        cleanup._wrapper_primary = self.root
+        cleanup.paths = paths
+        cleanup.now = datetime.now(timezone.utc)
+        references = {"delivery": {self.review_root.resolve(): [self.name]}}
+
+        items = cleanup._unmanaged_builds(set(), references)
+
+        item = next(row for row in items if Path(row["path"]) == self.review_root)
+        self.assertEqual(item["disposition"], "protected")
+        self.assertIn("delivery_reference", item["reasons"])
+        self.assertEqual(item["references"]["delivery"], [self.name])
+
+
+class MigrationDeliveryBarrierTests(unittest.TestCase):
+    def test_active_delivery_evidence_refuses_repository_migration(self) -> None:
+        migration = object.__new__(RepositoryMigration)
+        migration.repository_root = Path("/tmp/wrapper")
+        migration.paths = SimpleNamespace(workspace=Path("/tmp/workspace"))
+        migration.manifest = SimpleNamespace()
+        with mock.patch(
+            "atrinik_workspace.migration.inventory_active_delivery_evidence",
+            return_value=ActiveDeliveryEvidence(
+                Path("/tmp/reviews"), {}, ("delivery.json",), ("delivery.json",)
+            ),
+        ), mock.patch.object(
+            migration, "_inspect_classic", return_value=(None, {}, [])
+        ), mock.patch.object(
+            migration, "_inspect_profiles", return_value=([], [], [], [])
+        ), mock.patch.object(
+            migration, "_topology_inventory", return_value=([], [])
+        ), mock.patch.object(
+            migration, "_inert_inventory", return_value=([], [])
+        ):
+            inspection = migration._inspect()
+
+        self.assertEqual(
+            [row["code"] for row in inspection.plan["refusals"]],
+            ["active_delivery"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_delivery.py
+++ b/tests/test_delivery.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 from pathlib import Path
+import subprocess
 from types import SimpleNamespace
 import tempfile
 import unittest
@@ -126,6 +127,132 @@ class DeliveryEvidenceTests(unittest.TestCase):
         ):
             with self.assertRaisesRegex(WorkspaceError, "old schema"):
                 inventory_active_delivery_evidence(self.root)
+
+    def test_absent_and_invalid_review_roots_fail_closed(self) -> None:
+        absent = self.root / "absent"
+        evidence = inventory_active_delivery_evidence(absent)
+        self.assertEqual(evidence.references, {})
+
+        invalid = self.root / "invalid"
+        invalid.mkdir()
+        (invalid / "build").mkdir()
+        (invalid / "build" / "reviews").write_text("not a directory", encoding="utf-8")
+        with self.assertRaisesRegex(WorkspaceError, "regular directory"):
+            inventory_active_delivery_evidence(invalid)
+
+    def test_helper_missing_timeout_and_output_limit_fail_closed(self) -> None:
+        self.helper.unlink()
+        with self.assertRaisesRegex(WorkspaceError, "delivery-ledger helper is missing"):
+            inventory_active_delivery_evidence(self.root)
+
+        self.helper.write_text("trusted helper\n", encoding="utf-8")
+        with mock.patch(
+            "atrinik_workspace.delivery.subprocess.run",
+            side_effect=subprocess.TimeoutExpired("inventory", 30),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "inventory failed"):
+                inventory_active_delivery_evidence(self.root)
+
+        completed = SimpleNamespace(returncode=0, stdout="12", stderr="")
+        with mock.patch(
+            "atrinik_workspace.delivery._INVENTORY_LIMIT", 1
+        ), mock.patch(
+            "atrinik_workspace.delivery.subprocess.run", return_value=completed
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "output limit"):
+                inventory_active_delivery_evidence(self.root)
+
+    def test_helper_json_and_inventory_shapes_fail_closed(self) -> None:
+        outputs = (
+            ("not json", "valid JSON"),
+            (json.dumps({"schema_version": 2}), "unsupported"),
+            (json.dumps({"schema_version": 1}), "ledgers are invalid"),
+            (json.dumps({"schema_version": 1, "ledgers": ["bad"]}), r"ledgers\[0\] is invalid"),
+            (
+                json.dumps({"schema_version": 1, "ledgers": [{"name": "bad", "document": {}}]}),
+                r"ledgers\[0\] is invalid",
+            ),
+            (
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "ledgers": [{"name": self.name, "document": {"artifacts": {}}}],
+                    }
+                ),
+                "artifacts is invalid",
+            ),
+        )
+        for output, message in outputs:
+            with self.subTest(message=message), mock.patch(
+                "atrinik_workspace.delivery.subprocess.run",
+                return_value=SimpleNamespace(returncode=0, stdout=output, stderr=""),
+            ):
+                with self.assertRaisesRegex(WorkspaceError, message):
+                    inventory_active_delivery_evidence(self.root)
+
+    def test_inventory_rejects_invalid_worktree_paths_and_preserves_old_evidence(self) -> None:
+        output = {
+            "schema_version": 1,
+            "ledgers": [
+                {
+                    "name": self.name,
+                    "document": {
+                        "artifacts": [
+                            {"kind": "worktree", "current": "invalid"},
+                        ]
+                    },
+                }
+            ],
+            "pending": [{"target": self.name}],
+            "legacy_reports": [{"name": self.name}],
+            "releases": [],
+            "archives": [{"ledger_name": self.name}],
+            "reclaims": [{"name": self.name}],
+            "historical_ledgers": [{"name": self.name}],
+        }
+        with mock.patch(
+            "atrinik_workspace.delivery.subprocess.run",
+            return_value=SimpleNamespace(returncode=0, stdout=json.dumps(output), stderr=""),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "current is invalid"):
+                inventory_active_delivery_evidence(self.root)
+
+        output["ledgers"][0]["document"]["artifacts"] = [
+            {"kind": "worktree", "current": {"path": "relative"}}
+        ]
+        with mock.patch(
+            "atrinik_workspace.delivery.subprocess.run",
+            return_value=SimpleNamespace(returncode=0, stdout=json.dumps(output), stderr=""),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "current.path is not an absolute path"):
+                inventory_active_delivery_evidence(self.root)
+
+    def test_inventory_preserves_pending_legacy_and_terminal_evidence(self) -> None:
+        output = json.loads(self.inventory_output(self.root))
+        output.update(
+            {
+                "pending": [{"target": self.name}],
+                "legacy_reports": [{"name": self.name}],
+                "releases": [{"target": self.name}],
+                "archives": [{"ledger_name": self.name}],
+                "reclaims": [{"name": self.name}],
+                "historical_ledgers": [{"name": self.name}],
+            }
+        )
+        with mock.patch(
+            "atrinik_workspace.delivery.subprocess.run",
+            return_value=SimpleNamespace(returncode=0, stdout=json.dumps(output), stderr=""),
+        ):
+            evidence = inventory_active_delivery_evidence(self.root)
+
+        labels = evidence.references[self.review_root.resolve()]
+        self.assertIn(f"pending:{self.name}", labels)
+        self.assertIn(f"legacy:{self.name}", labels)
+        self.assertIn(f"release:{self.name}", labels)
+        self.assertIn(f"archive:{self.name}", labels)
+        self.assertIn(f"reclaim:{self.name}", labels)
+        self.assertIn(f"historical:{self.name}", labels)
+        self.assertIn(f"pending:{self.name}", evidence.transition_blockers)
 
     def test_unmanaged_review_root_is_protected(self) -> None:
         paths = SimpleNamespace(


### PR DESCRIPTION
Closes #471

## Summary

- Preserve active delivery ledgers, reports, and registered worktrees during wrapper and workspace transitions.
- Reject terminal lifecycle transitions that would discard active or unrecognized delivery evidence.
- Add crash and recovery coverage for generation-1 planned deliveries and older evidence.

## Validation

- `python3 -m unittest tests.test_delivery_ledger tests.test_migration`
- `python3 -m unittest discover -v`
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `git diff --check`
