### PR TITLE
fix(delivery): preserve lost evidence diagnostics

### DIFF
--- a/.agents/skills/atrinik-issue-delivery/references/delivery-ledger.md
+++ b/.agents/skills/atrinik-issue-delivery/references/delivery-ledger.md
@@ -1780,6 +1780,25 @@ completed pre-schema human report may later change; its frozen snapshot,
 complete marker, and ledger history retain the migration anchor. Loss or change
 of a required member stops.
 
+### Lost active evidence is an explicit stop
+
+If the inventory shows a missing canonical ledger, report, lock, migration
+member, marker, snapshot, or registered worktree, do not use a new `create`, a
+reconstructed report, or a branch/reflection of live GitHub state to take
+ownership. Preserve all remaining files, Git refs, and prunable registrations;
+the inventory error is the durable diagnostic and no issue, Project, branch,
+worktree, or PR mutation is permitted.
+
+The only recovery path is a separately authenticated `explicit-recovery`
+authority issued by the maintainer. The authority must bind the exact
+repository/issue or PR, branch/head, worktree, surviving source/report bytes,
+and recovery objective. With a surviving exact canonical report, rerun the
+matching provenance-preserving migration with its exact source digest and
+current coordinate candidate. If any required report or evidence is gone, the
+delivery cannot be re-created: stop and obtain a new maintainer decision. A
+durable goal, assignment, timestamp, authorship, reflog, link, or push access
+can corroborate continuity but cannot grant authority or replace bytes.
+
 ## Recover interrupted transactions
 
 Run `inventory` first. If it succeeds with a recognized pending operation,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,8 +148,11 @@ validation.
 Cleanup or repository-layout changes must also cover active issue-delivery
 evidence: an active ledger protects its review root, report, lock, and
 worktree; missing or unsupported evidence fails closed; and repository
-migration refuses active ledgers without mutating them. Recovery tests must
-prove that the wrapper does not synthesize missing ledger bytes or authority.
+migration refuses active ledgers without mutating them. Diagnostics must
+surface delivery-inventory failure on the affected review root. Recovery tests
+must prove that the wrapper does not synthesize missing ledger bytes or
+authority, and that only a separately authenticated explicit-recovery grant
+can select a provenance-preserving migration.
 
 For development-scope changes, also cover distinct scopes sharing one physical
 checkout, same-name/label/branch races, every publication boundary, exact JSON

--- a/README.md
+++ b/README.md
@@ -836,11 +836,14 @@ When `build/reviews` exists, cleanup inventories it through the canonical
 delivery-ledger helper and protects the review root, every active ledger's
 report and lock, and each ledger-owned worktree. Missing reports or locks,
 unsupported helper output, and unrecognized inventory errors protect the
-complete cleanup plan; the wrapper never recreates missing evidence. The
-repository migration preview and apply paths use the same inventory and refuse
-while any active ledger exists. Recovery therefore requires the authenticated
-delivery authority and exact preserved bytes; a fresh ledger, timestamp,
-branch, worktree, or issue assignment cannot substitute for lost evidence.
+complete cleanup plan and surface the inventory error on the affected review
+root; the wrapper never recreates missing evidence. The repository migration
+preview and apply paths use the same inventory and refuse while any active
+ledger exists. Recovery therefore requires a separately authenticated
+`explicit-recovery` grant and exact preserved bytes. A fresh ledger, timestamp,
+branch, worktree, issue assignment, Project state, or push access cannot
+substitute for lost evidence; when a required canonical report or member is
+gone, the safe result is an explicit stop awaiting maintainer direction.
 
 Profile builds are eligible only as direct
 `workspace/build/profiles/<profile>-<key>` children with an exact regular

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -2470,7 +2470,9 @@ class Cleanup:
                     reference_errors,
                 )
             )
-            items.extend(self._unmanaged_builds(registered, references))
+            items.extend(
+                self._unmanaged_builds(registered, references, reference_errors)
+            )
         if "temporary-states" in scopes and names is None:
             items.extend(self._temporary_states(older_than_days))
         if "npm-cache" in scopes:
@@ -5636,7 +5638,10 @@ class Cleanup:
             return False, str(error), None
 
     def _unmanaged_builds(
-        self, registered: set[Path], references: dict[str, Any]
+        self,
+        registered: set[Path],
+        references: dict[str, Any],
+        reference_errors: set[str],
     ) -> list[dict[str, Any]]:
         items: list[dict[str, Any]] = []
         roots: list[tuple[Path, list[Path]]] = []
