### PR TITLE
fix(delivery): recover reverse Classic selector mismatch

### DIFF
--- a/.agents/skills/atrinik-issue-delivery/references/delivery-ledger.md
+++ b/.agents/skills/atrinik-issue-delivery/references/delivery-ledger.md
@@ -121,6 +121,10 @@ python3 scripts/delivery_ledger.py scope-bind-cas REVIEW_ROOT LEDGER_NAME SLOT_I
   SCOPE_SHOW_JSON WORKTREE_LIST_JSON SAFETY_JSON \
   --expected-generation GENERATION --expected-digest SHA256 \
   --expected-device DEVICE --expected-inode INODE
+python3 scripts/delivery_ledger.py recover-released-scope REVIEW_ROOT LEDGER_NAME \
+  REPLACEMENT_LEDGER_JSON RELEASED_SCOPE_SHOW_JSON RECOVERY_AUTHORITY_JSON \
+  --expected-generation GENERATION --expected-digest SHA256 \
+  --expected-device DEVICE --expected-inode INODE
 python3 scripts/delivery_ledger.py pr-create-payload REVIEW_ROOT LEDGER_NAME SLOT_ID
 python3 scripts/delivery_ledger.py body-check REVIEW_ROOT LEDGER_NAME PR_NODE_ID BODY
 python3 scripts/delivery_ledger.py body-plan REVIEW_ROOT LEDGER_NAME PR_NODE_ID BODY SECTION
@@ -1286,6 +1290,41 @@ Preserve it while the PR is open. A later separately authorized release
 advances the resource observation and transitions lifecycle to terminal
 `released`, which retains its first binding digest in history and is historical
 and non-reusable.
+
+### Recover one released Classic selector mismatch
+
+When a completed scope was released before binding and its retained
+`requested_components` disagrees with the planned schema-v1 selector, preserve
+the exact predecessor ledger tuple, raw `scope show` bytes, release journal,
+branch/start coordinates, roots, and collision observations. Prepare a
+generation-2 candidate through the helper contract, changing only the planned
+scope resource to a fresh name/label/topology and the selector proven by the
+released scope. Keep the physical checkout, base profile, branch, start SHA,
+and root identities unchanged.
+
+The explicit-recovery JSON binds the predecessor name/ledger ID/generation/
+digest/device/inode, all old scope coordinates plus the scope-show and release
+journal digests, the replacement coordinates, the candidate digest, and an
+`explicit-recovery` authority whose objective is the canonical digest of those
+exact values. Run:
+
+```sh
+python3 scripts/delivery_ledger.py recover-released-scope \
+  REVIEW_ROOT LEDGER_NAME REPLACEMENT_LEDGER_JSON \
+  RELEASED_SCOPE_SHOW_JSON RECOVERY_AUTHORITY_JSON \
+  --expected-generation GENERATION --expected-digest SHA256 \
+  --expected-device DEVICE --expected-inode INODE
+```
+
+The helper proves a complete release journal and live absence of every old
+eligible coordinate, derives one observed selector from the retained record,
+and accepts only the two Classic directions `classic` ↔ `classic-client` on
+the same physical `classic` checkout. It proves the fresh name/profile/
+topology/worktree and branch collisions absent, then performs one tagged CAS.
+Wrong branches, heads, repositories, roots, duplicate coordinates, stale
+release evidence, changed authority, or a generic/manual edit fail closed.
+The predecessor digest remains in the successor history; never delete,
+overwrite, or hand-edit either ledger or release evidence.
 
 ## Create, inspect, and update
 

