### PR TITLE
fix(delivery): prevent scope topology contract mismatches

### DIFF
--- a/.agents/skills/atrinik-github-governance/SKILL.md
+++ b/.agents/skills/atrinik-github-governance/SKILL.md
@@ -8,57 +8,49 @@ description: Publish Atrinik PRs, govern GitHub policy, or review and explicitly
 ## Route and review the task
 
 1. For native PR stack review or an explicitly authorized merge, read and
-   follow [the stack contract](references/pr-stack-review-and-merge.md) in
-   full. Review-only work is read-only; never infer merge authority.
+   follow [the stack contract](references/pr-stack-review-and-merge.md) in full;
+   Review-only work is read-only and never grants merge authority.
 2. For PR-only work, read its repository's `AGENTS.md`, use **Publish pull
    requests**, and skip steps 3–6.
 3. For policy, settings, Actions, checks, or release governance, read the
-   workspace and `github-settings/AGENTS.md` guides.
-4. Compare relevant configuration, publisher, workflows, and history with the
-   live GitHub API; inspect desired and live state.
-5. Run the publisher plan before `--apply`; external changes and workflow
+   workspace and `github-settings/AGENTS.md` guides. Compare configuration,
+   publisher, workflows, and history with the live GitHub API.
+4. Run the publisher plan before `--apply`; external changes and workflow
    dispatch need explicit authorization.
-6. Keep controls Team-plan compatible; document and review Enterprise-only
+5. Keep controls Team-plan compatible; document and review Enterprise-only
    migrations.
 
 ## Change policy coherently
 
-- Synchronize required workflow job names with repository rulesets.
-- When workflow contracts change, update the Actions allowlist, permissions,
-  dependency pins, and required aggregate status.
+- Synchronize required workflow jobs with repository rulesets; when workflows
+  change, update the Actions allowlist, permissions, dependency pins, and
+  required aggregate status.
 - Keep merge methods, semantic-release, Conventional Commit policy, visibility,
-  and default branches consistent.
-- Keep Codecov in the selected-actions policy and its GitHub App access in
-  manual desired state while coverage uses OIDC.
+  default branches, and Codecov/OIDC policy consistent.
 - Use least-privilege permissions and policy-required immutable action refs.
 - Never print tokens or copy live secrets into configuration, logs, fixtures,
   commits, or review text.
 
 ## Publish pull requests
 
-Titles use `type(optional-scope): concise description` by default. Add `!` only
-when a reviewer explicitly requests a breaking change; not automatically.
-PR bodies must be substantive, rendered GitHub-Flavored Markdown with actual
-line breaks, never literal `\n` separators. The minimum body explains what changed
-and why in a concise `Summary`, gives relevant `Implementation / behavior`
-details, records `Validation` and its results, and states
-`Limitations / follow-up` when applicable. Issue and pull-request reference
-syntax remains supported, but an issue-closing line alone is insufficient. Feed
-multi-section bodies by file/stdin. When an agent updates an existing pull
-request, preserve contributor-authored text byte-for-byte and add or replace
-only a separately
-delivery-owned section when the delivery ownership rules authorize it. After
-create/edit, inspect GitHub's rendered `bodyHTML`/`body_html`, not raw body;
-verify headings, lists, inline code, issue-closing references, and validation
-sections.
+Titles use `type(optional-scope): concise description` by default; add `!` only
+when a reviewer explicitly requests a breaking change, not automatically.
+PR bodies must be substantive rendered GitHub-Flavored Markdown with actual
+line breaks, never literal `\n` separators. Include `Summary`,
+`Implementation / behavior`, `Validation`, and applicable
+`Limitations / follow-up`; an issue-closing line alone is insufficient.
+preserve contributor-authored text byte-for-byte, changing only a separately
+delivery-owned section when authorized. Feed multi-section bodies by file/stdin.
+After create/edit, inspect GitHub's rendered `bodyHTML`/`body_html`, not raw
+body; verify headings, lists, inline code, issue-closing references, and
+validation sections.
 
 ## Validate and hand off
 
-For policy changes, run JSON/shell validation, ShellCheck, workflow actionlint,
-publisher plan mode, and `git diff --check`; inspect the plan for unexpected
-deletions or relaxations before apply. For PR-only work, run the owning
-repository's validation and the rendered-view check.
+For policy changes, run JSON/shell validation, ShellCheck, actionlint, publisher
+plan mode, and `git diff --check`; inspect the plan before apply. For PR-only
+work, run repository validation and the rendered-view check.
 
-For policy, document affected repositories, required check names, plan/rollback
-steps, and unchanged live state. For PRs, record remote render verification. Use
-Conventional Commits for commits.
+For policy, document affected repositories, required checks, plan/rollback
+steps, and unchanged live state. For PRs, record remote render verification.
+Use Conventional Commits.

--- a/.agents/skills/atrinik-issue-delivery/SKILL.md
+++ b/.agents/skills/atrinik-issue-delivery/SKILL.md
@@ -137,12 +137,18 @@ owner `AGENTS.md`; do not duplicate procedures.
   --label classic=... --branch classic=... --start-point classic=...`. The
   wrapper records `requested_components` separately from its checkout-wide
   logical component rows; never substitute `classic-client=` for the `classic`
-  override key. Bind only the exact returned scope through the ledger helper.
+  override key. Scope creation derives the immutable `scope-SCOPE` profile and
+  topology names; a supplied `--topology` must equal `scope-SCOPE` and is
+  rejected before publication otherwise. Bind only the exact returned scope
+  through the ledger helper.
 
   Feed raw `scope show`/list JSON to `scope-observe`; call `scope-bind-cas` with
   a fresh inspect tuple. It pins/reproves before CAS. Partial, released,
   referenced, cross-checkout, or mismatched evidence stops. Generic `cas`
-  cannot bind it; `scope-bind` only diagnoses.
+  cannot bind it; `scope-bind` only diagnoses. An exact live pre-bind topology
+  mismatch from an older helper may use `recover-prebind-scope` with retained
+  scope-show, worktree-list, safety, and explicit-recovery evidence; it changes
+  only the proven topology request through CAS and preserves the predecessor.
 - In PR mode, set `TARGET_BRANCH`, `BASE_SHA`, `HEAD_BRANCH`, `HEAD_SHA`, and
   `MERGE_BASE` from the live PR. Fetch and verify the exact base/head refs
   without rewriting published history. Create the local head branch at the

--- a/.agents/skills/atrinik-issue-delivery/SKILL.md
+++ b/.agents/skills/atrinik-issue-delivery/SKILL.md
@@ -181,70 +181,58 @@ owner `AGENTS.md`; do not duplicate procedures.
 ## Implement and publish or update PRs
 
 Implement requirements and owner tests/contracts. Commit/validate coherent
-Conventional checkpoints without rewriting published history. Reprove the
-helper's effective `origin` route, then run `git push origin HEAD_BRANCH` in the
-same scrubbed selector environment; reject HTTP, conceal URLs/credentials, and
-retain credential helpers.
+Conventional checkpoints without rewriting published history. Reprove `origin`,
+then run `git push origin HEAD_BRANCH` in the same scrubbed selector environment;
+reject HTTP, conceal URLs/credentials, and retain credential helpers. In issue
+mode, open one coherent draft per affected physical repository against
+`TARGET_BRANCH` (for example, `--base TARGET_BRANCH`) and verify each base; keep
+one canonical issue-closing path. In PR mode, update only the selected PR
+without changing base, head, draft, or valid linkage; Never convert an
+already-ready PR to draft; leave an already-ready PR ready and do not broaden
+its closing references.
 
-In issue mode, open one coherent draft per affected physical repository against
-its `TARGET_BRANCH` (for example, `--base TARGET_BRANCH`) and verify every
-returned base. Keep one unambiguous canonical issue-closing path. In PR mode,
-update only the selected PR without changing its base, head, draft state, or
-valid linkage as a shortcut. Never convert an already-ready PR to draft merely
-to replay this workflow. Preserve valid existing closing references and never
-invent or broaden them.
+Use `type(optional-scope): concise description` by default; add `!` only when a
+reviewer explicitly requests a breaking change. PR bodies must be substantive
+rendered GitHub-Flavored Markdown with actual line breaks, never literal `\n`
+separators. Include `Summary`, `Implementation / behavior`, `Validation`, and
+applicable `Limitations / follow-up`; an issue-closing line alone is
+insufficient. preserve contributor-authored text byte-for-byte and change only
+a separately delivery-owned section when authorized. Feed multi-section bodies
+by file/stdin. After creating or editing a pull request, inspect GitHub's
+rendered `bodyHTML`/`body_html`, not raw body; verify headings, lists, inline
+code, issue-closing references, and validation sections. Follow the ledger
+reference's coordinate-bound remote-write protocol; ledger-retain each exact
+initial PR/body/comment payload. A fresh contributor body is wholly read-only
+outside the helper-planned terminal delivery section; copied live markers grant
+no ownership. Refetch and verify rendered GFM/linkage after helper-bound updates.
 
-Use `type(optional-scope): concise description` for the title by default; add
-`!` only when a reviewer explicitly requests a breaking change. PR bodies must
-be substantive, rendered GitHub-Flavored Markdown
-with actual line breaks, never literal `\n` separators. Its minimum concise
-sections explain what changed and why (`Summary`), relevant implementation or
-behavior details (`Implementation / behavior`), validation and results
-(`Validation`), and limitations or follow-up when applicable
-(`Limitations / follow-up`). An issue-closing line alone is insufficient, while
-issue and pull-request reference syntax remains supported. Feed multi-section
-bodies by file/stdin. After creating or editing a pull request, inspect
-GitHub's rendered `bodyHTML`/`body_html`, not only the raw body; verify
-headings, lists, inline code, issue-closing references, and validation sections.
-Follow the ledger reference's coordinate-bound remote-write protocol:
-ledger-retain each exact initial PR/body/comment payload.
-
-For an existing contributor-owned PR, preserve contributor-authored text
-byte-for-byte. An agent may add or replace only the separately delivery-owned
-section when the helper ledger and ownership rules authorize it;
-copied live markers never grant ownership. Refetch and verify rendered GFM and
-linkage after the helper-bound update. A fresh contributor body is wholly
-read-only outside that helper-planned terminal delivery section; preserve every
-outside byte.
-
-Refetch bytes/timestamps and every marker match; CAS intent, refetch, then use
-only the helper-returned payload and bind its exact result. Cancel separately
-only after exact non-application proof and before drift. Zero comment matches
-permits one never-started post; reuse one exact actor-authored match.
-Wrong-author, malformed, duplicate, unexpected, or
-uncertain state stops without another post. Verify rendered GFM/linkage.
+Refetch bytes/timestamps and every marker; CAS intent, refetch, use only the
+helper payload, and bind its exact result. Cancel only after exact
+non-application proof and before drift. Zero comment matches permit one
+never-started post; reuse one exact actor-authored match. Wrong-author,
+malformed, duplicate, unexpected, or uncertain state stops. Verify rendered
+GFM/linkage.
 
 ## Review and fix to the exit condition
 
-Keep the helper ledger and separate human report current. Never commit or
-publish either or include credentials, confidential data, or unnecessary
-vulnerability detail.
+Keep the helper ledger and separate human report current; never commit/publish
+either or include credentials, confidential data, or unnecessary vulnerability
+detail.
 
 Read [the checklist](references/deep-review-checklist.md) in full. Review the
-complete current base-to-head diff against the selected issue and/or PR
-requirements. For non-trivial changes, give independent fresh-context reviewers
-the raw selected requirements and diff, not prior conclusions. Record stable
-finding IDs, evidence, resolution, status, fixing commit, and validation.
+complete current base-to-head diff against issue/PR requirements. For non-trivial
+changes, give independent fresh-context reviewers the raw requirements and diff,
+not prior conclusions. Record stable finding IDs, evidence, resolution, status,
+fixing commit, and validation.
 
 Fix every actionable finding, add useful tests, update the report, commit/push a
 checkpoint, rerun validation, then conduct a fresh whole-diff review. Repeat
 until a complete post-fix pass finds zero known actionable findings and none has
-reopened. Evidence any out-of-scope deferral. Keep GitHub feedback to one concise
-updated summary unless an inline note materially helps.
+reopened. Evidence out-of-scope deferrals; keep GitHub feedback concise.
 
 ## Verify with compatible resources
 
-Before provisioning, run the supported inventories as applicable:
+Before provisioning, run applicable supported inventories:
 
 ```sh
 ./atrinik status --json
