### PR TITLE
fix(agents): ignore proven-inactive topology references during target refresh

### DIFF
--- a/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
+++ b/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
@@ -3007,6 +3007,13 @@ def _workspace_safety_lease(
             parameter is not None and parameter.kind is Parameter.VAR_KEYWORD
             for parameter in source_reference_parameters.values()
         )
+        supports_inactive_topology_exclusion = (
+            "exclude_inactive_topologies" in source_reference_parameters
+            or any(
+                parameter.kind is Parameter.VAR_KEYWORD
+                for parameter in source_reference_parameters.values()
+            )
+        )
         if not supports_reference_authority:
             wrapper_self = (
                 request["component"] == "atrinik"
@@ -3189,16 +3196,22 @@ def _workspace_safety_lease(
                                 )
                         if scope_record is not None:
                             _verify_live_scope(workspace, scope_record, context)
+                        reference_arguments = {
+                            "profiles_directory_fd": profiles_directory,
+                            "profiles_directory_absent": profiles_absent,
+                            "profiles_inventory": (
+                                None
+                                if profiles_snapshot is None
+                                else profiles_snapshot[1]
+                            ),
+                        }
+                        if supports_inactive_topology_exclusion:
+                            reference_arguments[
+                                "exclude_inactive_topologies"
+                            ] = True
                         references = set(
                             workspace._source_references(
-                                Path(path),
-                                profiles_directory_fd=profiles_directory,
-                                profiles_directory_absent=profiles_absent,
-                                profiles_inventory=(
-                                    None
-                                    if profiles_snapshot is None
-                                    else profiles_snapshot[1]
-                                ),
+                                Path(path), **reference_arguments
                             )
                         )
                         references.update(

--- a/README.md
+++ b/README.md
@@ -789,6 +789,22 @@ opt-in `temporary-states`, `npm-cache`, `compiler-cache`, and `sound-cache`;
 Topology history is a separate opt-in `topologies` scope and is deliberately
 excluded from both the default and `all`, so a broad cache/worktree cleanup
 cannot silently expand to runtime history.
+For one abandoned topology, pass its exact name as the positional selector
+and inspect the JSON before applying the identical request:
+
+~~~sh
+./atrinik ps TOPOLOGY --json
+./atrinik cleanup --scope topologies TOPOLOGY --older-than 0 --dry-run --json
+./atrinik cleanup --scope topologies TOPOLOGY --older-than 0 --apply --json
+~~~
+
+The preview is eligible only when `reference_classification` is
+`inactive_topology`. That shared classification requires a published stop,
+unreachable or legacy control, released process/runtime/port/layout leases,
+removed temporary state, and complete mutable-output cleanup. Active,
+reachable, retained, malformed, or uncertain records remain protected. This
+is lifecycle-bound evidence; age never proves that a topology is safe, and an
+exact selector prevents recovery from selecting another agent's topology.
 Delivered cleanup receipts use the separate `cleanup-journals` scope, also
 excluded from `all`. Broad inventory remains bounded; an exact-name selection
 and its current or legacy journal retry remain recoverable above that bound.
@@ -1239,6 +1255,10 @@ the explicit preview-first cleanup scope:
 
 Cleanup never stops a topology and never removes a live, busy, linked,
 malformed, registered, retained, promoted, or otherwise uncertain state.
+For topology-history recovery, use the exact topology name with `ps` and the
+`topologies` scope. Do not infer inactivity from directory age or choose a
+different state/topology when another agent owns it; retained state, lease
+uncertainty, and concurrent restart/replacement are deliberately fail-closed.
 
 ### Package a Classic review profile for Windows
 
@@ -1635,6 +1655,9 @@ profile remain distinguishable by topology. Omit both `--port` options to have
 the coordinator choose two available ports. Two live servers may not use the
 same state directory; the state lock
 turns that mistake into an immediate error instead of mutable-data corruption.
+The same rule applies to parallel agents: allocate a unique topology name,
+profile, state, and port for each run. Inspect or recover by exact topology
+name (`./atrinik ps NAME --json`), never through a broad topology cleanup.
 
 ### Use case: run only a headless server
 
@@ -1659,8 +1682,8 @@ worktrees, so commit, stash, or otherwise preserve intentional edits first:
 
 ~~~sh
 ./atrinik down combined-review
-./atrinik cleanup --scope topologies --older-than 7 --dry-run --json
-./atrinik cleanup --scope topologies --older-than 7 --apply
+./atrinik cleanup --scope topologies combined-review --older-than 0 --dry-run --json
+./atrinik cleanup --scope topologies combined-review --older-than 0 --apply --json
 ./atrinik profile set combined-review classic --primary
 ./atrinik profile set combined-review content --primary
 ./atrinik cleanup --scope worktrees --scope builds \

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -2413,6 +2413,11 @@ class Cleanup:
             ):
                 raise WorkspaceError("cleanup journal filters must be direct names")
             return selected
+        if scopes == ["topologies"]:
+            selected = set(names)
+            for name in selected:
+                validate_name(name, "topology name")
+            return selected
         selected: set[str] = set()
         unknown: list[str] = []
         for name in names:
@@ -2506,7 +2511,7 @@ class Cleanup:
                 self._sound_caches(older_than_days, reference_errors)
             )
         if "topologies" in scopes:
-            items.extend(self._topologies(older_than_days))
+            items.extend(self._topologies(older_than_days, names))
         if "cleanup-journals" in scopes:
             items.extend(self._cleanup_journals(older_than_days, names))
         items.sort(key=lambda item: (item["kind"], item["owner"], item["path"]))
@@ -2931,7 +2936,9 @@ class Cleanup:
                 )
         return item
 
-    def _topologies(self, older_than_days: int) -> list[dict[str, Any]]:
+    def _topologies(
+        self, older_than_days: int, names: set[str] | None = None
+    ) -> list[dict[str, Any]]:
         root = self.paths.topologies
         if not root.exists() and not root.is_symlink():
             return []
@@ -2944,6 +2951,7 @@ class Cleanup:
             self._topology_item(path, older_than_days)
             for path in sorted(root.iterdir())
             if path.name not in infrastructure
+            and (names is None or path.name in names)
         ]
 
     @staticmethod
@@ -2959,6 +2967,7 @@ class Cleanup:
                 "runtime_bundle_lease": "unverifiable",
                 "port_reservation_lease": "unverifiable",
                 "repository_layout_lease": "unverifiable",
