### PR TITLE
feat(devcontainer): support WSLg GPU and X11 client input

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,11 @@
 {
+  // This file is JSONC: comments document the WSLg contract used by the
+  // interactive Classic client and the GPU-backed Vulkan shader path.
   "name": "Atrinik 2026 Linux Build",
+  // Pin the published toolchain image so rebuilds use an auditable input.
   "image": "ghcr.io/atrinik/linux-build:1.3.0@sha256:260658d2709e993b41148a9d8f724c2d2f7f1fd93543a139b00d139b10e7f31a",
   "features": {
+    // The wrapper uses the Docker CLI for isolated runtime topologies.
     "ghcr.io/devcontainers/features/docker-in-docker:4": {
       "moby": false
     }
@@ -9,21 +13,47 @@
   "remoteUser": "ubuntu",
   "updateRemoteUserUID": true,
   "runArgs": [
+    // Let the client and server communicate through the host network namespace.
     "--network", "host",
+    // Permit the build/runtime tools to use their documented sandbox settings.
     "--security-opt", "seccomp=unconfined",
-    "--security-opt", "no-new-privileges=false"
+    "--security-opt", "no-new-privileges=false",
+    // WSL2 exposes the host GPU to Linux through the DirectX paravirtual device.
+    "--device=/dev/dxg",
+    // Ask Docker Desktop's NVIDIA runtime to make all GPU capabilities visible.
+    "--gpus=all"
   ],
   "initializeCommand": "install -d -m 700 \"${localEnv:HOME}/.codex-atrinik\" && if [ ! -e \"${localEnv:HOME}/.gitconfig\" ]; then install -m 600 /dev/null \"${localEnv:HOME}/.gitconfig\"; fi",
   "workspaceFolder": "/workspaces/atrinik",
   "mounts": [
+    // Keep Codex state and Git identity local to the host user.
     "source=${localEnv:HOME}/.codex-atrinik,target=/home/ubuntu/.codex,type=bind",
     "source=${localEnv:HOME}/.gitconfig,target=/home/ubuntu/.gitconfig,type=bind,readonly",
+    // WSLg owns the Wayland, X11, runtime, and audio endpoints under this tree.
+    "source=/mnt/wslg,target=/mnt/wslg,type=bind,readonly",
+    // WSLg's Xwayland socket lives here; expose it at the conventional X11 path.
+    "source=/mnt/wslg/.X11-unix,target=/tmp/.X11-unix,type=bind,readonly",
+    // Make WSL's NVIDIA user-mode libraries, including nvidia-smi, available.
+    "source=/usr/lib/wsl,target=/usr/lib/wsl,type=bind,readonly",
+    // Route SDL/Pulse audio to the WSLg host session.
     "source=/mnt/wslg/PulseServer,target=/mnt/wslg/PulseServer,type=bind"
   ],
   "containerEnv": {
+    // WSLg's Xwayland display; SDL uses it by default for reliable text input.
+    "DISPLAY": ":0",
+    // Keep the WSLg Wayland endpoint available to Vulkan and other clients.
+    "WAYLAND_DISPLAY": "wayland-0",
+    // Wayland discovers its socket and ancillary runtime files here.
+    "XDG_RUNTIME_DIR": "/mnt/wslg/runtime-dir",
+    // Resolve WSL's D3D12/NVIDIA user-mode libraries before container libraries.
+    "LD_LIBRARY_PATH": "/usr/lib/wsl/lib",
     "CODEX_HOME": "/home/ubuntu/.codex",
+    // WSLg currently lacks zwp_text_input_v3; SDL's X11 backend supplies text events.
+    "SDL_VIDEODRIVER": "x11",
     "PULSE_SERVER": "unix:/mnt/wslg/PulseServer",
-    "SDL_AUDIODRIVER": "pulse"
+    "SDL_AUDIODRIVER": "pulse",
+    // Expose graphics/display as well as compute and utility capabilities.
+    "NVIDIA_DRIVER_CAPABILITIES": "compute,utility,graphics,display"
   },
   "postCreateCommand": "./atrinik init",
   "customizations": {

--- a/atrinik_workspace/jsonc.py
+++ b/atrinik_workspace/jsonc.py
@@ -1,0 +1,69 @@
+"""Small JSONC compatibility helpers for configuration files."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def _strip_comments(text: str) -> str:
+    """Remove JSONC comments without changing string contents or line numbers."""
+    result: list[str] = []
+    in_string = False
+    escaped = False
+    line_comment = False
+    block_comment = False
+    index = 0
+
+    while index < len(text):
+        character = text[index]
+        next_character = text[index + 1] if index + 1 < len(text) else ""
+
+        if line_comment:
+            if character in "\r\n":
+                line_comment = False
+                result.append(character)
+            else:
+                result.append(" ")
+        elif block_comment:
+            if character == "*" and next_character == "/":
+                block_comment = False
+                result.extend((" ", " "))
+                index += 1
+            elif character in "\r\n":
+                result.append(character)
+            else:
+                result.append(" ")
+        elif in_string:
+            result.append(character)
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+        elif character == '"':
+            in_string = True
+            result.append(character)
+        elif character == "/" and next_character == "/":
+            line_comment = True
+            result.extend((" ", " "))
+            index += 1
+        elif character == "/" and next_character == "*":
+            block_comment = True
+            result.extend((" ", " "))
+            index += 1
+        else:
+            result.append(character)
+
+        index += 1
+
+    if block_comment:
+        raise json.JSONDecodeError("unterminated JSONC block comment", text, len(text))
+
+    return "".join(result)
+
+
+def loads(text: str, **kwargs: Any) -> Any:
+    """Parse JSON or JSONC using the same decoder options as ``json.loads``."""
+    return json.loads(_strip_comments(text), **kwargs)

--- a/atrinik_workspace/supply_chain.py
+++ b/atrinik_workspace/supply_chain.py
@@ -18,6 +18,7 @@ from .model import (
     load_json,
     require_keys,
 )
+from .jsonc import loads as jsonc_loads
 from .sound import validate_release_coordinates
 
 
@@ -1549,7 +1550,7 @@ def _container_references(relative: str, text: str) -> list[str]:
                 stages.add(stage.casefold())
         return references
     try:
-        value = json.loads(text, object_pairs_hook=_reject_duplicate_json_keys)
+        value = jsonc_loads(text, object_pairs_hook=_reject_duplicate_json_keys)
     except json.JSONDecodeError as error:
         raise WorkspaceError(f"invalid devcontainer JSON {relative}: {error}") from error
     image = value.get("image") if isinstance(value, dict) else None

--- a/tests/test_devcontainer.py
+++ b/tests/test_devcontainer.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-import json
 from pathlib import Path
 import unittest
+
+from atrinik_workspace.jsonc import loads as jsonc_loads
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -10,8 +11,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 class DevcontainerTests(unittest.TestCase):
     def load_config(self, relative_path: str) -> dict[str, object]:
-        with (ROOT / relative_path).open(encoding="utf-8") as config_file:
-            return json.load(config_file)
+        return jsonc_loads((ROOT / relative_path).read_text(encoding="utf-8"))
 
     def test_default_configuration_initializes_component_checkouts(self) -> None:
         config = self.load_config(".devcontainer/devcontainer.json")
@@ -23,6 +23,7 @@ class DevcontainerTests(unittest.TestCase):
             "ghcr.io/atrinik/linux-build:1.3.0@sha256:"
             "260658d2709e993b41148a9d8f724c2d2f7f1fd93543a139b00d139b10e7f31a",
         )
+        self.assertEqual(config["containerEnv"]["SDL_VIDEODRIVER"], "x11")
 
     def test_windows_configuration_validates_component_manifest(self) -> None:
         config = self.load_config(

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -9,6 +9,7 @@ import tempfile
 import unittest
 from unittest import mock
 
+from atrinik_workspace.jsonc import loads as jsonc_loads
 from atrinik_workspace.model import Manifest, WorkspaceError
 from atrinik_workspace.supply_chain import (
     ACTION_REFERENCE_PATTERN,
@@ -1342,6 +1343,24 @@ FROM toolchain AS final
                 ".devcontainer/devcontainer.json", '{"image":"example/image"}'
             ),
             ["example/image"],
+        )
+
+    def test_container_reference_parsing_accepts_jsonc_comments(self) -> None:
+        document = """
+        {
+          // Keep this comment while parsing the devcontainer contract.
+          "image": "example/image",
+          /* A URL-like string must remain untouched. */
+          "url": "https://example.invalid//path"
+        }
+        """
+
+        self.assertEqual(
+            _container_references(".devcontainer/devcontainer.json", document),
+            ["example/image"],
+        )
+        self.assertEqual(
+            jsonc_loads(document)["url"], "https://example.invalid//path"
         )
 
     def test_container_reference_validation_normalizes_registry_coordinates(self) -> None:


### PR DESCRIPTION
## Summary

- Configure the Linux devcontainer for Docker Desktop/WSL2 WSLg GPU, display,
  audio, and host-driver forwarding.
- Select SDL's X11 backend by default so the Classic client receives text input
  when WSLg's Wayland compositor lacks `zwp_text_input_v3`.
- Document each WSLg integration piece directly in the JSONC configuration.

## Implementation / behavior

- Adds `/dev/dxg`, `--gpus=all`, the WSLg runtime tree, the WSLg Xwayland socket,
  and `/usr/lib/wsl` to the Linux devcontainer.
- Sets the WSLg display/runtime/library/audio environment and NVIDIA graphics
  capabilities. The X11 socket is mounted from `/mnt/wslg/.X11-unix`, which is
  where WSLg provides `X0`.
- Sets `SDL_VIDEODRIVER=x11` as the default interactive backend. Headless
  callers can still override it, and the Wayland endpoint remains available for
  Vulkan and other clients.
- Adds a small JSONC parser used by devcontainer tests and supply-chain image
  reference scanning, retaining duplicate-key rejection and JSON error
  reporting while allowing explanatory comments.

## Validation

- `python3 -m unittest discover -s tests -p 'test_devcontainer.py' -v`
- `python3 -m unittest discover -s tests -p 'test_supply_chain.py' -v`
- `python3 -m compileall -q atrinik_workspace tests`
- `./atrinik manifest validate`
- `git diff --check`
- Manual WSL2/Docker Desktop validation confirmed host and container
  `nvidia-smi` access, Dozen enumeration through `dzn_icd.json`, and successful
  Classic client launch through the WSLg X11 socket.

## Limitations / follow-up

- The currently pinned published image still needs the Mesa Dozen/D3D12 runtime
  added to its image/package contract. A follow-up issue has been opened in
  `atrinik/devcontainer` for that image update; until it lands, the explicit
  Mesa/Dozen package workaround remains necessary.
- The default mounts and environment target WSL2 with WSLg. Other Linux hosts
  should override the display/GPU settings for their local runtime.
