### PR TITLE
fix(build): scope Git LFS audio filters to sound repository

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,17 +5,6 @@
 *.gif   filter=lfs diff=lfs merge=lfs -text
 *.webp  filter=lfs diff=lfs merge=lfs -text
 *.ico   filter=lfs diff=lfs merge=lfs -text
-*.flac  filter=lfs diff=lfs merge=lfs -text
-*.ogg   filter=lfs diff=lfs merge=lfs -text
-*.wav   filter=lfs diff=lfs merge=lfs -text
-*.mp3   filter=lfs diff=lfs merge=lfs -text
-*.opus  filter=lfs diff=lfs merge=lfs -text
-*.mid   filter=lfs diff=lfs merge=lfs -text
-*.midi  filter=lfs diff=lfs merge=lfs -text
-*.mod   filter=lfs diff=lfs merge=lfs -text
-*.s3m   filter=lfs diff=lfs merge=lfs -text
-*.xm    filter=lfs diff=lfs merge=lfs -text
-*.it    filter=lfs diff=lfs merge=lfs -text
 *.otf   filter=lfs diff=lfs merge=lfs -text
 *.ttf   filter=lfs diff=lfs merge=lfs -text
 *.woff  filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Summary

Keep audio and tracker-format Git LFS wildcard rules in `atrinik/sound`, the
repository that owns the audio corpus.

## Implementation / behavior

- Remove the broad audio/tracker suffix rules from this repository's
  `.gitattributes`.
- Preserve the existing non-audio image, font, and archive LFS rules.
- Keep `go.mod` and any repository-local test/probe fixtures as ordinary Git
  files rather than LFS objects.
- No source or runtime behavior changes.

## Validation

- Audited all manifest repositories for tracked audio/tracker extensions and
  LFS attributes; only `atrinik/sound` retains the audio globs.
- Verified this repository's relevant tracked paths do not resolve to the LFS
  filter.
- `git diff --check`

## Limitations / follow-up

- Existing clones may need to refresh their checkout after this change so
  previously misclassified files are materialized normally.