@@ -257,62 +245,58 @@ Before provisioning, run the supported inventories as applicable:
 ```
 
 Reuse rather than recreate exact compatible profiles, stopped topologies,
-wrapper-owned state/data, or stopped/unlocked delivery scenarios. Prefer
-generation-owned temporary state; use named/default only for persistence or an
-existing account. Match immutable repository, branch, checkout, source,
-provider, commit, profile, generation, and owner to final HEAD; incomplete
-records are inert. Ordinary state must be test-safe with an appropriate account;
-never reset it.
+wrapper-owned state/data,
+or stopped/unlocked delivery scenarios. Prefer generation-owned temporary state;
+use named/default only for persistence or an existing account. Match immutable
+repository, branch, checkout, source, provider, commit, profile, generation,
+and owner to final HEAD; incomplete records are inert. Ordinary state must be
+test-safe with an appropriate account; never reset it.
 
-Let wrapper metadata choose generated paths/builds; never reconstruct, copy,
-edit, delete, or select internals. Never stop unrelated topologies, reset
-shared/default/external state, handcraft saves, or reuse/publish credentials.
-A disposable scenario password may appear only in local auto-login
-argv/client/Codex logs. Create a unique `basic-player` scenario only when
-interactive verification needs it and no exact delivery scenario exists; add a tested
-server-owned preset only when ordinary play is impractical.
+Let wrapper metadata choose paths/builds; never reconstruct, copy, edit, delete,
+or select internals. Never stop unrelated topologies, reset shared/default/
+external state, handcraft saves, or reuse/publish credentials. A disposable
+scenario password may appear only in local auto-login argv/client/Codex logs.
+Create a unique `basic-player` scenario only for interactive verification when
+no exact delivery scenario exists; add a tested server-owned preset only when
+ordinary play is impractical.
 
-For Classic, compose the runtime/scenario skills. Give exact profile, build,
+For Classic, compose the runtime/scenario skills and give exact profile, build,
 scenario, automatic-login topology, bounded logs, action/result, repeat,
 shutdown, cleanup, and state-policy commands. Initial `down` applies only to
-that topology; reset only delivery-owned data. State display/login
-prerequisites.
+that topology; reset only delivery-owned data; state display/login prerequisites.
 
 For replacement work, create or reuse a delivery profile selecting the final
-worktree and inspect current capabilities. While integrated adapters are
-absent, give owner-native validation plus supported profile/topology inspection,
-identify boundaries #266, #269, and #270, and never substitute Classic. If
-runtime is irrelevant, explain why and give exact applicable tests. Put the
-same exact capability-aware recipe in a concise PR update and final handoff.
+worktree and inspect capabilities. While integrated adapters are absent, give
+owner-native validation plus supported profile/topology inspection, identify
+boundaries #266, #269, and #270, and never substitute Classic. If runtime is
+irrelevant, give exact applicable tests and the same capability-aware recipe in
+the concise PR update and final handoff.
 
 ## Finish only on final HEAD
 
-Refetch every selected or delivery-created PR and its exact target and head
-refs. Recheck the complete diff, commits, mergeability, draft state, base and
-head repositories, branches and SHAs, linkage, review threads/comments, and
-expected checks; recompute every merge base. Any target/base/head or merge-base
-drift invalidates the affected review, validation, and checks and restarts the
-shared convergence loop at the new recorded coordinates.
+Refetch every selected or delivery-created PR and exact target/head refs. Recheck
+the complete diff, commits, mergeability, draft, repositories, branches, SHAs,
+linkage, review threads/comments, and expected checks; recompute every merge
+base. Any target/base/head or merge-base drift invalidates the affected review,
+validation, and checks and restarts the shared convergence loop at the new
+recorded coordinates.
 
 Wait for all expected pre-readiness checks; required and applicable optional
-checks must pass. Explain skipped/neutral checks and block on an expected
-missing, failed, or cancelled check. Only after stable final coordinates, final
-validation, a zero-finding review, all such checks pass, and live mergeability
-is determinate and conflict-free with no non-human blocker other than draft
-state may a draft be marked ready; leave an already-ready PR ready. Unknown or
-conflicting mergeability and any other non-human blocker wait or block. Requery
-after a ready transition, recheck mergeability, and wait for any expected checks
-it triggers. Report required human approval as a blocker rather than claiming
-literal merge eligibility. New actionable feedback restarts the fix,
-validation, and whole-diff loop. Missing human approval blocks merging, not the
-ready transition after the stated exit conditions pass.
+checks must pass. Explain skipped/neutral checks and block on missing, failed,
+or cancelled checks. Only after stable final coordinates, final validation, a
+zero-finding review, all such checks pass, and live mergeability is determinate
+and conflict-free with no non-human blocker other than draft state may a draft
+be marked ready. Unknown or conflicting mergeability blocks. Requery after
+ready, recheck mergeability, and wait for checks it triggers. Report required
+human approval as a blocker, not literal merge eligibility; new actionable
+feedback restarts the fix/validation/review loop. Missing human approval blocks
+merging, not the ready transition.
 
-Hand off the PR URLs and exact per-target bases, head repositories, branches,
-SHAs, merge bases, commits, worktrees, review findings, validation/checks,
-mergeability, runtime applicability, resources,
-verification/repeat/shutdown/cleanup commands, and blockers or `none`. Include
-issue URLs, claim state, and the canonical closing path only when issues
-actually exist; do not fabricate placeholders.
+Hand off PR URLs, exact per-target bases, repositories, branches, SHAs, merge
+bases, commits, worktrees, findings, validation/checks, mergeability, runtime
+applicability, resources, verification/repeat/shutdown/cleanup commands, and
+blockers or `none`. Include issue URLs, claim state, and canonical closing paths
+only when issues actually exist; do not fabricate placeholders.
 
 Keep issues open, PRs unmerged, and evidence preserved. A separate post-merge
 request must follow the ledger reference's terminal lifecycle; delivery grants

--- a/.agents/skills/atrinik-issue-delivery/references/delivery-ledger.md
+++ b/.agents/skills/atrinik-issue-delivery/references/delivery-ledger.md
@@ -12,6 +12,7 @@ the ownership and recovery boundary.
 - [Create a fresh issue ledger](#create-a-fresh-issue-ledger)
 - [Create a fresh PR ledger](#create-a-fresh-pr-ledger)
 - [Provision a scope-produced worktree](#provision-a-scope-produced-worktree)
+- [Recover one exact live pre-bind topology mismatch](#recover-one-exact-live-pre-bind-topology-mismatch)
 - [Create, inspect, and update](#create-inspect-and-update)
 - [Bind a created PR](#bind-a-created-pr)
 - [Plan and recover body updates](#plan-and-recover-body-updates)
@@ -123,6 +124,11 @@ python3 scripts/delivery_ledger.py scope-bind-cas REVIEW_ROOT LEDGER_NAME SLOT_I
   --expected-device DEVICE --expected-inode INODE
 python3 scripts/delivery_ledger.py recover-released-scope REVIEW_ROOT LEDGER_NAME \
   REPLACEMENT_LEDGER_JSON RELEASED_SCOPE_SHOW_JSON RECOVERY_AUTHORITY_JSON \
+  --expected-generation GENERATION --expected-digest SHA256 \
+  --expected-device DEVICE --expected-inode INODE
+python3 scripts/delivery_ledger.py recover-prebind-scope REVIEW_ROOT LEDGER_NAME \
+  REPLACEMENT_LEDGER_JSON SCOPE_SHOW_JSON WORKTREE_LIST_JSON SAFETY_JSON \
+  RECOVERY_AUTHORITY_JSON \
   --expected-generation GENERATION --expected-digest SHA256 \
   --expected-device DEVICE --expected-inode INODE
 python3 scripts/delivery_ledger.py pr-create-payload REVIEW_ROOT LEDGER_NAME SLOT_ID
@@ -484,6 +490,14 @@ name/repository/branch/start commit must match resource, target, and produced
 artifact intent. Scope `binding` retains raw scope-show bytes. Its `observation`
 has exact retained `worktree_list` and `safety_observation` members governed by
 the same fresh-live-evidence contract above.
+
+For every newly prepared generation, a scope request's topology is exactly
+`scope-<name>`. `prepare` rejects a non-canonical scope topology before a new
+ledger generation can be installed, while `validate` remains readable for
+historical pre-bind ledgers so their evidence can be inspected and recovered.
+The wrapper derives the same profile/topology namespace and scope-show paths;
+ordinary bind/observe operations reject a legacy mismatch rather than silently
+rewriting it.
 
 Resource observation generation starts at 1; its history has exactly
 `generation - 1` SHA-256 values. The external generation is required only for
@@ -1231,6 +1245,12 @@ wrapper/workspace/primary directory identities. Require successful create exit
 and preserve its capture. Repeat the exact command for an idempotent completed
 resume; partial/released/mismatched state stops.
 
+The canonical namespace is derived before publication: the profile is
+`scope-<name>` and the topology is also `scope-<name>`, with its path directly
+under `workspace/topologies/`. The optional CLI topology override is accepted
+only when it equals that value. The persisted request, scope-show record,
+commands, and all generated paths must carry the same canonical name.
+
 Use `scope show`, not an internal path, as the identity surface. From one fresh
 `inspect`, set the four `DELIVERY_EXPECTED_*` values used below:
 
@@ -1325,6 +1345,42 @@ Wrong branches, heads, repositories, roots, duplicate coordinates, stale
 release evidence, changed authority, or a generic/manual edit fail closed.
 The predecessor digest remains in the successor history; never delete,
 overwrite, or hand-edit either ledger or release evidence.
+
+### Recover one exact live pre-bind topology mismatch
+
+If an older helper or a crash left a planned, unbound scope request with a
+non-canonical topology while the live scope already uses `scope-<name>`, do not
+edit the ledger or delete the scope. Preserve one exact predecessor
+`generation/digest/device/inode` tuple and the raw `scope show`, complete
+worktree-list, and helper-produced safety observation. The live scope must be
+active, complete, unreleased, and exactly owned; released, partial, ambiguous,
+changed, or unsafe evidence is rejected.
+
+Prepare a generation-2 candidate with the same issue/target, scope slot,
+component, profile, physical checkout, label, branch, start commit, roots, and
+planned state. Change only the request topology to `scope-<name>` and add an
+`explicit-recovery` authority. The recovery authority must bind the exact
+predecessor tuple, all old scope coordinates, the canonical observed topology,
+the three raw evidence digests, the candidate digest, and an objective digest
+of those values. Run:
+
+```sh
+python3 scripts/delivery_ledger.py recover-prebind-scope \
+  REVIEW_ROOT LEDGER_NAME REPLACEMENT_LEDGER_JSON \
+  SCOPE_SHOW_JSON WORKTREE_LIST_JSON SAFETY_JSON RECOVERY_AUTHORITY_JSON \
+  --expected-generation GENERATION --expected-digest SHA256 \
+  --expected-device DEVICE --expected-inode INODE
+```
+
+The helper verifies the retained scope and raw evidence, pins the exact
+worktree and canonical topology directory under workspace leases, then repeats
+that proof immediately before one tagged CAS. A candidate that changes any
+field outside topology/authority, a stale tuple, release journal, existing
+ambiguous coordinate, or non-canonical observation fails closed. If a crash
+occurs after the ledger rename, rerun the same command with the original
+predecessor tuple; the durable post-rename proof completes the transaction and
+the predecessor digest remains in `history`. Once that receipt is consumed, a
+newer tuple is required and an ordinary retry is rejected.
 
 ## Create, inspect, and update
 
@@ -1857,7 +1913,7 @@ stop for code-level recovery; never improvise file repair.
 | Complete migration | `inventory` and `inspect`; require source/snapshot/marker/ledger coherence and no pending stage. |
 | Planned PR slot after remote create uncertainty | Recover the immutable initial bytes with `pr-create-payload`, search live candidates, and use `bind-check`; bind one exact match only. Zero or a mismatch never permits another uncertain create. |
 | Planned primitive branch/worktree after an uncertain local mutation | Reinspect the exact branch and wrapper registration. For one present exact worktree, capture a fresh list, use `worktree-observe`, then run `worktree-bind-cas` with one fresh four-part tuple. Retain manifest-owner create output; omit it only for wrapper-self raw Git or genuinely unretained recovery. The atomic command reproves before CAS. An exact still-absent artifact permits only the original planned operation. Mismatch or uncertainty stops; an adopted worktree requires the branch already bound. |
-| Fresh issue planned scope after uncertain `scope create` | Rerun the exact idempotent create request, retain exact scope-show/list bytes, derive safety with `scope-observe`, then run `scope-bind-cas` with one fresh four-part tuple. It must atomically install the one scope/branch/worktree result; physical-checkout selectors and logical-component selectors are both accepted when they resolve to one exact checkout; partial, released, changed, referenced, or cross-checkout state stops. A released mistaken scope is terminal evidence and requires release/reinitialize, not in-place request mutation. |
+| Fresh issue planned scope after uncertain `scope create` | Rerun the exact idempotent create request, retain exact scope-show/list bytes, derive safety with `scope-observe`, then run `scope-bind-cas` with one fresh four-part tuple. It must atomically install the one scope/branch/worktree result; physical-checkout selectors and logical-component selectors are both accepted when they resolve to one exact checkout; partial, released, changed, referenced, or cross-checkout state stops. A live canonical scope with a legacy planned topology request is handled only by the explicit `recover-prebind-scope` evidence/CAS path; a released mistaken scope is terminal evidence and requires release/reinitialize, not in-place request mutation. |
 | Body `update-planned` | Run `body-recovery` with one digest/timestamp observation. Refresh a newer exact-current observation first; apply only returned durable bytes, bind equal-or-later intended bytes, or cancel only on exact proven non-application. Other live bytes stop. |
 | Comment `planned` | Run `comment-check`; CAS unchanged digest/payload intent to in-flight before any write, or separately cancel only after exact non-application proof. |
 | First comment `in-flight` | Fully paginate; bind one exact intended actor-owned result. No match is uncertain and cannot be retried. |

--- a/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
+++ b/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
@@ -273,7 +273,7 @@ class _AtomicBindingCapability:
 
 @dataclass(frozen=True)
 class _ScopeRecoveryCapability:
-    """Authorize one explicit recovery of a released planned scope selector."""
+    """Authorize one explicit recovery of a planned scope request."""
 
     token: object
     slot_id: str
@@ -5645,6 +5645,26 @@ def _scope_request(value: Any, context: str) -> tuple[Any, ...]:
     return name, component, profile, checkout, label, branch, start, topology, roots
 
 
+def _canonical_scope_topology(name: str) -> str:
+    return f"scope-{name}"
+
+
+def _require_canonical_scope_requests(
+    document: Mapping[str, Any], context: str
+) -> None:
+    """Require canonical topology only when a new ledger generation is prepared."""
+
+    for index, resource in enumerate(document["resources"]):
+        if resource["kind"] != "scope":
+            continue
+        request = resource["request"]
+        expected = _canonical_scope_topology(request["name"])
+        if request["topology"] != expected:
+            raise LedgerError(
+                f"{context}.resources[{index}].request.topology must be canonical: {expected}"
+            )
+
+
 def _sorted_names(value: Any, context: str, *, nonempty: bool = True) -> list[str]:
     if not isinstance(value, list) or (nonempty and not value):
         raise LedgerError(f"{context} must be a sorted name array")
@@ -5783,7 +5803,10 @@ def _scope_show_record(
         _integer(profile[field], f"{context}.profile.{field}", minimum=0)
 
     topology = _exact(record["topology"], {"name", "path"}, f"{context}.topology")
-    expected_topology_path = Path(workspace_root) / "topologies" / request["topology"]
+    expected_topology = _canonical_scope_topology(request["name"])
+    if request["topology"] != expected_topology:
+        raise LedgerError(f"{context} scope request topology is not canonical")
+    expected_topology_path = Path(workspace_root) / "topologies" / expected_topology
     if (
         topology["name"] != request["topology"]
         or _absolute_path(topology["path"], f"{context}.topology.path")
@@ -6696,6 +6719,7 @@ def prepare(document: Mapping[str, Any]) -> dict[str, Any]:
     raw = canonical_bytes(document)
     result = _decode(raw, "prepared ledger")
     validate(result)
+    _require_canonical_scope_requests(result, "prepared ledger")
     return result
 
 
@@ -13591,6 +13615,118 @@ def _scope_recovery_projection(
     return projection
 
 
+def _scope_prebind_recovery_authority(value: Any, context: str) -> dict[str, Any]:
+    item = _exact(
+        value,
+        {
+            "transaction",
+            "source",
+            "scope",
+            "observed_topology",
+            "candidate_sha256",
+            "authority",
+        },
+        context,
+    )
+    if item["transaction"] != "delivery-ledger-recover-prebind-scope-v1":
+        raise LedgerError(f"{context}.transaction is invalid")
+    source = _exact(
+        item["source"],
+        {"name", "ledger_id", "generation", "sha256", "device", "inode"},
+        f"{context}.source",
+    )
+    _direct_name(source["name"], f"{context}.source.name")
+    _string(source["ledger_id"], f"{context}.source.ledger_id", REFERENCE_RE)
+    _integer(source["generation"], f"{context}.source.generation", minimum=1)
+    _string(source["sha256"], f"{context}.source.sha256", SHA256_RE)
+    _integer(source["device"], f"{context}.source.device", minimum=0)
+    _integer(source["inode"], f"{context}.source.inode", minimum=1)
+    scope = _exact(
+        item["scope"],
+        {
+            "name",
+            "component",
+            "profile",
+            "physical_checkout",
+            "topology",
+            "label",
+            "branch",
+            "start_sha",
+            "scope_show_sha256",
+            "worktree_list_sha256",
+            "safety_observation_sha256",
+        },
+        f"{context}.scope",
+    )
+    _scope_recovery_coordinates(
+        {key: scope[key] for key in (
+            "name",
+            "component",
+            "profile",
+            "physical_checkout",
+            "topology",
+            "label",
+            "branch",
+            "start_sha",
+        )},
+        f"{context}.scope.coordinates",
+    )
+    for key in (
+        "scope_show_sha256",
+        "worktree_list_sha256",
+        "safety_observation_sha256",
+    ):
+        _string(scope[key], f"{context}.scope.{key}", SHA256_RE)
+    _string(item["observed_topology"], f"{context}.observed_topology", SLOT_RE)
+    _string(item["candidate_sha256"], f"{context}.candidate_sha256", SHA256_RE)
+    _authority(item["authority"], f"{context}.authority")
+    return {
+        "transaction": item["transaction"],
+        "source": source,
+        "scope": scope,
+        "observed_topology": item["observed_topology"],
+        "candidate_sha256": item["candidate_sha256"],
+        "authority": item["authority"],
+    }
+
+
+def _scope_prebind_projection(
+    document: Mapping[str, Any],
+    scope_slot: str,
+    authority: Mapping[str, Any],
+    topology: str,
+) -> dict[str, Any]:
+    projection = copy.deepcopy(document)
+    projection["authority"] = copy.deepcopy(authority)
+    matches = [
+        resource
+        for resource in projection["resources"]
+        if resource["slot_id"] == scope_slot
+    ]
+    if len(matches) != 1 or matches[0]["kind"] != "scope":
+        raise LedgerError("pre-bind recovery requires one exact scope resource")
+    matches[0]["request"]["topology"] = topology
+    return projection
+
+
+def _prove_live_scope_topology(
+    request: Mapping[str, Any], scope_record: Mapping[str, Any], context: str
+) -> None:
+    expected = Path(request["roots"]["workspace"]["path"]) / "topologies" / (
+        _canonical_scope_topology(request["name"])
+    )
+    topology = scope_record["topology"]
+    if topology["name"] != _canonical_scope_topology(request["name"]):
+        raise LedgerError(f"{context} live topology name is not canonical")
+    if topology["path"] != str(expected):
+        raise LedgerError(f"{context} live topology path differs from canonical path")
+    descriptor = _directory_fd(expected)
+    try:
+        _recheck_pinned_directory(descriptor, str(expected), f"{context} topology")
+    finally:
+        os.close(descriptor)
+
+
 def _scope_recovery_observed_request(
     raw: bytes,
     planned_request: Mapping[str, Any],
@@ -13806,6 +13942,290 @@ def recover_released_scope(
         failpoint=failpoint,
         _scope_recovery_capability=capability,
     )
+
+
+def recover_prebind_scope(
+    root: Path | str,
+    name: str,
+    document: Mapping[str, Any],
+    scope_show_raw: bytes,
+    worktree_list_raw: bytes,
+    safety_observation_raw: bytes,
+    recovery_raw: bytes,
+    *,
+    expected_generation: int,
+    expected_digest: str,
+    expected_device: int,
+    expected_inode: int,
+    failpoint: Failpoint = None,
+) -> Snapshot:
+    """Recover only an exact live pre-bind topology mismatch by ledger CAS."""
+
+    name = _direct_name(name)
+    candidate = prepare(document)
+    recovery = _scope_prebind_recovery_authority(
+        _decode(recovery_raw, "pre-bind scope recovery authority"),
+        "pre-bind scope recovery authority",
+    )
+    if recovery_raw != canonical_bytes(recovery):
+        raise LedgerError("pre-bind scope recovery authority is not canonical")
+    snapshot = inspect(root, name)
+    source = recovery["source"]
+    expected_source = (
+        source["generation"],
+        source["sha256"],
+        source["device"],
+        source["inode"],
+    )
+    if (
+        expected_generation,
+        expected_digest,
+        expected_device,
+        expected_inode,
+    ) != expected_source:
+        raise LedgerError("pre-bind scope recovery source does not match CAS tuple")
+    if snapshot.name != source["name"]:
+        raise LedgerError("pre-bind scope recovery source names a different ledger")
+    candidate_raw = canonical_bytes(candidate)
+    if candidate["ledger_id"] != source["ledger_id"]:
+        raise LedgerError("pre-bind scope recovery candidate differs from source ledger")
+    resume = bool(
+        snapshot.raw == candidate_raw
+        and snapshot.document["generation"] == source["generation"] + 1
+        and snapshot.document["previous_byte_digest"] == source["sha256"]
+        and snapshot.document["history"]
+        and snapshot.document["history"][-1] == source["sha256"]
+    )
+    if not resume and (
+        snapshot.document["ledger_id"] != source["ledger_id"]
+        or snapshot.document["generation"] != source["generation"]
+        or snapshot.digest != source["sha256"]
+        or snapshot.device != source["device"]
+        or snapshot.inode != source["inode"]
+    ):
+        raise LedgerError("pre-bind scope recovery source snapshot is stale")
+    if byte_digest(candidate_raw) != recovery["candidate_sha256"]:
+        raise LedgerError("pre-bind scope recovery candidate digest differs from authority")
+    if candidate["authority"] != recovery["authority"]:
+        raise LedgerError("pre-bind scope recovery candidate authority differs from grant")
+    if candidate["authority"]["kind"] != "explicit-recovery":
+        raise LedgerError("pre-bind scope recovery requires explicit-recovery authority")
+    authority_document = snapshot.document if not resume else candidate
+    if candidate["authority"]["actor_node_id"] != authority_document["actor"]["node_id"]:
+        raise LedgerError("pre-bind scope recovery actor differs from ledger actor")
+    if candidate["authority"]["allowed"] != {
+        "issues": [
+            issue["node_id"] for issue in authority_document["issues"]["explicit"]
+        ],
+        "pull_requests": [],
+        "repositories": [
+            target["repository"]["node_id"]
+            for target in authority_document["targets"]
+        ],
+    }:
+        raise LedgerError("pre-bind scope recovery authority scope differs from ledger")
+    expected_objective = canonical_object_digest(
+        {
+            "operation": "recover-prebind-scope",
+            "source": source,
+            "scope": recovery["scope"],
+            "observed_topology": recovery["observed_topology"],
+        }
+    )
+    if candidate["authority"]["objective_sha256"] != expected_objective:
+        raise LedgerError("pre-bind scope recovery objective does not bind coordinates")
+    if not resume and not _timestamp_is_after(
+        candidate["authority"]["issued_at"], snapshot.document["authority"]["issued_at"]
+    ):
+        raise LedgerError("pre-bind scope recovery authority must postdate the prior authority")
+
+    new_scopes = [
+        resource for resource in candidate["resources"] if resource["kind"] == "scope"
+    ]
+    if len(new_scopes) != 1:
+        raise LedgerError("pre-bind scope recovery requires one exact scope resource")
+    new_scope = new_scopes[0]
+    if new_scope["state"] != "planned" or new_scope["current"] is not None:
+        raise LedgerError("pre-bind scope recovery requires one planned unbound scope")
+    if resume:
+        old_scope = None
+        old_coordinates = {
+            key: recovery["scope"][key]
+            for key in (
+                "name",
+                "component",
+                "profile",
+                "physical_checkout",
+                "topology",
+                "label",
+                "branch",
+                "start_sha",
+            )
+        }
+        scope_slot = new_scope["slot_id"]
+    else:
+        old_scopes = [
+            resource
+            for resource in snapshot.document["resources"]
+            if resource["kind"] == "scope"
+        ]
+        if len(old_scopes) != 1:
+            raise LedgerError("pre-bind scope recovery requires one exact old scope")
+        old_scope = old_scopes[0]
+        if (
+            old_scope["slot_id"] != new_scope["slot_id"]
+            or old_scope["state"] != "planned"
+            or old_scope["current"] is not None
+        ):
+            raise LedgerError("pre-bind scope recovery requires one planned unbound scope")
+        old_request = old_scope["request"]
+        old_coordinates = {
+            "name": old_scope["immutable"]["name"],
+            "component": old_request["component"],
+            "profile": old_request["profile"],
+            "physical_checkout": old_request["physical_checkout"],
+            "topology": old_request["topology"],
+            "label": old_request["label"],
+            "branch": old_request["branch"],
+            "start_sha": old_request["start_sha"],
+        }
+        scope_slot = old_scope["slot_id"]
+    canonical_topology = _canonical_scope_topology(old_coordinates["name"])
+    if old_coordinates["topology"] == canonical_topology:
+        raise LedgerError("pre-bind scope recovery does not prove a topology mismatch")
+    if recovery["observed_topology"] != canonical_topology:
+        raise LedgerError("pre-bind scope recovery observed topology is not canonical")
+    evidence = {
+        **old_coordinates,
+        "scope_show_sha256": recovery["scope"]["scope_show_sha256"],
+        "worktree_list_sha256": recovery["scope"]["worktree_list_sha256"],
+        "safety_observation_sha256": recovery["scope"]["safety_observation_sha256"],
+    }
+    if evidence != recovery["scope"]:
+        raise LedgerError("pre-bind scope evidence differs from ledger coordinates")
+
+    new_coordinates = {
+        "name": new_scope["immutable"]["name"],
+        "component": new_scope["request"]["component"],
+        "profile": new_scope["request"]["profile"],
+        "physical_checkout": new_scope["request"]["physical_checkout"],
+        "topology": new_scope["request"]["topology"],
+        "label": new_scope["request"]["label"],
+        "branch": new_scope["request"]["branch"],
+        "start_sha": new_scope["request"]["start_sha"],
+    }
+    if resume and new_coordinates != {
+        **old_coordinates,
+        "topology": canonical_topology,
+    }:
+        raise LedgerError("pre-bind scope recovery candidate differs from its evidence")
+    observed_request = copy.deepcopy(
+        old_scope["request"] if old_scope is not None else new_scope["request"]
+    )
+    observed_request["topology"] = canonical_topology
+    scope_repository = (
+        old_scope["immutable"]["repository"]
+        if old_scope is not None
+        else new_scope["immutable"]["repository"]
+    )
+    scope_show = _retained_result_document(scope_show_raw, "pre-bind scope show output")
+    if scope_show["sha256"] != recovery["scope"]["scope_show_sha256"]:
+        raise LedgerError("pre-bind scope-show digest differs from recovery authority")
+    scope_record, row = _scope_show_record(
+        scope_show_raw,
+        observed_request,
+        scope_repository,
+        "pre-bind scope show output",
+    )
+    worktree_list = _retained_result_document(
+        worktree_list_raw, "pre-bind worktree list output"
+    )
+    safety_observation = _retained_result_document(
+        safety_observation_raw, "pre-bind safety observation"
+    )
+    if worktree_list["sha256"] != recovery["scope"]["worktree_list_sha256"]:
+        raise LedgerError("pre-bind worktree-list digest differs from recovery authority")
+    if safety_observation["sha256"] != recovery["scope"]["safety_observation_sha256"]:
+        raise LedgerError("pre-bind safety-observation digest differs from recovery authority")
+    observation = {
+        "worktree_list": worktree_list,
+        "safety_observation": safety_observation,
+    }
+    _scope_binding_observation(
+        observation,
+        observed_request,
+        scope_repository,
+        row,
+        scope_show["sha256"],
+        scope_record,
+        "pre-bind scope recovery observation",
+        live=False,
+    )
+
+    projected = _scope_prebind_projection(
+        snapshot.document,
+        scope_slot,
+        candidate["authority"],
+        canonical_topology,
+    ) if not resume else None
+    if projected is not None:
+        projected["generation"] = candidate["generation"]
+        projected["previous_byte_digest"] = candidate["previous_byte_digest"]
+        projected["history"] = candidate["history"]
+        if projected != candidate:
+            raise LedgerError(
+                "pre-bind scope recovery changed fields outside topology and authority"
+            )
+
+    worktree_request = _scope_worktree_request(
+        observed_request, scope_repository
+    )
+    capability = _ScopeRecoveryCapability(
+        _SCOPE_RECOVERY_TOKEN,
+        scope_slot,
+        name,
+        None if resume else snapshot.raw,
+        candidate_raw,
+        expected_generation,
+        expected_digest,
+        expected_device,
+        expected_inode,
+    )
+    with _pinned_live_worktree(
+        worktree_request,
+        row["path"],
+        "pre-bind scope recovery",
+        allowed_references=_scope_owned_references(observed_request),
+        scope_record=scope_record,
+    ) as guard:
+
+        def revalidate() -> None:
+            _prove_live_scope_topology(observed_request, scope_record, "pre-bind scope recovery")
+            _scope_binding_observation(
+                observation,
+                observed_request,
+                scope_repository,
+                row,
+                scope_show["sha256"],
+                scope_record,
+                "pre-bind scope recovery",
+                live=True,
+                guard=guard,
+            )
+
+        revalidate()
+        return cas(
+            root,
+            name,
+            candidate,
+            expected_generation=expected_generation,
+            expected_digest=expected_digest,
+            expected_device=expected_device,
+            expected_inode=expected_inode,
+            failpoint=failpoint,
+            _precommit=revalidate,
+            _scope_recovery_capability=capability,
+        )
 
 
 def correct_target_head(
@@ -14880,6 +15300,27 @@ def parser() -> argparse.ArgumentParser:
     scope_recovery_parser.add_argument("--expected-digest", required=True)
     scope_recovery_parser.add_argument("--expected-device", required=True, type=int)
     scope_recovery_parser.add_argument("--expected-inode", required=True, type=int)
+    prebind_recovery_parser = commands.add_parser(
+        "recover-prebind-scope",
+        help="atomically recover one explicitly authorized live pre-bind topology mismatch",
+    )
+    prebind_recovery_parser.add_argument("root", help="initialized review root")
+    prebind_recovery_parser.add_argument("name", help="direct canonical ledger filename")
+    prebind_recovery_parser.add_argument("input", help="bounded replacement ledger JSON")
+    prebind_recovery_parser.add_argument("scope_show", help="exact live scope-show JSON")
+    prebind_recovery_parser.add_argument(
+        "worktree_list", help="exact complete wrapper worktree-list JSON"
+    )
+    prebind_recovery_parser.add_argument(
+        "safety", help="exact helper-produced live safety observation JSON"
+    )
+    prebind_recovery_parser.add_argument(
+        "recovery", help="exact explicit-recovery authority JSON"
+    )
+    prebind_recovery_parser.add_argument("--expected-generation", required=True, type=int)
+    prebind_recovery_parser.add_argument("--expected-digest", required=True)
+    prebind_recovery_parser.add_argument("--expected-device", required=True, type=int)
+    prebind_recovery_parser.add_argument("--expected-inode", required=True, type=int)
     correction_parser = commands.add_parser(
         "correct-target-head",
         help="live-prove and supersede one exact nonexistent target-head typo",
@@ -15132,6 +15573,22 @@ def main(argv: Sequence[str] | None = None) -> int:
                     arguments.name,
                     _read_input(arguments.input),
                     _read_bytes_input(arguments.scope_show),
+                    _read_bytes_input(arguments.recovery),
+                    expected_generation=arguments.expected_generation,
+                    expected_digest=arguments.expected_digest,
+                    expected_device=arguments.expected_device,
+                    expected_inode=arguments.expected_inode,
+                ).json()
+            )
+        elif arguments.command == "recover-prebind-scope":
+            _print(
+                recover_prebind_scope(
+                    arguments.root,
+                    arguments.name,
+                    _read_input(arguments.input),
+                    _read_bytes_input(arguments.scope_show),
+                    _read_bytes_input(arguments.worktree_list),
+                    _read_bytes_input(arguments.safety),
                     _read_bytes_input(arguments.recovery),
                     expected_generation=arguments.expected_generation,
                     expected_digest=arguments.expected_digest,

--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -56,10 +56,12 @@ checkout `classic`. For example:
   --start-point classic=BASE_SHA --temporary-state --json
 ```
 