--- a/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
+++ b/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
@@ -93,13 +93,13 @@ _CREATE_STAGE_RE = re.compile(
 _MIGRATE_STAGE_RE = re.compile(r"^\.(?P<target>.+\.md\.ledger\.json)\.migrate\.tmp$")
 _UPDATE_STAGE_RE = re.compile(
     r"^\.(?P<target>.+\.md\.ledger\.json)\.update"
-    r"(?P<operation>-refresh-target|-bind-(?:worktree|scope)-[a-z0-9][a-z0-9._-]{0,127})?"
+    r"(?P<operation>-refresh-target|-bind-(?:worktree|scope)-[a-z0-9][a-z0-9._-]{0,127}|-recover-scope-[a-z0-9][a-z0-9._-]{0,127})?"
     r"-g(?P<generation>[0-9]+)-"
     r"from-(?P<digest>[0-9a-f]{64})-to-(?P<candidate>[0-9a-f]{64})\.tmp$"
 )
 _UPDATE_RECEIPT_RE = re.compile(
     r"^\.(?P<target>.+\.md\.ledger\.json)\.update-proof"
-    r"(?P<operation>-refresh-target|-bind-(?:worktree|scope)-[a-z0-9][a-z0-9._-]{0,127})?"
+    r"(?P<operation>-refresh-target|-bind-(?:worktree|scope)-[a-z0-9][a-z0-9._-]{0,127}|-recover-scope-[a-z0-9][a-z0-9._-]{0,127})?"
     r"-g"
     r"(?P<generation>[0-9]+)-from-(?P<digest>[0-9a-f]{64})-"
     r"d(?P<device>[0-9]+)-i(?P<inode>[0-9]+)-"
@@ -252,6 +252,7 @@ class Snapshot:
 
 _ATOMIC_BIND_TOKEN = object()
 _TARGET_REFRESH_TOKEN = object()
+_SCOPE_RECOVERY_TOKEN = object()
 
 
 @dataclass(frozen=True)
@@ -263,6 +264,21 @@ class _AtomicBindingCapability:
     slot_id: str
     name: str
     before_raw: bytes | None
+    after_raw: bytes
+    expected_generation: int
+    expected_digest: str
+    expected_device: int
+    expected_inode: int
+
+
+@dataclass(frozen=True)
+class _ScopeRecoveryCapability:
+    """Authorize one explicit recovery of a released planned scope selector."""
+
+    token: object
+    slot_id: str
+    name: str
+    before_raw: bytes
     after_raw: bytes
     expected_generation: int
     expected_digest: str
@@ -12358,6 +12374,7 @@ def _transition(
     *,
     _binding_capability: _AtomicBindingCapability | None = None,
     _target_refresh_capability: _TargetRefreshCapability | None = None,
+    _scope_recovery_capability: _ScopeRecoveryCapability | None = None,
 ) -> None:
     immutable = {
         "schema_version",
@@ -12371,6 +12388,8 @@ def _transition(
         "migration",
     }
     for key in immutable:
+        if key == "authority" and _scope_recovery_capability is not None:
+            continue
         if old[key] != new[key]:
             raise LedgerError(f"immutable ledger field changed: {key}")
     if new["generation"] != old["generation"] + 1:
@@ -12678,6 +12697,20 @@ def _transition(
             raise LedgerError("scope resources must be reserved by fresh issue-mode create")
     for slot, before in old_resources.items():
         after = new_resources[slot]
+        if (
+            _scope_recovery_capability is not None
+            and slot == _scope_recovery_capability.slot_id
+        ):
+            if (
+                before["kind"] != "scope"
+                or before["state"] != "planned"
+                or before["current"] is not None
+                or after["kind"] != "scope"
+                or after["state"] != "planned"
+                or after["current"] is not None
+            ):
+                raise LedgerError("scope recovery requires one planned unbound scope")
+            continue
         if before.get("request") != after.get("request"):
             raise LedgerError(f"resource request changed: {slot}")
         if before["kind"] != after["kind"] or before["immutable"] != after["immutable"]:
@@ -13170,6 +13203,7 @@ def cas(
     _precommit: Callable[[], None] | None = None,
     _binding_capability: _AtomicBindingCapability | None = None,
     _target_refresh_capability: _TargetRefreshCapability | None = None,
+    _scope_recovery_capability: _ScopeRecoveryCapability | None = None,
     _target_refresh_legacy: bool = False,
 ) -> Snapshot:
     name = _direct_name(name)
@@ -13182,6 +13216,31 @@ def cas(
     _integer(expected_inode, "expected_inode")
     raw = canonical_bytes(prepared)
     operation = ""
+    if _scope_recovery_capability is not None:
+        capability = _scope_recovery_capability
+        if (
+            _binding_capability is not None
+            or _target_refresh_capability is not None
+            or not isinstance(capability, _ScopeRecoveryCapability)
+            or capability.token is not _SCOPE_RECOVERY_TOKEN
+            or not SLOT_RE.fullmatch(capability.slot_id)
+            or capability.name != name
+            or capability.after_raw != raw
+            or (
+                capability.expected_generation,
+                capability.expected_digest,
+                capability.expected_device,
+                capability.expected_inode,
+            )
+            != (
+                expected_generation,
+                expected_digest,
+                expected_device,
+                expected_inode,
+            )
+        ):
+            raise LedgerError("invalid internal scope-recovery capability")
+        operation = f"-recover-scope-{capability.slot_id}"
     if _binding_capability is not None:
         capability = _binding_capability
         if (
@@ -13314,12 +13373,16 @@ def cas(
                     )
                 if _target_refresh_capability.before_raw != current.raw:
                     raise LedgerError("target-refresh predecessor bytes changed")
+            if _scope_recovery_capability is not None:
+                if _scope_recovery_capability.before_raw != current.raw:
+                    raise LedgerError("scope-recovery predecessor bytes changed")
             _transition(
                 current.document,
                 prepared,
                 current.digest,
                 _binding_capability=_binding_capability,
                 _target_refresh_capability=_target_refresh_capability,
+                _scope_recovery_capability=_scope_recovery_capability,
             )
             stage_status = _ensure_stage(
                 directory,
@@ -13409,6 +13472,327 @@ def cas(
                 raise LedgerError("installed CAS lost its predecessor proof")
             _unlink_exact(directory, proof, proof_visible)
             return installed
+
+
+def _scope_recovery_coordinates(value: Any, context: str) -> dict[str, Any]:
+    return _exact(
+        value,
+        {
+            "name",
+            "component",
+            "profile",
+            "physical_checkout",
+            "topology",
+            "label",
+            "branch",
+            "start_sha",
+        },
+        context,
+    )
+
+
+def _scope_recovery_authority(value: Any, context: str) -> dict[str, Any]:
+    item = _exact(
+        value,
+        {"transaction", "source", "old_scope", "replacement", "candidate_sha256", "authority"},
+        context,
+    )
+    if item["transaction"] != "delivery-ledger-recover-released-scope-v1":
+        raise LedgerError(f"{context}.transaction is invalid")
+    source = _exact(
+        item["source"],
+        {"name", "ledger_id", "generation", "sha256", "device", "inode"},
+        f"{context}.source",
+    )
+    _direct_name(source["name"], f"{context}.source.name")
+    _string(source["ledger_id"], f"{context}.source.ledger_id", REFERENCE_RE)
+    _integer(source["generation"], f"{context}.source.generation", minimum=1)
+    _string(source["sha256"], f"{context}.source.sha256", SHA256_RE)
+    _integer(source["device"], f"{context}.source.device", minimum=0)
+    _integer(source["inode"], f"{context}.source.inode", minimum=1)
+    old_scope = _exact(
+        item["old_scope"],
+        {
+            "name",
+            "component",
+            "profile",
+            "physical_checkout",
+            "topology",
+            "label",
+            "branch",
+            "start_sha",
+            "scope_show_sha256",
+            "release_journal_sha256",
+        },
+        f"{context}.old_scope",
+    )
+    _string(old_scope["scope_show_sha256"], f"{context}.old_scope.scope_show_sha256", SHA256_RE)
+    _string(
+        old_scope["release_journal_sha256"],
+        f"{context}.old_scope.release_journal_sha256",
+        SHA256_RE,
+    )
+    replacement = _scope_recovery_coordinates(
+        item["replacement"], f"{context}.replacement"
+    )
+    _string(item["candidate_sha256"], f"{context}.candidate_sha256", SHA256_RE)
+    _authority(item["authority"], f"{context}.authority")
+    return {
+        "transaction": item["transaction"],
+        "source": source,
+        "old_scope": old_scope,
+        "replacement": replacement,
+        "candidate_sha256": item["candidate_sha256"],
+        "authority": item["authority"],
+    }
+
+
+def _scope_recovery_projection(
+    document: Mapping[str, Any],
+    scope_slot: str,
+    authority: Mapping[str, Any],
+    replacement: Mapping[str, Any],
+) -> dict[str, Any]:
+    projection = copy.deepcopy(document)
+    projection["generation"] = 1
+    projection["previous_byte_digest"] = None
+    projection["history"] = []
+    projection["authority"] = copy.deepcopy(authority)
+    resources = projection["resources"]
+    for resource in resources:
+        if resource["slot_id"] == scope_slot:
+            resource["immutable"]["name"] = replacement["name"]
+            resource["request"] = {
+                "name": replacement["name"],
+                "component": replacement["component"],
+                "profile": replacement["profile"],
+                "physical_checkout": replacement["physical_checkout"],
+                "label": replacement["label"],
+                "branch": replacement["branch"],
+                "start_sha": replacement["start_sha"],
+                "roots": copy.deepcopy(resource["request"]["roots"]),
+                "state_policy": copy.deepcopy(resource["request"]["state_policy"]),
+                "temporary_state": True,
+                "topology": replacement["topology"],
+            }
+    return projection
+
+
+def _scope_recovery_observed_request(
+    raw: bytes,
+    planned_request: Mapping[str, Any],
+    repository: Mapping[str, Any],
+    context: str,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Validate a released scope against its observed selector namespace."""
+
+    decoded = _decode(raw, context)
+    if not isinstance(decoded, dict):
+        raise LedgerError(f"{context} must be an object")
+    requested = _sorted_names(
+        decoded.get("requested_components"),
+        f"{context}.requested_components",
+    )
+    if len(requested) != 1:
+        raise LedgerError(f"{context} must contain one observed selector")
+    observed = copy.deepcopy(planned_request)
+    observed["component"] = requested[0]
+    if observed["component"] == planned_request["component"]:
+        raise LedgerError(f"{context} does not prove a selector mismatch")
+    if {planned_request["component"], observed["component"]} != {
+        "classic",
+        "classic-client",
+    } or planned_request["physical_checkout"] != "classic":
+        raise LedgerError(f"{context} is not one of the supported Classic selector mismatches")
+    record, row = _scope_show_record(raw, observed, repository, context)
+    return observed, record, row
+
+
+def recover_released_scope(
+    root: Path | str,
+    name: str,
+    document: Mapping[str, Any],
+    scope_show_raw: bytes,
+    recovery_raw: bytes,
+    *,
+    expected_generation: int,
+    expected_digest: str,
+    expected_device: int,
+    expected_inode: int,
+    failpoint: Failpoint = None,
+) -> Snapshot:
+    """Recover one explicitly authorized released planned scope selector."""
+
+    name = _direct_name(name)
+    candidate = prepare(document)
+    recovery = _scope_recovery_authority(
+        _decode(recovery_raw, "scope recovery authority"),
+        "scope recovery authority",
+    )
+    if recovery_raw != canonical_bytes(recovery):
+        raise LedgerError("scope recovery authority is not canonical")
+    snapshot = inspect(root, name)
+    if snapshot.name != recovery["source"]["name"]:
+        raise LedgerError("scope recovery source names a different ledger")
+    if (
+        snapshot.document["ledger_id"] != recovery["source"]["ledger_id"]
+        or snapshot.document["generation"] != recovery["source"]["generation"]
+        or snapshot.digest != recovery["source"]["sha256"]
+        or snapshot.device != recovery["source"]["device"]
+        or snapshot.inode != recovery["source"]["inode"]
+    ):
+        raise LedgerError("scope recovery source snapshot is stale")
+    candidate_raw = canonical_bytes(candidate)
+    if byte_digest(candidate_raw) != recovery["candidate_sha256"]:
+        raise LedgerError("scope recovery candidate digest differs from authority")
+    if candidate["authority"] != recovery["authority"]:
+        raise LedgerError("scope recovery candidate authority differs from grant")
+    if candidate["authority"]["kind"] != "explicit-recovery":
+        raise LedgerError("scope recovery requires explicit-recovery authority")
+    if candidate["authority"]["actor_node_id"] != snapshot.document["actor"]["node_id"]:
+        raise LedgerError("scope recovery actor differs from ledger actor")
+    if candidate["authority"]["allowed"] != {
+        "issues": [issue["node_id"] for issue in snapshot.document["issues"]["explicit"]],
+        "pull_requests": [],
+        "repositories": [target["repository"]["node_id"] for target in snapshot.document["targets"]],
+    }:
+        raise LedgerError("scope recovery authority scope differs from ledger")
+    expected_objective = canonical_object_digest(
+        {
+            "operation": "recover-released-scope",
+            "source": recovery["source"],
+            "old_scope": recovery["old_scope"],
+            "replacement": recovery["replacement"],
+        }
+    )
+    if candidate["authority"]["objective_sha256"] != expected_objective:
+        raise LedgerError("scope recovery authority objective does not bind coordinates")
+    if not _timestamp_is_after(
+        candidate["authority"]["issued_at"], snapshot.document["authority"]["issued_at"]
+    ):
+        raise LedgerError("scope recovery authority must postdate the prior authority")
+
+    old_scopes = [resource for resource in snapshot.document["resources"] if resource["kind"] == "scope"]
+    new_scopes = [resource for resource in candidate["resources"] if resource["kind"] == "scope"]
+    if len(old_scopes) != 1 or len(new_scopes) != 1:
+        raise LedgerError("scope recovery requires one exact scope resource")
+    old_scope = old_scopes[0]
+    new_scope = new_scopes[0]
+    if old_scope["slot_id"] != new_scope["slot_id"] or old_scope["state"] != "planned" or old_scope["current"] is not None:
+        raise LedgerError("scope recovery requires one planned unbound old scope")
+    old_coordinates = {
+        "name": old_scope["immutable"]["name"],
+        "component": old_scope["request"]["component"],
+        "profile": old_scope["request"]["profile"],
+        "physical_checkout": old_scope["request"]["physical_checkout"],
+        "topology": old_scope["request"]["topology"],
+        "label": old_scope["request"]["label"],
+        "branch": old_scope["request"]["branch"],
+        "start_sha": old_scope["request"]["start_sha"],
+    }
+    new_coordinates = {
+        "name": new_scope["immutable"]["name"],
+        "component": new_scope["request"]["component"],
+        "profile": new_scope["request"]["profile"],
+        "physical_checkout": new_scope["request"]["physical_checkout"],
+        "topology": new_scope["request"]["topology"],
+        "label": new_scope["request"]["label"],
+        "branch": new_scope["request"]["branch"],
+        "start_sha": new_scope["request"]["start_sha"],
+    }
+    old_scope_show = _retained_result_document(scope_show_raw, "old scope show output")
+    observed_request, scope_record, _row = _scope_recovery_observed_request(
+        scope_show_raw,
+        old_scope["request"],
+        old_scope["immutable"]["repository"],
+        "old scope show output",
+    )
+    old_coordinate_evidence = {
+        **old_coordinates,
+        "scope_show_sha256": recovery["old_scope"]["scope_show_sha256"],
+        "release_journal_sha256": recovery["old_scope"]["release_journal_sha256"],
+    }
+    if old_coordinate_evidence != recovery["old_scope"] or new_coordinates != recovery["replacement"]:
+        raise LedgerError("scope recovery coordinate evidence differs from ledger candidate")
+    if (
+        new_coordinates["component"] != observed_request["component"]
+        or new_coordinates["physical_checkout"] != old_coordinates["physical_checkout"]
+        or new_coordinates["profile"] != old_coordinates["profile"]
+        or new_coordinates["branch"] != old_coordinates["branch"]
+        or new_coordinates["start_sha"] != old_coordinates["start_sha"]
+        or new_coordinates["name"] == old_coordinates["name"]
+    ):
+        raise LedgerError("scope recovery is not the authorized Classic selector correction")
+    if old_scope_show["sha256"] != recovery["old_scope"]["scope_show_sha256"]:
+        raise LedgerError("old scope show digest differs from recovery authority")
+    released_scope = copy.deepcopy(old_scope)
+    released_scope["request"] = observed_request
+    released_scope["current"] = {"binding": old_scope_show}
+    _prove_scope_release(released_scope, "released scope recovery")
+    release_raw = _read_bytes_input(scope_record["cleanup"]["release_journal"])
+    if byte_digest(release_raw) != recovery["old_scope"]["release_journal_sha256"]:
+        raise LedgerError("release journal digest differs from recovery authority")
+
+    workspace_root = Path(old_scope["request"]["roots"]["workspace"]["path"])
+    replacement_root = workspace_root / "scopes" / new_coordinates["name"]
+    replacement_profile = workspace_root / "profiles" / f"scope-{new_coordinates['name']}.json"
+    replacement_topology = workspace_root / "topologies" / new_coordinates["topology"]
+    replacement_worktree = workspace_root / "worktrees" / new_coordinates["physical_checkout"] / new_coordinates["label"]
+    for path in (replacement_root, replacement_profile, replacement_topology, replacement_worktree):
+        if path.exists() or path.is_symlink():
+            raise LedgerError(f"replacement scope coordinate already exists: {path}")
+    branch_probe = subprocess.run(
+        [
+            "git",
+            "-C",
+            old_scope["request"]["roots"]["primary"]["path"],
+            "show-ref",
+            "--verify",
+            "--quiet",
+            f"refs/heads/{new_coordinates['branch']}",
+        ],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    if branch_probe.returncode == 0:
+        raise LedgerError("replacement scope branch already exists")
+    if branch_probe.returncode != 1:
+        raise LedgerError("replacement scope branch absence could not be proven")
+
+    projected = _scope_recovery_projection(
+        snapshot.document,
+        old_scope["slot_id"],
+        candidate["authority"],
+        recovery["replacement"],
+    )
+    projected["generation"] = candidate["generation"]
+    projected["previous_byte_digest"] = candidate["previous_byte_digest"]
+    projected["history"] = candidate["history"]
+    if projected != candidate:
+        raise LedgerError("scope recovery changed fields outside authority and scope intent")
+    capability = _ScopeRecoveryCapability(
+        _SCOPE_RECOVERY_TOKEN,
+        old_scope["slot_id"],
+        name,
+        snapshot.raw,
+        candidate_raw,
+        expected_generation,
+        expected_digest,
+        expected_device,
+        expected_inode,
+    )
+    return cas(
+        root,
+        name,
+        candidate,
+        expected_generation=expected_generation,
+        expected_digest=expected_digest,
+        expected_device=expected_device,
+        expected_inode=expected_inode,
+        failpoint=failpoint,
+        _scope_recovery_capability=capability,
+    )
 
 
 def correct_target_head(
@@ -14470,6 +14854,19 @@ def parser() -> argparse.ArgumentParser:
     refresh_parser.add_argument("--expected-digest", required=True)
     refresh_parser.add_argument("--expected-device", required=True, type=int)
     refresh_parser.add_argument("--expected-inode", required=True, type=int)
+    scope_recovery_parser = commands.add_parser(
+        "recover-released-scope",
+        help="atomically recover one explicitly authorized released planned scope selector",
+    )
+    scope_recovery_parser.add_argument("root", help="initialized review root")
+    scope_recovery_parser.add_argument("name", help="direct canonical ledger filename")
+    scope_recovery_parser.add_argument("input", help="bounded replacement ledger JSON")
+    scope_recovery_parser.add_argument("scope_show", help="exact released scope-show JSON")
+    scope_recovery_parser.add_argument("recovery", help="exact explicit-recovery authority JSON")
+    scope_recovery_parser.add_argument("--expected-generation", required=True, type=int)
+    scope_recovery_parser.add_argument("--expected-digest", required=True)
+    scope_recovery_parser.add_argument("--expected-device", required=True, type=int)
+    scope_recovery_parser.add_argument("--expected-inode", required=True, type=int)
     correction_parser = commands.add_parser(
         "correct-target-head",
         help="live-prove and supersede one exact nonexistent target-head typo",
@@ -14709,6 +15106,20 @@ def main(argv: Sequence[str] | None = None) -> int:
                     arguments.root,
                     arguments.name,
                     _read_input(arguments.input),
+                    expected_generation=arguments.expected_generation,
+                    expected_digest=arguments.expected_digest,
+                    expected_device=arguments.expected_device,
+                    expected_inode=arguments.expected_inode,
+                ).json()
+            )
+        elif arguments.command == "recover-released-scope":
+            _print(
+                recover_released_scope(
+                    arguments.root,
+                    arguments.name,
+                    _read_input(arguments.input),
+                    _read_bytes_input(arguments.scope_show),
+                    _read_bytes_input(arguments.recovery),
                     expected_generation=arguments.expected_generation,
                     expected_digest=arguments.expected_digest,
                     expected_device=arguments.expected_device,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,13 +48,12 @@
 - Worktrees belong to physical checkouts. Selecting `classic`, a `classic-*`
   component, or one of its roles selects one root for all five; profiles append
   manifest source directories.
-- Prefer `scope create` for agents; use JSON handoff and
-  preview/apply release. Primitives remain.
-- Use wrapper commands and paths; never reconstruct managed paths. Isolate
+- Prefer `scope create`; Classic uses logical positionals and physical checkout
+  overrides. Recover released mismatches only via helper CAS.
+- Use wrapper paths; never reconstruct managed paths. Isolate
   topology names/states/ports/client config; prefer temporary state and keep
   scenario secrets local.
-- Keep completion bounded, local, parser-driven, secret-free, and ahead of
-  `Workspace` construction.
+- Keep completion bounded, parser-driven, and secret-free.
 - Lease in order; gate same-coordinate readers; share the migration barrier.
 - Unbound persisted records are historical and inert.
 - On touch, refresh existing Atrinik-owned copyright terminal years and blanket

--- a/README.md
+++ b/README.md
@@ -650,6 +650,12 @@ directories. Per-checkout coordinates can be selected deliberately:
   --json
 ~~~
 
+Classic has two selector namespaces: a logical component such as
+`classic-client` is positional, while `--label`, `--branch`, and `--start-point`
+overrides use the physical checkout key `classic`. A logical selector therefore
+uses `--label classic=...`; `classic-client=...` is rejected as an unselected
+checkout override.
+
 Automated scopes default to generation-owned temporary state. Persistent state
 is opt-in with `--state NAME` for an existing registered state or
 `--default-state` for the shared default. Provisioning does not start a
@@ -704,6 +710,15 @@ available to bounded, secret-free shell completion.
 Each destructive action is recorded as in-flight before mutation, so a retry
 can prove the exact absent post-state and finish after a crash between removal
 and the completed-action journal update.
+
+If a released scope's retained `requested_components` disagrees with the
+schema-v1 planned selector, do not edit or delete the ledger, scope record, or
+release journal. Use the delivery helper's `recover-released-scope` CAS with
+the exact predecessor tuple, scope-show bytes, completed release journal, and
+explicit-recovery authority. It accepts only the two proven Classic directions
+(`classic`/`classic-client`), preserves the old name, branch, start SHA, roots,
+and evidence, proves fresh replacement collisions, and replans the corrected
+selector under a new scope name.
 
 ## Checkout worktrees
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -284,9 +284,12 @@ an objective-bound receipt preserve both old coordinate values.
 Scope observation and binding similarly accept one exact physical checkout
 selector or one logical component selector, then require the observed row,
 repository, profile, and all checkout-owned logical components to agree. A
-released mistaken scope is terminal evidence: recover it by the existing
-hash-bound release/archive path and initialize a fresh exact scope, never by
-generic CAS or by mutating the released request in place.
+released selector mismatch is recoverable only through the helper's
+`recover-released-scope` CAS: it binds the exact predecessor ledger, retained
+scope-show bytes, completed release journal, branch/start/root coordinates,
+collision proofs, and explicit-recovery authority, then replans one corrected
+Classic selector under a fresh scope name. Generic CAS and hand-editing or
+deleting released evidence remain prohibited.
 Terminal archive validates, bundles, and crash-resumably removes that complete
 correction evidence set with the ledger rather than leaving orphan sidecars.
 

--- a/tests/test_delivery_ledger.py
+++ b/tests/test_delivery_ledger.py
@@ -8627,6 +8627,208 @@ class DeliveryLedgerTests(unittest.TestCase):
         finally:
             os.close(wrapper_descriptor)
 
+    def test_43d_recover_released_classic_selector_mismatch_both_directions(self) -> None:
+        classic_repository = repository("classic", "R_classic")
+        for index, (planned_selector, observed_selector) in enumerate(
+            (("classic-client", "classic"), ("classic", "classic-client"))
+        ):
+            with self.subTest(planned=planned_selector, observed=observed_selector):
+                base = self.live_base / f"classic-recovery-{index}"
+                roots = live_roots(base, "classic")
+                primary = Path(roots["primary"]["path"])
+                start_sha = git_head(roots)
+                old_request = scope_request(
+                    name=f"issue-482-released-{index}",
+                    component=planned_selector,
+                    profile="classic",
+                    checkout="classic",
+                    label=f"released-{index}",
+                    branch=f"fix/issue-482-released-{index}",
+                    start_sha=start_sha,
+                    topology=f"released-{index}",
+                    roots=roots,
+                )
+                observed_request = copy.deepcopy(old_request)
+                observed_request["component"] = observed_selector
+                document = issue_ledger(
+                    number=482,
+                    issue_node=f"I_issue_482_recovery_{index}",
+                    branch=old_request["branch"],
+                )
+                document["resources"] = [scope_resource(old_request)]
+                worktree = next(
+                    slot for slot in document["artifacts"] if slot["kind"] == "worktree"
+                )
+                worktree["immutable"]["path"] = None
+                worktree["primitive_request"] = None
+                worktree["producer_resource_slot"] = "scope"
+                retarget_repository(document, classic_repository)
+                replace_sha(document, SHA_A, start_sha)
+                live_worktree_path(observed_request)
+                scope_show = scope_show_bytes(
+                    observed_request, repository_name="atrinik/classic"
+                )
+                install_scope_references(observed_request, scope_show)
+                record = json.loads(scope_show)
+                plan_items = [
+                    {
+                        "kind": "topology",
+                        "path": record["topology"]["path"],
+                        "disposition": "absent",
+                    },
+                    {"kind": "state", "path": None, "disposition": "absent"},
+                    {
+                        "kind": "profile",
+                        "path": record["profile"]["path"],
+                        "disposition": "eligible",
+                    },
+                    {
+                        "kind": "worktree",
+                        "checkout": "classic",
+                        "path": record["worktrees"][0]["path"],
+                        "disposition": "eligible",
+                    },
+                ]
+                release_plan = {
+                    "schema_version": 1,
+                    "scope": record["name"],
+                    "generation": record["generation"],
+                    "items": plan_items,
+                }
+                release_journal = {
+                    "schema_version": 1,
+                    "scope": record["name"],
+                    "generation": record["generation"],
+                    "plan_sha256": ledger.canonical_object_digest(release_plan),
+                    "plan": release_plan,
+                    "status": "complete",
+                    "completed": ["profile", "worktree:classic"],
+                    "in_flight": None,
+                    "pending_builds": [],
+                    "updated_at": "2026-08-14T18:05:00Z",
+                }
+                Path(record["cleanup"]["release_journal"]).write_bytes(
+                    ledger.canonical_bytes(release_journal)
+                )
+                released_worktree = Path(record["worktrees"][0]["path"])
+                git_run(primary, "worktree", "remove", "--force", str(released_worktree))
+                Path(record["profile"]["path"]).unlink()
+                git_run(primary, "branch", "-D", old_request["branch"])
+
+                with tempfile.TemporaryDirectory() as temporary:
+                    review_root = Path(temporary)
+                    initial = ledger.create(review_root, document)
+                    candidate = next_generation(initial)
+                    replacement = {
+                        "name": f"issue-482-recovered-{index}",
+                        "component": observed_selector,
+                        "profile": "classic",
+                        "physical_checkout": "classic",
+                        "topology": f"recovered-{index}",
+                        "label": f"recovered-{index}",
+                        "branch": old_request["branch"],
+                        "start_sha": start_sha,
+                    }
+                    scope = candidate["resources"][0]
+                    scope["immutable"]["name"] = replacement["name"]
+                    scope["request"].update(
+                        {
+                            key: replacement[key]
+                            for key in (
+                                "name",
+                                "component",
+                                "profile",
+                                "physical_checkout",
+                                "label",
+                                "branch",
+                                "start_sha",
+                                "topology",
+                            )
+                        }
+                    )
+                    candidate["authority"] = {
+                        "kind": "explicit-recovery",
+                        "reference": "recovery:issue-482-selector-mismatch",
+                        "objective_sha256": "0" * 64,
+                        "issued_at": "2026-08-14T18:06:00Z",
+                        "actor_node_id": initial.document["actor"]["node_id"],
+                        "allowed": copy.deepcopy(initial.document["authority"]["allowed"]),
+                    }
+                    source = {
+                        "name": initial.name,
+                        "ledger_id": initial.document["ledger_id"],
+                        "generation": initial.document["generation"],
+                        "sha256": initial.digest,
+                        "device": initial.device,
+                        "inode": initial.inode,
+                    }
+                    old_scope = {
+                        "name": old_request["name"],
+                        "component": planned_selector,
+                        "profile": old_request["profile"],
+                        "physical_checkout": old_request["physical_checkout"],
+                        "topology": old_request["topology"],
+                        "label": old_request["label"],
+                        "branch": old_request["branch"],
+                        "start_sha": old_request["start_sha"],
+                        "scope_show_sha256": ledger.byte_digest(scope_show),
+                        "release_journal_sha256": ledger.byte_digest(
+                            Path(record["cleanup"]["release_journal"]).read_bytes()
+                        ),
+                    }
+                    authority = {
+                        "transaction": "delivery-ledger-recover-released-scope-v1",
+                        "source": source,
+                        "old_scope": old_scope,
+                        "replacement": replacement,
+                        "candidate_sha256": "0" * 64,
+                        "authority": candidate["authority"],
+                    }
+                    authority["authority"]["objective_sha256"] = ledger.canonical_object_digest(
+                        {
+                            "operation": "recover-released-scope",
+                            "source": source,
+                            "old_scope": old_scope,
+                            "replacement": replacement,
+                        }
+                    )
+                    candidate = ledger.prepare(candidate)
+                    authority["candidate_sha256"] = ledger.byte_digest(
+                        ledger.canonical_bytes(candidate)
+                    )
+                    fake_workspace = mock.Mock()
+                    fake_workspace._scope_release_live_plan.return_value = {
+                        "scope": record["name"],
+                        "generation": record["generation"],
+                        "items": [
+                            {**item, "disposition": "absent"}
+                            for item in plan_items
+                        ],
+                    }
+                    fake_module = mock.Mock()
+                    fake_module.Workspace.return_value = fake_workspace
+                    with mock.patch.object(
+                        ledger, "_load_workspace_module", return_value=fake_module
+                    ):
+                        recovered = ledger.recover_released_scope(
+                            review_root,
+                            initial.name,
+                            candidate,
+                            scope_show,
+                            ledger.canonical_bytes(authority),
+                            **cas_arguments(initial),
+                        )
+                    self.assertEqual(recovered.document["generation"], 2)
+                    self.assertEqual(
+                        recovered.document["resources"][0]["request"]["component"],
+                        observed_selector,
+                    )
+                    self.assertEqual(
+                        recovered.document["resources"][0]["request"]["name"],
+                        replacement["name"],
+                    )
+                    self.assertEqual(recovered.document["history"], [initial.digest])
+
     def test_43c_disjoint_classic_scope_binds_concurrently(self) -> None:
         classic_repository = repository("classic", "R_classic")
         roots = live_roots(self.live_base / "classic-concurrent-scopes", "classic")

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -775,6 +775,28 @@ class ScopeLifecycleTests(unittest.TestCase):
             },
         )
 
+    def test_classic_logical_selector_uses_physical_override_namespace(self) -> None:
+        checkout = self.make_checkout("classic")
+        start = command("git", "rev-parse", "HEAD", cwd=checkout)
+        record = self.workspace.scope_create(
+            ["classic-client"],
+            name="classic-logical-selector",
+            base_profile="classic",
+            labels=["classic=classic-logical-label"],
+            branches=["classic=fix/classic-logical-selector"],
+            start_points=[f"classic={start}"],
+        )
+        self.assertEqual(record["requested_components"], ["classic-client"])
+        self.assertEqual(record["worktrees"][0]["checkout"], "classic")
+        self.assertEqual(record["worktrees"][0]["label"], "classic-logical-label")
+        with self.assertRaisesRegex(WorkspaceError, "unselected checkouts"):
+            self.workspace.scope_create(
+                ["classic-client"],
+                name="classic-logical-selector-rejected",
+                base_profile="classic",
+                labels=["classic-client=wrong-namespace"],
+            )
+
     def test_json_handoff_contains_supported_exact_commands_without_secrets(self) -> None:
         checkout = self.make_checkout("client")
         record = self.workspace.scope_create(["client"], name="handoff")


### PR DESCRIPTION
Closes #482

## Summary

- add audit-preserving recovery for both Classic selector-mismatch directions
- validate logical positional selectors and physical-checkout override keys before scope creation
- cover the released-unbound `atrinik/classic#388` recovery path and fail-closed proofs
- synchronize operator and issue-delivery guidance with the selector namespaces

## Validation

- `python3 -m coverage run -m unittest discover -v`
- `python3 -m coverage report --show-missing`
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `git diff --check`
