### PR TITLE
docs(agents): guard retired content delivery line

### DIFF
--- a/.agents/skills/atrinik-content-change/SKILL.md
+++ b/.agents/skills/atrinik-content-change/SKILL.md
@@ -7,9 +7,11 @@ description: Change authored content on `main`, including maps, archetypes, medi
 
 `content@main` is the sole authored source for replacement and Classic targets.
 Use a `content` worktree and select the target-specific publisher during
-validation; never edit or create a PR against the retired `1.x` line. Retained
-`content-1x` checkouts, artifacts, and records are immutable migration or
-release evidence. Add `atrinik-multi-repo-workspace` for cross-repository work.
+validation; never edit, recreate, or create a PR against the former `1.x`
+line. Retained `content-1x` checkouts, artifacts, and records are immutable
+migration or release evidence. When drafting a linked content/Classic issue,
+name `content@main` and the Classic-target artifact generated from it. Add
+`atrinik-multi-repo-workspace` for cross-repository work.
 
 ## Establish the contract
 

--- a/.agents/skills/atrinik-issue-delivery/SKILL.md
+++ b/.agents/skills/atrinik-issue-delivery/SKILL.md
@@ -113,10 +113,11 @@ owner `AGENTS.md`; do not duplicate procedures.
   issue/Project mutations. Such a PR is complete; never create a placeholder or
   broaden its closing scope.
 - For content, author only on `main` and validate every affected target and
-  consumer. The retired `1.x` line, artifacts, and local paths are immutable
-  migration/release evidence; never publish a new `1.x` PR. A content `main`
-  PR may close an explicitly selected issue when merged, but leave every issue
-  open for maintainers.
+  consumer. The former `1.x` branch no longer exists as a live delivery target;
+  its tags, artifacts, and local paths are immutable migration/release
+  evidence. Never recreate it, publish a new `1.x` PR, or request a backport
+  there. A content `main` PR may close an explicitly selected issue when
+  merged, but leave every issue open for maintainers.
 
 - In issue mode, set `TARGET_BRANCH` to the explicit or manifest/live target,
   fetch it, record exact `BASE_SHA`, and choose safe lowercase

--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -13,8 +13,9 @@ description: Coordinate work across checkouts, profiles, worktrees, cleanup, rel
    orchestration/contracts here.
 
 Checkouts are ignored repositories. One `classic` worktree holds all five
-`classic-*` components; both stacks share `content@main` and `content-1x` is
-historical.
+`classic-*` components; both stacks share `content@main`. `content-1x` and the
+former 1.x branch are historical migration evidence only, never active
+components or delivery targets.
 
 ## Prepare safe worktrees
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,9 +22,11 @@
   `build/` are ignored generated state, so root status omits them.
 - Resolve ownership through `components.json` and the checkout's nearest
   `AGENTS.md`; keep implementation, tests, packages, and releases there.
-- `classic/` provides `classic-*`; stacks share `content@main`; `content-1x/`
-  is historical; `playtester/` is classic-only. `tools/` is MIT-default except
-  GPL-2.0-or-later `map-checker-qt/` (`LicenseRef-Atrinik-Tools-Mixed`).
+- `classic/` provides `classic-*`; stacks share `content@main`. `content-1x/`
+  and the former 1.x branch are historical only: preserve any local migration
+  evidence, but never select, recreate, or backport delivery to them.
+  `playtester/` is classic-only. `tools/` is MIT-default except GPL-2.0-or-later
+  `map-checker-qt/` (`LicenseRef-Atrinik-Tools-Mixed`).
 
 ## Core behaviors and patterns
 
@@ -61,6 +63,10 @@
 - Update `supply-chain/inventory.json` when dependency ownership/validation
   changes. Keep Actions/images immutable, add no submodules, and audit a full
   profile; only aggregate-root workflows and Dependabot are active.
+- New content/Classic issues name `content@main` and its Classic-target
+  artifact. No live 1.x branch, checkout, release label, maintenance line,
+  publication target, or backport destination exists; historical evidence is
+  immutable.
 - Commits and PR titles use `type(optional-scope): concise description`; add
   `!` only when a reviewer explicitly requests a breaking change, not auto.
   PR bodies must be substantive rendered GitHub-Flavored Markdown with actual

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,17 @@ that transfer clear; otherwise open a main-targeted pull request carrying the
 equivalent change. Do not merge `main` back into a maintenance branch, because
 that can introduce commits outside its patch range.
 