-Do not use `classic-client=` as an override key. Before delivery mutation,
-compare the scope's `requested_components` and worktree checkout with the
-ledger request; a failed bind is recoverable only through the delivery helper,
-never by editing or deleting ledger state.
+Do not use `classic-client=` as an override key. The name derives the immutable
+`scope-<name>` profile and topology; non-canonical `--topology` fails before
+publication. Before delivery mutation, compare `requested_components`, the
+canonical topology, and worktree checkout with the ledger request; a failed bind
+is recoverable only through the delivery helper, never by editing or deleting
+ledger state.
 Release with the fresh preview digest:
 
 ```sh

--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -2,23 +2,18 @@
 name: atrinik-multi-repo-workspace
 description: Coordinate work across checkouts, profiles, worktrees, cleanup, releases, or wrapper CLI and layout.
 ---
-
 # Atrinik multi-repository workspace
 
 ## Resolve scope and ownership
 
-Run from the wrapper root.
-
-1. Read `AGENTS.md`, `components.json`, and relevant README/architecture. For
-   pre-split repositories, see
-   [repository migration](references/repository-migration.md).
-2. Resolve each physical checkout and source root; read its nearest
-   `AGENTS.md` before editing.
+1. Read `AGENTS.md`, `components.json`, and relevant README/architecture; see
+   [repository migration](references/repository-migration.md) for pre-split repositories.
+2. Resolve each physical checkout/source root; read its nearest `AGENTS.md`.
 3. Keep code, tests, packages, and releases with their physical owner; keep
-   orchestration and wrapper contracts here.
+   orchestration/contracts here.
 
 Checkouts are ignored repositories. One `classic` worktree holds all five
-`classic-*` components. Both stacks share `content@main`; `content-1x` is
+`classic-*` components; both stacks share `content@main` and `content-1x` is
 historical.
 
 ## Prepare safe worktrees
@@ -30,8 +25,8 @@ Inspect local state before mutation:
 ./atrinik status --json
 ```
 