@@ -5694,6 +5699,10 @@ class Cleanup:
             if delivery_references:
                 item["references"]["delivery"] = sorted(delivery_references)
                 item["reasons"].append("delivery_reference")
+            if "delivery_inventory_error" in reference_errors and _path_relation(
+                path, self._wrapper_primary / "build" / "reviews"
+            ):
+                item["reasons"].append("delivery_inventory_error")
             if error:
                 item["reasons"].append("filesystem_traversal_error")
                 item["error"] = error

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -509,15 +509,18 @@ inventory and projects every active ledger's review root, JSON sidecar,
 canonical report, persistent lock, and current worktree into its reference
 graph. A missing report or lock, unsupported helper result, malformed ledger,
 or any other inventory uncertainty makes the complete cleanup plan fail closed;
-the wrapper does not recreate or timestamp missing bytes. Unmanaged build
+the wrapper does not recreate or timestamp missing bytes, and the affected
+review root reports `delivery_inventory_error` for diagnosis. Unmanaged build
 discovery therefore cannot reclaim `build/reviews`, and a prunable Git
 worktree registration remains protected by the ledger's exact path reference.
 Repository migration uses the same barrier and refuses both preview and apply
 while active ledgers exist, so workspace-layout changes cannot move or lose
-their evidence. Recovery is authenticated and exact: only the delivery
-authority may continue a preserved ledger or explicitly recover a historical
-generation, and no reconstructed branch, worktree, timestamp, or issue state
-can stand in for missing authority.
+their evidence. Recovery is authenticated and exact: only a separately
+issued `explicit-recovery` authority may continue a preserved ledger or use a
+provenance-preserving migration. If the canonical report or another required
+member is gone, the delivery remains stopped; no reconstructed branch,
+worktree, timestamp, issue state, Project state, or push authority can stand
+in for missing evidence.
 
 Worktree status is inspected with `--ignore-submodules=none`. A populated
 submodule protects the worktree even when its visible files are clean because

--- a/tests/test_delivery.py
+++ b/tests/test_delivery.py
@@ -266,12 +266,31 @@ class DeliveryEvidenceTests(unittest.TestCase):
         cleanup.now = datetime.now(timezone.utc)
         references = {"delivery": {self.review_root.resolve(): [self.name]}}
 
-        items = cleanup._unmanaged_builds(set(), references)
+        items = cleanup._unmanaged_builds(set(), references, set())
 
         item = next(row for row in items if Path(row["path"]) == self.review_root)
         self.assertEqual(item["disposition"], "protected")
         self.assertIn("delivery_reference", item["reasons"])
         self.assertEqual(item["references"]["delivery"], [self.name])
+
+    def test_delivery_inventory_error_is_visible_on_review_root(self) -> None:
+        paths = SimpleNamespace(
+            repository=self.root,
+            builds=self.root / "workspace" / "build",
+        )
+        paths.builds.mkdir(parents=True)
+        cleanup = Cleanup.__new__(Cleanup)
+        cleanup._wrapper_primary = self.root
+        cleanup.paths = paths
+        cleanup.now = datetime.now(timezone.utc)
+
+        items = cleanup._unmanaged_builds(
+            set(), {"delivery": {}}, {"delivery_inventory_error"}
+        )
+
+        item = next(row for row in items if Path(row["path"]) == self.review_root)
+        self.assertEqual(item["disposition"], "protected")
+        self.assertIn("delivery_inventory_error", item["reasons"])
 
 
 class MigrationDeliveryBarrierTests(unittest.TestCase):


### PR DESCRIPTION
Closes #472

## Summary
- Preserve active issue-delivery recovery records across wrapper upgrades, workspace transitions, and terminal lifecycle operations.
- Fail closed on missing, unsupported, or unrecognized recovery evidence and retain explicit recovery authority for lost evidence.
- Add crash and recovery coverage for generation-1 planned wrapper-self deliveries and lifecycle boundaries.

## Validation
- `python3 -m unittest tests.test_delivery tests.test_migration tests.test_delivery_ledger`
- `python3 -m unittest discover -v`
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `git diff --check`