+                "reference_classification": "uncertain_topology",
                 "age_observed_at": None,
                 "deletion_paths": [],
                 "tree_identity": None,
@@ -3006,6 +3015,8 @@ class Cleanup:
         item["tree_identity"] = identity
         item["deletion_paths"] = deletion_paths
         item["_inodes"] = inodes
+        operation_active: bool | None = None
+        operation_uncertain = False
         if tree_error is not None:
             reasons.append("invalid_topology_tree")
             item["error"] = tree_error
@@ -3031,16 +3042,29 @@ class Cleanup:
             operation_lock = path / "operation.lock"
             if not operation_lock.exists() and not operation_lock.is_symlink():
                 reasons.append("topology_operation_lock_unavailable")
+                operation_uncertain = True
             else:
                 busy, lock_error = self._lock_busy(operation_lock)
+                operation_active = busy
                 if busy:
                     reasons.append("active_topology_operation")
                 if lock_error:
                     reasons.append("invalid_topology_operation_lock")
                     item["error"] = lock_error
+                    operation_uncertain = True
 
         try:
             status = self.workspace.topology_status(path.name)
+            item["reference_classification"] = (
+                self.workspace.topology_reference_classification(
+                    path.name,
+                    status,
+                    operation_active=(
+                        False if not check_operation else operation_active
+                    ),
+                    operation_uncertain=operation_uncertain,
+                )
+            )
             supervisor = status["supervisor"]
             services = status["services"].values()
             observed = [supervisor["liveness"], *(row["liveness"] for row in services)]
@@ -3202,6 +3226,7 @@ class Cleanup:
             "repository_layout_lease",
             "age_basis",
             "age_observed_at",
+            "reference_classification",
             "tree_identity",
             "deletion_paths",
         )

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -246,7 +246,7 @@ def parser() -> argparse.ArgumentParser:
         nargs="*",
         help=(
             "limit worktrees to checkout/component identities, or select exact "
-            "cleanup-journal names"
+            "topology or cleanup-journal names"
         ),
     ), "component")
     cleanup.add_argument(

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -5985,8 +5985,14 @@ class Workspace:
         profiles_directory_fd: int | None = None,
         profiles_directory_absent: bool = False,
         profiles_inventory: tuple[tuple[str, bytes], ...] | None = None,
+        exclude_inactive_topologies: bool = False,
     ) -> list[str]:
-        """Return exact persisted references while the caller holds source exclusive."""
+        """Return exact persisted references while the caller holds source exclusive.
+
+        Historical topology records remain references for ordinary callers.  A
+        caller that has a live source proof may explicitly exclude only records
+        whose lifecycle evidence is classified as ``inactive_topology``.
+        """
 
         if profiles_directory_fd is not None and profiles_directory_absent:
             raise WorkspaceError("profile inventory authority is ambiguous")
@@ -6085,45 +6091,116 @@ class Workspace:
             }
             if target in roots:
                 references.append(f"profile:{profile['name']}")
-        for container, record_name in (
-            (self.paths.topologies, "topology"),
-            (self.paths.scenarios, "scenario"),
-        ):
-            if not container.exists():
-                continue
-            for directory in sorted(container.iterdir()):
-                if (
-                    directory.name.startswith(".")
-                    or not directory.is_dir()
-                    or directory.is_symlink()
-                ):
-                    continue
-                candidates = (
-                    (directory / "spec.json", directory / "status.json")
-                    if record_name == "topology"
-                    else (directory / "scenario.json",)
+        topology_leases = ExitStack()
+        try:
+            topology_snapshot: tuple[tuple[str, int, int], ...] = ()
+            if exclude_inactive_topologies:
+                topology_snapshot = self._topology_reference_snapshot()
+                topology_leases.enter_context(
+                    self._resource_locks(
+                        [
+                            self._lease_request(
+                                "topology",
+                                name,
+                                "shared",
+                                "classify topology source references",
+                            )
+                            for name, _device, _inode in topology_snapshot
+                        ]
+                    )
                 )
-                for record_path in candidates:
-                    if not record_path.exists():
+                if self._topology_reference_snapshot() != topology_snapshot:
+                    raise WorkspaceError(
+                        "topology reference inventory changed while its leases were acquired"
+                    )
+            for container, record_name in (
+                (self.paths.topologies, "topology"),
+                (self.paths.scenarios, "scenario"),
+            ):
+                if not container.exists():
+                    continue
+                for directory in sorted(container.iterdir()):
+                    if (
+                        directory.name.startswith(".")
+                        or not directory.is_dir()
+                        or directory.is_symlink()
+                    ):
                         continue
-                    value = load_json(record_path)
-                    resolved = value.get("resolved") if isinstance(value, dict) else None
-                    if not isinstance(resolved, dict):
-                        raise WorkspaceError(
-                            f"cannot prove {record_name} references: {record_path}"
-                        )
-                    for coordinate in resolved.values():
-                        if not isinstance(coordinate, dict):
+                    candidates = (
+                        (directory / "spec.json", directory / "status.json")
+                        if record_name == "topology"
+                        else (directory / "scenario.json",)
+                    )
+                    matched = False
+                    for record_path in candidates:
+                        if not record_path.exists():
                             continue
-                        raw_path = coordinate.get("checkout_path") or coordinate.get("path")
-                        if isinstance(raw_path, str) and Path(raw_path).resolve(
-                            strict=False
-                        ) == target:
-                            references.append(f"{record_name}:{directory.name}")
-                            break
-                    if references and references[-1] == f"{record_name}:{directory.name}":
-                        break
+                        value = load_json(record_path)
+                        resolved = (
+                            value.get("resolved")
+                            if isinstance(value, dict)
+                            else None
+                        )
+                        if not isinstance(resolved, dict):
+                            raise WorkspaceError(
+                                f"cannot prove {record_name} references: {record_path}"
+                            )
+                        for coordinate in resolved.values():
+                            if not isinstance(coordinate, dict):
+                                continue
+                            raw_path = coordinate.get("checkout_path") or coordinate.get(
+                                "path"
+                            )
+                            if isinstance(raw_path, str) and Path(raw_path).resolve(
+                                strict=False
+                            ) == target:
+                                matched = True
+                                break
+                    if matched and not (
+                        record_name == "topology"
+                        and exclude_inactive_topologies
+                        and self.topology_reference_classification(directory.name)
+                        == "inactive_topology"
+                    ):
+                        references.append(f"{record_name}:{directory.name}")
+            if (
+                exclude_inactive_topologies
+                and self._topology_reference_snapshot() != topology_snapshot
+            ):
+                raise WorkspaceError(
+                    "topology reference inventory changed during classification"
+                )
+        finally:
+            topology_leases.close()
         return sorted(set(references))
+
+    def _topology_reference_snapshot(self) -> tuple[tuple[str, int, int], ...]:
+        """Return direct topology directory identities for a guarded scan."""
+
+        root = self.paths.topologies
+        try:
+            metadata = root.lstat()
+        except FileNotFoundError:
+            return ()
+        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+            raise WorkspaceError(f"topology reference root is invalid: {root}")
+        rows: list[tuple[str, int, int]] = []
+        try:
+            for directory in sorted(root.iterdir()):
+                if directory.name.startswith(".") or directory.name in {
+                    "port-reservations",
+                    "ports.lock",
+                }:
+                    continue
+                child = directory.lstat()
+                if stat.S_ISLNK(child.st_mode) or not stat.S_ISDIR(child.st_mode):
+                    continue
+                rows.append((directory.name, child.st_dev, child.st_ino))
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot inventory topology reference root: {root}: {error}"
+            ) from error
+        return tuple(rows)
 
     def _scope_source_references(self, target: Path) -> list[str]:
         """Keep complete or recoverable scope inputs visible to cleanup."""
