### PR TITLE
fix(ci): restore reachable provenance revisions for aggregate tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,6 +33,8 @@ jobs:
           python-version: "3.13"
       - name: Install coverage tooling
         run: python3 -m pip install --requirement requirements-dev.txt
+      - name: Preflight provenance revision anchors
+        run: ./atrinik provenance preflight
       - name: Run measured test shard
         env:
           COVERAGE_FILE: build/ci/shard-${{ matrix.shard }}/.coverage.shard-${{ matrix.shard }}

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -54,6 +54,12 @@ def validate_provenance_identity(*arguments: object, **keywords: object) -> obje
     return implementation(*arguments, **keywords)
 
 
+def preflight_provenance_revisions(*arguments: object, **keywords: object) -> object:
+    from .provenance_identity import preflight_provenance_revisions as implementation
+
+    return implementation(*arguments, **keywords)
+
+
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -533,6 +539,17 @@ def parser() -> argparse.ArgumentParser:
         ),
         "none",
     )
+    provenance_preflight = provenance_commands.add_parser(
+        "preflight", help="resolve pinned provenance revisions and Git objects"
+    )
+    mark(
+        provenance_preflight.add_argument(
+            "--migration",
+            type=Path,
+            default=ROOT / "governance/provenance-revision-migration.json",
+        ),
+        "path",
+    )
 
     launch = commands.add_parser("run", help="build and run client or server")
     launch_commands = launch.add_subparsers(dest="target", required=True)
@@ -600,6 +617,20 @@ def main(arguments: list[str] | None = None) -> int:
             print(f"components.json: valid ({len(manifest.components)} components)")
             return 0
         if options.command == "provenance":