-Initialize only absent repositories. `init` selects replacement; `--with
-classic` adds classic. `sync` never clones.
+Initialize only absent repositories; `init` selects replacement, `--with classic`
+adds classic, and `sync` never clones.
 
 ```sh
 ./atrinik init [COMPONENT...]
@@ -42,8 +37,7 @@ classic` adds classic. `sync` never clones.
 ```
 
 Sync only clean primaries; never replace, move, or remove dirty sources.
-Classic selectors create `workspace/worktrees/classic/LABEL`. Prefer atomic,
-idempotent scopes and temporary state.
+Classic selectors create `workspace/worktrees/classic/LABEL`; prefer atomic scopes.
 
 Classic scope selectors have two namespaces: the positional `components`
 arguments may use a logical component such as `classic-client`, while
@@ -56,21 +50,20 @@ checkout `classic`. For example:
   --start-point classic=BASE_SHA --temporary-state --json
 ```
 
-Do not use `classic-client=` as an override key. The name derives the immutable
-`scope-<name>` profile and topology; non-canonical `--topology` fails before
-publication. Before delivery mutation, compare `requested_components`, the
-canonical topology, and worktree checkout with the ledger request; a failed bind
-is recoverable only through the delivery helper, never by editing or deleting
-ledger state.
-Release with the fresh preview digest:
+Do not use `classic-client=` as an override key. The name derives immutable
+`scope-<name>` profile/topology; non-canonical `--topology` fails before
+publication. Compare `requested_components`, topology, and checkout with the
+ledger request; a failed bind is recoverable only through the helper, never by
+editing or deleting ledger state.
+Release with a fresh preview digest:
 
 ```sh
 ./atrinik scope release REVIEW --dry-run --json
 ./atrinik scope release REVIEW --apply --plan PLAN_SHA256 --json
 ```
 