@@ -14302,9 +14379,16 @@ class Workspace:
         validate_name(state_name, "state name")
         return state_mode, state_name
 
-    def _topology_directory(self, name: str, create: bool = False) -> Path:
+    def _topology_directory(
+        self,
+        name: str,
+        create: bool = False,
+        *,
+        ensure_workspace: bool = True,
+    ) -> Path:
         validate_name(name, "topology name")
-        self.paths.ensure()
+        if ensure_workspace:
+            self.paths.ensure()
         path = self.paths.topologies / name
         marker = path / MANAGED_MARKER
         metadata = {"schema_version": SCHEMA_VERSION, "purpose": f"topology:{name}"}
@@ -16306,6 +16390,209 @@ class Workspace:
                 f"cannot inspect topology process-tree lease {path}: {error}"
             ) from error
 
+    @staticmethod
+    def _topology_operation_lock_state(root: Path) -> str:
+        """Observe one topology operation lock without creating or changing it."""
+
+        path = root / "operation.lock"
+        try:
+            metadata = path.lstat()
+        except FileNotFoundError:
+            return "unverifiable"
+        if (
+            stat.S_ISLNK(metadata.st_mode)
+            or not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+        ):
+            return "unverifiable"
+        flags = os.O_RDWR | os.O_CLOEXEC
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        try:
+            descriptor = os.open(path, flags)
+        except OSError:
+            return "unverifiable"
+        try:
+            opened = os.fstat(descriptor)
+            visible = path.stat(follow_symlinks=False)
+            if (
+                not stat.S_ISREG(opened.st_mode)
+                or opened.st_nlink != 1
+                or (opened.st_dev, opened.st_ino)
+                != (visible.st_dev, visible.st_ino)
+            ):
+                return "unverifiable"
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                return "active"
+            except OSError:
+                return "unverifiable"
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+            return "available"
+        except OSError:
+            return "unverifiable"
+        finally:
+            os.close(descriptor)
+
+    def topology_reference_classification(
+        self,
+        name: str,
+        status: dict[str, Any] | None = None,
+        *,
+        operation_active: bool | None = None,
+        operation_uncertain: bool = False,
+    ) -> str:
+        """Classify whether one topology record still owns source coordinates.
+
+        ``inactive_topology`` is granted only by current lifecycle evidence:
+        the stop is published, every runtime/port/process/layout lease is
+        released, temporary state is removed, mutable runtime output cleanup is
+        complete, and no topology operation is active.  Age is deliberately
+        absent from this predicate.
+        """
+
+        if operation_uncertain:
+            return "uncertain_topology"
+        try:
+            topology_root = self._topology_directory(
+                name, ensure_workspace=False
+            )
+        except Exception:
+            return "uncertain_topology"
+        if operation_active is None:
+            operation_state = self._topology_operation_lock_state(topology_root)
+            if operation_state == "active":
+                return "active_topology"
+            if operation_state != "available":
+                return "uncertain_topology"
+        elif operation_active:
+            return "active_topology"
+
+        if status is None:
+            try:
+                status = self.topology_status(name)
+            except Exception:
+                return "uncertain_topology"
+        if not isinstance(status, dict) or not isinstance(
+            status.get("observation"), dict
+        ):
+            return "uncertain_topology"
+        if not isinstance(status.get("stopped_at"), str) or not status["stopped_at"]:
+            return "uncertain_topology"
+
+        observation = status["observation"]
+        supervisor = status.get("supervisor")
+        services = status.get("services")
+        liveness = []
+        if isinstance(supervisor, dict):
+            liveness.append(supervisor.get("liveness"))
+        if isinstance(services, dict):
+            liveness.extend(
+                row.get("liveness")
+                for row in services.values()
+                if isinstance(row, dict)
+            )
+        if "live" in liveness:
+            return "active_topology"
+        if "unreachable" in liveness:
+            return "uncertain_topology"
+        if observation.get("control") == "reachable":
+            return "active_topology"
+        if observation.get("control") not in {"unreachable", "legacy"}:
+            return "uncertain_topology"
+        if observation.get("process_tree_lease") != "released":
+            return (
+                "active_topology"
+                if observation.get("process_tree_lease") == "retained"
+                else "uncertain_topology"
+            )
+        runtime_lease = observation.get("runtime_bundle_lease")
+        if runtime_lease not in {"released", "historical"}:
+            return (
+                "active_topology"
+                if runtime_lease == "retained"
+                else "uncertain_topology"
+            )
+        port = observation.get("port_reservation")
+        if isinstance(port, dict) and port.get("lease") != "released":
+            return (
+                "active_topology"
+                if port.get("lease") == "retained"
+                else "uncertain_topology"
+            )
+        if observation.get("server_state_lease_owner") is not None:
+            return "active_topology"
+        if observation.get("repository_layout_lease_owner") is not None:
+            return "active_topology"
+
+        state = status.get("state")
+        policy = status.get("state_policy")
+        if state is not None:
+            if not isinstance(policy, dict):
+                return "retained_state"
+            if (
+                policy.get("mode") == "temporary"
+                and policy.get("lifecycle") == "removed"
+            ):
+                state_path = Path(state)
+                if (
+                    state_path.exists()
+                    or state_path.is_symlink()
+                    or Path(f"{state}.lock").exists()
+                    or Path(f"{state}.lock").is_symlink()
+                ):
+                    return "uncertain_topology"
+            else:
+                return "retained_state"
+        elif isinstance(policy, dict):
+            if policy.get("mode") != "temporary":
+                return "retained_state"
+            if policy.get("lifecycle") != "removed":
+                return "retained_state"
+
+        cleanup = status.get("mutable_state_cleanup")
+        if isinstance(cleanup, dict):
+            entries = cleanup.get("entries")
+            if not isinstance(entries, list) or any(
+                not isinstance(entry, dict) or entry.get("status") != "complete"
+                for entry in entries
+            ):
+                return "retained_state"
+        elif cleanup is not None:
+            return "uncertain_topology"
+
+        runtime = status.get("runtime")
+        if isinstance(runtime, dict):
+            outputs = runtime.get("mutable_state_outputs")
+            if outputs is not None:
+                identities = runtime.get("mutable_state_output_identities")
+                if not isinstance(outputs, list):
+                    return "uncertain_topology"
+                if identities is not None and (
+                    not isinstance(identities, list) or len(identities) != len(outputs)
+                ):
+                    return "uncertain_topology"
+                if outputs and identities is None:
+                    return "uncertain_topology"
+                for index, value in enumerate(outputs):
+                    if not isinstance(value, str):
+                        return "uncertain_topology"
+                    output = Path(value)
+                    if output.exists() or output.is_symlink():
+                        return "retained_state"
+                    if isinstance(identities, list):
+                        identity = identities[index]
+                        if isinstance(identity, dict) and (
+                            _owned_tree_tombstone_path(output, identity).exists()
+                            or _owned_tree_tombstone_path(output, identity).is_symlink()
+                        ):
+                            return "retained_state"
+        elif runtime is not None:
+            return "uncertain_topology"
+
+        return "inactive_topology"
+
     def _validate_topology_state_policy(
         self,
         name: str,
@@ -16489,7 +16776,7 @@ class Workspace:
             self._validate_state_implementation(path, implementation)
 
     def topology_status(self, name: str) -> dict[str, Any]:
-        root = self._topology_directory(name)
+        root = self._topology_directory(name, ensure_workspace=False)
         status_path = root / "status.json"
         if not status_path.is_file() or status_path.is_symlink():
             raise WorkspaceError(f"topology has not been started: {name}")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -230,6 +230,18 @@ unreachable, stale, historical, mismatched, retained, busy, dirty/detached,
 replaced, unexpected, or uncertain inputs fail closed. The completed scope and
 release journal remain durable evidence after release.
 
+Delivery target refresh has one narrower, explicit exception for source
+references: its live proof opts into the wrapper's shared
+`topology_reference_classification` after acquiring shared topology leases and
+rechecking every direct topology directory's name/device/inode inventory. Only
+`inactive_topology` history may be omitted from the reference set. That
+classification requires a published stop, no active operation, unreachable or
+legacy control, released process/runtime/port/layout leases, removed temporary
+state, and complete mutable-output cleanup. Active, reachable, retained,
+malformed, or uncertain records remain references. The final inventory check
+and target-refresh CAS therefore reject a concurrent restart, replacement, or
+identity change; age alone is never inactivity evidence.
+
 The complete concurrency acceptance matrix composes the focused contracts
 rather than duplicating them:
 
@@ -1121,6 +1133,13 @@ advance. Generation directories stay with the marker-owned topology record so
 the preview-first topology reclamation contract in #397 can remove only an
 inactive, released, fully validated record; malformed, linked, unreachable, or
 retained generations fail closed.
+Topology cleanup exposes the same lifecycle classification in its JSON item
+and accepts exact topology names only when `--scope topologies` is selected.
+Preview and apply use the topology lease, revalidate the classification and
+directory identity, and preserve active, retained, malformed, linked, or
+uncertain history. This is the recovery path for one abandoned agent run;
+parallel agents must use distinct topology/profile/state/port identities and
+must inspect or reclaim by exact topology name rather than broadening cleanup.
 Generation-owned state has its own `temporary-states` cleanup scope. Dry-run
 inventory reports exact topology/generation ownership and only classifies an
 old disposable state as eligible after proving its markers, metadata, path

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -468,6 +468,192 @@ class CleanupTests(unittest.TestCase):
             "retained_state",
         )
 
