### PR TITLE
feat(release): support semantic-release maintenance branches

### DIFF
--- a/.agents/skills/atrinik-github-governance/SKILL.md
+++ b/.agents/skills/atrinik-github-governance/SKILL.md
@@ -36,7 +36,9 @@ description: Publish Atrinik PRs, govern GitHub policy, or review and explicitly
 
 ## Publish pull requests
 
-Use `type(optional-scope)!: concise description` for PR titles. Write bodies as
+Use `type(optional-scope): concise description` for PR titles by default. Add
+`!` only when a reviewer explicitly requests a breaking change that should
+trigger the next major release; do not add it automatically. Write bodies as
 renderable GitHub-Flavored Markdown with actual line breaks, never visible
 literal `\n` separators. Pass multi-section bodies by file, standard input, or
 another newline-preserving method. After create/edit, inspect GitHub's rendered

--- a/.agents/skills/atrinik-github-governance/SKILL.md
+++ b/.agents/skills/atrinik-github-governance/SKILL.md
@@ -36,15 +36,12 @@ description: Publish Atrinik PRs, govern GitHub policy, or review and explicitly
 
 ## Publish pull requests
 
-Use `type(optional-scope): concise description` for PR titles by default. Add
-`!` only when a reviewer explicitly requests a breaking change that should
-trigger the next major release; do not add it automatically. Write bodies as
-renderable GitHub-Flavored Markdown with actual line breaks, never visible
-literal `\n` separators. Pass multi-section bodies by file, standard input, or
-another newline-preserving method. After create/edit, inspect GitHub's rendered
-web view or rendered `bodyHTML`/`body_html`, not only the raw body. Verify
-headings, lists, inline code, issue-closing references, and validation sections
-render normally.
+Titles use `type(optional-scope): concise description` by default. Add `!` only
+when a reviewer explicitly requests a breaking change; not automatically.
+Bodies: GitHub-Flavored Markdown with actual line breaks, never literal `\n`
+separators. Feed multi-section bodies by file/stdin. After create/edit, inspect
+GitHub's `bodyHTML`/`body_html`, not raw body; verify headings, lists,
+inline code, issue-closing references, and validation sections.
 
 ## Validate and hand off
 

--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -124,10 +124,11 @@ executables or generated paths.
 ## Coordinate publication and policy
 
 Use `atrinik-github-governance` for PRs or policy. Titles use
-`type(optional-scope)!: concise description`; bodies require renderable
-GitHub-Flavored Markdown and actual line breaks, never visible literal `\n`
-separators. Feed multi-section bodies by file/stdin. After create/edit, verify remote
-render.
+`type(optional-scope): concise description` by default; add `!` only when a
+reviewer explicitly requests a breaking change that should trigger the next
+major release. Bodies require renderable GitHub-Flavored Markdown and actual
+line breaks, never visible literal `\n` separators. Feed multi-section bodies
+by file/stdin. After create/edit, verify remote render.
 Semantic-release owns publication. Dependency changes update inventory and
 audit a profile. Follow `docs/PROVENANCE.md`; fail uncertainty closed.
 

--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -123,12 +123,11 @@ executables or generated paths.
 
 ## Coordinate publication and policy
 
-Use `atrinik-github-governance` for PRs or policy. Titles use
+Use `atrinik-github-governance` for PRs. Titles:
 `type(optional-scope): concise description` by default; add `!` only when a
-reviewer explicitly requests a breaking change that should trigger the next
-major release. Bodies require renderable GitHub-Flavored Markdown and actual
-line breaks, never visible literal `\n` separators. Feed multi-section bodies
-by file/stdin. After create/edit, verify remote render.
+reviewer explicitly requests a breaking change, not auto. Bodies use
+GitHub-Flavored Markdown, actual line breaks, never literal `\n` separators.
+Feed multi-section bodies by file/stdin; after create/edit, verify remote.
 Semantic-release owns publication. Dependency changes update inventory and
 audit a profile. Follow `docs/PROVENANCE.md`; fail uncertainty closed.
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -20,6 +20,7 @@ jobs:
           pattern='^[a-z][a-z0-9-]*(\([a-z0-9][a-z0-9._/-]*\))?(!)?: .+'
           if [[ ! ${PR_TITLE} =~ ${pattern} ]]; then
             echo "PR title must use Conventional Commits style:" >&2
