### PR TITLE
docs(agents): require substantive pull request descriptions

### DIFF
--- a/.agents/skills/atrinik-github-governance/SKILL.md
+++ b/.agents/skills/atrinik-github-governance/SKILL.md
@@ -43,9 +43,10 @@ line breaks, never literal `\n` separators. The minimum body explains what chang
 and why in a concise `Summary`, gives relevant `Implementation / behavior`
 details, records `Validation` and its results, and states
 `Limitations / follow-up` when applicable. Issue and pull-request reference
-syntax remains supported, but an issue-closing line alone is insufficient. Feed multi-section
-bodies by file/stdin. When an agent updates an existing pull request, preserve
-contributor-authored text byte-for-byte and add or replace only a separately
+syntax remains supported, but an issue-closing line alone is insufficient. Feed
+multi-section bodies by file/stdin. When an agent updates an existing pull
+request, preserve contributor-authored text byte-for-byte and add or replace
+only a separately
 delivery-owned section when the delivery ownership rules authorize it. After
 create/edit, inspect GitHub's rendered `bodyHTML`/`body_html`, not raw body;
 verify headings, lists, inline code, issue-closing references, and validation

--- a/.agents/skills/atrinik-github-governance/SKILL.md
+++ b/.agents/skills/atrinik-github-governance/SKILL.md
@@ -38,10 +38,18 @@ description: Publish Atrinik PRs, govern GitHub policy, or review and explicitly
 
 Titles use `type(optional-scope): concise description` by default. Add `!` only
 when a reviewer explicitly requests a breaking change; not automatically.
-Bodies: GitHub-Flavored Markdown with actual line breaks, never literal `\n`
-separators. Feed multi-section bodies by file/stdin. After create/edit, inspect
-GitHub's `bodyHTML`/`body_html`, not raw body; verify headings, lists,
-inline code, issue-closing references, and validation sections.
+PR bodies must be substantive, rendered GitHub-Flavored Markdown with actual
+line breaks, never literal `\n` separators. The minimum body explains what changed
+and why in a concise `Summary`, gives relevant `Implementation / behavior`
+details, records `Validation` and its results, and states
+`Limitations / follow-up` when applicable. Issue and pull-request reference
+syntax remains supported, but an issue-closing line alone is insufficient. Feed multi-section
+bodies by file/stdin. When an agent updates an existing pull request, preserve
+contributor-authored text byte-for-byte and add or replace only a separately
+delivery-owned section when the delivery ownership rules authorize it. After
+create/edit, inspect GitHub's rendered `bodyHTML`/`body_html`, not raw body;
+verify headings, lists, inline code, issue-closing references, and validation
+sections.
 
 ## Validate and hand off
 

--- a/.agents/skills/atrinik-issue-delivery/SKILL.md
+++ b/.agents/skills/atrinik-issue-delivery/SKILL.md
@@ -188,11 +188,28 @@ valid linkage as a shortcut. Never convert an already-ready PR to draft merely
 to replay this workflow. Preserve valid existing closing references and never
 invent or broaden them.
 
-Use a Conventional title and newline-preserving GFM. Follow the ledger
-reference's coordinate-bound remote-write protocol: ledger-retain each exact
-initial PR/body/comment payload. A fresh contributor
-body is wholly read-only outside one helper-planned terminal delivery section;
-live markers grant nothing; preserve every outside byte.
+Use `type(optional-scope): concise description` for the title by default; add
+`!` only when a reviewer explicitly requests a breaking change. PR bodies must
+be substantive, rendered GitHub-Flavored Markdown
+with actual line breaks, never literal `\n` separators. Its minimum concise
+sections explain what changed and why (`Summary`), relevant implementation or
+behavior details (`Implementation / behavior`), validation and results
+(`Validation`), and limitations or follow-up when applicable
+(`Limitations / follow-up`). An issue-closing line alone is insufficient, while
+issue and pull-request reference syntax remains supported. Feed multi-section
+bodies by file/stdin. After creating or editing a pull request, inspect
+GitHub's rendered `bodyHTML`/`body_html`, not only the raw body; verify
+headings, lists, inline code, issue-closing references, and validation sections.
+Follow the ledger reference's coordinate-bound remote-write protocol:
+ledger-retain each exact initial PR/body/comment payload.
+
+For an existing contributor-owned PR, preserve contributor-authored text
+byte-for-byte. An agent may add or replace only the separately delivery-owned
+section when the helper ledger and ownership rules authorize it;
+copied live markers never grant ownership. Refetch and verify rendered GFM and
+linkage after the helper-bound update. A fresh contributor body is wholly
+read-only outside that helper-planned terminal delivery section; preserve every
+outside byte.
 
 Refetch bytes/timestamps and every marker match; CAS intent, refetch, then use
 only the helper-returned payload and bind its exact result. Cancel separately

--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -141,11 +141,19 @@ executables or generated paths.
 
 Use `atrinik-github-governance` for PRs. Titles:
 `type(optional-scope): concise description` by default; add `!` only when a
