### PR TITLE
fix(cleanup): keep oversized terminal receipts recoverable

### DIFF
--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -63,6 +63,9 @@ from .workspace import (
 CLEANUP_SCHEMA_VERSION = 1
 CLEANUP_JOURNAL_SCHEMA_VERSION = 2
 CLEANUP_JOURNAL_LIMIT = 4096
+# Cleanup receipts may contain one bounded deletion-path report, so they need
+# more room than the generic JSON reader while retaining a finite per-file cap.
+CLEANUP_JOURNAL_MAX_BYTES = 16 * 1024 * 1024
 OWNED_TREE_CLEANUP_KINDS = frozenset(
     {
         "profile-build",
@@ -1772,7 +1775,11 @@ class Cleanup:
                     continue
                 raise WorkspaceError(f"cleanup journal is unsafe: {path}")
             try:
-                value = load_regular_json(path, f"cleanup journal {path.name}")
+                value = load_regular_json(
+                    path,
+                    f"cleanup journal {path.name}",
+                    limit=CLEANUP_JOURNAL_MAX_BYTES,
+                )
             except (OSError, WorkspaceError):
                 if path == cursor_match:
                     raise WorkspaceError(
@@ -2371,7 +2378,11 @@ class Cleanup:
             ],
             include_wrapper=False,
         ):
-            journal = load_regular_json(journal_path, "cleanup acknowledgement journal")
+            journal = load_regular_json(
+                journal_path,
+                "cleanup acknowledgement journal",
+                limit=CLEANUP_JOURNAL_MAX_BYTES,
+            )
             if (
                 not isinstance(journal, dict)
                 or journal.get("schema_version") != CLEANUP_JOURNAL_SCHEMA_VERSION
@@ -2594,7 +2605,11 @@ class Cleanup:
             ):
                 reasons.append("unsafe_cleanup_journal")
             else:
-                value = load_regular_json(path, f"cleanup journal {path.name}")
+                value = load_regular_json(
+                    path,
+                    f"cleanup journal {path.name}",
+                    limit=CLEANUP_JOURNAL_MAX_BYTES,
+                )
         except (OSError, WorkspaceError) as error:
             reasons.append("invalid_cleanup_journal")
             item["error"] = str(error)

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -4673,6 +4673,48 @@ class CleanupTests(unittest.TestCase):
         self.assertEqual(preview["summary"]["candidate_count"], 1)
         self.assertEqual(preview["items"][0]["path"], str(receipt_path))
 
+    def test_cleanup_recovers_oversized_terminal_receipt(self) -> None:
+        request: dict[str, object] = {
+            "scopes": ["cleanup-journals"],
+            "older_than_days": 7,
+            "filters": [],
+        }
+        coordinate = cleanup_module._canonical_json_sha256(request)
+        deleted_path = "/already-removed-" + (
+            "x" * (cleanup_module.CLEANUP_JOURNAL_MAX_BYTES // 6)
+        )
+        receipt = self.make_delivered_cleanup_journal(
+            f"20000101T000000000000Z-{coordinate}-000000000000.json",
+            targets=[{"kind": "profile-build", "path": deleted_path}],
+            request=request,
+        )
+        value = json.loads(receipt.read_text(encoding="utf-8"))
+        value["status"] = "complete-pending-output"
+        value.pop("delivered_at")
+        receipt.write_text(json.dumps(value), encoding="utf-8")
+        receipt.chmod(0o600)
+
+        self.assertGreater(receipt.stat().st_size, 4 * 1024 * 1024)
+        self.assertLessEqual(
+            receipt.stat().st_size, cleanup_module.CLEANUP_JOURNAL_MAX_BYTES
+        )
+
+        recovered = self.workspace.cleanup(
+            ["cleanup-journals"], 7, [], True
+        )
+        self.assertEqual(recovered["journal"], str(receipt))
+        self.assertEqual(
+            recovered["completed_actions"],
+            [{"kind": "profile-build", "path": deleted_path}],
+        )
+        self.workspace.cleanup_acknowledge(recovered)
+
+        preview = self.workspace.cleanup(
+            ["cleanup-journals"], 0, [receipt.name], False
+        )
+        self.assertEqual(preview["summary"]["candidate_count"], 1)
+        self.assertEqual(preview["items"][0]["path"], str(receipt))
+
     def test_current_coordinate_recovery_pages_past_4096_receipts(self) -> None:
         journal_root = self.workspace.paths.workspace / "cleanup-journals"
         journal_root.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

Keep valid terminal cleanup receipts recoverable when their serialized JSON exceeds the generic 4 MiB JSON reader limit.

Closes #498

## Implementation / behavior

- Add a cleanup-journal-specific byte limit for terminal receipt reads.
- Preserve the existing no-follow, ownership, mode, link-count, exact-name, entry-count, and deletion-byte checks.
- Add regression coverage for oversized terminal receipt recovery while keeping the generic JSON limit unchanged.

## Validation

- `python3 -m unittest tests.test_cleanup`
- `python3 -m unittest discover -v`