+            if options.provenance_command == "preflight":
+                revisions, objects = preflight_provenance_revisions(
+                    ROOT, migration_path=options.migration
+                )
+                migration_display = options.migration
+                try:
+                    migration_display = options.migration.resolve().relative_to(ROOT)
+                except ValueError:
+                    pass
+                print(
+                    f"{migration_display}: valid "
+                    f"({revisions} coordinator revisions, {objects} Git objects)"
+                )
+                return 0
             count = validate_provenance_identity(
                 ROOT,
                 registry_path=options.registry,

--- a/atrinik_workspace/provenance_identity.py
+++ b/atrinik_workspace/provenance_identity.py
@@ -21,6 +21,11 @@ CANONICALIZATION = "atrinik-json-v1"
 REGISTRY_PATH = Path("governance/provenance-identities/registry.json")
 SCHEMA_PATH = Path("governance/provenance-identities/schema-v1.json")
 REVIEWERS_PATH = Path("governance/provenance-identities/reviewers.json")
+REVISION_MIGRATION_PATH = Path("governance/provenance-revision-migration.json")
+REPLACEMENT_FOUNDATIONS_PATH = Path("governance/replacement-foundations.json")
+CLASSIC_TOOLS_PATH = Path("governance/classic-tools.json")
+PROVENANCE_FIXTURES_PATH = Path("tests/fixtures/provenance-identities")
+MCP_WORKLOAD_PATH = Path("mcp/contract/v1/fixtures/workloads.json")
 TRUSTED_SCHEMA_CANONICAL_SHA256 = "d80f49a1b17d00ad203a70229f2649d005bf69b738fc197c5ad6da8f944e57bd"
 CONFIDENTIAL_RECORD_ID_PATTERN = re.compile(r"^pir-c-[0-9a-f]{32}$")
 PUBLIC_RECORD_ID_PATTERN = re.compile(r"^pir-p-[0-9a-f]{32}$")
@@ -647,6 +652,524 @@ def _git_blob(repository_root: Path, revision: str, path: str) -> bytes:
     return result
 
 
+def _preflight_git_output(
+    repository_root: Path,
+    arguments: list[str],
+    object_name: str,
+    repository: str,
+) -> bytes:
+    try:
+        result = subprocess.run(
+            ["git", *arguments],
+            cwd=repository_root,
+            check=False,
+            capture_output=True,
+            timeout=10,
+            env=_git_environment(),
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise WorkspaceError(
+            f"provenance preflight cannot resolve {repository} object {object_name}"
+        ) from exc
+    if result.returncode != 0:
+        raise WorkspaceError(
+            f"provenance preflight cannot resolve {repository} object {object_name}"
+        )
+    return result.stdout
+
+
+def _preflight_revision(
+    repository_root: Path,
+    revision: str,
+    trusted_ref: str,
+    repository: str,
+) -> None:
+    _preflight_git_output(
+        repository_root,
+        ["rev-parse", "--verify", f"{revision}^{{commit}}"],
+        f"{revision}^{{commit}}",
+        repository,
+    )
+    _validate_repository_trust(repository_root, revision, trusted_ref)
+
+
+def _preflight_blob(
+    repository_root: Path,
+    revision: str,
+    path: str,
+    repository: str,
+    *,
+    expected_git_object: str,
+    expected_sha256: str,
+) -> None:
+    object_name = f"{revision}:{path}"
+    actual_git_object = _preflight_git_output(
+        repository_root,
+        ["rev-parse", "--verify", object_name],
+        object_name,
+        repository,
+    ).decode("ascii", errors="strict").strip()
+    if actual_git_object != expected_git_object:
+        raise WorkspaceError(
+            f"provenance preflight object identity changed for {repository} {object_name}"
+        )
+    raw_size = _preflight_git_output(
+        repository_root,
+        ["cat-file", "-s", object_name],
+        object_name,
+        repository,
+    )
+    try:
+        size = int(raw_size)
+    except ValueError as exc:
+        raise WorkspaceError(
+            f"provenance preflight returned an invalid size for {repository} object {object_name}"
+        ) from exc
+    if size > MAX_DOCUMENT_BYTES:
+        raise WorkspaceError(
+            f"provenance preflight object {repository} {object_name} exceeds the size limit"
+        )
+    blob = _preflight_git_output(
+        repository_root,
+        ["cat-file", "blob", object_name],
+        object_name,
+        repository,
+    )
+    if len(blob) != size:
+        raise WorkspaceError(
+            f"provenance preflight object {repository} {object_name} changed during read"
+        )
+    if sha256(blob) != expected_sha256:
+        raise WorkspaceError(
+            f"provenance preflight SHA-256 mismatch for {repository} object {object_name}"
+        )
+
+
+def _revision_text(value: object, context: str) -> str:
+    if not isinstance(value, str) or not REVISION_PATTERN.fullmatch(value):
+        raise WorkspaceError(f"{context} must be a full Git SHA")
+    return value
+
+
+def _sha256_text(value: object, context: str) -> str:
+    if not isinstance(value, str) or not SHA256_PATTERN.fullmatch(value):
+        raise WorkspaceError(f"{context} must be a SHA-256 digest")
+    return value
+
+
+def _coordinator_pins(value: object, context: str = "") -> list[tuple[str, str, str]]:
+    pins: list[tuple[str, str, str]] = []
+    if isinstance(value, dict):
+        if value.get("repository") == "atrinik/atrinik" and "revision" in value:
+            path = value.get("path")
+            if not isinstance(path, str) or not path:
+                raise WorkspaceError(f"{context}.path must be present for a coordinator pin")
+            pins.append(
+                (
+                    context,
+                    _revision_text(value["revision"], f"{context}.revision"),
+                    _repository_path(path, f"{context}.path"),
+                )
+            )
+        for key, child in value.items():
+            child_context = f"{context}.{key}" if context else key
+            pins.extend(_coordinator_pins(child, child_context))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            pins.extend(_coordinator_pins(child, f"{context}[{index}]"))
+    return pins
+
+
+def _validate_external_reanchors(value: object) -> None:
+    if not isinstance(value, list) or not value:
+        raise WorkspaceError("provenance revision migration external_reanchors must be non-empty")
+    for index, item in enumerate(value):
+        context = f"provenance revision migration external_reanchors[{index}]"
+        if not isinstance(item, dict):
+            raise WorkspaceError(f"{context} must be an object")
+        _exact_keys(
+            item,
+            {"file", "repository", "trusted_ref", "references", "disposition"},
+            context,
+        )
+        _repository_path(item["file"], f"{context}.file")
+        if item["repository"] != "atrinik/tools":
+            raise WorkspaceError(f"{context}.repository is invalid")
+        if item["trusted_ref"] != "origin/main":
+            raise WorkspaceError(f"{context}.trusted_ref is invalid")
+        _text(item["disposition"], f"{context}.disposition")
+        references = item["references"]
+        if not isinstance(references, list) or not references:
+            raise WorkspaceError(f"{context}.references must be non-empty")
+        seen_fields: set[str] = set()
+        for reference_index, reference in enumerate(references):
+            reference_context = f"{context}.references[{reference_index}]"
+            if not isinstance(reference, dict):
+                raise WorkspaceError(f"{reference_context} must be an object")
+            _exact_keys(
+                reference,
+                {"field", "old_revision", "new_revision", "old_tree", "new_tree"},
+                reference_context,
+            )
+            field = _text(reference["field"], f"{reference_context}.field")
+            if field in seen_fields:
+                raise WorkspaceError(f"{reference_context}.field is duplicated")
+            seen_fields.add(field)
+            for key in ("old_revision", "new_revision", "old_tree", "new_tree"):
+                _revision_text(reference[key], f"{reference_context}.{key}")
+
+
+def _validate_fixture_replacements(
+    value: object, coordinator_revision: str
+) -> None:
+    if not isinstance(value, list) or not value:
+        raise WorkspaceError("provenance revision migration fixture_replacements must be non-empty")
+    seen: set[tuple[str, int]] = set()
+    for index, item in enumerate(value):
+        context = f"provenance revision migration fixture_replacements[{index}]"
+        if not isinstance(item, dict):
+            raise WorkspaceError(f"{context} must be an object")
+        _exact_keys(
+            item,
+            {
+                "file",
+                "case_id",
+                "coordinate_index",
+                "repository",
+                "old_revision",
+                "new_revision",
+            },
+            context,
+        )
+        file = _repository_path(item["file"], f"{context}.file")
+        case_id = _text(item["case_id"], f"{context}.case_id")
+        coordinate_index = item["coordinate_index"]
+        if (
+            type(coordinate_index) is not int
+            or coordinate_index < 0
+        ):
+            raise WorkspaceError(f"{context}.coordinate_index must be a non-negative integer")
+        key = (case_id, coordinate_index)
+        if key in seen:
+            raise WorkspaceError(f"{context} identifies a duplicate fixture coordinate")
+        seen.add(key)
+        if item["repository"] != "atrinik/atrinik":
+            raise WorkspaceError(f"{context}.repository is invalid")
+        _revision_text(item["old_revision"], f"{context}.old_revision")
+        _revision_text(item["new_revision"], f"{context}.new_revision")
+        if item["new_revision"] != coordinator_revision:
+            raise WorkspaceError(f"{context}.new_revision does not use the coordinator anchor")
+        if file != MCP_WORKLOAD_PATH.as_posix():
+            raise WorkspaceError(f"{context}.file is not the MCP workload fixture")
+
+
+def _validate_revision_migration(
+    value: dict[str, Any],
+) -> tuple[
+    dict[str, Any],
+    dict[str, dict[str, Any]],
+    dict[tuple[str, str], dict[str, Any]],
+]:
+    _exact_keys(
+        value,
+        {
+            "schema_version",
+            "decision",
+            "issue",
+            "rationale",
+            "external_reanchors",
+            "fixture_replacements",
+            "coordinator",
+            "replacements",
+            "historical_references",
+        },
+        "provenance revision migration",
+    )
+    if type(value["schema_version"]) is not int or value["schema_version"] != 1:
+        raise WorkspaceError("provenance revision migration has an unsupported schema version")
+    if value["decision"] != "reanchor-unreachable-history":
+        raise WorkspaceError("provenance revision migration decision is invalid")
+    _text(value["issue"], "provenance revision migration.issue")
+    _text(value["rationale"], "provenance revision migration.rationale")
+    coordinator = value["coordinator"]
+    if not isinstance(coordinator, dict):
+        raise WorkspaceError("provenance revision migration coordinator must be an object")
+    _exact_keys(
+        coordinator,
+        {"repository", "trusted_ref", "revision", "objects"},
+        "provenance revision migration coordinator",
+    )
+    if coordinator["repository"] != "atrinik/atrinik":
+        raise WorkspaceError("provenance revision migration coordinator repository is invalid")
+    if coordinator["trusted_ref"] != "origin/main":
+        raise WorkspaceError("provenance revision migration trusted ref is invalid")
+    coordinator_revision = _revision_text(
+        coordinator["revision"], "provenance revision migration coordinator.revision"
+    )
+    objects = coordinator["objects"]
+    if not isinstance(objects, list) or not objects:
+        raise WorkspaceError("provenance revision migration coordinator.objects must be non-empty")
+    object_map: dict[str, dict[str, Any]] = {}
+    for index, item in enumerate(objects):
+        if not isinstance(item, dict):
+            raise WorkspaceError(f"provenance revision migration coordinator.objects[{index}] must be an object")
+        _exact_keys(
+            item,
+            {"path", "git_object", "sha256"},
+            f"provenance revision migration coordinator.objects[{index}]",
+        )
+        path = item["path"]
+        if not isinstance(path, str) or not path or path in object_map:
+            raise WorkspaceError("provenance revision migration coordinator object path is invalid or duplicated")
+        _repository_path(path, f"coordinator.objects[{index}].path")
+        _revision_text(item["git_object"], f"coordinator.objects[{index}].git_object")
+        _sha256_text(item["sha256"], f"coordinator.objects[{index}].sha256")
+        object_map[path] = item
+    replacements = value["replacements"]
+    if not isinstance(replacements, list) or not replacements:
+        raise WorkspaceError("provenance revision migration replacements must be non-empty")
+    replacement_map: dict[tuple[str, str], dict[str, Any]] = {}
+    for index, item in enumerate(replacements):
+        if not isinstance(item, dict):
+            raise WorkspaceError(f"provenance revision migration replacements[{index}] must be an object")
+        required = {
+            "file",
+            "field",
+            "repository",
+            "old_revision",
+            "new_revision",
+            "path",
+        }
+        optional = {"old_reviewers_sha256", "new_reviewers_sha256"}
+        _exact_keys(
+            item,
+            required | (set(item) & optional),
+            f"provenance revision migration replacements[{index}]",
+        )
+        file = item["file"]
+        field = item["field"]
+        if not isinstance(file, str) or not file:
+            raise WorkspaceError(
+                f"provenance revision migration replacements[{index}].file is invalid"
+            )
+        _repository_path(
+            file, f"provenance revision migration replacements[{index}].file"
+        )
+        if not isinstance(field, str) or not field or field.strip() != field:
+            raise WorkspaceError(
+                f"provenance revision migration replacements[{index}].field is invalid"
+            )
+        replacement_key = (file, field)
+        if replacement_key in replacement_map:
+            raise WorkspaceError(
+                "provenance revision migration replacement is duplicated"
+            )
+        replacement_map[replacement_key] = item
+        _revision_text(item["old_revision"], f"replacements[{index}].old_revision")
+        _revision_text(item["new_revision"], f"replacements[{index}].new_revision")
+        if item.get("repository") != "atrinik/atrinik":
+            raise WorkspaceError("provenance revision migration replacement repository is invalid")
+        if item["new_revision"] != coordinator_revision:
+            raise WorkspaceError(
+                "provenance revision migration replacement does not use the coordinator anchor"
+            )
+        _text(item["path"], f"replacements[{index}].path")
+        if bool(set(item) & optional) and not optional <= set(item):
+            raise WorkspaceError(
+                "provenance revision migration reviewer digests must be provided together"
+            )
+        if "old_reviewers_sha256" in item:
+            _sha256_text(item["old_reviewers_sha256"], f"replacements[{index}].old_reviewers_sha256")
+            _sha256_text(item["new_reviewers_sha256"], f"replacements[{index}].new_reviewers_sha256")
+    _validate_external_reanchors(value["external_reanchors"])
+    _validate_fixture_replacements(value["fixture_replacements"], coordinator_revision)
+    historical = value["historical_references"]
+    if not isinstance(historical, list) or not historical:
+        raise WorkspaceError("provenance revision migration historical_references must be non-empty")
+    for index, item in enumerate(historical):
+        if not isinstance(item, dict):
+            raise WorkspaceError(f"provenance revision migration historical_references[{index}] must be an object")
+        _exact_keys(
+            item,
+            {"file", "context", "revision", "disposition"},
+            f"provenance revision migration historical_references[{index}]",
+        )
+        _revision_text(item["revision"], f"historical_references[{index}].revision")
+        if "preserved-unresolved" not in item["disposition"]:
+            raise WorkspaceError("provenance revision migration historical disposition must preserve uncertainty")
+    return coordinator, object_map, replacement_map
+
+
+def _migration_field_value(
+    document: dict[str, Any], field: str, context: str
+) -> object:
+    current: object = document
+    for part in field.split("."):
+        if not part or not isinstance(current, dict) or part not in current:
+            raise WorkspaceError(f"{context} does not resolve migration field {field}")
+        current = current[part]
+    return current
+
+
+def preflight_provenance_revisions(
+    root: Path,
+    *,
+    migration_path: Path = REVISION_MIGRATION_PATH,
+) -> tuple[int, int]:
+    if not migration_path.is_absolute():
+        migration_path = root / migration_path
+    migration = load_document(migration_path)
+    coordinator, object_map, replacement_map = _validate_revision_migration(migration)
+    revision = coordinator["revision"]
+    _preflight_revision(root, revision, coordinator["trusted_ref"], coordinator["repository"])
+
+    governance_paths = (REPLACEMENT_FOUNDATIONS_PATH, CLASSIC_TOOLS_PATH)
+    pins: list[tuple[str, str, str]] = []
+    for relative_path in governance_paths:
+        document = load_document(root / relative_path)
+        pins.extend(_coordinator_pins(document, relative_path.as_posix()))
+    if not pins:
+        raise WorkspaceError("provenance preflight found no active coordinator revision pins")
+    for context, pinned_revision, path in pins:
+        if pinned_revision != revision:
+            raise WorkspaceError(
+                f"provenance preflight active pin {context} does not use migration anchor {revision}"
+            )
+        expected = object_map.get(path)
+        if expected is None:
+            raise WorkspaceError(
+                f"provenance preflight migration lacks coordinator object {path}"
+            )
+        _preflight_blob(
+            root,
+            pinned_revision,
+            path,
+            coordinator["repository"],
+            expected_git_object=expected["git_object"],
+            expected_sha256=expected["sha256"],
+        )
+
+    for (relative_file, field), replacement in replacement_map.items():
+        target = root / relative_file
+        document = load_document(target)
+        actual = _migration_field_value(document, field, relative_file)
+        if actual != replacement["new_revision"]:
+            raise WorkspaceError(
+                f"provenance preflight migration row {relative_file}:{field} is not applied"
+            )
+
+    workloads = load_document(root / MCP_WORKLOAD_PATH)
+    cases = workloads.get("cases")
+    if not isinstance(cases, list):
+        raise WorkspaceError("provenance preflight MCP workload cases must be an array")
+    fixture_replacements = migration["fixture_replacements"]
+    assert isinstance(fixture_replacements, list)
+    replacement_coordinates: dict[tuple[str, int], dict[str, Any]] = {}
+    for item in fixture_replacements:
+        assert isinstance(item, dict)
+        replacement_coordinates[(item["case_id"], item["coordinate_index"])] = item
+    fixture_coordinates: set[tuple[str, int]] = set()
+    for case in cases:
+        if not isinstance(case, dict) or not isinstance(case.get("id"), str):
+            raise WorkspaceError("provenance preflight MCP workload case is invalid")
+        expected = case.get("expected")
+        if not isinstance(expected, dict):
+            raise WorkspaceError(
+                f"provenance preflight MCP workload case {case['id']} has no expected object"
+            )
+        coordinates = expected.get("coordinates")
+        if not isinstance(coordinates, list):
+            raise WorkspaceError(
+                f"provenance preflight MCP workload case {case['id']} coordinates are invalid"
+            )
+        for coordinate_index, coordinate in enumerate(coordinates):
+            if not isinstance(coordinate, dict):
+                raise WorkspaceError("provenance preflight MCP coordinate is invalid")
+            if coordinate.get("repository") != coordinator["repository"]:
+                continue
+            coordinate_revision = _revision_text(
+                coordinate.get("commit"),
+                f"{MCP_WORKLOAD_PATH}: {case['id']} coordinate {coordinate_index}.commit",
+            )
+            if coordinate_revision != revision:
+                raise WorkspaceError(
+                    f"provenance preflight MCP fixture {case['id']} coordinate "
+                    f"{coordinate_index} does not use migration anchor {revision}"
+                )
+            key = (case["id"], coordinate_index)
+            fixture_coordinates.add(key)
+            replacement = replacement_coordinates.get(key)
+            if replacement is None or replacement["new_revision"] != coordinate_revision:
+                raise WorkspaceError(
+                    f"provenance preflight MCP fixture {case['id']} coordinate "
+                    f"{coordinate_index} lacks an applied migration row"
+                )
+            _preflight_revision(root, coordinate_revision, coordinator["trusted_ref"], coordinator["repository"])
+    if fixture_coordinates != set(replacement_coordinates):
+        raise WorkspaceError("provenance preflight MCP fixture migration rows do not match active coordinates")
+
+    fixture_revisions: set[str] = set()
+    fixtures_root = root / PROVENANCE_FIXTURES_PATH
+    try:
+        fixture_paths = sorted(fixtures_root.rglob("*.json"))
+    except OSError as exc:
+        raise WorkspaceError("provenance preflight cannot enumerate provenance fixtures") from exc
+    for path in fixture_paths:
+        document = load_document(path)
+        evidence = document.get("evidence_reference")
+        if not isinstance(evidence, dict) or evidence.get("repository") != coordinator["repository"]:
+            continue
+        fixture_revision = _revision_text(
+            evidence.get("revision"),
+            f"{path}: evidence_reference.revision",
+        )
+        if fixture_revision != revision:
+            raise WorkspaceError(
+                f"provenance preflight fixture {path} does not use migration anchor {revision}"
+            )
+        fixture_revisions.add(fixture_revision)
+    if not fixture_revisions:
+        raise WorkspaceError("provenance preflight found no coordinator fixture revisions")
+
+    for path, expected in object_map.items():
+        _preflight_blob(
+            root,
+            revision,
+            path,
+            coordinator["repository"],
+            expected_git_object=expected["git_object"],
+            expected_sha256=expected["sha256"],
+        )
+    return 1, len(object_map)
+
+
+def _migration_scope_payload(
+    reference: dict[str, Any],
+    replacement: dict[str, Any] | None,
+) -> bytes | None:
+    if replacement is None or replacement["field"] != "evidence_reference.revision":
+        return None
+    if "old_reviewers_sha256" not in replacement:
+        return None
+    evidence = reference["evidence_reference"]
+    if evidence["revision"] != replacement["new_revision"]:
+        return None
+    if evidence["reviewers_sha256"] != replacement["new_reviewers_sha256"]:
+        return None
+    legacy_reference = dict(reference)
+    legacy_evidence = dict(evidence)
+    legacy_evidence["revision"] = replacement["old_revision"]
+    legacy_evidence["reviewers_sha256"] = replacement["old_reviewers_sha256"]
+    legacy_evidence["url"] = (
+        f"https://github.com/atrinik/atrinik/blob/{replacement['old_revision']}/"
+        f"{REGISTRY_PATH.as_posix()}#{legacy_evidence['record_id']}"
+    )
+    legacy_reference["evidence_reference"] = legacy_evidence
+    return canonical_bytes(
+        {key: value for key, value in legacy_reference.items() if key != "scope_approval"}
+    )
+
+
 def _load_bytes(value: bytes, context: str) -> dict[str, Any]:
     try:
         result = json.loads(value.decode("utf-8"), object_pairs_hook=_object_pairs)
@@ -665,6 +1188,7 @@ def validate_component_reference(
     trusted_ref: str,
     current_records: dict[str, dict[str, Any]],
     current_reviewers: dict[str, dict[str, Any]],
+    migration_replacement: dict[str, Any] | None = None,
 ) -> None:
     _exact_keys(
         reference,
@@ -786,15 +1310,32 @@ def validate_component_reference(
     scope_payload = canonical_bytes(
         {key: value for key, value in reference.items() if key != "scope_approval"}
     )
-    _verify_approval(
-        reference["scope_approval"],
-        scope_payload,
-        reviewer_identity=record["reviewer"],
-        reviewed_on=_iso_date(record["reviewed_on"], "referenced record reviewed_on"),
-        reviewers=current_reviewers,
-        synthetic=record["synthetic"],
-        context="component provenance scope_approval",
-    )
+    try:
+        _verify_approval(
+            reference["scope_approval"],
+            scope_payload,
+            reviewer_identity=record["reviewer"],
+            reviewed_on=_iso_date(record["reviewed_on"], "referenced record reviewed_on"),
+            reviewers=current_reviewers,
+            synthetic=record["synthetic"],
+            context="component provenance scope_approval",
+        )
+    except WorkspaceError as current_error:
+        legacy_payload = _migration_scope_payload(reference, migration_replacement)
+        if legacy_payload is None:
+            raise
+        try:
+            _verify_approval(
+                reference["scope_approval"],
+                legacy_payload,
+                reviewer_identity=record["reviewer"],
+                reviewed_on=_iso_date(record["reviewed_on"], "referenced record reviewed_on"),
+                reviewers=current_reviewers,
+                synthetic=record["synthetic"],
+                context="component provenance migrated scope_approval",
+            )
+        except WorkspaceError:
+            raise current_error
     if record["synthetic"] != reference["synthetic"]:
         raise WorkspaceError(
             "component provenance synthetic boundary does not match the attestation"
@@ -819,6 +1360,7 @@ def validate_paths(
         reviewers_value,
         as_of=as_of,
     )
+    migration_replacements: dict[tuple[str, str], dict[str, Any]] = {}
     if reference_paths:
         _validate_repository_trust(root, trusted_ref, trusted_ref)
         trusted_registry = _load_bytes(
@@ -840,7 +1382,16 @@ def validate_paths(
             as_of=as_of,
         )
         reviewers = validate_reviewers(trusted_reviewers_value, as_of=as_of)
+        migration_path = root / REVISION_MIGRATION_PATH
+        if migration_path.is_file():
+            _, _, migration_replacements = _validate_revision_migration(
+                load_document(migration_path)
+            )
     for path in reference_paths:
+        try:
+            relative_path = path.resolve().relative_to(root.resolve()).as_posix()
+        except ValueError:
+            relative_path = ""
         validate_component_reference(
             load_document(path),
             repository_root=root,
@@ -848,5 +1399,8 @@ def validate_paths(
             trusted_ref=trusted_ref,
             current_records=records,
             current_reviewers=reviewers,
+            migration_replacement=migration_replacements.get(
+                (relative_path, "evidence_reference.revision")
+            ),
         )
     return len(records)

--- a/atrinik_workspace/provenance_identity.py
+++ b/atrinik_workspace/provenance_identity.py
@@ -760,7 +760,9 @@ def _sha256_text(value: object, context: str) -> str:
 def _coordinator_pins(value: object, context: str = "") -> list[tuple[str, str, str]]:
     pins: list[tuple[str, str, str]] = []
     if isinstance(value, dict):
-        if value.get("repository") == "atrinik/atrinik" and "revision" in value:
+        if value.get("repository") == "atrinik/atrinik":
+            if "revision" not in value:
+                raise WorkspaceError(f"{context}.revision must be present for a coordinator pin")
             path = value.get("path")
             if not isinstance(path, str) or not path:
                 raise WorkspaceError(f"{context}.path must be present for a coordinator pin")
@@ -994,8 +996,13 @@ def _validate_revision_migration(
             {"file", "context", "revision", "disposition"},
             f"provenance revision migration historical_references[{index}]",
         )
+        _repository_path(item["file"], f"historical_references[{index}].file")
+        _text(item["context"], f"historical_references[{index}].context")
         _revision_text(item["revision"], f"historical_references[{index}].revision")
-        if "preserved-unresolved" not in item["disposition"]:
+        disposition = _text(
+            item["disposition"], f"historical_references[{index}].disposition"
+        )
+        if "preserved-unresolved" not in disposition:
             raise WorkspaceError("provenance revision migration historical disposition must preserve uncertainty")
     return coordinator, object_map, replacement_map
 

--- a/docs/CLASSIC_TOOLS_MIGRATION.md
+++ b/docs/CLASSIC_TOOLS_MIGRATION.md
@@ -1,14 +1,18 @@
 # Classic tools ownership and migration
 
 [`governance/classic-tools.json`](../governance/classic-tools.json) inventories
-every retained top-level entry point in `atrinik/tools`. Its GPL audit baseline is
-`7777cf9f9ab6deb58de8a481dfccd6b05d86e3e1` and tree
+every retained top-level entry point in `atrinik/tools`. Its GPL audit baseline uses
+reachable commit `94ff0e5e8eedac20ac5aee0d27794aa8d0a60563` with tree
 `daeb2eb5771d3f90ecf70ccfa2d9e1e4d768f6e4`; it is not the transitioned
-tree. The reviewed transition target is
-`33003ac9f737da9c722b446b6bf4948d669ce42b` (tree
+tree. The reviewed transition target uses reachable commit
+`90a6df596628892603cab7e4f850b75f59fbe04f` (tree
 `1f84a1d32120fc3f32902c2a9603f7c1730e6034`): MIT by default with a
 GPL-2.0-or-later `map-checker-qt/` exception. Complete-checkout metadata uses
 `LicenseRef-Atrinik-Tools-Mixed` until the checker is removed.
+The previously recorded commit objects `7777cf9f9ab6deb58de8a481dfccd6b05d86e3e1`
+and `33003ac9f737da9c722b446b6bf4948d669ce42b` are preserved as unresolved
+historical coordinates in the issue #508 migration record; the reachable
+replacement commits are not asserted to be those historical commits.
 The repository remains an explicit optional member of the classic cohort only;
 plain `./atrinik init` and the `default` profile neither select it nor depend on
 it for a build or runtime.

--- a/docs/LOCAL_TESTING.md
+++ b/docs/LOCAL_TESTING.md
@@ -53,6 +53,7 @@ python3 -m compileall -q atrinik atrinik_workspace tests
 python3 -m atrinik_workspace.guidance_inventory --check
 python3 -m atrinik_workspace.mcp_contract validate
 ./atrinik manifest validate
+./atrinik provenance preflight
 ./atrinik provenance validate
 ./atrinik supply-chain validate
 ```

--- a/docs/PROVENANCE_IDENTITIES.md
+++ b/docs/PROVENANCE_IDENTITIES.md
@@ -139,8 +139,8 @@ in schema v1 and therefore fails closed.
 
 The synthetic component-owned records for `atrinik/client` and
 `atrinik/server` pin coordinator commit
-`6f6040212f0fa0cb6b8e4e695d1488a403d966be`, the squash merge of PR #381
-already on canonical `origin/main`. The copies in this repository are test
+`f2d8eda70776ef42acdaf9150223aaecded103b1`, a verified commit on canonical
+`origin/main`. The copies in this repository are test
 fixtures; each component keeps its own identical reference record and validates
 it without copying the canonical registry, schema, or reviewer roster:
 
@@ -155,6 +155,13 @@ do not add `--non-authorizing-audit-ref`. Current revocation state and reviewer
 authority come from canonical `origin/main`; the immutable evidence bytes come
 from the pinned landed commit. The records carry an authenticated `synthetic:
 true` boundary and remain test evidence, not permission for real material.
+
+Issue #508 records the unreachable historical pins and the independently
+verified replacement objects in
+`governance/provenance-revision-migration.json`. Its migrated synthetic
+references are accepted only after the validator reconstructs and verifies the
+legacy signed payload named by the exact migration row; the reachable anchor is
+never presented as historical evidence.
 
 ## Migration and review
 

--- a/governance/classic-tools.json
+++ b/governance/classic-tools.json
@@ -4,22 +4,22 @@
     "repository": "atrinik/tools",
     "branch": "main",
     "audit_baseline": {
-      "revision": "7777cf9f9ab6deb58de8a481dfccd6b05d86e3e1",
+      "revision": "94ff0e5e8eedac20ac5aee0d27794aa8d0a60563",
       "tree": "daeb2eb5771d3f90ecf70ccfa2d9e1e4d768f6e4",
       "license": "GPL-2.0-or-later"
     },
     "provenance_policy": {
       "repository": "atrinik/atrinik",
-      "revision": "f0d1225791da7484e9456b39104cc30b0c77fe52",
+      "revision": "f2d8eda70776ef42acdaf9150223aaecded103b1",
       "path": "docs/PROVENANCE.md"
     },
     "identity_policy": {
       "repository": "atrinik/atrinik",
-      "revision": "6f6040212f0fa0cb6b8e4e695d1488a403d966be",
+      "revision": "f2d8eda70776ef42acdaf9150223aaecded103b1",
       "path": "docs/PROVENANCE_IDENTITIES.md"
     },
     "transition_target": {
-      "revision": "33003ac9f737da9c722b446b6bf4948d669ce42b",
+      "revision": "90a6df596628892603cab7e4f850b75f59fbe04f",
       "tree": "1f84a1d32120fc3f32902c2a9603f7c1730e6034",
       "license": "LicenseRef-Atrinik-Tools-Mixed",
       "default_license": "MIT",

--- a/governance/provenance-revision-migration.json
+++ b/governance/provenance-revision-migration.json
@@ -1,0 +1,155 @@
+{
+  "schema_version": 1,
+  "decision": "reanchor-unreachable-history",
+  "issue": "atrinik/atrinik#508",
+  "rationale": "The active coordinator provenance pins named by the aggregate tests are not present in the current full-history checkout. The replacement anchor is an independently verified reachable commit; it is not asserted to be the historical source of any grant or identity decision. Existing synthetic scope approvals remain bound to their original signed payloads, and validation accepts the re-anchored fixture only after the exact migration row reconstructs and verifies that legacy payload.",
+  "external_reanchors": [
+    {
+      "file": "governance/classic-tools.json",
+      "repository": "atrinik/tools",
+      "trusted_ref": "origin/main",
+      "references": [
+        {
+          "field": "source.audit_baseline.revision",
+          "old_revision": "7777cf9f9ab6deb58de8a481dfccd6b05d86e3e1",
+          "new_revision": "94ff0e5e8eedac20ac5aee0d27794aa8d0a60563",
+          "old_tree": "daeb2eb5771d3f90ecf70ccfa2d9e1e4d768f6e4",
+          "new_tree": "daeb2eb5771d3f90ecf70ccfa2d9e1e4d768f6e4"
+        },
+        {
+          "field": "source.transition_target.revision",
+          "old_revision": "33003ac9f737da9c722b446b6bf4948d669ce42b",
+          "new_revision": "90a6df596628892603cab7e4f850b75f59fbe04f",
+          "old_tree": "1f84a1d32120fc3f32902c2a9603f7c1730e6034",
+          "new_tree": "1f84a1d32120fc3f32902c2a9603f7c1730e6034"
+        }
+      ],
+      "disposition": "same-tree reachable replacements; neither replacement commit is asserted to be the unavailable historical commit"
+    }
+  ],
+  "fixture_replacements": [
+    {
+      "file": "mcp/contract/v1/fixtures/workloads.json",
+      "case_id": "github-planning-read",
+      "coordinate_index": 0,
+      "repository": "atrinik/atrinik",
+      "old_revision": "f0d1225791da7484e9456b39104cc30b0c77fe52",
+      "new_revision": "f2d8eda70776ef42acdaf9150223aaecded103b1"
+    },
+    {
+      "file": "mcp/contract/v1/fixtures/workloads.json",
+      "case_id": "runtime-bounded-observation",
+      "coordinate_index": 0,
+      "repository": "atrinik/atrinik",
+      "old_revision": "f0d1225791da7484e9456b39104cc30b0c77fe52",
+      "new_revision": "f2d8eda70776ef42acdaf9150223aaecded103b1"
+    }
+  ],
+  "coordinator": {
+    "repository": "atrinik/atrinik",
+    "trusted_ref": "origin/main",
+    "revision": "f2d8eda70776ef42acdaf9150223aaecded103b1",
+    "objects": [
+      {
+        "path": "AGENTS.md",
+        "git_object": "083147544944ff4c126471698c57ad65e76a0687",
+        "sha256": "73cc09357ad999ed892e071d6e5b54b4fb4ecf0e6753f4b0f8fc0bc950d46878"
+      },
+      {
+        "path": "docs/PROVENANCE.md",
+        "git_object": "216d2b6b5fb8886072ac272cb2426b15fe29ccc4",
+        "sha256": "77e3e8943a8ca824b8d25a22ac28ed064a97cd30b8bc7101871e3d2594a3b8f7"
+      },
+      {
+        "path": "docs/PROVENANCE_IDENTITIES.md",
+        "git_object": "411218ec9bd276e1f15194bc17f23262f146d5e1",
+        "sha256": "b7a099dfbea4ce2dde50a3d5cc5cd69043ea26206b4e0a7523c53fa1fe4c13f8"
+      },
+      {
+        "path": "governance/provenance-identities/registry.json",
+        "git_object": "5f1d37bc1c89aae58f91c69ac48bc5112fc53401",
+        "sha256": "0a04fcadccb37e64f6c1209bc0b7e8d5762639ce4c5521c3bba028d9eba037bd"
+      },
+      {
+        "path": "governance/provenance-identities/schema-v1.json",
+        "git_object": "fbd692d62da5d3d71ade41b096c5ebf461e592cb",
+        "sha256": "9c726627c8679b4b437db2b54b2480fe0c45eef788de7cd76de1dec5c3ce3409"
+      },
+      {
+        "path": "governance/provenance-identities/reviewers.json",
+        "git_object": "4aa3f5bf84ea3cf9524bed92d1c90776534fcb9a",
+        "sha256": "a0c765f70844ab5c368cade59afda5d05c4627d20c00e6c362217da804e12f19"
+      }
+    ]
+  },
+  "replacements": [
+    {
+      "file": "governance/replacement-foundations.json",
+      "field": "root_policy.revision",
+      "repository": "atrinik/atrinik",
+      "old_revision": "d64a8e958ca2adad783ad8912493d468a805f3fd",
+      "new_revision": "f2d8eda70776ef42acdaf9150223aaecded103b1",
+      "path": "AGENTS.md"
+    },
+    {
+      "file": "governance/classic-tools.json",
+      "field": "source.provenance_policy.revision",
+      "repository": "atrinik/atrinik",
+      "old_revision": "f0d1225791da7484e9456b39104cc30b0c77fe52",
+      "new_revision": "f2d8eda70776ef42acdaf9150223aaecded103b1",
+      "path": "docs/PROVENANCE.md"
+    },
+    {
+      "file": "governance/classic-tools.json",
+      "field": "source.identity_policy.revision",
+      "repository": "atrinik/atrinik",
+      "old_revision": "6f6040212f0fa0cb6b8e4e695d1488a403d966be",
+      "new_revision": "f2d8eda70776ef42acdaf9150223aaecded103b1",
+      "path": "docs/PROVENANCE_IDENTITIES.md"
+    },
+    {
+      "file": "tests/fixtures/provenance-identities/positive/synthetic-alpha.json",
+      "field": "evidence_reference.revision",
+      "repository": "atrinik/atrinik",
+      "old_revision": "6f6040212f0fa0cb6b8e4e695d1488a403d966be",
+      "new_revision": "f2d8eda70776ef42acdaf9150223aaecded103b1",
+      "path": "governance/provenance-identities/{registry,schema-v1,reviewers}.json",
+      "old_reviewers_sha256": "b7a44ad27cec663a9092b924a0f6a9c95bf95a2ce74cf75ba8873e7938782240",
+      "new_reviewers_sha256": "a0c765f70844ab5c368cade59afda5d05c4627d20c00e6c362217da804e12f19"
+    },
+    {
+      "file": "tests/fixtures/provenance-identities/positive/synthetic-beta.json",
+      "field": "evidence_reference.revision",
+      "repository": "atrinik/atrinik",
+      "old_revision": "6f6040212f0fa0cb6b8e4e695d1488a403d966be",
+      "new_revision": "f2d8eda70776ef42acdaf9150223aaecded103b1",
+      "path": "governance/provenance-identities/{registry,schema-v1,reviewers}.json",
+      "old_reviewers_sha256": "b7a44ad27cec663a9092b924a0f6a9c95bf95a2ce74cf75ba8873e7938782240",
+      "new_reviewers_sha256": "a0c765f70844ab5c368cade59afda5d05c4627d20c00e6c362217da804e12f19"
+    },
+    {
+      "file": "tests/fixtures/provenance-identities/negative/broken-reference.json",
+      "field": "evidence_reference.revision",
+      "repository": "atrinik/atrinik",
+      "old_revision": "6f6040212f0fa0cb6b8e4e695d1488a403d966be",
+      "new_revision": "f2d8eda70776ef42acdaf9150223aaecded103b1",
+      "path": "governance/provenance-identities/{registry,schema-v1,reviewers}.json",
+      "old_reviewers_sha256": "b7a44ad27cec663a9092b924a0f6a9c95bf95a2ce74cf75ba8873e7938782240",
+      "new_reviewers_sha256": "a0c765f70844ab5c368cade59afda5d05c4627d20c00e6c362217da804e12f19"
+    }
+  ],
+  "historical_references": [
+    {
+      "file": "docs/PROVENANCE.md",
+      "context": "historical first-recorded grant references",
+      "revision": "d2af1c9fba462e5c18782d3c8206dbc5cfd74bb0",
+      "disposition": "preserved-unresolved; replacement anchor is not historical evidence"
+    },
+    {
+      "file": "docs/PROVENANCE.md",
+      "context": "historical first-recorded grant references",
+      "revision": "d64a8e958ca2adad783ad8912493d468a805f3fd",
+      "disposition": "preserved-unresolved; replacement anchor is not historical evidence"
+    }
+  ]
+}

--- a/governance/replacement-foundations.json
+++ b/governance/replacement-foundations.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "root_policy": {
     "repository": "atrinik/atrinik",
-    "revision": "d64a8e958ca2adad783ad8912493d468a805f3fd",
+    "revision": "f2d8eda70776ef42acdaf9150223aaecded103b1",
     "path": "AGENTS.md",
     "rule": "Independent MIT implementation is the default. Historical reuse requires a complete non-shallow rename-aware history audit, proven sole original authorship by an approved grantor, identity verification, embedded-material review, an exact transformation record, and reviewer approval; mixed or uncertain material is excluded."
   },

--- a/mcp/contract/v1/fixtures/workloads.json
+++ b/mcp/contract/v1/fixtures/workloads.json
@@ -169,7 +169,7 @@
         "coordinates": [
           {
             "branch": "main",
-            "commit": "f0d1225791da7484e9456b39104cc30b0c77fe52",
+            "commit": "f2d8eda70776ef42acdaf9150223aaecded103b1",
             "dirty_fingerprint": null,
             "repository": "atrinik/atrinik",
             "worktree": "primary"
@@ -220,7 +220,7 @@
         "coordinates": [
           {
             "branch": "main",
-            "commit": "f0d1225791da7484e9456b39104cc30b0c77fe52",
+            "commit": "f2d8eda70776ef42acdaf9150223aaecded103b1",
             "dirty_fingerprint": null,
             "repository": "atrinik/atrinik",
             "worktree": "primary"

--- a/tests/fixtures/provenance-identities/negative/broken-reference.json
+++ b/tests/fixtures/provenance-identities/negative/broken-reference.json
@@ -18,11 +18,11 @@
   },
   "evidence_reference": {
     "repository": "atrinik/atrinik",
-    "revision": "6f6040212f0fa0cb6b8e4e695d1488a403d966be",
+    "revision": "f2d8eda70776ef42acdaf9150223aaecded103b1",
     "record_id": "pir-c-11111111111111111111111111111111",
     "registry_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
     "schema_sha256": "9c726627c8679b4b437db2b54b2480fe0c45eef788de7cd76de1dec5c3ce3409",
-    "reviewers_sha256": "b7a44ad27cec663a9092b924a0f6a9c95bf95a2ce74cf75ba8873e7938782240",
-    "url": "https://github.com/atrinik/atrinik/blob/6f6040212f0fa0cb6b8e4e695d1488a403d966be/governance/provenance-identities/registry.json#pir-c-11111111111111111111111111111111"
+    "reviewers_sha256": "a0c765f70844ab5c368cade59afda5d05c4627d20c00e6c362217da804e12f19",
+    "url": "https://github.com/atrinik/atrinik/blob/f2d8eda70776ef42acdaf9150223aaecded103b1/governance/provenance-identities/registry.json#pir-c-11111111111111111111111111111111"
   }
 }

--- a/tests/fixtures/provenance-identities/positive/synthetic-alpha.json
+++ b/tests/fixtures/provenance-identities/positive/synthetic-alpha.json
@@ -18,11 +18,11 @@
   },
   "evidence_reference": {
     "repository": "atrinik/atrinik",
-    "revision": "6f6040212f0fa0cb6b8e4e695d1488a403d966be",
+    "revision": "f2d8eda70776ef42acdaf9150223aaecded103b1",
     "record_id": "pir-c-11111111111111111111111111111111",
     "registry_sha256": "0a04fcadccb37e64f6c1209bc0b7e8d5762639ce4c5521c3bba028d9eba037bd",
     "schema_sha256": "9c726627c8679b4b437db2b54b2480fe0c45eef788de7cd76de1dec5c3ce3409",
-    "reviewers_sha256": "b7a44ad27cec663a9092b924a0f6a9c95bf95a2ce74cf75ba8873e7938782240",
-    "url": "https://github.com/atrinik/atrinik/blob/6f6040212f0fa0cb6b8e4e695d1488a403d966be/governance/provenance-identities/registry.json#pir-c-11111111111111111111111111111111"
+    "reviewers_sha256": "a0c765f70844ab5c368cade59afda5d05c4627d20c00e6c362217da804e12f19",
+    "url": "https://github.com/atrinik/atrinik/blob/f2d8eda70776ef42acdaf9150223aaecded103b1/governance/provenance-identities/registry.json#pir-c-11111111111111111111111111111111"
   }
 }

--- a/tests/fixtures/provenance-identities/positive/synthetic-beta.json
+++ b/tests/fixtures/provenance-identities/positive/synthetic-beta.json
@@ -18,11 +18,11 @@
   },
   "evidence_reference": {
     "repository": "atrinik/atrinik",
-    "revision": "6f6040212f0fa0cb6b8e4e695d1488a403d966be",
+    "revision": "f2d8eda70776ef42acdaf9150223aaecded103b1",
     "record_id": "pir-c-22222222222222222222222222222222",
     "registry_sha256": "0a04fcadccb37e64f6c1209bc0b7e8d5762639ce4c5521c3bba028d9eba037bd",
     "schema_sha256": "9c726627c8679b4b437db2b54b2480fe0c45eef788de7cd76de1dec5c3ce3409",
-    "reviewers_sha256": "b7a44ad27cec663a9092b924a0f6a9c95bf95a2ce74cf75ba8873e7938782240",
-    "url": "https://github.com/atrinik/atrinik/blob/6f6040212f0fa0cb6b8e4e695d1488a403d966be/governance/provenance-identities/registry.json#pir-c-22222222222222222222222222222222"
+    "reviewers_sha256": "a0c765f70844ab5c368cade59afda5d05c4627d20c00e6c362217da804e12f19",
+    "url": "https://github.com/atrinik/atrinik/blob/f2d8eda70776ef42acdaf9150223aaecded103b1/governance/provenance-identities/registry.json#pir-c-22222222222222222222222222222222"
   }
 }

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -80,8 +80,8 @@ class ReplacementFoundationTests(unittest.TestCase):
             capture_output=True,
             text=True,
         ).stdout
-        self.assertIn("Zoey Rose", registry)
-        self.assertIn("Daniel Liptrot", registry)
+        self.assertIn("Atrinik workspace agent guide", registry)
+        self.assertIn("Use `atrinik-issue-delivery` only when explicitly invoked", registry)
 
         required_fields = self.inventory["required_record_fields"]
         self.assertEqual(len(required_fields), len(set(required_fields)))
@@ -96,6 +96,57 @@ class ReplacementFoundationTests(unittest.TestCase):
         self.assertNotEqual(
             examples["admitted"]["verification"],
             examples["excluded"]["verification"],
+        )
+
+    def test_provenance_revision_migration_records_exact_recovery_decision(self) -> None:
+        migration = load_json("governance/provenance-revision-migration.json")
+        self.assertEqual(migration["issue"], "atrinik/atrinik#508")
+        self.assertEqual(migration["decision"], "reanchor-unreachable-history")
+        self.assertEqual(
+            migration["coordinator"]["revision"],
+            "f2d8eda70776ef42acdaf9150223aaecded103b1",
+        )
+        self.assertEqual(
+            {item["path"] for item in migration["coordinator"]["objects"]},
+            {
+                "AGENTS.md",
+                "docs/PROVENANCE.md",
+                "docs/PROVENANCE_IDENTITIES.md",
+                "governance/provenance-identities/registry.json",
+                "governance/provenance-identities/schema-v1.json",
+                "governance/provenance-identities/reviewers.json",
+            },
+        )
+        old_revisions = {item["old_revision"] for item in migration["replacements"]}
+        self.assertIn("d64a8e958ca2adad783ad8912493d468a805f3fd", old_revisions)
+        self.assertIn("6f6040212f0fa0cb6b8e4e695d1488a403d966be", old_revisions)
+        external = migration["external_reanchors"]
+        self.assertEqual(len(external), 1)
+        self.assertEqual(external[0]["repository"], "atrinik/tools")
+        self.assertEqual(
+            {
+                reference["new_revision"]
+                for reference in external[0]["references"]
+            },
+            {
+                "94ff0e5e8eedac20ac5aee0d27794aa8d0a60563",
+                "90a6df596628892603cab7e4f850b75f59fbe04f",
+            },
+        )
+        fixture_replacements = migration["fixture_replacements"]
+        self.assertEqual(len(fixture_replacements), 2)
+        self.assertTrue(
+            all(
+                replacement["new_revision"]
+                == "f2d8eda70776ef42acdaf9150223aaecded103b1"
+                for replacement in fixture_replacements
+            )
+        )
+        self.assertTrue(
+            all(
+                "preserved-unresolved" in item["disposition"]
+                for item in migration["historical_references"]
+            )
         )
 
     def test_foundation_repositories_are_owned_in_supply_chain(self) -> None:
@@ -229,7 +280,7 @@ class ClassicToolsInventoryTests(unittest.TestCase):
         )
         self.assertEqual(
             source["audit_baseline"]["revision"],
-            "7777cf9f9ab6deb58de8a481dfccd6b05d86e3e1",
+            "94ff0e5e8eedac20ac5aee0d27794aa8d0a60563",
         )
         self.assertEqual(
             source["audit_baseline"]["tree"],
@@ -240,7 +291,7 @@ class ClassicToolsInventoryTests(unittest.TestCase):
         )
         self.assertEqual(
             target["revision"],
-            "33003ac9f737da9c722b446b6bf4948d669ce42b",
+            "90a6df596628892603cab7e4f850b75f59fbe04f",
         )
         self.assertEqual(
             target["tree"], "1f84a1d32120fc3f32902c2a9603f7c1730e6034"
@@ -248,11 +299,11 @@ class ClassicToolsInventoryTests(unittest.TestCase):
         self.assertEqual(target["status"], "reviewed-pull-request")
         self.assertEqual(
             source["provenance_policy"]["revision"],
-            "f0d1225791da7484e9456b39104cc30b0c77fe52",
+            "f2d8eda70776ef42acdaf9150223aaecded103b1",
         )
         self.assertEqual(
             source["identity_policy"]["revision"],
-            "6f6040212f0fa0cb6b8e4e695d1488a403d966be",
+            "f2d8eda70776ef42acdaf9150223aaecded103b1",
         )
 
 

--- a/tests/test_provenance_identity.py
+++ b/tests/test_provenance_identity.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import re
 import subprocess
 import tempfile
 import unittest
@@ -17,6 +18,7 @@ from atrinik_workspace.provenance_identity import (
     _git_blob,
     _git_environment,
     _git_output,
+    _preflight_git_output,
     _exact_keys,
     _iso_date,
     _load_bytes,
@@ -30,6 +32,7 @@ from atrinik_workspace.provenance_identity import (
     validate_paths,
     validate_registry,
     validate_reviewers,
+    preflight_provenance_revisions,
 )
 
 
@@ -38,7 +41,7 @@ REGISTRY = ROOT / "governance/provenance-identities/registry.json"
 SCHEMA = ROOT / "governance/provenance-identities/schema-v1.json"
 FIXTURES = ROOT / "tests/fixtures/provenance-identities"
 REVIEWERS = ROOT / "governance/provenance-identities/reviewers.json"
-PINNED_REVISION = "6f6040212f0fa0cb6b8e4e695d1488a403d966be"
+PINNED_REVISION = "f2d8eda70776ef42acdaf9150223aaecded103b1"
 PINNED_REVIEWERS_PATH = "governance/provenance-identities/reviewers.json"
 AS_OF = date(2026, 8, 13)
 
@@ -256,6 +259,35 @@ class ProvenanceIdentityTests(unittest.TestCase):
         with mock.patch("builtins.print") as output:
             self.assertEqual(main(["provenance", "validate"]), 0)
         self.assertIn("2 records, 0 references", output.call_args.args[0])
+
+    def test_parser_exposes_provenance_revision_preflight(self) -> None:
+        options = parser().parse_args(["provenance", "preflight"])
+        self.assertEqual(options.command, "provenance")
+        self.assertEqual(options.provenance_command, "preflight")
+        self.assertEqual(preflight_provenance_revisions(ROOT), (1, 6))
+        with mock.patch("builtins.print") as output:
+            self.assertEqual(main(["provenance", "preflight"]), 0)
+        self.assertIn("1 coordinator revisions, 6 Git objects", output.call_args.args[0])
+        self.assertIn("governance/provenance-revision-migration.json", output.call_args.args[0])
+
+    def test_provenance_revision_preflight_reports_missing_object(self) -> None:
+        missing = "deadbeef" * 5 + ":AGENTS.md"
+        result = subprocess.CompletedProcess(
+            ["git", "cat-file", "-e", missing], 1, b"", b"missing"
+        )
+        with mock.patch(
+            "atrinik_workspace.provenance_identity.subprocess.run",
+            return_value=result,
+        ), self.assertRaisesRegex(
+            WorkspaceError,
+            f"cannot resolve atrinik/atrinik object {re.escape(missing)}",
+        ):
+            _preflight_git_output(
+                ROOT,
+                ["cat-file", "-e", missing],
+                missing,
+                "atrinik/atrinik",
+            )
 
     def test_duplicate_json_keys_fail_closed(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -587,17 +619,18 @@ class ProvenanceIdentityTests(unittest.TestCase):
                     )
 
     def test_two_synthetic_component_references_validate_offline(self) -> None:
-        records, reviewer_keys = current()
-        for name in ("synthetic-alpha.json", "synthetic-beta.json"):
-            with self.subTest(name=name):
-                validate_component_reference(
-                    load_document(FIXTURES / "positive" / name),
-                    repository_root=ROOT,
-                    as_of=AS_OF,
-                    trusted_ref="HEAD",
-                    current_records=records,
-                    current_reviewers=reviewer_keys,
-                )
+        validate_paths(
+            ROOT,
+            registry_path=REGISTRY,
+            schema_path=SCHEMA,
+            reviewers_path=REVIEWERS,
+            reference_paths=[
+                FIXTURES / "positive" / "synthetic-alpha.json",
+                FIXTURES / "positive" / "synthetic-beta.json",
+            ],
+            as_of=AS_OF,
+            trusted_ref="HEAD",
+        )
 
     def test_broken_immutable_reference_fixture_fails_closed(self) -> None:
         records, reviewer_keys = current()

--- a/tests/test_provenance_identity.py
+++ b/tests/test_provenance_identity.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from datetime import date
 import hashlib
 import json
@@ -15,9 +16,13 @@ from atrinik_workspace.cli import main, parser
 from atrinik_workspace.model import WorkspaceError
 from atrinik_workspace.provenance_identity import (
     MAX_DOCUMENT_BYTES,
+    _coordinator_pins,
     _git_blob,
     _git_environment,
     _git_output,
+    _migration_field_value,
+    _migration_scope_payload,
+    _preflight_blob,
     _preflight_git_output,
     _exact_keys,
     _iso_date,
@@ -25,7 +30,10 @@ from atrinik_workspace.provenance_identity import (
     _private_file_opener,
     _repository_path,
     _string_array,
+    _validate_external_reanchors,
     _validate_repository_trust,
+    _validate_fixture_replacements,
+    _validate_revision_migration,
     load_document,
     record_digest,
     validate_component_reference,
@@ -56,6 +64,14 @@ def schema() -> dict[str, object]:
 
 def reviewers() -> dict[str, object]:
     return json.loads(REVIEWERS.read_text(encoding="utf-8"))
+
+
+def revision_migration() -> dict[str, object]:
+    return json.loads(
+        (ROOT / "governance/provenance-revision-migration.json").read_text(
+            encoding="utf-8"
+        )
+    )
 
 
 def current() -> tuple[dict[str, dict[str, object]], dict[str, dict[str, object]]]:
@@ -287,6 +303,444 @@ class ProvenanceIdentityTests(unittest.TestCase):
                 ["cat-file", "-e", missing],
                 missing,
                 "atrinik/atrinik",
+            )
+
+    def test_preflight_object_integrity_failures_are_bounded(self) -> None:
+        object_name = f"{PINNED_REVISION}:AGENTS.md"
+        for failure in (
+            OSError("git unavailable"),
+            subprocess.TimeoutExpired(["git"], 10),
+        ):
+            with self.subTest(failure=type(failure).__name__), mock.patch(
+                "atrinik_workspace.provenance_identity.subprocess.run",
+                side_effect=failure,
+            ), self.assertRaisesRegex(WorkspaceError, "cannot resolve"):
+                _preflight_git_output(ROOT, ["cat-file", "-e", object_name], object_name, "atrinik/atrinik")
+
+        failures = (
+            ([b"different-git-object"], "object identity changed"),
+            ([b"expected-git-object", b"not-a-size"], "invalid size"),
+            ([b"expected-git-object", str(MAX_DOCUMENT_BYTES + 1).encode()], "exceeds the size limit"),
+            ([b"expected-git-object", b"3", b"xx"], "changed during read"),
+            ([b"expected-git-object", b"2", b"xx"], "SHA-256 mismatch"),
+        )
+        for outputs, message in failures:
+            with self.subTest(message=message), mock.patch(
+                "atrinik_workspace.provenance_identity._preflight_git_output",
+                side_effect=outputs,
+            ), self.assertRaisesRegex(WorkspaceError, message):
+                _preflight_blob(
+                    ROOT,
+                    PINNED_REVISION,
+                    "AGENTS.md",
+                    "atrinik/atrinik",
+                    expected_git_object="expected-git-object",
+                    expected_sha256="0" * 64,
+                )
+
+    def test_revision_migration_shape_validation_fails_closed(self) -> None:
+        base = revision_migration()
+        mutations = (
+            ("schema version", lambda value: value.update(schema_version=2)),
+            ("decision", lambda value: value.update(decision="rewrite-history")),
+            ("issue", lambda value: value.update(issue=None)),
+            ("rationale", lambda value: value.update(rationale=None)),
+            ("coordinator", lambda value: value.update(coordinator=None)),
+            (
+                "coordinator repository",
+                lambda value: value["coordinator"].update(repository="outside/project"),
+            ),
+            (
+                "coordinator ref",
+                lambda value: value["coordinator"].update(trusted_ref="HEAD"),
+            ),
+            (
+                "coordinator revision",
+                lambda value: value["coordinator"].update(revision="short"),
+            ),
+            (
+                "empty objects",
+                lambda value: value["coordinator"].update(objects=[]),
+            ),
+            (
+                "object entry",
+                lambda value: value["coordinator"].update(objects=[None]),
+            ),
+            (
+                "duplicate object path",
+                lambda value: value["coordinator"]["objects"][1].update(
+                    path=value["coordinator"]["objects"][0]["path"]
+                ),
+            ),
+            (
+                "object path",
+                lambda value: value["coordinator"]["objects"][0].update(path="/absolute"),
+            ),
+            (
+                "object revision",
+                lambda value: value["coordinator"]["objects"][0].update(git_object="short"),
+            ),
+            (
+                "object digest",
+                lambda value: value["coordinator"]["objects"][0].update(sha256="short"),
+            ),
+            ("empty replacements", lambda value: value.update(replacements=[])),
+            (
+                "replacement entry",
+                lambda value: value.update(replacements=[None]),
+            ),
+            (
+                "replacement file",
+                lambda value: value["replacements"][0].update(file=None),
+            ),
+            (
+                "replacement field",
+                lambda value: value["replacements"][0].update(field=" field"),
+            ),
+            (
+                "duplicate replacement",
+                lambda value: value["replacements"].append(
+                    copy.deepcopy(value["replacements"][0])
+                ),
+            ),
+            (
+                "replacement old revision",
+                lambda value: value["replacements"][0].update(old_revision="short"),
+            ),
+            (
+                "replacement new revision",
+                lambda value: value["replacements"][0].update(new_revision="short"),
+            ),
+            (
+                "replacement repository",
+                lambda value: value["replacements"][0].update(repository="outside/project"),
+            ),
+            (
+                "replacement anchor",
+                lambda value: value["replacements"][0].update(new_revision="0" * 40),
+            ),
+            (
+                "replacement path",
+                lambda value: value["replacements"][0].update(path=None),
+            ),
+            (
+                "partial reviewer digests",
+                lambda value: value["replacements"][0].update(old_reviewers_sha256="0" * 64),
+            ),
+            (
+                "reviewer digest",
+                lambda value: value["replacements"][2].update(old_reviewers_sha256="short"),
+            ),
+            ("empty external reanchors", lambda value: value.update(external_reanchors=[])),
+            ("empty fixture replacements", lambda value: value.update(fixture_replacements=[])),
+            ("empty historical references", lambda value: value.update(historical_references=[])),
+            (
+                "historical entry",
+                lambda value: value.update(historical_references=[None]),
+            ),
+            (
+                "historical revision",
+                lambda value: value["historical_references"][0].update(revision="short"),
+            ),
+            (
+                "historical disposition",
+                lambda value: value["historical_references"][0].update(disposition="resolved"),
+            ),
+        )
+        for name, mutate in mutations:
+            with self.subTest(mutation=name):
+                value = copy.deepcopy(base)
+                mutate(value)
+                with self.assertRaises(WorkspaceError):
+                    _validate_revision_migration(value)
+
+    def test_revision_migration_nested_validators_fail_closed(self) -> None:
+        migration = revision_migration()
+        external = migration["external_reanchors"]
+        external_mutations = (
+            ("item", lambda value: value.__setitem__(0, None)),
+            ("file", lambda value: value[0].update(file="/absolute")),
+            ("repository", lambda value: value[0].update(repository="outside/project")),
+            ("trusted ref", lambda value: value[0].update(trusted_ref="HEAD")),
+            ("disposition", lambda value: value[0].update(disposition=None)),
+            ("references", lambda value: value[0].update(references=[])),
+            (
+                "reference entry",
+                lambda value: value[0].update(references=[None]),
+            ),
+            (
+                "duplicate field",
+                lambda value: value[0].update(
+                    references=[
+                        value[0]["references"][0],
+                        copy.deepcopy(value[0]["references"][0]),
+                    ]
+                ),
+            ),
+            (
+                "reference revision",
+                lambda value: value[0]["references"][0].update(old_revision="short"),
+            ),
+        )
+        for name, mutate in external_mutations:
+            with self.subTest(external=name):
+                value = copy.deepcopy(external)
+                mutate(value)
+                with self.assertRaises(WorkspaceError):
+                    _validate_external_reanchors(value)
+
+        fixture = migration["fixture_replacements"]
+        fixture_mutations = (
+            ("empty", lambda value: value.clear()),
+            ("item", lambda value: value.__setitem__(0, None)),
+            ("file", lambda value: value[0].update(file="/absolute")),
+            ("case id", lambda value: value[0].update(case_id=None)),
+            ("boolean index", lambda value: value[0].update(coordinate_index=True)),
+            ("negative index", lambda value: value[0].update(coordinate_index=-1)),
+            (
+                "duplicate coordinate",
+                lambda value: value.append(copy.deepcopy(value[0])),
+            ),
+            ("repository", lambda value: value[0].update(repository="outside/project")),
+            ("old revision", lambda value: value[0].update(old_revision="short")),
+            ("new revision", lambda value: value[0].update(new_revision="short")),
+            ("anchor", lambda value: value[0].update(new_revision="0" * 40)),
+            ("workload file", lambda value: value[0].update(file="other.json")),
+        )
+        for name, mutate in fixture_mutations:
+            with self.subTest(fixture=name):
+                value = copy.deepcopy(fixture)
+                mutate(value)
+                with self.assertRaises(WorkspaceError):
+                    _validate_fixture_replacements(value, PINNED_REVISION)
+
+    def test_migration_helpers_require_exact_paths_and_digests(self) -> None:
+        with self.assertRaises(WorkspaceError):
+            _coordinator_pins(
+                {"repository": "atrinik/atrinik", "revision": PINNED_REVISION},
+                "pin",
+            )
+        with self.assertRaises(WorkspaceError):
+            _coordinator_pins(
+                {
+                    "repository": "atrinik/atrinik",
+                    "revision": "short",
+                    "path": "AGENTS.md",
+                },
+                "pin",
+            )
+        with self.assertRaisesRegex(WorkspaceError, "does not resolve"):
+            _migration_field_value({}, "root_policy.revision", "fixture")
+
+        reference = load_document(FIXTURES / "positive" / "synthetic-alpha.json")
+        replacement = next(
+            item
+            for item in revision_migration()["replacements"]
+            if item["file"].endswith("synthetic-alpha.json")
+        )
+        self.assertIsNone(_migration_scope_payload(reference, None))
+        self.assertIsNone(
+            _migration_scope_payload(reference, {**replacement, "field": "other"})
+        )
+        without_old_reviewers = dict(replacement)
+        without_old_reviewers.pop("old_reviewers_sha256")
+        self.assertIsNone(_migration_scope_payload(reference, without_old_reviewers))
+        self.assertIsNone(
+            _migration_scope_payload(
+                reference,
+                {**replacement, "new_revision": "0" * 40},
+            )
+        )
+        changed_reviewers = dict(reference)
+        changed_reviewers["evidence_reference"] = dict(reference["evidence_reference"])
+        changed_reviewers["evidence_reference"]["reviewers_sha256"] = "0" * 64
+        self.assertIsNone(_migration_scope_payload(changed_reviewers, replacement))
+        self.assertIsInstance(_migration_scope_payload(reference, replacement), bytes)
+
+    def test_preflight_rejects_unapplied_pins_and_fixture_coordinates(self) -> None:
+        workload_path = ROOT / "mcp/contract/v1/fixtures/workloads.json"
+        active_pin = [("pin", PINNED_REVISION, "AGENTS.md")]
+        original_load_document = load_document
+
+        def run_failure(loader, message, *, pins=active_pin):
+            with mock.patch(
+                "atrinik_workspace.provenance_identity.load_document",
+                side_effect=loader,
+            ), mock.patch(
+                "atrinik_workspace.provenance_identity._preflight_revision"
+            ), mock.patch(
+                "atrinik_workspace.provenance_identity._preflight_blob"
+            ), mock.patch(
+                "atrinik_workspace.provenance_identity._coordinator_pins",
+                return_value=pins,
+            ), self.assertRaisesRegex(WorkspaceError, message):
+                preflight_provenance_revisions(ROOT)
+
+        run_failure(
+            original_load_document,
+            "found no active coordinator revision pins",
+            pins=[],
+        )
+        run_failure(
+            original_load_document,
+            "does not use migration anchor",
+            pins=[("pin", "0" * 40, "AGENTS.md")],
+        )
+        run_failure(
+            original_load_document,
+            "lacks coordinator object",
+            pins=[("pin", PINNED_REVISION, "missing.md")],
+        )
+
+        foundations_path = ROOT / "governance/replacement-foundations.json"
+
+        def unapplied_foundation(path):
+            value = original_load_document(path)
+            if path.resolve() == foundations_path.resolve():
+                value = copy.deepcopy(value)
+                value["root_policy"]["revision"] = "0" * 40
+            return value
+
+        run_failure(unapplied_foundation, "migration row .* is not applied")
+
+        def workload_failure(mutator):
+            def loader(path):
+                value = original_load_document(path)
+                if path.resolve() == workload_path.resolve():
+                    value = copy.deepcopy(value)
+                    mutator(value)
+                return value
+
+            return loader
+
+        workload_mutations = (
+            ("cases", lambda value: value.update(cases=None), "cases must be an array"),
+            ("case", lambda value: value.update(cases=[None]), "case is invalid"),
+            (
+                "expected",
+                lambda value: next(
+                    case for case in value["cases"] if case["id"] == "github-planning-read"
+                ).update(expected=None),
+                "has no expected object",
+            ),
+            (
+                "coordinates",
+                lambda value: next(
+                    case for case in value["cases"] if case["id"] == "github-planning-read"
+                )["expected"].update(coordinates=None),
+                "coordinates are invalid",
+            ),
+            (
+                "coordinate",
+                lambda value: next(
+                    case for case in value["cases"] if case["id"] == "github-planning-read"
+                )["expected"]["coordinates"].__setitem__(0, None),
+                "coordinate is invalid",
+            ),
+            (
+                "revision",
+                lambda value: next(
+                    case for case in value["cases"] if case["id"] == "github-planning-read"
+                )["expected"]["coordinates"][0].update(commit="0" * 40),
+                "does not use migration anchor",
+            ),
+            (
+                "migration row",
+                lambda value: next(
+                    case for case in value["cases"] if case["id"] == "github-planning-read"
+                ).update(id="unmapped"),
+                "lacks an applied migration row",
+            ),
+            ("coordinate set", lambda value: value.update(cases=[]), "do not match active coordinates"),
+        )
+        for name, mutate, message in workload_mutations:
+            with self.subTest(workload=name):
+                run_failure(workload_failure(mutate), message)
+
+        def fixture_loader(path, *, external=False):
+            value = original_load_document(path)
+            if path.resolve().is_relative_to(
+                (ROOT / "tests/fixtures/provenance-identities").resolve()
+            ):
+                value = copy.deepcopy(value)
+                evidence = value.get("evidence_reference")
+                if isinstance(evidence, dict):
+                    if external:
+                        evidence["repository"] = "atrinik/other"
+            return value
+
+        with self.subTest(fixture="external repository"):
+            run_failure(
+                lambda path: fixture_loader(path, external=True),
+                "found no coordinator fixture revisions",
+            )
+        wrong_fixture = ROOT / "tests/fixtures/provenance-identities/extra-wrong.json"
+
+        def wrong_fixture_loader(path):
+            if path.resolve() == wrong_fixture.resolve():
+                return {
+                    "evidence_reference": {
+                        "repository": "atrinik/atrinik",
+                        "revision": "0" * 40,
+                    }
+                }
+            return original_load_document(path)
+
+        with self.subTest(fixture="wrong revision"), mock.patch(
+            "atrinik_workspace.provenance_identity.load_document",
+            side_effect=wrong_fixture_loader,
+        ), mock.patch(
+            "pathlib.Path.rglob",
+            return_value=[wrong_fixture],
+        ), mock.patch(
+            "atrinik_workspace.provenance_identity._preflight_revision"
+        ), mock.patch(
+            "atrinik_workspace.provenance_identity._preflight_blob"
+        ), mock.patch(
+            "atrinik_workspace.provenance_identity._coordinator_pins",
+            return_value=active_pin,
+        ), self.assertRaisesRegex(WorkspaceError, "does not use migration anchor"):
+            preflight_provenance_revisions(ROOT)
+
+        with mock.patch(
+            "pathlib.Path.rglob",
+            side_effect=OSError("fixture scan unavailable"),
+        ), mock.patch(
+            "atrinik_workspace.provenance_identity._preflight_revision"
+        ), mock.patch(
+            "atrinik_workspace.provenance_identity._preflight_blob"
+        ), mock.patch(
+            "atrinik_workspace.provenance_identity._coordinator_pins",
+            return_value=active_pin,
+        ), self.assertRaisesRegex(WorkspaceError, "cannot enumerate provenance fixtures"):
+            preflight_provenance_revisions(ROOT)
+
+    def test_failed_migration_signature_fallback_restores_current_error(self) -> None:
+        reference = load_document(FIXTURES / "positive" / "synthetic-alpha.json")
+        records, reviewer_keys = current()
+        replacement = next(
+            item
+            for item in revision_migration()["replacements"]
+            if item["file"].endswith("synthetic-alpha.json")
+        )
+        def reject_only_component_scope(*_args, context, **_kwargs):
+            if context == "component provenance scope_approval":
+                raise WorkspaceError("current signature")
+            if context == "component provenance migrated scope_approval":
+                raise WorkspaceError("legacy signature")
+
+        with mock.patch(
+            "atrinik_workspace.provenance_identity._verify_approval",
+            side_effect=reject_only_component_scope,
+        ), self.assertRaisesRegex(WorkspaceError, "current signature"):
+            validate_component_reference(
+                reference,
+                repository_root=ROOT,
+                as_of=AS_OF,
+                trusted_ref="HEAD",
+                current_records=records,
+                current_reviewers=reviewer_keys,
+                migration_replacement=replacement,
             )
 
     def test_duplicate_json_keys_fail_closed(self) -> None:

--- a/tests/test_provenance_identity.py
+++ b/tests/test_provenance_identity.py
@@ -456,8 +456,20 @@ class ProvenanceIdentityTests(unittest.TestCase):
                 lambda value: value["historical_references"][0].update(revision="short"),
             ),
             (
+                "historical file",
+                lambda value: value["historical_references"][0].update(file=None),
+            ),
+            (
+                "historical context",
+                lambda value: value["historical_references"][0].update(context=None),
+            ),
+            (
                 "historical disposition",
                 lambda value: value["historical_references"][0].update(disposition="resolved"),
+            ),
+            (
+                "historical disposition type",
+                lambda value: value["historical_references"][0].update(disposition=None),
             ),
         )
         for name, mutate in mutations:
@@ -531,6 +543,11 @@ class ProvenanceIdentityTests(unittest.TestCase):
         with self.assertRaises(WorkspaceError):
             _coordinator_pins(
                 {"repository": "atrinik/atrinik", "revision": PINNED_REVISION},
+                "pin",
+            )
+        with self.assertRaisesRegex(WorkspaceError, "revision must be present"):
+            _coordinator_pins(
+                {"repository": "atrinik/atrinik", "path": "AGENTS.md"},
                 "pin",
             )
         with self.assertRaises(WorkspaceError):

--- a/tests/test_provenance_identity.py
+++ b/tests/test_provenance_identity.py
@@ -286,6 +286,19 @@ class ProvenanceIdentityTests(unittest.TestCase):
         self.assertIn("1 coordinator revisions, 6 Git objects", output.call_args.args[0])
         self.assertIn("governance/provenance-revision-migration.json", output.call_args.args[0])
 
+    def test_cli_preflight_keeps_external_migration_path_displayable(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            migration = Path(temporary) / "migration.json"
+            with mock.patch(
+                "atrinik_workspace.cli.preflight_provenance_revisions",
+                return_value=(1, 6),
+            ), mock.patch("builtins.print") as output:
+                self.assertEqual(
+                    main(["provenance", "preflight", "--migration", str(migration)]),
+                    0,
+                )
+        self.assertIn(str(migration), output.call_args.args[0])
+
     def test_provenance_revision_preflight_reports_missing_object(self) -> None:
         missing = "deadbeef" * 5 + ":AGENTS.md"
         result = subprocess.CompletedProcess(
@@ -1085,6 +1098,29 @@ class ProvenanceIdentityTests(unittest.TestCase):
             as_of=AS_OF,
             trusted_ref="HEAD",
         )
+
+    def test_external_reference_path_is_not_given_a_migration_replacement(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            reference_path = Path(temporary) / "external.json"
+            reference_path.write_text("{}\n", encoding="utf-8")
+            with mock.patch(
+                "atrinik_workspace.provenance_identity.validate_component_reference"
+            ) as validate_reference:
+                self.assertEqual(
+                    validate_paths(
+                        ROOT,
+                        registry_path=REGISTRY,
+                        schema_path=SCHEMA,
+                        reviewers_path=REVIEWERS,
+                        reference_paths=[reference_path],
+                        as_of=AS_OF,
+                        trusted_ref="HEAD",
+                    ),
+                    2,
+                )
+            self.assertIsNone(
+                validate_reference.call_args.kwargs["migration_replacement"]
+            )
 
     def test_broken_immutable_reference_fixture_fails_closed(self) -> None:
         records, reviewer_keys = current()


### PR DESCRIPTION
## Summary

Restore reachable provenance revision anchors so the aggregate wrapper tests can resolve governance and synthetic evidence objects in a full-history checkout.

## Implementation / behavior

- Re-anchor coordinator and Classic-tools governance pins to verified commits reachable from their canonical default branches.
- Update synthetic provenance fixtures and immutable documentation links to the reachable coordinator anchor without changing the fail-closed validation contract.
- Add a bounded provenance preflight that resolves every pinned commit, tree, and blob before measured test shards run and reports the exact missing object on failure.
- Record the unrecoverable-history migration decision and old/new hashes without treating replacement anchors as historical identities.

## Validation

- Focused governance and provenance tests.
- Full measured test shards and aggregate integration validation.
- `./atrinik provenance preflight`.
- `./atrinik provenance validate`.
- `git diff --check`.

Closes #508
