### PR TITLE
fix(build): auto-wire Classic GPU shader toolchain in managed builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1334,6 +1334,32 @@ one manifest-derived build-root selection across the `client`, `server`,
 `metaserver-worker` roles. Only the requested game service targets are built;
 the wider selection keeps their incremental outputs and recorded coordinates
 on one root. Partial profiles retain the requested service's dependency closure.
+
+### Classic GPU shader toolchain
+
+On x86-64 Linux, a managed Classic client build prepares the checksum-pinned
+shader toolchain from the selected Classic checkout and passes its absolute
+paths to CMake. The preparation is shared by standalone `build client`, paired
+`up`, and the client portion of `build all`; its lockfile and shader-manifest
+identity are retained in the profile build metadata. No caller `PATH` changes
+are required.
+
+For a host-provided toolchain, set both executable overrides and optionally the
+DXC library directory before invoking the wrapper:
+
+~~~sh
+export ATRINIK_DXC_EXECUTABLE=/absolute/path/to/dxc
+export ATRINIK_SPIRV_CROSS_EXECUTABLE=/absolute/path/to/spirv-cross
+export ATRINIK_DXC_LIBRARY_DIRECTORY=/absolute/path/to/dxc/lib
+./atrinik build client --profile classic --test
+~~~
+
+Alternatively, set `ATRINIK_GPU_SHADER_DIRECTORY` to an absolute directory
+containing a generated cohort and its `SHA256SUMS` manifest. The explicit
+cohort is validated by the Classic CMake contract. Do not combine that variable
+with the executable overrides; on platforms where the pinned cohort is not
+available, use one of these explicit overrides.
+
 Provider selection is stack-coherent: a classic service never binds a
 replacement protocol or `content@main`. Today the `classic` stack is the
 runnable implementation; the `default` replacement profile will become

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -57,6 +57,7 @@ from .workspace import (
     load_regular_json,
     rename_no_replace_at,
     remove_owned_tree,
+    validate_gpu_shader_record,
 )
 
 
@@ -130,6 +131,7 @@ SUPPORTED_SCOPES = (*ALL_SCOPES, "topologies", "cleanup-journals")
 BUILD_RETENTION_RECORD = "retention.json"
 LEGACY_BUILD_METADATA_SCHEMA_VERSION = 1
 PRE_SOURCE_GENERATION_BUILD_METADATA_SCHEMA_VERSION = 2
+PRE_GPU_SHADER_BUILD_METADATA_SCHEMA_VERSION = 3
 LEGACY_BUILD_METADATA_KEYS = {
     "schema_version",
     "profile",
@@ -138,7 +140,8 @@ LEGACY_BUILD_METADATA_KEYS = {
     "coordinates",
     "last_used_at",
 }
-BUILD_METADATA_KEYS = {*LEGACY_BUILD_METADATA_KEYS, "sound"}
+PRE_GPU_SHADER_BUILD_METADATA_KEYS = {*LEGACY_BUILD_METADATA_KEYS, "sound"}
+BUILD_METADATA_KEYS = {*PRE_GPU_SHADER_BUILD_METADATA_KEYS, "gpu_shader"}
 BUILD_COORDINATE_KEYS = {
     "component",
     "checkout",
@@ -5488,7 +5491,15 @@ class Cleanup:
         expected_keys = (
             LEGACY_BUILD_METADATA_KEYS
             if schema_version == LEGACY_BUILD_METADATA_SCHEMA_VERSION
-            else BUILD_METADATA_KEYS
+            else (
+                PRE_GPU_SHADER_BUILD_METADATA_KEYS
+                if schema_version
+                in {
+                    PRE_SOURCE_GENERATION_BUILD_METADATA_SCHEMA_VERSION,
+                    PRE_GPU_SHADER_BUILD_METADATA_SCHEMA_VERSION,
+                }
+                else BUILD_METADATA_KEYS
+            )
         )
         if set(value) != expected_keys:
             raise WorkspaceError("build metadata fields are invalid")
@@ -5497,6 +5508,7 @@ class Cleanup:
             not in {
                 LEGACY_BUILD_METADATA_SCHEMA_VERSION,
                 PRE_SOURCE_GENERATION_BUILD_METADATA_SCHEMA_VERSION,
+                PRE_GPU_SHADER_BUILD_METADATA_SCHEMA_VERSION,
                 BUILD_METADATA_SCHEMA_VERSION,
             }
             or value.get("profile") != item["profile"]
@@ -5640,6 +5652,9 @@ class Cleanup:
             if sound is not None:
                 from .sound import validate_sound_record
                 validate_sound_record(sound)
+            gpu_shader = value.get("gpu_shader")
+            if gpu_shader is not None:
+                validate_gpu_shader_record(gpu_shader)
         return value
 
     def _build_lock_busy(self, profile: str, key: str) -> tuple[bool, str | None]:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -210,7 +210,107 @@ SCENARIO_INERT_HISTORICAL_IDENTITY = "historical_identity"
 SCENARIO_INERT_PROFILE_UNRESOLVABLE = "profile_unresolvable"
 SCENARIO_INERT_INVALID_RECORD = "invalid_record"
 BUILD_METADATA = ".atrinik-build.json"
-BUILD_METADATA_SCHEMA_VERSION = 3
+BUILD_METADATA_SCHEMA_VERSION = 4
+GPU_SHADER_RECORD_SCHEMA_VERSION = 1
+GPU_SHADER_OVERRIDE_NAMES = (
+    "ATRINIK_GPU_SHADER_DIRECTORY",
+    "ATRINIK_DXC_EXECUTABLE",
+    "ATRINIK_SPIRV_CROSS_EXECUTABLE",
+    "ATRINIK_DXC_LIBRARY_DIRECTORY",
+)
+GPU_SHADER_WRAPPER_IDENTITY_ARGUMENT = "ATRINIK_GPU_SHADER_WRAPPER_IDENTITY"
+GPU_SHADER_RECORD_KEYS = {
+    "external": {
+        "schema_version",
+        "mode",
+        "shader_directory",
+        "manifest_path",
+        "manifest_sha256",
+        "identity",
+    },
+    "system": {
+        "schema_version",
+        "mode",
+        "dxc_executable",
+        "dxc_sha256",
+        "spirv_cross_executable",
+        "spirv_cross_sha256",
+        "dxc_library_directory",
+        "identity",
+    },
+    "managed": {
+        "schema_version",
+        "mode",
+        "source_path",
+        "lock_path",
+        "lock_sha256",
+        "builder_path",
+        "builder_sha256",
+        "manifest_path",
+        "manifest_sha256",
+        "toolchain_root",
+        "toolchain_tree_sha256",
+        "dxc_executable",
+        "spirv_cross_executable",
+        "dxc_library_directory",
+        "identity",
+    },
+}
+GPU_SHADER_SHA256_FIELDS = {
+    "manifest_sha256",
+    "dxc_sha256",
+    "spirv_cross_sha256",
+    "lock_sha256",
+    "builder_sha256",
+    "toolchain_tree_sha256",
+}
+GPU_SHADER_PATH_FIELDS = {
+    "shader_directory",
+    "manifest_path",
+    "dxc_executable",
+    "spirv_cross_executable",
+    "source_path",
+    "lock_path",
+    "builder_path",
+    "toolchain_root",
+}
+
+
+def validate_gpu_shader_record(value: object) -> dict[str, Any]:
+    """Validate persisted provenance for a Classic GPU shader configuration."""
+
+    if not isinstance(value, dict):
+        raise WorkspaceError("GPU shader provenance record is not an object")
+    mode = value.get("mode")
+    if not isinstance(mode, str) or mode not in GPU_SHADER_RECORD_KEYS:
+        raise WorkspaceError("GPU shader provenance mode is invalid")
+    if (
+        value.get("schema_version") != GPU_SHADER_RECORD_SCHEMA_VERSION
+        or set(value) != GPU_SHADER_RECORD_KEYS[mode]
+    ):
+        raise WorkspaceError("GPU shader provenance record fields are invalid")
+    for key in GPU_SHADER_PATH_FIELDS & GPU_SHADER_RECORD_KEYS[mode]:
+        path = value.get(key)
+        if not isinstance(path, str) or not path or not Path(path).is_absolute():
+            raise WorkspaceError(f"GPU shader provenance path is invalid: {key}")
+    for key in GPU_SHADER_SHA256_FIELDS & GPU_SHADER_RECORD_KEYS[mode]:
+        digest = value.get(key)
+        if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+            raise WorkspaceError(f"GPU shader provenance digest is invalid: {key}")
+    identity = value.get("identity")
+    if not isinstance(identity, str) or not re.fullmatch(r"[0-9a-f]{64}", identity):
+        raise WorkspaceError("GPU shader provenance identity is invalid")
+    if mode in {"system", "managed"}:
+        library = value.get("dxc_library_directory")
+        if library is not None and (
+            not isinstance(library, str)
+            or not library
+            or not Path(library).is_absolute()
+        ):
+            raise WorkspaceError("GPU shader provenance library path is invalid")
+    return value
+
+
 PROFILE_RESOLUTION_METADATA = ".atrinik-profile-resolution.json"
 PROFILE_RESOLUTION_SCHEMA_VERSION = 3
 SOURCE_GENERATION_METADATA = ".atrinik-source-generation.json"
@@ -7680,9 +7780,14 @@ class Workspace:
             managed_directory(root, self.paths.builds, f"profile:{profile_name}:{key}")
             sound_root = selected.get("sound")
             sound_record: dict[str, Any] | None = None
+            gpu_shader: dict[str, Any] | None = None
             if "client" in targets:
                 if sound_root is not None:
                     sound_root, sound_record = self._prepare_sound(
+                        root, selected, profile_name
+                    )
+                if stack.name == "classic":
+                    gpu_shader = self._prepare_gpu_shader(
                         root, selected, profile_name
                     )
             elif sound_root is not None:
@@ -7690,7 +7795,7 @@ class Workspace:
                 if profile["sound_mode"] == SOURCE_MODE:
                     sound_record = self._sound_source_record(sound_root)
             self._refresh_build_metadata(
-                root, profile_name, key, selected, sound_record
+                root, profile_name, key, selected, sound_record, gpu_shader
             )
             if "content" in targets or "server" in targets:
                 self._collect_content(root, selected, profile_name)
@@ -7705,7 +7810,11 @@ class Workspace:
                         f"integrated Classic profile {profile_name} has no sound provider"
                     )
                 self._build_integrated_classic(
-                    root, selected, tests, sound_root=sound_root
+                    root,
+                    selected,
+                    tests,
+                    sound_root=sound_root,
+                    gpu_shader=gpu_shader,
                 )
             else:
                 if "protocol" in targets:
@@ -7719,6 +7828,7 @@ class Workspace:
                         tests,
                         component=stack.providers["client"],
                         sound_root=sound_root,
+                        gpu_shader=gpu_shader,
                     )
                 if "server" in targets:
                     self._build_server(
@@ -7750,6 +7860,7 @@ class Workspace:
         key: str,
         selected: dict[str, Path],
         sound: dict[str, Any] | None = None,
+        gpu_shader: dict[str, Any] | None = None,
     ) -> None:
         profile = self._load_profile(profile_name, require_file=False)
         stack = self.manifest.stack(profile["stack"])
