### PR TITLE
fix(workspace): allow libatrinik tests to mutate copied protocol fixtures

### DIFF
--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -10231,12 +10231,15 @@ class Workspace:
         self._record_classic_graph(root, {"client", "server"}, "integrated")
 
     def _build_library(self, root: Path, selected: dict[str, Path], tests: bool) -> None:
+        protocol = self._mutable_cmake_source_view(
+            root, "protocol", selected["protocol"]
+        )
         self._cmake(
             selected["libatrinik"],
             root / "build" / "libatrinik",
             [
                 "-DENABLE_WARNING_ERRORS=ON",
-                f"-DATRINIK_PROTOCOL_SOURCE_DIR={selected['protocol']}",
+                f"-DATRINIK_PROTOCOL_SOURCE_DIR={protocol}",
             ],
             tests,
         )

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7826,6 +7826,42 @@ class WorkspaceTests(unittest.TestCase):
         readme.write_text("mutable\n", encoding="utf-8")
         self.assertEqual(readme.read_text(encoding="utf-8"), "mutable\n")
 
+    def test_library_build_uses_mutable_protocol_source_view(self) -> None:
+        with self.workspace._resolved_profile_operation(
+            "default",
+            {"client"},
+            "build library",
+            materialize_clean_primaries=True,
+        ) as snapshot:
+            protocol = snapshot.paths()["protocol"]
+            root = self.workspace.paths.builds / "profiles" / "mutable-library"
+            managed_directory(root, self.workspace.paths.builds, "test-profile")
+            library = self.root / "libatrinik"
+            library.mkdir()
+
+            with mock.patch.object(self.workspace, "_cmake") as cmake:
+                self.workspace._build_library(
+                    root,
+                    {"libatrinik": library, "protocol": protocol},
+                    tests=True,
+                )
+
+            protocol_view = root / "sources" / "protocol"
+            cmake.assert_called_once_with(
+                library,
+                root / "build" / "libatrinik",
+                [
+                    "-DENABLE_WARNING_ERRORS=ON",
+                    f"-DATRINIK_PROTOCOL_SOURCE_DIR={protocol_view}",
+                ],
+                True,
+            )
+            self.assertNotEqual(protocol_view, protocol)
+            readme = protocol_view / "README"
+            self.assertTrue(readme.stat().st_mode & stat.S_IWUSR)
+            readme.write_text("mutable\n", encoding="utf-8")
+            self.assertEqual(readme.read_text(encoding="utf-8"), "mutable\n")
+
     def test_source_view_link_rejects_symlinked_nested_parent(self) -> None:
         view = self.workspace.paths.builds / "profiles" / "test" / "sources"
         managed_directory(view, self.workspace.paths.builds, "test-sources")


### PR DESCRIPTION
## Summary

Fix Classic libatrinik test failures when the protocol source is materialized as a sealed, read-only generation.

Closes #515

## Implementation / behavior

- Resolve the protocol dependency through the existing mutable CMake source-view helper before passing it to libatrinik.
- Keep published protocol source generations sealed while giving copytree-based tests an owner-writable private view.
- Add wrapper regression coverage for the libatrinik consumer path using a sealed protocol generation.

## Validation

- Focused wrapper regression tests for the sealed protocol dependency path.
- `./atrinik build all --profile classic --test`

## Limitations / follow-up

- No runtime behavior or generated source-generation permissions change is intended.
