### PR TITLE
fix(release): preserve maintenance patch ranges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
+      - name: Verify release branch policy
+        run: node scripts/release/test-release-policy.cjs
       - name: Analyze commits and publish
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,7 +2,7 @@
   "branches": ["+([0-9]).+([0-9]).x", "main"],
   "tagFormat": "v${version}",
   "plugins": [
-    ["@semantic-release/commit-analyzer", {"preset": "conventionalcommits", "releaseRules": [{"breaking": true, "release": "major"}, {"type": "feat", "release": "minor"}, {"type": "*", "release": "patch"}]}],
+    ["@semantic-release/commit-analyzer", {"preset": "conventionalcommits", "releaseRules": "./scripts/release/release-rules.cjs"}],
     ["@semantic-release/release-notes-generator", {"preset": "conventionalcommits"}],
     ["@semantic-release/exec", {"publishCmd": "scripts/build-release-assets.sh ${nextRelease.version}"}],
     ["@semantic-release/github", {"assets": [{"path": "build/release/*"}]}]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,11 @@
   file/stdin; after create/edit, verify remote. Use `atrinik-github-governance`
   for PRs. Semantic-release owns tags; keep unreleased work off
   public surfaces.
+- Release-owning repositories use the shared branch policy: `main` advances
+  every release-driving commit to the next minor line, while `X.Y.x` branches
+  remain patch-only from their published `vX.Y.0` baseline. Keep the policy
+  module, workflow trigger, configuration test, and release documentation
+  aligned; preserve the historical `v8.0.1` tag as-is.
 
 ## Working agreements and commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,13 +68,7 @@
   not auto. Bodies use GitHub-Flavored Markdown and actual
   line breaks, never literal `\n` separators. Feed multi-section bodies by
   file/stdin; after create/edit, verify remote. Use `atrinik-github-governance`
-  for PRs. Semantic-release owns tags; keep unreleased work off
-  public surfaces.
-- Release-owning repositories use the shared branch policy: `main` advances
-  every release-driving commit to the next minor line, while `X.Y.x` branches
-  remain patch-only from their published `vX.Y.0` baseline. Keep the policy
-  module, workflow trigger, configuration test, and release documentation
-  aligned; preserve the historical `v8.0.1` tag as-is.
+  for PRs. Semantic-release owns branch-aware tags; see `CONTRIBUTING.md`.
 
 ## Working agreements and commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,10 @@ squash-merged, and the squash title becomes the release-driving commit on
 
 ## Release branches
 
-`main` is the forward development line. A maintenance branch uses the native
-semantic-release `X.Y.x` form and is cut from the existing `vX.Y.0` tag, for
-example:
+`main` is the forward development line. Every release-driving mainline commit
+starts the next minor line: after `vX.Y.0`, a patch-like commit produces
+`vX.(Y+1).0`. A maintenance branch uses the native semantic-release `X.Y.x`
+form and is cut from the existing `vX.Y.0` tag, for example:
 
 ~~~sh
 git switch --create 5.50.x v5.50.0
@@ -27,7 +28,10 @@ git push origin 5.50.x
 The first fix on `5.50.x` publishes `v5.50.1`; later fixes publish
 `v5.50.2`, `v5.50.3`, and so on. The baseline `v5.50.0` tag is never
 recreated. Semantic-release constrains the maintenance line to its `X.Y.x`
-range, so an out-of-range release or a conflicting version is refused.
+range and keeps feature/breaking transitions from escaping it, so an
+out-of-range or conflicting version is refused. The already-published `v8.0.1`
+is preserved as historical evidence; do not rewrite its tag or release without
+a separate recovery decision.
 
 After a maintenance fix is released, forward-port it to `main` through an
 explicit pull request. Merge the maintenance branch when its ancestry makes

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1282,22 +1282,29 @@ untracked files untouched.
 Pull-request titles and squash commits use Conventional Commits syntax without
 an automatic breaking marker. A reviewer may request `!` (or an equivalent
 breaking-change footer) when the change intentionally starts the next major
-release. Pushes to `main` run semantic-release with the standard
-conventional-commits parser: `fix` and other recognized work produce a patch,
-`feat` produces a minor, and a breaking change produces a major.
+release. Pushes to `main` run semantic-release with a branch-aware
+conventional-commits policy: every accepted release-driving commit advances the
+next minor line, while a breaking change still takes the explicitly requested
+major transition. Thus a patch-like commit after `vX.Y.0` produces `vX.(Y+1).0`,
+never `vX.Y.1`.
 
 The same release workflow also runs for numeric `X.Y.x` maintenance branches.
 Create each maintenance branch from its existing `vX.Y.0` tag; semantic-release
 then keeps it in that patch range, publishing `vX.Y.1`, `vX.Y.2`, and later
-pointfixes without recreating the baseline tag. Its distribution channel and
-tag uniqueness checks reject out-of-range or conflicting versions. Every
-maintenance fix is forward-ported to `main` through an explicit pull request;
-merge the maintenance line directly only when its ancestry is clear, and use
-an equivalent main-targeted change when it is not. Do not merge `main` into a
-maintenance line.
+pointfixes without recreating the baseline tag. Feature or breaking rules that
+would leave the branch range fail closed rather than silently publishing an
+out-of-range version. Its distribution channel and tag uniqueness checks reject
+conflicting versions. Every maintenance fix is forward-ported to `main`
+through an explicit pull request; merge the maintenance line directly only
+when its ancestry is clear, and use an equivalent main-targeted change when it
+is not. Do not merge `main` into a maintenance line.
 
-The catch-all patch rule ensures every accepted squash commit produces a
-release. Releases attach the exact component manifest and its SHA-256 checksum;
+The mainline catch-all minor rule and maintenance catch-all patch rule ensure
+every accepted squash commit produces a release on the correct line. The
+already-published `v8.0.1` from `898f547` after `v8.0.0` at `d96127b` remains
+historical evidence of the old policy; this change does not rewrite that tag,
+release, or commit. Any recovery decision for it requires a separately reviewed
+operation. Releases attach the exact component manifest and its SHA-256 checksum;
 component artifacts remain owned by their respective repositories. The workflow
 has a no-input manual dispatch trigger for recovering a missed or interrupted
 Actions run; semantic-release remains responsible for selecting the unreleased

--- a/scripts/release/release-policy.cjs
+++ b/scripts/release/release-policy.cjs
@@ -16,10 +16,12 @@ const MAINTENANCE_RULES = [
 ];
 
 function currentBranch() {
+  const refName = process.env.GITHUB_REF_NAME;
   const branch =
     process.env.ATRINIK_RELEASE_BRANCH ||
-    process.env.GITHUB_REF_NAME ||
-    process.env.GITHUB_HEAD_REF;
+    (typeof refName === "string" && /^\d+\/merge$/.test(refName)
+      ? process.env.GITHUB_BASE_REF || "main"
+      : refName || process.env.GITHUB_HEAD_REF);
   if (typeof branch !== "string" || branch.length === 0) {
     throw new Error("ATRINIK_RELEASE_BRANCH is required");
   }

--- a/scripts/release/release-policy.cjs
+++ b/scripts/release/release-policy.cjs
@@ -1,0 +1,79 @@
+"use strict";
+
+const MAINTENANCE_BRANCH = /^[0-9]+\.[0-9]+\.x$/;
+const RELEASE_RANK = {patch: 1, minor: 2, major: 3};
+
+const MAIN_RULES = [
+  {breaking: true, release: "major"},
+  {type: "feat", release: "minor"},
+  {type: "*", release: "minor"},
+];
+
+const MAINTENANCE_RULES = [
+  {breaking: true, release: "major"},
+  {type: "feat", release: "minor"},
+  {type: "*", release: "patch"},
+];
+
+function currentBranch() {
+  const branch =
+    process.env.ATRINIK_RELEASE_BRANCH ||
+    process.env.GITHUB_REF_NAME ||
+    process.env.GITHUB_HEAD_REF;
+  if (typeof branch !== "string" || branch.length === 0) {
+    throw new Error("ATRINIK_RELEASE_BRANCH is required");
+  }
+  return branch;
+}
+
+function rulesForBranch(branch) {
+  if (branch === "main") {
+    return MAIN_RULES.map((rule) => ({...rule}));
+  }
+  if (MAINTENANCE_BRANCH.test(branch)) {
+    return MAINTENANCE_RULES.map((rule) => ({...rule}));
+  }
+  throw new Error("unsupported semantic-release branch: " + branch);
+}
+
+function releaseForCommit(branch, commit) {
+  const matches = rulesForBranch(branch).filter((rule) => {
+    if (rule.breaking === true) {
+      return commit.breaking === true;
+    }
+    return rule.type === "*" || rule.type === commit.type;
+  });
+  if (matches.length === 0) {
+    return null;
+  }
+  return matches.reduce((release, rule) =>
+    RELEASE_RANK[rule.release] > RELEASE_RANK[release] ? rule.release : release,
+  "patch");
+}
+
+function nextVersion(value, release) {
+  const match = /^([0-9]+)\.([0-9]+)\.([0-9]+)$/.exec(value);
+  if (!match || !Object.hasOwn(RELEASE_RANK, release)) {
+    throw new Error("version or release level is invalid");
+  }
+  let [major, minor, patch] = match.slice(1).map(Number);
+  if (release === "major") {
+    major += 1;
+    minor = 0;
+    patch = 0;
+  } else if (release === "minor") {
+    minor += 1;
+    patch = 0;
+  } else {
+    patch += 1;
+  }
+  return major + "." + minor + "." + patch;
+}
+
+module.exports = {
+  MAINTENANCE_BRANCH,
+  currentBranch,
+  nextVersion,
+  releaseForCommit,
+  rulesForBranch,
+};

--- a/scripts/release/release-rules.cjs
+++ b/scripts/release/release-rules.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+const {currentBranch, rulesForBranch} = require("./release-policy.cjs");
+
+module.exports = rulesForBranch(currentBranch());

--- a/scripts/release/test-release-policy.cjs
+++ b/scripts/release/test-release-policy.cjs
@@ -1,0 +1,37 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const {
+  nextVersion,
+  releaseForCommit,
+  rulesForBranch,
+} = require("./release-policy.cjs");
+
+assert.equal(
+  releaseForCommit("main", {type: "docs", breaking: false}),
+  "minor",
+);
+assert.equal(nextVersion("8.0.0", "minor"), "8.1.0");
+assert.equal(
+  releaseForCommit("8.3.x", {type: "fix", breaking: false}),
+  "patch",
+);
+assert.equal(nextVersion("8.3.0", "patch"), "8.3.1");
+assert.equal(
+  releaseForCommit("8.3.x", {type: "feat", breaking: false}),
+  "minor",
+);
+assert.equal(
+  releaseForCommit("main", {type: "fix", breaking: true}),
+  "major",
+);
+assert.throws(() => rulesForBranch("release"), /unsupported/);
+
+process.env.ATRINIK_RELEASE_BRANCH = "main";
+delete require.cache[require.resolve("./release-rules.cjs")];
+assert.equal(require("./release-rules.cjs").at(-1).release, "minor");
+process.env.ATRINIK_RELEASE_BRANCH = "8.3.x";
+delete require.cache[require.resolve("./release-rules.cjs")];
+assert.equal(require("./release-rules.cjs").at(-1).release, "patch");
+
+console.log("release policy: mainline and maintenance transitions verified");

--- a/scripts/release/test-release-policy.cjs
+++ b/scripts/release/test-release-policy.cjs
@@ -2,6 +2,7 @@
 
 const assert = require("node:assert/strict");
 const {
+  currentBranch,
   nextVersion,
   releaseForCommit,
   rulesForBranch,
@@ -26,6 +27,13 @@ assert.equal(
   "major",
 );
 assert.throws(() => rulesForBranch("release"), /unsupported/);
+
+delete process.env.ATRINIK_RELEASE_BRANCH;
+process.env.GITHUB_REF_NAME = "421/merge";
+process.env.GITHUB_BASE_REF = "8.3.x";
+assert.equal(currentBranch(), "8.3.x");
+delete process.env.GITHUB_REF_NAME;
+delete process.env.GITHUB_BASE_REF;
 
 process.env.ATRINIK_RELEASE_BRANCH = "main";
 delete require.cache[require.resolve("./release-rules.cjs")];

--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -2473,7 +2473,7 @@
       "owner": "server",
       "scope": ["server"],
       "required": true,
-      "version": "Go-1.26.5",
+      "version": "Go-1.26.6",
       "version_source": "go.mod, go.sum, and policy/dependencies.json",
       "license": "NOASSERTION",
       "source_url": "https://proxy.golang.org/",
@@ -4557,11 +4557,11 @@
       "owner": "server",
       "scope": ["protocol", "server"],
       "required": true,
-      "version": "1.26.5",
+      "version": "1.26.6",
       "version_source": "Server .go-version and protocol/server module/tool policy",
       "license": "BSD-3-Clause",
       "source_url": "https://go.dev/dl/",
-      "locator": "pkg:generic/go@1.26.5",
+      "locator": "pkg:generic/go@1.26.6",
       "commit": null,
       "checksum": null,
       "acquisition": "Pinned devcontainer image and actions/setup-go module-file resolution",
@@ -4572,8 +4572,8 @@
       "disposition": "retain",
       "packages": [],
       "evidence": [
-        {"repository":"protocol","path":"README.md","contains":"Go 1.26.5"},
-        {"repository":"server","path":".go-version","contains":"1.26.5"}
+        {"repository":"protocol","path":"README.md","contains":"Go 1.26.6"},
+        {"repository":"server","path":".go-version","contains":"1.26.6"}
       ]
     },
     {

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -610,12 +610,10 @@ class ReleaseConfigurationTests(unittest.TestCase):
         self.assertEqual(analyzer[0], "@semantic-release/commit-analyzer")
         self.assertEqual(
             analyzer[1]["releaseRules"],
-            [
-                {"breaking": True, "release": "major"},
-                {"type": "feat", "release": "minor"},
-                {"type": "*", "release": "patch"},
-            ],
+            "./scripts/release/release-rules.cjs",
         )
+        self.assertTrue((root / "scripts/release/release-policy.cjs").is_file())
+        self.assertTrue((root / "scripts/release/test-release-policy.cjs").is_file())
 
     def test_release_branch_matrix_covers_mainline_and_pointfix_lines(self) -> None:
         root = Path(__file__).resolve().parents[1]
@@ -625,6 +623,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
         )
 
         self.assertIn("- main\n      - '[0-9]+.[0-9]+.x'", workflow)
+        self.assertIn("node scripts/release/test-release-policy.cjs", workflow)
         maintenance = re.compile(r"^[0-9]+\.[0-9]+\.x$")
         for branch in ("5.50.x", "12.3.x"):
             with self.subTest(branch=branch):


### PR DESCRIPTION
## Summary

Align semantic-release mainline and maintenance-branch policy for `atrinik/atrinik`.

- `main` treats every release-driving commit as the next minor line, so a patch-like commit after `vX.Y.0` produces `vX.(Y+1).0`.
- `X.Y.x` remains a patch-only maintenance line, so a fix after `vX.Y.0` produces `vX.Y.1`.
- Add bounded configuration tests while preserving each repository's existing release packaging and recovery behavior.

## Validation

- Mainline transition: `v8.0.0` -> `v8.1.0`.
- Maintenance transition: `v8.3.0` on `8.3.x` -> `v8.3.1`.
- Existing `v8.0.1` is documented as historical; no tag or release is rewritten.

Closes #491

