### PR TITLE
fix(delivery): classify normal PR comments during atomic binding

### DIFF
--- a/.agents/skills/atrinik-issue-delivery/SKILL.md
+++ b/.agents/skills/atrinik-issue-delivery/SKILL.md
@@ -152,8 +152,12 @@ owner `AGENTS.md`; do not duplicate procedures.
 - In issue mode, `bind-check` only diagnoses a remotely created planned PR.
   Use the helper-owned `pr-bind-cas` with the exact PR number and a fresh
   four-part ledger tuple. It re-proves the authenticated actor, same-repository
-  draft PR, durable body, comments, target, and bound worktree immediately
-  before its private CAS; generic `cas` cannot perform this initial PR bind.
+  draft PR, durable body, complete paginated comment collection, target, and
+  bound worktree immediately before its private CAS; generic `cas` cannot
+  perform this initial PR bind. Ordinary Codecov, reviewer, and other external
+  comments are expected and remain untouched. Any malformed or reserved
+  `atrinik-delivery:comment:` marker, invalid comment page, duplicate node, or
+  incomplete/bounded-out pagination fails closed.
 - In PR mode, set `TARGET_BRANCH`, `BASE_SHA`, `HEAD_BRANCH`, `HEAD_SHA`, and
   `MERGE_BASE` from the live PR. Fetch and verify the exact base/head refs
   without rewriting published history. Create the local head branch at the
@@ -212,8 +216,11 @@ outside the helper-planned terminal delivery section; copied live markers grant
 no ownership. Refetch and verify rendered GFM/linkage after helper-bound updates.
 
 Refetch bytes/timestamps and every marker; CAS intent, refetch, use only the
-helper payload, and bind its exact result. Cancel only after exact
-non-application proof and before drift. Zero comment matches permit one
+helper payload, and bind its exact result. For an issue-mode initial PR bind,
+the helper's complete comment pagination classifies ordinary external comments
+as non-delivery state without recording or deleting them; reserved delivery
+comment markers and incomplete pagination stop the bind. Cancel only after
+exact non-application proof and before drift. Zero comment matches permit one
 never-started post; reuse one exact actor-authored match. Wrong-author,
 malformed, duplicate, unexpected, or uncertain state stops. Verify rendered
 GFM/linkage.