-            echo "  type(optional-scope)!: concise description" >&2
+            echo "  type(optional-scope): concise description" >&2
+            echo "  add ! only for an explicitly requested breaking change" >&2
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,9 @@ name: Semantic Release
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches:
+      - main
+      - '[0-9]+.[0-9]+.x'
 
 permissions:
   contents: write

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": ["main"],
+  "branches": ["+([0-9]).+([0-9]).x", "main"],
   "tagFormat": "v${version}",
   "plugins": [
     ["@semantic-release/commit-analyzer", {"preset": "conventionalcommits", "releaseRules": [{"breaking": true, "release": "major"}, {"type": "feat", "release": "minor"}, {"type": "*", "release": "patch"}]}],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,12 +63,16 @@
 - Update `supply-chain/inventory.json` when dependency ownership/validation
   changes. Keep Actions/images immutable, add no submodules, and audit a full
   profile. Only aggregate-root workflows and Dependabot are active.
-- Commits and PR titles use `type(optional-scope)!: concise description`. PR
-  bodies require renderable GitHub-Flavored Markdown and actual line breaks,
-  never visible literal `\n` separators. Feed multi-section bodies by file or
-  stdin; after create/edit, verify remote rendering. Use
+- Commits and PR titles use `type(optional-scope): concise description` by
+  default. Add `!` only when a reviewer explicitly requests a breaking change
+  that should trigger the next major release. PR bodies require renderable
+  GitHub-Flavored Markdown and actual line breaks, never visible literal `\n`
+  separators. Feed multi-section bodies by file or stdin; after create/edit,
+  verify remote rendering. Use
   `atrinik-github-governance` for publication, policy, or native PR stacks.
-  Semantic-release owns tags/assets; keep unreleased work off public surfaces.
+  Semantic-release owns tags/assets; `main` is the forward release line and
+  numeric `X.Y.x` branches are patch-only maintenance lines. Keep unreleased
+  work off public surfaces.
 
 ## Working agreements and commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,15 +64,12 @@
   changes. Keep Actions/images immutable, add no submodules, and audit a full
   profile. Only aggregate-root workflows and Dependabot are active.
 - Commits and PR titles use `type(optional-scope): concise description` by
-  default. Add `!` only when a reviewer explicitly requests a breaking change
-  that should trigger the next major release. PR bodies require renderable
-  GitHub-Flavored Markdown and actual line breaks, never visible literal `\n`
-  separators. Feed multi-section bodies by file or stdin; after create/edit,
-  verify remote rendering. Use
-  `atrinik-github-governance` for publication, policy, or native PR stacks.
-  Semantic-release owns tags/assets; `main` is the forward release line and
-  numeric `X.Y.x` branches are patch-only maintenance lines. Keep unreleased
-  work off public surfaces.
+  default. Add `!` only when a reviewer explicitly requests a breaking change;
+  not auto. Bodies use GitHub-Flavored Markdown and actual
+  line breaks, never literal `\n` separators. Feed multi-section bodies by
+  file/stdin; after create/edit, verify remote. Use `atrinik-github-governance`
+  for PRs. Semantic-release owns tags; keep unreleased work off
+  public surfaces.
 
 ## Working agreements and commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,12 +3,37 @@
 Use Conventional Commits syntax for commits and pull-request titles:
 
 ~~~text
-type(optional-scope)!: concise description
+type(optional-scope): concise description
 ~~~
 
 Examples include `fix(cli): reject mismatched checkout paths` and
-`feat!: revise the profile schema`. Pull requests are squash-merged, and the
-squash title becomes the release-driving commit on `main`.
+`feat(agents): revise the profile schema`. Add the optional `!` marker only
+when a reviewer explicitly requests a breaking change that should trigger the
+next major release; agents should not add it automatically. Pull requests are
+squash-merged, and the squash title becomes the release-driving commit on
+`main`.
+
+## Release branches
+
+`main` is the forward development line. A maintenance branch uses the native
+semantic-release `X.Y.x` form and is cut from the existing `vX.Y.0` tag, for
+example:
+
+~~~sh
+git switch --create 5.50.x v5.50.0
+git push origin 5.50.x
+~~~
+
+The first fix on `5.50.x` publishes `v5.50.1`; later fixes publish
+`v5.50.2`, `v5.50.3`, and so on. The baseline `v5.50.0` tag is never
+recreated. Semantic-release constrains the maintenance line to its `X.Y.x`
+range, so an out-of-range release or a conflicting version is refused.
+
+After a maintenance fix is released, forward-port it to `main` through an
+explicit pull request. Merge the maintenance branch when its ancestry makes
+that transfer clear; otherwise open a main-targeted pull request carrying the
+equivalent change. Do not merge `main` back into a maintenance branch, because
+that can introduce commits outside its patch range.
 
 Write pull-request descriptions as renderable GitHub-Flavored Markdown with
 actual line breaks, never visible literal `\n` separators. For a multi-section

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1260,15 +1260,28 @@ untracked files untouched.
 
 ## Release model
 
-Pull-request titles and squash commits use Conventional Commits syntax. A push
-to `main` runs semantic-release with the standard conventional-commits
-parser: `fix` and other recognized work produce a patch, `feat` produces a
-minor, and a breaking change produces a major. The catch-all patch rule ensures
-every accepted squash commit produces a release. Releases attach the exact
-component manifest and its SHA-256 checksum; component artifacts remain owned
-by their respective repositories. The same workflow has a no-input manual
-dispatch trigger for recovering a missed or interrupted Actions run; semantic-
-release remains responsible for selecting the unreleased commit range and next
-version. Release ownership follows physical repositories: the five classic
-logical components share the `atrinik/classic` repository's commit and release
-history rather than publishing as independent checkouts.
+Pull-request titles and squash commits use Conventional Commits syntax without
+an automatic breaking marker. A reviewer may request `!` (or an equivalent
+breaking-change footer) when the change intentionally starts the next major
+release. Pushes to `main` run semantic-release with the standard
+conventional-commits parser: `fix` and other recognized work produce a patch,
+`feat` produces a minor, and a breaking change produces a major.
+
+The same release workflow also runs for numeric `X.Y.x` maintenance branches.
+Create each maintenance branch from its existing `vX.Y.0` tag; semantic-release
+then keeps it in that patch range, publishing `vX.Y.1`, `vX.Y.2`, and later
+pointfixes without recreating the baseline tag. Its distribution channel and
+tag uniqueness checks reject out-of-range or conflicting versions. Every
+maintenance fix is forward-ported to `main` through an explicit pull request;
+merge the maintenance line directly only when its ancestry is clear, and use
+an equivalent main-targeted change when it is not. Do not merge `main` into a
+maintenance line.
+
+The catch-all patch rule ensures every accepted squash commit produces a
+release. Releases attach the exact component manifest and its SHA-256 checksum;
+component artifacts remain owned by their respective repositories. The workflow
+has a no-input manual dispatch trigger for recovering a missed or interrupted
+Actions run; semantic-release remains responsible for selecting the unreleased
+commit range and next version. Release ownership follows physical repositories:
+the five classic logical components share the `atrinik/classic` repository's
+commit and release history rather than publishing as independent checkouts.

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -1184,7 +1184,8 @@ class AgentGuidanceTests(unittest.TestCase):
             workspace_skill,
         ]
         markers = {
-            "type(optional-scope)!: concise description",
+            "type(optional-scope): concise description",
+            "reviewer explicitly requests a breaking change",
             "GitHub-Flavored Markdown",
             "actual line breaks",
             "literal `\\n` separators",
@@ -1195,6 +1196,10 @@ class AgentGuidanceTests(unittest.TestCase):
             for marker in markers:
                 with self.subTest(path=path.relative_to(ROOT), marker=marker):
                     self.assertIn(marker, guidance)
+            with self.subTest(path=path.relative_to(ROOT), marker="no automatic !"):
+                self.assertNotIn(
+                    "type(optional-scope)!: concise description", guidance
+                )
             with self.subTest(path=path.relative_to(ROOT), marker="body input"):
                 self.assertRegex(
                     guidance,
@@ -1230,7 +1235,10 @@ class AgentGuidanceTests(unittest.TestCase):
             "types: [opened, edited, synchronize, reopened]", title_workflow
         )
         self.assertIn("name: Conventional PR title", title_workflow)
-        self.assertIn("type(optional-scope)!: concise description", title_workflow)
+        self.assertIn("type(optional-scope): concise description", title_workflow)
+        self.assertIn(
+            "add ! only for an explicitly requested breaking change", title_workflow
+        )
 
         run_match = re.search(
             r"(?m)^ {8}run: \|\n(?P<script>(?:^ {10}.*(?:\n|$))+)",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,6 +4,7 @@ import copy
 import json
 import os
 from pathlib import Path
+import re
 import stat
 import sys
 import tempfile
@@ -603,7 +604,9 @@ class ReleaseConfigurationTests(unittest.TestCase):
         config = json.loads((root / ".releaserc.json").read_text(encoding="utf-8"))
         analyzer = config["plugins"][0]
 
-        self.assertEqual(config["branches"], ["main"])
+        self.assertEqual(
+            config["branches"], ["+([0-9]).+([0-9]).x", "main"]
+        )
         self.assertEqual(analyzer[0], "@semantic-release/commit-analyzer")
         self.assertEqual(
             analyzer[1]["releaseRules"],
@@ -613,6 +616,23 @@ class ReleaseConfigurationTests(unittest.TestCase):
                 {"type": "*", "release": "patch"},
             ],
         )
+
+    def test_release_branch_matrix_covers_mainline_and_pointfix_lines(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        config = json.loads((root / ".releaserc.json").read_text(encoding="utf-8"))
+        workflow = (root / ".github/workflows/release.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("- main\n      - '[0-9]+.[0-9]+.x'", workflow)
+        maintenance = re.compile(r"^[0-9]+\.[0-9]+\.x$")
+        for branch in ("5.50.x", "12.3.x"):
+            with self.subTest(branch=branch):
+                self.assertTrue(maintenance.fullmatch(branch))
+        for branch in ("5.x", "5.50.0", "v5.50.x", "main"):
+            with self.subTest(branch=branch):
+                self.assertFalse(maintenance.fullmatch(branch))
+        self.assertEqual(config["tagFormat"], "v${version}")
 
     def test_every_component_checkout_is_ignored_at_wrapper_root(self) -> None:
         root = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary

- Configure semantic-release to recognize numeric `X.Y.x` maintenance branches alongside `main`.
- Trigger the release workflow for both the mainline and maintenance release lines.
- Document pointfix tags, forward-porting, and reviewer-controlled breaking-change markers.
- Add configuration and guidance coverage for the mainline/maintenance release matrix.

## Release model

Create a maintenance branch such as `5.50.x` from the existing `v5.50.0` tag. A fix on that branch publishes `v5.50.1`, then subsequent fixes publish `v5.50.2` and later patch versions in the same `5.50.x` range. The baseline tag is never republished.

Maintenance fixes must be forward-ported to `main` through an explicit pull request, using a merge or equivalent change transfer that preserves the intended fix. Semantic-release keeps the branch range and version tags authoritative so an out-of-range or conflicting release is rejected.

## Validation

- Release configuration tests cover `main`, `5.50.x`, and invalid maintenance branch shapes.
- Agent-guidance tests cover the reviewer-controlled `!` convention and the synchronized publication guidance.
- Full wrapper validation is run before handoff.

Closes #486
