### PR TITLE
feat(workspace): register observatory checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /legacy-server/
 /libatrinik/
 /metaserver-worker/
+/observatory/
 /protocol/
 /playtester/
 /renderer/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,8 @@
 - This MIT Python 3.11+ repository coordinates Atrinik repositories, not source;
   `./atrinik` and `components.json` manage profiles, worktrees, builds, runtimes,
   cleanup, migration, and supply-chain reports.
-- `default` selects the MIT replacement stack (Rust, Go, Protobuf, and Astro).
+- `default` selects the MIT replacement stack (Rust, Go, Protobuf, Astro, and
+  source-only Observatory).
   Its standalone M1 foundations lack wrapper build/runtime integration.
   `classic` selects playable C17/CMake/Ninja plus the MIT playtester. Never mix
   providers or route unavailable replacement adapters through classic.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,9 @@ Do not normalize them as source headers; change one only through deliberate
 repository-owned legal review.
 
 The canonical `server`, `client`, `editor`, `protocol`, `renderer`,
-`content-toolkit`, and `website` repositories form the MIT replacement stack.
+`content-toolkit`, `website`, and `observatory` repositories form the MIT
+replacement stack. `observatory` is source-only in the wrapper: it has no
+wrapper build adapter or runtime dependency and remains default-cohort only.
 Plain `./atrinik init` is replacement/default-only. Exact
 `./atrinik init --with classic` adds the complete currently playable classic
 cohort: the `atrinik/classic` monorepo checkout, the independent MIT

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ profiles, builds components whose contracts are available, and shares
 persistent server state safely.
 
 No checkout is a submodule. Primary repositories are ignored, independent Git
-checkouts directly beside this README (`./client`, `./server`, `./classic`, and
-so on). The `atrinik/classic` checkout at `./classic` contains the logical
+checkouts directly beside this README (`./client`, `./server`, `./classic`,
+`./observatory`, and so on). The `atrinik/classic` checkout at `./classic`
+contains the logical
 `classic-client`, `classic-server`, `classic-editor`,
 `classic-libatrinik`, and `classic-protocol` source roots. Generated worktrees,
 builds, profiles, and default state live under the ignored `workspace/`
@@ -388,7 +389,8 @@ identity are coordinated here, while installation and tests remain owned by
 `atrinik/playtester`.
 
 Checkout entries have explicit local destinations; normally these are direct
-children of the wrapper root such as `./client`, `./classic`, and `./content`.
+children of the wrapper root such as `./client`, `./classic`, `./content`, and
+`./observatory`.
 Logical components name their owning checkout and a safe source root within
 it. Both stacks map role `content` to that one shared checkout. A local
 `./content-1x` directory may remain as preserved migration history, but it is
@@ -405,7 +407,9 @@ checkouts are reported as optional rather than invalidating status or a
 built-in profile.
 
 The manifest assigns logical roles such as `client`, `server`, `protocol`,
-`libatrinik`, `content`, and `playtester` to providers within each stack. The
+`libatrinik`, `content`, `playtester`, and source-only `observatory` to
+providers within each stack. The `observatory` role is default-only and has no
+wrapper build adapter or runtime dependency. The
 built-in `default` and `classic` profiles resolve exactly one compatible
 provider for every role they require.
 A runnable service closure cannot combine replacement and classic