+## Issue authoring contract
+
+New content and Classic issue drafts must name `content@main` as the sole
+authored source and identify the Classic-target artifact generated from it.
+Do not request the retired `1.x` branch, checkout, release label, maintenance
+line, publication target, or backport destination. The former line is
+historical evidence only: tags, releases, provenance, parity records, and
+preserved migration snapshots remain valid but immutable. Before publishing a
+draft, run `python3 -m atrinik_workspace.issue_contract PATH` and fix every
+reported active retired-line requirement.
+
 PR bodies must be substantive, renderable GitHub-Flavored Markdown with actual
 line breaks, never visible literal `\n` separators. The minimum body uses
 concise sections for:

--- a/atrinik_workspace/issue_contract.py
+++ b/atrinik_workspace/issue_contract.py
@@ -34,6 +34,14 @@ _HISTORICAL_CONTEXT = re.compile(
     r"should\s+not|cannot|without)\b",
     re.IGNORECASE,
 )
+_HISTORICAL_ISSUE_CONTEXT = re.compile(
+    r"(?:https?://github\.com/[^/\s)]+/[^/\s)]+/issues/\d+|"
+    r"(?:issue|#)\s*\d+)"
+    r"[^.!?\n]{0,160}\b(?:was|were|had|already|previously|carried|"
+    r"required|requested|repeated|established|corrected|"
+    r"preserved|remained)\b",
+    re.IGNORECASE,
+)
 _MARKDOWN_BLOCK_START = re.compile(
     r"^(?:[-+*]\s+|\d+[.)]\s+|#{1,6}\s+|>\s?|\|)"
 )
@@ -89,7 +97,9 @@ def find_violations(body: str) -> tuple[ContractViolation, ...]:
     for line_number, block in _markdown_blocks(body.splitlines()):
         if not re.search(_RETIRED_REFERENCE, block, re.IGNORECASE):
             continue