+        cases = (
+            (
+                "invalid-control",
+                self.topology_observation("exited", control="invalid"),
+                "uncertain_topology",
+            ),
+            (
+                "retained-server-state-lease",
+                {
+                    **self.topology_observation("exited"),
+                    "observation": {
+                        **self.topology_observation("exited")["observation"],
+                        "server_state_lease_owner": root.name,
+                    },
+                },
+                "active_topology",
+            ),
+            (
+                "retained-layout-lease",
+                self.topology_observation(
+                    "exited", repository_layout_lease_owner=root.name
+                ),
+                "active_topology",
+            ),
+            (
+                "retained-port-lease",
+                self.topology_observation(
+                    "exited", port_reservation={"lease": "retained"}
+                ),
+                "active_topology",
+            ),
+            (
+                "invalid-port-lease",
+                self.topology_observation(
+                    "exited", port_reservation={"lease": "invalid"}
+                ),
+                "uncertain_topology",
+            ),
+            (
+                "state-policy-missing",
+                {
+                    **self.topology_observation("exited"),
+                    "state": str(root / "state"),
+                    "state_policy": "invalid",
+                },
+                "retained_state",
+            ),
+            (
+                "temporary-state-retained",
+                {
+                    **self.topology_observation("exited"),
+                    "state": str(root / "state"),
+                    "state_policy": {
+                        "mode": "temporary",
+                        "lifecycle": "removed",
+                    },
+                },
+                "uncertain_topology",
+            ),
+            (
+                "named-policy-without-state",
+                {
+                    **self.topology_observation("exited"),
+                    "state_policy": {"mode": "named", "lifecycle": "active"},
+                },
+                "retained_state",
+            ),
+            (
+                "temporary-policy-without-state",
+                {
+                    **self.topology_observation("exited"),
+                    "state_policy": {
+                        "mode": "temporary",
+                        "lifecycle": "active",
+                    },
+                },
+                "retained_state",
+            ),
+            (
+                "invalid-cleanup-record",
+                {
+                    **self.topology_observation("exited"),
+                    "mutable_state_cleanup": "invalid",
+                },
+                "uncertain_topology",
+            ),
+            (
+                "invalid-runtime-outputs",
+                {
+                    **self.topology_observation("exited"),
+                    "runtime": {"mutable_state_outputs": "invalid"},
+                },
+                "uncertain_topology",
+            ),
+            (
+                "invalid-runtime-identities",
+                {
+                    **self.topology_observation("exited"),
+                    "runtime": {
+                        "mutable_state_outputs": [str(root / "output")],
+                        "mutable_state_output_identities": [],
+                    },
+                },
+                "uncertain_topology",
+            ),
+            (
+                "missing-runtime-identities",
+                {
+                    **self.topology_observation("exited"),
+                    "runtime": {"mutable_state_outputs": [str(root / "output")]},
+                },
+                "uncertain_topology",
+            ),
+            (
+                "invalid-runtime-output-path",
+                {
+                    **self.topology_observation("exited"),
+                    "runtime": {
+                        "mutable_state_outputs": [123],
+                        "mutable_state_output_identities": [{}],
+                    },
+                },
+                "uncertain_topology",
+            ),
+            (
+                "runtime-output-present",
+                {
+                    **self.topology_observation("exited"),
+                    "runtime": {
+                        "mutable_state_outputs": [str(root / "output")],
+                        "mutable_state_output_identities": [
+                            {"device": 1, "inode": 2}
+                        ],
+                    },
+                },
+                "retained_state",
+            ),
+            (
+                "invalid-runtime-record",
+                {
+                    **self.topology_observation("exited"),
+                    "runtime": "invalid",
+                },
+                "uncertain_topology",
+            ),
+        )
+        (root / "state").mkdir()
+        (root / "output").mkdir()
+        tombstone_output = root / "tombstone-output"
+        tombstone_identity = {"device": 3, "inode": 4}
+        tombstone = workspace_module._owned_tree_tombstone_path(
+            tombstone_output, tombstone_identity
+        )
+        tombstone.touch()
+        cases += (
+            (
+                "runtime-output-tombstone",
+                {
+                    **self.topology_observation("exited"),
+                    "runtime": {
+                        "mutable_state_outputs": [str(tombstone_output)],
+                        "mutable_state_output_identities": [tombstone_identity],
+                    },
+                },
+                "retained_state",
+            ),
+        )
+        for name, status, expected in cases:
+            with self.subTest(name=name):
+                self.assertEqual(
+                    self.workspace.topology_reference_classification(
+                        root.name, status, operation_active=False
+                    ),
+                    expected,
+                )
+
+        with mock.patch.object(
+            self.workspace, "topology_status", side_effect=WorkspaceError("invalid")
+        ):
+            self.assertEqual(
+                self.workspace.topology_reference_classification(
+                    root.name, None, operation_active=False
+                ),
+                "uncertain_topology",
+            )
+
     def test_topology_cleanup_supports_exact_name_recovery(self) -> None:
         selected = self.make_topology_record("exact-recovery-selected")
         preserved = self.make_topology_record("exact-recovery-preserved")

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -355,6 +355,85 @@ class CleanupTests(unittest.TestCase):
         self.assertEqual(item["liveness"], "exited")
         self.assertEqual(item["age_basis"], "stopped-at")
 