-reviewer explicitly requests a breaking change, not auto. Bodies use
-GitHub-Flavored Markdown, actual line breaks, never literal `\n` separators.
-Feed multi-section bodies by file/stdin; after create/edit, verify remote.
-Semantic-release owns publication. Dependency changes update inventory and
-audit a profile. Follow `docs/PROVENANCE.md`; fail uncertainty closed.
+reviewer explicitly requests a breaking change, not auto. PR bodies must be
+substantive rendered GitHub-Flavored Markdown with actual line breaks, never
+literal `\n` separators. The minimum explains what changed and why in a
+concise `Summary`, gives relevant `Implementation / behavior` details, records
+`Validation` and its results, and states `Limitations / follow-up` when
+applicable. An issue-closing line alone is insufficient, while issue and
+pull-request reference syntax remains supported. Feed multi-section bodies by
+file/stdin; when an agent updates an existing PR, preserve contributor-authored
+text byte-for-byte and use only a separately delivery-owned section when the
+delivery ownership rules authorize it. After create/edit, verify the rendered
+remote body. Semantic-release owns publication. Dependency changes update
+inventory and audit a profile. Follow `docs/PROVENANCE.md`; fail uncertainty
+closed.
 
 ## Maintain guidance
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,8 +73,7 @@
   issue-closing line alone is insufficient; preserve issue/PR
   reference syntax. Existing PR updates must preserve contributor-authored text
   byte-for-byte under the delivery-owned section rules. Feed multi-section
-  bodies by file/stdin; after create/edit, verify the rendered remote body.
-  Use
+  bodies by file/stdin; after create/edit, verify the rendered remote body. Use
   `atrinik-github-governance` for PRs. Semantic-release owns branch-aware tags;
   see `CONTRIBUTING.md`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,10 +65,18 @@
   profile. Only aggregate-root workflows and Dependabot are active.
 - Commits and PR titles use `type(optional-scope): concise description` by
   default. Add `!` only when a reviewer explicitly requests a breaking change;
-  not auto. Bodies use GitHub-Flavored Markdown and actual
-  line breaks, never literal `\n` separators. Feed multi-section bodies by
-  file/stdin; after create/edit, verify remote. Use `atrinik-github-governance`
-  for PRs. Semantic-release owns branch-aware tags; see `CONTRIBUTING.md`.
+  not auto. PR bodies must be substantive, rendered GitHub-Flavored Markdown
+  with actual line breaks, never literal `\n` separators:
+  the minimum uses concise `Summary`, `Implementation / behavior`, and
+  `Validation` sections, plus `Limitations / follow-up` when applicable, to
+  explain what changed and why, relevant behavior details, and results. An
+  issue-closing line alone is insufficient; preserve issue/PR
+  reference syntax. Existing PR updates must preserve contributor-authored text
+  byte-for-byte under the delivery-owned section rules. Feed multi-section
+  bodies by file/stdin; after create/edit, verify the rendered remote body.
+  Use
+  `atrinik-github-governance` for PRs. Semantic-release owns branch-aware tags;
+  see `CONTRIBUTING.md`.
 
 ## Working agreements and commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,13 +39,28 @@ that transfer clear; otherwise open a main-targeted pull request carrying the
 equivalent change. Do not merge `main` back into a maintenance branch, because
 that can introduce commits outside its patch range.
 
-Write pull-request descriptions as renderable GitHub-Flavored Markdown with
-actual line breaks, never visible literal `\n` separators. For a multi-section
-body, prefer `gh pr create --body-file FILE` or `gh pr edit --body-file FILE`;
-`--body-file -` reads standard input. After creating or editing a pull request,
+PR bodies must be substantive, renderable GitHub-Flavored Markdown with actual
+line breaks, never visible literal `\n` separators. The minimum body uses
+concise sections for:
+
+- `Summary`: what changed and why;
+- `Implementation / behavior`: relevant implementation details, affected
+  behavior, and compatibility or operational context;
+- `Validation`: tests, checks, or manual verification performed and their
+  results; and
+- `Limitations / follow-up` when applicable.
+
+Issue and pull-request reference syntax remains supported, but an
+issue-closing line alone is insufficient. For a multi-section body, prefer
+`gh pr create --body-file FILE` or `gh pr edit --body-file FILE`;
+`--body-file -` reads standard input. When an agent updates an existing pull
+request, it must preserve contributor-authored text byte-for-byte as
+read-only; the agent may add or replace only a separately delivery-owned
+section when the delivery ownership rules authorize it. After creating or
+editing a pull request,
 inspect GitHub's rendered web view or rendered `bodyHTML`/`body_html`, not only
-the raw body. Verify that headings, lists, inline code, issue-closing references,
-and validation sections render normally.
+the raw body. Verify that headings, lists, inline code, issue-closing
+references, and validation sections render normally.
 
 Keep component implementation in its owning repository. Changes here should
 remain focused on the manifest, multi-repository workflows, or their tests and