@@ -7786,6 +7897,7 @@ class Workspace:
                 "purpose": f"profile:{profile_name}:{key}",
                 "coordinates": coordinates,
                 "sound": sound,
+                "gpu_shader": gpu_shader,
                 "last_used_at": datetime.now(timezone.utc).isoformat(),
             },
         )
@@ -8111,6 +8223,466 @@ class Workspace:
             f"{record['output_tree_sha256']} at {output}"
         )
         return output, record
+
+    @staticmethod
+    def _gpu_shader_identity(inputs: dict[str, Any]) -> str:
+        payload = json.dumps(
+            inputs, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+        ).encode("utf-8")
+        return hashlib.sha256(payload).hexdigest()
+
+    @staticmethod
+    def _resolve_gpu_shader_override(
+        value: str, description: str, *, directory: bool
+    ) -> Path:
+        raw = value.strip()
+        if not raw:
+            raise WorkspaceError(f"{description} must not be empty")
+        try:
+            path = Path(raw).expanduser().resolve(strict=True)
+            metadata = path.stat()
+        except (OSError, RuntimeError, ValueError) as error:
+            raise WorkspaceError(
+                f"{description} is not a usable path: {raw}"
+            ) from error
+        if directory:
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise WorkspaceError(f"{description} is not a directory: {path}")
+        elif not stat.S_ISREG(metadata.st_mode) or not os.access(path, os.X_OK):
+            raise WorkspaceError(
+                f"{description} is not an executable regular file: {path}"
+            )
+        return path
+
+    def _gpu_shader_external_record(self, value: str) -> dict[str, Any]:
+        directory = self._resolve_gpu_shader_override(
+            value, "ATRINIK_GPU_SHADER_DIRECTORY", directory=True
+        )
+        manifest = directory / "SHA256SUMS"
+        try:
+            metadata = manifest.lstat()
+        except OSError as error:
+            raise WorkspaceError(
+                "ATRINIK_GPU_SHADER_DIRECTORY must contain a regular SHA256SUMS "
+                f"manifest: {manifest}"
+            ) from error
+        if not stat.S_ISREG(metadata.st_mode) or manifest.is_symlink():
+            raise WorkspaceError(
+                "ATRINIK_GPU_SHADER_DIRECTORY must contain a regular SHA256SUMS "
+                f"manifest: {manifest}"
+            )
+        manifest_sha256 = _file_digest(manifest, "GPU shader cohort manifest")
+        identity = self._gpu_shader_identity(
+            {
+                "mode": "external",
+                "directory": str(directory),
+                "manifest_sha256": manifest_sha256,
+            }
+        )
+        return {
+            "schema_version": GPU_SHADER_RECORD_SCHEMA_VERSION,
+            "mode": "external",
+            "shader_directory": str(directory),
+            "manifest_path": str(manifest.resolve()),
+            "manifest_sha256": manifest_sha256,
+            "identity": identity,
+        }
+
+    def _gpu_shader_system_record(
+        self,
+        dxc_value: str,
+        spirv_cross_value: str,
+        library_value: str,
+    ) -> dict[str, Any]:
+        dxc = self._resolve_gpu_shader_override(
+            dxc_value, "ATRINIK_DXC_EXECUTABLE", directory=False
+        )
+        spirv_cross = self._resolve_gpu_shader_override(
+            spirv_cross_value,
+            "ATRINIK_SPIRV_CROSS_EXECUTABLE",
+            directory=False,
+        )
+        library = (
+            self._resolve_gpu_shader_override(
+                library_value, "ATRINIK_DXC_LIBRARY_DIRECTORY", directory=True
+            )
+            if library_value
+            else None
+        )
+        dxc_sha256 = _file_digest(dxc, "DXC executable")
+        spirv_cross_sha256 = _file_digest(spirv_cross, "SPIRV-Cross executable")
+        record: dict[str, Any] = {
+            "schema_version": GPU_SHADER_RECORD_SCHEMA_VERSION,
+            "mode": "system",
+            "dxc_executable": str(dxc),
+            "dxc_sha256": dxc_sha256,
+            "spirv_cross_executable": str(spirv_cross),
+            "spirv_cross_sha256": spirv_cross_sha256,
+            "dxc_library_directory": str(library) if library is not None else None,
+        }
+        record["identity"] = self._gpu_shader_identity(
+            {
+                "mode": "system",
+                "dxc": {"path": str(dxc), "sha256": dxc_sha256},
+                "spirv_cross": {
+                    "path": str(spirv_cross),
+                    "sha256": spirv_cross_sha256,
+                },
+                "dxc_library_directory": (
+                    str(library) if library is not None else None
+                ),
+            }
+        )
+        return record
+
+    def _validate_gpu_shader_toolchain(
+        self, output: Path, lock: Path, lock_sha256: str
+    ) -> tuple[Path, Path, Path, str]:
+        if output.is_symlink() or not output.is_dir():
+            raise WorkspaceError(
+                f"prepared GPU shader toolchain is not a directory: {output}"
+            )
+        tree_sha256 = _tree_digest(
+            output,
+            set(),
+            reject_hardlinks=True,
+            reject_symlinks=True,
+        )
+        marker = output / "toolchain.json"
+        state = load_json(marker)
+        if (
+            not isinstance(state, dict)
+            or set(state) != {"schema_version", "lock_sha256", "spirv_cross_sha256"}
+            or state["schema_version"] != 1
+            or state["lock_sha256"] != lock_sha256
+            or not isinstance(state["spirv_cross_sha256"], str)
+        ):
+            raise WorkspaceError(
+                f"prepared GPU shader toolchain marker is invalid: {marker}"
+            )
+        lock_value = load_json(lock)
+        dxc_entry = lock_value.get("dxc") if isinstance(lock_value, dict) else None
+        files = dxc_entry.get("files") if isinstance(dxc_entry, dict) else None
+        if not isinstance(files, dict) or not files:
+            raise WorkspaceError("GPU shader lock has no DXC file contract")
+        for name, expected in files.items():
+            if not isinstance(name, str) or not isinstance(expected, str):
+                raise WorkspaceError("GPU shader lock has an invalid DXC file contract")
+            relative = PurePosixPath(name)
+            if (
+                relative.is_absolute()
+                or not relative.parts
+                or any(part in {"", ".", ".."} for part in relative.parts)
+            ):
+                raise WorkspaceError(f"GPU shader lock has an unsafe DXC path: {name}")
+            path = output / "dxc" / Path(*relative.parts)
+            if (
+                path.is_symlink()
+                or not path.is_file()
+                or _file_digest(path, f"DXC toolchain file {name}") != expected
+            ):
+                raise WorkspaceError(
+                    f"prepared GPU shader toolchain file is stale or tampered: {name}"
+                )
+        dxc = output / "dxc" / "bin" / "dxc"
+        spirv_cross = output / "spirv-cross" / "bin" / "spirv-cross"
+        library = output / "dxc" / "lib"
+        license_path = output / "spirv-cross" / "LICENSE"
+        if (
+            dxc.is_symlink()
+            or not dxc.is_file()
+            or not os.access(dxc, os.X_OK)
+            or spirv_cross.is_symlink()
+            or not spirv_cross.is_file()
+            or not os.access(spirv_cross, os.X_OK)
+            or library.is_symlink()
+            or not library.is_dir()
+            or license_path.is_symlink()
+            or not license_path.is_file()
+            or _file_digest(spirv_cross, "SPIRV-Cross toolchain file")
+            != state["spirv_cross_sha256"]
+        ):
+            raise WorkspaceError(
+                f"prepared GPU shader toolchain layout is invalid: {output}"
+            )
+        return dxc, spirv_cross, library, tree_sha256
+
+    def _gpu_shader_existing_toolchain(
+        self, source: Path, profile_name: str
+    ) -> Path | None:
+        if self._source_generation_record(source) is None:
+            source_root = source
+        else:
+            profile = self._load_profile(profile_name, require_file=False)
+            stack = self.manifest.stack(profile["stack"])
+            component = stack.providers["client"]
+            checkout = self._selector_root(profile, component)
+            if component.source == ".":
+                source_root = checkout
+            else:
+                source_root = checkout.joinpath(
+                    *PurePosixPath(component.source).parts
+                )
+        candidate = source_root / "build" / "gpu-shader-toolchain"
+        for path in (source_root, source_root / "build", candidate):
+            try:
+                metadata = path.lstat()
+            except FileNotFoundError:
+                if path == source_root:
+                    return None
+                continue
+            except OSError:
+                return None
+            if stat.S_ISLNK(metadata.st_mode) or (
+                path != candidate and not stat.S_ISDIR(metadata.st_mode)
+            ):
+                return None
+        return candidate
+
+    def _gpu_shader_managed_record(
+        self,
+        root: Path,
+        source: Path,
+        profile_name: str,
+        *,
+        existing_output: Path | None = None,
+    ) -> dict[str, Any]:
+        lock = source / "shaders" / "toolchain.lock.json"
+        builder = source / "tools" / "prepare_gpu_shader_toolchain.py"
+        manifest = source / "shaders" / "SHA256SUMS"
+        for path, description in (
+            (lock, "Classic GPU shader lock"),
+            (builder, "Classic GPU shader toolchain preparer"),
+            (manifest, "Classic GPU shader cohort manifest"),
+        ):
+            try:
+                metadata = path.lstat()
+            except OSError as error:
+                raise WorkspaceError(f"{description} is missing: {path}") from error
+            if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
+                raise WorkspaceError(f"{description} is not a regular file: {path}")
+        input_digests = {
+            "lock_sha256": _file_digest(lock, "Classic GPU shader lock"),
+            "builder_sha256": _file_digest(
+                builder, "Classic GPU shader toolchain preparer"
+            ),
+            "manifest_sha256": _file_digest(
+                manifest, "Classic GPU shader cohort manifest"
+            ),
+        }
+        output: Path | None = None
+        dxc: Path | None = None
+        spirv_cross: Path | None = None
+        library: Path | None = None
+        tree_sha256: str | None = None
+        producer = _managed_path_no_symlinks(
+            root / "producers", self.paths.builds
+        )
+        producer.mkdir(parents=True, exist_ok=True)
+        downloads = _managed_path_no_symlinks(
+            producer / "classic-gpu-shader-downloads", self.paths.builds
+        )
+        toolchains = _managed_path_no_symlinks(
+            producer / "classic-gpu-shader-toolchains", self.paths.builds
+        )
+        downloads.mkdir(parents=True, exist_ok=True)
+        toolchains.mkdir(parents=True, exist_ok=True)
+        try:
+            if existing_output is not None and (
+                existing_output.exists() or existing_output.is_symlink()
+            ):
+                try:
+                    run(
+                        [
+                            sys.executable,
+                            str(builder.resolve()),
+                            "--lock",
+                            str(lock.resolve()),
+                            "--cache",
+                            str(downloads),
+                            "--output",
+                            str(existing_output),
+                        ],
+                        cwd=source,
+                    )
+                    dxc, spirv_cross, library, tree_sha256 = (
+                        self._validate_gpu_shader_toolchain(
+                            existing_output, lock, input_digests["lock_sha256"]
+                        )
+                    )
+                    output = existing_output
+                except (OSError, WorkspaceError):
+                    # A stale source-checkout preparation is not authoritative;
+                    # rebuild it in the wrapper-owned producer cache below.
+                    output = None
+            if output is None:
+                output = _managed_path_no_symlinks(
+                    toolchains / input_digests["lock_sha256"], self.paths.builds
+                )
+                run(
+                    [
+                        sys.executable,
+                        str(builder.resolve()),
+                        "--lock",
+                        str(lock.resolve()),
+                        "--cache",
+                        str(downloads),
+                        "--output",
+                        str(output),
+                    ],
+                    cwd=source,
+                )
+                dxc, spirv_cross, library, tree_sha256 = (
+                    self._validate_gpu_shader_toolchain(
+                        output, lock, input_digests["lock_sha256"]
+                    )
+                )
+            assert (
+                output is not None
+                and dxc is not None
+                and spirv_cross is not None
+                and library is not None
+                and tree_sha256 is not None
+            )
+            final_digests = {
+                "lock_sha256": _file_digest(lock, "Classic GPU shader lock"),
+                "builder_sha256": _file_digest(
+                    builder, "Classic GPU shader toolchain preparer"
+                ),
+                "manifest_sha256": _file_digest(
+                    manifest, "Classic GPU shader cohort manifest"
+                ),
+            }
+            if final_digests != input_digests:
+                raise WorkspaceError(
+                    "Classic GPU shader inputs changed during toolchain preparation"
+                )
+        except (OSError, WorkspaceError) as error:
+            raise WorkspaceError(
+                f"profile {profile_name} Classic GPU shader toolchain preparation "
+                f"failed: {error}"
+            ) from error
+        record: dict[str, Any] = {
+            "schema_version": GPU_SHADER_RECORD_SCHEMA_VERSION,
+            "mode": "managed",
+            "source_path": str(source.resolve()),
+            "lock_path": str(lock.resolve()),
+            "lock_sha256": input_digests["lock_sha256"],
+            "builder_path": str(builder.resolve()),
+            "builder_sha256": input_digests["builder_sha256"],
+            "manifest_path": str(manifest.resolve()),
+            "manifest_sha256": input_digests["manifest_sha256"],
+            "toolchain_root": str(output.resolve()),
+            "toolchain_tree_sha256": tree_sha256,
+            "dxc_executable": str(dxc.resolve()),
+            "spirv_cross_executable": str(spirv_cross.resolve()),
+            "dxc_library_directory": str(library.resolve()),
+        }
+        record["identity"] = self._gpu_shader_identity(
+            {
+                "mode": "managed",
+                "lock_sha256": record["lock_sha256"],
+                "builder_sha256": record["builder_sha256"],
+                "manifest_sha256": record["manifest_sha256"],
+                "toolchain_tree_sha256": record["toolchain_tree_sha256"],
+            }
+        )
+        return record
+
+    def _prepare_gpu_shader(
+        self,
+        root: Path,
+        selected: dict[str, Path],
+        profile_name: str,
+    ) -> dict[str, Any]:
+        values = {
+            name: os.environ.get(name, "").strip()
+            for name in GPU_SHADER_OVERRIDE_NAMES
+        }
+        try:
+            if values["ATRINIK_GPU_SHADER_DIRECTORY"]:
+                if any(
+                    values[name]
+                    for name in GPU_SHADER_OVERRIDE_NAMES[1:]
+                ):
+                    raise WorkspaceError(
+                        "ATRINIK_GPU_SHADER_DIRECTORY cannot be combined with "
+                        "explicit GPU tool overrides"
+                    )
+                return self._gpu_shader_external_record(
+                    values["ATRINIK_GPU_SHADER_DIRECTORY"]
+                )
+            if any(
+                values[name]
+                for name in GPU_SHADER_OVERRIDE_NAMES[1:]
+            ):
+                if not values["ATRINIK_DXC_EXECUTABLE"] or not values[
+                    "ATRINIK_SPIRV_CROSS_EXECUTABLE"
+                ]:
+                    raise WorkspaceError(
+                        "set both ATRINIK_DXC_EXECUTABLE and "
+                        "ATRINIK_SPIRV_CROSS_EXECUTABLE for a system GPU "
+                        "shader override"
+                    )
+                return self._gpu_shader_system_record(
+                    values["ATRINIK_DXC_EXECUTABLE"],
+                    values["ATRINIK_SPIRV_CROSS_EXECUTABLE"],
+                    values["ATRINIK_DXC_LIBRARY_DIRECTORY"],
+                )
+            if platform.system() != "Linux" or platform.machine() not in {
+                "x86_64",
+                "AMD64",
+            }:
+                raise WorkspaceError(
+                    "the pinned Classic GPU shader toolchain targets x86-64 Linux; "
+                    "set ATRINIK_DXC_EXECUTABLE and "
+                    "ATRINIK_SPIRV_CROSS_EXECUTABLE for system tools, or set "
+                    "ATRINIK_GPU_SHADER_DIRECTORY to a validated external cohort"
+                )
+            return self._gpu_shader_managed_record(
+                root,
+                selected["client"],
+                profile_name,
+                existing_output=self._gpu_shader_existing_toolchain(
+                    selected["client"], profile_name
+                ),
+            )
+        except (OSError, WorkspaceError) as error:
+            if isinstance(error, WorkspaceError) and str(error).startswith(
+                f"profile {profile_name} Classic GPU shader toolchain preparation"
+            ):
+                raise
+            raise WorkspaceError(
+                f"profile {profile_name} Classic GPU shader configuration failed: "
+                f"{error}"
+            ) from error
+
+    @staticmethod
+    def _gpu_shader_cmake_arguments(record: dict[str, Any]) -> list[str]:
+        mode = record.get("mode")
+        if mode == "external":
+            arguments = [
+                f"-DATRINIK_GPU_SHADER_DIRECTORY={record['shader_directory']}"
+            ]
+        elif mode in {"managed", "system"}:
+            arguments = [
+                f"-DATRINIK_DXC_EXECUTABLE={record['dxc_executable']}",
+                f"-DATRINIK_SPIRV_CROSS_EXECUTABLE={record['spirv_cross_executable']}",
+            ]
+            if record.get("dxc_library_directory"):
+                arguments.append(
+                    "-DATRINIK_DXC_LIBRARY_DIRECTORY="
+                    f"{record['dxc_library_directory']}"
+                )
+        else:
+            raise WorkspaceError(f"unsupported GPU shader record mode: {mode}")
+        identity = record.get("identity")
+        if not isinstance(identity, str) or not re.fullmatch(r"[0-9a-f]{64}", identity):
+            raise WorkspaceError("GPU shader record identity is invalid")
+        arguments.append(
+            f"-D{GPU_SHADER_WRAPPER_IDENTITY_ARGUMENT}={identity}"
+        )
+        return arguments
 
     def _clean_sound_source_inputs(self, source: Path) -> dict[str, str]:
         generation = self._source_generation_record(source)
