### PR TITLE
fix(delivery): add an atomic PR binding operation

### DIFF
--- a/.agents/skills/atrinik-issue-delivery/SKILL.md
+++ b/.agents/skills/atrinik-issue-delivery/SKILL.md
@@ -149,6 +149,11 @@ owner `AGENTS.md`; do not duplicate procedures.
   mismatch from an older helper may use `recover-prebind-scope` with retained
   scope-show, worktree-list, safety, and explicit-recovery evidence; it changes
   only the proven topology request through CAS and preserves the predecessor.
+- In issue mode, `bind-check` only diagnoses a remotely created planned PR.
+  Use the helper-owned `pr-bind-cas` with the exact PR number and a fresh
+  four-part ledger tuple. It re-proves the authenticated actor, same-repository
+  draft PR, durable body, comments, target, and bound worktree immediately
+  before its private CAS; generic `cas` cannot perform this initial PR bind.
 - In PR mode, set `TARGET_BRANCH`, `BASE_SHA`, `HEAD_BRANCH`, `HEAD_SHA`, and
   `MERGE_BASE` from the live PR. Fetch and verify the exact base/head refs
   without rewriting published history. Create the local head branch at the

--- a/.agents/skills/atrinik-issue-delivery/references/delivery-ledger.md
+++ b/.agents/skills/atrinik-issue-delivery/references/delivery-ledger.md
@@ -106,6 +106,9 @@ python3 scripts/delivery_ledger.py check-reuse REVIEW_ROOT LEDGER_NAME --kind al
 python3 scripts/delivery_ledger.py check-reuse REVIEW_ROOT LEDGER_NAME --kind artifacts
 python3 scripts/delivery_ledger.py check-reuse REVIEW_ROOT LEDGER_NAME --kind resources
 python3 scripts/delivery_ledger.py bind-check REVIEW_ROOT LEDGER_NAME SLOT_ID INPUT
+python3 scripts/delivery_ledger.py pr-bind-cas REVIEW_ROOT LEDGER_NAME SLOT_ID PR_NUMBER \
+  --expected-generation GENERATION --expected-digest SHA256 \
+  --expected-device DEVICE --expected-inode INODE
 python3 scripts/delivery_ledger.py worktree-bind REVIEW_ROOT LEDGER_NAME SLOT_ID \
   WORKTREE_LIST_JSON SAFETY_JSON [--create-output OUTPUT]
 python3 scripts/delivery_ledger.py worktree-observe REVIEW_ROOT LEDGER_NAME SLOT_ID \
@@ -162,6 +165,14 @@ candidate, and returns exactly `classification`, `slot_id`, `request_sha256`,
 `inspect`; stale identity or changed live state stops. A pending predecessor
 receipt can be recovered only with its original predecessor tuple. A fresh
 current tuple cannot treat that receipt as an ordinary `bound-match` retry.
+For an issue-mode planned PR, `bind-check` is likewise diagnostic only;
+`pr-bind-cas` is the mutation boundary. It accepts the slot, PR number, and one
+fresh four-part ledger tuple, then re-fetches the authenticated actor, complete
+same-repository draft PR identity, durable body bytes, comment state, target,
+and bound local worktree before its private CAS. Generic `cas` cannot perform
+this initial PR bind. An interrupted PR bind is retried with the identical
+original command and predecessor tuple so the helper can accept only its exact
+receipt.
 
 Before any dynamic `Workspace` import or Python execution, live proof performs
 a bounded component-wise no-follow ownership/mode prevalidation of the complete