-        if _HISTORICAL_CONTEXT.search(block):
+        if _HISTORICAL_CONTEXT.search(block) or _HISTORICAL_ISSUE_CONTEXT.search(
+            block
+        ):
             continue
         if any(pattern.search(block) for pattern in _ACTIVE_PATTERNS):
             violations.append(

--- a/atrinik_workspace/issue_contract.py
+++ b/atrinik_workspace/issue_contract.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import sys
+
+
+MAX_ISSUE_BYTES = 512 * 1024
+_RETIRED_REFERENCE = r"(?:`?1\.x`?|`?content-1x`?)"
+_ACTION = (
+    r"(?:backport|back-port|publish|release|ship|select|target|checkout|"
+    r"create|recreate|maintain|use|merge|edit|modify|label|branch|maintenance)"
+)
+_ACTIVE_PATTERNS = (
+    re.compile(
+        rf"\b{_ACTION}\b[^.!?\n]{{0,120}}\b{_RETIRED_REFERENCE}\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"\b{_RETIRED_REFERENCE}\b[^.!?\n]{{0,120}}\b{_ACTION}\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"\breleased\s+on\s+@?{_RETIRED_REFERENCE}\b",
+        re.IGNORECASE,
+    ),
+)
+_HISTORICAL_CONTEXT = re.compile(
+    r"\b(?:historical|retired|former|immutable|inert|preserved|frozen|"
+    r"no\s+longer|no\s+live|no\s+future|no\s+new|no\s+active|never|"
+    r"do\s+not|does\s+not|must\s+not|"
+    r"should\s+not|cannot|without)\b",
+    re.IGNORECASE,
+)
+_MARKDOWN_BLOCK_START = re.compile(
+    r"^(?:[-+*]\s+|\d+[.)]\s+|#{1,6}\s+|>\s?|\|)"
+)
+
+
+class IssueContractError(ValueError):
+    """A bounded, stable issue-contract validation failure."""
+
+
+@dataclass(frozen=True)
+class ContractViolation:
+    line: int
+    text: str
+
+
+def _markdown_blocks(lines: list[str]) -> tuple[tuple[int, str], ...]:
+    """Join wrapped Markdown blocks while retaining each block's first line."""
+
+    blocks: list[tuple[int, str]] = []
+    start: int | None = None
+    current: list[str] = []
+
+    def flush() -> None:
+        nonlocal start, current
+        if start is not None:
+            blocks.append((start, " ".join(part.strip() for part in current)))
+        start = None
+        current = []
+
+    for index, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if not stripped:
+            flush()
+            continue
+        if current and _MARKDOWN_BLOCK_START.match(stripped):
+            flush()
+        if start is None:
+            start = index
+        current.append(line)
+    flush()
+    return tuple(blocks)
+
+
+def find_violations(body: str) -> tuple[ContractViolation, ...]:
+    """Return active retired-line requirements found in one issue body."""
+
+    if len(body.encode("utf-8")) > MAX_ISSUE_BYTES:
+        raise IssueContractError(
+            f"issue body exceeds the {MAX_ISSUE_BYTES}-byte validation bound"
+        )
+
+    violations: list[ContractViolation] = []
+    for line_number, block in _markdown_blocks(body.splitlines()):
+        if not re.search(_RETIRED_REFERENCE, block, re.IGNORECASE):
+            continue
+        if _HISTORICAL_CONTEXT.search(block):
+            continue
+        if any(pattern.search(block) for pattern in _ACTIVE_PATTERNS):
+            violations.append(
+                ContractViolation(
+                    line=line_number,
+                    text=block or "retired-line requirement",
+                )
+            )
+    return tuple(violations)
+
+
+def validate_issue_contract(body: str) -> None:
+    violations = find_violations(body)
+    if violations:
+        details = "; ".join(
+            f"line {violation.line}: {violation.text}" for violation in violations
+        )
+        raise IssueContractError(
+            "active 1.x/content-1x delivery requirement; use content@main "
+            "and the Classic-target artifact instead ("
+            f"{details})"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Reject active retired 1.x delivery requirements in an issue body."
+    )
+    parser.add_argument("path", nargs="?", type=Path)
+    parser.add_argument(
+        "--stdin", action="store_true", help="read the issue body from standard input"
+    )
+    args = parser.parse_args(argv)
+    if args.stdin == (args.path is not None):
+        parser.error("provide exactly one of PATH or --stdin")
+
+    body = sys.stdin.read() if args.stdin else args.path.read_text(encoding="utf-8")
+    try:
+        validate_issue_contract(body)
+    except (OSError, UnicodeError, IssueContractError) as error:
+        print(f"issue-contract: {error}", file=sys.stderr)
+        return 1
+    print("issue-contract: pass")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -715,14 +715,16 @@ class AgentGuidanceTests(unittest.TestCase):
         for marker in {
             "`content@main` is the sole authored source",
             "select the target-specific publisher",
-            "never edit or create a PR against the retired `1.x` line",
+            "never edit, recreate, or create a PR against the former `1.x` line",
+            "Classic-target artifact generated from it",
         }:
             with self.subTest(surface="content", marker=marker):
                 self.assertIn(marker, content)
         for marker in {
             "author only on `main`",
             "validate every affected target and consumer",
-            "never publish a new `1.x` PR",
+            "former `1.x` branch no longer exists as a live delivery target",
+            "request a backport there",
             "A content `main` PR may close an explicitly selected issue",
             "per-target bases",
         }:
@@ -732,6 +734,25 @@ class AgentGuidanceTests(unittest.TestCase):
         self.assertIn("cross-repository or cross-line", checklist)
         self.assertIn("Issue-closing path", report)
         self.assertIn("manual post-merge close", checklist)
+
+    def test_issue_authoring_contract_names_supported_content_path(self) -> None:
+        root_guide = " ".join(
+            (ROOT / "AGENTS.md").read_text(encoding="utf-8").split()
+        )
+        contributing = " ".join(
+            (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8").split()
+        )
+        for surface in (root_guide, contributing):
+            for marker in {
+                "content@main",
+                "Classic-target artifact",
+                "historical evidence",
+                "release label",
+                "backport destination",
+            }:
+                with self.subTest(surface=surface[:24], marker=marker):
+                    self.assertIn(marker, surface)
+        self.assertIn("python3 -m atrinik_workspace.issue_contract PATH", contributing)
 
     def test_program_delivery_is_explicit_and_merge_gated(self) -> None:
         skill = ROOT / ".agents/skills/atrinik-program-delivery"

--- a/tests/test_issue_contract.py
+++ b/tests/test_issue_contract.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from contextlib import redirect_stderr, redirect_stdout
 import io
+from pathlib import Path
+import runpy
 import unittest
 from unittest import mock
 
 from atrinik_workspace.issue_contract import (
     MAX_ISSUE_BYTES,
     IssueContractError,
+    find_violations,
     main,
     validate_issue_contract,
 )
@@ -45,6 +48,38 @@ class IssueContractTests(unittest.TestCase):
             "required a backport to `1.x` and carried the old release label."
         )
         validate_issue_contract(body)
+
+    def test_scans_markdown_blocks_and_skips_unrelated_text(self) -> None:
+        body = """\
+        content@main is the source of truth.
+        - The `1.x` tag is recorded.
+        - Backport the change to `1.x`.
+        """
+        violations = find_violations(body)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0].line, 3)
+
+    def test_cli_rejects_ambiguous_input(self) -> None:
+        for argv in ([], ["body.md", "--stdin"]):
+            with self.subTest(argv=argv), redirect_stderr(io.StringIO()):
+                with self.assertRaises(SystemExit):
+                    main(argv)
+
+    def test_module_entry_point_returns_success(self) -> None:
+        stdout = io.StringIO()
+        module_path = (
+            Path(__file__).resolve().parents[1]
+            / "atrinik_workspace"
+            / "issue_contract.py"
+        )
+        with redirect_stdout(stdout), mock.patch(
+            "sys.argv", [str(module_path), "--stdin"]
+        ), mock.patch(
+            "sys.stdin", io.StringIO("content@main is valid.\n")
+        ), self.assertRaises(SystemExit) as exit_info:
+            runpy.run_path(str(module_path), run_name="__main__")
+        self.assertEqual(exit_info.exception.code, 0)
+        self.assertIn("issue-contract: pass", stdout.getvalue())
 
     def test_rejects_oversized_input(self) -> None:
         with self.assertRaisesRegex(IssueContractError, "byte validation bound"):