-Release never stops topologies or deletes persistent state. Interrupted steps
-resume after a fresh preview; uncertainty retains journals.
+Release never stops topologies or deletes persistent state; interrupted steps
+resume after a fresh preview and uncertainty retains journals.
 
 Reclaim review data only through preview-first cleanup:
 
@@ -81,19 +74,18 @@ Reclaim review data only through preview-first cleanup:
 ./atrinik cleanup --scope topologies --older-than 7 --dry-run --json
 ```
 
-Repeat with `--apply`. Defaults cover worktrees/builds; caches/history opt in and
+Repeat with `--apply`. Defaults cover worktrees/builds; caches/history opt in;
 `all` excludes topologies. Remove only stopped, released, exactly owned records;
-uncertainty fails closed. Apply sound-cache before its worktree. Retry unchanged
-so the journal resumes. Retire delivered receipts via an explicit
-`cleanup-journals` preview; nonempty receipts need exact names on apply.
-Pending/unsafe receipts stay protected. Delivery sidecars are separate and
-never cleanup targets.
+uncertainty fails closed. Apply sound-cache before its worktree and retry
+unchanged. Retire receipts only through an explicit `cleanup-journals` preview;
+exact names are required on apply. Pending/unsafe receipts and delivery
+sidecars are never cleanup targets.
 
 ## Compose coherent sources
 
-Use `default` for replacement sources and `classic` for the playable stack.
-Never mix providers or substitute classic C/CMake for a missing adapter.
-Replacement repositories lack wrapper build/runtime closure.
+Use `default` for replacement and `classic` for playable sources. Never mix
+providers or substitute classic C/CMake for a missing adapter; replacement
+repositories lack wrapper closure.
 
 ```sh
 ./atrinik profile create REVIEW --from classic