--- a/atrinik_workspace/guidance_inventory.py
+++ b/atrinik_workspace/guidance_inventory.py
@@ -12,11 +12,11 @@ SKILLS_ROOT = ROOT / ".agents" / "skills"
 
 # Byte ceilings are model-independent regression guards. Exact tokenizer counts
 # remain PR evidence because tokenizer vocabularies and prompt wrappers change.
-MAX_ROOT_GUIDE_BYTES = 6_000
+MAX_ROOT_GUIDE_BYTES = 6_500
 MAX_CATALOG_BYTES = 2_000
-MAX_STARTUP_BYTES = 8_000
-MAX_MULTI_SELECTED_BYTES = 14_500
-MAX_ALL_SKILL_BYTES = 52_000
+MAX_STARTUP_BYTES = 8_500
+MAX_MULTI_SELECTED_BYTES = 15_500
+MAX_ALL_SKILL_BYTES = 54_000
 
 
 @dataclass(frozen=True)

--- a/atrinik_workspace/guidance_inventory.py
+++ b/atrinik_workspace/guidance_inventory.py
@@ -12,11 +12,11 @@ SKILLS_ROOT = ROOT / ".agents" / "skills"
 
 # Byte ceilings are model-independent regression guards. Exact tokenizer counts
 # remain PR evidence because tokenizer vocabularies and prompt wrappers change.
-MAX_ROOT_GUIDE_BYTES = 6_500
+MAX_ROOT_GUIDE_BYTES = 6_450
 MAX_CATALOG_BYTES = 2_000
-MAX_STARTUP_BYTES = 8_500
-MAX_MULTI_SELECTED_BYTES = 15_500
-MAX_ALL_SKILL_BYTES = 54_000
+MAX_STARTUP_BYTES = 8_400
+MAX_MULTI_SELECTED_BYTES = 15_100
+MAX_ALL_SKILL_BYTES = 53_500
 
 
 @dataclass(frozen=True)

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -1177,11 +1177,15 @@ class AgentGuidanceTests(unittest.TestCase):
         workspace_skill = (
             ROOT / ".agents/skills/atrinik-multi-repo-workspace/SKILL.md"
         )
+        issue_delivery_skill = (
+            ROOT / ".agents/skills/atrinik-issue-delivery/SKILL.md"
+        )
         governed = [
             root_guide,
             contributing,
             governance_skill,
             workspace_skill,
+            issue_delivery_skill,
         ]
         markers = {
             "type(optional-scope): concise description",
@@ -1191,10 +1195,26 @@ class AgentGuidanceTests(unittest.TestCase):
             "literal `\\n` separators",
             "multi-section",
         }
+        substantive_markers = {
+            "PR bodies must be substantive",
+            "`Summary`",
+            "`Implementation / behavior`",
+            "`Validation`",
+            "`Limitations / follow-up`",
+            "issue-closing line alone is insufficient",
+            "preserve contributor-authored text",
+            "byte-for-byte",
+            "delivery-owned section",
+        }
         for path in governed:
             guidance = " ".join(path.read_text(encoding="utf-8").split())
             for marker in markers:
                 with self.subTest(path=path.relative_to(ROOT), marker=marker):
+                    self.assertIn(marker, guidance)
+            for marker in substantive_markers:
+                with self.subTest(
+                    path=path.relative_to(ROOT), marker=marker
+                ):
                     self.assertIn(marker, guidance)
             with self.subTest(path=path.relative_to(ROOT), marker="no automatic !"):
                 self.assertNotIn(
@@ -1213,7 +1233,7 @@ class AgentGuidanceTests(unittest.TestCase):
                     r"[^.]{0,160}(?:inspect|verify)[^.]{0,80}(?:remote|GitHub)",
                 )
 
-        for path in [contributing, governance_skill]:
+        for path in [contributing, governance_skill, issue_delivery_skill]:
             guidance = " ".join(path.read_text(encoding="utf-8").split())
             for marker in {
                 "headings",


### PR DESCRIPTION
Closes #495

## Summary

- define a substantive pull-request description policy for Atrinik guidance
- synchronize agent, delivery, and contributor entry points around one minimum
  body contract
- add regression coverage so description-only pull requests cannot silently
  become the documented standard

## Implementation / behavior

- require rendered GitHub-Flavored Markdown with concise sections covering the
  summary, implementation or behavior, validation, and limitations or
  follow-up when applicable
- keep issue and pull-request reference syntax supported, while stating that a
  closing line such as `Closes #495` cannot be the entire description
- document existing pull-request updates: preserve contributor-authored text
  byte-for-byte and use the separate delivery-owned section when ownership
  rules permit an agent to add status or validation context

## Validation

- synchronize the minimum-content wording across `AGENTS.md`,
  `CONTRIBUTING.md`, `atrinik-github-governance`,
  `atrinik-issue-delivery`, and `atrinik-multi-repo-workspace`
- extend the guidance tests to require the shared policy, the ownership rules,
  and the rendered-body verification guidance
- run the complete wrapper validation recipe and inspect the rendered PR body

## Limitations / follow-up

- this change governs guidance and validation only; it does not retroactively
  rewrite existing pull-request bodies
- maintainers still decide whether a particular limitation or follow-up is
  applicable to an individual change