+    def test_topology_reference_classification_is_lifecycle_bound(self) -> None:
+        root = self.make_topology_record("classification")
+        inactive = self.topology_observation(
+            "exited", control="unreachable", stopped_at="2026-07-01T00:00:00+00:00"
+        )
+        inactive["state"] = str(root / "removed-state")
+        inactive["state_policy"] = {
+            "mode": "temporary",
+            "lifecycle": "removed",
+        }
+        self.assertEqual(
+            self.workspace.topology_reference_classification(
+                root.name, inactive, operation_active=False
+            ),
+            "inactive_topology",
+        )
+
+        cases = (
+            ("live", self.topology_observation("live"), "active_topology"),
+            (
+                "retained-state",
+                {
+                    **self.topology_observation("exited"),
+                    "state": str(root / "retained-state"),
+                    "state_policy": {"mode": "named", "lifecycle": "active"},
+                },
+                "retained_state",
+            ),
+            (
+                "uncertain-lease",
+                self.topology_observation(
+                    "exited", runtime_bundle_lease="unverifiable"
+                ),
+                "uncertain_topology",
+            ),
+            (
+                "unpublished-stop",
+                self.topology_observation("exited", stopped_at=None),
+                "uncertain_topology",
+            ),
+        )
+        for name, status, expected in cases:
+            with self.subTest(name=name):
+                self.assertEqual(
+                    self.workspace.topology_reference_classification(
+                        root.name, status, operation_active=False
+                    ),
+                    expected,
+                )
+        self.assertEqual(
+            self.workspace.topology_reference_classification(
+                root.name, inactive, operation_active=True
+            ),
+            "active_topology",
+        )
+        self.assertEqual(
+            self.workspace.topology_reference_classification(
+                root.name, inactive, operation_uncertain=True
+            ),
+            "uncertain_topology",
+        )
+
+    def test_topology_cleanup_supports_exact_name_recovery(self) -> None:
+        selected = self.make_topology_record("exact-recovery-selected")
+        preserved = self.make_topology_record("exact-recovery-preserved")
+
+        preview = self.workspace.cleanup(
+            ["topologies"], 0, [selected.name], False
+        )
+        self.assertEqual(
+            [item["name"] for item in preview["items"]], [selected.name]
+        )
+        applied = self.workspace.cleanup(
+            ["topologies"], 0, [selected.name], True
+        )
+        self.assertFalse(selected.exists())
+        self.assertTrue(preserved.exists())
+        self.assertEqual(applied["summary"]["removed_count"], 1)
+
     def test_topology_cleanup_preserves_generation_owned_state(self) -> None:
         root = self.make_topology_record("stateful-history")
         container = root / "temporary-states"

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -416,6 +416,57 @@ class CleanupTests(unittest.TestCase):
             ),
             "uncertain_topology",
         )