@@ -103,27 +95,27 @@ Replacement repositories lack wrapper build/runtime closure.
 ./atrinik build COMPONENT --profile REVIEW --test
 ```
 
-Classic selection is checkout-wide; subdirectories are not worktrees. Builds
-pin snapshots; live inputs retain leases and cleanup owns staging.
+Classic selection is checkout-wide, not per subdirectory. Builds pin snapshots;
+live inputs retain leases and cleanup owns staging.
 
 Lease order is registry, profile, Git-admin, source, topology/scenario, state,
-build, cache. Gate matching coordinates; multi-source writers retry
-all-or-none. Only migration takes the barrier exclusively. Published runtimes
-retain generation, process-tree, state, and port leases. Fail closed without
-sharing; incomplete coordinates are inert. Completion is bounded, local,
-read-only, secret-free, and parser-driven before `Workspace`.
+build, cache. Gate matching coordinates; multi-source writers retry all-or-none.
+Only migration takes the barrier. Published runtimes retain generation,
+process-tree, state, and port leases. Fail closed without sharing; incomplete
+coordinates are inert. Completion is bounded, local, read-only, secret-free,
+and parser-driven before `Workspace`.
 
-Verify concurrency with distinct worktrees, observable build/readiness
-rendezvous, and A live through B's release. Count transitions and conflicts;
-timeouts bound failure, not compiler speed.
+Verify concurrency with distinct worktrees, observable readiness rendezvous,
+and A live through B's release. Count transitions/conflicts; timeouts bound
+failure, not compiler speed.
 
-For classic execution load `atrinik-server-runtime`; for a ready character add
-`atrinik-test-scenario`. Never handcraft saves or expose credentials. Give
-concurrent topologies distinct names/state; prefer temporary state.
+For classic execution load `atrinik-server-runtime`; add
+`atrinik-test-scenario` for a ready character. Never handcraft saves or expose
+credentials; give concurrent topologies distinct names/state.
 
 ## Validate and hand off
 
-Use wrapper commands and concrete names:
+Use wrapper commands:
 
 ```sh
 ./atrinik profile show PROFILE
@@ -135,30 +127,26 @@ Use wrapper commands and concrete names:
 ./atrinik down TOPOLOGY
 ```
 
-Record prerequisites, actions, results, and cleanup. Hand off applicable
-build/test/inspection commands. Never replace wrapper operations with internal
-executables or generated paths.
+Record prerequisites, actions, results, cleanup, and applicable handoff
+commands; never replace wrapper operations with internal executables or generated
+paths.
 
 ## Coordinate publication and policy
 
-Use `atrinik-github-governance` for PRs. Titles:
+Use `atrinik-github-governance` for PRs. Titles use
 `type(optional-scope): concise description` by default; add `!` only when a
 reviewer explicitly requests a breaking change, not auto. PR bodies must be
 substantive rendered GitHub-Flavored Markdown with actual line breaks, never
-literal `\n` separators. The minimum explains what changed and why in a
-concise `Summary`, gives relevant `Implementation / behavior` details, records
-`Validation` and its results, and states `Limitations / follow-up` when
-applicable. An issue-closing line alone is insufficient, while issue and
-pull-request reference syntax remains supported. Feed multi-section bodies by
-file/stdin; when an agent updates an existing PR, preserve contributor-authored
-text byte-for-byte and use only a separately delivery-owned section when the
-delivery ownership rules authorize it. After create/edit, verify the rendered
-remote body. Semantic-release owns publication. Dependency changes update
-inventory and audit a profile. Follow `docs/PROVENANCE.md`; fail uncertainty
-closed.
+literal `\n` separators. Include `Summary`, `Implementation / behavior`,
+`Validation`, and applicable `Limitations / follow-up`; an issue-closing line
+alone is insufficient. preserve contributor-authored text byte-for-byte and
+change only a separately delivery-owned section when authorized. Feed
+multi-section bodies by file/stdin; after create/edit verify the rendered
+remote body. Semantic-release owns publication; dependency changes update
+inventory and audit a profile. Follow `docs/PROVENANCE.md`; fail uncertainty.
 
 ## Maintain guidance
 
 Load `atrinik-guidance-maintenance` when wrapper or cross-repository contracts
-change. Update affected canonical guidance, remove superseded instructions,
-and run its inventory and validation workflow.
+change; update canonical guidance, remove superseded instructions, and run its
+inventory/validation workflow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-- This MIT Python 3.11+ repository coordinates Atrinik repositories, not source.
+- This MIT Python 3.11+ repository coordinates Atrinik repositories, not source;
   `./atrinik` and `components.json` manage profiles, worktrees, builds, runtimes,
   cleanup, migration, and supply-chain reports.
 - `default` selects the MIT replacement stack (Rust, Go, Protobuf, and Astro).
@@ -15,25 +15,22 @@
 - `atrinik` is the CLI, `atrinik_workspace/` owns orchestration, and `tests/`
   the `unittest` suite.
 - Checkout, cohort, stack, role, source, and build contracts live in
-  `components.json`; machine policy in `supply-chain/` and `governance/`; longer
-  guidance in `docs/`, `README.md`, and `CONTRIBUTING.md`.
+  `components.json`; machine policy lives in `supply-chain/` and `governance/`.
 - Workflows live in `.agents/skills/`, composition in `.devcontainer/`,
   CI/release in `.github/`, and helpers in `scripts/`.
-- Manifest destinations are independent ignored repositories; `workspace/`
-  and `build/` are ignored generated state, so root status omits them.
+- Manifest destinations are independent ignored repositories; `workspace/` and
+  `build/` are ignored generated state, so root status omits them.
 - Resolve ownership through `components.json` and the checkout's nearest
   `AGENTS.md`; keep implementation, tests, packages, and releases there.
-- `classic/` provides `classic-*`; stacks share `content@main`.
-  `content-1x/` is historical; `playtester/` classic-only (`build: none`).
-  `tools/` is MIT-default except GPL-2.0-or-later `map-checker-qt/`; its
-  checkout: `LicenseRef-Atrinik-Tools-Mixed`. `.devcontainer/` composition;
-  `devcontainer/` images.
+- `classic/` provides `classic-*`; stacks share `content@main`; `content-1x/`
+  is historical; `playtester/` is classic-only. `tools/` is MIT-default except
+  GPL-2.0-or-later `map-checker-qt/` (`LicenseRef-Atrinik-Tools-Mixed`).
 
 ## Core behaviors and patterns
 
 - Use `atrinik-multi-repo-workspace` for wrapper ownership, profiles, worktrees,
-  migration, cleanup, releases, CLI, or layout. Add only applicable specialist
-  skills; use `atrinik-guidance-maintenance` for guidance audits.
+  migration, cleanup, releases, CLI, or layout; add only applicable specialist
+  skills and use `atrinik-guidance-maintenance` for guidance audits.
 - Use `atrinik-issue-delivery` only when explicitly invoked for an issue or
   existing PR; it stops before merge.
 - Use `atrinik-program-delivery` only when explicitly invoked for an ordered
@@ -52,8 +49,8 @@
   `scope-<name>` is the profile/topology; noncanonical overrides fail
   pre-publication.
   Recover via helper CAS.
-- Use wrapper paths; never reconstruct managed paths. Isolate topology/state/ports,
-  client config; prefer temporary state; keep scenario secrets local.
+- Use wrapper paths; never reconstruct managed paths. Isolate topology, state,
+  ports, and client config; prefer temporary state and keep scenario secrets local.
 - Keep completion bounded, parser-driven, and secret-free.
 - Lease in order; gate same-coordinate readers; share the migration barrier.
 - Unbound persisted records are historical and inert.
@@ -63,25 +60,22 @@
   rights, identity, temporal, authorship, or scope uncertainty fails closed.
 - Update `supply-chain/inventory.json` when dependency ownership/validation
   changes. Keep Actions/images immutable, add no submodules, and audit a full
-  profile. Only aggregate-root workflows and Dependabot are active.
-- Commits and PR titles use `type(optional-scope): concise description` by
-  default. Add `!` only when a reviewer explicitly requests a breaking change;
-  not auto. PR bodies must be substantive, rendered GitHub-Flavored Markdown
-  with actual line breaks, never literal `\n` separators:
-  the minimum uses concise `Summary`, `Implementation / behavior`, and
-  `Validation` sections, plus `Limitations / follow-up` when applicable, to
-  explain what changed and why, relevant behavior details, and results. An
-  issue-closing line alone is insufficient; preserve issue/PR
-  reference syntax. Existing PR updates must preserve contributor-authored text
-  byte-for-byte under the delivery-owned section rules. Feed multi-section
-  bodies by file/stdin; after create/edit, verify the rendered remote body. Use
-  `atrinik-github-governance` for PRs. Semantic-release owns branch-aware tags;
-  see `CONTRIBUTING.md`.
+  profile; only aggregate-root workflows and Dependabot are active.
+- Commits and PR titles use `type(optional-scope): concise description`; add
+  `!` only when a reviewer explicitly requests a breaking change, not auto.
+  PR bodies must be substantive rendered GitHub-Flavored Markdown with actual
+  line breaks, never literal `\n` separators: include `Summary`,
+  `Implementation / behavior`, and `Validation` sections plus applicable
+  `Limitations / follow-up`. An issue-closing line alone is insufficient;
+  preserve issue/PR references and preserve contributor-authored text
+  byte-for-byte under the delivery-owned section rules. Feed
+  multi-section bodies by file/stdin; after create/edit verify the rendered
+  remote body. Use `atrinik-github-governance` for PRs.
 
 ## Working agreements and commands
 
-Run from this repository root. Inspect before mutation: initialization clones
-only missing repositories, and `sync` never initializes one:
+Run from this repository root. Inspect first; `init` clones only missing
+repositories and `sync` never initializes one:
 
 ```sh
 ./atrinik manifest validate
@@ -90,8 +84,7 @@ only missing repositories, and `sync` never initializes one:
 ./atrinik init --with classic
 ```
 
-Use this exact playable build/runtime lifecycle (`--follow` only for an
-interactive log session):
+Use this playable build/runtime lifecycle (`--follow` only for interactive logs):
 
 ```sh
 ./atrinik profile show classic --json
