### PR TITLE
chore(supply-chain): track Classic content v6.0.0

### DIFF
--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -2635,13 +2635,13 @@
         "classic-server"
       ],
       "required": true,
-      "version": "v5.0.0",
+      "version": "v6.0.0",
       "version_source": "Classic server dependencies.lock.json content runtime input",
       "license": "LicenseRef-Atrinik-Asset-Per-File",
-      "source_url": "https://github.com/atrinik/content/releases/tag/v5.0.0",
-      "locator": "pkg:github/atrinik/content@v5.0.0",
-      "commit": "b0ccf98ed5e65d3d1a66f6dfce44c19122b26eef",
-      "checksum": "sha256:ac15a58d6ac07e9cbef64076dded0024a9a0c8b03d07748c1f0224d5901f4178",
+      "source_url": "https://github.com/atrinik/content/releases/tag/v6.0.0",
+      "locator": "pkg:github/atrinik/content@v6.0.0",
+      "commit": "7a4904172eee99fdd65482450fac219061676e5e",
+      "checksum": "sha256:dad5ef25be949e5874baba854b1ff008881e03ea42eefab0a14c6be38558b23d",
       "acquisition": "Classic release packaging obtains the archive from the exact durable dependency-bundle digest and rechecks it before safe extraction",
       "update_cadence_days": 30,
       "update_mechanism": "Daily fail-closed GitHub App proposal plus reviewed Classic compatibility update",
@@ -2653,7 +2653,7 @@
         {
           "repository": "classic-server",
           "path": "dependencies.lock.json",
-          "contains": "atrinik-content-5.0.0-classic-runtime.tar.gz"
+          "contains": "atrinik-content-6.0.0-classic-runtime.tar.gz"
         }
       ]
     },

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -255,10 +255,10 @@ class InventoryTests(unittest.TestCase):
             "source/atrinik-content-runtime"
         ]
         self.assertEqual(content_runtime.scope, ("classic-server",))
-        self.assertEqual(content_runtime.version, "v5.0.0")
+        self.assertEqual(content_runtime.version, "v6.0.0")
         self.assertEqual(
             content_runtime.checksum,
-            "sha256:ac15a58d6ac07e9cbef64076dded0024a9a0c8b03d07748c1f0224d5901f4178",
+            "sha256:dad5ef25be949e5874baba854b1ff008881e03ea42eefab0a14c6be38558b23d",
         )
 
         playtester_content_runtime = inventory.dependencies_by_id[


### PR DESCRIPTION
Synchronizes the wrapper supply-chain record with the verified Classic content lock update in [atrinik/classic#376](https://github.com/atrinik/classic/pull/376).

## Updated coordinate

- Tag: `v6.0.0`
- Source commit: `7a4904172eee99fdd65482450fac219061676e5e`
- Archive: `atrinik-content-6.0.0-classic-runtime.tar.gz`
- SHA-256: `dad5ef25be949e5874baba854b1ff008881e03ea42eefab0a14c6be38558b23d`

## Changes

- Update `supply-chain/inventory.json` for the Classic server content archive.
- Update the inventory regression expectation.

## Validation

- `python3 -m unittest tests.test_supply_chain -v` (53 passed)
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- Classic dependency-lock validation passed against `v6.0.0`.
- `git diff --check`

The durable Classic dependency bundle remains a separate publication step after the Classic lock PR merges.