@@ -1506,17 +1517,33 @@ python3 scripts/delivery_ledger.py bind-check \
   "$DELIVERY_PR_IDENTITY"
 ```
 
-Proceed only on `classification: bind-exact`. CAS the planned PR artifact to
-`created`, using the exact candidate as current identity, the target head, and
-freshly proven artifact safety. Append exactly one selected PR. Its repository
-and head repository are identical; its base/head match the wholly unchanged
-target; its authenticated actor is the author; it remains draft with null ready
-intent; its comment state is none; and its `delivery-created`/`written` body has
-null observed/intended digest/payload, null section, and equal current/outside
-digest matching the planned slot. Its PR artifact permanently retains the
-initial payload. This exception applies only while immutable
-`authority.allowed.pull_requests` is empty. The helper does not expand or
-rewrite authority and never adopts this result.
+Use `bind-check` only as a preflight diagnostic; it does not authorize a
+caller-built CAS. Immediately before mutation, inspect the ledger and run the
+purpose-specific binder with the exact PR number and the four identity values
+from that same snapshot:
+
+```sh
+python3 scripts/delivery_ledger.py pr-bind-cas \
+  "$DELIVERY_REVIEW_ROOT" "$DELIVERY_LEDGER" pull-request 423 \
+  --expected-generation "$DELIVERY_EXPECTED_GENERATION" \
+  --expected-digest "$DELIVERY_EXPECTED_DIGEST" \
+  --expected-device "$DELIVERY_EXPECTED_DEVICE" \
+  --expected-inode "$DELIVERY_EXPECTED_INODE"
+```
+
+`pr-bind-cas` performs the live authenticated-author, same-repository,
+unchanged-target, draft, durable-body, and no-comment proof itself immediately
+before the ledger CAS. On `bind-exact`, it marks the planned PR artifact
+`created` and appends exactly one selected PR. On an identical completed retry,
+it returns `bound-match`. The selected PR's repository and head repository are
+identical; its base/head match the wholly unchanged target; its authenticated
+actor is the author; it remains draft with null ready intent; its comment state
+is none; and its `delivery-created`/`written` body has null observed/intended
+digest/payload, null section, and equal current/outside digest matching the
+planned slot. Its PR artifact permanently retains the initial payload. This
+exception applies only while immutable `authority.allowed.pull_requests` is
+empty. The helper does not expand or rewrite authority and never adopts this
+result through generic `cas`.
 
 This CAS may change only ledger generation/history, that one PR slot, and that
 one matching selected PR. Normalizing generation/history, removing the added
@@ -1526,10 +1553,12 @@ or any root-coordinate change fails. Refetch and inspect after CAS.
 
 If remote creation returned an error or timed out, search all candidate PRs and
 run `bind-check` on the sole possible match, comparing the durable initial
-payload digest. Zero is not permission to retry an uncertain create; multiple
-or mismatched candidates stop. `pr-create-payload` reconstructs intent for
-recovery but never authorizes another uncertain create. PR mode never uses this
-path because its selected PR and adopted slot exist at genesis.
+payload digest. If it is exact, run `pr-bind-cas` for that PR number with a
+fresh ledger tuple; never use generic `cas`. Zero is not permission to retry an
+uncertain create; multiple or mismatched candidates stop.
+`pr-create-payload` reconstructs intent for recovery but never authorizes
+another uncertain create. PR mode never uses this path because its selected PR
+and adopted slot exist at genesis.
 
 ## Plan and recover body updates
 
@@ -1911,7 +1940,7 @@ stop for code-level recovery; never improvise file repair.
 | Atomic worktree/scope bind interrupted at either CAS boundary | Rerun the identical `worktree-bind-cas` or `scope-bind-cas` with the same retained inputs and original four-part predecessor tuple, never generic `cas`. The helper freshly reproves live state before replacement and before accepting an installed post-rename receipt; drift preserves evidence and stops. |
 | Migration operation-digest plan/snapshot/report/prepared/ledger/complete boundary | Rerun exact `migrate` with identical null-migration candidate, kind, direct source name, and original source identity/digest. A different candidate or source cannot reuse even a short planned-stage prefix. |
 | Complete migration | `inventory` and `inspect`; require source/snapshot/marker/ledger coherence and no pending stage. |
-| Planned PR slot after remote create uncertainty | Recover the immutable initial bytes with `pr-create-payload`, search live candidates, and use `bind-check`; bind one exact match only. Zero or a mismatch never permits another uncertain create. |
+| Planned PR slot after remote create uncertainty | Recover the immutable initial bytes with `pr-create-payload`, search live candidates, and use `bind-check`; for one exact match run `pr-bind-cas` with its number and a fresh tuple. Zero or a mismatch never permits another uncertain create. |
 | Planned primitive branch/worktree after an uncertain local mutation | Reinspect the exact branch and wrapper registration. For one present exact worktree, capture a fresh list, use `worktree-observe`, then run `worktree-bind-cas` with one fresh four-part tuple. Retain manifest-owner create output; omit it only for wrapper-self raw Git or genuinely unretained recovery. The atomic command reproves before CAS. An exact still-absent artifact permits only the original planned operation. Mismatch or uncertainty stops; an adopted worktree requires the branch already bound. |
 | Fresh issue planned scope after uncertain `scope create` | Rerun the exact idempotent create request, retain exact scope-show/list bytes, derive safety with `scope-observe`, then run `scope-bind-cas` with one fresh four-part tuple. It must atomically install the one scope/branch/worktree result; physical-checkout selectors and logical-component selectors are both accepted when they resolve to one exact checkout; partial, released, changed, referenced, or cross-checkout state stops. A live canonical scope with a legacy planned topology request is handled only by the explicit `recover-prebind-scope` evidence/CAS path; a released mistaken scope is terminal evidence and requires release/reinitialize, not in-place request mutation. |
 | Body `update-planned` | Run `body-recovery` with one digest/timestamp observation. Refresh a newer exact-current observation first; apply only returned durable bytes, bind equal-or-later intended bytes, or cancel only on exact proven non-application. Other live bytes stop. |

--- a/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
+++ b/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
@@ -93,13 +93,13 @@ _CREATE_STAGE_RE = re.compile(
 _MIGRATE_STAGE_RE = re.compile(r"^\.(?P<target>.+\.md\.ledger\.json)\.migrate\.tmp$")
 _UPDATE_STAGE_RE = re.compile(
     r"^\.(?P<target>.+\.md\.ledger\.json)\.update"
-    r"(?P<operation>-refresh-target|-bind-(?:worktree|scope)-[a-z0-9][a-z0-9._-]{0,127}|-recover-scope-[a-z0-9][a-z0-9._-]{0,127})?"
+    r"(?P<operation>-refresh-target|-bind-(?:worktree|scope|pr)-[a-z0-9][a-z0-9._-]{0,127}|-recover-scope-[a-z0-9][a-z0-9._-]{0,127})?"
     r"-g(?P<generation>[0-9]+)-"
     r"from-(?P<digest>[0-9a-f]{64})-to-(?P<candidate>[0-9a-f]{64})\.tmp$"
 )
 _UPDATE_RECEIPT_RE = re.compile(
     r"^\.(?P<target>.+\.md\.ledger\.json)\.update-proof"
-    r"(?P<operation>-refresh-target|-bind-(?:worktree|scope)-[a-z0-9][a-z0-9._-]{0,127}|-recover-scope-[a-z0-9][a-z0-9._-]{0,127})?"
+    r"(?P<operation>-refresh-target|-bind-(?:worktree|scope|pr)-[a-z0-9][a-z0-9._-]{0,127}|-recover-scope-[a-z0-9][a-z0-9._-]{0,127})?"
     r"-g"
     r"(?P<generation>[0-9]+)-from-(?P<digest>[0-9a-f]{64})-"
     r"d(?P<device>[0-9]+)-i(?P<inode>[0-9]+)-"
@@ -7391,6 +7391,415 @@ def classify_pr_binding(
     return "bind-exact"
 
 
+def _pr_binding_remote(
+    document: Mapping[str, Any], target: Mapping[str, Any], pr_number: int
+) -> dict[str, Any]:
+    """Fetch and prove the complete remote state for one issue-created PR bind."""
+
+    number = _integer(pr_number, "PR binding number")
+    repository = target["repository"]
+    owner = repository["owner"]
+    name = repository["name"]
+    full_name = f"{owner}/{name}"
+    actor = _gh_json(
+        ("api", "--hostname", "github.com", "user"),
+        "PR binding authenticated actor",
+    )
+    if not isinstance(actor, dict) or actor.get("node_id") != document["actor"]["node_id"]:
+        raise LedgerError("authenticated GitHub actor differs from PR binding authority")
+    actor_node = _string(
+        actor.get("node_id"), "PR binding authenticated actor.node_id", NODE_RE
+    )
+    live = _gh_json(
+        (
+            "api",
+            "--hostname",
+            "github.com",
+            f"repos/{owner}/{name}/pulls/{number}",
+        ),
+        f"PR binding pull request {number}",
+    )
+    if not isinstance(live, dict):
+        raise LedgerError("PR binding pull request observation is not an object")
+
+    def prove_repository(value: Any, context: str) -> None:
+        if not isinstance(value, dict):
+            raise LedgerError(f"{context} is not an object")
+        if value.get("node_id") != repository["node_id"] or value.get("full_name") != full_name:
+            raise LedgerError(f"{context} differs from the exact target repository")
+
+    base = live.get("base")
+    head = live.get("head")
+    if not isinstance(base, dict) or not isinstance(head, dict):
+        raise LedgerError("PR binding observation lacks exact base and head objects")
+    prove_repository(base.get("repo"), "PR binding base repository")
+    prove_repository(head.get("repo"), "PR binding head repository")
+    live_number = _integer(live.get("number"), "PR binding observed number")
+    node = _string(live.get("node_id"), "PR binding observed node_id", NODE_RE)
+    if live_number != number:
+        raise LedgerError("PR binding observed number differs from the requested PR")
+    if live.get("state") != "open" or live.get("draft") is not True:
+        raise LedgerError("PR binding requires the exact open draft PR state")
+    author = live.get("user")
+    if not isinstance(author, dict) or author.get("node_id") != actor_node:
+        raise LedgerError("PR binding PR author differs from the authenticated actor")
+    base_branch = _branch(live.get("base", {}).get("ref"), "PR binding base branch")
+    head_branch = _branch(live.get("head", {}).get("ref"), "PR binding head branch")
+    base_sha = _string(
+        live.get("base", {}).get("sha"), "PR binding base head SHA", COMMIT_RE
+    )
+    head_sha = _string(
+        live.get("head", {}).get("sha"), "PR binding PR head SHA", COMMIT_RE
+    )
+    body = live.get("body")
+    if not isinstance(body, str):
+        raise LedgerError("PR binding requires a non-null UTF-8 PR body")
+    try:
+        body_raw = body.encode("utf-8")
+    except UnicodeError as error:
+        raise LedgerError("PR binding PR body is not valid UTF-8") from error
+    if len(body_raw) > MAX_RETAINED_RESULT_BYTES:
+        raise LedgerError("PR binding PR body exceeds the retained result limit")
+    updated_at = _string(
+        live.get("updated_at"), "PR binding PR updated_at", TIMESTAMP_RE
+    )
+    _timestamp_key(updated_at, "PR binding PR updated_at")
+    comments = _gh_json(
+        (
+            "api",
+            "--hostname",
+            "github.com",
+            f"repos/{owner}/{name}/issues/{number}/comments?per_page=1",
+        ),
+        f"PR binding comments for pull request {number}",
+    )
+    if not isinstance(comments, list):
+        raise LedgerError("PR binding comment pagination is not an array")
+    if comments and all(isinstance(page, list) for page in comments):
+        has_comments = any(bool(page) for page in comments)
+    elif comments and all(isinstance(comment, dict) for comment in comments):
+        # This is accepted for test doubles and older gh versions that return a
+        # single page without --slurp; any non-empty result is still unsafe.
+        has_comments = True
+    elif comments:
+        raise LedgerError("PR binding comment pagination has an invalid page")
+    else:
+        has_comments = False
+    if has_comments:
+        raise LedgerError("PR binding found external PR comments")
+    digest = byte_digest(body_raw)
+    pull = {
+        "repository": copy.deepcopy(repository),
+        "head_repository": copy.deepcopy(repository),
+        "number": number,
+        "node_id": node,
+        "author_node_id": actor_node,
+        "base_branch": base_branch,
+        "head_branch": head_branch,
+        "draft": True,
+        "draft_intent": None,
+        "body": {
+            "ownership": "delivery-created",
+            "state": "written",
+            "observed_digest": None,
+            "intended_digest": None,
+            "intended_payload": None,
+            "current_digest": digest,
+            "outside_digest": digest,
+            "section_digest": None,
+            "updated_at": updated_at,
+        },
+        "comment": {
+            "state": "none",
+            "marker": None,
+            "intended_digest": None,
+            "intended_payload": None,
+            "node_id": None,
+            "current_digest": None,
+        },
+    }
+    return {
+        "pull": pull,
+        "base_sha": base_sha,
+        "head_sha": head_sha,
+        "body_digest": digest,
+    }
+
+
+def _pr_binding_coordinates(
+    document: Mapping[str, Any], slot_id: str
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Resolve the exact target branch/worktree that a PR bind must protect."""
+
+    item = validate(document)
+    slot_id = _string(slot_id, "slot_id", SLOT_RE)
+    slots = [slot for slot in item["artifacts"] if slot["slot_id"] == slot_id]
+    if len(slots) != 1 or slots[0]["kind"] != "pull_request":
+        raise LedgerError("PR binding requires one exact pull-request slot")
+    pr_slot = slots[0]
+    targets = [
+        target
+        for target in item["targets"]
+        if target["repository"] == pr_slot["immutable"]["repository"]
+        and target["head"]["branch"] == pr_slot["immutable"]["branch"]
+    ]
+    if len(targets) != 1:
+        raise LedgerError("PR binding requires one exact target coordinate")
+    target = targets[0]
+    branches = [
+        slot
+        for slot in item["artifacts"]
+        if slot["kind"] == "branch"
+        and slot["immutable"]["repository"] == target["repository"]
+        and slot["immutable"]["branch"] == target["head"]["branch"]
+    ]
+    worktrees = [
+        slot
+        for slot in item["artifacts"]
+        if slot["kind"] == "worktree"
+        and slot["immutable"]["repository"] == target["repository"]
+        and slot["immutable"]["branch"] == target["head"]["branch"]
+    ]
+    if len(branches) != 1 or len(worktrees) != 1:
+        raise LedgerError("PR binding requires one exact branch and worktree")
+    branch = branches[0]
+    worktree = worktrees[0]
+    if (
+        branch["state"] == "planned"
+        or worktree["state"] == "planned"
+        or branch["safety"] != SAFE_ARTIFACT_STATE
+        or worktree["safety"] != SAFE_ARTIFACT_STATE
+        or worktree["current"] is None
+        or worktree["current"]["path"] is None
+    ):
+        raise LedgerError("PR binding requires one already-bound safe worktree")
+    return item, pr_slot, target, branch, worktree
+
+
+def _pr_binding_classification(
+    document: Mapping[str, Any],
+    slot_id: str,
+    target: Mapping[str, Any],
+    remote: Mapping[str, Any],
+) -> str:
+    """Classify the first bind or an exact installed post-rename retry."""
+
+    item, slot, _, _, _ = _pr_binding_coordinates(document, slot_id)
+    pull = remote["pull"]
+    if slot["state"] == "planned":
+        if item["entry_mode"] != "issue" or item["authority"]["allowed"]["pull_requests"]:
+            raise LedgerError("PR binding requires an issue-mode planned PR authority")
+        if remote["pull"]["base_branch"] != target["base"]["branch"]:
+            raise LedgerError("PR binding base branch differs from the exact target")
+        classify_pr_binding(
+            item,
+            slot_id,
+            {
+                "repository": copy.deepcopy(pull["repository"]),
+                "head_branch": pull["head_branch"],
+                "number": pull["number"],
+                "node_id": pull["node_id"],
+                "head_sha": remote["head_sha"],
+                "body_digest": remote["body_digest"],
+            },
+        )
+        if remote["base_sha"] != target["base"]["current_sha"]:
+            raise LedgerError("PR binding base head differs from the exact target")
+        return "bind-exact"
+    if slot["state"] not in {"created", "adopted"} or slot["current"] is None:
+        raise LedgerError("PR binding slot is not safely reusable")
+    selected = [
+        value
+        for value in item["selected_prs"]
+        if value["number"] == pull["number"] and value["node_id"] == pull["node_id"]
+    ]
+    current = slot["current"]
+    if (
+        len(selected) != 1
+        or selected[0] != pull
+        or current["number"] != pull["number"]
+        or current["node_id"] != pull["node_id"]
+        or current["head_sha"] != remote["head_sha"]
+        or current["body_digest"] != remote["body_digest"]
+        or pull["base_branch"] != target["base"]["branch"]
+    ):
+        raise LedgerError("bound PR differs from the exact live PR observation")
+    if remote["base_sha"] != target["base"]["current_sha"]:
+        raise LedgerError("bound PR base head differs from the exact target")
+    return "bound-match"
+
+
+def _pr_binding_candidate(
+    snapshot: Snapshot, slot_id: str, remote: Mapping[str, Any]
+) -> dict[str, Any]:
+    candidate = _json_object_copy(snapshot.document, "atomic PR binding candidate")
+    candidate["generation"] += 1
+    candidate["previous_byte_digest"] = snapshot.digest
+    candidate["history"].append(snapshot.digest)
+    slot = next(value for value in candidate["artifacts"] if value["slot_id"] == slot_id)
+    current = {
+        **copy.deepcopy(slot["immutable"]),
+        "number": remote["pull"]["number"],
+        "node_id": remote["pull"]["node_id"],
+        "head_sha": remote["head_sha"],
+    }
+    slot_result = _json_object_copy(slot, "atomic PR binding slot")
+    slot_result.update(
+        state="created",
+        current=current,
+        safety=dict(SAFE_ARTIFACT_STATE),
+    )
+    candidate["artifacts"] = [
+        slot_result if value["slot_id"] == slot_id else value
+        for value in candidate["artifacts"]
+    ]
+    candidate["selected_prs"] = [
+        *candidate["selected_prs"],
+        copy.deepcopy(remote["pull"]),
+    ]
+    return prepare(candidate)
+
+
+@contextmanager
+def _pr_binding_live_safety(
+    document: Mapping[str, Any], target: Mapping[str, Any], worktree: Mapping[str, Any]
+) -> Iterator[Callable[[], None]]:
+    """Pin the exact delivery worktree before each authenticated PR observation."""
+
+    request = worktree.get("primitive_request")
+    allowed: frozenset[str] = frozenset()
+    scope_record = None
+    scope_proof = None
+    if request is None:
+        request, allowed, scope_record, scope_proof = _target_refresh_worktree_provenance(
+            document, worktree
+        )
+    request = _decode(canonical_bytes(request), "PR binding worktree request")
+    # Target refresh advances artifact heads while preserving the original
+    # primitive request as immutable provenance.  Pin the live worktree to the
+    # refreshed target tip for this operation, just as target-refresh-cas does.
+    request["expected_head_sha"] = target["head"]["current_sha"]
+    path = worktree["current"]["path"]
+    with _pinned_live_worktree(
+        request,
+        path,
+        "atomic PR binding",
+        allowed_references=allowed,
+        scope_record=scope_record,
+    ) as guard:
+        def prove() -> None:
+            guard.prove()
+            if scope_proof is not None:
+                _scope_binding_observation(
+                    scope_proof["observation"],
+                    scope_proof["request"],
+                    scope_proof["repository"],
+                    scope_proof["row"],
+                    scope_proof["binding_digest"],
+                    scope_proof["record"],
+                    "atomic PR binding scope observation",
+                    live=True,
+                    guard=guard,
+                    live_request=request,
+                )
+
+        prove()
+        yield prove
+
+
+def bind_pr_cas(
+    root: Path | str,
+    name: str,
+    slot_id: str,
+    pr_number: int,
+    *,
+    expected_generation: int,
+    expected_digest: str,
+    expected_device: int,
+    expected_inode: int,
+    failpoint: Failpoint = None,
+) -> dict[str, Any]:
+    """Live-prove and atomically bind one issue-created draft PR slot."""
+
+    snapshot = inspect(root, name)
+    _, _, target, _, worktree = _pr_binding_coordinates(snapshot.document, slot_id)
+    with _pr_binding_live_safety(snapshot.document, target, worktree) as prove_local:
+        prove_local()
+        remote = _pr_binding_remote(snapshot.document, target, pr_number)
+        classification = _pr_binding_classification(
+            snapshot.document, slot_id, target, remote
+        )
+        _hit(failpoint, "pr-bind:classified")
+
+        def revalidate() -> None:
+            prove_local()
+            latest = _pr_binding_remote(snapshot.document, target, pr_number)
+            if latest != remote:
+                raise LedgerError("PR binding remote observation changed before CAS")
+
+        revalidate()
+        if (
+            classification == "bound-match"
+            and _snapshot_matches_tuple(
+                snapshot,
+                expected_generation,
+                expected_digest,
+                expected_device,
+                expected_inode,
+            )
+        ):
+            installed = _require_clean_bound_snapshot(root, snapshot)
+        else:
+            if classification == "bound-match":
+                candidate = snapshot.document
+                capability = _AtomicBindingCapability(
+                    _ATOMIC_BIND_TOKEN,
+                    "pr",
+                    slot_id,
+                    snapshot.name,
+                    None,
+                    snapshot.raw,
+                    expected_generation,
+                    expected_digest,
+                    expected_device,
+                    expected_inode,
+                )
+            else:
+                candidate = _pr_binding_candidate(snapshot, slot_id, remote)
+                capability = _AtomicBindingCapability(
+                    _ATOMIC_BIND_TOKEN,
+                    "pr",
+                    slot_id,
+                    snapshot.name,
+                    snapshot.raw,
+                    canonical_bytes(candidate),
+                    expected_generation,
+                    expected_digest,
+                    expected_device,
+                    expected_inode,
+                )
+            installed = cas(
+                root,
+                snapshot.name,
+                candidate,
+                expected_generation=expected_generation,
+                expected_digest=expected_digest,
+                expected_device=expected_device,
+                expected_inode=expected_inode,
+                failpoint=failpoint,
+                _precommit=revalidate,
+                _binding_capability=capability,
+            )
+    return {
+        "classification": classification,
+        "slot_id": slot_id,
+        "number": remote["pull"]["number"],
+        "node_id": remote["pull"]["node_id"],
+        "body_digest": remote["body_digest"],
+        "snapshot": installed.json(),
+    }
+
+
 def planned_pr_payload(document: Mapping[str, Any], slot_id: str) -> bytes:
     """Return the exact durable initial body for one still-planned PR slot."""
 
@@ -12689,6 +13098,7 @@ def _transition(
     if issue_created_prs:
         if len(issue_created_prs) != 1 or added_pr_keys != {issue_created_prs[0][0]}:
             raise LedgerError("issue-created PR bind must add exactly one selected PR")
+        protected_binding_kinds.add("pr")
         key, _, before_slot, after_slot = issue_created_prs[0]
         normalized = _decode(canonical_bytes(new), "issue-created PR transition")
         normalized["generation"] = old["generation"]
@@ -13283,7 +13693,7 @@ def cas(
         if (
             not isinstance(capability, _AtomicBindingCapability)
             or capability.token is not _ATOMIC_BIND_TOKEN
-            or capability.kind not in {"worktree", "scope"}
+            or capability.kind not in {"worktree", "scope", "pr"}
             or not SLOT_RE.fullmatch(capability.slot_id)
             or capability.name != name
             or capability.after_raw != raw
@@ -15409,6 +15819,17 @@ def parser() -> argparse.ArgumentParser:
     bind_parser.add_argument("name", help="direct canonical ledger filename")
     bind_parser.add_argument("slot_id", help="planned pull-request artifact slot")
     bind_parser.add_argument("input", help="bounded no-follow remote identity JSON file")
+    pr_bind_cas_parser = commands.add_parser(
+        "pr-bind-cas", help="atomically live-prove and bind an issue-created draft PR"
+    )
+    pr_bind_cas_parser.add_argument("root", help="initialized review root")
+    pr_bind_cas_parser.add_argument("name", help="direct canonical ledger filename")
+    pr_bind_cas_parser.add_argument("slot_id", help="planned pull-request artifact slot")
+    pr_bind_cas_parser.add_argument("pr_number", type=int, help="remote pull-request number")
+    pr_bind_cas_parser.add_argument("--expected-generation", required=True, type=int)
+    pr_bind_cas_parser.add_argument("--expected-digest", required=True)
+    pr_bind_cas_parser.add_argument("--expected-device", required=True, type=int)
+    pr_bind_cas_parser.add_argument("--expected-inode", required=True, type=int)
     worktree_bind_parser = commands.add_parser(
         "worktree-bind", help="classify retained fresh wrapper worktree evidence"
     )
@@ -15713,6 +16134,19 @@ def main(argv: Sequence[str] | None = None) -> int:
                         _read_input(arguments.input),
                     ),
                 }
+            )
+        elif arguments.command == "pr-bind-cas":
+            _print(
+                bind_pr_cas(
+                    arguments.root,
+                    arguments.name,
+                    arguments.slot_id,
+                    arguments.pr_number,
+                    expected_generation=arguments.expected_generation,
+                    expected_digest=arguments.expected_digest,
+                    expected_device=arguments.expected_device,
+                    expected_inode=arguments.expected_inode,
+                )
             )
         elif arguments.command == "worktree-bind":
             snapshot = inspect(arguments.root, arguments.name)

--- a/README.md
+++ b/README.md
@@ -1721,7 +1721,10 @@ operator prepares exact post-merge evidence and runs:
 Target base/head movement is likewise helper-owned: generic ledger CAS rejects
 it. The target-refresh CAS pins the recorded primitive/scope worktree, proves
 descendant commits and the exact live merge base, and rechecks immediately
-before replacement. An explicit recovery can correct one historical nonexistent
+before replacement. Fresh issue-mode draft PR binding is similarly
+helper-owned: `bind-check` is only a diagnostic, while `pr-bind-cas` re-proves
+the authenticated PR, comments, target, and bound worktree immediately before
+its private CAS. An explicit recovery can correct one historical nonexistent
 head plus its bound stale merge base while retaining both source generations.
 
 ~~~sh

--- a/tests/test_delivery_ledger.py
+++ b/tests/test_delivery_ledger.py
@@ -1828,6 +1828,52 @@ def bind_issue_created_pr(
     return update
 
 
+def cas_issue_created_pr(
+    root: Path, snapshot: object, candidate: dict[str, object]
+) -> object:
+    """Install a fixture through the private PR-binding capability."""
+
+    assert isinstance(snapshot, ledger.Snapshot)
+    prepared = ledger.prepare(candidate)
+    old_slots = {
+        slot["slot_id"]: slot
+        for slot in snapshot.document["artifacts"]
+        if slot["kind"] == "pull_request"
+    }
+    new_slots = {
+        slot["slot_id"]: slot
+        for slot in prepared["artifacts"]
+        if slot["kind"] == "pull_request"
+    }
+    slot_ids = [
+        slot_id
+        for slot_id, old in old_slots.items()
+        if old["state"] == "planned"
+        and new_slots[slot_id]["state"] == "created"
+    ]
+    assert len(slot_ids) == 1
+    after_raw = ledger.canonical_bytes(prepared)
+    capability = ledger._AtomicBindingCapability(
+        ledger._ATOMIC_BIND_TOKEN,
+        "pr",
+        slot_ids[0],
+        snapshot.name,
+        snapshot.raw,
+        after_raw,
+        snapshot.document["generation"],
+        snapshot.digest,
+        snapshot.device,
+        snapshot.inode,
+    )
+    return ledger.cas(
+        root,
+        snapshot.name,
+        prepared,
+        **cas_arguments(snapshot),
+        _binding_capability=capability,
+    )
+
+
 def directory_snapshot(root: Path) -> tuple[tuple[object, ...], ...]:
     result: list[tuple[object, ...]] = []
     for path in sorted(root.iterdir(), key=lambda value: value.name):
@@ -3851,7 +3897,7 @@ class DeliveryLedgerTests(unittest.TestCase):
                     "certain": True,
                 },
             )
-            bound = ledger.cas(root, initial.name, update, **cas_arguments(initial))
+            bound = cas_issue_created_pr(root, initial, update)
             self.assertEqual(bound.document["selected_prs"][0]["node_id"], "P_issue_created")
 
         invalid_timestamp = pr_ledger(
@@ -4153,6 +4199,7 @@ class DeliveryLedgerTests(unittest.TestCase):
             "body-recovery",
             "pr-create-payload",
             "bind-check",
+            "pr-bind-cas",
             "comment-check",
         )
         for command in commands:
@@ -4373,17 +4420,8 @@ class DeliveryLedgerTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             initial = ledger.create(root, issue_ledger())
-            bound = ledger.cas(root, initial.name, bind_one(initial), **cas_arguments(initial))
-            self.assertEqual(bound.document["authority"]["allowed"]["pull_requests"], [])
-            self.assertEqual(bound.document["selected_prs"][0]["node_id"], "P_issue_created")
-            self.assertEqual(
-                next(
-                    slot
-                    for slot in bound.document["artifacts"]
-                    if slot["kind"] == "pull_request"
-                )["state"],
-                "created",
-            )
+            with self.assertRaisesRegex(ledger.LedgerError, "initial pr binding"):
+                ledger.cas(root, initial.name, bind_one(initial), **cas_arguments(initial))
 
         def reject(label: str, mutate: object) -> None:
             with self.subTest(rejected=label), tempfile.TemporaryDirectory() as temporary:
@@ -4534,6 +4572,280 @@ class DeliveryLedgerTests(unittest.TestCase):
                 ledger.cas(root, initial.name, candidate, **cas_arguments(initial))
             self.assertEqual(directory_snapshot(root), before)
 
+    def test_25_pr_bind_cas_live_proof_drift_comments_and_recovery(self) -> None:
+        def document(roots: dict[str, object] | None = None) -> dict[str, object]:
+            branch = "docs/issue-499"
+            if roots is None:
+                worktree = "/workspace/worktrees/issue-499"
+            else:
+                worktree = str(
+                    Path(roots["workspace"]["path"])
+                    / "worktrees"
+                    / "atrinik"
+                    / "issue-499"
+                )
+            value = issue_ledger(
+                number=499,
+                issue_node="I_499",
+                branch=branch,
+                worktree=worktree,
+            )
+            if roots is not None:
+                live_head = git_head(roots)
+                replace_sha(value, SHA_A, live_head)
+                worktree_slot = next(
+                    slot for slot in value["artifacts"] if slot["kind"] == "worktree"
+                )
+                assert worktree_slot["primitive_request"] is not None
+                worktree_slot["primitive_request"]["roots"] = copy.deepcopy(roots)
+                worktree_slot["primitive_request"]["expected_head_sha"] = live_head
+            return value
+
+        def install_bound(root: Path, live_base: Path) -> tuple[dict[str, object], object]:
+            roots = live_roots(live_base, "atrinik")
+            value = document(roots)
+            initial = ledger.create(root, value)
+            worktree = next(
+                slot for slot in value["artifacts"] if slot["kind"] == "worktree"
+            )
+            request = worktree["primitive_request"]
+            assert request is not None
+            worktree_list = worktree_list_bytes(request)
+            safety = safety_observation_bytes(
+                request,
+                worktree_list,
+                producer_kind="primitive",
+                producer_digest=None,
+            )
+            bound_result = ledger.bind_worktree_cas(
+                root,
+                initial.name,
+                "worktree",
+                worktree_list,
+                safety,
+                **cas_arguments(initial),
+            )
+            return value, ledger.inspect(root, initial.name)
+
+        def live_pr(
+            value: dict[str, object],
+            *,
+            head_sha: str | None = None,
+            body: bytes = INITIAL_PR_BODY,
+            draft: bool = True,
+            base_branch: str | None = None,
+        ) -> dict[str, object]:
+            repository_value = {
+                "node_id": "R_repo",
+                "full_name": "atrinik/atrinik",
+            }
+            target = value["targets"][0]
+            if head_sha is None:
+                head_sha = target["head"]["current_sha"]
+            return {
+                "node_id": "P_issue_created",
+                "number": 500,
+                "state": "open",
+                "draft": draft,
+                "user": {"node_id": "U_actor"},
+                "base": {
+                    "ref": (
+                        target["base"]["branch"]
+                        if base_branch is None
+                        else base_branch
+                    ),
+                    "sha": target["base"]["current_sha"],
+                    "repo": copy.deepcopy(repository_value),
+                },
+                "head": {
+                    "ref": target["head"]["branch"],
+                    "sha": head_sha,
+                    "repo": copy.deepcopy(repository_value),
+                },
+                "body": body.decode("utf-8"),
+                "updated_at": "2026-08-14T18:00:00Z",
+            }
+
+        def gh_observer(live: dict[str, object], comments: object = None):
+            response_comments = [[]] if comments is None else comments
+
+            def observe(arguments: object, context: str) -> object:
+                del context
+                if tuple(arguments)[-1] == "user":
+                    return {"node_id": "U_actor"}
+                endpoint = tuple(arguments)[-1]
+                if "/pulls/500" in endpoint:
+                    return copy.deepcopy(live)
+                if "/comments?" in endpoint:
+                    return copy.deepcopy(response_comments)
+                raise AssertionError(f"unexpected gh observation: {arguments}")
+
+            return observe
+
+        with tempfile.TemporaryDirectory() as temporary, tempfile.TemporaryDirectory() as live_temporary:
+            root = Path(temporary)
+            value, bound = install_bound(root, Path(live_temporary))
+            with mock.patch.object(
+                ledger,
+                "_gh_json",
+                side_effect=gh_observer(live_pr(value)),
+            ):
+                bound_result = ledger.bind_pr_cas(
+                    root,
+                    bound.name,
+                    "pull-request",
+                    500,
+                    **cas_arguments(bound),
+                )
+                bound = ledger.inspect(root, bound.name)
+                repeated = ledger.bind_pr_cas(
+                    root,
+                    bound.name,
+                    "pull-request",
+                    500,
+                    **cas_arguments(bound),
+                )
+            self.assertEqual(bound_result["classification"], "bind-exact")
+            self.assertEqual(repeated["classification"], "bound-match")
+            self.assertEqual(bound.document["generation"], 3)
+            self.assertEqual(bound.document["selected_prs"][0]["node_id"], "P_issue_created")
+
+        def reject_live_drift(label: str, *, head_sha: str | None = None, body: bytes = INITIAL_PR_BODY) -> None:
+            with self.subTest(rejected=label), tempfile.TemporaryDirectory() as temporary, tempfile.TemporaryDirectory() as live_temporary:
+                root = Path(temporary)
+                value, bound = install_bound(root, Path(live_temporary))
+                first = live_pr(value)
+                second = live_pr(value, head_sha=head_sha, body=body)
+                reads = 0
+
+                def observe(arguments: object, context: str) -> object:
+                    nonlocal reads
+                    del context
+                    endpoint = tuple(arguments)[-1]
+                    if endpoint == "user":
+                        return {"node_id": "U_actor"}
+                    if "/pulls/500" in endpoint:
+                        value = first if reads == 0 else second
+                        reads += 1
+                        return copy.deepcopy(value)
+                    if "/comments?" in endpoint:
+                        return [[]]
+                    raise AssertionError(f"unexpected gh observation: {arguments}")
+
+                before = directory_snapshot(root)
+                with mock.patch.object(
+                    ledger, "_gh_json", side_effect=observe
+                ), self.assertRaisesRegex(ledger.LedgerError, "remote observation changed"):
+                    ledger.bind_pr_cas(
+                        root,
+                        bound.name,
+                        "pull-request",
+                        500,
+                        **cas_arguments(bound),
+                    )
+                self.assertEqual(directory_snapshot(root), before)
+
+        reject_live_drift("target head drift", head_sha=SHA_B)
+        reject_live_drift("PR body drift", body=b"changed body\n")
+
+        with tempfile.TemporaryDirectory() as temporary, tempfile.TemporaryDirectory() as live_temporary:
+            root = Path(temporary)
+            value, bound = install_bound(root, Path(live_temporary))
+            before = directory_snapshot(root)
+            with mock.patch.object(
+                ledger,
+                "_gh_json",
+                side_effect=gh_observer(live_pr(value, base_branch="develop")),
+            ), self.assertRaisesRegex(ledger.LedgerError, "base branch differs"):
+                ledger.bind_pr_cas(
+                    root,
+                    bound.name,
+                    "pull-request",
+                    500,
+                    **cas_arguments(bound),
+                )
+            self.assertEqual(directory_snapshot(root), before)
+
+        with tempfile.TemporaryDirectory() as temporary, tempfile.TemporaryDirectory() as live_temporary:
+            root = Path(temporary)
+            value, bound = install_bound(root, Path(live_temporary))
+            before = directory_snapshot(root)
+            with mock.patch.object(
+                ledger,
+                "_gh_json",
+                side_effect=gh_observer(
+                    live_pr(value), [[{"id": 1, "user": {"type": "Bot"}}]]
+                ),
+            ), self.assertRaisesRegex(ledger.LedgerError, "external PR comments"):
+                ledger.bind_pr_cas(
+                    root,
+                    bound.name,
+                    "pull-request",
+                    500,
+                    **cas_arguments(bound),
+                )
+            self.assertEqual(directory_snapshot(root), before)
+
+        with tempfile.TemporaryDirectory() as temporary, tempfile.TemporaryDirectory() as live_temporary:
+            root = Path(temporary)
+            value, bound = install_bound(root, Path(live_temporary))
+            with mock.patch.object(
+                ledger,
+                "_gh_json",
+                side_effect=gh_observer(live_pr(value)),
+            ), self.assertRaises(ledger.InjectedCrash):
+                ledger.bind_pr_cas(
+                    root,
+                    bound.name,
+                    "pull-request",
+                    500,
+                    failpoint="cas:renamed",
+                    **cas_arguments(bound),
+                )
+            installed = ledger.inspect(root, bound.name)
+            self.assertEqual(installed.document["generation"], 3)
+            self.assertNotEqual(ledger.inventory(root).pending, ())
+            with mock.patch.object(
+                ledger,
+                "_gh_json",
+                side_effect=gh_observer(live_pr(value)),
+            ):
+                recovered = ledger.bind_pr_cas(
+                    root,
+                    installed.name,
+                    "pull-request",
+                    500,
+                    **cas_arguments(bound),
+                )
+            self.assertEqual(recovered["classification"], "bound-match")
+            self.assertEqual(ledger.inventory(root).pending, ())
+
+        with tempfile.TemporaryDirectory() as temporary, tempfile.TemporaryDirectory() as live_temporary:
+            root = Path(temporary)
+            predecessor, candidate, _actual_head, _base_head, _live = target_refresh_setup(
+                Path(live_temporary), root, "pr-bind-target-refresh", stale_predecessor=False
+            )
+            refreshed = ledger.target_refresh_cas(
+                root,
+                predecessor.name,
+                candidate,
+                **cas_arguments(predecessor),
+            )
+            with mock.patch.object(
+                ledger,
+                "_gh_json",
+                side_effect=gh_observer(live_pr(refreshed.document)),
+            ):
+                result = ledger.bind_pr_cas(
+                    root,
+                    refreshed.name,
+                    "pull-request",
+                    500,
+                    **cas_arguments(refreshed),
+                )
+            self.assertEqual(result["classification"], "bind-exact")
+            self.assertEqual(ledger.inspect(root, refreshed.name).document["generation"], 5)
+
     def test_25_strict_authority_genesis_and_git_ref_contracts(self) -> None:
         strict = issue_ledger()
         strict["schema_version"] = 1.0
@@ -4611,12 +4923,7 @@ class DeliveryLedgerTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             initial = ledger.create(root, issue_ledger())
-            bound = ledger.cas(
-                root,
-                initial.name,
-                bind_issue_created_pr(initial),
-                **cas_arguments(initial),
-            )
+            bound = cas_issue_created_pr(root, initial, bind_issue_created_pr(initial))
             old_digest = bound.document["selected_prs"][0]["body"]["current_digest"]
             body_projection = ledger.describe_body_plan(
                 bound.document,
@@ -10579,11 +10886,8 @@ class DeliveryLedgerTests(unittest.TestCase):
             ).stdout.strip()
             git_run(live, "merge", "--ff-only", actual)
             if mirror_pull_request:
-                predecessor = ledger.cas(
-                    root,
-                    predecessor.name,
-                    bind_issue_created_pr(predecessor),
-                    **cas_arguments(predecessor),
+                predecessor = cas_issue_created_pr(
+                    root, predecessor, bind_issue_created_pr(predecessor)
                 )
             incident_bad_head = bad_head
             if bad_kind == "blob":
@@ -12103,13 +12407,12 @@ class DeliveryLedgerTests(unittest.TestCase):
                 **cas_arguments(first),
             )
             bound = ledger.inspect(root, first.name)
-            pull_bound = ledger.cas(
+            pull_bound = cas_issue_created_pr(
                 root,
-                bound.name,
+                bound,
                 bind_issue_created_pr(
                     bound, number=460, node="P_archive_correction"
                 ),
-                **cas_arguments(bound),
             )
             ready_intent = next_generation(pull_bound)
             ready_intent["selected_prs"][0]["draft_intent"] = "ready"


### PR DESCRIPTION
## Summary

Add a helper-owned `pr-bind-cas` operation for issue-mode planned pull-request slots.

## Implementation / behavior

- Revalidate the live target and remote draft PR immediately before the ledger CAS.
- Preserve same-repository, authenticated-author, durable-body, draft, and delivery-owned state invariants.
- Keep first-bind recovery and interrupted replacement bounded to the exact predecessor.

## Validation

- Added focused unit and CLI tests for successful bind, drift, comments, and recovery.

Closes #499