@@ -10165,6 +10737,7 @@ class Workspace:
         tests: bool,
         *,
         sound_root: Path | None = None,
+        gpu_shader: dict[str, Any] | None = None,
     ) -> None:
         checkout = selected["client"].parent.resolve()
         view = self._profile_source_view(
@@ -10218,16 +10791,14 @@ class Workspace:
             root / "runtime" / "resources",
             target_is_directory=True,
         )
-        self._cmake(
-            view,
-            root / "build" / "integrated",
-            [
-                "-DENABLE_WARNING_ERRORS=ON",
-                "-DPACKAGE_TYPE=none",
-                "-DENABLE_PYTHON_PLUGIN=ON",
-            ],
-            tests,
-        )
+        arguments = [
+            "-DENABLE_WARNING_ERRORS=ON",
+            "-DPACKAGE_TYPE=none",
+            "-DENABLE_PYTHON_PLUGIN=ON",
+        ]
+        if gpu_shader is not None:
+            arguments.extend(self._gpu_shader_cmake_arguments(gpu_shader))
+        self._cmake(view, root / "build" / "integrated", arguments, tests)
         self._record_classic_graph(root, {"client", "server"}, "integrated")
 
     def _build_library(self, root: Path, selected: dict[str, Path], tests: bool) -> None:
@@ -10342,6 +10913,7 @@ class Workspace:
         *,
         component: Component,
         sound_root: Path | None = None,
+        gpu_shader: dict[str, Any] | None = None,
     ) -> None:
         view = self._profile_source_view(
             root,
@@ -10365,17 +10937,15 @@ class Workspace:
         library = self._mutable_cmake_source_view(
             root, "libatrinik", selected["libatrinik"]
         )
-        self._cmake(
-            view,
-            root / "build" / "client",
-            [
-                "-DENABLE_WARNING_ERRORS=ON",
-                "-DPACKAGE_TYPE=none",
-                f"-DFETCHCONTENT_SOURCE_DIR_ATRINIK_PROTOCOL={protocol}",
-                f"-DFETCHCONTENT_SOURCE_DIR_LIBATRINIK={library}",
-            ],
-            tests,
-        )
+        arguments = [
+            "-DENABLE_WARNING_ERRORS=ON",
+            "-DPACKAGE_TYPE=none",
+            f"-DFETCHCONTENT_SOURCE_DIR_ATRINIK_PROTOCOL={protocol}",
+            f"-DFETCHCONTENT_SOURCE_DIR_LIBATRINIK={library}",
+        ]
+        if gpu_shader is not None:
+            arguments.extend(self._gpu_shader_cmake_arguments(gpu_shader))
+        self._cmake(view, root / "build" / "client", arguments, tests)
         self._record_classic_graph(root, {"client"}, "standalone")
 
     def _build_server(

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -2999,6 +2999,60 @@ class CleanupTests(unittest.TestCase):
         )
         self.assertIsNotNone(_parse_time(metadata["last_used_at"], "last use"))
 
+    def test_gpu_shader_build_metadata_is_reclaimable_and_prior_schema_survives(
+        self,
+    ) -> None:
+        worktree = self.make_component_worktree()
+        head = command("git", "rev-parse", "HEAD", cwd=worktree)
+        coordinate = {
+            "component": "client",
+            "checkout": "client",
+            "repository": "atrinik/client",
+            "branch": "main",
+            "source": ".",
+            "checkout_path": str(worktree),
+            "source_path": str(worktree),
+            "head": head,
+        }
+        gpu_shader = {
+            "schema_version": 1,
+            "mode": "system",
+            "dxc_executable": "/opt/dxc",
+            "dxc_sha256": "a" * 64,
+            "spirv_cross_executable": "/opt/spirv-cross",
+            "spirv_cross_sha256": "b" * 64,
+            "dxc_library_directory": None,
+            "identity": "c" * 64,
+        }
+        for schema_version, extra in (
+            (3, {}),
+            (workspace_module.BUILD_METADATA_SCHEMA_VERSION, {"gpu_shader": gpu_shader}),
+        ):
+            with self.subTest(schema_version=schema_version):
+                key = f"{schema_version:012d}"[-12:]
+                profile = f"metadata-{schema_version}"
+                build = self.make_build(
+                    profile,
+                    key,
+                )
+                atomic_json(
+                    build / ".atrinik-build.json",
+                    {
+                        "schema_version": schema_version,
+                        "profile": profile,
+                        "key": key,
+                        "purpose": f"profile:{profile}:{key}",
+                        "coordinates": {"client": coordinate},
+                        "sound": None,
+                        **extra,
+                        "last_used_at": self.old.isoformat(),
+                    },
+                )
+                report = self.plan(["builds"])
+                item = next(row for row in report["items"] if row["path"] == str(build))
+                self.assertEqual(item["disposition"], "eligible")
+                self.assertEqual(item["reasons"], ["stale_profile_build"])
+
     def test_invalid_or_future_build_metadata_protects_profile_root(self) -> None:
         worktree = self.make_component_worktree()
         build = self.make_build()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -2723,6 +2723,7 @@ class WorkspaceTests(unittest.TestCase):
                     None,
                 ),
             ),
