### PR TITLE
perf(build): add incremental Classic development workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,46 @@ project, so protocol and libatrinik are compiled once and shared by the client
 and server. A component-specific build such as `build client` or `build server`
 continues to exercise that module's supported standalone FetchContent path.
 
+### Incremental Classic development
+
+Use the development workflow when iterating on a playable Classic service:
+
+~~~sh
+./atrinik dev build --profile classic --services server,client
+./atrinik dev build --profile classic --services server --json
+./atrinik dev up --profile classic --name classic-local \
+  --services server,client --temporary-state
+./atrinik dev restart classic-local --service server
+./atrinik dev restart classic-local --service client
+./atrinik down classic-local
+~~~
+
+`dev build` and `dev up` resolve the complete client/server dependency closure
+and use the same topology build root, so a warm direct development build warms
+the paired launch. `--services server`, `--services client`, and
+`--services both` select the playable service set; selecting one service limits
+the CMake build targets and does not rebuild the other service. Content,
+resources, region maps, source views, CMake configure state, and the shared
+compiler cache report `reused` or `refreshed` decisions in JSON output. Add
+`--test` when the selected development build should materialize the configured
+CMake graph and run its CTest validation; this explicit mode may build both
+playable services so the unfiltered suite has all of its targets. The
+metaserver worker is not part of this playable scope; use the explicit
+`build all --profile classic --test` workflow for full validation. JSON output
+also includes elapsed build time and per-CMake configure/build/test timings for
+the cold/warm and service-only rebuild matrix.
+
+`dev up` keeps local paired launch offline: the server disables port mapping and
+STUN, and the client disables the metaserver and STUN while connecting to the
+reserved loopback endpoint. `dev restart` requires a currently supervised
+topology, performs a controlled stop, rebuilds only the requested service
+target, and publishes a fresh immutable runtime generation. Persistent state
+and the reserved endpoint port are retained; disposable temporary state is
+copied into the new generation and the superseded copy is removed only after
+the replacement is ready. The topology may therefore restart both supervised
+processes as one sealed-generation transaction while keeping compilation
+service-selective and preserving the state/port contract.
+
 Managed source views are reconciled in place, so unchanged links and copied
 files retain their identity while changed, retargeted, and stale entries are
 updated without following unsafe symlinks. Linked-directory structure and

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -330,6 +330,83 @@ def parser() -> argparse.ArgumentParser:
         help="disable automatic C/C++ compiler caching",
     )
 
+    dev = commands.add_parser(
+        "dev", help="incremental, service-selective Classic development workflow"
+    )
+    dev_commands = dev.add_subparsers(dest="dev_command", required=True)
+    dev_build = dev_commands.add_parser(
+        "build", help="warm an incremental playable service build"
+    )
+    mark(dev_build.add_argument("--profile", default="classic"), "profile")
+    mark(
+        dev_build.add_argument(
+            "--services",
+            default="server,client",
+            metavar="SERVICE,...",
+            help="server, client, or both (default: server,client)",
+        ),
+        "dev_services",
+    )
+    dev_build.add_argument("--test", action="store_true")
+    dev_build.add_argument(
+        "--force-reconfigure",
+        action="store_true",
+        help="run CMake configure even when its managed fingerprint is unchanged",
+    )
+    dev_build.add_argument(
+        "--no-ccache",
+        action="store_true",
+        help="disable automatic C/C++ compiler caching",
+    )
+    dev_build.add_argument("--json", action="store_true")
+
+    dev_up = dev_commands.add_parser(
+        "up", help="build and start a local loopback development topology"
+    )
+    mark(dev_up.add_argument("--name"), "none")
+    mark(dev_up.add_argument("--profile", default="classic"), "profile")
+    mark(
+        dev_up.add_argument(
+            "--services",
+            default="server,client",
+            metavar="SERVICE,...",
+            help="server, client, or both (default: server,client)",
+        ),
+        "dev_services",
+    )
+    dev_up_state = dev_up.add_mutually_exclusive_group()
+    mark(dev_up_state.add_argument("--state", default="default"), "state")
+    dev_up_state.add_argument(
+        "--temporary-state",
+        dest="state_mode",
+        action="store_const",
+        const="temporary",
+        help="use a fresh disposable state owned by this topology generation",
+    )
+    dev_up_state.add_argument(
+        "--default-state",
+        dest="state_mode",
+        action="store_const",
+        const="default",
+        help="deliberately select the legacy managed persistent default state",
+    )
+    mark(
+        dev_up.add_argument(
+            "--port",
+            type=int,
+            help="server UDP port (default: choose an available port)",
+        ),
+        "none",
+    )
+    dev_up.add_argument("--json", action="store_true")
+
+    dev_restart = dev_commands.add_parser(
+        "restart", help="rebuild and restart one service in an existing topology"
+    )
+    mark(dev_restart.add_argument("name"), "topology")
+    dev_restart.add_argument("--service", choices=["server", "client"], required=True)
+    dev_restart.add_argument("--json", action="store_true")
+
     package = commands.add_parser(
         "package", help="package a resolved profile for another host"
     )
@@ -572,6 +649,23 @@ def parser() -> argparse.ArgumentParser:
 
 def _forwarded_arguments(arguments: list[str]) -> list[str]:
     return arguments[1:] if arguments and arguments[0] == "--" else arguments
+
+
+def _parse_services(value: str) -> list[str]:
+    """Parse the compact development service selector used by the CLI."""
+
+    if value == "both":
+        return ["server", "client"]
+    services = [item.strip() for item in value.split(",")]
+    if not services or any(not item for item in services):
+        raise WorkspaceError("--services must name server, client, or both")
+    if len(set(services)) != len(services):
+        raise WorkspaceError("--services cannot contain duplicates")
+    if set(services) - {"server", "client"}:
+        raise WorkspaceError(
+            "--services must contain only server and client, or both"
+        )
+    return [service for service in ("server", "client") if service in services]
 
 
 def _print_scenario(summary: dict[str, object]) -> None:
@@ -1095,6 +1189,65 @@ def main(arguments: list[str] | None = None) -> int:
                     use_ccache=not options.no_ccache,
                 )
             )