--- a/tests/test_issue_contract.py
+++ b/tests/test_issue_contract.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from contextlib import redirect_stderr, redirect_stdout
+import io
+import unittest
+from unittest import mock
+
+from atrinik_workspace.issue_contract import (
+    MAX_ISSUE_BYTES,
+    IssueContractError,
+    main,
+    validate_issue_contract,
+)
+
+
+class IssueContractTests(unittest.TestCase):
+    def test_rejects_active_retired_line_requirements(self) -> None:
+        cases = (
+            "Backport the fix to `1.x`.",
+            "Backport the fix to\n`1.x`.",
+            "Publish the release on the `1.x` branch.",
+            "Select the `content-1x` checkout for this issue.",
+            "Add the `released on @1.x` label.",
+            "Maintain the `1.x` maintenance line.",
+        )
+        for body in cases:
+            with self.subTest(body=body):
+                with self.assertRaisesRegex(IssueContractError, "active 1.x"):
+                    validate_issue_contract(body)
+
+    def test_allows_supported_and_historical_references(self) -> None:
+        body = """\
+        Author the change in `content@main` and publish the Classic-target
+        artifact generated from it. The former `1.x` branch is retired; its
+        tags, releases, provenance, parity records, and migration snapshots
+        remain immutable historical evidence. Do not backport to the retired
+        line.
+        """
+        validate_issue_contract(body)
+
+    def test_rejects_oversized_input(self) -> None:
+        with self.assertRaisesRegex(IssueContractError, "byte validation bound"):
+            validate_issue_contract("x" * (MAX_ISSUE_BYTES + 1))
+
+    def test_cli_accepts_stdin_and_reports_failures(self) -> None:
+        stdout = io.StringIO()
+        with redirect_stdout(stdout), mock.patch(
+            "sys.stdin", io.StringIO("Historical `1.x` tags remain immutable.\n")
+        ):
+            self.assertEqual(main(["--stdin"]), 0)
+        self.assertIn("issue-contract: pass", stdout.getvalue())
+
+        stderr = io.StringIO()
+        with redirect_stderr(stderr), mock.patch(
+            "sys.stdin", io.StringIO("Use branch `1.x` for this work.\n")
+        ):
+            self.assertEqual(main(["--stdin"]), 1)
+        self.assertIn("issue-contract:", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_issue_contract.py
+++ b/tests/test_issue_contract.py
@@ -22,6 +22,7 @@ class IssueContractTests(unittest.TestCase):
             "Select the `content-1x` checkout for this issue.",
             "Add the `released on @1.x` label.",
             "Maintain the `1.x` maintenance line.",
+            "Required: backport the change to `1.x`.",
         )
         for body in cases:
             with self.subTest(body=body):
@@ -36,6 +37,13 @@ class IssueContractTests(unittest.TestCase):
         remain immutable historical evidence. Do not backport to the retired
         line.
         """
+        validate_issue_contract(body)
+
+    def test_allows_linked_historical_issue_account(self) -> None:
+        body = (
+            "[content#239](https://github.com/atrinik/content/issues/239) "
+            "required a backport to `1.x` and carried the old release label."
+        )
         validate_issue_contract(body)
 
     def test_rejects_oversized_input(self) -> None:


### PR DESCRIPTION
## Summary

- Make `content@main` the sole authored source for new content and Classic issue contracts.
- Treat the retired `1.x` line as historical evidence only and reject new delivery requirements for it.
- Add a bounded issue-contract validator and guidance regression coverage.

## Implementation / behavior

- Update the root guide, contributor checklist, and agent skills to name `content@main` and the Classic-target artifact generated from it.
- Reject active `1.x` branch, checkout, release, label, maintenance-line, publication, and backport requirements while allowing historical references.
- Leave migration, provenance, parity, tags, releases, and preserved `1.x` evidence untouched.

## Validation

- Guidance, corrected issue, and wrapper checks pass.

Closes #503