--- a/.agents/skills/atrinik-issue-delivery/references/delivery-ledger.md
+++ b/.agents/skills/atrinik-issue-delivery/references/delivery-ledger.md
@@ -1532,18 +1532,23 @@ python3 scripts/delivery_ledger.py pr-bind-cas \
 ```
 
 `pr-bind-cas` performs the live authenticated-author, same-repository,
-unchanged-target, draft, durable-body, and no-comment proof itself immediately
-before the ledger CAS. On `bind-exact`, it marks the planned PR artifact
-`created` and appends exactly one selected PR. On an identical completed retry,
-it returns `bound-match`. The selected PR's repository and head repository are
-identical; its base/head match the wholly unchanged target; its authenticated
-actor is the author; it remains draft with null ready intent; its comment state
-is none; and its `delivery-created`/`written` body has null observed/intended
-digest/payload, null section, and equal current/outside digest matching the
-planned slot. Its PR artifact permanently retains the initial payload. This
-exception applies only while immutable `authority.allowed.pull_requests` is
-empty. The helper does not expand or rewrite authority and never adopts this
-result through generic `cas`.
+unchanged-target, draft, durable-body, and complete-comment-pagination proof
+itself immediately before the ledger CAS. Ordinary external comments, such as
+Codecov or reviewer comments, are classified as non-delivery state and remain
+untouched; a malformed or reserved `atrinik-delivery:comment:` marker, invalid
+page, duplicate node, or pagination that cannot reach a bounded final page
+fails closed. The helper records no external comments in the planned PR slot.
+On `bind-exact`, it marks the planned PR artifact `created` and appends exactly
+one selected PR. On an identical completed retry, it returns `bound-match`. The
+selected PR's repository and head repository are identical; its base/head match
+the wholly unchanged target; its authenticated actor is the author; it remains
+draft with null ready intent; its comment state is none; and its
+`delivery-created`/`written` body has null observed/intended digest/payload,
+null section, and equal current/outside digest matching the planned slot. Its
+PR artifact permanently retains the initial payload. This exception applies
+only while immutable `authority.allowed.pull_requests` is empty. The helper
+does not expand or rewrite authority and never adopts this result through
+generic `cas`.
 
 This CAS may change only ledger generation/history, that one PR slot, and that
 one matching selected PR. Normalizing generation/history, removing the added

--- a/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
+++ b/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
@@ -41,6 +41,10 @@ MAX_RETAINED_RESULT_BYTES = 512 * 1024
 MAX_INVENTORY_ENTRIES = 4096
 MAX_INVENTORY_BYTES = 32 * 1024 * 1024
 MAX_ARCHIVE_BYTES = 16 * 1024 * 1024
+PR_BIND_COMMENT_PAGE_SIZE = 100
+MAX_PR_BIND_COMMENT_PAGES = MAX_INVENTORY_ENTRIES
+MAX_PR_BIND_COMMENT_ENTRIES = MAX_INVENTORY_ENTRIES
+MAX_PR_BIND_COMMENT_BODY_BYTES = MAX_RETAINED_RESULT_BYTES
 LEDGER_SUFFIX = ".md.ledger.json"
 ENTRY_MODES = {"issue", "pr"}
 ARTIFACT_KINDS = {"branch", "worktree", "pull_request"}
@@ -7391,6 +7395,72 @@ def classify_pr_binding(
     return "bind-exact"
 
 
+def _observe_pr_binding_comments(owner: str, name: str, number: int) -> None:
+    """Prove all pre-bind comments are ordinary external comments."""
+
+    seen_nodes: set[str] = set()
+    total = 0
+    for page_number in range(1, MAX_PR_BIND_COMMENT_PAGES + 1):
+        page = _gh_json(
+            (
+                "api",
+                "--hostname",
+                "github.com",
+                f"repos/{owner}/{name}/issues/{number}/comments?"
+                f"per_page={PR_BIND_COMMENT_PAGE_SIZE}&page={page_number}",
+            ),
+            f"PR binding comments page {page_number} for pull request {number}",
+        )
+        if not isinstance(page, list):
+            raise LedgerError(
+                f"PR binding comment page {page_number} is not an array"
+            )
+        if len(page) > PR_BIND_COMMENT_PAGE_SIZE:
+            raise LedgerError(
+                f"PR binding comment page {page_number} exceeds the page size"
+            )
+        total += len(page)
+        if total > MAX_PR_BIND_COMMENT_ENTRIES:
+            raise LedgerError("PR binding comment pagination exceeds the bounded limit")
+        for index, raw_comment in enumerate(page):
+            if not isinstance(raw_comment, dict):
+                raise LedgerError(
+                    f"PR binding comment page {page_number} entry {index} is not an object"
+                )
+            body = raw_comment.get("body")
+            if not isinstance(body, str):
+                raise LedgerError(
+                    f"PR binding comment page {page_number} entry {index} has an invalid body"
+                )
+            try:
+                body_raw = body.encode("utf-8")
+            except UnicodeError as error:
+                raise LedgerError(
+                    f"PR binding comment page {page_number} entry {index} has invalid UTF-8"
+                ) from error
+            if len(body_raw) > MAX_PR_BIND_COMMENT_BODY_BYTES:
+                raise LedgerError(
+                    f"PR binding comment page {page_number} entry {index} is too large"
+                )
+            node = _string(
+                raw_comment.get("node_id"),
+                f"PR binding comment page {page_number} entry {index}.node_id",
+                NODE_RE,
+            )
+            if node in seen_nodes:
+                raise LedgerError("PR binding comment pagination contains duplicate nodes")
+            seen_nodes.add(node)
+            # Before the selected PR is recorded, no comment marker can be
+            # proven to belong to this delivery coordinate.
+            if "atrinik-delivery:comment:" in body:
+                raise LedgerError(
+                    "PR binding found a delivery-owned or malformed comment marker"
+                )
+        if len(page) < PR_BIND_COMMENT_PAGE_SIZE:
+            return
+    raise LedgerError("PR binding comment pagination did not reach a bounded final page")
+
+
 def _pr_binding_remote(
     document: Mapping[str, Any], target: Mapping[str, Any], pr_number: int
 ) -> dict[str, Any]:
@@ -7464,29 +7534,7 @@ def _pr_binding_remote(
         live.get("updated_at"), "PR binding PR updated_at", TIMESTAMP_RE
     )
     _timestamp_key(updated_at, "PR binding PR updated_at")
-    comments = _gh_json(
-        (
-            "api",
-            "--hostname",
-            "github.com",
-            f"repos/{owner}/{name}/issues/{number}/comments?per_page=1",
-        ),
-        f"PR binding comments for pull request {number}",
-    )
-    if not isinstance(comments, list):
-        raise LedgerError("PR binding comment pagination is not an array")
-    if comments and all(isinstance(page, list) for page in comments):
-        has_comments = any(bool(page) for page in comments)
-    elif comments and all(isinstance(comment, dict) for comment in comments):
-        # This is accepted for test doubles and older gh versions that return a
-        # single page without --slurp; any non-empty result is still unsafe.
-        has_comments = True
-    elif comments:
-        raise LedgerError("PR binding comment pagination has an invalid page")
-    else:
-        has_comments = False
-    if has_comments:
-        raise LedgerError("PR binding found external PR comments")
+    _observe_pr_binding_comments(owner, name, number)
     digest = byte_digest(body_raw)
     pull = {
         "repository": copy.deepcopy(repository),
@@ -7524,6 +7572,18 @@ def _pr_binding_remote(
         "head_sha": head_sha,
         "body_digest": digest,
     }
+
+
+def _pr_binding_remote_equal(
+    left: Mapping[str, Any], right: Mapping[str, Any]
+) -> bool:
+    """Compare bind identity while ignoring comment-only PR timestamps."""
+
+    left_value = copy.deepcopy(left)
+    right_value = copy.deepcopy(right)
+    left_value["pull"]["body"]["updated_at"] = None
+    right_value["pull"]["body"]["updated_at"] = None
+    return left_value == right_value
 
 
 def _pr_binding_coordinates(
@@ -7731,13 +7791,14 @@ def bind_pr_cas(
         )
         _hit(failpoint, "pr-bind:classified")
 
-        def revalidate() -> None:
+        def revalidate(expected: Mapping[str, Any]) -> dict[str, Any]:
             prove_local()
             latest = _pr_binding_remote(snapshot.document, target, pr_number)
-            if latest != remote:
+            if not _pr_binding_remote_equal(latest, expected):
                 raise LedgerError("PR binding remote observation changed before CAS")
+            return latest
 
-        revalidate()
+        remote = revalidate(remote)
         if (
             classification == "bound-match"
             and _snapshot_matches_tuple(
@@ -7787,7 +7848,7 @@ def bind_pr_cas(
                 expected_device=expected_device,
                 expected_inode=expected_inode,
                 failpoint=failpoint,
-                _precommit=revalidate,
+                _precommit=lambda: revalidate(remote),
                 _binding_capability=capability,
             )
     return {

--- a/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
+++ b/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
@@ -7574,6 +7574,18 @@ def _pr_binding_remote(
     }
 
 
+def _pr_binding_pull_equal(
+    left: Mapping[str, Any], right: Mapping[str, Any]
+) -> bool:
+    """Compare pull identity while ignoring comment-only PR timestamps."""
+
+    left_value = copy.deepcopy(left)
+    right_value = copy.deepcopy(right)
+    left_value["body"]["updated_at"] = None
+    right_value["body"]["updated_at"] = None
+    return left_value == right_value
+
+
 def _pr_binding_remote_equal(
     left: Mapping[str, Any], right: Mapping[str, Any]
 ) -> bool:
@@ -7581,9 +7593,9 @@ def _pr_binding_remote_equal(
 
     left_value = copy.deepcopy(left)
     right_value = copy.deepcopy(right)
-    left_value["pull"]["body"]["updated_at"] = None
-    right_value["pull"]["body"]["updated_at"] = None
-    return left_value == right_value
+    left_pull = left_value.pop("pull")
+    right_pull = right_value.pop("pull")
+    return _pr_binding_pull_equal(left_pull, right_pull) and left_value == right_value
 
 
 def _pr_binding_coordinates(
@@ -7676,7 +7688,7 @@ def _pr_binding_classification(
     current = slot["current"]
     if (
         len(selected) != 1
-        or selected[0] != pull
+        or not _pr_binding_pull_equal(selected[0], pull)
         or current["number"] != pull["number"]
         or current["node_id"] != pull["node_id"]
         or current["head_sha"] != remote["head_sha"]

--- a/tests/test_delivery_ledger.py
+++ b/tests/test_delivery_ledger.py
@@ -4711,7 +4711,23 @@ class DeliveryLedgerTests(unittest.TestCase):
                     500,
                     **cas_arguments(bound),
                 )
-                bound = ledger.inspect(root, bound.name)
+            bound = ledger.inspect(root, bound.name)
+            with mock.patch.object(
+                ledger,
+                "_gh_json",
+                side_effect=gh_observer(
+                    live_pr(value, updated_at="2026-08-14T18:01:00Z"),
+                    {
+                        1: [
+                            {
+                                "node_id": "I_post_bind_reviewer",
+                                "body": "A reviewer comment arrived after binding.",
+                                "user": {"login": "reviewer", "type": "User"},
+                            }
+                        ]
+                    },
+                ),
+            ):
                 repeated = ledger.bind_pr_cas(
                     root,
                     bound.name,

--- a/tests/test_delivery_ledger.py
+++ b/tests/test_delivery_ledger.py
@@ -4634,6 +4634,7 @@ class DeliveryLedgerTests(unittest.TestCase):
             body: bytes = INITIAL_PR_BODY,
             draft: bool = True,
             base_branch: str | None = None,
+            updated_at: str = "2026-08-14T18:00:00Z",
         ) -> dict[str, object]:
             repository_value = {
                 "node_id": "R_repo",
@@ -4663,11 +4664,20 @@ class DeliveryLedgerTests(unittest.TestCase):
                     "repo": copy.deepcopy(repository_value),
                 },
                 "body": body.decode("utf-8"),
-                "updated_at": "2026-08-14T18:00:00Z",
+                "updated_at": updated_at,
             }
 
-        def gh_observer(live: dict[str, object], comments: object = None):
-            response_comments = [[]] if comments is None else comments
+        def gh_observer(
+            live: dict[str, object],
+            comments: object = None,
+            observed_pages: list[int] | None = None,
+        ):
+            if comments is None:
+                response_comments: object = {1: []}
+            elif isinstance(comments, dict):
+                response_comments = comments
+            else:
+                response_comments = {1: comments}
 
             def observe(arguments: object, context: str) -> object:
                 del context
@@ -4677,7 +4687,11 @@ class DeliveryLedgerTests(unittest.TestCase):
                 if "/pulls/500" in endpoint:
                     return copy.deepcopy(live)
                 if "/comments?" in endpoint:
-                    return copy.deepcopy(response_comments)
+                    page = int(endpoint.rsplit("page=", 1)[1])
+                    if observed_pages is not None:
+                        observed_pages.append(page)
+                    assert isinstance(response_comments, dict)
+                    return copy.deepcopy(response_comments.get(page, []))
                 raise AssertionError(f"unexpected gh observation: {arguments}")
 
             return observe
@@ -4729,7 +4743,7 @@ class DeliveryLedgerTests(unittest.TestCase):
                         reads += 1
                         return copy.deepcopy(value)
                     if "/comments?" in endpoint:
-                        return [[]]
+                        return []
                     raise AssertionError(f"unexpected gh observation: {arguments}")
 
                 before = directory_snapshot(root)
@@ -4770,13 +4784,125 @@ class DeliveryLedgerTests(unittest.TestCase):
             root = Path(temporary)
             value, bound = install_bound(root, Path(live_temporary))
             before = directory_snapshot(root)
+            pull_reads = 0
+            existing_comment = {
+                "node_id": "I_existing",
+                "body": "A reviewer comment already present.",
+                "user": {"login": "reviewer", "type": "User"},
+            }
+            concurrent_comment = {
+                "node_id": "I_concurrent",
+                "body": "A second reviewer comment arrived during binding.",
+                "user": {"login": "reviewer-two", "type": "User"},
+            }
+
+            def observe_concurrent(arguments: object, context: str) -> object:
+                nonlocal pull_reads
+                del context
+                endpoint = tuple(arguments)[-1]
+                if endpoint == "user":
+                    return {"node_id": "U_actor"}
+                if "/pulls/500" in endpoint:
+                    pull_reads += 1
+                    return copy.deepcopy(
+                        live_pr(
+                            value,
+                            updated_at=(
+                                "2026-08-14T18:00:00Z"
+                                if pull_reads == 1
+                                else "2026-08-14T18:01:00Z"
+                            ),
+                        )
+                    )
+                if "/comments?" in endpoint:
+                    return copy.deepcopy(
+                        [existing_comment]
+                        if pull_reads == 1
+                        else [existing_comment, concurrent_comment]
+                    )
+                raise AssertionError(f"unexpected gh observation: {arguments}")
+
+            with mock.patch.object(
+                ledger, "_gh_json", side_effect=observe_concurrent
+            ):
+                result = ledger.bind_pr_cas(
+                    root,
+                    bound.name,
+                    "pull-request",
+                    500,
+                    **cas_arguments(bound),
+                )
+            self.assertEqual(result["classification"], "bind-exact")
+            self.assertEqual(
+                ledger.inspect(root, bound.name).document["selected_prs"][0]["body"]["updated_at"],
+                "2026-08-14T18:01:00Z",
+            )
+            self.assertNotEqual(directory_snapshot(root), before)
+
+        with tempfile.TemporaryDirectory() as temporary, tempfile.TemporaryDirectory() as live_temporary:
+            root = Path(temporary)
+            value, bound = install_bound(root, Path(live_temporary))
+            before = directory_snapshot(root)
+            observed_pages: list[int] = []
+            paginated_comments = {
+                1: [
+                    {
+                        "node_id": f"I_codecov_{index}",
+                        "body": f"Codecov coverage report {index}",
+                        "user": {"login": "codecov", "type": "Bot"},
+                    }
+                    for index in range(100)
+                ],
+                2: [
+                    {
+                        "node_id": "I_reviewer",
+                        "body": "Reviewed the change and it looks good.",
+                        "user": {"login": "reviewer", "type": "User"},
+                    }
+                ],
+            }
             with mock.patch.object(
                 ledger,
                 "_gh_json",
                 side_effect=gh_observer(
-                    live_pr(value), [[{"id": 1, "user": {"type": "Bot"}}]]
+                    live_pr(value), paginated_comments, observed_pages
                 ),
-            ), self.assertRaisesRegex(ledger.LedgerError, "external PR comments"):
+            ):
+                result = ledger.bind_pr_cas(
+                    root,
+                    bound.name,
+                    "pull-request",
+                    500,
+                    **cas_arguments(bound),
+                )
+            self.assertEqual(result["classification"], "bind-exact")
+            self.assertEqual(sorted(set(observed_pages)), [1, 2])
+            bound = ledger.inspect(root, bound.name)
+            self.assertEqual(bound.document["selected_prs"][0]["comment"]["state"], "none")
+            self.assertNotEqual(directory_snapshot(root), before)
+
+        with tempfile.TemporaryDirectory() as temporary, tempfile.TemporaryDirectory() as live_temporary:
+            root = Path(temporary)
+            value, bound = install_bound(root, Path(live_temporary))
+            before = directory_snapshot(root)
+            with mock.patch.object(
+                ledger,
+                "_gh_json",
+                side_effect=gh_observer(
+                    live_pr(value),
+                    {
+                        1: [
+                            {
+                                "node_id": "I_delivery_marker",
+                                "body": "<!-- atrinik-delivery:comment:foreign -->",
+                                "user": {"login": "reviewer", "type": "User"},
+                            }
+                        ]
+                    },
+                ),
+            ), self.assertRaisesRegex(
+                ledger.LedgerError, "delivery-owned or malformed comment marker"
+            ):
                 ledger.bind_pr_cas(
                     root,
                     bound.name,


### PR DESCRIPTION
Closes #502

## Summary

- allow expected external PR comments during issue-mode atomic binding
- paginate comment observations and reject only delivery-owned marker drift or unsafe comment state
- add regression coverage and document the binding contract

## Implementation / behavior

`pr-bind-cas` now observes the complete issue-comment collection before its final revalidation. Ordinary Codecov, reviewer, and other external comments remain preserved and do not block the initial bind. Delivery-owned comment markers, malformed or foreign marker namespaces, incomplete pagination, duplicate matches, and any identity, body, target, or worktree drift remain fail-closed.

## Validation

- `python3 -m unittest tests.test_delivery_ledger.DeliveryLedgerTests.test_25_pr_bind_cas_live_proof_drift_comments_and_recovery`
- `python3 -m unittest discover -v`
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `git diff --check`