+        elif options.command == "dev":
+            if options.dev_command == "build":
+                services = _parse_services(options.services)
+                result = workspace.dev_build(
+                    options.profile,
+                    services,
+                    options.test,
+                    force_reconfigure=options.force_reconfigure,
+                    use_ccache=not options.no_ccache,
+                )
+                if options.json:
+                    print(json.dumps(result, indent=2, sort_keys=True))
+                else:
+                    print(f"dev-build\t{result['build_root']}")
+                    print(f"services\t{','.join(result['services'])}")
+                    print(f"cache\t{result['cache']['build_root']}")
+                    for name, value in sorted(result["cache"]["inputs"].items()):
+                        print(f"cache\t{name}\t{value}")
+                    print(f"runtime\t{result['runtime']['staging']}")
+                    print(
+                        f"elapsed\t{result['timing']['elapsed_seconds']:.3f}s"
+                    )
+            elif options.dev_command == "up":
+                services = _parse_services(options.services)
+                name = options.name or options.profile
+                state = None if options.state_mode == "temporary" else options.state
+                status = workspace.dev_up(
+                    name,
+                    options.profile,
+                    state,
+                    services,
+                    options.port,
+                    state_mode=options.state_mode,
+                )
+                if options.json:
+                    print(json.dumps(status, indent=2, sort_keys=True))
+                else:
+                    endpoint = status.get("endpoint")
+                    suffix = (
+                        f" at {endpoint['host']}:{endpoint['port']}"
+                        if endpoint
+                        else ""
+                    )
+                    print(f"topology {name}: started{suffix}")
+            else:
+                status = workspace.dev_restart(options.name, options.service)
+                if options.json:
+                    print(json.dumps(status, indent=2, sort_keys=True))
+                else:
+                    endpoint = status.get("endpoint")
+                    suffix = (
+                        f" at {endpoint['host']}:{endpoint['port']}"
+                        if endpoint
+                        else ""
+                    )
+                    print(
+                        f"topology {options.name}: restarted "
+                        f"{options.service}{suffix}"
+                    )
         elif options.command == "package":
             summary = workspace.package_windows_profile(
                 options.profile,

--- a/atrinik_workspace/completion.py
+++ b/atrinik_workspace/completion.py
@@ -357,6 +357,8 @@ def _dynamic_candidates(
         return _scenario_names(manifest, paths)
     if kind == "topology":
         return _topology_names(manifest, paths)
+    if kind == "dev_services":
+        return ["server", "client", "server,client", "client,server", "both"]
     if kind == "scope":
         return _scope_names(paths)
     return []

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -4,7 +4,7 @@ import binascii
 import copy
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from contextlib import AbstractContextManager, ExitStack, contextmanager
+from contextlib import AbstractContextManager, ExitStack, contextmanager, nullcontext
 from contextvars import copy_context
 import ctypes
 from dataclasses import dataclass
@@ -1968,6 +1968,44 @@ def durable_atomic_json_at(directory_fd: int, name: str, value: Any) -> None:
             os.close(descriptor)
 
 
+def durable_replace_json_at(directory_fd: int, name: str, value: Any) -> None:
+    """Durably replace one JSON file relative to a pinned directory."""
+
+    if Path(name).name != name:
+        raise WorkspaceError(f"descriptor-relative JSON name is invalid: {name}")
+    temporary = f".{name}.{secrets.token_hex(12)}.tmp"
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            0o600,
+            dir_fd=directory_fd,
+        )
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            descriptor = None
+            json.dump(value, stream, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.rename(
+            temporary,
+            name,
+            src_dir_fd=directory_fd,
+            dst_dir_fd=directory_fd,
+        )
+        os.fsync(directory_fd)
+    except BaseException:
+        try:
+            os.unlink(temporary, dir_fd=directory_fd)
+        except FileNotFoundError:
+            pass
+        raise
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
 def rename_no_replace_at(
     source_directory_fd: int,
     source: str,
@@ -2211,6 +2249,18 @@ class Workspace:
     @_profile_snapshot.setter
     def _profile_snapshot(self, value: ProfileResolutionSnapshot | None) -> None:
         self._build_state.profile_snapshot = value
+
+    @property
+    def _build_summary(self) -> dict[str, Any]:
+        current = getattr(self._build_state, "build_summary", None)
+        if current is None:
+            current = {}
+            self._build_state.build_summary = current
+        return current
+
+    @_build_summary.setter
+    def _build_summary(self, value: dict[str, Any]) -> None:
+        self._build_state.build_summary = value
 
     @staticmethod
     def _lease_recovery(kind: str, coordinate: str) -> str:
@@ -7636,6 +7686,198 @@ class Workspace:
                 use_ccache=use_ccache,
             )
 
+    def dev_build(
+        self,
+        profile_name: str,
+        services: list[str] | None = None,
+        tests: bool = False,
+        *,
+        force_reconfigure: bool = False,
+        use_ccache: bool = True,
+    ) -> dict[str, Any]:
+        """Build only the selected playable Classic services incrementally."""
+
+        started = time.monotonic()
+        self.paths.ensure()
+        selected_services = self._topology_services(services)
+        self._require_classic_contracts(profile_name, set(TOPOLOGY_SERVICES))
+        profile = self._load_profile(profile_name, require_file=False)
+        build_roles = self._dependency_roles(profile, set(TOPOLOGY_SERVICES))
+        with self._resolved_profile_operation(
+            profile_name,
+            build_roles,
+            f"dev build {profile_name} {','.join(selected_services)}",
+            materialize_clean_primaries=True,
+        ) as snapshot:
+            targets = [
+                target for target in ALL_BUILD_TARGETS if target in snapshot.paths()
+            ]
+            root = self._build_resolved(
+                "topology",
+                profile_name,
+                tests,
+                targets,
+                snapshot.paths(),
+                force_reconfigure=force_reconfigure,
+                use_ccache=use_ccache,
+                build_services=set(selected_services),
+            )
+            summary = copy.deepcopy(self._build_summary)
+        cache = summary.get("cache", {})
+        if not isinstance(cache, dict):
+            cache = {}
+        inputs = cache.get("inputs", {})
+        if not isinstance(inputs, dict):
+            inputs = {}
+        return {
+            "schema_version": 1,
+            "profile": profile_name,
+            "services": selected_services,
+            "tests": tests,
+            "build_root": str(root),
+            "cache": {
+                "build_root": cache.get("build_root", "unknown"),
+                "inputs": dict(sorted(inputs.items())),
+                "cmake": cache.get("cmake", {}),
+                "source_views": cache.get("source_views", "unknown"),
+            },
+            "runtime": {
+                "staging": "deferred until dev up; immutable generation required"
+            },
+            "timing": {
+                "elapsed_seconds": round(time.monotonic() - started, 3)
+            },
+        }
+
+    def dev_up(
+        self,
+        name: str,
+        profile_name: str,
+        state_name: str | None,
+        services: list[str] | None = None,
+        port: int | None = None,
+        state_mode: str | None = None,
+    ) -> dict[str, Any]:
+        """Start the same warmable topology root used by :meth:`dev_build`."""
+
+        return self.topology_up(
+            name,
+            profile_name,
+            state_name,
+            services,
+            port,
+            state_mode=state_mode,
+            build_services=set(self._topology_services(services)),
+        )
+
+    def dev_restart(self, name: str, service: str) -> dict[str, Any]:
+        """Rebuild one service and republish the complete local topology."""
+
+        self.paths.ensure()
+        if service not in TOPOLOGY_SERVICES:
+            raise WorkspaceError(f"unknown topology service: {service}")
+        initial = self.topology_status(name)
+        if initial.get("inert_historical_record"):
+            raise WorkspaceError(
+                f"topology {name} is an inert historical record; choose a new topology"
+            )
+        services = [
+            candidate
+            for candidate in TOPOLOGY_SERVICES
+            if candidate in initial.get("services", {})
+        ]
+        if service not in services:
+            raise WorkspaceError(
+                f"topology {name} does not contain the {service} service"
+            )
+        control = initial.get("control")
+        if (
+            not isinstance(control, dict)
+            or not isinstance(initial.get("supervisor"), dict)
+            or not initial["supervisor"].get("running")
+            or (
+                "server" in services
+                and not isinstance(initial.get("state_policy"), dict)
+            )
+        ):
+            raise WorkspaceError(
+                f"topology {name} is not a current supervised development topology"
+            )
+        profile_name = initial["profile"]
+        state_policy = initial.get("state_policy")
+        if "server" in services:
+            assert isinstance(state_policy, dict)
+            state_mode = state_policy.get("mode")
+            state_name = state_policy.get("name")
+            if state_mode not in {"temporary", "named", "default"}:
+                raise WorkspaceError(
+                    f"topology {name} has an invalid state policy for restart"
+                )
+            if state_mode == "temporary" and state_policy.get("lifecycle") != "disposable":
+                raise WorkspaceError(
+                    f"topology {name} temporary state is not disposable; preserve it before restart"
+                )
+        else:
+            state_mode = "default"
+            state_name = None
+        endpoint = initial.get("endpoint")
+        port = endpoint.get("port") if isinstance(endpoint, dict) else None
+
+        with self._resolved_profile_operation(
+            profile_name,
+            set(TOPOLOGY_SERVICES),
+            f"dev restart {name} {service}",
+            materialize_clean_primaries=True,
+        ):
+            requests = [
+                self._lease_request(
+                    "topology", name, "exclusive", f"dev restart {name} {service}"
+                )
+            ]
+            if (
+                isinstance(state_name, str)
+                and state_name.startswith("scenario-")
+            ):
+                requests.append(
+                    self._lease_request(
+                        "scenario",
+                        state_name.removeprefix("scenario-"),
+                        "shared",
+                        f"dev restart {name} {service}",
+                    )
+                )
+            with self._resource_locks(requests):
+                topology_root = self._topology_directory(name)
+                with exclusive_lock(
+                    topology_root / "operation.lock",
+                    f"topology {name} operation",
+                    nonblocking=True,
+                ):
+                    current = self.topology_status(name)
+                    if current.get("control") != control:
+                        raise WorkspaceError(
+                            f"topology {name} changed before development restart; retry"
+                        )
+                    stopped, clean = self._controlled_topology_down(
+                        name, current, 15
+                    )
+                    if not clean:
+                        raise WorkspaceError(
+                            f"topology {name} did not complete a confirmed clean stop; "
+                            "preserve the stopped record for diagnosis"
+                        )
+                    return self._topology_up(
+                        name,
+                        profile_name,
+                        state_name,
+                        services,
+                        port,
+                        state_mode,
+                        build_services={service},
+                        restart_status=stopped,
+                        operation_lock_held=True,
+                    )
+
     def _build(
         self,
         target: str,
@@ -7668,7 +7910,19 @@ class Workspace:
         *,
         force_reconfigure: bool = False,
         use_ccache: bool = True,
+        build_services: set[str] | None = None,
     ) -> Path:
+        requested_services = set(targets).intersection(TOPOLOGY_SERVICES)
+        selective_build = build_services is not None
+        if build_services is None:
+            build_services = set(requested_services)
+        else:
+            invalid_services = set(build_services) - requested_services
+            if invalid_services:
+                raise WorkspaceError(
+                    "selective build services are outside the requested topology: "
+                    + ", ".join(sorted(invalid_services))
+                )
         key = self._profile_build_key(profile_name, selected)
         root = self.paths.builds / "profiles" / f"{profile_name}-{key}"
         profile = self._load_profile(profile_name, require_file=False)
@@ -7677,6 +7931,17 @@ class Workspace:
             self._force_reconfigure = force_reconfigure
             self._use_ccache = use_ccache
             self._source_view_unchanged = {}
+            self._build_summary = {
+                "cache": {
+                    "build_root": (
+                        "reused"
+                        if root.exists() and not root.is_symlink()
+                        else "created"
+                    ),
+                    "inputs": {},
+                    "cmake": {},
+                }
+            }
             managed_directory(root, self.paths.builds, f"profile:{profile_name}:{key}")
             sound_root = selected.get("sound")
             sound_record: dict[str, Any] | None = None
@@ -7704,28 +7969,45 @@ class Workspace:
                     raise WorkspaceError(
                         f"integrated Classic profile {profile_name} has no sound provider"
                     )
-                self._build_integrated_classic(
-                    root, selected, tests, sound_root=sound_root
-                )
+                if selective_build:
+                    self._build_integrated_classic(
+                        root,
+                        selected,
+                        tests,
+                        sound_root=sound_root,
+                        build_services=build_services,
+                    )
+                else:
+                    self._build_integrated_classic(
+                        root, selected, tests, sound_root=sound_root
+                    )
             else:
                 if "protocol" in targets:
                     self._build_protocol(root, selected, tests)
                 if "libatrinik" in targets:
                     self._build_library(root, selected, tests)
-                if "client" in targets:
+                if "client" in targets and "client" in build_services:
+                    client_arguments: dict[str, Any] = {
+                        "component": stack.providers["client"],
+                        "sound_root": sound_root,
+                    }
+                    if selective_build:
+                        client_arguments["build_target"] = "atrinik"
                     self._build_client(
-                        root,
-                        selected,
-                        tests,
-                        component=stack.providers["client"],
-                        sound_root=sound_root,
+                        root, selected, tests, **client_arguments
                     )
-                if "server" in targets:
+                if "server" in targets and "server" in build_services:
+                    server_arguments: dict[str, Any] = {
+                        "component": stack.providers["server"],
+                    }
+                    if selective_build:
+                        server_arguments["build_targets"] = [
+                            "atrinik-server",
+                            "plugin_arena",
+                            "plugin_python",
+                        ]
                     self._build_server(
-                        root,
-                        selected,
-                        tests,
-                        component=stack.providers["server"],
+                        root, selected, tests, **server_arguments
                     )
             if "server" in targets:
                 self._generate_region_maps(root, profile_name, selected)
@@ -7733,6 +8015,15 @@ class Workspace:
                 self._build_worker(root, selected)
             if target in {"sound", "resources"}:
                 print(f"{target}: selected {selected[target]}")
+            cache = self._build_summary.setdefault("cache", {})
+            cache["source_views"] = (
+                "reused"
+                if self._source_view_unchanged
+                and all(self._source_view_unchanged.values())
+                else "refreshed"
+                if self._source_view_unchanged
+                else "not-applicable"
+            )
         return root
 
     @contextmanager
@@ -9198,6 +9489,9 @@ class Workspace:
             and validated_cacheable == cacheable
             and validated_cacheable
         ):
+            self._build_summary.setdefault("cache", {}).setdefault(
+                "inputs", {}
+            )["content"] = "reused"
             print(f"content: cached {output}")
             return output
         inputs, cacheable = validated_inputs, validated_cacheable
@@ -9263,6 +9557,9 @@ class Workspace:
             if staging.exists():
                 shutil.rmtree(staging)
             raise
+        self._build_summary.setdefault("cache", {}).setdefault(
+            "inputs", {}
+        )["content"] = "refreshed"
         print(f"content: collected {output}")
         return output
 
@@ -9301,6 +9598,9 @@ class Workspace:
             and validated_runtime_paths == runtime_paths
             and validated_tracked == tracked
         ):
+            self._build_summary.setdefault("cache", {}).setdefault(
+                "inputs", {}
+            )["resources"] = "reused"
             print(f"resources: cached {output}")
             return output
         inputs, cacheable = validated_inputs, validated_cacheable
@@ -9392,6 +9692,9 @@ class Workspace:
             if staging.exists():
                 shutil.rmtree(staging)
             raise
+        self._build_summary.setdefault("cache", {}).setdefault(
+            "inputs", {}
+        )["resources"] = "refreshed"
         print(f"resources: staged {output}")
         return output
 
@@ -9401,10 +9704,19 @@ class Workspace:
         binary: Path,
         arguments: list[str],
         tests: bool,
+        *,
+        build_targets: list[str] | None = None,
     ) -> None:
         self._prepare_cmake_binary(binary)
         environment = os.environ.copy()
         ccache = shutil.which("ccache") if self._use_ccache else None