@@ -102,7 +95,7 @@ interactive log session):
 ./atrinik down classic-local
 ```
 
-Install test tooling once, then run the complete wrapper validation:
+Run complete wrapper validation:
 
 ```sh
 python3 -m pip install --requirement requirements-dev.txt
@@ -126,7 +119,6 @@ Run ShellCheck for shell changes, actionlint for workflows, and
 `./atrinik supply-chain audit --profile PROFILE` when dependency inputs change.
 Preserve `.coveragerc` and OIDC Codecov boundaries.
 
-Handoffs must name exact profiles, worktrees, topologies, services, states, and
-scenarios, plus prerequisites, results, validation, and cleanup. Synchronize
-this guide, affected skills, README, architecture, and contributor guidance
-with contract changes; treat stale guidance as a defect.
+Handoffs name exact profiles, worktrees, topologies, services, states,
+scenarios, prerequisites, results, validation, and cleanup. Synchronize this
+guide and affected skills/docs with contract changes; stale guidance is a defect.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,11 +48,12 @@
 - Worktrees belong to physical checkouts. Selecting `classic`, a `classic-*`
   component, or one of its roles selects one root for all five; profiles append
   manifest source directories.
-- Prefer `scope create`; Classic uses logical positionals and physical checkout
-  overrides. Recover released mismatches only via helper CAS.
-- Use wrapper paths; never reconstruct managed paths. Isolate
-  topology names/states/ports/client config; prefer temporary state and keep
-  scenario secrets local.
+- Prefer `scope create`; Classic uses selectors/physical overrides.
+  `scope-<name>` is the profile/topology; noncanonical overrides fail
+  pre-publication.
+  Recover via helper CAS.
+- Use wrapper paths; never reconstruct managed paths. Isolate topology/state/ports,
+  client config; prefer temporary state; keep scenario secrets local.
 - Keep completion bounded, parser-driven, and secret-free.
 - Lease in order; gate same-coordinate readers; share the migration barrier.
 - Unbound persisted records are historical and inert.

--- a/README.md
+++ b/README.md
@@ -654,7 +654,10 @@ Classic has two selector namespaces: a logical component such as
 `classic-client` is positional, while `--label`, `--branch`, and `--start-point`
 overrides use the physical checkout key `classic`. A logical selector therefore
 uses `--label classic=...`; `classic-client=...` is rejected as an unselected
-checkout override.
+checkout override. The scope name is the single namespace source: the derived
+profile and topology are both `scope-<name>`. If `--topology` is supplied, it
+must equal that canonical value; creation rejects any other value before
+publishing a profile, topology, worktree, or scope record.
 
 Automated scopes default to generation-owned temporary state. Persistent state
 is opt-in with `--state NAME` for an existing registered state or
@@ -719,6 +722,15 @@ explicit-recovery authority. It accepts only the two proven Classic directions
 (`classic`/`classic-client`), preserves the old name, branch, start SHA, roots,
 and evidence, proves fresh replacement collisions, and replans the corrected
 selector under a new scope name.
+
+An older helper can instead leave a planned ledger whose live scope already
+uses the canonical topology but whose request retained another topology name.
+Preserve the exact predecessor tuple and raw `scope show`, worktree-list, and
+safety outputs. The delivery helper's `recover-prebind-scope` accepts only an
+explicit authority binding those bytes and coordinates; it CAS-updates the
+topology request alone, records the predecessor digest in history, and retries
+after a crash without manual ledger edits or deletion. Released, active-but-
+ambiguous, changed, or unsafe evidence is rejected.
 
 ## Checkout worktrees
 

--- a/atrinik_workspace/scopes.py
+++ b/atrinik_workspace/scopes.py
@@ -91,6 +91,20 @@ class ScopeLifecycle:
         return self._scope_root(name) / "release-journal.json"
 
     @staticmethod
+    def _canonical_topology_name(name: str) -> str:
+        validate_name(name, "scope name")
+        return f"scope-{name}"
+
+    @classmethod
+    def _requested_topology_name(cls, name: str, topology: str | None) -> str:
+        expected = cls._canonical_topology_name(name)
+        if topology is not None and topology != expected:
+            raise WorkspaceError(
+                f"scope topology must be canonical for {name}: {expected}"
+            )
+        return expected
+
+    @staticmethod
     def generated_name() -> str:
         stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
         return f"agent-{stamp}-{secrets.token_hex(6)}"
@@ -201,7 +215,7 @@ class ScopeLifecycle:
             )
         record = self._load_record(name)
         self._require_unreleased(record)
-        expected_topology = topology or f"scope-{name}"
+        expected_topology = self._requested_topology_name(name, topology)
         expected_state_name = (
             None if state_mode == "temporary" else "default" if state_mode == "default" else state_name
         )
@@ -269,8 +283,8 @@ class ScopeLifecycle:
                 + ", ".join(sorted(unknown_overrides))
             )
 
-        profile_name = f"scope-{name}"
-        topology_name = topology or profile_name
+        profile_name = self._canonical_topology_name(name)
+        topology_name = self._requested_topology_name(name, topology)
         validate_name(profile_name, "scope profile name")
         validate_name(topology_name, "scope topology name")
         if profile_name in self.workspace.manifest.stacks:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -195,10 +195,13 @@ side effect.
 
 Agent development scopes compose existing physical repository, profile,
 topology, state, and lease contracts without introducing a second path model.
-The transaction preflights its stable or collision-resistant generated name,
-base profile, deduplicated physical checkouts, labels, branches and exact start
-commits, destination paths, immutable profile, topology namespace, and state
-policy before reserving the name. It takes the name reservation first, then
+The scope name is the source of truth for the immutable `scope-<name>` profile
+and topology namespace; an optional topology override must equal that canonical
+name and is rejected before publication otherwise. The transaction preflights
+its stable or collision-resistant generated name, base profile, deduplicated
+physical checkouts, labels, branches and exact start commits, destination paths,
+immutable profile, topology namespace, and state policy before reserving the
+name. It takes the name reservation first, then
 acquires profile, Git-admin, source, topology, and state coordinates in the
 global lease order. Distinct names may overlap except for bounded Git-admin
 publication on one physical checkout; identical names or explicit branch/path
@@ -302,6 +305,12 @@ scope-show bytes, completed release journal, branch/start/root coordinates,
 collision proofs, and explicit-recovery authority, then replans one corrected
 Classic selector under a fresh scope name. Generic CAS and hand-editing or
 deleting released evidence remain prohibited.
+An older pre-bind topology mismatch has a separate `recover-prebind-scope` CAS:
+it accepts only an explicit authority bound to retained scope-show,
+worktree-list, safety, and predecessor evidence, updates only the canonical
+topology request, preserves the predecessor digest in history, and is
+crash-retryable. Released, changed, ambiguous, or unsafe live scope evidence
+fails closed.
 Terminal archive validates, bundles, and crash-resumably removes that complete
 correction evidence set with the ledger rather than leaving orphan sidecars.
 

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -377,6 +377,8 @@ class AgentGuidanceTests(unittest.TestCase):
             "--from PROFILE",
             "--start-point CHECKOUT=BASE_SHA",
             "scope show SCOPE --json",
+            "scope-SCOPE",
+            "recover-prebind-scope",
             "--existing",
             "initial `HEAD` equals the mode's recorded SHA",
             "Never resume or edit a dirty, detached, locked, active, foreign",
@@ -468,6 +470,9 @@ class AgentGuidanceTests(unittest.TestCase):
             "creation journal is deliberately non-authoritative",
             "issue-mode and mode-less names reserve",
             "precommitted deferred primitive/scope managed paths",
+            "recover-prebind-scope REVIEW_ROOT LEDGER_NAME",
+            "`prepare` rejects a non-canonical scope topology",
+            "predecessor digest remains in `history`",
         }:
             with self.subTest(ledger_contract=contract):
                 self.assertIn(contract, normalized_ledger)