+            mock.patch.object(self.workspace, "_prepare_gpu_shader", return_value=None),
             mock.patch.object(
                 self.workspace, "_collect_content", side_effect=prepare_runtime
             ),
@@ -6260,6 +6261,313 @@ class WorkspaceTests(unittest.TestCase):
             self.workspace._classic_binary_directory(root, "server"),
             root / "build" / "integrated" / "server",
         )
+
+    def test_classic_gpu_shader_preparation_is_lock_keyed_and_recorded(self) -> None:
+        source = self.root / "classic-client"
+        (source / "shaders").mkdir(parents=True)
+        (source / "tools").mkdir()
+        dxc_bytes = b"test dxc\n"
+        dxc_digest = hashlib.sha256(dxc_bytes).hexdigest()
+        lock = {
+            "schema_version": 1,
+            "dxc": {"files": {"bin/dxc": dxc_digest}},
+        }
+        lock_path = source / "shaders" / "toolchain.lock.json"
+        lock_path.write_text(json.dumps(lock), encoding="utf-8")
+        builder = source / "tools" / "prepare_gpu_shader_toolchain.py"
+        builder.write_text("# test preparer\n", encoding="utf-8")
+        manifest = source / "shaders" / "SHA256SUMS"
+        manifest.write_text("final_fragment.dxil test\n", encoding="utf-8")
+        root = self.workspace.paths.builds / "profiles" / "classic-gpu"
+        managed_directory(root, self.workspace.paths.builds, "profile:classic-gpu")
+        observed: list[tuple[list[str], Path]] = []
+
+        def prepare(arguments: list[str], **kwargs: object) -> None:
+            output = Path(arguments[arguments.index("--output") + 1])
+            observed.append((arguments, Path(kwargs["cwd"])))
+            (output / "dxc" / "bin").mkdir(parents=True, exist_ok=True)
+            (output / "dxc" / "lib").mkdir(exist_ok=True)
+            dxc = output / "dxc" / "bin" / "dxc"
+            dxc.write_bytes(dxc_bytes)
+            dxc.chmod(0o755)
+            (output / "spirv-cross" / "bin").mkdir(parents=True, exist_ok=True)
+            spirv_cross = output / "spirv-cross" / "bin" / "spirv-cross"
+            spirv_cross.write_bytes(b"test spirv-cross\n")
+            spirv_cross.chmod(0o755)
+            (output / "spirv-cross" / "LICENSE").write_text(
+                "license\n", encoding="utf-8"
+            )
+            atomic_json(
+                output / "toolchain.json",
+                {
+                    "schema_version": 1,
+                    "lock_sha256": hashlib.sha256(lock_path.read_bytes()).hexdigest(),
+                    "spirv_cross_sha256": hashlib.sha256(
+                        spirv_cross.read_bytes()
+                    ).hexdigest(),
+                },
+            )
+
+        overrides = {name: "" for name in workspace_module.GPU_SHADER_OVERRIDE_NAMES}
+        with (
+            mock.patch.dict(os.environ, overrides, clear=False),
+            mock.patch.object(workspace_module, "run", side_effect=prepare),
+        ):
+            record = self.workspace._prepare_gpu_shader(
+                root, {"client": source}, "classic"
+            )
+
+        self.assertEqual(record["mode"], "managed")
+        self.assertEqual(record["lock_sha256"], hashlib.sha256(lock_path.read_bytes()).hexdigest())
+        self.assertEqual(len(observed), 1)
+        self.assertEqual(observed[0][1], source)
+        self.assertEqual(
+            observed[0][0][0:2], [sys.executable, str(builder)]
+        )
+        self.assertEqual(
+            record["toolchain_root"],
+            str(
+                root
+                / "producers"
+                / "classic-gpu-shader-toolchains"
+                / record["lock_sha256"]
+            ),
+        )
+        checkout_toolchain = source / "build" / "gpu-shader-toolchain"
+        shutil.copytree(record["toolchain_root"], checkout_toolchain)
+        with (
+            mock.patch.dict(os.environ, overrides, clear=False),
+            mock.patch.object(workspace_module, "run", side_effect=prepare),
+        ):
+            reused = self.workspace._prepare_gpu_shader(
+                root, {"client": source}, "classic"
+            )
+        self.assertEqual(reused["mode"], "managed")
+        self.assertEqual(reused["toolchain_root"], str(checkout_toolchain.resolve()))
+        self.assertEqual(len(observed), 2)
+        self.assertEqual(
+            observed[1][0][observed[1][0].index("--output") + 1],
+            str(checkout_toolchain),
+        )
+        self.workspace._refresh_build_metadata(
+            root,
+            "default",
+            "classic-gpu",
+            {"client": self.workspace.paths.repositories / "client"},
+            None,
+            record,
+        )
+        self.assertEqual(
+            load_json(root / workspace_module.BUILD_METADATA)["gpu_shader"],
+            record,
+        )
+
+        external_build = self.root / "external-build"
+        external_build.mkdir()
+        unsafe_source = self.root / "unsafe-source"
+        unsafe_source.mkdir()
+        (unsafe_source / "build").symlink_to(
+            external_build, target_is_directory=True
+        )
+        self.assertIsNone(
+            self.workspace._gpu_shader_existing_toolchain(unsafe_source, "classic")
+        )
+
+    def test_classic_gpu_shader_explicit_system_and_external_overrides(self) -> None:
+        dxc = self.root / "bin" / "dxc"
+        spirv_cross = self.root / "bin" / "spirv-cross"
+        dxc.parent.mkdir()
+        for executable in (dxc, spirv_cross):
+            executable.write_text("#!/bin/sh\n", encoding="utf-8")
+            executable.chmod(0o755)
+        library = self.root / "dxc-lib"
+        library.mkdir()
+        external = self.root / "shader-cohort"
+        external.mkdir()
+        (external / "SHA256SUMS").write_text(
+            "final_fragment.dxil 0000000000000000000000000000000000000000000000000000000000000000\n",
+            encoding="utf-8",
+        )
+        source = self.root / "classic-client"
+        source.mkdir()
+
+        system_values = {
+            name: ""
+            for name in workspace_module.GPU_SHADER_OVERRIDE_NAMES
+        }
+        system_values.update(
+            {
+                "ATRINIK_DXC_EXECUTABLE": str(dxc),
+                "ATRINIK_SPIRV_CROSS_EXECUTABLE": str(spirv_cross),
+                "ATRINIK_DXC_LIBRARY_DIRECTORY": str(library),
+                "PATH": "",
+            }
+        )
+        with mock.patch.dict(os.environ, system_values, clear=False):
+            system = self.workspace._prepare_gpu_shader(
+                self.workspace.paths.builds / "profiles" / "system",
+                {"client": source},
+                "classic",
+            )
+        self.assertEqual(system["mode"], "system")
+        self.assertEqual(system["dxc_executable"], str(dxc.resolve()))
+        self.assertEqual(
+            self.workspace._gpu_shader_cmake_arguments(system),
+            [
+                f"-DATRINIK_DXC_EXECUTABLE={dxc.resolve()}",
+                f"-DATRINIK_SPIRV_CROSS_EXECUTABLE={spirv_cross.resolve()}",
+                f"-DATRINIK_DXC_LIBRARY_DIRECTORY={library.resolve()}",
+                f"-D{workspace_module.GPU_SHADER_WRAPPER_IDENTITY_ARGUMENT}={system['identity']}",
+            ],
+        )
+
+        external_values = {
+            name: "" for name in workspace_module.GPU_SHADER_OVERRIDE_NAMES
+        }
+        external_values["ATRINIK_GPU_SHADER_DIRECTORY"] = str(external)
+        with mock.patch.dict(os.environ, external_values, clear=False):
+            cohort = self.workspace._prepare_gpu_shader(
+                self.workspace.paths.builds / "profiles" / "external",
+                {"client": source},
+                "classic",
+            )
+        self.assertEqual(cohort["mode"], "external")
+        self.assertEqual(cohort["shader_directory"], str(external.resolve()))
+        self.assertEqual(
+            self.workspace._gpu_shader_cmake_arguments(cohort),
+            [
+                f"-DATRINIK_GPU_SHADER_DIRECTORY={external.resolve()}",
+                f"-D{workspace_module.GPU_SHADER_WRAPPER_IDENTITY_ARGUMENT}={cohort['identity']}",
+            ],
+        )
+
+        partial = {name: "" for name in workspace_module.GPU_SHADER_OVERRIDE_NAMES}
+        partial["ATRINIK_DXC_EXECUTABLE"] = str(dxc)
+        with mock.patch.dict(os.environ, partial, clear=False):
+            with self.assertRaisesRegex(
+                WorkspaceError, "set both ATRINIK_DXC_EXECUTABLE"
+            ):
+                self.workspace._prepare_gpu_shader(
+                    self.workspace.paths.builds / "profiles" / "partial",
+                    {"client": source},
+                    "classic",
+                )
+
+        unsupported = {
+            name: "" for name in workspace_module.GPU_SHADER_OVERRIDE_NAMES
+        }
+        with (
+            mock.patch.dict(os.environ, unsupported, clear=False),
+            mock.patch.object(workspace_module.platform, "system", return_value="Darwin"),
+            mock.patch.object(
+                workspace_module.platform, "machine", return_value="arm64"
+            ),
+        ):
+            with self.assertRaisesRegex(
+                WorkspaceError, "pinned Classic GPU shader toolchain targets"
+            ):
+                self.workspace._prepare_gpu_shader(
+                    self.workspace.paths.builds / "profiles" / "unsupported",
+                    {"client": source},
+                    "classic",
+                )
+
+    def test_classic_gpu_shader_arguments_are_added_to_both_cmake_graphs(self) -> None:
+        checkout = self.root / "classic"
+        for role in ("client", "server", "protocol", "libatrinik"):
+            (checkout / role).mkdir(parents=True)
+            (checkout / role / "README").write_text(role + "\n", encoding="utf-8")
+        (checkout / "CMakeLists.txt").write_text(
+            "project(classic)\n", encoding="utf-8"
+        )
+        (checkout / "server" / "install_data").mkdir()
+        sound = self.root / "sound"
+        sound.mkdir()
+        selected = {
+            role: checkout / role
+            for role in ("client", "server", "protocol", "libatrinik")
+        }
+        selected["sound"] = sound
+        root = self.workspace.paths.builds / "profiles" / "classic-gpu-graphs"
+        root.mkdir(parents=True)
+        (root / "runtime" / "content").mkdir(parents=True)
+        (root / "runtime" / "resources").mkdir()
+        gpu = {
+            "mode": "system",
+            "dxc_executable": "/opt/dxc/bin/dxc",
+            "spirv_cross_executable": "/opt/spirv-cross/bin/spirv-cross",
+            "dxc_library_directory": "/opt/dxc/lib",
+            "identity": "a" * 64,
+        }
+
+        with mock.patch.object(self.workspace, "_cmake") as cmake:
+            self.workspace._build_integrated_classic(
+                root, selected, tests=True, sound_root=sound, gpu_shader=gpu
+            )
+        integrated_arguments = cmake.call_args.args[2]
+        self.assertEqual(
+            integrated_arguments[-4:], self.workspace._gpu_shader_cmake_arguments(gpu)
+        )
+
+        standalone_root = self.workspace.paths.builds / "profiles" / "classic-gpu-client"
+        standalone_root.mkdir(parents=True)
+        with mock.patch.object(self.workspace, "_cmake") as cmake:
+            self.workspace._build_client(
+                standalone_root,
+                selected,
+                tests=False,
+                component=self.workspace.manifest.by_name["client"],
+                sound_root=sound,
+                gpu_shader=gpu,
+            )
+        standalone_arguments = cmake.call_args.args[2]
+        self.assertEqual(
+            standalone_arguments[-4:], self.workspace._gpu_shader_cmake_arguments(gpu)
+        )
+
+    def test_classic_build_resolved_wires_gpu_record_before_client_graph(self) -> None:
+        stack = mock.Mock()
+        stack.name = "classic"
+        stack.providers = {"client": self.workspace.manifest.by_name["client"]}
+        selected = {"client": self.root / "classic-client"}
+        selected["client"].mkdir()
+        gpu = {
+            "mode": "system",
+            "dxc_executable": "/opt/dxc",
+            "spirv_cross_executable": "/opt/spirv-cross",
+            "dxc_library_directory": None,
+            "identity": "b" * 64,
+        }
+        root = self.workspace.paths.builds / "profiles" / "classic-routed-routed"
+        marker = {"schema_version": 1, "purpose": "profile:classic-routed:routed"}
+
+        with (
+            mock.patch.object(
+                self.workspace,
+                "_load_profile",
+                return_value={"stack": "classic", "sound_mode": "source"},
+            ),
+            mock.patch.object(self.workspace.manifest, "stack", return_value=stack),
+            mock.patch.object(self.workspace, "_profile_build_key", return_value="routed"),
+            mock.patch.object(
+                self.workspace,
+                "_prepare_gpu_shader",
+                return_value=gpu,
+            ) as prepare_gpu,
+            mock.patch.object(self.workspace, "_refresh_build_metadata") as refresh,
+            mock.patch.object(
+                self.workspace, "_uses_integrated_classic_build", return_value=False
+            ),
+            mock.patch.object(self.workspace, "_build_client") as build_client,
+        ):
+            self.workspace._build_resolved(
+                "client", "classic-routed", False, ["client"], selected
+            )
+
+        prepare_gpu.assert_called_once_with(root, selected, "classic-routed")
+        self.assertIs(refresh.call_args.args[5], gpu)
+        self.assertIs(build_client.call_args.kwargs["gpu_shader"], gpu)
+        self.assertEqual(load_json(root / MANAGED_MARKER), marker)
 
     def test_paired_classic_build_falls_back_without_shared_role_builds(self) -> None:
         selected = {

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -6472,6 +6472,407 @@ class WorkspaceTests(unittest.TestCase):
                     "classic",
                 )
 