+        self.assertEqual(
+            self.workspace.topology_reference_classification(
+                "missing-classification", inactive, operation_active=False
+            ),
+            "uncertain_topology",
+        )
+        self.assertEqual(
+            self.workspace.topology_reference_classification(root.name),
+            "inactive_topology",
+        )
+        operation_descriptor = os.open(root / "operation.lock", os.O_RDWR)
+        try:
+            fcntl.flock(operation_descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            self.assertEqual(
+                self.workspace.topology_reference_classification(root.name, inactive),
+                "active_topology",
+            )
+        finally:
+            fcntl.flock(operation_descriptor, fcntl.LOCK_UN)
+            os.close(operation_descriptor)
+        (root / "operation.lock").unlink()
+        self.assertEqual(
+            self.workspace.topology_reference_classification(root.name, inactive),
+            "uncertain_topology",
+        )
+        self.assertEqual(
+            self.workspace.topology_reference_classification(
+                root.name,
+                {"observation": [], "stopped_at": "published"},
+                operation_active=False,
+            ),
+            "uncertain_topology",
+        )
+        self.assertEqual(
+            self.workspace.topology_reference_classification(
+                root.name,
+                self.topology_observation("exited", control="reachable"),
+                operation_active=False,
+            ),
+            "active_topology",
+        )
+        retained_cleanup = self.topology_observation("exited")
+        retained_cleanup["mutable_state_cleanup"] = {
+            "entries": [{"status": "pending"}]
+        }
+        self.assertEqual(
+            self.workspace.topology_reference_classification(
+                root.name, retained_cleanup, operation_active=False
+            ),
+            "retained_state",
+        )
 
     def test_topology_cleanup_supports_exact_name_recovery(self) -> None:
         selected = self.make_topology_record("exact-recovery-selected")
@@ -582,6 +633,9 @@ class CleanupTests(unittest.TestCase):
         (linked / "unsafe-link").symlink_to(self.root)
         missing_lock = self.make_topology_record("missing-operation-lock")
         (missing_lock / "operation.lock").unlink()
+        invalid_lock = self.make_topology_record("invalid-operation-lock")
+        (invalid_lock / "operation.lock").unlink()
+        (invalid_lock / "operation.lock").symlink_to(self.root)
         active = self.make_topology_record("active-operation")
         descriptor = os.open(active / "operation.lock", os.O_RDWR)
         fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -611,6 +665,10 @@ class CleanupTests(unittest.TestCase):
         self.assertIn(
             "topology_operation_lock_unavailable",
             items["missing-operation-lock"]["reasons"],
+        )
+        self.assertIn(
+            "invalid_topology_operation_lock",
+            items["invalid-operation-lock"]["reasons"],
         )
         self.assertIn("active_topology_operation", items["active-operation"]["reasons"])
         self.assertTrue(all(row["disposition"] == "protected" for row in items.values()))

--- a/tests/test_delivery_ledger.py
+++ b/tests/test_delivery_ledger.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import base64
 from contextlib import contextmanager, nullcontext
+import fcntl
 import hashlib
 import importlib.util
 import json
@@ -570,6 +571,55 @@ def target_refresh_setup(
         if slot["kind"] in {"branch", "worktree"}:
             slot["current"]["head_sha"] = actual_head
     return predecessor, candidate, actual_head, base_head, live
+
+
+def make_historical_topology_reference(
+    live: Path, name: str, *, state: str | None = None
+) -> tuple[Path, Path]:
+    """Publish the smallest valid stopped topology record for reference tests."""
+
+    workspace = live.parents[2]
+    root = workspace / "topologies" / name
+    root.mkdir(parents=True)
+    (root / ".atrinik-workspace-managed.json").write_text(
+        json.dumps(
+            {"schema_version": 1, "purpose": f"topology:{name}"}
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (root / "operation.lock").touch(mode=0o600)
+    (root / "status.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "name": name,
+                "profile": "default",
+                "dependencies": [],
+                "state": state,
+                "build_root": str(workspace / "builds" / "profiles" / "fixture"),
+                "resolved": {},
+                "endpoint": None,
+                "ready": False,
+                "started_at": "2026-08-01T00:00:00Z",
+                "stopped_at": "2026-08-02T00:00:00Z",
+                "supervisor": {"pid": 999999, "start_time": "1"},
+                "services": {},
+                "error": "historical fixture",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    spec_path = root / "spec.json"
+    spec_path.write_text(
+        json.dumps(
+            {"resolved": {"client": {"checkout_path": str(live)}}}
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return root, root / "status.json"
 
 
 def stale_coordinate_recovery(
@@ -11396,7 +11446,138 @@ class DeliveryLedgerTests(unittest.TestCase):
                 base_head,
             )
 
-    def test_48c_target_head_correction_failpoints_are_resumable(self) -> None:
+    def test_48c_target_refresh_ignores_only_proven_inactive_topology_history(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            predecessor, candidate, _actual_head, _base_head, live = (
+                target_refresh_setup(self.live_base, root, "inactive-topology")
+            )
+            topology, status_path = make_historical_topology_reference(
+                live, "historical-topology"
+            )
+
+            refreshed = ledger.target_refresh_cas(
+                root,
+                predecessor.name,
+                candidate,
+                **cas_arguments(predecessor),
+            )
+
+            def advance(previous: object, marker: str) -> dict[str, object]:
+                assert isinstance(previous, ledger.Snapshot)
+                (live / marker).write_text("advance\n", encoding="utf-8")
+                git_run(live, "add", marker)
+                git_run(live, "commit", "-m", marker)
+                head = git_run(live, "rev-parse", "HEAD").stdout.strip()
+                next_document = next_generation(previous)
+                target = next_document["targets"][0]
+                target["head"]["current_sha"] = head
+                target["head"]["lineage"].append(head)
+                for slot in next_document["artifacts"]:
+                    if slot["kind"] in {"branch", "worktree"}:
+                        slot["current"]["head_sha"] = head
+                return next_document
+
+            operation_descriptor = os.open(
+                topology / "operation.lock", os.O_RDWR
+            )
+            try:
+                fcntl.flock(
+                    operation_descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB
+                )
+                active_candidate = advance(refreshed, "active-topology")
+                with self.assertRaisesRegex(
+                    ledger.LedgerError, "reference set differs"
+                ):
+                    ledger.target_refresh_cas(
+                        root,
+                        refreshed.name,
+                        active_candidate,
+                        **cas_arguments(refreshed),
+                    )
+            finally:
+                fcntl.flock(operation_descriptor, fcntl.LOCK_UN)
+                os.close(operation_descriptor)
+
+            status = json.loads(status_path.read_text(encoding="utf-8"))
+            status["state"] = str(live.parent.parent.parent / "retained-state")
+            status_path.write_text(json.dumps(status) + "\n", encoding="utf-8")
+            retained_candidate = advance(refreshed, "retained-topology")
+            with self.assertRaisesRegex(
+                ledger.LedgerError, "reference set differs"
+            ):
+                ledger.target_refresh_cas(
+                    root,
+                    refreshed.name,
+                    retained_candidate,
+                    **cas_arguments(refreshed),
+                )
+
+            status["state"] = None
+            status_path.write_text(json.dumps(status) + "\n", encoding="utf-8")
+            (topology / "operation.lock").unlink()
+            uncertain_candidate = advance(refreshed, "uncertain-topology")
+            with self.assertRaisesRegex(
+                ledger.LedgerError, "reference set differs"
+            ):
+                ledger.target_refresh_cas(
+                    root,
+                    refreshed.name,
+                    uncertain_candidate,
+                    **cas_arguments(refreshed),
+                )
+
+            (topology / "operation.lock").touch(mode=0o600)
+            raced = False
+            original_loader = ledger._load_workspace_module
+
+            def load_racing_module(wrapper_root: str) -> object:
+                module = original_loader(wrapper_root)
+
+                class RacingWorkspace(module.Workspace):
+                    def topology_reference_classification(
+                        self, *arguments: object, **keywords: object
+                    ) -> str:
+                        nonlocal raced
+                        result = super().topology_reference_classification(
+                            *arguments, **keywords
+                        )
+                        if not raced:
+                            raced = True
+                            current = json.loads(
+                                status_path.read_text(encoding="utf-8")
+                            )
+                            current["state"] = str(
+                                live.parent.parent.parent / "replacement-state"
+                            )
+                            status_path.write_text(
+                                json.dumps(current) + "\n", encoding="utf-8"
+                            )
+                        return result
+
+                return type(
+                    "RacingTopologyWorkspaceModule",
+                    (),
+                    {"Manifest": module.Manifest, "Workspace": RacingWorkspace},
+                )
+
+            raced_candidate = advance(refreshed, "replacement-topology")
+            with mock.patch.object(
+                ledger, "_load_workspace_module", side_effect=load_racing_module
+            ), self.assertRaisesRegex(
+                ledger.LedgerError, "reference set differs"
+            ):
+                ledger.target_refresh_cas(
+                    root,
+                    refreshed.name,
+                    raced_candidate,
+                    **cas_arguments(refreshed),
+                )
+            self.assertTrue(raced)
+
+    def test_48d_target_head_correction_failpoints_are_resumable(self) -> None:
         bad_head = "f0f8d7493278dc691710056c79d0d63f1d802488"
         for index, failpoint in enumerate(
             (

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -13266,6 +13266,140 @@ class WorkspaceTests(unittest.TestCase):
                 profiles_directory_absent=True,
             )
 
+    def test_topology_reference_exclusion_is_guarded_and_exact(self) -> None:
+        source = self.workspace.paths.repositories / "content"
+        topologies = self.workspace.paths.topologies
+        topologies.mkdir(parents=True, exist_ok=True)
+        inactive = topologies / "historical-reference"
+        active = topologies / "active-reference"
+        for root, key in ((inactive, "checkout_path"), (active, "path")):
+            root.mkdir()
+            atomic_json(
+                root / "spec.json",
+                {
+                    "resolved": {
+                        "ignored": "not-a-coordinate",
+                        "matched": {key: str(source)},
+                    }
+                },
+            )
+
+        def classify(name: str) -> str:
+            return (
+                "inactive_topology"
+                if name == inactive.name
+                else "active_topology"
+            )
+
+        with (
+            mock.patch.object(
+                self.workspace, "_scope_source_references", return_value=[]
+            ),
+            mock.patch.object(
+                self.workspace, "_physical_reference_records", return_value=[]
+            ),
+            mock.patch.object(
+                self.workspace,
+                "topology_reference_classification",
+                side_effect=classify,
+            ),
+        ):
+            references = self.workspace._source_references(
+                source,
+                profiles_directory_absent=True,
+                exclude_inactive_topologies=True,
+            )
+
+        self.assertEqual(references, [f"topology:{active.name}"])
+        self.assertEqual(
+            self.workspace._source_references(
+                source,
+                profiles_directory_absent=True,
+            ),
+            [
+                f"topology:{active.name}",
+                f"topology:{inactive.name}",
+            ],
+        )
+
+    def test_topology_reference_snapshot_and_operation_lock_are_no_follow(
+        self,
+    ) -> None:
+        topologies = self.workspace.paths.topologies
+        topologies.mkdir(parents=True, exist_ok=True)
+        visible = topologies / "visible-reference"
+        visible.mkdir()
+        (topologies / ".hidden-reference").mkdir()
+        (topologies / "port-reservations").mkdir()
+        (topologies / "ports.lock").write_text("", encoding="utf-8")
+        (topologies / "not-a-directory").write_text("", encoding="utf-8")
+        (topologies / "linked-reference").symlink_to(visible, target_is_directory=True)
+        self.assertEqual(
+            self.workspace._topology_reference_snapshot(),
+            ((visible.name, visible.stat().st_dev, visible.stat().st_ino),),
+        )
+
+        replaced = topologies.with_name("topologies-real")
+        topologies.rename(replaced)
+        topologies.symlink_to(replaced, target_is_directory=True)
+        try:
+            with self.assertRaisesRegex(WorkspaceError, "topology reference root is invalid"):
+                self.workspace._topology_reference_snapshot()
+        finally:
+            topologies.unlink()
+            replaced.rename(topologies)
+
+        operation_root = topologies / "operation-lock-observation"
+        operation_root.mkdir()
+        operation_lock = operation_root / "operation.lock"
+        self.assertEqual(
+            self.workspace._topology_operation_lock_state(operation_root),
+            "unverifiable",
+        )
+        operation_lock.touch(mode=0o600)
+        self.assertEqual(
+            self.workspace._topology_operation_lock_state(operation_root),
+            "available",
+        )
+        descriptor = os.open(operation_lock, os.O_RDWR)
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            self.assertEqual(
+                self.workspace._topology_operation_lock_state(operation_root),
+                "active",
+            )
+        finally:
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+            os.close(descriptor)
+
+        os.link(operation_lock, operation_root / "operation-copy")
+        self.assertEqual(
+            self.workspace._topology_operation_lock_state(operation_root),
+            "unverifiable",
+        )
+        (operation_root / "operation-copy").unlink()
+        operation_lock.unlink()
+        operation_lock.symlink_to(operation_root / "operation-target")
+        self.assertEqual(
+            self.workspace._topology_operation_lock_state(operation_root),
+            "unverifiable",
+        )
+        operation_lock.unlink()
+        operation_lock.mkdir()
+        self.assertEqual(
+            self.workspace._topology_operation_lock_state(operation_root),
+            "unverifiable",
+        )
+        operation_lock.rmdir()
+        operation_lock.touch(mode=0o600)
+        with mock.patch.object(
+            workspace_module.os, "open", side_effect=OSError("open unavailable")
+        ):
+            self.assertEqual(
+                self.workspace._topology_operation_lock_state(operation_root),
+                "unverifiable",
+            )
+
     def test_profile_reference_inventory_fails_closed_on_enumeration_errors(
         self,
     ) -> None:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -13399,6 +13399,129 @@ class WorkspaceTests(unittest.TestCase):
                 self.workspace._topology_operation_lock_state(operation_root),
                 "unverifiable",
             )
+        operation_lock.unlink()
+        mismatch = mock.Mock(
+            st_mode=stat.S_IFREG,
+            st_nlink=1,
+            st_dev=operation_root.stat().st_dev,
+            st_ino=operation_root.stat().st_ino,
+        )
+        operation_lock.touch(mode=0o600)
+        with mock.patch.object(workspace_module.os, "fstat", return_value=mismatch):
+            self.assertEqual(
+                self.workspace._topology_operation_lock_state(operation_root),
+                "unverifiable",
+            )
+        with mock.patch.object(
+            workspace_module.fcntl,
+            "flock",
+            side_effect=BlockingIOError("operation in progress"),
+        ):
+            self.assertEqual(
+                self.workspace._topology_operation_lock_state(operation_root),
+                "active",
+            )
+        with mock.patch.object(
+            workspace_module.fcntl,
+            "flock",
+            side_effect=OSError("flock unavailable"),
+        ):
+            self.assertEqual(
+                self.workspace._topology_operation_lock_state(operation_root),
+                "unverifiable",
+            )
+        with mock.patch.object(
+            workspace_module.os,
+            "fstat",
+            side_effect=OSError("fstat unavailable"),
+        ):
+            self.assertEqual(
+                self.workspace._topology_operation_lock_state(operation_root),
+                "unverifiable",
+            )
+        operation_lock.unlink()
+        operation_root.rmdir()
+        shutil.rmtree(topologies)
+        self.assertEqual(self.workspace._topology_reference_snapshot(), ())
+        topologies.mkdir()
+        with mock.patch.object(
+            workspace_module.Path,
+            "iterdir",
+            side_effect=OSError("topology inventory unavailable"),
+        ), self.assertRaisesRegex(
+            WorkspaceError, "cannot inventory topology reference root"
+        ):
+            self.workspace._topology_reference_snapshot()
+
+    def test_topology_reference_inventory_fails_closed_on_races_and_malformed_records(
+        self,
+    ) -> None:
+        source = self.workspace.paths.repositories / "content"
+        topologies = self.workspace.paths.topologies
+        scenarios = self.workspace.paths.scenarios
+        topologies.mkdir(parents=True, exist_ok=True)
+        if scenarios.exists():
+            shutil.rmtree(scenarios)
+        try:
+            with (
+                mock.patch.object(
+                    self.workspace, "_scope_source_references", return_value=[]
+                ),
+                mock.patch.object(
+                    self.workspace, "_physical_reference_records", return_value=[]
+                ),
+                mock.patch.object(
+                    self.workspace, "_resource_locks", return_value=nullcontext()
+                ),
+            ):
+                self.assertEqual(
+                    self.workspace._source_references(
+                        source,
+                        profiles_directory_absent=True,
+                        exclude_inactive_topologies=True,
+                    ),
+                    [],
+                )
+
+                with mock.patch.object(
+                    self.workspace,
+                    "_topology_reference_snapshot",
+                    side_effect=[(), (("replacement", 1, 2),)],
+                ), self.assertRaisesRegex(
+                    WorkspaceError,
+                    "changed while its leases were acquired",
+                ):
+                    self.workspace._source_references(
+                        source,
+                        profiles_directory_absent=True,
+                        exclude_inactive_topologies=True,
+                    )
+
+                with mock.patch.object(
+                    self.workspace,
+                    "_topology_reference_snapshot",
+                    side_effect=[(), (), (("replacement", 1, 2),)],
+                ), self.assertRaisesRegex(
+                    WorkspaceError, "changed during classification"
+                ):
+                    self.workspace._source_references(
+                        source,
+                        profiles_directory_absent=True,
+                        exclude_inactive_topologies=True,
+                    )
+
+                malformed = topologies / "malformed-reference"
+                malformed.mkdir()
+                atomic_json(malformed / "spec.json", {"resolved": []})
+                with self.assertRaisesRegex(
+                    WorkspaceError, "cannot prove topology references"
+                ):
+                    self.workspace._source_references(
+                        source,
+                        profiles_directory_absent=True,
+                    )
+        finally:
+            scenarios.mkdir(parents=True, exist_ok=True)
 
     def test_profile_reference_inventory_fails_closed_on_enumeration_errors(
         self,


### PR DESCRIPTION
## Summary

- classify topology references as proven inactive only after wrapper lifecycle proofs
- allow target refresh to ignore only inert topology history while active and uncertain references still block
- cover exact-name recovery, agent isolation, and concurrent topology restart behavior

## Validation

- `python3 -m coverage run -m unittest discover -v --durations 50`
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `git diff --check`

Closes #489
