### PR TITLE
test(delivery): reject multiple PR mirrors

### DIFF
--- a/tests/test_delivery_ledger.py
+++ b/tests/test_delivery_ledger.py
@@ -10328,12 +10328,21 @@ class DeliveryLedgerTests(unittest.TestCase):
             ) -> None:
                 pull_request_slot(after)["current"]["body_digest"] = "9" * 64
 
+            def reject_multiple_pr_mirrors(
+                before: dict[str, object], after: dict[str, object]
+            ) -> None:
+                for document in (before, after):
+                    duplicate = copy.deepcopy(pull_request_slot(document))
+                    duplicate["slot_id"] = "pull-request-secondary"
+                    document["artifacts"].append(duplicate)
+
             rejection_cases = (
                 ("adopted", reject_adopted),
                 ("contributor-owned", reject_contributor_body),
                 ("foreign-head", reject_foreign_head_repository),
                 ("actor-mismatch", reject_actor_mismatch),
                 ("additional-current-change", reject_additional_current_change),
+                ("multiple-pr-mirrors", reject_multiple_pr_mirrors),
             )
             for label, mutation in rejection_cases:
                 with self.subTest(pull_request_rejection=label):


### PR DESCRIPTION
Closes #456

## Summary

- add explicit regression coverage for rejecting multiple PR mirrors during target-head correction
- preserve the existing exact delivery-created PR binding and artifact safety contract

## Validation

- `python3 -m unittest tests.test_delivery_ledger.DeliveryLedgerTests.test_49_exact_target_head_correction_is_audited_and_resumable`
- `python3 -m unittest discover -v`
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `git diff --check`

<!-- atrinik-delivery:body:526aab9207734a7a7d6f225859f3592069aea605600b9c0553785c3c8fa3c9e6:start -->
## Delivery evidence

- Whole-diff review found no actionable findings; the change adds explicit rejection coverage for multiple PR mirrors while preserving the existing exact-binding contract.
- Local validation: 1,203 tests passed; coverage report, compileall, guidance inventory, manifest validation, supply-chain validation, and `git diff --check` passed.
- PR checks: CodeQL, policy, all integration shards, integration validation, and Codecov patch passed on head `6e337abfa76cf8f4d479f7a334fbf58489a84c1e`.

<!-- atrinik-delivery:body:526aab9207734a7a7d6f225859f3592069aea605600b9c0553785c3c8fa3c9e6:end -->