--- a/atrinik_workspace/model.py
+++ b/atrinik_workspace/model.py
@@ -57,6 +57,7 @@ REQUIRED_COHORT_CHECKOUTS = {
         "metaserver-worker",
         "devcontainer",
         "github-settings",
+        "observatory",
     },
     "classic": {
         "classic",
@@ -79,6 +80,7 @@ REQUIRED_STACK_PROVIDERS = {
         "metaserver-worker": "metaserver-worker",
         "devcontainer": "devcontainer",
         "github-settings": "github-settings",
+        "observatory": "observatory",
     },
     "classic": {
         "client": "classic-client",
@@ -113,6 +115,7 @@ LOGICAL_ROLES = {
     "metaserver-worker",
     "devcontainer",
     "github-settings",
+    "observatory",
 }
 IMPLEMENTATION_ROLES = {
     "client",

--- a/components.json
+++ b/components.json
@@ -14,7 +14,8 @@
       "resources",
       "metaserver-worker",
       "devcontainer",
-      "github-settings"
+      "github-settings",
+      "observatory"
     ],
     "classic": [
       "classic",
@@ -38,7 +39,8 @@
         "resources",
         "metaserver-worker",
         "devcontainer",
-        "github-settings"
+        "github-settings",
+        "observatory"
       ],
       "providers": {
         "client": "client",
@@ -53,7 +55,8 @@
         "resources": "resources",
         "metaserver-worker": "metaserver-worker",
         "devcontainer": "devcontainer",
-        "github-settings": "github-settings"
+        "github-settings": "github-settings",
+        "observatory": "observatory"
       }
     },
     "classic": {
@@ -193,6 +196,14 @@
       "branch": "main",
       "path": "github-settings",
       "generation": "shared",
+      "license": "MIT"
+    },
+    {
+      "name": "observatory",
+      "repository": "atrinik/observatory",
+      "branch": "main",
+      "path": "observatory",
+      "generation": "replacement",
       "license": "MIT"
     },
     {
@@ -351,6 +362,16 @@
       "build": "none",
       "generation": "shared",
       "provides": ["github-settings"],
+      "requires": [],
+      "license": "MIT"
+    },
+    {
+      "name": "observatory",
+      "checkout": "observatory",
+      "source": ".",
+      "build": "none",
+      "generation": "replacement",
+      "provides": ["observatory"],
       "requires": [],
       "license": "MIT"
     },

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -40,6 +40,10 @@ The classic-only `playtester` component occupies `atrinik/playtester@main` at
 `./playtester`, provides the `playtester` role, and requires the classic stack's
 `content`, `libatrinik`, and `protocol` providers. Its `build: none` contract
 keeps repository-owned installation and validation outside wrapper adapters.
+The default-only `observatory` component occupies
+`atrinik/observatory@main` at `./observatory` and provides a source-only
+`observatory` role. It has no wrapper build adapter or runtime dependency;
+Classic never selects it.
 
 Manifest validation rejects duplicate checkout or component names, duplicate
 local destinations, unsafe or overlapping source roots within one checkout,

--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -337,6 +337,28 @@
       "audit_mode": "full",
       "branch": "main",
       "cohorts": [
+        "default"
+      ],
+      "license": "MIT",
+      "commit": null,
+      "name": "observatory",
+      "repository": "atrinik/observatory",
+      "role": "Read-only build, release, package, deployment, and public-service status dashboard",
+      "roles": [
+        "observatory"
+      ],
+      "stacks": [
+        "default"
+      ],
+      "supported": true,
+      "checkout": "observatory",
+      "source": "."
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
         "classic"
       ],
       "license": "MIT",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -664,6 +664,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
                 "metaserver-worker",
                 "devcontainer",
                 "github-settings",
+                "observatory",
             },
         )
         self.assertEqual(
@@ -675,6 +676,19 @@ class ReleaseConfigurationTests(unittest.TestCase):
             },
         )
         self.assertEqual(manifest.by_name["content"].branch, "main")
+        self.assertEqual(
+            manifest.by_checkout["observatory"].repository,
+            "atrinik/observatory",
+        )
+        self.assertEqual(
+            manifest.by_name["observatory"].requires,
+            (),
+        )
+        self.assertEqual(
+            manifest.stack("default").providers["observatory"].name,
+            "observatory",
+        )
+        self.assertNotIn("observatory", manifest.cohorts["classic"])
         self.assertEqual(manifest.effective_build("default", "content"), "none")
         self.assertEqual(
             manifest.effective_build("classic", "content"), "classic-content"

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -182,6 +182,13 @@ class InventoryTests(unittest.TestCase):
         self.assertIn("nawerhals", inventory.repositories_by_name)
         self.assertFalse(inventory.repositories_by_name["nawerhals"].supported)
         self.assertNotIn("content-1x", inventory.repositories_by_name)
+        observatory = inventory.repositories_by_name["observatory"]
+        self.assertEqual(observatory.repository, "atrinik/observatory")
+        self.assertEqual(observatory.cohorts, ("default",))
+        self.assertEqual(observatory.stacks, ("default",))
+        self.assertEqual(observatory.roles, ("observatory",))
+        self.assertEqual(observatory.license, "MIT")
+        self.assertEqual(observatory.audit_mode, "full")
         self.assertEqual(
             inventory.repositories_by_name["content"].stacks,
             ("classic", "default"),


### PR DESCRIPTION
## Summary

Register `atrinik/observatory` as a wrapper-owned replacement-stack checkout while keeping its implementation in its own repository.

Related: [atrinik/observatory#1](https://github.com/atrinik/observatory/issues/1)

## Implementation / behavior

- Adds the `observatory` physical checkout to the `default` cohort and replacement stack.
- Registers the MIT `observatory` logical component as source-only with no wrapper build adapter or runtime dependency.
- Keeps the Classic stack and provider boundary unchanged.
- Updates the wrapper model fixtures, guidance, and supply-chain inventory required by the manifest contract.

## Validation

- `./atrinik manifest validate`
- `./atrinik profile show default --json`
- `./atrinik status --json`
- Focused wrapper model, guidance, and supply-chain tests
- `git diff --check`

Closes #506