+    def test_classic_gpu_shader_provenance_and_override_validation(self) -> None:
+        digest = "a" * 64
+        external = {
+            "schema_version": 1,
+            "mode": "external",
+            "shader_directory": str(self.root.resolve()),
+            "manifest_path": str((self.root / "SHA256SUMS").resolve()),
+            "manifest_sha256": digest,
+            "identity": digest,
+        }
+        invalid_records = [
+            None,
+            {**external, "mode": "unknown"},
+            {**external, "schema_version": 2},
+            {**external, "shader_directory": "relative/cohort"},
+            {**external, "manifest_sha256": "not-a-digest"},
+            {**external, "identity": "not-a-digest"},
+        ]
+        for value in invalid_records:
+            with self.assertRaises(WorkspaceError):
+                workspace_module.validate_gpu_shader_record(value)
+        self.assertIs(workspace_module.validate_gpu_shader_record(external), external)
+
+        system = {
+            "schema_version": 1,
+            "mode": "system",
+            "dxc_executable": "/opt/dxc/bin/dxc",
+            "dxc_sha256": digest,
+            "spirv_cross_executable": "/opt/spirv-cross/bin/spirv-cross",
+            "spirv_cross_sha256": digest,
+            "dxc_library_directory": None,
+            "identity": digest,
+        }
+        self.assertIs(workspace_module.validate_gpu_shader_record(system), system)
+        with self.assertRaises(WorkspaceError):
+            workspace_module.validate_gpu_shader_record(
+                {**system, "dxc_library_directory": "relative/lib"}
+            )
+
+        missing = self.root / "missing-override"
+        with self.assertRaisesRegex(WorkspaceError, "must not be empty"):
+            self.workspace._resolve_gpu_shader_override(
+                "", "GPU override", directory=True
+            )
+        with self.assertRaisesRegex(WorkspaceError, "not a usable path"):
+            self.workspace._resolve_gpu_shader_override(
+                str(missing), "GPU override", directory=True
+            )
+
+        regular = self.root / "regular-override"
+        regular.write_text("not a directory\n", encoding="utf-8")
+        with self.assertRaisesRegex(WorkspaceError, "not a directory"):
+            self.workspace._resolve_gpu_shader_override(
+                str(regular), "GPU override", directory=True
+            )
+        non_executable = self.root / "non-executable"
+        non_executable.write_text("not executable\n", encoding="utf-8")
+        non_executable.chmod(0o644)
+        with self.assertRaisesRegex(WorkspaceError, "not an executable"):
+            self.workspace._resolve_gpu_shader_override(
+                str(non_executable), "GPU override", directory=False
+            )
+
+        missing_cohort = self.root / "missing-cohort-manifest"
+        missing_cohort.mkdir()
+        with self.assertRaisesRegex(WorkspaceError, "regular SHA256SUMS"):
+            self.workspace._gpu_shader_external_record(str(missing_cohort))
+        manifest_source = self.root / "manifest-source"
+        manifest_source.write_text("manifest\n", encoding="utf-8")
+        (missing_cohort / "SHA256SUMS").symlink_to(manifest_source)
+        with self.assertRaisesRegex(WorkspaceError, "regular SHA256SUMS"):
+            self.workspace._gpu_shader_external_record(str(missing_cohort))
+
+        combined_cohort = self.root / "combined-cohort"
+        combined_cohort.mkdir()
+        (combined_cohort / "SHA256SUMS").write_text(
+            "final_fragment.dxil " + "0" * 64 + "\n", encoding="utf-8"
+        )
+        combined = {
+            name: "" for name in workspace_module.GPU_SHADER_OVERRIDE_NAMES
+        }
+        combined.update(
+            {
+                "ATRINIK_GPU_SHADER_DIRECTORY": str(combined_cohort),
+                "ATRINIK_DXC_EXECUTABLE": "/opt/dxc",
+            }
+        )
+        with mock.patch.dict(os.environ, combined, clear=False):
+            with self.assertRaisesRegex(
+                WorkspaceError, "cannot be combined with explicit"
+            ):
+                self.workspace._prepare_gpu_shader(
+                    self.workspace.paths.builds / "profiles" / "combined",
+                    {"client": self.root / "classic-client"},
+                    "classic",
+                )
+
+        missing_source = self.root / "missing-managed-source"
+        empty_overrides = {
+            name: "" for name in workspace_module.GPU_SHADER_OVERRIDE_NAMES
+        }
+        with (
+            mock.patch.dict(os.environ, empty_overrides, clear=False),
+            mock.patch.object(workspace_module.platform, "system", return_value="Linux"),
+            mock.patch.object(
+                workspace_module.platform, "machine", return_value="x86_64"
+            ),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "configuration failed"):
+                self.workspace._prepare_gpu_shader(
+                    self.workspace.paths.builds / "profiles" / "missing-managed",
+                    {"client": missing_source},
+                    "classic",
+                )
+
+        with (
+            mock.patch.object(
+                self.workspace,
+                "_gpu_shader_existing_toolchain",
+                return_value=None,
+            ),
+            mock.patch.object(
+                self.workspace,
+                "_gpu_shader_managed_record",
+                side_effect=WorkspaceError(
+                    "profile classic Classic GPU shader toolchain preparation "
+                    "failed: test"
+                ),
+            ),
+            mock.patch.dict(os.environ, empty_overrides, clear=False),
+            mock.patch.object(workspace_module.platform, "system", return_value="Linux"),
+            mock.patch.object(
+                workspace_module.platform, "machine", return_value="x86_64"
+            ),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "toolchain preparation failed"):
+                self.workspace._prepare_gpu_shader(
+                    self.workspace.paths.builds / "profiles" / "managed-error",
+                    {"client": missing_source},
+                    "classic",
+                )
+
+        with self.assertRaisesRegex(WorkspaceError, "unsupported GPU shader record"):
+            self.workspace._gpu_shader_cmake_arguments(
+                {"mode": "unknown", "identity": "a" * 64}
+            )
+        self.assertEqual(
+            self.workspace._gpu_shader_cmake_arguments(
+                {
+                    "mode": "system",
+                    "dxc_executable": "/opt/dxc",
+                    "spirv_cross_executable": "/opt/spirv-cross",
+                    "dxc_library_directory": None,
+                    "identity": "a" * 64,
+                }
+            ),
+            [
+                "-DATRINIK_DXC_EXECUTABLE=/opt/dxc",
+                "-DATRINIK_SPIRV_CROSS_EXECUTABLE=/opt/spirv-cross",
+                "-DATRINIK_GPU_SHADER_WRAPPER_IDENTITY=" + "a" * 64,
+            ],
+        )
+        with self.assertRaisesRegex(WorkspaceError, "identity is invalid"):
+            self.workspace._gpu_shader_cmake_arguments(
+                {
+                    "mode": "external",
+                    "shader_directory": "/opt/shaders",
+                    "identity": "invalid",
+                }
+            )
+
+    def test_classic_gpu_shader_toolchain_validation_and_source_guards(self) -> None:
+        lock = self.root / "shader-lock.json"
+
+        def write_lock(files: dict[str, object]) -> None:
+            atomic_json(lock, {"dxc": {"files": files}})
+
+        def write_marker(output: Path, spirv_digest: str = "b" * 64) -> None:
+            output.mkdir(parents=True, exist_ok=True)
+            atomic_json(
+                output / "toolchain.json",
+                {
+                    "schema_version": 1,
+                    "lock_sha256": "a" * 64,
+                    "spirv_cross_sha256": spirv_digest,
+                },
+            )
+
+        with self.assertRaisesRegex(WorkspaceError, "not a directory"):
+            self.workspace._validate_gpu_shader_toolchain(
+                self.root / "missing-toolchain", lock, "a" * 64
+            )
+        symlink_target = self.root / "toolchain-target"
+        symlink_target.mkdir()
+        symlink_output = self.root / "toolchain-symlink"
+        symlink_output.symlink_to(symlink_target, target_is_directory=True)
+        with self.assertRaisesRegex(WorkspaceError, "not a directory"):
+            self.workspace._validate_gpu_shader_toolchain(
+                symlink_output, lock, "a" * 64
+            )
+
+        invalid_marker = self.root / "invalid-marker"
+        write_marker(invalid_marker)
+        atomic_json(invalid_marker / "toolchain.json", {"schema_version": 1})
+        with self.assertRaisesRegex(WorkspaceError, "marker is invalid"):
+            self.workspace._validate_gpu_shader_toolchain(
+                invalid_marker, lock, "a" * 64
+            )
+
+        no_files = self.root / "no-files"
+        write_marker(no_files)
+        write_lock({})
+        with self.assertRaisesRegex(WorkspaceError, "no DXC file contract"):
+            self.workspace._validate_gpu_shader_toolchain(
+                no_files, lock, "a" * 64
+            )
+
+        invalid_contract = self.root / "invalid-contract"
+        write_marker(invalid_contract)
+        write_lock({"bin/dxc": 1})
+        with self.assertRaisesRegex(WorkspaceError, "invalid DXC file contract"):
+            self.workspace._validate_gpu_shader_toolchain(
+                invalid_contract, lock, "a" * 64
+            )
+
+        unsafe_path = self.root / "unsafe-path"
+        write_marker(unsafe_path)
+        write_lock({"../dxc": "a" * 64})
+        with self.assertRaisesRegex(WorkspaceError, "unsafe DXC path"):
+            self.workspace._validate_gpu_shader_toolchain(
+                unsafe_path, lock, "a" * 64
+            )
+
+        stale = self.root / "stale-toolchain"
+        write_marker(stale)
+        dxc = stale / "dxc" / "bin" / "dxc"
+        dxc.parent.mkdir(parents=True)
+        dxc.write_bytes(b"stale")
+        dxc.chmod(0o755)
+        write_lock({"bin/dxc": "a" * 64})
+        with self.assertRaisesRegex(WorkspaceError, "stale or tampered"):
+            self.workspace._validate_gpu_shader_toolchain(
+                stale, lock, "a" * 64
+            )
+
+        invalid_layout = self.root / "invalid-layout"
+        dxc = invalid_layout / "dxc" / "bin" / "dxc"
+        dxc.parent.mkdir(parents=True)
+        dxc.write_bytes(b"dxc-layout")
+        dxc.chmod(0o755)
+        write_marker(invalid_layout)
+        write_lock({"bin/dxc": hashlib.sha256(dxc.read_bytes()).hexdigest()})
+        with self.assertRaisesRegex(WorkspaceError, "layout is invalid"):
+            self.workspace._validate_gpu_shader_toolchain(
+                invalid_layout, lock, "a" * 64
+            )
+
+        missing_source = self.root / "missing-source-root"
+        self.assertIsNone(
+            self.workspace._gpu_shader_existing_toolchain(missing_source, "classic")
+        )
+        generated_source = self.root / "generated-source"
+        checkout = self.root / "selector-checkout"
+        checkout.mkdir()
+        component = mock.Mock(source=".")
+        stack = mock.Mock(providers={"client": component})
+        with (
+            mock.patch.object(
+                self.workspace, "_source_generation_record", return_value={}
+            ),
+            mock.patch.object(
+                self.workspace, "_load_profile", return_value={"stack": "classic"}
+            ),
+            mock.patch.object(self.workspace.manifest, "stack", return_value=stack),
+            mock.patch.object(self.workspace, "_selector_root", return_value=checkout),
+        ):
+            self.assertEqual(
+                self.workspace._gpu_shader_existing_toolchain(
+                    generated_source, "classic"
+                ),
+                checkout / "build" / "gpu-shader-toolchain",
+            )
+            component.source = "client"
+            (checkout / "client").mkdir()
+            self.assertEqual(
+                self.workspace._gpu_shader_existing_toolchain(
+                    generated_source, "classic"
+                ),
+                checkout / "client" / "build" / "gpu-shader-toolchain",
+            )
+        with (
+            mock.patch.object(
+                self.workspace, "_source_generation_record", return_value=None
+            ),
+            mock.patch.object(Path, "lstat", side_effect=OSError("denied")),
+        ):
+            self.assertIsNone(
+                self.workspace._gpu_shader_existing_toolchain(
+                    self.root / "unreadable-source", "classic"
+                )
+            )
+
+    def test_classic_gpu_shader_managed_preparation_fails_closed(self) -> None:
+        dxc_bytes = b"test dxc\n"
+        dxc_digest = hashlib.sha256(dxc_bytes).hexdigest()
+
+        def source_fixture(name: str) -> tuple[Path, Path, Path]:
+            source = self.root / name
+            (source / "shaders").mkdir(parents=True)
+            (source / "tools").mkdir()
+            lock = source / "shaders" / "toolchain.lock.json"
+            atomic_json(
+                lock,
+                {"dxc": {"files": {"bin/dxc": dxc_digest}}},
+            )
+            builder = source / "tools" / "prepare_gpu_shader_toolchain.py"
+            builder.write_text("# test preparer\n", encoding="utf-8")
+            manifest = source / "shaders" / "SHA256SUMS"
+            manifest.write_text("manifest\n", encoding="utf-8")
+            return source, lock, manifest
+
+        def write_output(arguments: list[str], lock: Path) -> None:
+            output = Path(arguments[arguments.index("--output") + 1])
+            (output / "dxc" / "bin").mkdir(parents=True, exist_ok=True)
+            (output / "dxc" / "lib").mkdir()
+            dxc = output / "dxc" / "bin" / "dxc"
+            dxc.write_bytes(dxc_bytes)
+            dxc.chmod(0o755)
+            (output / "spirv-cross" / "bin").mkdir(parents=True)
+            spirv_cross = output / "spirv-cross" / "bin" / "spirv-cross"
+            spirv_cross.write_bytes(b"test spirv-cross\n")
+            spirv_cross.chmod(0o755)
+            (output / "spirv-cross" / "LICENSE").write_text(
+                "license\n", encoding="utf-8"
+            )
+            atomic_json(
+                output / "toolchain.json",
+                {
+                    "schema_version": 1,
+                    "lock_sha256": hashlib.sha256(lock.read_bytes()).hexdigest(),
+                    "spirv_cross_sha256": hashlib.sha256(
+                        spirv_cross.read_bytes()
+                    ).hexdigest(),
+                },
+            )
+
+        source, lock, _ = source_fixture("fallback-source")
+        root = self.workspace.paths.builds / "profiles" / "classic-fallback"
+        managed_directory(root, self.workspace.paths.builds, "profile:classic-fallback")
+        existing = self.root / "stale-source-toolchain"
+        existing.mkdir()
+        calls: list[list[str]] = []
+
+        def fallback_run(arguments: list[str], **_kwargs: object) -> None:
+            calls.append(arguments)
+            if len(calls) == 1:
+                raise WorkspaceError("stale source output")
+            write_output(arguments, lock)
+
+        with mock.patch.object(workspace_module, "run", side_effect=fallback_run):
+            record = self.workspace._gpu_shader_managed_record(
+                root,
+                source,
+                "classic-fallback",
+                existing_output=existing,
+            )
+        self.assertEqual(record["mode"], "managed")
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(
+            record["toolchain_root"],
+            str(
+                root
+                / "producers"
+                / "classic-gpu-shader-toolchains"
+                / record["lock_sha256"]
+            ),
+        )
+
+        changed_source, changed_lock, changed_manifest = source_fixture(
+            "changed-input-source"
+        )
+        changed_root = self.workspace.paths.builds / "profiles" / "classic-changed"
+        managed_directory(changed_root, self.workspace.paths.builds, "profile:classic-changed")
+
+        def changing_run(arguments: list[str], **_kwargs: object) -> None:
+            write_output(arguments, changed_lock)
+            changed_manifest.write_text("changed\n", encoding="utf-8")
+
+        with mock.patch.object(workspace_module, "run", side_effect=changing_run):
+            with self.assertRaisesRegex(WorkspaceError, "inputs changed"):
+                self.workspace._gpu_shader_managed_record(
+                    changed_root, changed_source, "classic-changed"
+                )
+
+        invalid_source = self.root / "invalid-input-source"
+        (invalid_source / "shaders" / "toolchain.lock.json").mkdir(parents=True)
+        with self.assertRaisesRegex(WorkspaceError, "not a regular file"):
+            self.workspace._gpu_shader_managed_record(
+                root, invalid_source, "classic-invalid-input"
+            )
+
     def test_classic_gpu_shader_arguments_are_added_to_both_cmake_graphs(self) -> None:
         checkout = self.root / "classic"
         for role in ("client", "server", "protocol", "libatrinik"):


### PR DESCRIPTION
## Summary

Wire the governed Classic GPU shader inputs through managed builds.

## Implementation / behavior

Pass validated toolchain paths and their identity into standalone and integrated Classic client builds, while preserving explicit system-tool and generated-cohort overrides.

## Validation

Add a fresh-profile workspace regression that configures the Classic client without a caller-modified `PATH`, then run the required wrapper checks at the final head.

## Limitations / follow-up

The existing Classic CMake shader contract remains the consumer; hardware qualification is outside this wrapper issue.

Closes #520