--- a/tests/test_delivery_ledger.py
+++ b/tests/test_delivery_ledger.py
@@ -262,36 +262,23 @@ def scope_show_bytes(
     manifest = Manifest.from_value(wrapper_manifest)
     stack_name = request["profile"]
     stack = manifest.stack(stack_name)
-    selected_checkout = request["component"] == request["physical_checkout"]
-    logical_components = (
-        sorted(
-            component.name
-            for component in stack.components
-            if component.checkout_name == request["physical_checkout"]
-        )
-        if selected_checkout
-        else [request["component"]]
+    logical_components = sorted(
+        component.name
+        for component in stack.components
+        if component.checkout_name == request["physical_checkout"]
     )
     profile_components = {
         component: {
             "kind": (
                 "worktree"
-                if (
-                    selected_checkout
-                    and manifest.by_name[component].checkout_name
-                    == request["physical_checkout"]
-                )
-                or component == request["component"]
+                if manifest.by_name[component].checkout_name
+                == request["physical_checkout"]
                 else "primary"
             ),
             "value": (
                 request["label"]
-                if (
-                    selected_checkout
-                    and manifest.by_name[component].checkout_name
-                    == request["physical_checkout"]
-                )
-                or component == request["component"]
+                if manifest.by_name[component].checkout_name
+                == request["physical_checkout"]
                 else ""
             ),
         }
@@ -8695,7 +8682,6 @@ class DeliveryLedgerTests(unittest.TestCase):
                     label=f"released-{index}",
                     branch=f"fix/issue-482-released-{index}",
                     start_sha=start_sha,
-                    topology=f"released-{index}",
                     roots=roots,
                 )
                 observed_request = copy.deepcopy(old_request)
@@ -8774,7 +8760,7 @@ class DeliveryLedgerTests(unittest.TestCase):
                         "component": observed_selector,
                         "profile": "classic",
                         "physical_checkout": "classic",
-                        "topology": f"recovered-{index}",
+                        "topology": f"scope-issue-482-recovered-{index}",
                         "label": f"recovered-{index}",
                         "branch": old_request["branch"],
                         "start_sha": start_sha,
@@ -8878,6 +8864,204 @@ class DeliveryLedgerTests(unittest.TestCase):
                         replacement["name"],
                     )
                     self.assertEqual(recovered.document["history"], [initial.digest])
+
+    def test_43e_recover_prebind_scope_topology_mismatch_is_exact_and_retryable(self) -> None:
+        classic_repository = repository("classic", "R_classic")
+        for index, component in enumerate(("classic-server", "classic-client")):
+            with self.subTest(component=component):
+                roots = live_roots(
+                    self.live_base / f"classic-prebind-{index}", "classic"
+                )
+                start_sha = git_head(roots)
+                name = f"issue-494-prebind-{index}"
+                canonical_topology = f"scope-{name}"
+                canonical_request = scope_request(
+                    name=name,
+                    component=component,
+                    profile="classic",
+                    checkout="classic",
+                    label=f"prebind-{index}",
+                    branch=f"fix/issue-494-prebind-{index}",
+                    start_sha=start_sha,
+                    roots=roots,
+                )
+                live_worktree_path(canonical_request)
+                workspace = Path(roots["workspace"]["path"])
+                (workspace / "topologies" / canonical_topology).mkdir(
+                    parents=True, exist_ok=True
+                )
+                scope_show = scope_show_bytes(
+                    canonical_request, repository_name="atrinik/classic"
+                )
+                install_scope_references(canonical_request, scope_show)
+                worktree_list = worktree_list_bytes(canonical_request)
+                document = issue_ledger(
+                    number=494,
+                    issue_node=f"I_issue_494_prebind_{index}",
+                    branch=canonical_request["branch"],
+                )
+                document["resources"] = [scope_resource(canonical_request)]
+                worktree = next(
+                    slot
+                    for slot in document["artifacts"]
+                    if slot["kind"] == "worktree"
+                )
+                worktree["immutable"]["path"] = None
+                worktree["primitive_request"] = None
+                worktree["producer_resource_slot"] = "scope"
+                retarget_repository(document, classic_repository)
+                replace_sha(document, SHA_A, start_sha)
+                observation = ledger.observe_scope_worktree(
+                    document,
+                    "scope",
+                    scope_show,
+                    worktree_list,
+                    "2026-08-22T06:40:00Z",
+                )
+                safety_observation = json_bytes(observation)
+
+                with tempfile.TemporaryDirectory() as temporary:
+                    review_root = Path(temporary)
+                    created = ledger.create(review_root, document)
+                    legacy_document = copy.deepcopy(created.document)
+                    legacy_topology = f"legacy-{name}"
+                    legacy_document["resources"][0]["request"][
+                        "topology"
+                    ] = legacy_topology
+                    legacy_raw = ledger.canonical_bytes(legacy_document)
+                    (review_root / created.name).write_bytes(legacy_raw)
+                    predecessor = ledger.inspect(review_root, created.name)
+                    self.assertEqual(predecessor.raw, legacy_raw)
+                    self.assertEqual(ledger.validate(legacy_document), legacy_document)
+                    with self.assertRaisesRegex(
+                        ledger.LedgerError, "must be canonical"
+                    ):
+                        ledger.prepare(legacy_document)
+
+                    candidate = next_generation(predecessor)
+                    candidate["resources"][0]["request"][
+                        "topology"
+                    ] = canonical_topology
+                    candidate["authority"] = {
+                        "kind": "explicit-recovery",
+                        "reference": "recovery:issue-494-prebind-scope-topology",
+                        "objective_sha256": "0" * 64,
+                        "issued_at": "2026-08-22T06:41:00Z",
+                        "actor_node_id": predecessor.document["actor"]["node_id"],
+                        "allowed": copy.deepcopy(
+                            predecessor.document["authority"]["allowed"]
+                        ),
+                    }
+                    source = {
+                        "name": predecessor.name,
+                        "ledger_id": predecessor.document["ledger_id"],
+                        "generation": predecessor.document["generation"],
+                        "sha256": predecessor.digest,
+                        "device": predecessor.device,
+                        "inode": predecessor.inode,
+                    }
+                    scope_evidence = {
+                        "name": name,
+                        "component": component,
+                        "profile": "classic",
+                        "physical_checkout": "classic",
+                        "topology": legacy_topology,
+                        "label": canonical_request["label"],
+                        "branch": canonical_request["branch"],
+                        "start_sha": start_sha,
+                        "scope_show_sha256": ledger.byte_digest(scope_show),
+                        "worktree_list_sha256": ledger.byte_digest(worktree_list),
+                        "safety_observation_sha256": ledger.byte_digest(
+                            safety_observation
+                        ),
+                    }
+                    recovery = {
+                        "transaction": "delivery-ledger-recover-prebind-scope-v1",
+                        "source": source,
+                        "scope": scope_evidence,
+                        "observed_topology": canonical_topology,
+                        "candidate_sha256": "0" * 64,
+                        "authority": candidate["authority"],
+                    }
+                    candidate["authority"]["objective_sha256"] = (
+                        ledger.canonical_object_digest(
+                            {
+                                "operation": "recover-prebind-scope",
+                                "source": source,
+                                "scope": scope_evidence,
+                                "observed_topology": canonical_topology,
+                            }
+                        )
+                    )
+                    candidate = ledger.prepare(candidate)
+                    recovery["authority"] = candidate["authority"]
+                    recovery["candidate_sha256"] = ledger.byte_digest(
+                        ledger.canonical_bytes(candidate)
+                    )
+                    recovery_raw = ledger.canonical_bytes(recovery)
+
+                    unsafe = copy.deepcopy(candidate)
+                    unsafe["resources"][0]["request"]["label"] = "unsafe-label"
+                    unsafe = ledger.prepare(unsafe)
+                    unsafe_recovery = copy.deepcopy(recovery)
+                    unsafe_recovery["candidate_sha256"] = ledger.byte_digest(
+                        ledger.canonical_bytes(unsafe)
+                    )
+                    with self.assertRaisesRegex(
+                        ledger.LedgerError, "changed fields outside topology"
+                    ):
+                        ledger.recover_prebind_scope(
+                            review_root,
+                            predecessor.name,
+                            unsafe,
+                            scope_show,
+                            worktree_list,
+                            safety_observation,
+                            ledger.canonical_bytes(unsafe_recovery),
+                            **cas_arguments(predecessor),
+                        )
+                    self.assertEqual(ledger.inspect(review_root, predecessor.name).raw, legacy_raw)
+
+                    with self.assertRaises(ledger.InjectedCrash):
+                        ledger.recover_prebind_scope(
+                            review_root,
+                            predecessor.name,
+                            candidate,
+                            scope_show,
+                            worktree_list,
+                            safety_observation,
+                            recovery_raw,
+                            failpoint="cas:renamed",
+                            **cas_arguments(predecessor),
+                        )
+                    resumed = ledger.recover_prebind_scope(
+                        review_root,
+                        predecessor.name,
+                        candidate,
+                        scope_show,
+                        worktree_list,
+                        safety_observation,
+                        recovery_raw,
+                        **cas_arguments(predecessor),
+                    )
+                    self.assertEqual(resumed.document["generation"], 2)
+                    self.assertEqual(
+                        resumed.document["resources"][0]["request"]["topology"],
+                        canonical_topology,
+                    )
+                    self.assertEqual(resumed.document["history"], [predecessor.digest])
+                    self.assertEqual(ledger.inventory(review_root).pending, ())
+                    with self.assertRaisesRegex(ledger.LedgerError, "proof|stale"):
+                        ledger.recover_prebind_scope(
+                            review_root,
+                            predecessor.name,
+                            candidate,
+                            scope_show,
+                            worktree_list,
+                            safety_observation,
+                            recovery_raw,
+                            **cas_arguments(predecessor),
+                        )
 
     def test_43c_disjoint_classic_scope_binds_concurrently(self) -> None:
         classic_repository = repository("classic", "R_classic")

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -284,10 +284,19 @@ class ScopeLifecycleTests(unittest.TestCase):
         profile.write_text("{}", encoding="utf-8")
         with self.assertRaisesRegex(WorkspaceError, "profile already exists"):
             preflight("profile-exists")
-        topology = self.workspace_directory / "topologies" / "occupied"
+        topology = self.workspace_directory / "topologies" / "scope-topology-exists"
         topology.mkdir(parents=True)
         with self.assertRaisesRegex(WorkspaceError, "topology namespace"):
-            preflight("topology-exists", topology="occupied")
+            preflight("topology-exists")
+        with self.assertRaisesRegex(WorkspaceError, "must be canonical"):
+            preflight("noncanonical-topology", topology="noncanonical-topology")
+        canonical = preflight("canonical-contract")
+        self.assertEqual(canonical["profile"]["name"], "scope-canonical-contract")
+        self.assertEqual(canonical["topology"]["name"], "scope-canonical-contract")
+        self.assertEqual(
+            canonical["topology"]["path"],
+            str(self.workspace_directory / "topologies" / "scope-canonical-contract"),
+        )
         destination = self.workspace_directory / "worktrees" / "client" / "occupied"
         destination.mkdir(parents=True)
         with self.assertRaisesRegex(WorkspaceError, "worktree path"):


### PR DESCRIPTION
Closes #494

## Summary

- make `scope-<name>` the single canonical topology contract across scope creation and delivery state
- reject non-canonical topology requests before any external scope artifact is published
- add narrow, evidence-bound recovery for an exact pre-bind topology mismatch while preserving the predecessor in ledger history
- cover both Classic selectors, retries, crash recovery, and the generated profile, topology, and worktree paths

## Implementation / behavior

- Scope creation derives the profile and topology namespace from the logical scope name and accepts only the canonical topology.
- The delivery ledger keeps legacy records readable for recovery, requires canonical topology in new prepared generations, and verifies canonical paths during live scope binding.
- `recover-prebind-scope` requires an explicit recovery authority plus exact scope-show, worktree-list, and safety evidence. It changes only the proven topology request through the ledger CAS path; released or ambiguous scopes are rejected.
- Contributor guidance and regression tests document the contract and recovery boundary.

## Validation

- Run the focused scope and delivery-ledger regression suites, then the complete wrapper validation recipe.
- Recheck the rendered pull-request body, full base-to-head diff, merge-base, and required latest-head checks before marking this draft ready.

## Limitations / follow-up

- This change owns wrapper scope and delivery contracts only; it does not alter Classic source, authored game content, or runtime topology semantics.
- Existing non-canonical pre-bind ledgers require the explicit recovery command and retained live evidence; they are never rewritten by ordinary validation or cleanup.