+        cache_inputs = self._build_summary.setdefault("cache", {}).setdefault(
+            "inputs", {}
+        )
+        if not self._use_ccache:
+            cache_inputs["compiler-cache"] = "disabled"
+        elif ccache is None:
+            cache_inputs["compiler-cache"] = "unavailable"
         cache_arguments = [
             "-DCMAKE_C_COMPILER_LAUNCHER=",
             "-DCMAKE_CXX_COMPILER_LAUNCHER=",
@@ -9414,6 +9726,11 @@ class Workspace:
         )
         if ccache is not None:
             cache = self.paths.builds / COMPILER_CACHE_PURPOSE
+            cache_inputs["compiler-cache"] = (
+                "reused"
+                if cache.is_dir() and not cache.is_symlink()
+                else "created"
+            )
             with exclusive_lock(
                 self.paths.builds / "locks" / "compiler-cache.lock",
                 "compiler cache initialization",
@@ -9500,24 +9817,56 @@ class Workspace:
         ):
             managed_reset(binary, self.paths.builds, "cmake-binary")
             configured = False
+        configured_now = False
+        configure_seconds: float | None = None
         if (
             self._force_reconfigure
             or not unchanged_view
             or not fingerprint["source"].get("configure_skip_safe", True)
             or not configured
         ):
+            configure_started = time.monotonic()
             run(configure, env=environment)
+            configure_seconds = time.monotonic() - configure_started
+            configured_now = True
             fingerprint = self._configure_fingerprint(
                 source, binary, configure, tests, environment, ccache
             )
             atomic_json(metadata_path, fingerprint)
         else:
             print(f"cmake: configure unchanged for {binary}; skipping", file=sys.stderr)
-        run(["cmake", "--build", str(binary), "--parallel"], env=environment)
+        build_command = ["cmake", "--build", str(binary), "--parallel"]
+        # CTest is registered for the whole configured graph.  An explicit
+        # validation request therefore has to materialize that graph before
+        # running the unfiltered suite; ordinary development builds retain
+        # their service-scoped target selection.
+        if build_targets and not tests:
+            build_command.extend(("--target", *build_targets))
+        build_started = time.monotonic()
+        run(build_command, env=environment)
+        build_seconds = time.monotonic() - build_started
+        cmake_summary = self._build_summary.setdefault("cache", {}).setdefault(
+            "cmake", {}
+        )
+        cmake_summary[str(binary)] = {
+            "configure": "refreshed" if configured_now else "reused",
+            "build": "targeted" if build_targets and not tests else "all",
+            "tests": tests,
+            "configure_seconds": (
+                round(configure_seconds, 3)
+                if configure_seconds is not None
+                else None
+            ),
+            "build_seconds": round(build_seconds, 3),
+        }
         if tests:
+            test_started = time.monotonic()
             run(
                 ["ctest", "--test-dir", str(binary), "--output-on-failure"],
                 env=environment,
+            )
+            cmake_summary[str(binary)]["test_seconds"] = round(
+                time.monotonic() - test_started, 3
             )
 
     def _prepare_cmake_binary(self, binary: Path) -> None:
@@ -10165,6 +10514,7 @@ class Workspace:
         tests: bool,
         *,
         sound_root: Path | None = None,
+        build_services: set[str] | None = None,
     ) -> None:
         checkout = selected["client"].parent.resolve()
         view = self._profile_source_view(
@@ -10218,16 +10568,33 @@ class Workspace:
             root / "runtime" / "resources",
             target_is_directory=True,
         )
-        self._cmake(
-            view,
-            root / "build" / "integrated",
-            [
-                "-DENABLE_WARNING_ERRORS=ON",
-                "-DPACKAGE_TYPE=none",
-                "-DENABLE_PYTHON_PLUGIN=ON",
-            ],
-            tests,
-        )
+        build_targets: list[str] | None = None
+        if build_services is not None and build_services != {"client", "server"}:
+            build_targets = []
+            if "client" in build_services:
+                build_targets.append("atrinik")
+            if "server" in build_services:
+                build_targets.extend(("atrinik-server", "plugin_arena", "plugin_python"))
+        arguments = [
+            "-DENABLE_WARNING_ERRORS=ON",
+            "-DPACKAGE_TYPE=none",
+            "-DENABLE_PYTHON_PLUGIN=ON",
+        ]
+        if build_targets is None:
+            self._cmake(
+                view,
+                root / "build" / "integrated",
+                arguments,
+                tests,
+            )
+        else:
+            self._cmake(
+                view,
+                root / "build" / "integrated",
+                arguments,
+                tests,
+                build_targets=build_targets,
+            )
         self._record_classic_graph(root, {"client", "server"}, "integrated")
 
     def _build_library(self, root: Path, selected: dict[str, Path], tests: bool) -> None:
@@ -10342,6 +10709,7 @@ class Workspace:
         *,
         component: Component,
         sound_root: Path | None = None,
+        build_target: str | None = None,
     ) -> None:
         view = self._profile_source_view(
             root,
@@ -10365,17 +10733,27 @@ class Workspace:
         library = self._mutable_cmake_source_view(
             root, "libatrinik", selected["libatrinik"]
         )
-        self._cmake(
-            view,
-            root / "build" / "client",
-            [
-                "-DENABLE_WARNING_ERRORS=ON",
-                "-DPACKAGE_TYPE=none",
-                f"-DFETCHCONTENT_SOURCE_DIR_ATRINIK_PROTOCOL={protocol}",
-                f"-DFETCHCONTENT_SOURCE_DIR_LIBATRINIK={library}",
-            ],
-            tests,
-        )
+        arguments = [
+            "-DENABLE_WARNING_ERRORS=ON",
+            "-DPACKAGE_TYPE=none",
+            f"-DFETCHCONTENT_SOURCE_DIR_ATRINIK_PROTOCOL={protocol}",
+            f"-DFETCHCONTENT_SOURCE_DIR_LIBATRINIK={library}",
+        ]
+        if build_target is None:
+            self._cmake(
+                view,
+                root / "build" / "client",
+                arguments,
+                tests,
+            )
+        else:
+            self._cmake(
+                view,
+                root / "build" / "client",
+                arguments,
+                tests,
+                build_targets=[build_target],
+            )
         self._record_classic_graph(root, {"client"}, "standalone")
 
     def _build_server(
@@ -10385,6 +10763,7 @@ class Workspace:
         tests: bool,
         *,
         component: Component,
+        build_targets: list[str] | None = None,
     ) -> None:
         view = self._profile_source_view(
             root,
@@ -10433,18 +10812,28 @@ class Workspace:
         library = self._mutable_cmake_source_view(
             root, "libatrinik", selected["libatrinik"]
         )
-        self._cmake(
-            view,
-            root / "build" / "server",
-            [
-                "-DENABLE_WARNING_ERRORS=ON",
-                "-DPACKAGE_TYPE=none",
-                f"-DFETCHCONTENT_SOURCE_DIR_ATRINIK_PROTOCOL={protocol}",
-                f"-DFETCHCONTENT_SOURCE_DIR_LIBATRINIK={library}",
-                "-DENABLE_PYTHON_PLUGIN=ON",
-            ],
-            tests,
-        )
+        arguments = [
+            "-DENABLE_WARNING_ERRORS=ON",
+            "-DPACKAGE_TYPE=none",
+            f"-DFETCHCONTENT_SOURCE_DIR_ATRINIK_PROTOCOL={protocol}",
+            f"-DFETCHCONTENT_SOURCE_DIR_LIBATRINIK={library}",
+            "-DENABLE_PYTHON_PLUGIN=ON",
+        ]
+        if build_targets is None:
+            self._cmake(
+                view,
+                root / "build" / "server",
+                arguments,
+                tests,
+            )
+        else:
+            self._cmake(
+                view,
+                root / "build" / "server",
+                arguments,
+                tests,
+                build_targets=build_targets,
+            )
         self._record_classic_graph(root, {"server"}, "standalone")
 
     def _region_map_inputs(
@@ -10583,6 +10972,9 @@ class Workspace:
         output.parent.mkdir(parents=True, exist_ok=True)
         inputs, cacheable = self._region_map_inputs(profile_name, selected)
         if self._region_map_cache_matches(output, inputs, cacheable):
+            self._build_summary.setdefault("cache", {}).setdefault(
+                "inputs", {}
+            )["region-maps"] = "reused"
             print(f"region maps: cached {output}")
             return output
         if output.exists() or output.is_symlink():
@@ -10642,6 +11034,9 @@ class Workspace:
         finally:
             if staging_root.exists():
                 shutil.rmtree(staging_root)
+        self._build_summary.setdefault("cache", {}).setdefault(
+            "inputs", {}
+        )["region-maps"] = "refreshed"
         print(f"region maps: generated {output}")
         return output
 
@@ -13100,6 +13495,308 @@ class Workspace:
                 f"server state {path} is busy but its exact owner cannot be "
                 "confirmed; inspect ./atrinik ps --json and preserve the state"
             ) from error
+
+    def _clone_temporary_state(
+        self,
+        topology_root: Path,
+        topology_name: str,
+        profile_name: str,
+        generation: str,
+        previous_policy: dict[str, Any],
+        implementation: dict[str, str],
+        server_coordinate: dict[str, Any],
+    ) -> tuple[Path, dict[str, Any]]:
+        """Clone stopped development state into a new generation safely."""
+
+        previous_owner = previous_policy.get("owner")
+        previous_state_value = previous_policy.get("path")
+        previous_state = (
+            Path(previous_state_value)
+            if isinstance(previous_state_value, str)
+            else Path("/")
+        )
+        if (
+            not previous_state.is_absolute()
+            or previous_policy.get("mode") != "temporary"
+            or not isinstance(previous_owner, dict)
+            or previous_owner.get("kind") != "topology-generation"
+            or previous_owner.get("topology") != topology_name
+            or not isinstance(previous_owner.get("generation"), str)
+            or previous_owner.get("generation") == generation
+            or previous_state.parent
+            != topology_root / "temporary-states"
+            or previous_state.name != previous_owner.get("generation")
+        ):
+            raise WorkspaceError(
+                f"temporary topology state cannot be cloned for restart: {topology_name}"
+            )
+        try:
+            with self._topology_state_lock(
+                previous_state,
+                preparing_topology=topology_name,
+                physical_identity=False,
+            ) as previous_lease:
+                previous_identity = previous_policy.get("identity")
+                previous_lease_identity = previous_policy.get("lease_identity")
+                if (
+                    not isinstance(previous_identity, dict)
+                    or not isinstance(previous_lease_identity, dict)
+                ):
+                    raise WorkspaceError(
+                        f"temporary topology state identity is invalid: {previous_state}"
+                    )
+                self._validate_temporary_state_lock(
+                    previous_state,
+                    previous_lease,
+                    previous_lease_identity,
+                )
+                previous_fd = self._open_validated_state_directory(
+                    previous_state,
+                    implementation,
+                    write_implementation=False,
+                )
+                try:
+                    previous_metadata = os.fstat(previous_fd)
+                    if previous_identity != {
+                        "device": previous_metadata.st_dev,
+                        "inode": previous_metadata.st_ino,
+                    }:
+                        raise WorkspaceError(
+                            f"temporary topology state identity changed: {previous_state}"
+                        )
+                    self._validate_temporary_state_integrity(
+                        previous_fd, previous_state, implementation
+                    )
+                    previous_marker = self._load_state_json_at(
+                        previous_fd,
+                        MANAGED_MARKER,
+                        "temporary state ownership marker",
+                    )
+                    if previous_marker != {
+                        "schema_version": SCHEMA_VERSION,
+                        "purpose": "temporary-topology-state",
+                        "topology": topology_name,
+                        "generation": previous_owner["generation"],
+                    }:
+                        raise WorkspaceError(
+                            f"temporary topology state ownership marker is invalid: {previous_state}"
+                        )
+                    previous_creation = self._load_state_json_at(
+                        previous_fd,
+                        TEMPORARY_STATE_METADATA,
+                        "temporary state creation record",
+                    )
+                    if not self._temporary_state_metadata_matches(
+                        previous_policy,
+                        previous_creation.get("state_policy")
+                        if isinstance(previous_creation, dict)
+                        else None,
+                    ):
+                        raise WorkspaceError(
+                            f"temporary topology state creation record is invalid: {previous_state}"
+                        )
+                    previous_digest = _tree_digest_descriptor(
+                        previous_fd, previous_state
+                    )
+                    container, container_fd = self._temporary_state_container(
+                        topology_root
+                    )
+                    staging: Path | None = None
+                    staging_fd: int | None = None
+                    published = False
+                    try:
+                        destination = container / generation
+                        try:
+                            os.stat(
+                                generation,
+                                dir_fd=container_fd,
+                                follow_symlinks=False,
+                            )
+                        except FileNotFoundError:
+                            pass
+                        else:
+                            raise WorkspaceError(
+                                f"temporary topology state already exists for generation {generation}"
+                            )
+                        staging = Path(
+                            tempfile.mkdtemp(
+                                prefix=f".{generation}.",
+                                dir=f"/proc/self/fd/{container_fd}",
+                            )
+                        )
+                        staging_name = staging.name
+                        staging_fd = os.open(
+                            staging_name,
+                            os.O_RDONLY
+                            | os.O_CLOEXEC
+                            | os.O_DIRECTORY
+                            | os.O_NOFOLLOW,
+                            dir_fd=container_fd,
+                        )
+                        shutil.copytree(
+                            Path(f"/proc/self/fd/{previous_fd}"),
+                            staging,
+                            dirs_exist_ok=True,
+                            symlinks=False,
+                        )
+                        if _tree_digest_descriptor(
+                            previous_fd, previous_state
+                        ) != previous_digest:
+                            raise WorkspaceError(
+                                "temporary topology state changed during clone"
+                            )
+                        self._make_tree_owner_writable(staging)
+                        old_generation = previous_owner["generation"]
+                        old_output = (
+                            staging
+                            / "tmp"
+                            / "runtime-assets"
+                            / old_generation
+                        )
+                        if old_output.exists() or old_output.is_symlink():
+                            directory_flags = (
+                                os.O_RDONLY
+                                | os.O_CLOEXEC
+                                | os.O_DIRECTORY
+                                | os.O_NOFOLLOW
+                            )
+                            tmp_fd = os.open(
+                                "tmp", directory_flags, dir_fd=staging_fd
+                            )
+                            try:
+                                runtime_assets_fd = os.open(
+                                    "runtime-assets",
+                                    directory_flags,
+                                    dir_fd=tmp_fd,
+                                )
+                                try:
+                                    remove_owned_tree(
+                                        old_output,
+                                        reject_links=True,
+                                        parent_directory_fd=runtime_assets_fd,
+                                    )
+                                finally:
+                                    os.close(runtime_assets_fd)
+                            finally:
+                                os.close(tmp_fd)
+                        staged_metadata = os.fstat(staging_fd)
+                        policy = {
+                            "mode": "temporary",
+                            "name": None,
+                            "path": str(destination),
+                            "owner": {
+                                "kind": "topology-generation",
+                                "topology": topology_name,
+                                "generation": generation,
+                            },
+                            "lifecycle": "disposable",
+                            "created_at": previous_policy["created_at"],
+                            "identity": {
+                                "device": staged_metadata.st_dev,
+                                "inode": staged_metadata.st_ino,
+                            },
+                            "implementation": implementation,
+                            "profile": profile_name,
+                            "server": server_coordinate,
+                        }
+                        durable_replace_json_at(
+                            staging_fd,
+                            MANAGED_MARKER,
+                            {
+                                "schema_version": SCHEMA_VERSION,
+                                "purpose": "temporary-topology-state",
+                                "topology": topology_name,
+                                "generation": generation,
+                            },
+                        )
+                        durable_replace_json_at(
+                            staging_fd,
+                            TEMPORARY_STATE_METADATA,
+                            {
+                                "schema_version": TEMPORARY_STATE_SCHEMA_VERSION,
+                                "state_policy": policy,
+                            },
+                        )
+                        self._validate_temporary_state_integrity(
+                            staging_fd,
+                            destination,
+                            implementation,
+                            container_fd,
+                            staging_name,
+                        )
+                        creation_record = self._load_state_json_at(
+                            staging_fd,
+                            TEMPORARY_STATE_METADATA,
+                            "temporary state creation record",
+                        )
+                        if not self._temporary_state_metadata_matches(
+                            policy,
+                            creation_record.get("state_policy")
+                            if isinstance(creation_record, dict)
+                            else None,
+                        ):
+                            raise WorkspaceError(
+                                "temporary topology state clone metadata is invalid"
+                            )
+                        rename_no_replace_at(
+                            container_fd, staging_name, container_fd, generation
+                        )
+                        published = True
+                        visible = os.stat(
+                            generation,
+                            dir_fd=container_fd,
+                            follow_symlinks=False,
+                        )
+                        if (visible.st_dev, visible.st_ino) != (
+                            policy["identity"]["device"],
+                            policy["identity"]["inode"],
+                        ):
+                            raise WorkspaceError(
+                                f"temporary topology state identity changed during clone: {destination}"
+                            )
+                        return destination, policy
+                    except BaseException:
+                        if published:
+                            remove_owned_tree(
+                                destination,
+                                expected_identity=policy["identity"],
+                                parent_directory_fd=container_fd,
+                            )
+                        elif staging is not None and staging.exists():
+                            remove_owned_tree(
+                                staging,
+                                parent_directory_fd=container_fd,
+                            )
+                        raise
+                    finally:
+                        if staging_fd is not None:
+                            os.close(staging_fd)
+                        os.close(container_fd)
+                finally:
+                    os.close(previous_fd)
+        except (KeyError, TypeError) as error:
+            raise WorkspaceError(
+                f"temporary topology state metadata is invalid: {previous_state}"
+            ) from error
+
+    def _remove_superseded_temporary_state(
+        self, policy: dict[str, Any]
+    ) -> None:
+        """Remove the stopped generation left behind by a development restart."""
+
+        state = Path(policy["path"])
+        with exclusive_lock(
+            Path(f"{state}.lock"),
+            f"superseded temporary topology state {state}",
+            nonblocking=True,
+        ) as state_lease:
+            self._rollback_temporary_state_creation(
+                state,
+                state_lease,
+                policy["identity"],
+                policy["lease_identity"],
+                implementation=policy["implementation"],
+            )
 
     def _create_temporary_state(
         self,
@@ -17755,6 +18452,8 @@ class Workspace:
         services: list[str] | None = None,
         port: int | None = None,
         state_mode: str | None = None,
+        *,
+        build_services: set[str] | None = None,
     ) -> dict[str, Any]:
         self.paths.ensure()
         selected_services = self._topology_services(services)
@@ -17777,7 +18476,11 @@ class Workspace:
                 )
         with self._resolved_profile_operation(
             profile_name,
-            set(selected_services),
+            (
+                set(TOPOLOGY_SERVICES)
+                if build_services is not None
+                else set(selected_services)
+            ),
             f"prepare topology {name}",
         ):
             requests = [
@@ -17804,6 +18507,7 @@ class Workspace:
                     services,
                     port,
                     normalized_mode,
+                    build_services=build_services,
                 )
 
     def _topology_resolved_status(
@@ -17838,6 +18542,10 @@ class Workspace:
         services: list[str] | None = None,
         port: int | None = None,
         state_mode: str | None = None,
+        *,
+        build_services: set[str] | None = None,
+        restart_status: dict[str, Any] | None = None,
+        operation_lock_held: bool = False,
     ) -> dict[str, Any]:
         selected_services = self._topology_services(services)
         state_mode, state_name = self._normalize_topology_state_request(
@@ -17847,15 +18555,27 @@ class Workspace:
             client_launch_label(profile_name, name)
         if "server" not in selected_services and port is not None:
             raise WorkspaceError("--port requires the server service")
-        self._require_classic_contracts(profile_name, set(selected_services))
+        self._require_classic_contracts(
+            profile_name,
+            set(TOPOLOGY_SERVICES)
+            if build_services is not None
+            else set(selected_services),
+        )
         topology_root = self._topology_directory(name, create=True)
         operation_lock = topology_root / "operation.lock"
-        with exclusive_lock(
-            operation_lock, f"topology {name} operation", nonblocking=True
-        ):
+        operation_context = (
+            nullcontext()
+            if operation_lock_held
+            else exclusive_lock(
+                operation_lock, f"topology {name} operation", nonblocking=True
+            )
+        )
+        with operation_context:
             process_tree_path = topology_root / TOPOLOGY_PROCESS_TREE_LEASE
             status_path = topology_root / "status.json"
             startup_error_path = topology_root / "startup-error.json"
+            restarting = restart_status is not None
+            previous: dict[str, Any] | None = None
             self._recover_runtime_state_output_transaction(
                 topology_root, name
             )
@@ -17863,6 +18583,13 @@ class Workspace:
                 if status_path.is_symlink():
                     raise WorkspaceError(f"topology status is invalid: {name}")
                 previous = self.topology_status(name)
+                if restarting and (
+                    not isinstance(restart_status, dict)
+                    or previous.get("control") != restart_status.get("control")
+                ):
+                    raise WorkspaceError(
+                        f"topology {name} changed before development restart; retry"
+                    )
                 if previous.get("inert_historical_record"):
                     raise WorkspaceError(
                         f"topology {name} is an inert pre-migration record; "
@@ -17873,7 +18600,7 @@ class Workspace:
                 ):
                     raise WorkspaceError(f"topology is already running: {name}")
                 previous_policy = previous.get("state_policy")
-                if (
+                if not restarting and (
                     isinstance(previous_policy, dict)
                     and previous_policy.get("mode") == "temporary"
                     and previous_policy.get("lifecycle")
@@ -17905,19 +18632,42 @@ class Workspace:
                         previous = self._cleanup_topology_mutable_state_outputs(
                             previous
                         )
+            elif restarting:
+                raise WorkspaceError(
+                    f"topology {name} has no stopped status to restart"
+                )
+
+            restart_status_backup = (
+                copy.deepcopy(previous)
+                if restarting and isinstance(previous, dict)
+                else None
+            )
+            restart_port_backup = (
+                copy.deepcopy(previous.get("port_reservation"))
+                if isinstance(previous, dict)
+                and isinstance(previous.get("port_reservation"), dict)
+                else None
+            )
 
             if "client" in selected_services:
                 self._require_client_display()
 
-            selected = self._resolve_build_profile(
-                profile_name, set(selected_services)
+            build_required = (
+                set(TOPOLOGY_SERVICES)
+                if build_services is not None
+                else set(selected_services)
             )
+            selected = self._resolve_build_profile(profile_name, build_required)
             required = set(selected)
-            targets = [
-                service
-                for service in ("client", "server")
-                if service in selected_services
-            ]
+            targets = (
+                [target for target in ALL_BUILD_TARGETS if target in selected]
+                if build_services is not None
+                else [
+                    service
+                    for service in ("client", "server")
+                    if service in selected_services
+                ]
+            )
             profile = self._load_profile(profile_name, require_file=False)
             selected_stack = self.manifest.stack(profile["stack"])
             providers = {
@@ -17926,6 +18676,25 @@ class Workspace:
             }
 
             with ExitStack() as stack:
+                restore_restart_status = [restart_status_backup is not None]
+
+                def restore_stopped_restart_record() -> None:
+                    if not restore_restart_status.pop():
+                        return
+                    if (
+                        status_path.exists()
+                        or status_path.is_symlink()
+                        or restart_status_backup is None
+                    ):
+                        return
+                    atomic_json(status_path, restart_status_backup)
+                    if restart_port_backup is not None:
+                        atomic_json(
+                            topology_root / TOPOLOGY_PORT_RESERVATION_RECORD,
+                            restart_port_backup,
+                        )
+
+                stack.callback(restore_stopped_restart_record)
                 process_tree_fd = open_regular_file(
                     process_tree_path,
                     os.O_RDWR | os.O_CREAT,
@@ -18009,7 +18778,12 @@ class Workspace:
                         state_expected_identity = self._state_identity(state_location)
 
                 root = self._build_resolved(
-                    "topology", profile_name, False, targets, selected
+                    "topology",
+                    profile_name,
+                    False,
+                    targets,
+                    selected,
+                    build_services=build_services,
                 )
                 resolved_status = self._topology_resolved_status(
                     profile_name, selected
@@ -18024,6 +18798,7 @@ class Workspace:
                 state: Path | None = None
                 state_policy: dict[str, Any] | None = None
                 state_directory_fd: int | None = None
+                superseded_temporary_policy: dict[str, Any] | None = None
                 temporary_state_owner: list[
                     tuple[
                         Path,
@@ -18038,15 +18813,38 @@ class Workspace:
                     assert implementation is not None
                     if state_mode == "temporary":
                         server_provider = providers["server"]
-                        state, state_policy = self._create_temporary_state(
-                            topology_root,
-                            name,
-                            profile_name,
-                            generation,
-                            selected["server"],
-                            implementation,
-                            resolved_status[server_provider],
-                        )
+                        if restarting:
+                            if not isinstance(previous, dict):
+                                raise WorkspaceError(
+                                    f"topology {name} has no restart state record"
+                                )
+                            previous_policy = previous.get("state_policy")
+                            if not isinstance(previous_policy, dict):
+                                raise WorkspaceError(
+                                    f"topology {name} temporary state policy is invalid"
+                                )
+                            superseded_temporary_policy = copy.deepcopy(
+                                previous_policy
+                            )
+                            state, state_policy = self._clone_temporary_state(
+                                topology_root,
+                                name,
+                                profile_name,
+                                generation,
+                                previous_policy,
+                                implementation,
+                                resolved_status[server_provider],
+                            )
+                        else:
+                            state, state_policy = self._create_temporary_state(
+                                topology_root,
+                                name,
+                                profile_name,
+                                generation,
+                                selected["server"],
+                                implementation,
+                                resolved_status[server_provider],
+                            )
                         state_location = state
                         try:
                             state_lock = stack.enter_context(
@@ -18543,7 +19341,20 @@ class Workspace:
                                 f"topology supervisor failed: {status['error']}"
                             )
                         if status["supervisor"]["running"] and status["ready"]:
+                            restore_restart_status[0] = False
                             process.wait(timeout=2)
+                            if superseded_temporary_policy is not None:
+                                try:
+                                    self._remove_superseded_temporary_state(
+                                        superseded_temporary_policy
+                                    )
+                                except (OSError, WorkspaceError) as error:
+                                    print(
+                                        "warning: development restart left the "
+                                        "previous temporary state for safe cleanup: "
+                                        f"{error}",
+                                        file=sys.stderr,
+                                    )
                             return status
                         if not status["supervisor"]["running"]:
                             raise WorkspaceError(

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -151,6 +151,13 @@ ALL_BUILD_TARGETS = (
     "server",
     "metaserver-worker",
 )
+PLAYABLE_BUILD_TARGETS = (
+    "content",
+    "protocol",
+    "libatrinik",
+    "client",
+    "server",
+)
 SOURCE_VIEW_METADATA = ".atrinik-source-view.json"
 SOURCE_VIEW_SCHEMA_VERSION = 2
 SOURCE_INCLUDE_VIEW_METADATA = ".atrinik-source-includes.json"
@@ -7710,7 +7717,9 @@ class Workspace:
             materialize_clean_primaries=True,
         ) as snapshot:
             targets = [
-                target for target in ALL_BUILD_TARGETS if target in snapshot.paths()
+                target
+                for target in PLAYABLE_BUILD_TARGETS
+                if target in snapshot.paths()
             ]
             root = self._build_resolved(
                 "topology",
@@ -18660,7 +18669,7 @@ class Workspace:
             selected = self._resolve_build_profile(profile_name, build_required)
             required = set(selected)
             targets = (
-                [target for target in ALL_BUILD_TARGETS if target in selected]
+                [target for target in PLAYABLE_BUILD_TARGETS if target in selected]
                 if build_services is not None
                 else [
                     service

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -152,6 +152,42 @@ workspace/
   cleanup-journals/                  cleanup recovery/delivery receipts
 ~~~
 
+## Incremental Classic development contract
+
+The playable development workflow has one build-coordinate rule and one
+runtime-coordinate rule. `dev build` and `dev up` resolve the full
+client/server dependency closure, including shared protocol, library, content,
+resource, and sound inputs, and derive one topology build key from that
+closure. This makes a `dev build --services server` or `--services client`
+operation a valid warm-up for the paired topology without aliasing the
+standalone `build client` or `build server` CMake trees. The full source
+closure remains under shared profile/source leases even when only one service
+target is compiled.
+
+The selected service set controls both the supervised service manifest and the
+CMake target list. Shared inputs are reconciled and their cache decisions are
+reported; only the selected Classic executable (and the server's required
+plugins) is built when one service is selected. `--test` is explicit and
+materializes the configured CMake graph before running its unfiltered CTest
+suite, while the metaserver worker remains outside this playable scope. The ordinary
+`build all --profile classic --test` command remains the opt-in full
+validation path.
+
+`dev restart NAME --service SERVICE` first verifies the current control
+generation, takes the topology and full paired source coordinates, and performs
+a confirmed controlled stop. It then rebuilds the selected CMake target,
+copies a stopped disposable state into the new generation when necessary, and
+publishes a complete immutable runtime snapshot. The new snapshot retains the
+same loopback port and persistent state coordinate; the old temporary state is
+removed only after the replacement supervisor is ready. A complete snapshot
+keeps the existing generation/status/runtime validation contract intact while
+allowing the compile operation to remain service-scoped.
+
+Paired local launch explicitly disables metaserver, STUN, and port mapping and
+uses the reserved `127.0.0.1` endpoint. Runtime staging is therefore deferred
+until `dev up` or `dev restart`; a development build reports cache/source-view
+decisions but does not publish a topology generation.
+
 Selected sound repositories may also contain producer-owned
 `build/atrinik-workspace/<20-hex-key>/` playtest trees. They remain outside the
 wrapper build root but are inventoried only by the explicit preview-first

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import unittest
 from unittest import mock
 
-from atrinik_workspace.cli import _human_bytes, main, parser
+from atrinik_workspace.cli import _human_bytes, _parse_services, main, parser
 from atrinik_workspace.model import WorkspaceError
 
 
@@ -564,6 +564,105 @@ class ParserTests(unittest.TestCase):
             True,
             force_reconfigure=True,
             use_ccache=False,
+        )
+
+    def test_dev_services_parse_in_stable_topology_order(self) -> None:
+        self.assertEqual(_parse_services("client, server"), ["server", "client"])
+        self.assertEqual(_parse_services("both"), ["server", "client"])
+        with self.assertRaisesRegex(WorkspaceError, "duplicates"):
+            _parse_services("server,server")
+        with self.assertRaisesRegex(WorkspaceError, "only server and client"):
+            _parse_services("worker")
+
+    def test_dev_build_dispatches_selective_incremental_controls(self) -> None:
+        summary = {
+            "schema_version": 1,
+            "profile": "classic",
+            "services": ["server"],
+            "tests": True,
+            "build_root": "/workspace/build/classic",
+            "cache": {
+                "build_root": "reused",
+                "inputs": {"content": "reused"},
+                "cmake": {},
+                "source_views": "reused",
+            },
+            "runtime": {"staging": "deferred until dev up"},
+        }
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.dev_build.return_value = summary
+            with mock.patch("builtins.print") as output:
+                result = main(
+                    [
+                        "dev",
+                        "build",
+                        "--profile",
+                        "classic",
+                        "--services",
+                        "server",
+                        "--test",
+                        "--force-reconfigure",
+                        "--no-ccache",
+                        "--json",
+                    ]
+                )
+
+        self.assertEqual(result, 0)
+        workspace_type.return_value.dev_build.assert_called_once_with(
+            "classic",
+            ["server"],
+            True,
+            force_reconfigure=True,
+            use_ccache=False,
+        )
+        self.assertEqual(json.loads(output.call_args.args[0]), summary)
+
+    def test_dev_up_and_restart_dispatch_exact_service_coordinates(self) -> None:
+        status = {
+            "name": "classic-local",
+            "endpoint": {"host": "127.0.0.1", "port": 17300},
+        }
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.dev_up.return_value = status
+            with mock.patch("builtins.print") as output:
+                result = main(
+                    [
+                        "dev",
+                        "up",
+                        "--name",
+                        "classic-local",
+                        "--services",
+                        "client,server",
+                        "--temporary-state",
+                        "--port",
+                        "17300",
+                    ]
+                )
+        self.assertEqual(result, 0)
+        workspace_type.return_value.dev_up.assert_called_once_with(
+            "classic-local",
+            "classic",
+            None,
+            ["server", "client"],
+            17300,
+            state_mode="temporary",
+        )
+        output.assert_called_once_with(
+            "topology classic-local: started at 127.0.0.1:17300"
+        )
+
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.dev_restart.return_value = status
+            with mock.patch("builtins.print") as output:
+                result = main(
+                    ["dev", "restart", "classic-local", "--service", "server"]
+                )
+        self.assertEqual(result, 0)
+        workspace_type.return_value.dev_restart.assert_called_once_with(
+            "classic-local", "server"
+        )
+        output.assert_called_once_with(
+            "topology classic-local: restarted server at 127.0.0.1:17300"
         )
 
     def test_windows_package_dispatches_profile_state_port_and_output(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -569,6 +569,8 @@ class ParserTests(unittest.TestCase):
     def test_dev_services_parse_in_stable_topology_order(self) -> None:
         self.assertEqual(_parse_services("client, server"), ["server", "client"])
         self.assertEqual(_parse_services("both"), ["server", "client"])
+        with self.assertRaisesRegex(WorkspaceError, "must name"):
+            _parse_services("server,")
         with self.assertRaisesRegex(WorkspaceError, "duplicates"):
             _parse_services("server,server")
         with self.assertRaisesRegex(WorkspaceError, "only server and client"):
@@ -588,6 +590,7 @@ class ParserTests(unittest.TestCase):
                 "source_views": "reused",
             },
             "runtime": {"staging": "deferred until dev up"},
+            "timing": {"elapsed_seconds": 0.0},
         }
         with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
             workspace_type.return_value.dev_build.return_value = summary
@@ -616,6 +619,32 @@ class ParserTests(unittest.TestCase):
             use_ccache=False,
         )
         self.assertEqual(json.loads(output.call_args.args[0]), summary)
+
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.dev_build.return_value = summary
+            with mock.patch("builtins.print") as output:
+                result = main(
+                    [
+                        "dev",
+                        "build",
+                        "--profile",
+                        "classic",
+                        "--services",
+                        "server",
+                    ]
+                )
+        self.assertEqual(result, 0)
+        self.assertEqual(
+            [call.args[0] for call in output.call_args_list],
+            [
+                "dev-build\t/workspace/build/classic",
+                "services\tserver",
+                "cache\treused",
+                "cache\tcontent\treused",
+                "runtime\tdeferred until dev up",
+                "elapsed\t0.000s",
+            ],
+        )
 
     def test_dev_up_and_restart_dispatch_exact_service_coordinates(self) -> None:
         status = {
@@ -664,6 +693,37 @@ class ParserTests(unittest.TestCase):
         output.assert_called_once_with(
             "topology classic-local: restarted server at 127.0.0.1:17300"
         )
+
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.dev_up.return_value = status
+            with mock.patch("builtins.print") as output:
+                result = main(
+                    [
+                        "dev",
+                        "up",
+                        "--name",
+                        "classic-local",
+                        "--json",
+                    ]
+                )
+        self.assertEqual(result, 0)
+        self.assertEqual(json.loads(output.call_args.args[0]), status)
+
+        with mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            workspace_type.return_value.dev_restart.return_value = status
+            with mock.patch("builtins.print") as output:
+                result = main(
+                    [
+                        "dev",
+                        "restart",
+                        "classic-local",
+                        "--service",
+                        "client",
+                        "--json",
+                    ]
+                )
+        self.assertEqual(result, 0)
+        self.assertEqual(json.loads(output.call_args.args[0]), status)
 
     def test_windows_package_dispatches_profile_state_port_and_output(self) -> None:
         summary = {

--- a/tests/test_cohorts.py
+++ b/tests/test_cohorts.py
@@ -524,6 +524,88 @@ class CohortWorkspaceTests(unittest.TestCase):
         )
         self.assertGreater(clean.call_count, 0)
 
+    def test_dev_build_uses_full_paired_closure_and_selected_service_target(self) -> None:
+        self.make_classic_build_profile(include_worker=False)
+        profile = self.workspace._load_profile("classic", require_file=False)
+        expected_roles = self.workspace._dependency_roles(
+            profile, {"client", "server"}
+        )
+        observed: dict[str, object] = {}
+
+        def build_resolved(
+            target: str,
+            profile_name: str,
+            tests: bool,
+            targets: list[str],
+            selected: dict[str, Path],
+            *,
+            force_reconfigure: bool = False,
+            use_ccache: bool = True,
+            build_services: set[str] | None = None,
+        ) -> Path:
+            observed.update(
+                {
+                    "target": target,
+                    "profile": profile_name,
+                    "tests": tests,
+                    "targets": set(targets),
+                    "selected": set(selected),
+                    "force_reconfigure": force_reconfigure,
+                    "use_ccache": use_ccache,
+                    "build_services": build_services,
+                }
+            )
+            return self.wrapper / "classic-build-root"
+
+        with (
+            mock.patch.object(
+                self.workspace, "_validate_selected_checkout", return_value="origin"
+            ),
+            mock.patch.object(
+                self.workspace, "_build_resolved", side_effect=build_resolved
+            ),
+            mock.patch(
+                "atrinik_workspace.workspace.git", return_value="a" * 40
+            ),
+            mock.patch("atrinik_workspace.workspace._is_clean", return_value=True),
+            mock.patch.object(
+                self.workspace,
+                "_git_common_directory",
+                return_value=self.wrapper / "classic",
+            ),
+            mock.patch.object(
+                self.workspace,
+                "_materialize_clean_primary_sources",
+                side_effect=lambda _profile, selected, _states: (
+                    selected,
+                    set(),
+                    {},
+                ),
+            ),
+        ):
+            result = self.workspace.dev_build(
+                "classic",
+                ["server"],
+                tests=True,
+                force_reconfigure=True,
+                use_ccache=False,
+            )
+
+        self.assertEqual(result["services"], ["server"])
+        self.assertTrue(result["tests"])
+        self.assertEqual(result["build_root"], str(self.wrapper / "classic-build-root"))
+        self.assertEqual(observed["target"], "topology")
+        self.assertEqual(observed["profile"], "classic")
+        self.assertTrue(observed["tests"])
+        self.assertEqual(
+            observed["targets"],
+            {"content", "protocol", "libatrinik", "client", "server"},
+        )
+        self.assertEqual(observed["selected"], expected_roles)
+        self.assertEqual(observed["build_services"], {"server"})
+        self.assertTrue(observed["force_reconfigure"])
+        self.assertFalse(observed["use_ccache"])
+
     def test_complete_default_selection_uses_requested_service_closure(self) -> None:
         profile = self.workspace._load_profile("default", require_file=False)
         stack = self.workspace.manifest.stack("default")

--- a/tests/test_cohorts.py
+++ b/tests/test_cohorts.py
@@ -601,6 +601,7 @@ class CohortWorkspaceTests(unittest.TestCase):
             observed["targets"],
             {"content", "protocol", "libatrinik", "client", "server"},
         )
+        self.assertNotIn("metaserver-worker", observed["targets"])
         self.assertEqual(observed["selected"], expected_roles)
         self.assertEqual(observed["build_services"], {"server"})
         self.assertTrue(observed["force_reconfigure"])

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -130,6 +130,11 @@ class CompletionTests(unittest.TestCase):
         self.assertEqual(profile_names, ["review"])
         _, profile_values = self.candidates("profile", "set", "review", "")
         self.assertIn("libatrinik", profile_values)
+        _, dev_services = self.candidates("dev", "build", "--services", "")
+        self.assertEqual(
+            dev_services,
+            sorted(["server", "client", "server,client", "client,server", "both"]),
+        )
         mode, values = self.candidates("logs", "default", "server", "--f")
         self.assertEqual(mode, "candidates")
         self.assertEqual(values, ["--follow"])

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -6288,6 +6288,116 @@ class WorkspaceTests(unittest.TestCase):
         build_client.assert_called_once()
         build_server.assert_called_once()
 
+    def test_selective_classic_build_targets_only_requested_service(self) -> None:
+        selected = {
+            role: self.workspace.paths.repositories / role
+            for role in ("client", "server", "protocol", "libatrinik")
+        }
+        with (
+            mock.patch.object(
+                self.workspace, "_profile_build_key", return_value="selective"
+            ),
+            mock.patch.object(self.workspace, "_refresh_build_metadata"),
+            mock.patch.object(self.workspace, "_collect_content"),
+            mock.patch.object(self.workspace, "_stage_resources"),
+            mock.patch.object(self.workspace, "_build_protocol"),
+            mock.patch.object(self.workspace, "_build_library"),
+            mock.patch.object(self.workspace, "_build_client") as build_client,
+            mock.patch.object(self.workspace, "_build_server") as build_server,
+            mock.patch.object(self.workspace, "_generate_region_maps"),
+            mock.patch.object(
+                self.workspace, "_uses_integrated_classic_build", return_value=False
+            ),
+        ):
+            self.workspace._build_resolved(
+                "topology",
+                "default",
+                False,
+                ["client", "server"],
+                selected,
+                build_services={"server"},
+            )
+
+        build_client.assert_not_called()
+        build_server.assert_called_once()
+        self.assertEqual(
+            build_server.call_args.kwargs["build_targets"],
+            ["atrinik-server", "plugin_arena", "plugin_python"],
+        )
+
+    def test_dev_restart_preserves_topology_coordinates_and_selects_one_service(self) -> None:
+        initial = {
+            "profile": "classic",
+            "services": {"server": {}, "client": {}},
+            "control": {"generation": "a" * 64},
+            "supervisor": {"running": True},
+            "state_policy": {
+                "mode": "temporary",
+                "name": None,
+                "lifecycle": "disposable",
+            },
+            "endpoint": {"host": "127.0.0.1", "port": 17300},
+        }
+        stopped = {
+            **initial,
+            "supervisor": {"running": False},
+            "services": {"server": {}, "client": {}},
+        }
+        result = {"name": "classic-local", "ready": True}
+        topology_root = self.root / "topologies" / "classic-local"
+
+        with (
+            mock.patch.object(
+                self.workspace,
+                "topology_status",
+                side_effect=[initial, initial],
+            ),
+            mock.patch.object(
+                self.workspace,
+                "_resolved_profile_operation",
+                return_value=nullcontext(),
+            ) as resolved,
+            mock.patch.object(
+                self.workspace, "_resource_locks", return_value=nullcontext()
+            ),
+            mock.patch.object(
+                self.workspace, "_topology_directory", return_value=topology_root
+            ),
+            mock.patch(
+                "atrinik_workspace.workspace.exclusive_lock",
+                return_value=nullcontext(),
+            ),
+            mock.patch.object(
+                self.workspace,
+                "_controlled_topology_down",
+                return_value=(stopped, True),
+            ) as controlled_down,
+            mock.patch.object(
+                self.workspace, "_topology_up", return_value=result
+            ) as topology_up,
+        ):
+            actual = self.workspace.dev_restart("classic-local", "server")
+
+        self.assertEqual(actual, result)
+        controlled_down.assert_called_once_with("classic-local", initial, 15)
+        topology_up.assert_called_once_with(
+            "classic-local",
+            "classic",
+            None,
+            ["server", "client"],
+            17300,
+            "temporary",
+            build_services={"server"},
+            restart_status=stopped,
+            operation_lock_held=True,
+        )
+        resolved.assert_called_once_with(
+            "classic",
+            {"server", "client"},
+            "dev restart classic-local server",
+            materialize_clean_primaries=True,
+        )
+
     def test_classic_binary_directory_tracks_last_successful_graph(self) -> None:
         root = self.workspace.paths.builds / "profiles" / "classic-test"
         (root / "build").mkdir(parents=True)
@@ -8165,6 +8275,100 @@ class WorkspaceTests(unittest.TestCase):
             ]))
 
         self.assertTrue((binary / CONFIGURE_METADATA).is_file())
+
+    def test_cmake_selective_build_passes_only_requested_target(self) -> None:
+        source = self.root / "classic-source"
+        source.mkdir()
+        binary = self.workspace.paths.builds / "profiles" / "test" / "build" / "classic"
+        binary.mkdir(parents=True)
+        fingerprint = {
+            "build_tree_identity": {"toolchain_file": None},
+            "source": {"configure_skip_safe": True},
+        }
+        atomic_json(binary / CONFIGURE_METADATA, fingerprint)
+
+        with (
+            mock.patch.object(self.workspace, "_prepare_cmake_binary"),
+            mock.patch("atrinik_workspace.workspace.shutil.which", return_value=None),
+            mock.patch.object(
+                self.workspace,
+                "_add_debug_prefix_environment",
+                return_value={"cc": True, "cxx": True},
+            ),
+            mock.patch.object(
+                self.workspace, "_configure_fingerprint", return_value=fingerprint
+            ),
+            mock.patch.object(
+                self.workspace, "_cmake_state_valid", return_value=True
+            ),
+            mock.patch("atrinik_workspace.workspace.run") as run,
+        ):
+            self.workspace._cmake(
+                source,
+                binary,
+                [],
+                tests=False,
+                build_targets=["atrinik-server"],
+            )
+
+        self.assertEqual(
+            [call.args[0] for call in run.call_args_list],
+            [[
+                "cmake",
+                "--build",
+                str(binary),
+                "--parallel",
+                "--target",
+                "atrinik-server",
+            ]],
+        )
+
+    def test_cmake_validation_builds_configured_graph_before_ctest(self) -> None:
+        source = self.root / "classic-source"
+        source.mkdir()
+        binary = self.workspace.paths.builds / "profiles" / "test" / "build" / "classic"
+        binary.mkdir(parents=True)
+        fingerprint = {
+            "build_tree_identity": {"toolchain_file": None},
+            "source": {"configure_skip_safe": True},
+        }
+        atomic_json(binary / CONFIGURE_METADATA, fingerprint)
+
+        with (
+            mock.patch.object(self.workspace, "_prepare_cmake_binary"),
+            mock.patch("atrinik_workspace.workspace.shutil.which", return_value=None),
+            mock.patch.object(
+                self.workspace,
+                "_add_debug_prefix_environment",
+                return_value={"cc": True, "cxx": True},
+            ),
+            mock.patch.object(
+                self.workspace, "_configure_fingerprint", return_value=fingerprint
+            ),
+            mock.patch.object(
+                self.workspace, "_cmake_state_valid", return_value=True
+            ),
+            mock.patch("atrinik_workspace.workspace.run") as run,
+        ):
+            self.workspace._cmake(
+                source,
+                binary,
+                [],
+                tests=True,
+                build_targets=["atrinik-server"],
+            )
+
+        self.assertEqual(
+            [call.args[0] for call in run.call_args_list],
+            [
+                ["cmake", "--build", str(binary), "--parallel"],
+                ["ctest", "--test-dir", str(binary), "--output-on-failure"],
+            ],
+        )
+        self.assertEqual(
+            self.workspace._build_summary["cache"]["cmake"][str(binary)]["build"],
+            "all",
+        )
 
     def test_cmake_fingerprint_invalidates_for_tests_environment_and_toolchain(self) -> None:
         source = self.workspace.paths.repositories / "content"
@@ -19189,6 +19393,78 @@ class WorkspaceTests(unittest.TestCase):
         container = topology / "temporary-states"
         self.assertEqual(
             {path.name for path in container.iterdir()}, {MANAGED_MARKER}
+        )
+
+    def test_temporary_state_clone_rekeys_generation_and_preserves_user_data(self) -> None:
+        topology = self.workspace._topology_directory(
+            "clone", create=True
+        )
+        server = self.workspace.paths.repositories / "server"
+        implementation = {
+            "stack": "default",
+            "provider": "server",
+            "repository": "atrinik/server",
+        }
+        old_generation = "a" * 64
+        new_generation = "b" * 64
+        old_state, old_policy = self.workspace._create_temporary_state(
+            topology,
+            "clone",
+            "default",
+            old_generation,
+            server,
+            implementation,
+            self.scenario_resolved_fixture()["server"],
+        )
+        (old_state / "player-progress").write_text(
+            "preserve\n", encoding="utf-8"
+        )
+        old_runtime_output = old_state / "tmp" / "runtime-assets" / old_generation
+        old_runtime_output.mkdir(parents=True)
+        (old_runtime_output / "generated").write_text(
+            "discard\n", encoding="utf-8"
+        )
+        old_lock = Path(f"{old_state}.lock")
+        with exclusive_lock(old_lock, "clone source state") as lease:
+            lease_metadata = os.fstat(lease.fileno())
+        old_policy = {
+            **old_policy,
+            "lease_identity": {
+                "device": lease_metadata.st_dev,
+                "inode": lease_metadata.st_ino,
+            },
+        }
+        cloned, policy = self.workspace._clone_temporary_state(
+            topology,
+            "clone",
+            "default",
+            new_generation,
+            old_policy,
+            implementation,
+            self.scenario_resolved_fixture()["server"],
+        )
+
+        self.assertEqual(cloned.name, new_generation)
+        self.assertEqual(
+            policy["owner"],
+            {
+                "kind": "topology-generation",
+                "topology": "clone",
+                "generation": new_generation,
+            },
+        )
+        self.assertEqual(
+            (cloned / "player-progress").read_text(encoding="utf-8"),
+            "preserve\n",
+        )
+        self.assertFalse((cloned / "tmp" / "runtime-assets" / old_generation).exists())
+        self.assertTrue(old_state.is_dir())
+        self.assertTrue(old_runtime_output.is_dir())
+        self.assertEqual(
+            load_json(cloned / workspace_module.TEMPORARY_STATE_METADATA)[
+                "state_policy"
+            ],
+            policy,
         )
 
     def test_temporary_state_publication_rejects_container_replacement(self) -> None:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -6261,6 +6261,40 @@ class WorkspaceTests(unittest.TestCase):
             root / "build" / "integrated" / "server",
         )
 
+        with mock.patch.object(self.workspace, "_cmake") as selective_cmake:
+            self.workspace._build_integrated_classic(
+                root, selected, tests=False, build_services={"server"}
+            )
+            selective_cmake.assert_called_once_with(
+                root / "sources" / "integrated",
+                root / "build" / "integrated",
+                [
+                    "-DENABLE_WARNING_ERRORS=ON",
+                    "-DPACKAGE_TYPE=none",
+                    "-DENABLE_PYTHON_PLUGIN=ON",
+                ],
+                False,
+                build_targets=[
+                    "atrinik-server", "plugin_arena", "plugin_python"
+                ],
+            )
+
+            selective_cmake.reset_mock()
+            self.workspace._build_integrated_classic(
+                root, selected, tests=False, build_services={"client"}
+            )
+            selective_cmake.assert_called_once_with(
+                root / "sources" / "integrated",
+                root / "build" / "integrated",
+                [
+                    "-DENABLE_WARNING_ERRORS=ON",
+                    "-DPACKAGE_TYPE=none",
+                    "-DENABLE_PYTHON_PLUGIN=ON",
+                ],
+                False,
+                build_targets=["atrinik"],
+            )
+
     def test_paired_classic_build_falls_back_without_shared_role_builds(self) -> None:
         selected = {
             role: self.workspace.paths.repositories / role
@@ -6325,6 +6359,96 @@ class WorkspaceTests(unittest.TestCase):
             ["atrinik-server", "plugin_arena", "plugin_python"],
         )
 
+    def test_selective_integrated_build_forwards_service_targets(self) -> None:
+        selected = {
+            role: self.workspace.paths.repositories / role
+            for role in ("client", "server", "protocol", "libatrinik", "sound")
+        }
+        with (
+            mock.patch.object(
+                self.workspace, "_profile_build_key", return_value="integrated"
+            ),
+            mock.patch.object(self.workspace, "_refresh_build_metadata"),
+            mock.patch.object(
+                self.workspace,
+                "_prepare_sound",
+                return_value=(selected["sound"], None),
+            ),
+            mock.patch.object(self.workspace, "_collect_content"),
+            mock.patch.object(self.workspace, "_stage_resources"),
+            mock.patch.object(self.workspace, "_generate_region_maps"),
+            mock.patch.object(
+                self.workspace, "_uses_integrated_classic_build", return_value=True
+            ),
+            mock.patch.object(
+                self.workspace, "_build_integrated_classic"
+            ) as build_integrated,
+        ):
+            self.workspace._build_resolved(
+                "topology",
+                "default",
+                False,
+                ["client", "server"],
+                selected,
+                build_services={"server"},
+            )
+
+        build_integrated.assert_called_once_with(
+            mock.ANY,
+            selected,
+            False,
+            sound_root=mock.ANY,
+            build_services={"server"},
+        )
+
+    def test_selective_component_builds_forward_targeted_cmake_arguments(self) -> None:
+        root = self.workspace.paths.builds / "profiles" / "component-targets"
+        root.mkdir(parents=True)
+        selected = {
+            "client": self.workspace.paths.repositories / "client",
+            "server": self.workspace.paths.repositories / "server",
+            "protocol": self.workspace.paths.repositories / "protocol",
+            "libatrinik": self.workspace.paths.repositories / "libatrinik",
+            "sound": self.workspace.paths.repositories / "sound",
+        }
+        with (
+            mock.patch.object(self.workspace, "_profile_source_view", return_value=root),
+            mock.patch.object(self.workspace, "_prepare_component_source_includes"),
+            mock.patch.object(self.workspace, "_source_view_link"),
+            mock.patch.object(
+                self.workspace,
+                "_mutable_cmake_source_view",
+                side_effect=[
+                    root / "protocol",
+                    root / "library",
+                    root / "protocol",
+                    root / "library",
+                ],
+            ),
+            mock.patch.object(self.workspace, "_cmake") as cmake,
+        ):
+            self.workspace._build_client(
+                root,
+                selected,
+                False,
+                component=self.workspace.manifest.by_name["client"],
+                build_target="atrinik",
+            )
+            self.workspace._build_server(
+                root,
+                selected,
+                False,
+                component=self.workspace.manifest.by_name["server"],
+                build_targets=["atrinik-server", "plugin_arena", "plugin_python"],
+            )
+
+        self.assertEqual(cmake.call_count, 2)
+        self.assertEqual(cmake.call_args_list[0].kwargs["build_targets"], ["atrinik"])
+        self.assertEqual(
+            cmake.call_args_list[1].kwargs["build_targets"],
+            ["atrinik-server", "plugin_arena", "plugin_python"],
+        )
+
     def test_dev_restart_preserves_topology_coordinates_and_selects_one_service(self) -> None:
         initial = {
             "profile": "classic",
@@ -6333,7 +6457,7 @@ class WorkspaceTests(unittest.TestCase):
             "supervisor": {"running": True},
             "state_policy": {
                 "mode": "temporary",
-                "name": None,
+                "name": "scenario-issue-519",
                 "lifecycle": "disposable",
             },
             "endpoint": {"host": "127.0.0.1", "port": 17300},
@@ -6383,7 +6507,7 @@ class WorkspaceTests(unittest.TestCase):
         topology_up.assert_called_once_with(
             "classic-local",
             "classic",
-            None,
+            "scenario-issue-519",
             ["server", "client"],
             17300,
             "temporary",
@@ -6397,6 +6521,171 @@ class WorkspaceTests(unittest.TestCase):
             "dev restart classic-local server",
             materialize_clean_primaries=True,
         )
+
+    def test_dev_up_delegates_to_warmable_topology_root(self) -> None:
+        result = {"name": "classic-local", "ready": True}
+        with mock.patch.object(
+            self.workspace, "topology_up", return_value=result
+        ) as topology_up:
+            actual = self.workspace.dev_up(
+                "classic-local",
+                "classic",
+                "default",
+                ["client"],
+                17300,
+                state_mode="default",
+            )
+
+        self.assertEqual(actual, result)
+        topology_up.assert_called_once_with(
+            "classic-local",
+            "classic",
+            "default",
+            ["client"],
+            17300,
+            state_mode="default",
+            build_services={"client"},
+        )
+
+    def test_dev_restart_rejects_invalid_topology_coordinates(self) -> None:
+        with self.assertRaisesRegex(WorkspaceError, "unknown topology service"):
+            self.workspace.dev_restart("classic-local", "worker")
+
+        with mock.patch.object(
+            self.workspace,
+            "topology_status",
+            return_value={"inert_historical_record": True},
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "inert historical"):
+                self.workspace.dev_restart("classic-local", "server")
+
+        missing_client = {
+            "services": {"server": {}},
+            "profile": "classic",
+            "control": {"generation": "a" * 64},
+            "supervisor": {"running": True},
+        }
+        with mock.patch.object(
+            self.workspace, "topology_status", return_value=missing_client
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "does not contain"):
+                self.workspace.dev_restart("classic-local", "client")
+
+        not_running = {
+            "services": {"server": {}, "client": {}},
+            "profile": "classic",
+            "control": {"generation": "a" * 64},
+            "supervisor": {"running": False},
+            "state_policy": {
+                "mode": "temporary",
+                "name": None,
+                "lifecycle": "disposable",
+            },
+        }
+        with mock.patch.object(
+            self.workspace, "topology_status", return_value=not_running
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "not a current"):
+                self.workspace.dev_restart("classic-local", "server")
+
+        invalid_state = {
+            **not_running,
+            "supervisor": {"running": True},
+            "state_policy": {
+                "mode": "unsupported",
+                "name": None,
+                "lifecycle": "disposable",
+            },
+        }
+        with mock.patch.object(
+            self.workspace, "topology_status", return_value=invalid_state
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "invalid state policy"):
+                self.workspace.dev_restart("classic-local", "server")
+
+        retained_state = {
+            **not_running,
+            "supervisor": {"running": True},
+            "state_policy": {
+                "mode": "temporary",
+                "name": None,
+                "lifecycle": "retained",
+            },
+        }
+        with mock.patch.object(
+            self.workspace, "topology_status", return_value=retained_state
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "not disposable"):
+                self.workspace.dev_restart("classic-local", "server")
+
+    def test_dev_restart_rechecks_control_and_requires_clean_stop(self) -> None:
+        initial = {
+            "profile": "classic",
+            "services": {"server": {}, "client": {}},
+            "control": {"generation": "a" * 64},
+            "supervisor": {"running": True},
+            "state_policy": {
+                "mode": "default",
+                "name": "default",
+                "lifecycle": "persistent",
+            },
+            "endpoint": {"host": "127.0.0.1", "port": 17300},
+        }
+        topology_root = self.root / "topologies" / "classic-local"
+        changed = {**initial, "control": {"generation": "b" * 64}}
+        with (
+            mock.patch.object(
+                self.workspace, "topology_status", side_effect=[initial, changed]
+            ),
+            mock.patch.object(
+                self.workspace,
+                "_resolved_profile_operation",
+                return_value=nullcontext(),
+            ),
+            mock.patch.object(
+                self.workspace, "_resource_locks", return_value=nullcontext()
+            ),
+            mock.patch.object(
+                self.workspace, "_topology_directory", return_value=topology_root
+            ),
+            mock.patch(
+                "atrinik_workspace.workspace.exclusive_lock",
+                return_value=nullcontext(),
+            ),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "changed before"):
+                self.workspace.dev_restart("classic-local", "server")
+
+        with (
+            mock.patch.object(
+                self.workspace, "topology_status", side_effect=[initial, initial]
+            ),
+            mock.patch.object(
+                self.workspace,
+                "_resolved_profile_operation",
+                return_value=nullcontext(),
+            ),
+            mock.patch.object(
+                self.workspace, "_resource_locks", return_value=nullcontext()
+            ),
+            mock.patch.object(
+                self.workspace, "_topology_directory", return_value=topology_root
+            ),
+            mock.patch(
+                "atrinik_workspace.workspace.exclusive_lock",
+                return_value=nullcontext(),
+            ),
+            mock.patch.object(
+                self.workspace,
+                "_controlled_topology_down",
+                return_value=(
+                    {**initial, "supervisor": {"running": False}},
+                    False,
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "confirmed clean stop"):
+                self.workspace.dev_restart("classic-local", "server")
 
     def test_classic_binary_directory_tracks_last_successful_graph(self) -> None:
         root = self.workspace.paths.builds / "profiles" / "classic-test"
@@ -19296,6 +19585,44 @@ class WorkspaceTests(unittest.TestCase):
         finally:
             os.close(directory_fd)
 
+    def test_descriptor_relative_json_replacement_fails_closed(self) -> None:
+        state = self.root / "descriptor-replacement"
+        state.mkdir()
+        directory_fd = os.open(state, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            with self.assertRaisesRegex(WorkspaceError, "descriptor-relative"):
+                workspace_module.durable_replace_json_at(
+                    directory_fd, "nested/value.json", {"invalid": True}
+                )
+
+            with (
+                mock.patch.object(
+                    workspace_module.os,
+                    "rename",
+                    side_effect=OSError("simulated replacement failure"),
+                ),
+                self.assertRaisesRegex(OSError, "replacement failure"),
+            ):
+                workspace_module.durable_replace_json_at(
+                    directory_fd, "metadata.json", {"value": 1}
+                )
+            self.assertEqual(list(state.iterdir()), [])
+
+            with (
+                mock.patch.object(
+                    workspace_module.os,
+                    "fdopen",
+                    side_effect=OSError("simulated open failure"),
+                ),
+                self.assertRaisesRegex(OSError, "open failure"),
+            ):
+                workspace_module.durable_replace_json_at(
+                    directory_fd, "metadata.json", {"value": 2}
+                )
+            self.assertEqual(list(state.iterdir()), [])
+        finally:
+            os.close(directory_fd)
+
     def test_physical_state_alias_conflict_reports_live_owner(self) -> None:
         first = self.root / "owner-alias"
         second = self.root / "contender-alias"
@@ -19465,6 +19792,102 @@ class WorkspaceTests(unittest.TestCase):
                 "state_policy"
             ],
             policy,
+        )
+
+    def test_temporary_state_clone_rejects_invalid_provenance_and_reuses_cleanup(self) -> None:
+        implementation = {
+            "stack": "default",
+            "provider": "server",
+            "repository": "atrinik/server",
+        }
+        coordinate = self.scenario_resolved_fixture()["server"]
+
+        invalid_root = self.workspace._topology_directory(
+            "clone-invalid", create=True
+        )
+        with self.assertRaisesRegex(WorkspaceError, "cannot be cloned"):
+            self.workspace._clone_temporary_state(
+                invalid_root,
+                "clone-invalid",
+                "default",
+                "b" * 64,
+                {"mode": "temporary"},
+                implementation,
+                coordinate,
+            )
+
+        def fixture(
+            name: str, old_generation: str
+        ) -> tuple[Path, Path, dict[str, object]]:
+            topology = self.workspace._topology_directory(name, create=True)
+            state, policy = self.workspace._create_temporary_state(
+                topology,
+                name,
+                "default",
+                old_generation,
+                self.workspace.paths.repositories / "server",
+                implementation,
+                coordinate,
+            )
+            with exclusive_lock(Path(f"{state}.lock"), "clone fixture") as lease:
+                metadata = os.fstat(lease.fileno())
+            return topology, state, {
+                **policy,
+                "lease_identity": {
+                    "device": metadata.st_dev,
+                    "inode": metadata.st_ino,
+                },
+            }
+
+        _, state, policy = fixture("clone-identity", "a" * 64)
+        bad_identity = {**policy, "identity": {"device": 0, "inode": 0}}
+        with self.assertRaisesRegex(WorkspaceError, "identity changed"):
+            self.workspace._clone_temporary_state(
+                state.parent.parent,
+                "clone-identity",
+                "default",
+                "b" * 64,
+                bad_identity,
+                implementation,
+                coordinate,
+            )
+
+        topology, state, policy = fixture("clone-marker", "c" * 64)
+        atomic_json(state / MANAGED_MARKER, {"schema_version": 1, "invalid": True})
+        with self.assertRaisesRegex(WorkspaceError, "ownership marker"):
+            self.workspace._clone_temporary_state(
+                topology,
+                "clone-marker",
+                "default",
+                "d" * 64,
+                policy,
+                implementation,
+                coordinate,
+            )
+
+        topology, state, policy = fixture("clone-destination", "e" * 64)
+        (topology / "temporary-states" / ("f" * 64)).mkdir()
+        with self.assertRaisesRegex(WorkspaceError, "already exists"):
+            self.workspace._clone_temporary_state(
+                topology,
+                "clone-destination",
+                "default",
+                "f" * 64,
+                policy,
+                implementation,
+                coordinate,
+            )
+
+        with mock.patch.object(
+            self.workspace, "_rollback_temporary_state_creation"
+        ) as rollback:
+            self.workspace._remove_superseded_temporary_state(policy)
+        rollback.assert_called_once_with(
+            state,
+            mock.ANY,
+            policy["identity"],
+            policy["lease_identity"],
+            implementation=implementation,
         )
 
     def test_temporary_state_publication_rejects_container_replacement(self) -> None:


### PR DESCRIPTION
## Summary

Add an explicit Classic development workflow that keeps client/server development incremental and service-selective.

## Implementation / behavior

- Add a playable development build scope for `server`, `client`, or both without implicitly validating the metaserver worker.
- Reuse one compatible Classic topology build root for direct warm builds and paired launch.
- Add service-scoped restart/rebuild while preserving topology state, port, and the unaffected service.
- Surface cache/no-op and runtime staging decisions, and keep local paired launch offline.

## Validation

- Cover cold and warm paired bring-up, client-only and server-only changes, restart invariants, cache reuse, and explicit `--test` validation.
- Run the focused unit tests and the complete repository validation required for the wrapper.

Closes #519
