### PR TITLE
fix(workspace): make filesystem identity portable

### DIFF
--- a/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
+++ b/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
@@ -243,12 +243,13 @@ class Snapshot:
     digest: str
     device: int
     inode: int
+    record_device: int | None = None
 
     def json(self) -> dict[str, Any]:
         return {
             "name": self.name,
             "digest": self.digest,
-            "device": self.device,
+            "device": _snapshot_record_device(self),
             "inode": self.inode,
             "document": self.document,
         }
@@ -353,13 +354,14 @@ class ReleaseRecord:
     digest: str
     device: int
     inode: int
+    record_device: int | None = None
 
     def json(self) -> dict[str, Any]:
         return {
             "name": self.name,
             "ledger_name": self.ledger_name,
             "digest": self.digest,
-            "device": self.device,
+            "device": self.device if self.record_device is None else self.record_device,
             "inode": self.inode,
             "document": self.document,
         }
@@ -375,13 +377,14 @@ class ArchiveRecord:
     device: int
     inode: int
     status: os.stat_result
+    record_device: int | None = None
 
     def json(self) -> dict[str, Any]:
         return {
             "name": self.name,
             "ledger_name": self.ledger_name,
             "digest": self.digest,
-            "device": self.device,
+            "device": self.device if self.record_device is None else self.record_device,
             "inode": self.inode,
             "document": self.document,
         }
@@ -573,6 +576,94 @@ def byte_digest(raw: bytes) -> str:
     return hashlib.sha256(raw).hexdigest()
 
 
+PORTABLE_FILESYSTEM_IDENTITY_SCHEMA_VERSION = 1
+
+
+def _portable_filesystem_identity(
+    status: os.stat_result, *, content_sha256: str | None = None
+) -> dict[str, Any]:
+    """Describe a live file or directory without persisting ``st_dev``."""
+
+    if not (stat.S_ISDIR(status.st_mode) or stat.S_ISREG(status.st_mode)):
+        raise LedgerError("portable filesystem identity requires a file or directory")
+    identity: dict[str, Any] = {
+        "schema_version": PORTABLE_FILESYSTEM_IDENTITY_SCHEMA_VERSION,
+        "kind": "directory" if stat.S_ISDIR(status.st_mode) else "file",
+        "inode": status.st_ino,
+        "mode": stat.S_IFMT(status.st_mode),
+    }
+    if stat.S_ISREG(status.st_mode):
+        identity["ctime_ns"] = status.st_ctime_ns
+        if content_sha256 is not None:
+            _string(content_sha256, "portable filesystem content digest", SHA256_RE)
+            identity["sha256"] = content_sha256
+    elif content_sha256 is not None:
+        raise LedgerError("directory portable identity cannot contain a content digest")
+    return identity
+
+
+def _portable_device(status: os.stat_result) -> int:
+    """Return the stable numeric projection retained by schema-v1 records."""
+
+    raw = json.dumps(
+        {
+            key: value
+            for key, value in _portable_filesystem_identity(status).items()
+            if key != "ctime_ns"
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("ascii")
+    return int.from_bytes(hashlib.sha256(raw).digest()[:8], "big")
+
+
+def _portable_pair(status: os.stat_result) -> dict[str, int]:
+    return {"device": _portable_device(status), "inode": status.st_ino}
+
+
+def _pair_matches_status(
+    value: Mapping[str, Any] | tuple[int, int], status: os.stat_result
+) -> bool:
+    """Accept old live pairs and the new portable projection during migration."""
+
+    if isinstance(value, tuple):
+        if len(value) != 2:
+            return False
+        device, inode = value
+    else:
+        if not {"device", "inode"}.issubset(value):
+            return False
+        device, inode = value["device"], value["inode"]
+    return (
+        type(device) is int
+        and device >= 0
+        and type(inode) is int
+        and inode >= 0
+        and inode == status.st_ino
+        and device in {status.st_dev, _portable_device(status)}
+    )
+
+
+def _snapshot_record_device(snapshot: Snapshot) -> int:
+    """Read the durable projection, retaining compatibility with test fixtures."""
+
+    value = getattr(snapshot, "record_device", None)
+    return snapshot.device if value is None else value
+
+
+def _snapshot_matches_identity(
+    snapshot: Snapshot, generation: int, digest: str, device: int, inode: int
+) -> bool:
+    """Match a persisted pair while accepting pre-migration raw-device callers."""
+
+    return (
+        snapshot.document["generation"] == generation
+        and snapshot.digest == digest
+        and snapshot.inode == inode
+        and device in {snapshot.device, _snapshot_record_device(snapshot)}
+    )
+
+
 def canonical_object_digest(value: Any) -> str:
     """Match the wrapper's canonical request digest (which has no final newline)."""
 
@@ -756,7 +847,7 @@ def _release_document(
             "ledger_id": snapshot.document["ledger_id"],
             "generation": snapshot.document["generation"],
             "sha256": snapshot.digest,
-            "device": snapshot.device,
+            "device": _snapshot_record_device(snapshot),
             "inode": snapshot.inode,
         },
         **request_copy,
@@ -1086,7 +1177,14 @@ def _release_record(name: str, raw: bytes, status: os.stat_result) -> ReleaseRec
     if name != _release_name(ledger_name):
         raise LedgerError(f"release marker filename is noncanonical: {name}")
     return ReleaseRecord(
-        name, ledger_name, document, raw, byte_digest(raw), status.st_dev, status.st_ino
+        name,
+        ledger_name,
+        document,
+        raw,
+        byte_digest(raw),
+        status.st_dev,
+        status.st_ino,
+        _portable_device(status),
     )
 
 
@@ -1791,7 +1889,7 @@ def _archive_member(name: str, raw: bytes, status: os.stat_result) -> dict[str, 
     return {
         "name": _direct_name(name, "archive member name"),
         "mode": stat.S_IMODE(status.st_mode),
-        "device": status.st_dev,
+        "device": _portable_device(status),
         "inode": status.st_ino,
         "sha256": byte_digest(raw),
         "raw_base64": base64.b64encode(raw).decode("ascii"),
@@ -1919,8 +2017,22 @@ def _validate_archived_head_correction(
         actual_head=receipt["actual_head"],
         actual_merge_base=receipt.get("actual_merge_base"),
     )
+    erroneous_snapshot = Snapshot(
+        erroneous_name,
+        erroneous,
+        erroneous_raw,
+        source,
+        erroneous_device,
+        erroneous_inode,
+        erroneous_device,
+    )
     _require_head_correction_recovery(
-        receipt["recovery"], erroneous, expected_intent, context
+        receipt["recovery"],
+        erroneous,
+        expected_intent,
+        context,
+        installed_snapshot=erroneous_snapshot,
+        allow_historical_device=True,
     )
     generation = corrected["generation"]
     current = snapshot.document
@@ -2018,6 +2130,7 @@ def _validate_archive_document(value: Any, context: str) -> dict[str, Any]:
         ledger_identity[3],
         ledger_identity[4],
         ledger_identity[5],
+        ledger_identity[4],
     )
     correction_members = _validate_archived_head_correction(
         archived_snapshot, members, context
@@ -2068,6 +2181,7 @@ def _validate_archive_document(value: Any, context: str) -> dict[str, Any]:
         item["release_sha256"],
         release_device,
         release_inode,
+        release_device,
     )
     archive_request = {
         key: item[key]
@@ -2104,7 +2218,15 @@ def _archive_record(name: str, raw: bytes, status: os.stat_result) -> ArchiveRec
         status.st_dev,
         status.st_ino,
         status,
+        _portable_device(status),
     )
+
+
+def _archive_record_device(archive: ArchiveRecord) -> int:
+    """Read the durable archive projection, retaining old fixture compatibility."""
+
+    value = getattr(archive, "record_device", None)
+    return archive.device if value is None else value
 
 
 def _exact(value: Any, keys: set[str], context: str) -> dict[str, Any]:
@@ -2691,7 +2813,7 @@ def _recheck_pinned_directory(
         not stat.S_ISDIR(opened.st_mode)
         or not stat.S_ISDIR(visible.st_mode)
         or identity != (visible.st_dev, visible.st_ino)
-        or (expected is not None and identity != expected)
+        or (expected is not None and not _pair_matches_status(expected, opened))
     ):
         raise LedgerError(f"{context} live path identity drifted")
     return opened
@@ -3330,8 +3452,13 @@ def _verify_live_scope(
             profile_status, f"{context} scope profile {profile_path}"
         )
         if (
-            (profile_status.st_dev, profile_status.st_ino)
-            != (profile.get("path_device"), profile.get("path_inode"))
+            not _pair_matches_status(
+                {
+                    "device": profile.get("path_device"),
+                    "inode": profile.get("path_inode"),
+                },
+                profile_status,
+            )
             or byte_digest(profile_raw) != profile.get("sha256")
         ):
             raise LedgerError(
@@ -4695,8 +4822,9 @@ def _prove_live_worktree_core(
         if primary_common_descriptor is not None:
             os.close(primary_common_descriptor)
     return {
-        "path_device": worktree_status.st_dev,
+        "path_device": _portable_device(worktree_status),
         "path_inode": worktree_status.st_ino,
+        "live_path_device": worktree_status.st_dev,
         "common_git_dir": common_git_dir,
         "tree": tree,
         "safety": dict(SAFE_ARTIFACT_STATE),
@@ -4787,8 +4915,9 @@ def _verify_live_observation(
     item: Mapping[str, Any], proof: Mapping[str, Any], context: str
 ) -> None:
     if (
-        (item["path_device"], item["path_inode"])
-        != (proof["path_device"], proof["path_inode"])
+        item["path_inode"] != proof["path_inode"]
+        or item["path_device"]
+        not in {proof["path_device"], proof.get("live_path_device")}
         or item["safety"] != proof["safety"]
     ):
         raise LedgerError(f"{context} differs from helper-owned live proof")
@@ -5415,7 +5544,15 @@ def _head_correction_receipt(value: Any, context: str) -> dict[str, Any]:
         or erroneous[0] != f"{expected_prefix}.erroneous.snapshot"
         or erroneous[1] != source_digest
         or recovery["intent"]["target"] != target
-        or recovery["intent"]["installed"] != source
+        or not (
+            recovery["intent"]["installed"] == source
+            or (
+                recovery["intent"]["installed"]["generation"]
+                == source["generation"]
+                and recovery["intent"]["installed"]["sha256"] == source["sha256"]
+                and recovery["intent"]["installed"]["inode"] == source["inode"]
+            )
+        )
         or recovery["intent"]["predecessor_sha256"] != predecessor[1]
         or recovery["intent"]["repository"] != item["repository"]
         or recovery["intent"]["branch"] != item["branch"]
@@ -5980,9 +6117,19 @@ def _scope_binding_observation(
         _verify_live_observation(observation, proof, context)
         if proof["common_git_dir"] != row["common_git_dir"]:
             raise LedgerError(f"{context} common Git directory differs from scope result")
-    if (observation["path_device"], observation["path_inode"]) != (
-        row["path_device"],
-        row["path_inode"],
+    try:
+        live_status = Path(path).stat(follow_symlinks=False)
+    except OSError as error:
+        raise LedgerError(f"{context} path identity cannot be rechecked") from error
+    if not _pair_matches_status(
+        {
+            "device": observation["path_device"],
+            "inode": observation["path_inode"],
+        },
+        live_status,
+    ) or not _pair_matches_status(
+        {"device": row["path_device"], "inode": row["path_inode"]},
+        live_status,
     ):
         raise LedgerError(f"{context} path identity differs from scope result")
 
@@ -8309,12 +8456,7 @@ def _snapshot_matches_tuple(
     device: int,
     inode: int,
 ) -> bool:
-    return (
-        snapshot.document["generation"],
-        snapshot.digest,
-        snapshot.device,
-        snapshot.inode,
-    ) == (generation, digest, device, inode)
+    return _snapshot_matches_identity(snapshot, generation, digest, device, inode)
 
 
 def _require_clean_bound_snapshot(root: Path | str, snapshot: Snapshot) -> Snapshot:
@@ -8819,7 +8961,15 @@ def _snapshot(directory: int, name: str) -> Snapshot:
     expected_name = canonical_name(document)
     if name != expected_name:
         raise LedgerError(f"ledger filename is noncanonical: {name}; expected {expected_name}")
-    return Snapshot(name, document, raw, byte_digest(raw), status.st_dev, status.st_ino)
+    return Snapshot(
+        name,
+        document,
+        raw,
+        byte_digest(raw),
+        status.st_dev,
+        status.st_ino,
+        _portable_device(status),
+    )
 
 
 def _exists(directory: int, name: str) -> bool:
@@ -8986,24 +9136,36 @@ def _ensure_head_correction_source_link(
     if (
         existing != raw
         or target_raw != raw
-        or (status.st_dev, status.st_ino) != (expected_device, expected_inode)
-        or (target_status.st_dev, target_status.st_ino)
-        != (expected_device, expected_inode)
+        or not _pair_matches_status(
+            {"device": expected_device, "inode": expected_inode}, status
+        )
+        or not _pair_matches_status(
+            {"device": expected_device, "inode": expected_inode}, target_status
+        )
     ):
         raise LedgerError("head-correction source hard link differs from exact CAS inode")
     return status
 
 
-def _unlink_exact(directory: int, name: str, expected: os.stat_result) -> None:
+def _unlink_exact(
+    directory: int,
+    name: str,
+    expected: os.stat_result,
+    *,
+    durable_device: int | None = None,
+) -> None:
     """Atomically quarantine the named inode before irreversible removal."""
 
+    durable_device = (
+        _portable_device(expected) if durable_device is None else durable_device
+    )
     token = hashlib.sha256(
-        f"{name}\0{expected.st_dev}\0{expected.st_ino}".encode("utf-8")
+        f"{name}\0{durable_device}\0{expected.st_ino}".encode("utf-8")
     ).hexdigest()
     receipt_document = {
         "schema_version": 1,
         "name": name,
-        "device": expected.st_dev,
+        "device": durable_device,
         "inode": expected.st_ino,
     }
     receipt_raw = canonical_bytes(receipt_document)
@@ -9054,7 +9216,9 @@ def _unlink_exact(directory: int, name: str, expected: os.stat_result) -> None:
                 _fsync(quarantine, "unlink quarantine after recovering transaction")
                 _fsync(directory, f"review root after recovering removal of {name}")
                 return
-            if (visible.st_dev, visible.st_ino) != (expected.st_dev, expected.st_ino):
+            if not _pair_matches_status(
+                {"device": durable_device, "inode": expected.st_ino}, visible
+            ):
                 raise LedgerError(f"staging file was replaced: {name}")
             os.rename(
                 name,
@@ -9072,7 +9236,9 @@ def _unlink_exact(directory: int, name: str, expected: os.stat_result) -> None:
                 pass
             else:
                 raise LedgerError(f"unlink transaction and source both exist: {name}")
-        if (payload.st_dev, payload.st_ino) != (expected.st_dev, expected.st_ino):
+        if not _pair_matches_status(
+            {"device": durable_device, "inode": expected.st_ino}, payload
+        ):
             raise LedgerError(f"quarantined file has the wrong identity: {name}")
         os.unlink("payload", dir_fd=transaction)
         _fsync(transaction, f"unlink transaction after removing {name}")
@@ -9166,9 +9332,16 @@ def _recover_unlink_quarantine(directory: int) -> None:
                 try:
                     visible = os.stat(name, dir_fd=directory, follow_symlinks=False)
                 except FileNotFoundError:
-                    _unlink_exact(directory, name, expected)
+                    _unlink_exact(
+                        directory,
+                        name,
+                        expected,
+                        durable_device=device,
+                    )
                     continue
-                if (visible.st_dev, visible.st_ino) != (device, inode):
+                if not _pair_matches_status(
+                    {"device": device, "inode": inode}, visible
+                ):
                     raise LedgerError(f"unlink recovery source identity changed: {name}")
                 # Intent was durable but the target was never quarantined. Do
                 # not let an inventory scan turn a forgeable same-UID receipt
@@ -9182,7 +9355,7 @@ def _recover_unlink_quarantine(directory: int) -> None:
                 os.rmdir(token, dir_fd=quarantine)
                 _fsync(quarantine, "unlink quarantine after aborting pre-commit intent")
                 continue
-            _unlink_exact(directory, name, expected)
+            _unlink_exact(directory, name, expected, durable_device=device)
         _fsync(directory, "review root after unlink recovery")
     finally:
         os.close(quarantine)
@@ -9882,9 +10055,47 @@ def _require_head_correction_recovery(
     document: Mapping[str, Any],
     expected_intent: Mapping[str, Any],
     context: str,
+    *,
+    installed_snapshot: Snapshot | None = None,
+    allow_historical_device: bool = False,
 ) -> None:
-    if recovery["intent"] != expected_intent:
-        raise LedgerError(f"{context} does not authorize the exact correction intent")
+    actual_intent = recovery["intent"]
+    if actual_intent != expected_intent:
+        compatible = False
+        if installed_snapshot is not None:
+            actual_installed = actual_intent.get("installed")
+            expected_installed = expected_intent.get("installed")
+            if isinstance(actual_installed, dict) and isinstance(expected_installed, dict):
+                normalized_actual = dict(actual_installed)
+                normalized_actual["device"] = expected_installed.get("device")
+                normalized_intent = dict(actual_intent)
+                normalized_intent["installed"] = normalized_actual
+                compatible = (
+                    normalized_intent == expected_intent
+                    and _snapshot_matches_identity(
+                        installed_snapshot,
+                        actual_installed.get("generation"),
+                        actual_installed.get("sha256"),
+                        actual_installed.get("device"),
+                        actual_installed.get("inode"),
+                    )
+                )
+        if allow_historical_device:
+            actual_installed = actual_intent.get("installed")
+            expected_installed = expected_intent.get("installed")
+            if (
+                isinstance(actual_installed, dict)
+                and isinstance(expected_installed, dict)
+                and type(actual_installed.get("device")) is int
+                and actual_installed["device"] >= 0
+            ):
+                normalized_actual = dict(actual_installed)
+                normalized_actual["device"] = expected_installed.get("device")
+                normalized_intent = dict(actual_intent)
+                normalized_intent["installed"] = normalized_actual
+                compatible = normalized_intent == expected_intent
+        if not compatible:
+            raise LedgerError(f"{context} does not authorize the exact correction intent")
     grant = recovery["grant"]
     if (
         grant["actor_node_id"] != document["actor"]["node_id"]
@@ -10429,6 +10640,7 @@ def _inventory_locked(directory: int) -> Inventory:
                     byte_digest(raw),
                     status.st_dev,
                     status.st_ino,
+                    _portable_device(status),
                 )
             )
             continue
@@ -10481,6 +10693,7 @@ def _inventory_locked(directory: int) -> Inventory:
                         byte_digest(raw),
                         status.st_dev,
                         status.st_ino,
+                        _portable_device(status),
                     )
                 )
                 break
@@ -10559,13 +10772,13 @@ def _inventory_locked(directory: int) -> Inventory:
                     or current.raw != erroneous_raw
                     or (erroneous_status.st_dev, erroneous_status.st_ino)
                     != (current.device, current.inode)
-                    or receipt["source"]
-                    != {
-                        "generation": current.document["generation"],
-                        "sha256": current.digest,
-                        "device": current.device,
-                        "inode": current.inode,
-                    }
+                    or not _snapshot_matches_identity(
+                        current,
+                        current.document["generation"],
+                        current.digest,
+                        receipt["source"]["device"],
+                        receipt["source"]["inode"],
+                    )
                 ):
                     raise LedgerError(f"head-correction source identity changed: {target}")
                 _, metadata, _ = _head_correction_document(
@@ -10591,12 +10804,22 @@ def _inventory_locked(directory: int) -> Inventory:
                     erroneous,
                     expected_intent,
                     f"head-correction receipt for {target}",
+                    installed_snapshot=current,
                 )
             continue
         if receipt is None or "erroneous" not in entries:
             raise LedgerError(f"installed head correction lacks evidence: {target}")
         erroneous_name, _, erroneous_raw, erroneous_status = entries["erroneous"]
         erroneous = validate(_decode(erroneous_raw, erroneous_name))
+        erroneous_snapshot = Snapshot(
+            erroneous_name,
+            erroneous,
+            erroneous_raw,
+            source_digest,
+            erroneous_status.st_dev,
+            erroneous_status.st_ino,
+            _portable_device(erroneous_status),
+        )
         if erroneous_raw != canonical_bytes(erroneous) or byte_digest(erroneous_raw) != source_digest:
             raise LedgerError(f"head-correction erroneous snapshot mismatch: {target}")
         corrected, metadata, _ = _head_correction_document(
@@ -10624,6 +10847,7 @@ def _inventory_locked(directory: int) -> Inventory:
             erroneous,
             expected_intent,
             f"head-correction receipt for {target}",
+            installed_snapshot=erroneous_snapshot,
         )
         correction_generation = corrected["generation"]
         correction_is_current = current.document["generation"] == correction_generation
@@ -10653,20 +10877,16 @@ def _inventory_locked(directory: int) -> Inventory:
             or receipt["predecessor_snapshot"] != {
                 "name": predecessor_name,
                 "sha256": byte_digest(predecessor_raw),
-                "device": predecessor_status.st_dev,
+                "device": _portable_device(predecessor_status),
                 "inode": predecessor_status.st_ino,
             }
             or receipt["erroneous_snapshot"] != {
                 "name": erroneous_name,
                 "sha256": source_digest,
-                "device": erroneous_status.st_dev,
+                "device": _portable_device(erroneous_status),
                 "inode": erroneous_status.st_ino,
             }
-            or (
-                receipt["source"]["device"],
-                receipt["source"]["inode"],
-            )
-            != (erroneous_status.st_dev, erroneous_status.st_ino)
+            or not _pair_matches_status(receipt["source"], erroneous_status)
             or "stage" in entries
         ):
             raise LedgerError(f"completed head correction evidence mismatch: {target}")
@@ -10798,8 +11018,9 @@ def _inventory_locked(directory: int) -> Inventory:
             related_raw, related_status = _read_regular(directory, related_name)
             if (
                 byte_digest(related_raw) != related_digest
-                or related_status.st_dev != related_device
-                or related_status.st_ino != related_inode
+                or not _pair_matches_status(
+                    {"device": related_device, "inode": related_inode}, related_status
+                )
             ):
                 raise LedgerError(f"migration related source changed: {related_name}")
         canonical_report = marker["canonical_report"]
@@ -10809,8 +11030,9 @@ def _inventory_locked(directory: int) -> Inventory:
         ):
             if (
                 byte_digest(source_raw) != source_digest
-                or source_status.st_dev != source_device
-                or source_status.st_ino != source_inode
+                or not _pair_matches_status(
+                    {"device": source_device, "inode": source_inode}, source_status
+                )
             ):
                 raise LedgerError(f"migration source changed: {source_name}")
         snapshot_raw: bytes | None = None
@@ -10832,8 +11054,9 @@ def _inventory_locked(directory: int) -> Inventory:
             )
             if (
                 byte_digest(snapshot_raw) != snapshot_digest
-                or snapshot_status.st_dev != snapshot_device
-                or snapshot_status.st_ino != snapshot_inode
+                or not _pair_matches_status(
+                    {"device": snapshot_device, "inode": snapshot_inode}, snapshot_status
+                )
             ):
                 raise LedgerError(f"migration snapshot changed: {snapshot_name}")
         try:
@@ -10965,7 +11188,7 @@ def _inventory_locked(directory: int) -> Inventory:
             identity["ledger_id"] != snapshot.document["ledger_id"]
             or identity["generation"] != snapshot.document["generation"]
             or identity["sha256"] != snapshot.digest
-            or identity["device"] != snapshot.device
+            or identity["device"] != _snapshot_record_device(snapshot)
             or identity["inode"] != snapshot.inode
         ):
             raise LedgerError(f"release marker is stale for {release.ledger_name}")
@@ -11011,6 +11234,7 @@ def _inventory_locked(directory: int) -> Inventory:
                 archive.document["ledger"]["sha256"],
                 archive.document["ledger"]["device"],
                 archive.document["ledger"]["inode"],
+                archive.document["ledger"]["device"],
             )
         )
     all_by_identity = {
@@ -11581,7 +11805,7 @@ def init_root(wrapper_root: Path | str) -> dict[str, Any]:
             raise LedgerError("initialized review root identity changed")
         return {
             "root": str(current_path),
-            "device": status.st_dev,
+            "device": _portable_device(status),
             "inode": status.st_ino,
         }
     finally:
@@ -12295,7 +12519,9 @@ def _finish_archive_members(
         if (
             current_raw != raw
             or stat.S_IMODE(status.st_mode) != mode
-            or (status.st_dev, status.st_ino) != (device, inode)
+            or not _pair_matches_status(
+                {"device": device, "inode": inode}, status
+            )
         ):
             raise LedgerError(f"archive member changed before removal: {name}")
         _unlink_exact(directory, name, status)
@@ -12318,7 +12544,15 @@ def _archive_snapshot(archive: ArchiveRecord) -> Snapshot:
     validate(document)
     if raw != canonical_bytes(document) or byte_digest(raw) != identity[3]:
         raise LedgerError("installed archive ledger member is mismatched")
-    return Snapshot(name, document, raw, identity[3], device, inode)
+    return Snapshot(
+        name,
+        document,
+        raw,
+        identity[3],
+        device,
+        inode,
+        device,
+    )
 
 
 def _require_archive_members_absent(directory: int, archive: ArchiveRecord) -> None:
@@ -12512,7 +12746,7 @@ def reclaim_preview(root: Path | str, name: str) -> dict[str, Any]:
                 "operation": "reclaim",
                 "archive": archive.name,
                 "sha256": archive.digest,
-                "device": archive.device,
+                "device": _archive_record_device(archive),
                 "inode": archive.inode,
                 "observed_at": observed,
             }
@@ -12522,7 +12756,7 @@ def reclaim_preview(root: Path | str, name: str) -> dict[str, Any]:
             "plan_sha256": plan,
             "archive": archive.name,
             "archive_sha256": archive.digest,
-            "device": archive.device,
+            "device": _archive_record_device(archive),
             "inode": archive.inode,
             "observed_at": observed,
             "state": "eligible",
@@ -12659,7 +12893,7 @@ def reclaim_apply(
                 "operation": "reclaim",
                 "archive": archive.name,
                 "sha256": archive.digest,
-                "device": archive.device,
+                "device": _archive_record_device(archive),
                 "inode": archive.inode,
                 "observed_at": item["observed_at"],
             }
@@ -12667,7 +12901,7 @@ def reclaim_apply(
         if (
             expected != plan
             or item["archive_sha256"] != archive.digest
-            or item["device"] != archive.device
+            or item["device"] != _archive_record_device(archive)
             or item["inode"] != archive.inode
         ):
             raise LedgerError("reclaim archive tuple or plan changed")
@@ -12765,6 +12999,7 @@ def create(
                 byte_digest(raw),
                 stage_status.st_dev,
                 stage_status.st_ino,
+                _portable_device(stage_status),
             )
             _reject_overlaps([*current.ledgers, staged_snapshot])
             try:
@@ -13682,10 +13917,13 @@ def target_refresh_cas(
     if (
         current.document["generation"],
         current.digest,
-        current.device,
+        _snapshot_record_device(current),
         current.inode,
     ) != expected:
-        raise LedgerError("stale target-refresh generation, digest, or inode")
+        if not _snapshot_matches_identity(
+            current, expected_generation, expected_digest, expected_device, expected_inode
+        ):
+            raise LedgerError("stale target-refresh generation, digest, or inode")
     change = _target_refresh_change(current.document, prepared, current.digest)
     capability = _TargetRefreshCapability(
         _TARGET_REFRESH_TOKEN,
@@ -13875,8 +14113,13 @@ def cas(
             if (
                 current.document["generation"] != expected_generation
                 or current.digest != expected_digest
-                or current.device != expected_device
-                or current.inode != expected_inode
+                or not _snapshot_matches_identity(
+                    current,
+                    expected_generation,
+                    expected_digest,
+                    expected_device,
+                    expected_inode,
+                )
             ):
                 raise LedgerError("stale CAS generation, digest, or inode")
             if _binding_capability is not None:
@@ -13951,8 +14194,13 @@ def cas(
             if (
                 rechecked.document["generation"] != expected_generation
                 or rechecked.digest != expected_digest
-                or rechecked.device != expected_device
-                or rechecked.inode != expected_inode
+                or not _snapshot_matches_identity(
+                    rechecked,
+                    expected_generation,
+                    expected_digest,
+                    expected_device,
+                    expected_inode,
+                )
             ):
                 raise LedgerError("CAS target changed after staging")
             staged_raw, staged_visible = _read_regular(
@@ -14270,8 +14518,13 @@ def recover_released_scope(
         snapshot.document["ledger_id"] != recovery["source"]["ledger_id"]
         or snapshot.document["generation"] != recovery["source"]["generation"]
         or snapshot.digest != recovery["source"]["sha256"]
-        or snapshot.device != recovery["source"]["device"]
-        or snapshot.inode != recovery["source"]["inode"]
+        or not _snapshot_matches_identity(
+            snapshot,
+            recovery["source"]["generation"],
+            recovery["source"]["sha256"],
+            recovery["source"]["device"],
+            recovery["source"]["inode"],
+        )
     ):
         raise LedgerError("scope recovery source snapshot is stale")
     candidate_raw = canonical_bytes(candidate)
@@ -14481,10 +14734,13 @@ def recover_prebind_scope(
     )
     if not resume and (
         snapshot.document["ledger_id"] != source["ledger_id"]
-        or snapshot.document["generation"] != source["generation"]
-        or snapshot.digest != source["sha256"]
-        or snapshot.device != source["device"]
-        or snapshot.inode != source["inode"]
+        or not _snapshot_matches_identity(
+            snapshot,
+            source["generation"],
+            source["sha256"],
+            source["device"],
+            source["inode"],
+        )
     ):
         raise LedgerError("pre-bind scope recovery source snapshot is stale")
     if byte_digest(candidate_raw) != recovery["candidate_sha256"]:
@@ -14764,14 +15020,27 @@ def correct_target_head(
     }
 
     snapshot = inspect(root, name)
+    installed_snapshot = snapshot
     if snapshot.digest == expected_digest:
         erroneous_raw = snapshot.raw
     else:
         with _locked_root(Path(root)) as directory:
-            erroneous_raw, _ = _read_regular(directory, erroneous_name, managed=True)
+            erroneous_raw, erroneous_status = _read_regular(
+                directory, erroneous_name, managed=True
+            )
     erroneous = validate(_decode(erroneous_raw, "head-correction erroneous bytes"))
     if byte_digest(erroneous_raw) != expected_digest:
         raise LedgerError("head-correction erroneous snapshot differs from expected digest")
+    if snapshot.digest != expected_digest:
+        installed_snapshot = Snapshot(
+            erroneous_name,
+            erroneous,
+            erroneous_raw,
+            expected_digest,
+            erroneous_status.st_dev,
+            erroneous_status.st_ino,
+            _portable_device(erroneous_status),
+        )
     corrected, metadata, live_provenance = _head_correction_document(
         predecessor,
         erroneous,
@@ -14789,7 +15058,7 @@ def correct_target_head(
     source_identity = {
         "generation": expected_generation,
         "sha256": expected_digest,
-        "device": expected_device,
+        "device": _snapshot_record_device(installed_snapshot),
         "inode": expected_inode,
     }
     expected_intent = _head_correction_intent(
@@ -14807,6 +15076,7 @@ def correct_target_head(
         erroneous,
         expected_intent,
         "head-correction recovery authority",
+        installed_snapshot=installed_snapshot,
     )
 
     live_context = (
@@ -14951,8 +15221,13 @@ def correct_target_head(
                 if (
                     current.document["generation"] != expected_generation
                     or current.digest != expected_digest
-                    or current.device != expected_device
-                    or current.inode != expected_inode
+                    or not _snapshot_matches_identity(
+                        current,
+                        expected_generation,
+                        expected_digest,
+                        expected_device,
+                        expected_inode,
+                    )
                     or current.raw != erroneous_raw
                 ):
                     raise LedgerError("stale head-correction generation, digest, or inode")
@@ -14984,13 +15259,13 @@ def correct_target_head(
                     "predecessor_snapshot": {
                         "name": predecessor_name,
                         "sha256": predecessor_digest,
-                        "device": predecessor_status.st_dev,
+                        "device": _portable_device(predecessor_status),
                         "inode": predecessor_status.st_ino,
                     },
                     "erroneous_snapshot": {
                         "name": erroneous_name,
                         "sha256": expected_digest,
-                        "device": erroneous_status.st_dev,
+                        "device": _portable_device(erroneous_status),
                         "inode": erroneous_status.st_ino,
                     },
                     "correction": {
@@ -15009,10 +15284,14 @@ def correct_target_head(
                 _hit(failpoint, "correct-target-head:receipt")
                 rechecked = _snapshot(directory, name)
                 if (
-                    rechecked.digest,
-                    rechecked.device,
-                    rechecked.inode,
-                ) != (expected_digest, expected_device, expected_inode):
+                    not _snapshot_matches_identity(
+                        rechecked,
+                        expected_generation,
+                        expected_digest,
+                        expected_device,
+                        expected_inode,
+                    )
+                ):
                     raise LedgerError("head-correction source changed before replacement")
                 staged_raw, staged_visible = _read_regular(
                     directory, stage, managed=True, sync=True
@@ -15234,7 +15513,7 @@ def migrate(
                 {
                     "name": name,
                     "sha256": byte_digest(raw),
-                    "device": status.st_dev,
+                    "device": _portable_device(status),
                     "inode": status.st_ino,
                 }
                 for name, raw, status in preflight_related
@@ -15246,7 +15525,7 @@ def migrate(
                 source={
                     "name": source_name,
                     "sha256": preflight_digest,
-                    "device": preflight_status.st_dev,
+                    "device": _portable_device(preflight_status),
                     "inode": preflight_status.st_ino,
                 },
                 related_sources=(
@@ -15423,16 +15702,14 @@ def migrate(
             if kind in LEGACY_MIGRATION_KINDS or marker["state"] != "complete":
                 if (
                     source_digest != source["sha256"]
-                    or source_status.st_dev != source["device"]
-                    or source_status.st_ino != source["inode"]
+                    or not _pair_matches_status(source, source_status)
                 ):
                     raise LedgerError("migration source changed before safe completion")
             for related in marker.get("related_sources", []):
                 related_raw, related_status = _read_regular(directory, related["name"])
                 if (
                     byte_digest(related_raw) != related["sha256"]
-                    or related_status.st_dev != related["device"]
-                    or related_status.st_ino != related["inode"]
+                    or not _pair_matches_status(related, related_status)
                 ):
                     raise LedgerError("migration related source changed before completion")
             if marker["state"] == "planned":
@@ -15451,7 +15728,7 @@ def migrate(
                 snapshot = {
                     "name": snapshot_name,
                     "sha256": byte_digest(snapshot_raw),
-                    "device": snapshot_visible.st_dev,
+                    "device": _portable_device(snapshot_visible),
                     "inode": snapshot_visible.st_ino,
                 }
                 _hit(failpoint, "migration:snapshot")
@@ -15542,8 +15819,7 @@ def migrate(
                 )
                 if (
                     byte_digest(snapshot_raw) != snapshot["sha256"]
-                    or snapshot_visible.st_dev != snapshot["device"]
-                    or snapshot_visible.st_ino != snapshot["inode"]
+                    or not _pair_matches_status(snapshot, snapshot_visible)
                 ):
                     raise LedgerError("immutable migration snapshot changed")
                 canonical_raw, _ = _read_regular(directory, canonical_report)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,14 @@ remain focused on the manifest, multi-repository workflows, or their tests and
 documentation. Preserve dirty physical checkouts and persistent state during
 manual validation.
 
+Filesystem-identity changes must keep the durable/ephemeral boundary explicit:
+portable identities are the only values written to workspace, topology, lease,
+scope, and delivery-ledger records; raw `st_dev` values are limited to live
+descriptor or mount fencing. Add a remount/rebind regression test that covers
+the explicit migration journal, changed-inode refusal, and rollback or audit
+behavior. Validate the documented command with `--dry-run` and `--audit` in a
+temporary test-owned workspace; never apply it to shared generated state.
+
 ## Copyright headers
 
 Use `The Atrinik Project` as the exact collective holder for every new or

--- a/README.md
+++ b/README.md
@@ -500,6 +500,32 @@ stopped records, states, logs, and historical coordinates remain preserved and
 inert; this migration never deletes them. Cleanup continues to inventory those
 references and remains a separate preview-first operation.
 
+## Recovering persisted filesystem identities after a remount
+
+Persisted workspace, topology, lease, and delivery-ledger records created by
+older wrapper versions may contain the host-specific filesystem device number.
+Use the explicit, checked recovery transaction after a devcontainer rebuild or
+other remount:
+
+~~~sh
+./atrinik migrate filesystem --dry-run --json
+./atrinik migrate filesystem --apply --confirm-remount
+./atrinik migrate filesystem --audit --json
+~~~
+
+The dry run is read-only. Apply snapshots every affected record, preserves
+legacy evidence, rewrites durable identities atomically, and records portable
+pre/post identities plus rollback state in a local journal. It refuses a
+changed inode, replacement, symlink, foreign-owned target, or ambiguous
+record; never hand-edit the JSON. Live descriptor and mount fencing continues
+to use the complete ephemeral `(st_dev, st_ino)` check, while durable records
+omit `st_dev` and therefore remain valid when the same workspace is mounted
+again. Rename-prone lease records intentionally omit ctime as well; their
+opened-descriptor, generation, and content fences remain live. See
+[`docs/FILESYSTEM-IDENTITY.md`](docs/FILESYSTEM-IDENTITY.md) for the schema
+boundary and recovery guarantees. This operation is separate from
+cleanup, topology shutdown, scope release, and repository migration.
+
 The current classic client command opens a graphical application. Verify that
 the devcontainer display forwarding socket is live before launching it. Use
 `--dry-run` to build and print either launch command without starting the

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -441,6 +441,13 @@ def _regular_text_identity(path: Path) -> tuple[str, tuple[int, int, int, int]]:
 def _text_evidence(path: Path) -> tuple[str, dict[str, Any]]:
     value, identity = _regular_text_identity(path)
     metadata = path.lstat()
+    if identity != (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_ctime_ns,
+        metadata.st_size,
+    ):
+        raise WorkspaceError(f"Git worktree metadata changed identity: {path}")
     if metadata.st_uid != os.geteuid():
         raise WorkspaceError(f"Git worktree metadata has a foreign owner: {path}")
     return value, _portable_text_identity(metadata, value)
@@ -564,6 +571,12 @@ def _text_evidence_matches(path: Path, expected: Any) -> bool:
         _value, observed = _text_evidence(path)
         metadata = path.lstat()
     except (OSError, RuntimeError, WorkspaceError):
+        return False
+    if (
+        observed.get("inode") != metadata.st_ino
+        or observed.get("ctime_ns") != metadata.st_ctime_ns
+        or observed.get("size") != metadata.st_size
+    ):
         return False
     if set(expected) != set(observed):
         return False

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -20,6 +20,16 @@ from typing import Any, Callable, Iterable, Iterator
 from .locking import LockBusyError, active_lock_fds
 from .content_migration import CONTENT_MIGRATION_PENDING, CONTENT_MIGRATION_RECORD
 from .delivery import inventory_active_delivery_evidence
+from .filesystem_identity import (
+    FilesystemIdentityError,
+    identity_matches,
+    is_legacy_identity,
+    pair_matches,
+    portable_device,
+    portable_identity,
+    portable_pair,
+    validate_identity,
+)
 from .migration import MIGRATION_PENDING, MIGRATION_RECORD, OPERATION_PATHS
 from .model import (
     MANAGED_MARKER,
@@ -52,6 +62,7 @@ from .workspace import (
     _descriptor_path,
     _open_directory_nofollow,
     _owned_tree_tombstone_path,
+    _portable_tombstone_path,
     _remote_matches,
     exclusive_lock,
     load_regular_json,
@@ -85,6 +96,164 @@ def _canonical_json_sha256(value: Any) -> str:
     return hashlib.sha256(
         json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
     ).hexdigest()
+
+
+def _portable_text_identity(
+    metadata: os.stat_result, value: str
+) -> dict[str, Any]:
+    """Describe Git text evidence without retaining the mount device."""
+
+    return {
+        "device": portable_device(metadata),
+        "inode": metadata.st_ino,
+        "ctime_ns": metadata.st_ctime_ns,
+        "size": metadata.st_size,
+        "sha256": hashlib.sha256(value.encode("utf-8")).hexdigest(),
+    }
+
+
+def _identity_matches_metadata(value: Any, metadata: os.stat_result) -> bool:
+    try:
+        if isinstance(value, dict) and set(value) == {"device", "inode"}:
+            return pair_matches(value, metadata)
+        return identity_matches(value, metadata)
+    except (FilesystemIdentityError, TypeError):
+        return False
+
+
+def _pair_matches_metadata(value: Any, metadata: os.stat_result) -> bool:
+    try:
+        return pair_matches(value, metadata)
+    except (FilesystemIdentityError, TypeError):
+        return False
+
+
+def _temporary_state_lock_tombstone(
+    lock: Path, identity: Any
+) -> Path | None:
+    """Find a state-lease tombstone by its live metadata, not its old device."""
+
+    candidates: list[Path] = []
+    for candidate in sorted(lock.parent.glob(f".{lock.name}.remove-*")):
+        try:
+            metadata = candidate.stat(follow_symlinks=False)
+        except FileNotFoundError:
+            continue
+        if _identity_matches_metadata(identity, metadata) or (
+            _pair_matches_metadata(identity, metadata)
+            if isinstance(identity, dict) and set(identity) == {"device", "inode"}
+            else False
+        ):
+            candidates.append(candidate)
+    if len(candidates) > 1:
+        raise WorkspaceError(
+            f"temporary topology state lease tombstones are ambiguous: {lock}"
+        )
+    return candidates[0] if candidates else None
+
+
+def _owned_tree_tombstone_for_identity(
+    path: Path, identity: Any
+) -> Path | None:
+    """Find a tree tombstone for either a portable or legacy record."""
+
+    if isinstance(identity, dict) and set(identity) == {"device", "inode"}:
+        digest = hashlib.sha256(path.name.encode("utf-8")).hexdigest()[:16]
+        candidates: list[Path] = []
+        for candidate in sorted(path.parent.iterdir()):
+            if not re.fullmatch(
+                rf"\.remove-{digest}-[0-9a-f]+-[0-9a-f]+",
+                candidate.name,
+            ):
+                continue
+            try:
+                metadata = candidate.stat(follow_symlinks=False)
+            except FileNotFoundError:
+                continue
+            if _pair_matches_metadata(identity, metadata):
+                candidates.append(candidate)
+        if len(candidates) > 1:
+            raise WorkspaceError(f"owned-tree tombstones are ambiguous: {path}")
+        return candidates[0] if candidates else None
+    if isinstance(identity, dict) and set(identity) == {
+        "device",
+        "inode",
+        "ctime_ns",
+        "file_type",
+    }:
+        pair = {key: identity[key] for key in ("device", "inode")}
+        digest = hashlib.sha256(path.name.encode("utf-8")).hexdigest()[:16]
+        candidates: list[Path] = []
+        for candidate in sorted(path.parent.iterdir()):
+            if not re.fullmatch(
+                rf"\.remove-{digest}-[0-9a-f]+-[0-9a-f]+",
+                candidate.name,
+            ):
+                continue
+            try:
+                metadata = candidate.stat(follow_symlinks=False)
+            except FileNotFoundError:
+                continue
+            if _pair_matches_metadata(pair, metadata):
+                candidates.append(candidate)
+        if len(candidates) > 1:
+            raise WorkspaceError(f"owned-tree tombstones are ambiguous: {path}")
+        return candidates[0] if candidates else None
+    if is_legacy_identity(identity):
+        candidate = _owned_tree_tombstone_path(path, identity)
+        return candidate if candidate.exists() or candidate.is_symlink() else None
+    return _portable_tombstone_path(path, identity)
+
+
+def _recovery_filesystem_matches(
+    value: Any, metadata: os.stat_result, check_ctime: bool
+) -> bool:
+    """Match the bounded temporary-state evidence to a live object."""
+
+    if (
+        isinstance(value, dict)
+        and set(value) == {"device", "inode", "ctime_ns", "file_type"}
+    ):
+        return (
+            _pair_matches_metadata(
+                {"device": value["device"], "inode": value["inode"]},
+                metadata,
+            )
+            and stat.S_IFMT(metadata.st_mode) == value["file_type"]
+            and (not check_ctime or metadata.st_ctime_ns == value["ctime_ns"])
+        )
+    return isinstance(value, dict) and _identity_matches_metadata(value, metadata)
+
+
+def _recovery_identity_matches_record(identity: Any, record: Any) -> bool:
+    """Compare a state-policy identity with temporary recovery evidence."""
+
+    if not isinstance(identity, dict) or not isinstance(record, dict):
+        return False
+    if identity.get("inode") != record.get("inode"):
+        return False
+    if set(identity) == {"device", "inode"} and "device" in record:
+        return identity["device"] == record["device"]
+    return identity.get("kind") == "directory"
+
+
+def _identity_records_match(left: Any, right: Any) -> bool:
+    if not isinstance(left, dict) or not isinstance(right, dict):
+        return False
+    if left.get("inode") != right.get("inode"):
+        return False
+    if set(left) == {"device", "inode"} and set(right) == {
+        "device",
+        "inode",
+    }:
+        return left["device"] == right["device"]
+    if "schema_version" in left and "schema_version" in right:
+        return left == right
+    if "schema_version" in left or "schema_version" in right:
+        # A legacy pair can be compared to a portable record only by the
+        # inode until the current object is opened and fenced below.
+        return True
+    return True
 
 
 def _cleanup_journal_name_matches_coordinate(name: str, coordinate: str) -> bool:
@@ -271,13 +440,7 @@ def _text_evidence(path: Path) -> tuple[str, dict[str, Any]]:
     metadata = path.lstat()
     if metadata.st_uid != os.geteuid():
         raise WorkspaceError(f"Git worktree metadata has a foreign owner: {path}")
-    return value, {
-        "device": identity[0],
-        "inode": identity[1],
-        "ctime_ns": identity[2],
-        "size": identity[3],
-        "sha256": hashlib.sha256(value.encode("utf-8")).hexdigest(),
-    }
+    return value, _portable_text_identity(metadata, value)
 
 
 def _linked_worktree_registration_identity(
@@ -335,17 +498,11 @@ def _linked_worktree_registration_identity(
     return {
         "schema_version": 1,
         "worktree": str(worktree.resolve()),
-        "worktree_identity": {
-            "device": worktree_metadata.st_dev,
-            "inode": worktree_metadata.st_ino,
-        },
+        "worktree_identity": portable_pair(worktree_metadata),
         "pointer": pointer,
         "common": str(common),
         "admin": str(git_directory),
-        "admin_identity": {
-            "device": admin_metadata.st_dev,
-            "inode": admin_metadata.st_ino,
-        },
+        "admin_identity": portable_pair(admin_metadata),
         "backlink": backlink,
     }
 
@@ -394,6 +551,52 @@ def _valid_linked_worktree_registration_identity(value: Any) -> bool:
         admin.parent == common / "worktrees"
         and admin.name not in {"", ".", ".."}
         and worktree.name not in {"", ".", ".."}
+    )
+
+
+def _text_evidence_matches(path: Path, expected: Any) -> bool:
+    if not isinstance(expected, dict):
+        return False
+    try:
+        _value, observed = _text_evidence(path)
+        metadata = path.lstat()
+    except (OSError, RuntimeError, WorkspaceError):
+        return False
+    if set(expected) != set(observed):
+        return False
+    return all(
+        observed[key] == expected[key]
+        for key in observed
+        if key != "device"
+    ) and _pair_matches_metadata(
+        {"device": expected.get("device"), "inode": expected.get("inode")},
+        metadata,
+    )
+
+
+def _linked_worktree_registration_matches(
+    worktree: Path, common: Path, expected: Any
+) -> bool:
+    if not _valid_linked_worktree_registration_identity(expected):
+        return False
+    try:
+        actual = _linked_worktree_registration_identity(worktree, common)
+        worktree_metadata = worktree.lstat()
+        admin_metadata = Path(actual["admin"]).lstat()
+    except (OSError, RuntimeError, WorkspaceError):
+        return False
+    if any(
+        actual[key] != expected[key]
+        for key in ("schema_version", "worktree", "common", "admin")
+    ):
+        return False
+    return (
+        _pair_matches_metadata(expected["worktree_identity"], worktree_metadata)
+        and _pair_matches_metadata(expected["admin_identity"], admin_metadata)
+        and _text_evidence_matches(worktree / ".git", expected["pointer"])
+        and _text_evidence_matches(
+            Path(actual["admin"]) / "gitdir", expected["backlink"]
+        )
     )
 
 
@@ -512,7 +715,8 @@ def _sound_producer_lock_snapshot(
     marker, identity = _regular_text_identity(path)
     if marker != SOUND_PRODUCER_LOCK_MARKER or path.lstat().st_uid != os.geteuid():
         raise WorkspaceError("sound producer cleanup lease marker is invalid")
-    return path, identity
+    metadata = path.lstat()
+    return path, (portable_device(metadata), metadata.st_ino, identity[2], identity[3])
 
 
 @contextmanager
@@ -528,6 +732,12 @@ def _exclusive_sound_producer_lease(
     try:
         metadata = os.fstat(descriptor)
         identity = (
+            portable_device(metadata),
+            metadata.st_ino,
+            metadata.st_ctime_ns,
+            metadata.st_size,
+        )
+        legacy_identity = (
             metadata.st_dev,
             metadata.st_ino,
             metadata.st_ctime_ns,
@@ -537,7 +747,7 @@ def _exclusive_sound_producer_lease(
             not stat.S_ISREG(metadata.st_mode)
             or metadata.st_nlink != 1
             or metadata.st_uid != os.geteuid()
-            or identity != expected_identity
+            or tuple(expected_identity) not in {identity, legacy_identity}
         ):
             raise WorkspaceError("sound producer cleanup lease changed identity")
         try:
@@ -1689,7 +1899,7 @@ class Cleanup:
             }
             if kind == "sound-cache":
                 expected.add("producer_identity")
-            if set(intent) != expected or not self._identity_pair(
+            if set(intent) != expected or not self._valid_filesystem_identity(
                 intent.get("identity")
             ):
                 return False
@@ -1717,7 +1927,7 @@ class Cleanup:
             return True
         if kind == "cleanup-journal":
             return set(intent) == {"action", "identity", "phase"} and (
-                self._identity_pair(intent.get("identity"))
+                self._valid_filesystem_identity(intent.get("identity"))
             )
         if kind == "temporary-state":
             return set(intent) == {"action", "phase", "recovery"} and (
@@ -2245,10 +2455,7 @@ class Cleanup:
                         raise WorkspaceError(
                             f"cleanup target is not a directory: {target['path']}"
                         )
-                    intent["identity"] = {
-                        "device": identity.st_dev,
-                        "inode": identity.st_ino,
-                    }
+                    intent["identity"] = portable_identity(identity)
                     intent["target_sha256"] = _canonical_json_sha256(
                         planned_target
                     )
@@ -2263,10 +2470,10 @@ class Cleanup:
                             else None
                         )
                 elif target["kind"] == "cleanup-journal":
-                    intent["identity"] = {
-                        "device": match["device"],
-                        "inode": match["inode"],
-                    }
+                    journal_metadata = Path(target["path"]).stat(
+                        follow_symlinks=False
+                    )
+                    intent["identity"] = portable_pair(journal_metadata)
                 elif target["kind"] == "temporary-state":
                     intent["recovery"] = self._temporary_state_recovery_evidence(
                         match
@@ -2591,7 +2798,7 @@ class Cleanup:
         metadata: os.stat_result | None = None
         try:
             metadata = path.lstat()
-            item["device"] = metadata.st_dev
+            item["device"] = portable_device(metadata)
             item["inode"] = metadata.st_ino
             item["_inodes"] = {
                 (metadata.st_dev, metadata.st_ino): metadata.st_blocks * 512
@@ -2804,9 +3011,19 @@ class Cleanup:
         kind = target["kind"]
         if kind == "cleanup-journal":
             item = self._cleanup_journal_item(path, older_than_days, names)
+            try:
+                metadata = path.lstat()
+            except OSError:
+                metadata = None
             if (
-                item.get("device") != target.get("device")
-                or item.get("inode") != target.get("inode")
+                metadata is None
+                or not pair_matches(
+                    {
+                        "device": target.get("device"),
+                        "inode": target.get("inode"),
+                    },
+                    metadata,
+                )
             ):
                 item["disposition"] = "protected"
                 item["reasons"] = ["cleanup_journal_identity_changed"]
@@ -3131,10 +3348,12 @@ class Cleanup:
                                 mutable_output_identities[index], dict
                             )
                         ):
-                            tombstone = _owned_tree_tombstone_path(
+                            tombstone = _owned_tree_tombstone_for_identity(
                                 output, mutable_output_identities[index]
                             )
-                            if tombstone.exists() or tombstone.is_symlink():
+                            if tombstone is not None and (
+                                tombstone.exists() or tombstone.is_symlink()
+                            ):
                                 output_evidence = True
                                 break
                     if output_evidence:
@@ -6181,10 +6400,13 @@ class Cleanup:
             )
             if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
                 raise WorkspaceError("orphan temporary state lease is invalid")
-            if expected_tombstone_identity is not None and (
-                metadata.st_dev,
-                metadata.st_ino,
-            ) != expected_tombstone_identity:
+            if expected_tombstone_identity is not None and not _pair_matches_metadata(
+                {
+                    "device": expected_tombstone_identity[0],
+                    "inode": expected_tombstone_identity[1],
+                },
+                metadata,
+            ):
                 raise WorkspaceError(
                     "orphan temporary state lease tombstone identity is invalid"
                 )
@@ -6347,10 +6569,19 @@ class Cleanup:
                         pending_path = logical.parent / (
                             f".{logical.name}.removal-pending"
                         )
-                        if path not in {
-                            _owned_tree_tombstone_path(logical, identity),
-                            _owned_tree_tombstone_path(pending_path, identity),
-                        }:
+                        valid_tombstones = {
+                            candidate
+                            for candidate in (
+                                _owned_tree_tombstone_for_identity(
+                                    logical, identity
+                                ),
+                                _owned_tree_tombstone_for_identity(
+                                    pending_path, identity
+                                ),
+                            )
+                            if candidate is not None
+                        }
+                        if path not in valid_tombstones:
                             raise WorkspaceError(
                                 "temporary state removal tombstone is invalid"
                             )
@@ -6380,16 +6611,19 @@ class Cleanup:
                 ):
                     logical = Path(policy["path"])
                     lock = Path(f"{logical}.lock")
-                    lease_identity = policy["lease_identity"]
-                    lock_tombstone = lock.parent / (
-                        f".{lock.name}.remove-{lease_identity['device']:x}-"
-                        f"{lease_identity['inode']:x}"
+                    lock_tombstone = _temporary_state_lock_tombstone(
+                        lock, policy["lease_identity"]
                     )
                     if policy["lifecycle"] == "removal-pending" or (
                         lock.exists()
                         or lock.is_symlink()
-                        or lock_tombstone.exists()
-                        or lock_tombstone.is_symlink()
+                        or (
+                            lock_tombstone is not None
+                            and (
+                                lock_tombstone.exists()
+                                or lock_tombstone.is_symlink()
+                            )
+                        )
                     ):
                         items.append(
                             self._detached_temporary_state_item(
@@ -6469,10 +6703,7 @@ class Cleanup:
             )
         lock = Path(f"{path}.lock")
         lease_identity = policy["lease_identity"]
-        lock_tombstone = lock.parent / (
-            f".{lock.name}.remove-{lease_identity['device']:x}-"
-            f"{lease_identity['inode']:x}"
-        )
+        lock_tombstone = _temporary_state_lock_tombstone(lock, lease_identity)
         if lock.exists() or lock.is_symlink():
             busy, lock_error, observed_identity = self._state_lock_observation(lock)
             if lock_error:
@@ -6480,15 +6711,21 @@ class Cleanup:
                 item["error"] = lock_error
             elif busy:
                 item["reasons"].append("active_state_lease")
-            elif observed_identity != lease_identity:
+            elif observed_identity is None or not _identity_matches_metadata(
+                lease_identity, lock.stat(follow_symlinks=False)
+            ) or observed_identity != {
+                "device": lock.stat(follow_symlinks=False).st_dev,
+                "inode": lock.stat(follow_symlinks=False).st_ino,
+            }:
                 item["reasons"].append("state_lease_identity_mismatch")
-        elif lock_tombstone.exists() or lock_tombstone.is_symlink():
+        elif lock_tombstone is not None and (
+            lock_tombstone.exists() or lock_tombstone.is_symlink()
+        ):
             metadata = lock_tombstone.stat(follow_symlinks=False)
             if (
                 not stat.S_ISREG(metadata.st_mode)
                 or metadata.st_nlink != 1
-                or {"device": metadata.st_dev, "inode": metadata.st_ino}
-                != lease_identity
+                or not _identity_matches_metadata(lease_identity, metadata)
             ):
                 item["reasons"].append("state_lease_identity_mismatch")
         else:
@@ -6629,8 +6866,9 @@ class Cleanup:
                     not isinstance(status_policy, dict)
                     or status_policy.get("lifecycle")
                     not in {"removal-pending", "removed"}
-                    or status_policy.get("identity")
-                    != {"device": metadata.st_dev, "inode": metadata.st_ino}
+                    or not _identity_matches_metadata(
+                        status_policy.get("identity"), metadata
+                    )
                 ):
                     raise WorkspaceError(
                         "temporary state removal status is invalid"
@@ -6687,8 +6925,9 @@ class Cleanup:
                     "topology": topology_name,
                     "generation": generation,
                 }
-                or creation_policy.get("identity")
-                != {"device": metadata.st_dev, "inode": metadata.st_ino}
+                or not _identity_matches_metadata(
+                    creation_policy.get("identity"), metadata
+                )
             ):
                 raise WorkspaceError("temporary state metadata is invalid")
             item["topology"] = topology_name
@@ -6701,12 +6940,18 @@ class Cleanup:
                 if registered == path:
                     registered_state = True
                     break
-                if registered.exists() and not registered.is_symlink() and (
-                    self.workspace._state_identity(registered)
-                    == {"device": metadata.st_dev, "inode": metadata.st_ino}
-                ):
-                    registered_state = True
-                    break
+                if registered.exists() and not registered.is_symlink():
+                    try:
+                        registered_identity = self.workspace._state_identity(
+                            registered
+                        )
+                    except (OSError, WorkspaceError):
+                        continue
+                    if _identity_records_match(
+                        registered_identity, creation_policy.get("identity")
+                    ):
+                        registered_state = True
+                        break
             if registered_state:
                 item["reasons"].append("registered_state")
             if not empty_removal_tombstone:
@@ -6740,8 +6985,8 @@ class Cleanup:
                         item["error"] = message
                 finally:
                     os.close(state_fd)
+            state_lock = Path(f"{path}.lock")
             if check_lock:
-                state_lock = Path(f"{path}.lock")
                 if not state_lock.exists() and not state_lock.is_symlink():
                     item["reasons"].append("state_lease_unverifiable")
                 else:
@@ -6780,11 +7025,28 @@ class Cleanup:
                             )
                         else:
                             policy = status_policy
-                            if (
-                                observed_lease_identity is None
-                                or status_policy.get("lease_identity")
-                                != observed_lease_identity
-                            ):
+                            if observed_lease_identity is None:
+                                lease_matches = False
+                            else:
+                                try:
+                                    lease_metadata = state_lock.stat(
+                                        follow_symlinks=False
+                                    )
+                                except OSError:
+                                    lease_matches = False
+                                else:
+                                    lease_matches = (
+                                        observed_lease_identity
+                                        == {
+                                            "device": lease_metadata.st_dev,
+                                            "inode": lease_metadata.st_ino,
+                                        }
+                                        and _identity_matches_metadata(
+                                            status_policy.get("lease_identity"),
+                                            lease_metadata,
+                                        )
+                                    )
+                            if not lease_matches:
                                 item["reasons"].append(
                                     "state_lease_identity_mismatch"
                                 )
@@ -6878,6 +7140,14 @@ class Cleanup:
             )
         )
 
+    @staticmethod
+    def _valid_filesystem_identity(value: Any) -> bool:
+        try:
+            validate_identity(value)
+        except FilesystemIdentityError:
+            return False
+        return True
+
     def _valid_temporary_state_recovery(
         self, action: Any, evidence: Any
     ) -> bool:
@@ -6900,7 +7170,7 @@ class Cleanup:
             or not isinstance(evidence.get("topology"), str)
             or not isinstance(evidence.get("generation"), str)
             or not re.fullmatch(r"[0-9a-f]{64}", evidence["generation"])
-            or not self._identity_pair(evidence.get("lease_identity"))
+            or not self._valid_filesystem_identity(evidence.get("lease_identity"))
         ):
             return False
         try:
@@ -6945,39 +7215,57 @@ class Cleanup:
         variant = evidence["variant"]
         if variant == "lease-only":
             return identity is None and evidence.get("physical_path") is None
-        if (
-            not isinstance(identity, dict)
-            or set(identity) != {"device", "inode", "ctime_ns", "file_type"}
-            or not all(
+        if not isinstance(evidence.get("physical_path"), str):
+            return False
+        legacy_filesystem = (
+            isinstance(identity, dict)
+            and set(identity) == {"device", "inode", "ctime_ns", "file_type"}
+            and all(
                 isinstance(identity.get(key), int)
                 and not isinstance(identity.get(key), bool)
                 and identity[key] >= 0
                 for key in identity
             )
-            or not isinstance(evidence.get("physical_path"), str)
-        ):
+        )
+        portable_filesystem = (
+            isinstance(identity, dict)
+            and self._valid_filesystem_identity(identity)
+            and identity.get("kind") in {"file", "directory"}
+        )
+        if not (legacy_filesystem or portable_filesystem):
             return False
         physical = Path(evidence["physical_path"])
         if variant == "state":
-            pair = {key: identity[key] for key in ("device", "inode")}
             pending = state.parent / f".{state.name}.removal-pending"
-            allowed = {
-                state,
-                pending,
-                _owned_tree_tombstone_path(state, pair),
-                _owned_tree_tombstone_path(pending, pair),
-            }
-            return physical in allowed and identity["file_type"] == stat.S_IFDIR
+            if physical in {state, pending}:
+                return (
+                    identity["file_type"] == stat.S_IFDIR
+                    if legacy_filesystem
+                    else identity.get("kind") == "directory"
+                )
+            if physical.parent != state.parent or not re.fullmatch(
+                r"\.remove-[0-9a-f]{16}-[0-9a-f]+-[0-9a-f]+",
+                physical.name,
+            ):
+                return False
+            return (
+                identity["file_type"] == stat.S_IFDIR
+                if legacy_filesystem
+                else identity.get("kind") == "directory"
+            )
         lock = Path(f"{state}.lock")
-        tombstone = lock.parent / (
-            f".{lock.name}.remove-{evidence['lease_identity']['device']:x}-"
-            f"{evidence['lease_identity']['inode']:x}"
+        lock_path = physical == lock
+        lock_tombstone = physical.parent == lock.parent and re.fullmatch(
+            rf"\.{re.escape(lock.name)}\.remove-[0-9a-f]+-[0-9a-f]+",
+            physical.name,
         )
         return (
-            identity["file_type"] == stat.S_IFREG
-            and physical == (lock if variant == "orphan-lock" else tombstone)
-            and {key: identity[key] for key in ("device", "inode")}
-            == evidence["lease_identity"]
+            (
+                identity["file_type"] == stat.S_IFREG
+                if legacy_filesystem
+                else identity.get("kind") == "file"
+            )
+            and (lock_path if variant == "orphan-lock" else lock_tombstone)
         )
 
     def _temporary_state_recovery_evidence(
@@ -6992,25 +7280,52 @@ class Cleanup:
             else "state"
         )
         raw_identity = item.get("_identity")
-        filesystem_identity = (
-            None
-            if raw_identity is None
-            else {
+        physical_value = item.get("_physical_path")
+        physical_metadata: os.stat_result | None = None
+        if isinstance(physical_value, str):
+            try:
+                physical_metadata = Path(physical_value).stat(
+                    follow_symlinks=False
+                )
+            except OSError:
+                physical_metadata = None
+        filesystem_identity = None
+        if physical_metadata is not None:
+            filesystem_identity = {
+                "device": portable_device(physical_metadata),
+                "inode": physical_metadata.st_ino,
+                "ctime_ns": physical_metadata.st_ctime_ns,
+                "file_type": stat.S_IFMT(physical_metadata.st_mode),
+            }
+        elif raw_identity is not None:
+            # A missing historical object cannot be re-derived safely.  Keep
+            # the old shape as an explicitly legacy, fail-closed record so
+            # migration can report it rather than guessing.
+            filesystem_identity = {
                 "device": raw_identity[0],
                 "inode": raw_identity[1],
                 "ctime_ns": raw_identity[2],
                 "file_type": raw_identity[3],
             }
-        )
         raw_container = item.get("_temporary_state_container_identity")
         if not isinstance(raw_container, tuple) or len(raw_container) != 3:
             raise WorkspaceError("temporary state container identity is missing")
         lease_identity = (
-            {"device": raw_identity[0], "inode": raw_identity[1]}
-            if variant.startswith("orphan-") and raw_identity is not None
+            portable_identity(physical_metadata)
+            if variant.startswith("orphan-") and physical_metadata is not None
             else state_policy.get("lease_identity")
             if isinstance(state_policy, dict)
             else None
+        )
+        container_path = Path(item["path"]).parent
+        try:
+            container_metadata = container_path.stat(follow_symlinks=False)
+        except OSError:
+            container_metadata = None
+        container_device = (
+            portable_device(container_metadata)
+            if container_metadata is not None
+            else raw_container[0]
         )
         evidence = {
             "variant": variant,
@@ -7019,7 +7334,7 @@ class Cleanup:
             "physical_path": item.get("_physical_path"),
             "filesystem_identity": filesystem_identity,
             "container_identity": {
-                "device": raw_container[0],
+                "device": container_device,
                 "inode": raw_container[1],
                 "mount_id": (
                     list(raw_container[2])
@@ -7058,19 +7373,24 @@ class Cleanup:
         root = self.workspace._topology_directory(topology)
         lock = Path(f"{path}.lock")
         lease_identity = evidence["lease_identity"]
-        lock_tombstone = lock.parent / (
-            f".{lock.name}.remove-{lease_identity['device']:x}-"
-            f"{lease_identity['inode']:x}"
-        )
+        lock_tombstone = _temporary_state_lock_tombstone(lock, lease_identity)
+        if lock_tombstone is None and evidence["variant"] == "orphan-tombstone":
+            candidate = Path(evidence["physical_path"])
+            if candidate.parent == lock.parent and re.fullmatch(
+                rf"\.{re.escape(lock.name)}\.remove-[0-9a-f]+-[0-9a-f]+",
+                candidate.name,
+            ):
+                lock_tombstone = candidate
         filesystem = evidence["filesystem_identity"]
         pending = path.parent / f".{path.name}.removal-pending"
         state_candidates = [path, pending]
         if filesystem is not None and evidence["variant"] == "state":
-            pair = {key: filesystem[key] for key in ("device", "inode")}
-            state_candidates.extend(
-                _owned_tree_tombstone_path(candidate, pair)
-                for candidate in tuple(state_candidates)
-            )
+            for candidate in tuple(state_candidates):
+                tombstone = _owned_tree_tombstone_for_identity(
+                    candidate, filesystem
+                )
+                if tombstone is not None:
+                    state_candidates.append(tombstone)
 
         with exclusive_lock(
             root / "operation.lock",
@@ -7079,7 +7399,16 @@ class Cleanup:
         ):
             container_fd, container_identity = self._open_temporary_state_container(root)
             try:
-                if container_identity != self._temporary_state_container_tuple(evidence):
+                container_metadata = (root / "temporary-states").stat(
+                    follow_symlinks=False
+                )
+                if not _pair_matches_metadata(
+                    {
+                        "device": evidence["container_identity"]["device"],
+                        "inode": evidence["container_identity"]["inode"],
+                    },
+                    container_metadata,
+                ):
                     raise WorkspaceError(
                         "temporary state container changed during cleanup recovery"
                     )
@@ -7095,19 +7424,15 @@ class Cleanup:
                     if (
                         filesystem is None
                         or not stat.S_ISDIR(metadata.st_mode)
-                        or (metadata.st_dev, metadata.st_ino)
-                        != (filesystem["device"], filesystem["inode"])
-                        or stat.S_IFMT(metadata.st_mode) != filesystem["file_type"]
-                        or (
-                            present_states[0] == path
-                            and metadata.st_ctime_ns != filesystem["ctime_ns"]
+                        or not _recovery_filesystem_matches(
+                            filesystem, metadata, present_states[0] == path
                         )
                     ):
                         raise WorkspaceError(
                             "temporary state identity changed during cleanup recovery"
                         )
                 lock_present = lock.exists() or lock.is_symlink()
-                tombstone_present = (
+                tombstone_present = lock_tombstone is not None and (
                     lock_tombstone.exists() or lock_tombstone.is_symlink()
                 )
                 if lock_present and tombstone_present:
@@ -7117,8 +7442,9 @@ class Cleanup:
                     if (
                         not stat.S_ISREG(metadata.st_mode)
                         or metadata.st_nlink != 1
-                        or (metadata.st_dev, metadata.st_ino)
-                        != (lease_identity["device"], lease_identity["inode"])
+                        or not _identity_matches_metadata(
+                            lease_identity, metadata
+                        )
                     ):
                         raise WorkspaceError(
                             "temporary state lease changed during cleanup recovery"
@@ -7129,8 +7455,9 @@ class Cleanup:
                         )
                     if evidence["variant"] == "orphan-lock" and (
                         filesystem is None
-                        or metadata.st_ctime_ns != filesystem["ctime_ns"]
-                        or stat.S_IFMT(metadata.st_mode) != filesystem["file_type"]
+                        or not _recovery_filesystem_matches(
+                            filesystem, metadata, True
+                        )
                     ):
                         raise WorkspaceError(
                             "orphan temporary state lease changed during cleanup recovery"
@@ -7184,9 +7511,12 @@ class Cleanup:
                     or policy.get("path") != str(path)
                     or policy.get("owner", {}).get("generation")
                     != evidence["generation"]
-                    or policy.get("identity")
-                    != {key: filesystem[key] for key in ("device", "inode")}
-                    or policy.get("lease_identity") != lease_identity
+                    or not _recovery_identity_matches_record(
+                        policy.get("identity"), filesystem
+                    )
+                    or not _identity_records_match(
+                        policy.get("lease_identity"), lease_identity
+                    )
                     or policy.get("lifecycle") != "removed"
                 ):
                     raise WorkspaceError(
@@ -7196,7 +7526,9 @@ class Cleanup:
                     not isinstance(policy, dict)
                     or policy.get("mode") != "temporary"
                     or policy.get("path") != str(path)
-                    or policy.get("lease_identity") != lease_identity
+                    or not _identity_records_match(
+                        policy.get("lease_identity"), lease_identity
+                    )
                     or policy.get("lifecycle") != "removed"
                 ):
                     raise WorkspaceError(
@@ -7221,10 +7553,9 @@ class Cleanup:
                         filesystem is None
                         or not stat.S_ISREG(metadata.st_mode)
                         or metadata.st_nlink != 1
-                        or metadata.st_ctime_ns != filesystem["ctime_ns"]
-                        or stat.S_IFMT(metadata.st_mode) != filesystem["file_type"]
-                        or (metadata.st_dev, metadata.st_ino)
-                        != (filesystem["device"], filesystem["inode"])
+                        or not _recovery_filesystem_matches(
+                            filesystem, metadata, True
+                        )
                     ):
                         raise WorkspaceError(
                             "orphan temporary state lease tombstone changed during recovery"
@@ -7432,8 +7763,10 @@ class Cleanup:
                         if (
                             recovery_evidence.get("variant")
                             not in {"state", "lease-only"}
-                            or expected_lease_identity
-                            != recovery_evidence.get("lease_identity")
+                            or not _identity_records_match(
+                                expected_lease_identity,
+                                recovery_evidence.get("lease_identity"),
+                            )
                         ):
                             raise WorkspaceError(
                                 "temporary state recovery lease policy changed"
@@ -7441,7 +7774,7 @@ class Cleanup:
                         expected_lease_identity = recovery_evidence[
                             "lease_identity"
                         ]
-                    if not self._identity_pair(expected_lease_identity):
+                    if not self._valid_filesystem_identity(expected_lease_identity):
                         raise WorkspaceError(
                             "removed temporary state lease identity is invalid"
                         )
@@ -7457,13 +7790,8 @@ class Cleanup:
                                 not stat.S_ISREG(lease_metadata.st_mode)
                                 or lease_metadata.st_nlink != 1
                                 or recovery_evidence is not None
-                                and (
-                                    lease_metadata.st_dev,
-                                    lease_metadata.st_ino,
-                                )
-                                != (
-                                    expected_lease_identity["device"],
-                                    expected_lease_identity["inode"],
+                                and not _identity_matches_metadata(
+                                    expected_lease_identity, lease_metadata
                                 )
                             ):
                                 raise WorkspaceError(
@@ -7508,13 +7836,8 @@ class Cleanup:
                     not stat.S_ISREG(lease_metadata.st_mode)
                     or lease_metadata.st_nlink != 1
                     or recovery_evidence is not None
-                    and (
-                        lease_metadata.st_dev,
-                        lease_metadata.st_ino,
-                    )
-                    != (
-                        recovery_evidence["lease_identity"]["device"],
-                        recovery_evidence["lease_identity"]["inode"],
+                    and not _identity_matches_metadata(
+                        recovery_evidence["lease_identity"], lease_metadata
                     )
                 ):
                     raise WorkspaceError(
@@ -7559,13 +7882,13 @@ class Cleanup:
                             "topology": topology,
                             "generation": recovery_evidence["generation"],
                         }
-                        or policy.get("identity")
-                        != {
-                            "device": filesystem["device"],
-                            "inode": filesystem["inode"],
-                        }
-                        or policy.get("lease_identity")
-                        != recovery_evidence["lease_identity"]
+                        or not _recovery_identity_matches_record(
+                            policy.get("identity"), filesystem
+                        )
+                        or not _identity_records_match(
+                            policy.get("lease_identity"),
+                            recovery_evidence["lease_identity"],
+                        )
                         or policy.get("lifecycle")
                         not in {"disposable", "removal-pending", "removed"}
                     ):
@@ -7573,7 +7896,7 @@ class Cleanup:
                             "temporary state recovery status changed"
                         )
                 pending = self.workspace._temporary_state_removal_path(policy)
-                removal_tombstone = _owned_tree_tombstone_path(
+                removal_tombstone = _owned_tree_tombstone_for_identity(
                     pending, policy["identity"]
                 )
                 mutation_path = next(
@@ -7737,24 +8060,37 @@ class Cleanup:
                         nonblocking=True,
                     )
                 )
-            tombstone = _owned_tree_tombstone_path(path, identity)
+            tombstone = (
+                _owned_tree_tombstone_path(path, identity)
+                if is_legacy_identity(identity)
+                else _portable_tombstone_path(path, identity)
+            )
             if (
                 path.exists()
                 or path.is_symlink()
-                or tombstone.exists()
-                or tombstone.is_symlink()
+                or (
+                    tombstone is not None
+                    and (tombstone.exists() or tombstone.is_symlink())
+                )
             ):
                 remove_owned_tree(path, expected_identity=identity)
 
     @staticmethod
     def _worktree_tree_location(
-        path: Path, identity: dict[str, int]
+        path: Path, identity: dict[str, Any]
     ) -> tuple[str, Path] | None:
         """Locate an exact removal root at its live name or durable tombstone."""
 
-        tombstone = _owned_tree_tombstone_path(path, identity)
+        tombstone = (
+            _owned_tree_tombstone_path(path, identity)
+            if is_legacy_identity(identity)
+            else _portable_tombstone_path(path, identity)
+        )
         found: list[tuple[str, Path]] = []
-        for label, candidate in (("live", path), ("tombstone", tombstone)):
+        candidates = [("live", path)]
+        if tombstone is not None:
+            candidates.append(("tombstone", tombstone))
+        for label, candidate in candidates:
             if not candidate.exists() and not candidate.is_symlink():
                 continue
             metadata = candidate.lstat()
@@ -7762,8 +8098,7 @@ class Cleanup:
                 not stat.S_ISDIR(metadata.st_mode)
                 or stat.S_ISLNK(metadata.st_mode)
                 or metadata.st_uid != os.geteuid()
-                or (metadata.st_dev, metadata.st_ino)
-                != (identity["device"], identity["inode"])
+                or not _identity_matches_metadata(identity, metadata)
             ):
                 raise WorkspaceError(
                     f"linked worktree recovery root changed identity: {candidate}"
@@ -7829,11 +8164,8 @@ class Cleanup:
             and admin_location is not None
             and admin_location[0] == "live"
         ):
-            if (
-                _linked_worktree_registration_identity(
-                    path, Path(evidence["common"])
-                )
-                != evidence
+            if not _linked_worktree_registration_matches(
+                path, Path(evidence["common"]), evidence
             ):
                 raise WorkspaceError(
                     "linked worktree registration changed before retry"
@@ -8119,11 +8451,10 @@ class Cleanup:
             ):
                 raise WorkspaceError("linked worktree removal identity is missing")
             if item["owner"] != "sound":
-                if (
-                    _linked_worktree_registration_identity(
-                        path, Path(registration_identity["common"])
-                    )
-                    != registration_identity
+                if not _linked_worktree_registration_matches(
+                    path,
+                    Path(registration_identity["common"]),
+                    registration_identity,
                 ):
                     raise WorkspaceError(
                         "linked worktree registration changed before removal"
@@ -8257,7 +8588,7 @@ class Cleanup:
     def _remove_cleanup_journal(
         self,
         item: dict[str, Any],
-        identity: dict[str, int],
+        identity: dict[str, Any],
         *,
         removal_started: Callable[[], None] | None,
     ) -> None:
@@ -8265,14 +8596,23 @@ class Cleanup:
         root = self.paths.workspace / "cleanup-journals"
         if path.parent != root or path.name in {"", ".", ".."}:
             raise WorkspaceError("cleanup journal path is invalid")
-        tombstone = _owned_tree_tombstone_path(path, identity)
         descriptor = _open_directory_nofollow(
             root,
             os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
         )
         try:
             visible_name: str | None = None
-            for name in (path.name, tombstone.name):
+            candidates = [path.name]
+            if not path.exists() and not path.is_symlink():
+                digest = hashlib.sha256(path.name.encode("utf-8")).hexdigest()[:16]
+                candidates.extend(
+                    name
+                    for name in sorted(os.listdir(descriptor))
+                    if re.fullmatch(
+                        rf"\.remove-{digest}-[0-9a-f]+-[0-9a-f]+", name
+                    )
+                )
+            for name in candidates:
                 try:
                     metadata = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
                 except FileNotFoundError:
@@ -8282,8 +8622,7 @@ class Cleanup:
                     or metadata.st_nlink != 1
                     or metadata.st_uid != os.geteuid()
                     or stat.S_IMODE(metadata.st_mode) != 0o600
-                    or metadata.st_dev != identity.get("device")
-                    or metadata.st_ino != identity.get("inode")
+                    or not _identity_matches_metadata(identity, metadata)
                 ):
                     raise WorkspaceError(
                         "cleanup journal identity changed before removal"
@@ -8296,6 +8635,13 @@ class Cleanup:
             if removal_started is not None:
                 removal_started()
             if visible_name == path.name:
+                metadata = os.stat(
+                    path.name, dir_fd=descriptor, follow_symlinks=False
+                )
+                tombstone = _owned_tree_tombstone_path(
+                    path,
+                    portable_pair(metadata),
+                )
                 rename_no_replace_at(
                     descriptor,
                     path.name,

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -20,6 +20,16 @@ from typing import Any, Callable, Iterable, Iterator
 from .locking import LockBusyError, active_lock_fds
 from .content_migration import CONTENT_MIGRATION_PENDING, CONTENT_MIGRATION_RECORD
 from .delivery import inventory_active_delivery_evidence
+from .filesystem_identity import (
+    FilesystemIdentityError,
+    identity_matches,
+    is_legacy_identity,
+    pair_matches,
+    portable_device,
+    portable_identity,
+    portable_pair,
+    validate_identity,
+)
 from .migration import MIGRATION_PENDING, MIGRATION_RECORD, OPERATION_PATHS
 from .model import (
     MANAGED_MARKER,
@@ -52,6 +62,7 @@ from .workspace import (
     _descriptor_path,
     _open_directory_nofollow,
     _owned_tree_tombstone_path,
+    _portable_tombstone_path,
     _remote_matches,
     exclusive_lock,
     load_regular_json,
@@ -86,6 +97,164 @@ def _canonical_json_sha256(value: Any) -> str:
     return hashlib.sha256(
         json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
     ).hexdigest()
+
+
+def _portable_text_identity(
+    metadata: os.stat_result, value: str
+) -> dict[str, Any]:
+    """Describe Git text evidence without retaining the mount device."""
+
+    return {
+        "device": portable_device(metadata),
+        "inode": metadata.st_ino,
+        "ctime_ns": metadata.st_ctime_ns,
+        "size": metadata.st_size,
+        "sha256": hashlib.sha256(value.encode("utf-8")).hexdigest(),
+    }
+
+
+def _identity_matches_metadata(value: Any, metadata: os.stat_result) -> bool:
+    try:
+        if isinstance(value, dict) and set(value) == {"device", "inode"}:
+            return pair_matches(value, metadata)
+        return identity_matches(value, metadata)
+    except (FilesystemIdentityError, TypeError):
+        return False
+
+
+def _pair_matches_metadata(value: Any, metadata: os.stat_result) -> bool:
+    try:
+        return pair_matches(value, metadata)
+    except (FilesystemIdentityError, TypeError):
+        return False
+
+
+def _temporary_state_lock_tombstone(
+    lock: Path, identity: Any
+) -> Path | None:
+    """Find a state-lease tombstone by its live metadata, not its old device."""
+
+    candidates: list[Path] = []
+    for candidate in sorted(lock.parent.glob(f".{lock.name}.remove-*")):
+        try:
+            metadata = candidate.stat(follow_symlinks=False)
+        except FileNotFoundError:
+            continue
+        if _identity_matches_metadata(identity, metadata) or (
+            _pair_matches_metadata(identity, metadata)
+            if isinstance(identity, dict) and set(identity) == {"device", "inode"}
+            else False
+        ):
+            candidates.append(candidate)
+    if len(candidates) > 1:
+        raise WorkspaceError(
+            f"temporary topology state lease tombstones are ambiguous: {lock}"
+        )
+    return candidates[0] if candidates else None
+
+
+def _owned_tree_tombstone_for_identity(
+    path: Path, identity: Any
+) -> Path | None:
+    """Find a tree tombstone for either a portable or legacy record."""
+
+    if isinstance(identity, dict) and set(identity) == {"device", "inode"}:
+        digest = hashlib.sha256(path.name.encode("utf-8")).hexdigest()[:16]
+        candidates: list[Path] = []
+        for candidate in sorted(path.parent.iterdir()):
+            if not re.fullmatch(
+                rf"\.remove-{digest}-[0-9a-f]+-[0-9a-f]+",
+                candidate.name,
+            ):
+                continue
+            try:
+                metadata = candidate.stat(follow_symlinks=False)
+            except FileNotFoundError:
+                continue
+            if _pair_matches_metadata(identity, metadata):
+                candidates.append(candidate)
+        if len(candidates) > 1:
+            raise WorkspaceError(f"owned-tree tombstones are ambiguous: {path}")
+        return candidates[0] if candidates else None
+    if isinstance(identity, dict) and set(identity) == {
+        "device",
+        "inode",
+        "ctime_ns",
+        "file_type",
+    }:
+        pair = {key: identity[key] for key in ("device", "inode")}
+        digest = hashlib.sha256(path.name.encode("utf-8")).hexdigest()[:16]
+        candidates: list[Path] = []
+        for candidate in sorted(path.parent.iterdir()):
+            if not re.fullmatch(
+                rf"\.remove-{digest}-[0-9a-f]+-[0-9a-f]+",
+                candidate.name,
+            ):
+                continue
+            try:
+                metadata = candidate.stat(follow_symlinks=False)
+            except FileNotFoundError:
+                continue
+            if _pair_matches_metadata(pair, metadata):
+                candidates.append(candidate)
+        if len(candidates) > 1:
+            raise WorkspaceError(f"owned-tree tombstones are ambiguous: {path}")
+        return candidates[0] if candidates else None
+    if is_legacy_identity(identity):
+        candidate = _owned_tree_tombstone_path(path, identity)
+        return candidate if candidate.exists() or candidate.is_symlink() else None
+    return _portable_tombstone_path(path, identity)
+
+
+def _recovery_filesystem_matches(
+    value: Any, metadata: os.stat_result, check_ctime: bool
+) -> bool:
+    """Match the bounded temporary-state evidence to a live object."""
+
+    if (
+        isinstance(value, dict)
+        and set(value) == {"device", "inode", "ctime_ns", "file_type"}
+    ):
+        return (
+            _pair_matches_metadata(
+                {"device": value["device"], "inode": value["inode"]},
+                metadata,
+            )
+            and stat.S_IFMT(metadata.st_mode) == value["file_type"]
+            and (not check_ctime or metadata.st_ctime_ns == value["ctime_ns"])
+        )
+    return isinstance(value, dict) and _identity_matches_metadata(value, metadata)
+
+
+def _recovery_identity_matches_record(identity: Any, record: Any) -> bool:
+    """Compare a state-policy identity with temporary recovery evidence."""
+
+    if not isinstance(identity, dict) or not isinstance(record, dict):
+        return False
+    if identity.get("inode") != record.get("inode"):
+        return False
+    if set(identity) == {"device", "inode"} and "device" in record:
+        return identity["device"] == record["device"]
+    return identity.get("kind") == "directory"
+
+
+def _identity_records_match(left: Any, right: Any) -> bool:
+    if not isinstance(left, dict) or not isinstance(right, dict):
+        return False
+    if left.get("inode") != right.get("inode"):
+        return False
+    if set(left) == {"device", "inode"} and set(right) == {
+        "device",
+        "inode",
+    }:
+        return left["device"] == right["device"]
+    if "schema_version" in left and "schema_version" in right:
+        return left == right
+    if "schema_version" in left or "schema_version" in right:
+        # A legacy pair can be compared to a portable record only by the
+        # inode until the current object is opened and fenced below.
+        return True
+    return True
 
 
 def _cleanup_journal_name_matches_coordinate(name: str, coordinate: str) -> bool:
@@ -274,13 +443,7 @@ def _text_evidence(path: Path) -> tuple[str, dict[str, Any]]:
     metadata = path.lstat()
     if metadata.st_uid != os.geteuid():
         raise WorkspaceError(f"Git worktree metadata has a foreign owner: {path}")
-    return value, {
-        "device": identity[0],
-        "inode": identity[1],
-        "ctime_ns": identity[2],
-        "size": identity[3],
-        "sha256": hashlib.sha256(value.encode("utf-8")).hexdigest(),
-    }
+    return value, _portable_text_identity(metadata, value)
 
 
 def _linked_worktree_registration_identity(
@@ -338,17 +501,11 @@ def _linked_worktree_registration_identity(
     return {
         "schema_version": 1,
         "worktree": str(worktree.resolve()),
-        "worktree_identity": {
-            "device": worktree_metadata.st_dev,
-            "inode": worktree_metadata.st_ino,
-        },
+        "worktree_identity": portable_pair(worktree_metadata),
         "pointer": pointer,
         "common": str(common),
         "admin": str(git_directory),
-        "admin_identity": {
-            "device": admin_metadata.st_dev,
-            "inode": admin_metadata.st_ino,
-        },
+        "admin_identity": portable_pair(admin_metadata),
         "backlink": backlink,
     }
 
@@ -397,6 +554,52 @@ def _valid_linked_worktree_registration_identity(value: Any) -> bool:
         admin.parent == common / "worktrees"
         and admin.name not in {"", ".", ".."}
         and worktree.name not in {"", ".", ".."}
+    )
+
+
+def _text_evidence_matches(path: Path, expected: Any) -> bool:
+    if not isinstance(expected, dict):
+        return False
+    try:
+        _value, observed = _text_evidence(path)
+        metadata = path.lstat()
+    except (OSError, RuntimeError, WorkspaceError):
+        return False
+    if set(expected) != set(observed):
+        return False
+    return all(
+        observed[key] == expected[key]
+        for key in observed
+        if key != "device"
+    ) and _pair_matches_metadata(
+        {"device": expected.get("device"), "inode": expected.get("inode")},
+        metadata,
+    )
+
+
+def _linked_worktree_registration_matches(
+    worktree: Path, common: Path, expected: Any
+) -> bool:
+    if not _valid_linked_worktree_registration_identity(expected):
+        return False
+    try:
+        actual = _linked_worktree_registration_identity(worktree, common)
+        worktree_metadata = worktree.lstat()
+        admin_metadata = Path(actual["admin"]).lstat()
+    except (OSError, RuntimeError, WorkspaceError):
+        return False
+    if any(
+        actual[key] != expected[key]
+        for key in ("schema_version", "worktree", "common", "admin")
+    ):
+        return False
+    return (
+        _pair_matches_metadata(expected["worktree_identity"], worktree_metadata)
+        and _pair_matches_metadata(expected["admin_identity"], admin_metadata)
+        and _text_evidence_matches(worktree / ".git", expected["pointer"])
+        and _text_evidence_matches(
+            Path(actual["admin"]) / "gitdir", expected["backlink"]
+        )
     )
 
 
@@ -515,7 +718,8 @@ def _sound_producer_lock_snapshot(
     marker, identity = _regular_text_identity(path)
     if marker != SOUND_PRODUCER_LOCK_MARKER or path.lstat().st_uid != os.geteuid():
         raise WorkspaceError("sound producer cleanup lease marker is invalid")
-    return path, identity
+    metadata = path.lstat()
+    return path, (portable_device(metadata), metadata.st_ino, identity[2], identity[3])
 
 
 @contextmanager
@@ -531,6 +735,12 @@ def _exclusive_sound_producer_lease(
     try:
         metadata = os.fstat(descriptor)
         identity = (
+            portable_device(metadata),
+            metadata.st_ino,
+            metadata.st_ctime_ns,
+            metadata.st_size,
+        )
+        legacy_identity = (
             metadata.st_dev,
             metadata.st_ino,
             metadata.st_ctime_ns,
@@ -540,7 +750,7 @@ def _exclusive_sound_producer_lease(
             not stat.S_ISREG(metadata.st_mode)
             or metadata.st_nlink != 1
             or metadata.st_uid != os.geteuid()
-            or identity != expected_identity
+            or tuple(expected_identity) not in {identity, legacy_identity}
         ):
             raise WorkspaceError("sound producer cleanup lease changed identity")
         try:
@@ -1692,7 +1902,7 @@ class Cleanup:
             }
             if kind == "sound-cache":
                 expected.add("producer_identity")
-            if set(intent) != expected or not self._identity_pair(
+            if set(intent) != expected or not self._valid_filesystem_identity(
                 intent.get("identity")
             ):
                 return False
@@ -1720,7 +1930,7 @@ class Cleanup:
             return True
         if kind == "cleanup-journal":
             return set(intent) == {"action", "identity", "phase"} and (
-                self._identity_pair(intent.get("identity"))
+                self._valid_filesystem_identity(intent.get("identity"))
             )
         if kind == "temporary-state":
             return set(intent) == {"action", "phase", "recovery"} and (
@@ -2248,10 +2458,7 @@ class Cleanup:
                         raise WorkspaceError(
                             f"cleanup target is not a directory: {target['path']}"
                         )
-                    intent["identity"] = {
-                        "device": identity.st_dev,
-                        "inode": identity.st_ino,
-                    }
+                    intent["identity"] = portable_identity(identity)
                     intent["target_sha256"] = _canonical_json_sha256(
                         planned_target
                     )
@@ -2266,10 +2473,10 @@ class Cleanup:
                             else None
                         )
                 elif target["kind"] == "cleanup-journal":
-                    intent["identity"] = {
-                        "device": match["device"],
-                        "inode": match["inode"],
-                    }
+                    journal_metadata = Path(target["path"]).stat(
+                        follow_symlinks=False
+                    )
+                    intent["identity"] = portable_pair(journal_metadata)
                 elif target["kind"] == "temporary-state":
                     intent["recovery"] = self._temporary_state_recovery_evidence(
                         match
@@ -2594,7 +2801,7 @@ class Cleanup:
         metadata: os.stat_result | None = None
         try:
             metadata = path.lstat()
-            item["device"] = metadata.st_dev
+            item["device"] = portable_device(metadata)
             item["inode"] = metadata.st_ino
             item["_inodes"] = {
                 (metadata.st_dev, metadata.st_ino): metadata.st_blocks * 512
@@ -2807,9 +3014,19 @@ class Cleanup:
         kind = target["kind"]
         if kind == "cleanup-journal":
             item = self._cleanup_journal_item(path, older_than_days, names)
+            try:
+                metadata = path.lstat()
+            except OSError:
+                metadata = None
             if (
-                item.get("device") != target.get("device")
-                or item.get("inode") != target.get("inode")
+                metadata is None
+                or not pair_matches(
+                    {
+                        "device": target.get("device"),
+                        "inode": target.get("inode"),
+                    },
+                    metadata,
+                )
             ):
                 item["disposition"] = "protected"
                 item["reasons"] = ["cleanup_journal_identity_changed"]
@@ -3134,10 +3351,12 @@ class Cleanup:
                                 mutable_output_identities[index], dict
                             )
                         ):
-                            tombstone = _owned_tree_tombstone_path(
+                            tombstone = _owned_tree_tombstone_for_identity(
                                 output, mutable_output_identities[index]
                             )
-                            if tombstone.exists() or tombstone.is_symlink():
+                            if tombstone is not None and (
+                                tombstone.exists() or tombstone.is_symlink()
+                            ):
                                 output_evidence = True
                                 break
                     if output_evidence:
@@ -6196,10 +6415,13 @@ class Cleanup:
             )
             if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
                 raise WorkspaceError("orphan temporary state lease is invalid")
-            if expected_tombstone_identity is not None and (
-                metadata.st_dev,
-                metadata.st_ino,
-            ) != expected_tombstone_identity:
+            if expected_tombstone_identity is not None and not _pair_matches_metadata(
+                {
+                    "device": expected_tombstone_identity[0],
+                    "inode": expected_tombstone_identity[1],
+                },
+                metadata,
+            ):
                 raise WorkspaceError(
                     "orphan temporary state lease tombstone identity is invalid"
                 )
@@ -6362,10 +6584,19 @@ class Cleanup:
                         pending_path = logical.parent / (
                             f".{logical.name}.removal-pending"
                         )
-                        if path not in {
-                            _owned_tree_tombstone_path(logical, identity),
-                            _owned_tree_tombstone_path(pending_path, identity),
-                        }:
+                        valid_tombstones = {
+                            candidate
+                            for candidate in (
+                                _owned_tree_tombstone_for_identity(
+                                    logical, identity
+                                ),
+                                _owned_tree_tombstone_for_identity(
+                                    pending_path, identity
+                                ),
+                            )
+                            if candidate is not None
+                        }
+                        if path not in valid_tombstones:
                             raise WorkspaceError(
                                 "temporary state removal tombstone is invalid"
                             )
@@ -6395,16 +6626,19 @@ class Cleanup:
                 ):
                     logical = Path(policy["path"])
                     lock = Path(f"{logical}.lock")
-                    lease_identity = policy["lease_identity"]
-                    lock_tombstone = lock.parent / (
-                        f".{lock.name}.remove-{lease_identity['device']:x}-"
-                        f"{lease_identity['inode']:x}"
+                    lock_tombstone = _temporary_state_lock_tombstone(
+                        lock, policy["lease_identity"]
                     )
                     if policy["lifecycle"] == "removal-pending" or (
                         lock.exists()
                         or lock.is_symlink()
-                        or lock_tombstone.exists()
-                        or lock_tombstone.is_symlink()
+                        or (
+                            lock_tombstone is not None
+                            and (
+                                lock_tombstone.exists()
+                                or lock_tombstone.is_symlink()
+                            )
+                        )
                     ):
                         items.append(
                             self._detached_temporary_state_item(
@@ -6484,10 +6718,7 @@ class Cleanup:
             )
         lock = Path(f"{path}.lock")
         lease_identity = policy["lease_identity"]
-        lock_tombstone = lock.parent / (
-            f".{lock.name}.remove-{lease_identity['device']:x}-"
-            f"{lease_identity['inode']:x}"
-        )
+        lock_tombstone = _temporary_state_lock_tombstone(lock, lease_identity)
         if lock.exists() or lock.is_symlink():
             busy, lock_error, observed_identity = self._state_lock_observation(lock)
             if lock_error:
@@ -6495,15 +6726,21 @@ class Cleanup:
                 item["error"] = lock_error
             elif busy:
                 item["reasons"].append("active_state_lease")
-            elif observed_identity != lease_identity:
+            elif observed_identity is None or not _identity_matches_metadata(
+                lease_identity, lock.stat(follow_symlinks=False)
+            ) or observed_identity != {
+                "device": lock.stat(follow_symlinks=False).st_dev,
+                "inode": lock.stat(follow_symlinks=False).st_ino,
+            }:
                 item["reasons"].append("state_lease_identity_mismatch")
-        elif lock_tombstone.exists() or lock_tombstone.is_symlink():
+        elif lock_tombstone is not None and (
+            lock_tombstone.exists() or lock_tombstone.is_symlink()
+        ):
             metadata = lock_tombstone.stat(follow_symlinks=False)
             if (
                 not stat.S_ISREG(metadata.st_mode)
                 or metadata.st_nlink != 1
-                or {"device": metadata.st_dev, "inode": metadata.st_ino}
-                != lease_identity
+                or not _identity_matches_metadata(lease_identity, metadata)
             ):
                 item["reasons"].append("state_lease_identity_mismatch")
         else:
@@ -6644,8 +6881,9 @@ class Cleanup:
                     not isinstance(status_policy, dict)
                     or status_policy.get("lifecycle")
                     not in {"removal-pending", "removed"}
-                    or status_policy.get("identity")
-                    != {"device": metadata.st_dev, "inode": metadata.st_ino}
+                    or not _identity_matches_metadata(
+                        status_policy.get("identity"), metadata
+                    )
                 ):
                     raise WorkspaceError(
                         "temporary state removal status is invalid"
@@ -6702,8 +6940,9 @@ class Cleanup:
                     "topology": topology_name,
                     "generation": generation,
                 }
-                or creation_policy.get("identity")
-                != {"device": metadata.st_dev, "inode": metadata.st_ino}
+                or not _identity_matches_metadata(
+                    creation_policy.get("identity"), metadata
+                )
             ):
                 raise WorkspaceError("temporary state metadata is invalid")
             item["topology"] = topology_name
@@ -6716,12 +6955,18 @@ class Cleanup:
                 if registered == path:
                     registered_state = True
                     break
-                if registered.exists() and not registered.is_symlink() and (
-                    self.workspace._state_identity(registered)
-                    == {"device": metadata.st_dev, "inode": metadata.st_ino}
-                ):
-                    registered_state = True
-                    break
+                if registered.exists() and not registered.is_symlink():
+                    try:
+                        registered_identity = self.workspace._state_identity(
+                            registered
+                        )
+                    except (OSError, WorkspaceError):
+                        continue
+                    if _identity_records_match(
+                        registered_identity, creation_policy.get("identity")
+                    ):
+                        registered_state = True
+                        break
             if registered_state:
                 item["reasons"].append("registered_state")
             if not empty_removal_tombstone:
@@ -6755,8 +7000,8 @@ class Cleanup:
                         item["error"] = message
                 finally:
                     os.close(state_fd)
+            state_lock = Path(f"{path}.lock")
             if check_lock:
-                state_lock = Path(f"{path}.lock")
                 if not state_lock.exists() and not state_lock.is_symlink():
                     item["reasons"].append("state_lease_unverifiable")
                 else:
@@ -6795,11 +7040,28 @@ class Cleanup:
                             )
                         else:
                             policy = status_policy
-                            if (
-                                observed_lease_identity is None
-                                or status_policy.get("lease_identity")
-                                != observed_lease_identity
-                            ):
+                            if observed_lease_identity is None:
+                                lease_matches = False
+                            else:
+                                try:
+                                    lease_metadata = state_lock.stat(
+                                        follow_symlinks=False
+                                    )
+                                except OSError:
+                                    lease_matches = False
+                                else:
+                                    lease_matches = (
+                                        observed_lease_identity
+                                        == {
+                                            "device": lease_metadata.st_dev,
+                                            "inode": lease_metadata.st_ino,
+                                        }
+                                        and _identity_matches_metadata(
+                                            status_policy.get("lease_identity"),
+                                            lease_metadata,
+                                        )
+                                    )
+                            if not lease_matches:
                                 item["reasons"].append(
                                     "state_lease_identity_mismatch"
                                 )
@@ -6893,6 +7155,14 @@ class Cleanup:
             )
         )
 
+    @staticmethod
+    def _valid_filesystem_identity(value: Any) -> bool:
+        try:
+            validate_identity(value)
+        except FilesystemIdentityError:
+            return False
+        return True
+
     def _valid_temporary_state_recovery(
         self, action: Any, evidence: Any
     ) -> bool:
@@ -6915,7 +7185,7 @@ class Cleanup:
             or not isinstance(evidence.get("topology"), str)
             or not isinstance(evidence.get("generation"), str)
             or not re.fullmatch(r"[0-9a-f]{64}", evidence["generation"])
-            or not self._identity_pair(evidence.get("lease_identity"))
+            or not self._valid_filesystem_identity(evidence.get("lease_identity"))
         ):
             return False
         try:
@@ -6960,39 +7230,57 @@ class Cleanup:
         variant = evidence["variant"]
         if variant == "lease-only":
             return identity is None and evidence.get("physical_path") is None
-        if (
-            not isinstance(identity, dict)
-            or set(identity) != {"device", "inode", "ctime_ns", "file_type"}
-            or not all(
+        if not isinstance(evidence.get("physical_path"), str):
+            return False
+        legacy_filesystem = (
+            isinstance(identity, dict)
+            and set(identity) == {"device", "inode", "ctime_ns", "file_type"}
+            and all(
                 isinstance(identity.get(key), int)
                 and not isinstance(identity.get(key), bool)
                 and identity[key] >= 0
                 for key in identity
             )
-            or not isinstance(evidence.get("physical_path"), str)
-        ):
+        )
+        portable_filesystem = (
+            isinstance(identity, dict)
+            and self._valid_filesystem_identity(identity)
+            and identity.get("kind") in {"file", "directory"}
+        )
+        if not (legacy_filesystem or portable_filesystem):
             return False
         physical = Path(evidence["physical_path"])
         if variant == "state":
-            pair = {key: identity[key] for key in ("device", "inode")}
             pending = state.parent / f".{state.name}.removal-pending"
-            allowed = {
-                state,
-                pending,
-                _owned_tree_tombstone_path(state, pair),
-                _owned_tree_tombstone_path(pending, pair),
-            }
-            return physical in allowed and identity["file_type"] == stat.S_IFDIR
+            if physical in {state, pending}:
+                return (
+                    identity["file_type"] == stat.S_IFDIR
+                    if legacy_filesystem
+                    else identity.get("kind") == "directory"
+                )
+            if physical.parent != state.parent or not re.fullmatch(
+                r"\.remove-[0-9a-f]{16}-[0-9a-f]+-[0-9a-f]+",
+                physical.name,
+            ):
+                return False
+            return (
+                identity["file_type"] == stat.S_IFDIR
+                if legacy_filesystem
+                else identity.get("kind") == "directory"
+            )
         lock = Path(f"{state}.lock")
-        tombstone = lock.parent / (
-            f".{lock.name}.remove-{evidence['lease_identity']['device']:x}-"
-            f"{evidence['lease_identity']['inode']:x}"
+        lock_path = physical == lock
+        lock_tombstone = physical.parent == lock.parent and re.fullmatch(
+            rf"\.{re.escape(lock.name)}\.remove-[0-9a-f]+-[0-9a-f]+",
+            physical.name,
         )
         return (
-            identity["file_type"] == stat.S_IFREG
-            and physical == (lock if variant == "orphan-lock" else tombstone)
-            and {key: identity[key] for key in ("device", "inode")}
-            == evidence["lease_identity"]
+            (
+                identity["file_type"] == stat.S_IFREG
+                if legacy_filesystem
+                else identity.get("kind") == "file"
+            )
+            and (lock_path if variant == "orphan-lock" else lock_tombstone)
         )
 
     def _temporary_state_recovery_evidence(
@@ -7007,25 +7295,52 @@ class Cleanup:
             else "state"
         )
         raw_identity = item.get("_identity")
-        filesystem_identity = (
-            None
-            if raw_identity is None
-            else {
+        physical_value = item.get("_physical_path")
+        physical_metadata: os.stat_result | None = None
+        if isinstance(physical_value, str):
+            try:
+                physical_metadata = Path(physical_value).stat(
+                    follow_symlinks=False
+                )
+            except OSError:
+                physical_metadata = None
+        filesystem_identity = None
+        if physical_metadata is not None:
+            filesystem_identity = {
+                "device": portable_device(physical_metadata),
+                "inode": physical_metadata.st_ino,
+                "ctime_ns": physical_metadata.st_ctime_ns,
+                "file_type": stat.S_IFMT(physical_metadata.st_mode),
+            }
+        elif raw_identity is not None:
+            # A missing historical object cannot be re-derived safely.  Keep
+            # the old shape as an explicitly legacy, fail-closed record so
+            # migration can report it rather than guessing.
+            filesystem_identity = {
                 "device": raw_identity[0],
                 "inode": raw_identity[1],
                 "ctime_ns": raw_identity[2],
                 "file_type": raw_identity[3],
             }
-        )
         raw_container = item.get("_temporary_state_container_identity")
         if not isinstance(raw_container, tuple) or len(raw_container) != 3:
             raise WorkspaceError("temporary state container identity is missing")
         lease_identity = (
-            {"device": raw_identity[0], "inode": raw_identity[1]}
-            if variant.startswith("orphan-") and raw_identity is not None
+            portable_identity(physical_metadata)
+            if variant.startswith("orphan-") and physical_metadata is not None
             else state_policy.get("lease_identity")
             if isinstance(state_policy, dict)
             else None
+        )
+        container_path = Path(item["path"]).parent
+        try:
+            container_metadata = container_path.stat(follow_symlinks=False)
+        except OSError:
+            container_metadata = None
+        container_device = (
+            portable_device(container_metadata)
+            if container_metadata is not None
+            else raw_container[0]
         )
         evidence = {
             "variant": variant,
@@ -7034,7 +7349,7 @@ class Cleanup:
             "physical_path": item.get("_physical_path"),
             "filesystem_identity": filesystem_identity,
             "container_identity": {
-                "device": raw_container[0],
+                "device": container_device,
                 "inode": raw_container[1],
                 "mount_id": (
                     list(raw_container[2])
@@ -7073,19 +7388,24 @@ class Cleanup:
         root = self.workspace._topology_directory(topology)
         lock = Path(f"{path}.lock")
         lease_identity = evidence["lease_identity"]
-        lock_tombstone = lock.parent / (
-            f".{lock.name}.remove-{lease_identity['device']:x}-"
-            f"{lease_identity['inode']:x}"
-        )
+        lock_tombstone = _temporary_state_lock_tombstone(lock, lease_identity)
+        if lock_tombstone is None and evidence["variant"] == "orphan-tombstone":
+            candidate = Path(evidence["physical_path"])
+            if candidate.parent == lock.parent and re.fullmatch(
+                rf"\.{re.escape(lock.name)}\.remove-[0-9a-f]+-[0-9a-f]+",
+                candidate.name,
+            ):
+                lock_tombstone = candidate
         filesystem = evidence["filesystem_identity"]
         pending = path.parent / f".{path.name}.removal-pending"
         state_candidates = [path, pending]
         if filesystem is not None and evidence["variant"] == "state":
-            pair = {key: filesystem[key] for key in ("device", "inode")}
-            state_candidates.extend(
-                _owned_tree_tombstone_path(candidate, pair)
-                for candidate in tuple(state_candidates)
-            )
+            for candidate in tuple(state_candidates):
+                tombstone = _owned_tree_tombstone_for_identity(
+                    candidate, filesystem
+                )
+                if tombstone is not None:
+                    state_candidates.append(tombstone)
 
         with exclusive_lock(
             root / "operation.lock",
@@ -7094,7 +7414,16 @@ class Cleanup:
         ):
             container_fd, container_identity = self._open_temporary_state_container(root)
             try:
-                if container_identity != self._temporary_state_container_tuple(evidence):
+                container_metadata = (root / "temporary-states").stat(
+                    follow_symlinks=False
+                )
+                if not _pair_matches_metadata(
+                    {
+                        "device": evidence["container_identity"]["device"],
+                        "inode": evidence["container_identity"]["inode"],
+                    },
+                    container_metadata,
+                ):
                     raise WorkspaceError(
                         "temporary state container changed during cleanup recovery"
                     )
@@ -7110,19 +7439,15 @@ class Cleanup:
                     if (
                         filesystem is None
                         or not stat.S_ISDIR(metadata.st_mode)
-                        or (metadata.st_dev, metadata.st_ino)
-                        != (filesystem["device"], filesystem["inode"])
-                        or stat.S_IFMT(metadata.st_mode) != filesystem["file_type"]
-                        or (
-                            present_states[0] == path
-                            and metadata.st_ctime_ns != filesystem["ctime_ns"]
+                        or not _recovery_filesystem_matches(
+                            filesystem, metadata, present_states[0] == path
                         )
                     ):
                         raise WorkspaceError(
                             "temporary state identity changed during cleanup recovery"
                         )
                 lock_present = lock.exists() or lock.is_symlink()
-                tombstone_present = (
+                tombstone_present = lock_tombstone is not None and (
                     lock_tombstone.exists() or lock_tombstone.is_symlink()
                 )
                 if lock_present and tombstone_present:
@@ -7132,8 +7457,9 @@ class Cleanup:
                     if (
                         not stat.S_ISREG(metadata.st_mode)
                         or metadata.st_nlink != 1
-                        or (metadata.st_dev, metadata.st_ino)
-                        != (lease_identity["device"], lease_identity["inode"])
+                        or not _identity_matches_metadata(
+                            lease_identity, metadata
+                        )
                     ):
                         raise WorkspaceError(
                             "temporary state lease changed during cleanup recovery"
@@ -7144,8 +7470,9 @@ class Cleanup:
                         )
                     if evidence["variant"] == "orphan-lock" and (
                         filesystem is None
-                        or metadata.st_ctime_ns != filesystem["ctime_ns"]
-                        or stat.S_IFMT(metadata.st_mode) != filesystem["file_type"]
+                        or not _recovery_filesystem_matches(
+                            filesystem, metadata, True
+                        )
                     ):
                         raise WorkspaceError(
                             "orphan temporary state lease changed during cleanup recovery"
@@ -7199,9 +7526,12 @@ class Cleanup:
                     or policy.get("path") != str(path)
                     or policy.get("owner", {}).get("generation")
                     != evidence["generation"]
-                    or policy.get("identity")
-                    != {key: filesystem[key] for key in ("device", "inode")}
-                    or policy.get("lease_identity") != lease_identity
+                    or not _recovery_identity_matches_record(
+                        policy.get("identity"), filesystem
+                    )
+                    or not _identity_records_match(
+                        policy.get("lease_identity"), lease_identity
+                    )
                     or policy.get("lifecycle") != "removed"
                 ):
                     raise WorkspaceError(
@@ -7211,7 +7541,9 @@ class Cleanup:
                     not isinstance(policy, dict)
                     or policy.get("mode") != "temporary"
                     or policy.get("path") != str(path)
-                    or policy.get("lease_identity") != lease_identity
+                    or not _identity_records_match(
+                        policy.get("lease_identity"), lease_identity
+                    )
                     or policy.get("lifecycle") != "removed"
                 ):
                     raise WorkspaceError(
@@ -7236,10 +7568,9 @@ class Cleanup:
                         filesystem is None
                         or not stat.S_ISREG(metadata.st_mode)
                         or metadata.st_nlink != 1
-                        or metadata.st_ctime_ns != filesystem["ctime_ns"]
-                        or stat.S_IFMT(metadata.st_mode) != filesystem["file_type"]
-                        or (metadata.st_dev, metadata.st_ino)
-                        != (filesystem["device"], filesystem["inode"])
+                        or not _recovery_filesystem_matches(
+                            filesystem, metadata, True
+                        )
                     ):
                         raise WorkspaceError(
                             "orphan temporary state lease tombstone changed during recovery"
@@ -7447,8 +7778,10 @@ class Cleanup:
                         if (
                             recovery_evidence.get("variant")
                             not in {"state", "lease-only"}
-                            or expected_lease_identity
-                            != recovery_evidence.get("lease_identity")
+                            or not _identity_records_match(
+                                expected_lease_identity,
+                                recovery_evidence.get("lease_identity"),
+                            )
                         ):
                             raise WorkspaceError(
                                 "temporary state recovery lease policy changed"
@@ -7456,7 +7789,7 @@ class Cleanup:
                         expected_lease_identity = recovery_evidence[
                             "lease_identity"
                         ]
-                    if not self._identity_pair(expected_lease_identity):
+                    if not self._valid_filesystem_identity(expected_lease_identity):
                         raise WorkspaceError(
                             "removed temporary state lease identity is invalid"
                         )
@@ -7472,13 +7805,8 @@ class Cleanup:
                                 not stat.S_ISREG(lease_metadata.st_mode)
                                 or lease_metadata.st_nlink != 1
                                 or recovery_evidence is not None
-                                and (
-                                    lease_metadata.st_dev,
-                                    lease_metadata.st_ino,
-                                )
-                                != (
-                                    expected_lease_identity["device"],
-                                    expected_lease_identity["inode"],
+                                and not _identity_matches_metadata(
+                                    expected_lease_identity, lease_metadata
                                 )
                             ):
                                 raise WorkspaceError(
@@ -7523,13 +7851,8 @@ class Cleanup:
                     not stat.S_ISREG(lease_metadata.st_mode)
                     or lease_metadata.st_nlink != 1
                     or recovery_evidence is not None
-                    and (
-                        lease_metadata.st_dev,
-                        lease_metadata.st_ino,
-                    )
-                    != (
-                        recovery_evidence["lease_identity"]["device"],
-                        recovery_evidence["lease_identity"]["inode"],
+                    and not _identity_matches_metadata(
+                        recovery_evidence["lease_identity"], lease_metadata
                     )
                 ):
                     raise WorkspaceError(
@@ -7574,13 +7897,13 @@ class Cleanup:
                             "topology": topology,
                             "generation": recovery_evidence["generation"],
                         }
-                        or policy.get("identity")
-                        != {
-                            "device": filesystem["device"],
-                            "inode": filesystem["inode"],
-                        }
-                        or policy.get("lease_identity")
-                        != recovery_evidence["lease_identity"]
+                        or not _recovery_identity_matches_record(
+                            policy.get("identity"), filesystem
+                        )
+                        or not _identity_records_match(
+                            policy.get("lease_identity"),
+                            recovery_evidence["lease_identity"],
+                        )
                         or policy.get("lifecycle")
                         not in {"disposable", "removal-pending", "removed"}
                     ):
@@ -7588,7 +7911,7 @@ class Cleanup:
                             "temporary state recovery status changed"
                         )
                 pending = self.workspace._temporary_state_removal_path(policy)
-                removal_tombstone = _owned_tree_tombstone_path(
+                removal_tombstone = _owned_tree_tombstone_for_identity(
                     pending, policy["identity"]
                 )
                 mutation_path = next(
@@ -7752,24 +8075,37 @@ class Cleanup:
                         nonblocking=True,
                     )
                 )
-            tombstone = _owned_tree_tombstone_path(path, identity)
+            tombstone = (
+                _owned_tree_tombstone_path(path, identity)
+                if is_legacy_identity(identity)
+                else _portable_tombstone_path(path, identity)
+            )
             if (
                 path.exists()
                 or path.is_symlink()
-                or tombstone.exists()
-                or tombstone.is_symlink()
+                or (
+                    tombstone is not None
+                    and (tombstone.exists() or tombstone.is_symlink())
+                )
             ):
                 remove_owned_tree(path, expected_identity=identity)
 
     @staticmethod
     def _worktree_tree_location(
-        path: Path, identity: dict[str, int]
+        path: Path, identity: dict[str, Any]
     ) -> tuple[str, Path] | None:
         """Locate an exact removal root at its live name or durable tombstone."""
 
-        tombstone = _owned_tree_tombstone_path(path, identity)
+        tombstone = (
+            _owned_tree_tombstone_path(path, identity)
+            if is_legacy_identity(identity)
+            else _portable_tombstone_path(path, identity)
+        )
         found: list[tuple[str, Path]] = []
-        for label, candidate in (("live", path), ("tombstone", tombstone)):
+        candidates = [("live", path)]
+        if tombstone is not None:
+            candidates.append(("tombstone", tombstone))
+        for label, candidate in candidates:
             if not candidate.exists() and not candidate.is_symlink():
                 continue
             metadata = candidate.lstat()
@@ -7777,8 +8113,7 @@ class Cleanup:
                 not stat.S_ISDIR(metadata.st_mode)
                 or stat.S_ISLNK(metadata.st_mode)
                 or metadata.st_uid != os.geteuid()
-                or (metadata.st_dev, metadata.st_ino)
-                != (identity["device"], identity["inode"])
+                or not _identity_matches_metadata(identity, metadata)
             ):
                 raise WorkspaceError(
                     f"linked worktree recovery root changed identity: {candidate}"
@@ -7844,11 +8179,8 @@ class Cleanup:
             and admin_location is not None
             and admin_location[0] == "live"
         ):
-            if (
-                _linked_worktree_registration_identity(
-                    path, Path(evidence["common"])
-                )
-                != evidence
+            if not _linked_worktree_registration_matches(
+                path, Path(evidence["common"]), evidence
             ):
                 raise WorkspaceError(
                     "linked worktree registration changed before retry"
@@ -8134,11 +8466,10 @@ class Cleanup:
             ):
                 raise WorkspaceError("linked worktree removal identity is missing")
             if item["owner"] != "sound":
-                if (
-                    _linked_worktree_registration_identity(
-                        path, Path(registration_identity["common"])
-                    )
-                    != registration_identity
+                if not _linked_worktree_registration_matches(
+                    path,
+                    Path(registration_identity["common"]),
+                    registration_identity,
                 ):
                     raise WorkspaceError(
                         "linked worktree registration changed before removal"
@@ -8272,7 +8603,7 @@ class Cleanup:
     def _remove_cleanup_journal(
         self,
         item: dict[str, Any],
-        identity: dict[str, int],
+        identity: dict[str, Any],
         *,
         removal_started: Callable[[], None] | None,
     ) -> None:
@@ -8280,14 +8611,23 @@ class Cleanup:
         root = self.paths.workspace / "cleanup-journals"
         if path.parent != root or path.name in {"", ".", ".."}:
             raise WorkspaceError("cleanup journal path is invalid")
-        tombstone = _owned_tree_tombstone_path(path, identity)
         descriptor = _open_directory_nofollow(
             root,
             os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
         )
         try:
             visible_name: str | None = None
-            for name in (path.name, tombstone.name):
+            candidates = [path.name]
+            if not path.exists() and not path.is_symlink():
+                digest = hashlib.sha256(path.name.encode("utf-8")).hexdigest()[:16]
+                candidates.extend(
+                    name
+                    for name in sorted(os.listdir(descriptor))
+                    if re.fullmatch(
+                        rf"\.remove-{digest}-[0-9a-f]+-[0-9a-f]+", name
+                    )
+                )
+            for name in candidates:
                 try:
                     metadata = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
                 except FileNotFoundError:
@@ -8297,8 +8637,7 @@ class Cleanup:
                     or metadata.st_nlink != 1
                     or metadata.st_uid != os.geteuid()
                     or stat.S_IMODE(metadata.st_mode) != 0o600
-                    or metadata.st_dev != identity.get("device")
-                    or metadata.st_ino != identity.get("inode")
+                    or not _identity_matches_metadata(identity, metadata)
                 ):
                     raise WorkspaceError(
                         "cleanup journal identity changed before removal"
@@ -8311,6 +8650,13 @@ class Cleanup:
             if removal_started is not None:
                 removal_started()
             if visible_name == path.name:
+                metadata = os.stat(
+                    path.name, dir_fd=descriptor, follow_symlinks=False
+                )
+                tombstone = _owned_tree_tombstone_path(
+                    path,
+                    portable_pair(metadata),
+                )
                 rename_no_replace_at(
                     descriptor,
                     path.name,

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -159,6 +159,17 @@ def parser() -> argparse.ArgumentParser:
     migrate_content_mode.add_argument("--audit", action="store_true")
     migrate_content_mode.add_argument("--restore", action="store_true")
     migrate_content.add_argument("--json", action="store_true")
+    migrate_filesystem = migrate_commands.add_parser(
+        "filesystem", help="convert legacy filesystem identities after a remount"
+    )
+    migrate_filesystem_mode = migrate_filesystem.add_mutually_exclusive_group(
+        required=True
+    )
+    migrate_filesystem_mode.add_argument("--dry-run", action="store_true")
+    migrate_filesystem_mode.add_argument("--apply", action="store_true")
+    migrate_filesystem_mode.add_argument("--audit", action="store_true")
+    migrate_filesystem.add_argument("--confirm-remount", action="store_true")
+    migrate_filesystem.add_argument("--json", action="store_true")
 
     worktree = commands.add_parser(
         "worktree", help="manage physical-checkout worktrees"
@@ -649,6 +660,41 @@ def main(arguments: list[str] | None = None) -> int:
                 prefix + "governance/provenance-identities/registry.json: valid "
                 f"({count} records, {len(options.reference)} references)"
             )
+            return 0
+
+        if (
+            options.command == "migrate"
+            and options.migrate_command == "filesystem"
+        ):
+            from .filesystem_migration import migrate_filesystem_records
+
+            mode = (
+                "apply"
+                if options.apply
+                else "audit"
+                if options.audit
+                else "dry-run"
+            )
+            result = migrate_filesystem_records(
+                ROOT,
+                mode,
+                confirm_remount=options.confirm_remount,
+            )
+            if options.json:
+                print(json.dumps(result, indent=2, sort_keys=True))
+            else:
+                print(f"migration\t{result['migration']}")
+                print(f"status\t{result['status']}")
+                for record in result.get("records", []):
+                    print(
+                        f"record\t{record.get('status', 'planned')}\t"
+                        f"{record['path']}"
+                    )
+                if result.get("requires_confirm_remount"):
+                    print(
+                        "recovery\tlegacy identities require "
+                        "--apply --confirm-remount"
+                    )
             return 0
 
         workspace_type = Workspace

--- a/atrinik_workspace/completion.py
+++ b/atrinik_workspace/completion.py
@@ -8,6 +8,7 @@ import re
 import stat
 from typing import Any, Iterable
 
+from .filesystem_identity import FilesystemIdentityError, validate_identity
 from .model import MANAGED_MARKER, Manifest, Paths, WorkspaceError, validate_name
 from .process_tree import control_socket_path
 from .sound import validate_release_coordinates
@@ -856,13 +857,7 @@ def _valid_topology(
         or control["socket"]
         != str(control_socket_path(topology_root, control["generation"]))
         or not isinstance(control.get("lease"), dict)
-        or set(control["lease"]) != {"device", "inode"}
-        or not all(
-            isinstance(value, int)
-            and not isinstance(value, bool)
-            and value >= 0
-            for value in control["lease"].values()
-        )
+        or not _valid_filesystem_identity(control["lease"])
     ):
         return False
     process_keys = (
@@ -1123,6 +1118,14 @@ def _valid_name(value: object) -> bool:
     try:
         validate_name(value, "completion candidate")
     except WorkspaceError:
+        return False
+    return True
+
+
+def _valid_filesystem_identity(value: Any) -> bool:
+    try:
+        validate_identity(value)
+    except FilesystemIdentityError:
         return False
     return True
 

--- a/atrinik_workspace/filesystem_identity.py
+++ b/atrinik_workspace/filesystem_identity.py
@@ -1,0 +1,359 @@
+"""Portable durable identities for wrapper-managed filesystem records.
+
+``st_dev`` is a useful *live* identity component, but it is a property of a
+mount namespace.  It is therefore deliberately absent from identities that
+are written to workspace records.  Callers that are fencing a live operation
+should continue to compare the descriptor's complete ``(st_dev, st_ino)``
+identity and, where applicable, its mount id.
+
+The portable identity is intentionally small.  Directories are identified by
+their inode and file type; their ctime is not retained because normal child
+creation changes a directory's ctime.  Regular files also retain ctime, so an
+atomic replacement cannot be accepted merely because it happens to reuse an
+inode.  Content digests remain a separate integrity assertion when a record
+already has one.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import stat
+from typing import Any, Mapping
+
+
+PORTABLE_IDENTITY_SCHEMA_VERSION = 1
+PORTABLE_DIRECTORY_IDENTITY_KEYS = {
+    "schema_version",
+    "kind",
+    "inode",
+    "mode",
+}
+PORTABLE_FILE_IDENTITY_KEYS = PORTABLE_DIRECTORY_IDENTITY_KEYS
+PORTABLE_FILE_OPTIONAL_KEYS = {"ctime_ns"}
+LEGACY_IDENTITY_KEYS = {"device", "inode"}
+
+
+class FilesystemIdentityError(ValueError):
+    """A durable filesystem identity is invalid or cannot be migrated."""
+
+
+class FilesystemIdentityMigrationRequired(FilesystemIdentityError):
+    """A pre-portable record needs the explicit remount migration command."""
+
+
+@dataclass(frozen=True)
+class LegacyIdentityEvidence:
+    """The old mount-bound identity retained in a migration audit record."""
+
+    device: int
+    inode: int
+
+    def json(self) -> dict[str, int]:
+        return {"device": self.device, "inode": self.inode}
+
+
+def live_identity(metadata: os.stat_result) -> tuple[int, int]:
+    """Return the complete identity used only for a live descriptor fence."""
+
+    return metadata.st_dev, metadata.st_ino
+
+
+def portable_identity(
+    metadata: os.stat_result,
+    *,
+    content_sha256: str | None = None,
+    include_ctime: bool = True,
+) -> dict[str, Any]:
+    """Build a mount-independent identity from one already-opened object.
+
+    ``include_ctime`` is retained for regular files whose replacement must be
+    detected.  Lease files that are deliberately renamed during their normal
+    lifecycle should use ``include_ctime=False`` and retain their separate
+    live descriptor, content, or creation-token fences.
+    """
+
+    if not (stat.S_ISDIR(metadata.st_mode) or stat.S_ISREG(metadata.st_mode)):
+        raise FilesystemIdentityError("portable identity requires a regular file or directory")
+    value: dict[str, Any] = {
+        "schema_version": PORTABLE_IDENTITY_SCHEMA_VERSION,
+        "kind": "directory" if stat.S_ISDIR(metadata.st_mode) else "file",
+        "inode": _nonnegative_integer(metadata.st_ino, "inode"),
+        "mode": stat.S_IFMT(metadata.st_mode),
+    }
+    if stat.S_ISREG(metadata.st_mode):
+        if include_ctime:
+            value["ctime_ns"] = _nonnegative_integer(
+                metadata.st_ctime_ns, "ctime_ns"
+            )
+        if content_sha256 is not None:
+            if not isinstance(content_sha256, str) or not _SHA256.fullmatch(
+                content_sha256
+            ):
+                raise FilesystemIdentityError("content digest is not a SHA-256 value")
+            value["sha256"] = content_sha256
+    elif content_sha256 is not None:
+        raise FilesystemIdentityError("directory identities cannot retain a content digest")
+    return value
+
+
+def portable_identity_from_path(
+    path: Path,
+    *,
+    content_sha256: str | None = None,
+    follow_symlinks: bool = False,
+) -> dict[str, Any]:
+    """Build a portable identity after a no-follow path observation."""
+
+    return portable_identity(
+        path.stat(follow_symlinks=follow_symlinks),
+        content_sha256=content_sha256,
+    )
+
+
+def validate_identity(
+    value: Any,
+    context: str = "filesystem identity",
+    *,
+    allow_legacy: bool = True,
+) -> dict[str, Any]:
+    """Validate a portable identity or an explicitly supported legacy pair."""
+
+    if not isinstance(value, dict):
+        raise FilesystemIdentityError(f"{context} must be an object")
+    keys = set(value)
+    if allow_legacy and keys == LEGACY_IDENTITY_KEYS:
+        for key in keys:
+            _nonnegative_integer(value[key], f"{context}.{key}")
+        return value
+    if value.get("schema_version") != PORTABLE_IDENTITY_SCHEMA_VERSION:
+        raise FilesystemIdentityError(f"{context} has an unsupported schema")
+    kind = value.get("kind")
+    expected = (
+        PORTABLE_DIRECTORY_IDENTITY_KEYS
+        if kind == "directory"
+        else PORTABLE_FILE_IDENTITY_KEYS
+        if kind == "file"
+        else None
+    )
+    if expected is None:
+        raise FilesystemIdentityError(f"{context}.kind is invalid")
+    allowed = expected | {"sha256"}
+    if kind == "file":
+        allowed |= PORTABLE_FILE_OPTIONAL_KEYS
+    if not keys <= allowed or not expected <= keys:
+        raise FilesystemIdentityError(f"{context} has an invalid shape")
+    _nonnegative_integer(value["inode"], f"{context}.inode")
+    mode = value["mode"]
+    if not isinstance(mode, int) or isinstance(mode, bool) or mode not in {
+        stat.S_IFREG,
+        stat.S_IFDIR,
+    }:
+        raise FilesystemIdentityError(f"{context}.mode is invalid")
+    if kind == "file" and "ctime_ns" in value:
+        _nonnegative_integer(value["ctime_ns"], f"{context}.ctime_ns")
+    if "sha256" in value and (
+        kind != "file"
+        or not isinstance(value["sha256"], str)
+        or not _SHA256.fullmatch(value["sha256"])
+    ):
+        raise FilesystemIdentityError(f"{context}.sha256 is invalid")
+    return value
+
+
+def is_portable_identity(value: Any) -> bool:
+    try:
+        validate_identity(value, allow_legacy=False)
+    except FilesystemIdentityError:
+        return False
+    return True
+
+
+def is_legacy_identity(value: Any) -> bool:
+    return isinstance(value, dict) and set(value) == LEGACY_IDENTITY_KEYS and all(
+        isinstance(item, int) and not isinstance(item, bool) and item >= 0
+        for item in value.values()
+    )
+
+
+def identity_matches(
+    value: Mapping[str, Any],
+    metadata: os.stat_result,
+    *,
+    content_sha256: str | None = None,
+) -> bool:
+    """Compare a durable identity with current metadata.
+
+    Legacy records deliberately still require the old device number.  A
+    mismatch is not guessed to be a remount: the caller must use the explicit
+    migration/rebind operation, which records the old evidence first.
+    """
+
+    validated = validate_identity(value)
+    if is_legacy_identity(validated):
+        return live_identity(metadata) == (
+            validated["device"],
+            validated["inode"],
+        )
+    current = portable_identity(metadata, content_sha256=content_sha256)
+    for key, expected in validated.items():
+        if key == "sha256" and content_sha256 is None:
+            return False
+        if current.get(key) != expected:
+            return False
+    return True
+
+
+def require_identity_match(
+    value: Mapping[str, Any],
+    metadata: os.stat_result,
+    context: str,
+    *,
+    content_sha256: str | None = None,
+) -> None:
+    """Raise a migration-specific error for a stale legacy mount identity."""
+
+    if is_legacy_identity(value) and live_identity(metadata) != (
+        value["device"],
+        value["inode"],
+    ):
+        raise FilesystemIdentityMigrationRequired(
+            f"{context} uses a pre-portable filesystem identity; run "
+            "./atrinik migrate filesystem --apply --confirm-remount"
+        )
+    if not identity_matches(value, metadata, content_sha256=content_sha256):
+        raise FilesystemIdentityError(f"{context} changed")
+
+
+def migrate_legacy_identity(
+    value: Mapping[str, Any],
+    metadata: os.stat_result,
+    context: str,
+    *,
+    confirm_remount: bool,
+) -> tuple[dict[str, Any], LegacyIdentityEvidence | None]:
+    """Convert one legacy identity with explicit remount confirmation.
+
+    The inode must still match.  A changed device is accepted only when the
+    operator explicitly selects the migration command; the returned evidence
+    is intended for the atomic migration journal and rollback record.
+    """
+
+    if not is_legacy_identity(value):
+        validated = validate_identity(value, context, allow_legacy=False)
+        return dict(validated), None
+    old = LegacyIdentityEvidence(value["device"], value["inode"])
+    current = live_identity(metadata)
+    if current[1] != old.inode:
+        raise FilesystemIdentityError(f"{context} inode changed; refusing rebind")
+    if current[0] != old.device and not confirm_remount:
+        raise FilesystemIdentityMigrationRequired(
+            f"{context} device changed; rerun with --confirm-remount"
+        )
+    return portable_identity(metadata), old
+
+
+def identity_digest(value: Mapping[str, Any]) -> str:
+    """Return a deterministic digest suitable for durable lock filenames."""
+
+    validate_identity(value, allow_legacy=False)
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("ascii")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def portable_device(metadata: os.stat_result) -> int:
+    """Return a stable numeric compatibility value for old ``device`` fields.
+
+    A few schema-v1 records expose a ``path_device``/``device`` pair as part
+    of a larger record shape.  New writers retain that shape for readers that
+    have not migrated yet, but the value is now a digest-derived portable
+    token, never ``st_dev``.  The projection omits regular-file ``ctime_ns``:
+    link/rename operations legitimately update ctime while preserving the
+    opened object.  New code should prefer the full identity object, with a
+    content digest and live descriptor fence when file replacement matters.
+    """
+
+    if stat.S_ISDIR(metadata.st_mode) or stat.S_ISREG(metadata.st_mode):
+        identity = portable_identity(metadata)
+        return portable_device_from_components(
+            identity["inode"], identity["mode"], identity["kind"]
+        )
+    # Owned-tree cleanup can quarantine symlinks and other entries when the
+    # caller has not requested link rejection.  They cannot be represented by
+    # the durable directory/file schema, but their tombstone name still needs
+    # a mount-independent projection of the opened no-follow metadata.
+    value = {
+        "schema_version": PORTABLE_IDENTITY_SCHEMA_VERSION,
+        "kind": "special",
+        "inode": _nonnegative_integer(metadata.st_ino, "inode"),
+        "mode": stat.S_IFMT(metadata.st_mode),
+    }
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("ascii")
+    return int.from_bytes(hashlib.sha256(raw).digest()[:8], "big")
+
+
+def portable_device_from_components(inode: int, mode: int, kind: str) -> int:
+    """Project known durable type/inode evidence without a live ``stat``.
+
+    This is used only for historical records whose object was intentionally
+    removed before an explicit migration could run.  The result is the same
+    projection as :func:`portable_device`; it is not a live identity proof.
+    Callers must retain the historical bytes and continue to fail closed when
+    a live object is required.
+    """
+
+    _nonnegative_integer(inode, "inode")
+    if kind not in {"file", "directory"}:
+        raise FilesystemIdentityError("portable identity kind is invalid")
+    if mode not in {stat.S_IFREG, stat.S_IFDIR}:
+        raise FilesystemIdentityError("portable identity mode is invalid")
+    if (kind == "file") != (mode == stat.S_IFREG):
+        raise FilesystemIdentityError("portable identity kind and mode disagree")
+    identity = {
+        "schema_version": PORTABLE_IDENTITY_SCHEMA_VERSION,
+        "kind": kind,
+        "inode": inode,
+        "mode": mode,
+    }
+    raw = json.dumps(identity, sort_keys=True, separators=(",", ":")).encode("ascii")
+    return int.from_bytes(hashlib.sha256(raw).digest()[:8], "big")
+
+
+def portable_pair(metadata: os.stat_result) -> dict[str, int]:
+    """Build the backwards-compatible two-integer projection of an identity."""
+
+    return {"device": portable_device(metadata), "inode": metadata.st_ino}
+
+
+def pair_matches(value: Mapping[str, Any], metadata: os.stat_result) -> bool:
+    """Match a portable pair while still accepting an untouched v1 pair."""
+
+    if set(value) != LEGACY_IDENTITY_KEYS:
+        return False
+    device = value.get("device")
+    inode = value.get("inode")
+    if (
+        not isinstance(device, int)
+        or isinstance(device, bool)
+        or device < 0
+        or not isinstance(inode, int)
+        or isinstance(inode, bool)
+        or inode < 0
+    ):
+        return False
+    if inode != metadata.st_ino:
+        return False
+    return device in {metadata.st_dev, portable_device(metadata)}
+
+
+def _nonnegative_integer(value: Any, context: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise FilesystemIdentityError(f"{context} must be a non-negative integer")
+    return value
+
+
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")

--- a/atrinik_workspace/filesystem_migration.py
+++ b/atrinik_workspace/filesystem_migration.py
@@ -292,6 +292,24 @@ def _transform_document(
 ) -> dict[str, Any] | None:
     if remapped_targets is None:
         remapped_targets = {}
+    if (
+        path.name == "atrinik-resource-leases.identity.json"
+        and isinstance(value, dict)
+        and set(value) == {"schema_version", "device", "inode"}
+        and value.get("schema_version") == 1
+    ):
+        namespace = path.with_name("atrinik-resource-leases")
+        metadata = _metadata(namespace, path)
+        try:
+            replacement, _evidence = migrate_legacy_identity(
+                {"device": value["device"], "inode": value["inode"]},
+                metadata,
+                str(path),
+                confirm_remount=True,
+            )
+        except FilesystemIdentityError as error:
+            raise FilesystemMigrationError(str(error)) from error
+        return {"schema_version": 2, "identity": replacement}
     changed = False
     evidence: list[dict[str, Any]] = []
 

--- a/atrinik_workspace/filesystem_migration.py
+++ b/atrinik_workspace/filesystem_migration.py
@@ -1,0 +1,1505 @@
+"""Explicit, atomic migration of pre-portable filesystem identities.
+
+The workspace intentionally keeps legacy ``{"device", "inode"}`` values
+readable, but never guesses that a changed device is a remount.  This module
+is the only supported path for converting those records.  It plans every
+conversion first, keeps the old bytes as historical rollback evidence, and
+publishes the converted JSON records one at a time behind a durable journal.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from contextlib import nullcontext
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import stat
+from typing import Any, Iterable, Mapping
+
+from .filesystem_identity import (
+    FilesystemIdentityError,
+    identity_matches,
+    identity_digest,
+    migrate_legacy_identity,
+    portable_device_from_components,
+    portable_pair,
+    portable_identity,
+    validate_identity,
+)
+from .locking import exclusive_lock
+from .model import Paths, WorkspaceError, durable_atomic_json
+
+
+FILESYSTEM_MIGRATION_SCHEMA_VERSION = 1
+FILESYSTEM_MIGRATION_TRANSACTION = "filesystem-identity-migration-v1"
+FILESYSTEM_MIGRATION_RECORD = "filesystem-identity-migration.json"
+FILESYSTEM_MIGRATION_LOCK = "filesystem-identity-migration.lock"
+MAX_MIGRATION_SNAPSHOT_BYTES = 64 * 1024 * 1024
+_JOURNAL_KEYS = {
+    "schema_version",
+    "transaction",
+    "state",
+    "created_at",
+    "completed_at",
+    "confirm_remount",
+    "records",
+    "rollback_error",
+}
+_JOURNAL_RECORD_KEYS = {
+    "path",
+    "before_sha256",
+    "after_sha256",
+    "before_base64",
+    "after_base64",
+    "before_identity",
+    "after_identity",
+    "rollback_identity",
+    "legacy_evidence",
+}
+_LEGACY_JOURNAL_RECORD_KEYS = {
+    "path",
+    "before_sha256",
+    "after_sha256",
+    "before_base64",
+    "after_base64",
+    "legacy_evidence",
+}
+_FULL_IDENTITY_CONTEXTS = {
+    "control",
+    "filesystem_identity",
+    "identity",
+    "lease",
+    "lease_identity",
+    "output_identity",
+    "state_identity",
+}
+_HISTORICAL_CONTEXTS = {
+    "archive",
+    "archived",
+    "erroneous_snapshot",
+    "historical",
+    "predecessor_snapshot",
+    "preview",
+    "rollback",
+}
+
+
+class FilesystemMigrationError(WorkspaceError):
+    """A filesystem identity migration cannot be proven safe."""
+
+
+def migrate_filesystem_records(
+    repository: Path,
+    mode: str,
+    *,
+    confirm_remount: bool = False,
+) -> dict[str, Any]:
+    """Audit, plan, or apply the wrapper's legacy filesystem identities."""
+
+    if mode not in {"dry-run", "audit", "apply"}:
+        raise ValueError(f"unsupported filesystem migration mode: {mode}")
+    paths = Paths.discover(repository)
+    if mode == "apply":
+        paths.workspace.mkdir(parents=True, exist_ok=True)
+    lock_path = paths.workspace / FILESYSTEM_MIGRATION_LOCK
+    lock_context = (
+        exclusive_lock(lock_path, "filesystem identity migration", nonblocking=True)
+        if mode == "apply"
+        else nullcontext()
+    )
+    with lock_context:
+        journal_path = paths.workspace / FILESYSTEM_MIGRATION_RECORD
+        if journal_path.exists() or journal_path.is_symlink():
+            journal = _read_journal(journal_path)
+            if mode == "audit":
+                return _audit_journal(journal_path, journal)
+            if journal["state"] in {"prepared", "applying", "rollback-required"}:
+                if mode != "apply":
+                    return _journal_plan(journal_path, journal, mode)
+                if not confirm_remount:
+                    raise FilesystemMigrationError(
+                        "an unfinished filesystem identity migration exists; "
+                        "rerun with --apply --confirm-remount"
+                    )
+                return _resume_journal(journal_path, journal)
+            if journal["state"] == "complete":
+                return _audit_journal(journal_path, journal)
+            raise FilesystemMigrationError(
+                f"filesystem identity migration journal has unsupported state: "
+                f"{journal['state']}"
+            )
+
+        # Planning is read-only and should explain what a remount confirmation
+        # would do.  The confirmation gate belongs to apply, not to discovery.
+        plan = _plan(paths, confirm_remount=True)
+        if mode != "apply":
+            return {
+                "migration": FILESYSTEM_MIGRATION_TRANSACTION,
+                "status": "dry-run" if mode == "dry-run" else "audit",
+                "records": [_public_record(record) for record in plan],
+                "requires_confirm_remount": bool(plan),
+            }
+        if plan and not confirm_remount:
+            raise FilesystemMigrationError(
+                "legacy filesystem identities require explicit remount confirmation; "
+                "rerun with --apply --confirm-remount"
+            )
+        if not plan:
+            return {
+                "migration": FILESYSTEM_MIGRATION_TRANSACTION,
+                "status": "complete",
+                "records": [],
+                "journal": None,
+            }
+        journal = _new_journal(plan, confirm_remount=confirm_remount)
+        durable_atomic_json(journal_path, journal)
+        return _apply_journal(journal_path, journal)
+
+
+def _plan(paths: Paths, *, confirm_remount: bool) -> list[dict[str, Any]]:
+    plans: list[dict[str, Any]] = []
+    namespace = _physical_lease_namespace(paths.repository)
+    identity_record = namespace.parent / "atrinik-resource-leases.identity.json"
+    if identity_record.exists() or identity_record.is_symlink():
+        if identity_record.is_symlink() or not identity_record.is_file():
+            raise FilesystemMigrationError(
+                f"physical lease namespace identity is not a regular file: "
+                f"{identity_record}"
+            )
+        value = _read_json(identity_record)
+        if (
+            isinstance(value, dict)
+            and set(value) == {"schema_version", "device", "inode"}
+            and value.get("schema_version") == 1
+        ):
+            metadata = _metadata(namespace, identity_record)
+            try:
+                replacement, evidence = migrate_legacy_identity(
+                    {"device": value["device"], "inode": value["inode"]},
+                    metadata,
+                    str(identity_record),
+                    confirm_remount=confirm_remount,
+                )
+            except FilesystemIdentityError as error:
+                raise FilesystemMigrationError(str(error)) from error
+            replacement_record = {
+                "schema_version": 2,
+                "identity": replacement,
+            }
+            plans.append(
+                _plan_record(
+                    identity_record,
+                    value,
+                    replacement_record,
+                    evidence=evidence.json() if evidence is not None else None,
+                )
+            )
+        elif isinstance(value, dict) and set(value) == {"schema_version", "identity"}:
+            # The new namespace record is already portable.  Validate it here
+            # so an audit cannot silently accept a malformed durable anchor.
+            _validate_portable_record_identity(value["identity"], identity_record)
+        else:
+            raise FilesystemMigrationError(
+                f"physical lease namespace identity has an unsupported schema: "
+                f"{identity_record}"
+            )
+
+    record_roots = [paths.workspace, paths.repository / "build" / "reviews"]
+    skip = {
+        identity_record,
+        paths.workspace / FILESYSTEM_MIGRATION_RECORD,
+        paths.workspace / FILESYSTEM_MIGRATION_LOCK,
+    }
+    seen: set[Path] = set()
+    for root in record_roots:
+        for path in _workspace_json_records(root, skip=skip):
+            canonical = path.resolve(strict=False)
+            if canonical in seen:
+                continue
+            seen.add(canonical)
+            value = _read_json(path)
+            transformed = _transform_document(path, value)
+            if transformed is None:
+                continue
+            plans.append(_plan_record(path, value, transformed))
+    return sorted(plans, key=_migration_record_sort_key)
+
+
+def _workspace_json_records(root: Path, *, skip: set[Path]) -> Iterable[Path]:
+    if not root.exists():
+        return ()
+    if root.is_symlink() or not root.is_dir():
+        raise FilesystemMigrationError(
+            f"filesystem migration record root is not a directory: {root}"
+        )
+    result: list[Path] = []
+    review_root = root.name == "reviews" and root.parent.name == "build"
+    try:
+        candidates = sorted(root.rglob("*.json"))
+    except OSError as error:
+        raise FilesystemMigrationError(
+            f"cannot enumerate filesystem migration records under {root}: {error}"
+        ) from error
+    for path in candidates:
+        if path in skip:
+            continue
+        if path.is_symlink():
+            raise FilesystemMigrationError(
+                f"filesystem migration record is a symlink: {path}"
+            )
+        if not path.is_file():
+            raise FilesystemMigrationError(
+                f"filesystem migration record is not a regular file: {path}"
+            )
+        if review_root and not _is_delivery_json_record(path.name):
+            continue
+        if path.name.endswith(".lock") or ".tmp" in path.name:
+            continue
+        result.append(path)
+    return result
+
+
+def _is_delivery_json_record(name: str) -> bool:
+    """Select canonical delivery records and their persisted JSON sidecars."""
+
+    if name == ".delivery-ledger-reclaim-complete.json":
+        return True
+    if name.endswith(".md.ledger.json"):
+        return True
+    return (
+        name.startswith(".")
+        and ".md.ledger.json." in name
+        and name.endswith(".json")
+    )
+
+
+def _migration_record_sort_key(record: Mapping[str, Any]) -> tuple[int, str]:
+    """Apply canonical delivery ledgers before sidecars that refer to them."""
+
+    path = str(record["path"])
+    return (0 if Path(path).name.endswith(".md.ledger.json") else 1, path)
+
+
+def _transform_document(
+    path: Path,
+    value: Any,
+    *,
+    remapped_targets: Mapping[Path, tuple[Mapping[str, Any], Mapping[str, Any]]] | None = None,
+) -> dict[str, Any] | None:
+    if remapped_targets is None:
+        remapped_targets = {}
+    changed = False
+    evidence: list[dict[str, Any]] = []
+
+    def visit(current: Any, ancestors: tuple[tuple[str | int | None, Any], ...]) -> Any:
+        nonlocal changed
+        if isinstance(current, list):
+            return [
+                visit(item, (*ancestors, (index, current)))
+                for index, item in enumerate(current)
+            ]
+        if not isinstance(current, dict):
+            return current
+
+        result = {
+            key: visit(item, (*ancestors, (key, current)))
+            for key, item in current.items()
+        }
+        key = _current_key(ancestors)
+        if _contains_legacy_pair(current) and _is_filesystem_pair_context(
+            current, key, ancestors
+        ):
+            result = _rewrite_pair(
+                path,
+                current,
+                result,
+                key,
+                ancestors,
+                evidence,
+                remapped_targets,
+                mark_changed=lambda: _mark_changed(),
+            )
+        if _contains_path_pair(current):
+            result = _rewrite_path_pair(
+                path,
+                current,
+                result,
+                key,
+                ancestors,
+                evidence,
+                remapped_targets,
+                mark_changed=lambda: _mark_changed(),
+            )
+        if _contains_git_common_pair(current):
+            result = _rewrite_named_pair(
+                path,
+                current,
+                result,
+                "git_common",
+                "git_common_device",
+                "git_common_inode",
+                "git_common_pair",
+                ancestors,
+                evidence,
+                remapped_targets,
+                mark_changed=lambda: _mark_changed(),
+            )
+        return result
+
+    def _mark_changed() -> None:
+        nonlocal changed
+        changed = True
+
+    transformed = visit(value, ())
+    if not changed:
+        return None
+    if not isinstance(transformed, dict):
+        raise FilesystemMigrationError(f"filesystem record root is not an object: {path}")
+    return transformed
+
+
+def _rewrite_pair(
+    document_path: Path,
+    current: dict[str, Any],
+    result: Any,
+    key: str | None,
+    ancestors: tuple[tuple[str | int | None, Any], ...],
+    evidence: list[dict[str, Any]],
+    remapped_targets: Mapping[Path, tuple[Mapping[str, Any], Mapping[str, Any]]],
+    *,
+    mark_changed: Any,
+) -> Any:
+    target, projection = _identity_target(document_path, current, key, ancestors)
+    if target is not None and not target.exists() and not target.is_symlink():
+        target = None
+    if target is None:
+        if not _is_historical_pair(document_path, current, ancestors):
+            raise FilesystemMigrationError(
+                f"cannot locate a safe filesystem object for {document_path}:{key or 'identity'}"
+            )
+        replacement = _historical_pair(current, key, ancestors, document_path)
+        if replacement is None:
+            raise FilesystemMigrationError(
+                f"historical filesystem identity lacks type evidence: "
+                f"{document_path}:{key or 'identity'}"
+            )
+        if set(current) == {"device", "inode"} and projection == "full":
+            raise FilesystemMigrationError(
+                f"cannot synthesize a full live identity for historical record "
+                f"{document_path}:{key or 'identity'}"
+            )
+        if set(current) == {"device", "inode"}:
+            if _pair_is_same(current, replacement):
+                return result
+            mark_changed()
+            evidence.append(
+                {
+                    "context": key or "identity",
+                    "legacy_pair_digest": _pair_digest(current),
+                    "portable_pair_digest": _pair_digest(replacement),
+                    "historical": True,
+                }
+            )
+            return replacement
+        if not _pair_is_same(current, replacement):
+            result = {**result, "device": replacement["device"], "inode": replacement["inode"]}
+            mark_changed()
+            evidence.append(
+                {
+                    "context": key or "identity",
+                    "legacy_pair_digest": _pair_digest(current),
+                    "portable_pair_digest": _pair_digest(replacement),
+                    "historical": True,
+                }
+            )
+        return result
+
+    metadata = _metadata(target, document_path)
+    portable = portable_pair(metadata)
+    if set(current) == {"device", "inode"} and projection == "pair" and _pair_is_same(
+        current, portable
+    ):
+        return result
+    if set(current) != {"device", "inode"} and _pair_is_same(current, portable):
+        return result
+    remapped = _target_was_migrated(
+        target, current["inode"], metadata, remapped_targets
+    )
+    if remapped:
+        replacement, old = portable_identity(metadata), None
+    else:
+        try:
+            replacement, old = migrate_legacy_identity(
+                {"device": current["device"], "inode": current["inode"]},
+                metadata,
+                f"{document_path}:{key or 'identity'}",
+                confirm_remount=True,
+            )
+        except FilesystemIdentityError as error:
+            raise FilesystemMigrationError(str(error)) from error
+    if projection == "stable":
+        replacement = portable_identity(metadata, include_ctime=False)
+    mark_changed()
+    evidence.append(
+        {
+            "context": key or "identity",
+            "legacy_digest": _pair_digest(current),
+            "portable_digest": identity_digest(replacement),
+            "old": old.json() if old is not None else None,
+            "remapped_target": str(target) if remapped else None,
+        }
+    )
+    if set(current) == {"device", "inode"}:
+        return portable if projection == "pair" else replacement
+    return {**result, "device": portable["device"], "inode": portable["inode"]}
+
+
+def _rewrite_path_pair(
+    document_path: Path,
+    current: dict[str, Any],
+    result: Any,
+    key: str | None,
+    ancestors: tuple[tuple[str | int | None, Any], ...],
+    evidence: list[dict[str, Any]],
+    remapped_targets: Mapping[Path, tuple[Mapping[str, Any], Mapping[str, Any]]],
+    *,
+    mark_changed: Any,
+) -> Any:
+    target, _ = _identity_target(document_path, current, key, ancestors)
+    if target is not None and not target.exists() and not target.is_symlink():
+        target = None
+    if target is None:
+        if not _is_historical_pair(document_path, current, ancestors):
+            raise FilesystemMigrationError(
+                f"cannot locate a safe path identity target for {document_path}:{key or 'path'}"
+            )
+        replacement = _historical_pair(current, key, ancestors, document_path)
+        if replacement is None:
+            raise FilesystemMigrationError(
+                f"historical path identity lacks type evidence: {document_path}"
+            )
+        if (
+            result.get("path_device") != replacement["device"]
+            or result.get("path_inode") != replacement["inode"]
+        ):
+            result = {
+                **result,
+                "path_device": replacement["device"],
+                "path_inode": replacement["inode"],
+            }
+            mark_changed()
+            evidence.append(
+                {
+                    "context": "path_pair",
+                    "legacy_pair_digest": _pair_digest(
+                        {
+                            "device": current["path_device"],
+                            "inode": current["path_inode"],
+                        }
+                    ),
+                    "portable_pair_digest": _pair_digest(replacement),
+                    "historical": True,
+                }
+            )
+        return result
+    metadata = _metadata(target, document_path)
+    replacement = portable_pair(metadata)
+    remapped = _target_was_migrated(
+        target, current["path_inode"], metadata, remapped_targets
+    )
+    if current["path_inode"] != replacement["inode"] and not remapped:
+        raise FilesystemMigrationError(
+            f"path identity inode changed; refusing rebind: {target}"
+        )
+    if (
+        current["path_device"] == replacement["device"]
+        and current["path_inode"] == replacement["inode"]
+    ):
+        return result
+    result = {
+        **result,
+        "path_device": replacement["device"],
+        "path_inode": replacement["inode"],
+    }
+    mark_changed()
+    evidence.append(
+        {
+            "context": "path_pair",
+            "legacy_pair_digest": _pair_digest(
+                {"device": current["path_device"], "inode": current["path_inode"]}
+            ),
+            "portable_pair_digest": _pair_digest(replacement),
+            "remapped_target": str(target) if remapped else None,
+        }
+    )
+    return result
+
+
+def _rewrite_named_pair(
+    document_path: Path,
+    current: dict[str, Any],
+    result: Any,
+    name_key: str,
+    device_key: str,
+    inode_key: str,
+    context: str,
+    ancestors: tuple[tuple[str | int | None, Any], ...],
+    evidence: list[dict[str, Any]],
+    remapped_targets: Mapping[Path, tuple[Mapping[str, Any], Mapping[str, Any]]],
+    *,
+    mark_changed: Any,
+) -> Any:
+    candidate = current.get(name_key)
+    if not isinstance(candidate, str) or not _valid_absolute_path(candidate):
+        raise FilesystemMigrationError(
+            f"filesystem identity has no safe {name_key} target: {document_path}"
+        )
+    target = Path(candidate)
+    target_metadata: os.stat_result | None = None
+    if not target.exists() and not target.is_symlink():
+        if not _is_historical_pair(document_path, current, ancestors):
+            raise FilesystemMigrationError(f"filesystem identity target is missing: {target}")
+        replacement = _historical_pair(
+            {"device": current[device_key], "inode": current[inode_key]},
+            _current_key(ancestors),
+            ancestors,
+            document_path,
+        )
+        if replacement is None:
+            raise FilesystemMigrationError(
+                f"historical {context} lacks type evidence: {document_path}"
+            )
+    else:
+        target_metadata = _metadata(target, document_path)
+        replacement = portable_pair(target_metadata)
+    if target_metadata is None:
+        remapped = False
+    else:
+        remapped = _target_was_migrated(
+            target, current[inode_key], target_metadata, remapped_targets
+        )
+    if current[inode_key] != replacement["inode"] and not remapped:
+        raise FilesystemMigrationError(
+            f"{context} inode changed; refusing rebind: {target}"
+        )
+    if (
+        current[device_key] == replacement["device"]
+        and current[inode_key] == replacement["inode"]
+    ):
+        return result
+    mark_changed()
+    evidence.append(
+        {
+            "context": context,
+            "legacy_pair_digest": _pair_digest(
+                {"device": current[device_key], "inode": current[inode_key]}
+            ),
+            "portable_pair_digest": _pair_digest(replacement),
+            "remapped_target": str(target) if remapped else None,
+        }
+    )
+    return {**result, device_key: replacement["device"], inode_key: replacement["inode"]}
+
+
+def _identity_target(
+    document_path: Path,
+    current: dict[str, Any],
+    key: str | None,
+    ancestors: tuple[tuple[str | int | None, Any], ...],
+) -> tuple[Path | None, str]:
+    candidate = current.get("path")
+    if isinstance(candidate, str) and _valid_absolute_path(candidate):
+        return Path(candidate), _projection_for(key, ancestors)
+    candidate = current.get("physical_path")
+    if isinstance(candidate, str) and _valid_absolute_path(candidate):
+        return Path(candidate), _projection_for(key, ancestors)
+
+    port_reservation = _ancestor_value(ancestors, "port_reservation")
+    if isinstance(port_reservation, dict):
+        reservation_path = port_reservation.get("path")
+        if isinstance(reservation_path, str) and _valid_absolute_path(reservation_path):
+            if key == "directory":
+                return Path(reservation_path).parent, "full"
+            if key == "lease":
+                return Path(reservation_path), "stable"
+
+    runtime = _ancestor_value(ancestors, "runtime")
+    if key == "lease" and isinstance(runtime, dict):
+        runtime_path = runtime.get("path")
+        if isinstance(runtime_path, str) and _valid_absolute_path(runtime_path):
+            return Path(runtime_path) / "generation.lease", "full"
+    if key == "lease" and _ancestor_value(ancestors, "control") is not None:
+        return document_path.parent / "process-tree.lease", "full"
+
+    if key == "output_identity":
+        state = _ancestor_value(ancestors, "state")
+        generation = _ancestor_value(ancestors, "generation")
+        if isinstance(state, str) and _valid_absolute_path(state) and isinstance(generation, str):
+            return Path(state) / "tmp" / "runtime-assets" / generation, "full"
+
+    if key == "mutable_state_output_identities":
+        index = _current_index(ancestors)
+        owner = _parallel_output_owner(ancestors)
+        if isinstance(owner, dict) and isinstance(index, int):
+            outputs = owner.get("mutable_state_outputs")
+            if isinstance(outputs, list) and 0 <= index < len(outputs):
+                output = outputs[index]
+                if isinstance(output, str) and _valid_absolute_path(output):
+                    return Path(output), "full"
+
+    if key == "lease_identity":
+        state_policy = _ancestor_value(ancestors, "state_policy")
+        if isinstance(state_policy, dict):
+            candidate = state_policy.get("path")
+            if isinstance(candidate, str) and _valid_absolute_path(candidate):
+                return Path(f"{candidate}.lock"), "stable"
+
+    for ancestor_key, ancestor in reversed(ancestors):
+        if not isinstance(ancestor, dict):
+            continue
+        candidate = ancestor.get("path")
+        if isinstance(candidate, str) and _valid_absolute_path(candidate):
+            if key == "lease_identity":
+                return Path(f"{candidate}.lock"), "stable"
+            return Path(candidate), _projection_for(key, ancestors)
+        candidate = ancestor.get("physical_path")
+        if isinstance(candidate, str) and _valid_absolute_path(candidate):
+            return Path(candidate), _projection_for(key, ancestors)
+
+    if key == "mutable_state_output_identities":
+        return None, "full"
+    if key in {"ledger", "source", "installed", "predecessor_snapshot", "erroneous_snapshot"}:
+        if document_path.name.endswith(".ledger.json"):
+            return document_path, "pair"
+    if document_path.name.endswith(".ledger.json") and _current_key(ancestors) in {
+        "device",
+        "inode",
+    }:
+        return document_path, "pair"
+    return _nearby_named_target(document_path, current, ancestors), _projection_for(
+        key, ancestors
+    )
+
+
+def _ancestor_value(
+    ancestors: tuple[tuple[str | int | None, Any], ...], key: str
+) -> Any:
+    for ancestor_key, ancestor in reversed(ancestors):
+        if isinstance(ancestor, dict) and ancestor_key == key:
+            return ancestor.get(key)
+    return None
+
+
+def _contains_legacy_pair(value: dict[str, Any]) -> bool:
+    return (
+        isinstance(value.get("device"), int)
+        and not isinstance(value.get("device"), bool)
+        and value["device"] >= 0
+        and isinstance(value.get("inode"), int)
+        and not isinstance(value.get("inode"), bool)
+        and value["inode"] >= 0
+    )
+
+
+def _contains_path_pair(value: dict[str, Any]) -> bool:
+    return (
+        isinstance(value.get("path_device"), int)
+        and not isinstance(value.get("path_device"), bool)
+        and value["path_device"] >= 0
+        and isinstance(value.get("path_inode"), int)
+        and not isinstance(value.get("path_inode"), bool)
+        and value["path_inode"] >= 0
+    )
+
+
+def _contains_git_common_pair(value: dict[str, Any]) -> bool:
+    return (
+        isinstance(value.get("git_common_device"), int)
+        and not isinstance(value.get("git_common_device"), bool)
+        and value["git_common_device"] >= 0
+        and isinstance(value.get("git_common_inode"), int)
+        and not isinstance(value.get("git_common_inode"), bool)
+        and value["git_common_inode"] >= 0
+    )
+
+
+def _is_filesystem_pair_context(
+    value: dict[str, Any],
+    key: str | None,
+    ancestors: tuple[tuple[str | int | None, Any], ...],
+) -> bool:
+    if set(value) == {"device", "inode"}:
+        return True
+    if any(
+        isinstance(value.get(name), str) and _valid_absolute_path(value[name])
+        for name in ("path", "physical_path", "name")
+    ):
+        return True
+    if key in _FULL_IDENTITY_CONTEXTS | _HISTORICAL_CONTEXTS | {
+        "directory",
+        "primary",
+        "workspace",
+        "wrapper",
+        "source",
+        "installed",
+        "predecessor_snapshot",
+        "erroneous_snapshot",
+        "repositories",
+    }:
+        return True
+    keys = {frame_key for frame_key, _ in ancestors if isinstance(frame_key, str)}
+    return bool(keys & (_FULL_IDENTITY_CONTEXTS | _HISTORICAL_CONTEXTS | {"roots", "ledger"}))
+
+
+def _current_key(
+    ancestors: tuple[tuple[str | int | None, Any], ...]
+) -> str | None:
+    for key, _ in reversed(ancestors):
+        if isinstance(key, str):
+            return key
+    return None
+
+
+def _current_index(
+    ancestors: tuple[tuple[str | int | None, Any], ...]
+) -> int | None:
+    for key, _ in reversed(ancestors):
+        if isinstance(key, int):
+            return key
+    return None
+
+
+def _parallel_output_owner(
+    ancestors: tuple[tuple[str | int | None, Any], ...]
+) -> dict[str, Any] | None:
+    for _, ancestor in reversed(ancestors):
+        if isinstance(ancestor, dict) and isinstance(
+            ancestor.get("mutable_state_outputs"), list
+        ):
+            return ancestor
+    return None
+
+
+def _projection_for(
+    key: str | None,
+    ancestors: tuple[tuple[str | int | None, Any], ...],
+) -> str:
+    if key in _FULL_IDENTITY_CONTEXTS:
+        return "full"
+    if key == "mutable_state_output_identities":
+        return "full"
+    if key == "directory" and _ancestor_value(ancestors, "port_reservation") is not None:
+        return "full"
+    if key == "lease" and (
+        _ancestor_value(ancestors, "control") is not None
+        or _ancestor_value(ancestors, "runtime") is not None
+        or _ancestor_value(ancestors, "port_reservation") is not None
+    ):
+        return "full"
+    return "pair"
+
+
+def _pair_is_same(current: dict[str, Any], replacement: dict[str, int]) -> bool:
+    return (
+        current.get("device") == replacement["device"]
+        and current.get("inode") == replacement["inode"]
+    )
+
+
+def _target_was_migrated(
+    target: Path,
+    current_inode: Any,
+    metadata: os.stat_result,
+    remapped_targets: Mapping[Path, tuple[Mapping[str, Any], Mapping[str, Any]]],
+) -> bool:
+    """Authorize a cross-record reference after its target was atomically replaced."""
+
+    record = remapped_targets.get(target.resolve(strict=False))
+    if record is None:
+        return False
+    before, after = record
+    return (
+        current_inode == before.get("inode")
+        and metadata.st_ino == after.get("inode")
+        and identity_matches(after, metadata)
+    )
+
+
+def _historical_pair(
+    current: dict[str, Any],
+    key: str | None,
+    ancestors: tuple[tuple[str | int | None, Any], ...],
+    document_path: Path,
+) -> dict[str, int] | None:
+    inode = current.get("inode")
+    if not isinstance(inode, int) or isinstance(inode, bool) or inode < 0:
+        return None
+    kind = current.get("kind")
+    if kind not in {"file", "directory"}:
+        kind = current.get("file_type")
+    if kind not in {"file", "directory"}:
+        if key in {"lease", "lease_identity", "source", "installed", "predecessor_snapshot", "erroneous_snapshot"}:
+            kind = "file"
+        elif key in {"directory", "identity", "output_identity", "primary", "workspace", "wrapper"}:
+            kind = "directory"
+    if kind not in {"file", "directory"}:
+        keys = {frame_key for frame_key, _ in ancestors if isinstance(frame_key, str)}
+        if "roots" in keys or "state_policy" in keys:
+            kind = "directory"
+        elif keys & {"control", "runtime", "port_reservation"}:
+            kind = "file"
+    if kind not in {"file", "directory"}:
+        if document_path.suffix in {".lock", ".lease"} or document_path.name.endswith(
+            ".json"
+        ):
+            kind = "file"
+    if kind not in {"file", "directory"}:
+        return None
+    mode = stat.S_IFREG if kind == "file" else stat.S_IFDIR
+    return {
+        "device": portable_device_from_components(inode, mode, kind),
+        "inode": inode,
+    }
+
+
+def _is_historical_pair(
+    document_path: Path,
+    current: dict[str, Any],
+    ancestors: tuple[tuple[str | int | None, Any], ...],
+) -> bool:
+    if _historical_only(document_path):
+        return True
+    keys = {frame_key for frame_key, _ in ancestors if isinstance(frame_key, str)}
+    if keys & _HISTORICAL_CONTEXTS:
+        return True
+    return any(
+        key in current
+        for key in {"raw_base64", "content_base64", "snapshot", "removed_at", "archived_at"}
+    )
+
+
+def _nearby_named_target(
+    document_path: Path,
+    current: dict[str, Any],
+    ancestors: tuple[tuple[str | int | None, Any], ...],
+) -> Path | None:
+    candidates: list[Any] = [current.get("name"), current.get("target")]
+    for _, ancestor in reversed(ancestors):
+        if isinstance(ancestor, dict):
+            candidates.extend((ancestor.get("name"), ancestor.get("target")))
+    for candidate in candidates:
+        if not isinstance(candidate, str) or not candidate or "\x00" in candidate:
+            continue
+        if _valid_absolute_path(candidate):
+            return Path(candidate)
+        if Path(candidate).name != candidate or candidate in {".", ".."}:
+            continue
+        target = document_path.parent / candidate
+        if target.exists() or target.is_symlink():
+            return target
+    return None
+
+
+def _plan_record(
+    path: Path,
+    before_value: Any,
+    after_value: Any,
+    *,
+    evidence: list[dict[str, Any]] | dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    del before_value
+    before, before_identity = _read_snapshot(path)
+    after = _canonical_json(after_value)
+    if len(before) > MAX_MIGRATION_SNAPSHOT_BYTES or len(after) > MAX_MIGRATION_SNAPSHOT_BYTES:
+        raise FilesystemMigrationError(f"filesystem migration record is too large: {path}")
+    if before == after:
+        raise FilesystemMigrationError(f"filesystem migration record has no change: {path}")
+    return {
+        "path": str(path),
+        "before_sha256": hashlib.sha256(before).hexdigest(),
+        "after_sha256": hashlib.sha256(after).hexdigest(),
+        "before_base64": base64.b64encode(before).decode("ascii"),
+        "after_base64": base64.b64encode(after).decode("ascii"),
+        "before_identity": before_identity,
+        "after_identity": None,
+        "rollback_identity": None,
+        "legacy_evidence": evidence or [],
+    }
+
+
+def _new_journal(records: list[dict[str, Any]], *, confirm_remount: bool) -> dict[str, Any]:
+    return {
+        "schema_version": FILESYSTEM_MIGRATION_SCHEMA_VERSION,
+        "transaction": FILESYSTEM_MIGRATION_TRANSACTION,
+        "state": "prepared",
+        "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "confirm_remount": confirm_remount,
+        "records": records,
+    }
+
+
+def _apply_journal(path: Path, journal: dict[str, Any]) -> dict[str, Any]:
+    journal = {**journal, "state": "applying"}
+    durable_atomic_json(path, journal)
+    applied: list[dict[str, Any]] = []
+    remapped_targets = _journal_remapped_targets(journal)
+    try:
+        for record in journal["records"]:
+            target = Path(record["path"])
+            current, current_identity = _read_snapshot(target)
+            current_digest = hashlib.sha256(current).hexdigest()
+            if current_digest == record["after_sha256"]:
+                _require_record_identity(
+                    record.get("after_identity"), current_identity, target, "after"
+                )
+                applied.append(record)
+                _remember_remapped_target(remapped_targets, record)
+                continue
+            if current_digest != record["before_sha256"]:
+                raise FilesystemMigrationError(
+                    f"filesystem migration input changed before apply: {target}"
+                )
+            _require_record_identity(
+                record.get("rollback_identity") or record.get("before_identity"),
+                current_identity,
+                target,
+                "before",
+            )
+            current_value = _decode_json(current, target)
+            transformed = _transform_document(
+                target, current_value, remapped_targets=remapped_targets
+            )
+            if transformed is None:
+                raise FilesystemMigrationError(
+                    f"filesystem migration plan no longer applies: {target}"
+                )
+            after = _canonical_json(transformed)
+            if len(after) > MAX_MIGRATION_SNAPSHOT_BYTES:
+                raise FilesystemMigrationError(
+                    f"filesystem migration record is too large: {target}"
+                )
+            if after != base64.b64decode(record["after_base64"], validate=True):
+                record["after_base64"] = base64.b64encode(after).decode("ascii")
+                record["after_sha256"] = hashlib.sha256(after).hexdigest()
+                record["after_identity"] = None
+                record["rollback_identity"] = None
+                durable_atomic_json(path, journal)
+            applied.append(record)
+            _write_json_bytes(target, base64.b64decode(record["after_base64"]))
+            after_bytes, after_identity = _read_snapshot(target)
+            if hashlib.sha256(after_bytes).hexdigest() != record["after_sha256"]:
+                raise FilesystemMigrationError(
+                    f"filesystem migration output could not be verified: {target}"
+                )
+            record["after_identity"] = after_identity
+            record["rollback_identity"] = None
+            durable_atomic_json(path, journal)
+            _remember_remapped_target(remapped_targets, record)
+    except BaseException as error:
+        rollback_error: BaseException | None = None
+        for record in reversed(applied):
+            try:
+                _rollback_record(record)
+            except BaseException as rollback_failure:
+                rollback_error = rollback_failure
+                break
+        failed = {
+            **journal,
+            "state": "rollback-required" if rollback_error is not None else "prepared",
+            "rollback_error": str(rollback_error) if rollback_error is not None else None,
+        }
+        try:
+            durable_atomic_json(path, failed)
+        except BaseException as journal_failure:
+            raise FilesystemMigrationError(
+                "filesystem migration failed and its rollback journal could not be "
+                f"persisted: {journal_failure}"
+            ) from error
+        if rollback_error is not None:
+            raise FilesystemMigrationError(
+                f"filesystem migration failed and rollback is uncertain: {rollback_error}"
+            ) from error
+        raise
+    complete = {**journal, "state": "complete", "completed_at": _now()}
+    durable_atomic_json(path, complete)
+    return _journal_plan(path, complete, "apply")
+
+
+def _journal_remapped_targets(
+    journal: Mapping[str, Any],
+) -> dict[Path, tuple[Mapping[str, Any], Mapping[str, Any]]]:
+    """Recover target replacements already durably recorded by a prior attempt."""
+
+    result: dict[Path, tuple[Mapping[str, Any], Mapping[str, Any]]] = {}
+    for record in journal["records"]:
+        _remember_remapped_target(result, record)
+    return result
+
+
+def _remember_remapped_target(
+    remapped_targets: dict[Path, tuple[Mapping[str, Any], Mapping[str, Any]]],
+    record: Mapping[str, Any],
+) -> None:
+    before = record.get("before_identity")
+    after = record.get("after_identity")
+    if isinstance(before, Mapping) and isinstance(after, Mapping):
+        remapped_targets[Path(str(record["path"])).resolve(strict=False)] = (
+            before,
+            after,
+        )
+
+
+def _resume_journal(path: Path, journal: dict[str, Any]) -> dict[str, Any]:
+    for record in journal["records"]:
+        target = Path(record["path"])
+        current, current_identity = _read_snapshot(target)
+        current_digest = hashlib.sha256(current).hexdigest()
+        if current_digest == record["before_sha256"]:
+            _require_record_identity(
+                record.get("rollback_identity") or record.get("before_identity"),
+                current_identity,
+                target,
+                "before",
+            )
+        elif current_digest == record["after_sha256"]:
+            _require_record_identity(
+                record.get("after_identity"), current_identity, target, "after"
+            )
+        else:
+            raise FilesystemMigrationError(
+                f"filesystem migration journal input is ambiguous: {record['path']}"
+            )
+    return _apply_journal(path, {**journal, "state": "prepared"})
+
+
+def _audit_journal(path: Path, journal: dict[str, Any]) -> dict[str, Any]:
+    records = journal["records"]
+    states: list[str] = []
+    for record in records:
+        target = Path(record["path"])
+        current, current_identity = _read_snapshot(target)
+        digest = hashlib.sha256(current).hexdigest()
+        if digest == record["after_sha256"]:
+            _require_record_identity(
+                record.get("after_identity"), current_identity, target, "after"
+            )
+            states.append("converted")
+        elif digest == record["before_sha256"]:
+            _require_record_identity(
+                record.get("rollback_identity") or record.get("before_identity"),
+                current_identity,
+                target,
+                "before",
+            )
+            states.append("legacy")
+        else:
+            raise FilesystemMigrationError(
+                f"filesystem migration journal record changed: {record['path']}"
+            )
+    return {
+        "migration": FILESYSTEM_MIGRATION_TRANSACTION,
+        "status": journal["state"],
+        "journal": str(path),
+        "records": [
+            {"path": record["path"], "status": state}
+            for record, state in zip(records, states, strict=True)
+        ],
+    }
+
+
+def _journal_plan(path: Path, journal: dict[str, Any], mode: str) -> dict[str, Any]:
+    return {
+        "migration": FILESYSTEM_MIGRATION_TRANSACTION,
+        "status": journal["state"] if mode == "apply" else mode,
+        "journal": str(path),
+        "records": [
+            {
+                "path": record["path"],
+                "before_sha256": record["before_sha256"],
+                "after_sha256": record["after_sha256"],
+            }
+            for record in journal["records"]
+        ],
+    }
+
+
+def _public_record(record: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "path": record["path"],
+        "before_sha256": record["before_sha256"],
+        "after_sha256": record["after_sha256"],
+        "legacy_evidence": record.get("legacy_evidence", []),
+    }
+
+
+def _read_journal(path: Path) -> dict[str, Any]:
+    value = _read_json(path)
+    if (
+        not isinstance(value, dict)
+        or set(value) - _JOURNAL_KEYS
+        or value.get("schema_version") != FILESYSTEM_MIGRATION_SCHEMA_VERSION
+        or value.get("transaction") != FILESYSTEM_MIGRATION_TRANSACTION
+        or value.get("state") not in {"prepared", "applying", "rollback-required", "complete"}
+        or not isinstance(value.get("created_at"), str)
+        or not isinstance(value.get("confirm_remount"), bool)
+        or not isinstance(value.get("records"), list)
+    ):
+        raise FilesystemMigrationError(f"filesystem migration journal is invalid: {path}")
+    _validate_timestamp(value["created_at"], path)
+    if "completed_at" in value:
+        if not isinstance(value["completed_at"], str):
+            raise FilesystemMigrationError(f"filesystem migration journal is invalid: {path}")
+        _validate_timestamp(value["completed_at"], path)
+        if value["state"] != "complete":
+            raise FilesystemMigrationError(
+                f"completed filesystem migration timestamp has unfinished state: {path}"
+            )
+    if "rollback_error" in value and value["rollback_error"] is not None and not isinstance(
+        value["rollback_error"], str
+    ):
+        raise FilesystemMigrationError(f"filesystem migration journal is invalid: {path}")
+    normalized_records: list[dict[str, Any]] = []
+    paths: list[str] = []
+    for record in value["records"]:
+        if (
+            not isinstance(record, dict)
+            or set(record) not in (_JOURNAL_RECORD_KEYS, _LEGACY_JOURNAL_RECORD_KEYS)
+            or not isinstance(record["path"], str)
+            or not _valid_absolute_path(record["path"])
+            or not _sha256(record["before_sha256"])
+            or not _sha256(record["after_sha256"])
+            or record["before_sha256"] == record["after_sha256"]
+            or not isinstance(record["legacy_evidence"], (list, dict))
+        ):
+            raise FilesystemMigrationError(f"filesystem migration journal record is invalid: {path}")
+        target = Path(record["path"])
+        if target == path or target == path.parent / FILESYSTEM_MIGRATION_LOCK:
+            raise FilesystemMigrationError(
+                f"filesystem migration journal targets its own control file: {target}"
+            )
+        if target.resolve(strict=False) != target:
+            raise FilesystemMigrationError(
+                f"filesystem migration journal path is not canonical: {target}"
+            )
+        before = _decode_snapshot(record["before_base64"], target)
+        after = _decode_snapshot(record["after_base64"], target)
+        if hashlib.sha256(before).hexdigest() != record["before_sha256"]:
+            raise FilesystemMigrationError(f"filesystem migration before snapshot is invalid: {path}")
+        if hashlib.sha256(after).hexdigest() != record["after_sha256"]:
+            raise FilesystemMigrationError(f"filesystem migration after snapshot is invalid: {path}")
+        if before == after:
+            raise FilesystemMigrationError(f"filesystem migration record has no change: {target}")
+        current_identity = _metadata(target, path)
+        normalized = dict(record)
+        if set(record) == _LEGACY_JOURNAL_RECORD_KEYS:
+            normalized.update(
+                {
+                    "before_identity": portable_identity(current_identity),
+                    "after_identity": (
+                        portable_identity(current_identity)
+                        if hashlib.sha256(_read_bytes(target)).hexdigest()
+                        == record["after_sha256"]
+                        else None
+                    ),
+                    "rollback_identity": None,
+                }
+            )
+        else:
+            _validate_journal_identity(normalized.get("before_identity"), target, "before")
+            if normalized.get("after_identity") is not None:
+                _validate_journal_identity(normalized["after_identity"], target, "after")
+            if normalized.get("rollback_identity") is not None:
+                _validate_journal_identity(
+                    normalized["rollback_identity"], target, "rollback"
+                )
+        normalized_records.append(normalized)
+        paths.append(record["path"])
+    if paths != [
+        str(record["path"])
+        for record in sorted(
+            normalized_records, key=_migration_record_sort_key
+        )
+    ] or len(paths) != len(set(paths)):
+        raise FilesystemMigrationError(
+            f"filesystem migration journal records are not unique and ordered: {path}"
+        )
+    return {**value, "records": normalized_records}
+
+
+def _physical_lease_namespace(repository: Path) -> Path:
+    marker = repository / ".git"
+    if marker.is_dir():
+        return marker.resolve() / "atrinik-resource-leases"
+    if marker.is_file():
+        try:
+            value = marker.read_text(encoding="utf-8").strip()
+        except OSError as error:
+            raise FilesystemMigrationError(f"cannot read Git worktree marker: {marker}") from error
+        prefix = "gitdir: "
+        if value.startswith(prefix):
+            gitdir = Path(value.removeprefix(prefix))
+            if not gitdir.is_absolute():
+                gitdir = marker.parent / gitdir
+            return gitdir.resolve().parent.parent / "atrinik-resource-leases"
+    return repository / "workspace" / "atrinik-resource-leases"
+
+
+def _metadata(path: Path, context: Path) -> os.stat_result:
+    _assert_safe_path(path)
+    try:
+        metadata = path.stat(follow_symlinks=False)
+    except OSError as error:
+        raise FilesystemMigrationError(
+            f"cannot inspect filesystem identity target {path} for {context}: {error}"
+        ) from error
+    if not (stat.S_ISDIR(metadata.st_mode) or stat.S_ISREG(metadata.st_mode)):
+        raise FilesystemMigrationError(f"filesystem identity target is not a file/directory: {path}")
+    if metadata.st_uid != os.geteuid():
+        raise FilesystemMigrationError(f"filesystem identity target has foreign ownership: {path}")
+    return metadata
+
+
+def _validate_portable_record_identity(value: Any, path: Path) -> None:
+    try:
+        validate_identity(value, str(path), allow_legacy=False)
+    except FilesystemIdentityError as error:
+        raise FilesystemMigrationError(str(error)) from error
+
+
+def _read_json(path: Path) -> Any:
+    return _decode_json(_read_bytes(path), path)
+
+
+def _read_bytes(path: Path) -> bytes:
+    return _read_snapshot(path)[0]
+
+
+def _read_snapshot(path: Path) -> tuple[bytes, dict[str, Any]]:
+    _assert_safe_path(path)
+    flags = os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_NOFOLLOW", 0)
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(path, flags)
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode) or opened.st_uid != os.geteuid():
+            raise FilesystemMigrationError(
+                f"filesystem migration record is not an owned regular file: {path}"
+            )
+        if opened.st_size > MAX_MIGRATION_SNAPSHOT_BYTES:
+            raise FilesystemMigrationError(
+                f"filesystem migration record is too large: {path}"
+            )
+        chunks: list[bytes] = []
+        remaining = opened.st_size
+        while remaining > 0:
+            chunk = os.read(descriptor, min(1024 * 1024, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        raw = b"".join(chunks)
+        after_read = os.fstat(descriptor)
+        if (
+            (opened.st_dev, opened.st_ino, opened.st_size, opened.st_ctime_ns)
+            != (
+                after_read.st_dev,
+                after_read.st_ino,
+                after_read.st_size,
+                after_read.st_ctime_ns,
+            )
+            or len(raw) != opened.st_size
+        ):
+            raise FilesystemMigrationError(
+                f"filesystem migration record changed while reading: {path}"
+            )
+        if len(raw) > MAX_MIGRATION_SNAPSHOT_BYTES:
+            raise FilesystemMigrationError(
+                f"filesystem migration record is too large: {path}"
+            )
+        visible = path.stat(follow_symlinks=False)
+        if (
+            not stat.S_ISREG(visible.st_mode)
+            or (opened.st_dev, opened.st_ino) != (visible.st_dev, visible.st_ino)
+        ):
+            raise FilesystemMigrationError(
+                f"filesystem migration record was replaced: {path}"
+            )
+        return raw, portable_identity(opened)
+    except FilesystemMigrationError:
+        raise
+    except OSError as error:
+        raise FilesystemMigrationError(
+            f"cannot read filesystem migration record {path}: {error}"
+        ) from error
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def _write_json_bytes(path: Path, raw: bytes) -> None:
+    value = _decode_json(raw, path)
+    if _canonical_json(value) != raw:
+        raise FilesystemMigrationError(
+            f"migration snapshot is not canonical JSON: {path}"
+        )
+    durable_atomic_json(path, value)
+
+
+def _decode_json(raw: bytes, path: Path) -> Any:
+    try:
+        return json.loads(
+            raw.decode("utf-8"), object_pairs_hook=_reject_duplicate_keys
+        )
+    except (UnicodeError, ValueError, RecursionError) as error:
+        raise FilesystemMigrationError(f"migration snapshot is not JSON: {path}") from error
+
+
+def _reject_duplicate_keys(pairs: Iterable[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError(f"duplicate JSON key: {key}")
+        value[key] = item
+    return value
+
+
+def _decode_snapshot(encoded: Any, path: Path) -> bytes:
+    if not isinstance(encoded, str):
+        raise FilesystemMigrationError(f"migration snapshot encoding is invalid: {path}")
+    try:
+        raw = base64.b64decode(encoded, validate=True)
+    except (ValueError, binascii.Error) as error:
+        raise FilesystemMigrationError(
+            f"migration snapshot is not valid base64: {path}"
+        ) from error
+    if len(raw) > MAX_MIGRATION_SNAPSHOT_BYTES:
+        raise FilesystemMigrationError(f"filesystem migration record is too large: {path}")
+    value = _decode_json(raw, path)
+    if _canonical_json(value) != raw:
+        raise FilesystemMigrationError(
+            f"migration snapshot is not canonical JSON: {path}"
+        )
+    return raw
+
+
+def _rollback_record(record: dict[str, Any]) -> None:
+    target = Path(record["path"])
+    current, current_identity = _read_snapshot(target)
+    digest = hashlib.sha256(current).hexdigest()
+    if digest == record["after_sha256"]:
+        _require_record_identity(
+            record.get("after_identity"), current_identity, target, "after"
+        )
+        _write_json_bytes(
+            target, base64.b64decode(record["before_base64"], validate=True)
+        )
+    elif digest == record["before_sha256"]:
+        _require_record_identity(
+            record.get("rollback_identity") or record.get("before_identity"),
+            current_identity,
+            target,
+            "before",
+        )
+    else:
+        raise FilesystemMigrationError(
+            f"filesystem migration rollback target changed: {target}"
+        )
+    restored, restored_identity = _read_snapshot(target)
+    if hashlib.sha256(restored).hexdigest() != record["before_sha256"]:
+        raise FilesystemMigrationError(
+            f"filesystem migration rollback could not be verified: {target}"
+        )
+    record["rollback_identity"] = restored_identity
+    record["after_identity"] = None
+
+
+def _require_record_identity(
+    expected: Any,
+    current: dict[str, Any],
+    target: Path,
+    label: str,
+) -> None:
+    _validate_journal_identity(expected, target, label)
+    if any(current.get(key) != value for key, value in expected.items()):
+        raise FilesystemMigrationError(
+            f"filesystem migration {label} identity changed: {target}"
+        )
+
+
+def _validate_journal_identity(value: Any, target: Path, label: str) -> None:
+    try:
+        validated = validate_identity(
+            value,
+            f"filesystem migration {label} identity at {target}",
+            allow_legacy=False,
+        )
+    except FilesystemIdentityError as error:
+        raise FilesystemMigrationError(str(error)) from error
+    if validated.get("kind") != "file":
+        raise FilesystemMigrationError(
+            f"filesystem migration {label} identity is not a file: {target}"
+        )
+
+
+def _validate_timestamp(value: str, path: Path) -> None:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise FilesystemMigrationError(
+            f"filesystem migration journal timestamp is invalid: {path}"
+        ) from error
+    if parsed.tzinfo is None:
+        raise FilesystemMigrationError(
+            f"filesystem migration journal timestamp has no timezone: {path}"
+        )
+
+
+def _assert_safe_path(path: Path) -> None:
+    if not path.is_absolute() or path == Path("/"):
+        raise FilesystemMigrationError(f"filesystem migration path is unsafe: {path}")
+    for parent in path.parents:
+        if parent == Path("/"):
+            break
+        if parent.is_symlink():
+            raise FilesystemMigrationError(
+                f"filesystem migration path has a symlinked parent: {path}"
+            )
+
+
+def _canonical_json(value: Any) -> bytes:
+    return (
+        json.dumps(value, ensure_ascii=True, sort_keys=True, indent=2) + "\n"
+    ).encode("ascii")
+
+
+def _valid_absolute_path(value: str) -> bool:
+    return (
+        value.startswith("/")
+        and value != "/"
+        and "\x00" not in value
+        and os.path.normpath(value) == value
+    )
+
+
+def _historical_only(path: Path) -> bool:
+    return ".archive-" in path.name or "/historical" in path.parts
+
+
+def _pair_digest(value: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":")).encode("ascii")
+    ).hexdigest()
+
+
+def _sha256(value: Any) -> bool:
+    return isinstance(value, str) and len(value) == 64 and all(
+        character in "0123456789abcdef" for character in value
+    )
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/atrinik_workspace/filesystem_migration.py
+++ b/atrinik_workspace/filesystem_migration.py
@@ -1486,7 +1486,7 @@ def _valid_absolute_path(value: str) -> bool:
 
 
 def _historical_only(path: Path) -> bool:
-    return ".archive-" in path.name or "/historical" in path.parts
+    return ".archive-" in path.name or "historical" in path.parts
 
 
 def _pair_digest(value: dict[str, Any]) -> str:

--- a/atrinik_workspace/migration.py
+++ b/atrinik_workspace/migration.py
@@ -17,6 +17,11 @@ import subprocess
 import tempfile
 from typing import Any, Callable, Iterable
 
+from .filesystem_identity import (
+    FilesystemIdentityError,
+    portable_device,
+    validate_identity,
+)
 from .locking import LockBusyError, active_lock_fds, exclusive_layout_lock
 from .delivery import inventory_active_delivery_evidence
 from .model import (
@@ -39,6 +44,14 @@ OLDEST_PROFILE_SCHEMA_VERSION = 3
 MIGRATION_NAME = "repositories"
 MIGRATION_RECORD = "migrations/repositories.json"
 MIGRATION_PENDING = "migrations/repositories.pending.json"
+
+
+def _valid_filesystem_identity(value: Any) -> bool:
+    try:
+        validate_identity(value)
+    except FilesystemIdentityError:
+        return False
+    return True
 
 
 def physical_repository_lock_path(repository_root: Path) -> Path:
@@ -3054,7 +3067,7 @@ class RepositoryMigration:
                 continue
             rows.append(
                 {
-                    "identity": f"{metadata.st_dev}:{metadata.st_ino}",
+                    "identity": f"{portable_device(metadata)}:{metadata.st_ino}",
                     "name": name,
                     "path": str(path),
                     "present": True,
@@ -3145,7 +3158,7 @@ class RepositoryMigration:
                     or control.get("socket")
                     != str(control_socket_path(directory, control["generation"]))
                     or not isinstance(control.get("lease"), dict)
-                    or set(control["lease"]) != {"device", "inode"}
+                    or not _valid_filesystem_identity(control["lease"])
                 ):
                     raise WorkspaceError("topology control identity is invalid")
                 generation = (

--- a/atrinik_workspace/port_reservation.py
+++ b/atrinik_workspace/port_reservation.py
@@ -11,6 +11,14 @@ import secrets
 import stat
 from typing import Any
 
+from .filesystem_identity import (
+    FilesystemIdentityError,
+    identity_matches,
+    pair_matches,
+    portable_identity,
+    validate_identity,
+)
+
 
 PORT_RESERVATION_SCHEMA_VERSION = 1
 PORT_RESERVATION_DIRECTORY = "port-reservations"
@@ -43,19 +51,13 @@ def _validate_port(port: Any) -> int:
     return port
 
 
-def _validate_identity(value: Any, description: str) -> dict[str, int]:
-    if (
-        not isinstance(value, dict)
-        or set(value) != {"device", "inode"}
-        or not all(
-            isinstance(item, int) and not isinstance(item, bool) and item >= 0
-            for item in value.values()
+def _validate_identity(value: Any, description: str) -> dict[str, Any]:
+    try:
+        return validate_identity(
+            value, f"topology port reservation {description} identity"
         )
-    ):
-        raise PortReservationError(
-            f"topology port reservation {description} identity is invalid"
-        )
-    return value
+    except FilesystemIdentityError as error:
+        raise PortReservationError(str(error)) from error
 
 
 def validate_record(value: Any, *, expected_path: Path | None = None) -> dict[str, Any]:
@@ -90,11 +92,11 @@ def validate_record(value: Any, *, expected_path: Path | None = None) -> dict[st
     return value
 
 
-def _directory_identity(metadata: os.stat_result) -> dict[str, int]:
-    return {"device": metadata.st_dev, "inode": metadata.st_ino}
+def _directory_identity(metadata: os.stat_result) -> dict[str, Any]:
+    return portable_identity(metadata)
 
 
-def _validate_directory_path(directory: Path, identity: dict[str, int]) -> None:
+def _validate_directory_path(directory: Path, identity: dict[str, Any]) -> None:
     descriptor: int | None = None
     try:
         metadata = directory.lstat()
@@ -104,10 +106,7 @@ def _validate_directory_path(directory: Path, identity: dict[str, int]) -> None:
         raise PortReservationError(
             f"cannot inspect topology port reservation directory {directory}: {error}"
         ) from error
-    if (
-        not stat.S_ISDIR(metadata.st_mode)
-        or _directory_identity(metadata) != identity
-    ):
+    if not stat.S_ISDIR(metadata.st_mode) or not identity_matches(identity, metadata):
         raise PortReservationError(
             f"topology port reservation directory was replaced: {directory}"
         )
@@ -115,7 +114,7 @@ def _validate_directory_path(directory: Path, identity: dict[str, int]) -> None:
 
 def open_directory(
     topologies: Path, *, root_identity: tuple[int, int] | None = None
-) -> tuple[int, Path, dict[str, int]]:
+) -> tuple[int, Path, dict[str, Any]]:
     directory = topologies / PORT_RESERVATION_DIRECTORY
     flags = os.O_RDONLY | os.O_CLOEXEC
     if hasattr(os, "O_DIRECTORY"):
@@ -169,8 +168,7 @@ def open_directory(
         or stat.S_IMODE(metadata.st_mode) != 0o700
         or metadata.st_uid != os.geteuid()
         or not stat.S_ISDIR(path_metadata.st_mode)
-        or (path_metadata.st_dev, path_metadata.st_ino)
-        != (metadata.st_dev, metadata.st_ino)
+        or not identity_matches(_directory_identity(metadata), path_metadata)
         or (visible_root.st_dev, visible_root.st_ino)
         != (root_metadata.st_dev, root_metadata.st_ino)
     ):
@@ -378,7 +376,7 @@ def active_owner(
 def create_lease(
     directory_descriptor: int,
     directory: Path,
-    directory_identity: dict[str, int],
+    directory_identity: dict[str, Any],
     *,
     port: int,
     topology: str,
@@ -407,7 +405,7 @@ def create_lease(
                 "generation": generation,
                 "path": str(path),
                 "directory": directory_identity,
-                "lease": {"device": metadata.st_dev, "inode": metadata.st_ino},
+                "lease": portable_identity(metadata, include_ctime=False),
                 "token": token,
             },
             expected_path=path,
@@ -436,7 +434,9 @@ def validate_held(descriptor: int, record: Any) -> dict[str, Any]:
     path = Path(validated["path"])
     directory_fd, directory, directory_identity = open_directory(path.parent.parent)
     try:
-        if directory != path.parent or directory_identity != validated["directory"]:
+        if directory != path.parent or not identity_matches(
+            validated["directory"], os.fstat(directory_fd)
+        ):
             raise PortReservationError(
                 "topology port reservation directory was replaced"
             )
@@ -444,10 +444,12 @@ def validate_held(descriptor: int, record: Any) -> dict[str, Any]:
     finally:
         os.close(directory_fd)
     identity = validated["lease"]
-    if (metadata.st_dev, metadata.st_ino) != (
-        identity["device"],
-        identity["inode"],
-    ):
+    lease_matches = (
+        pair_matches(identity, metadata)
+        if set(identity) == {"device", "inode"}
+        else identity_matches(identity, metadata)
+    )
+    if not lease_matches:
         raise PortReservationError("topology port reservation lease was replaced")
     if read_record(descriptor, path) != validated:
         raise PortReservationError("topology port reservation record changed")
@@ -469,7 +471,9 @@ def reservation_locked(record: Any) -> bool:
     path = Path(validated["path"])
     directory_fd, directory, directory_identity = open_directory(path.parent.parent)
     try:
-        if directory != path.parent or directory_identity != validated["directory"]:
+        if directory != path.parent or not identity_matches(
+            validated["directory"], os.fstat(directory_fd)
+        ):
             raise PortReservationError(
                 "topology port reservation directory was replaced"
             )

--- a/atrinik_workspace/process_tree.py
+++ b/atrinik_workspace/process_tree.py
@@ -7,6 +7,13 @@ import signal
 import stat
 from typing import Iterable
 
+from .filesystem_identity import (
+    FilesystemIdentityError,
+    identity_matches,
+    portable_identity,
+    validate_identity,
+)
+
 
 def control_socket_path(topology_root: Path, generation: str) -> Path:
     """Return the bounded workspace-shared endpoint for one topology generation."""
@@ -17,7 +24,7 @@ def control_socket_path(topology_root: Path, generation: str) -> Path:
     return path
 
 
-def initialize_lease(descriptor: int, generation: str) -> dict[str, int]:
+def initialize_lease(descriptor: int, generation: str) -> dict[str, object]:
     """Bind a locked lease inode to one topology generation."""
     payload = f"{generation}\n".encode()
     os.ftruncate(descriptor, 0)
@@ -26,21 +33,17 @@ def initialize_lease(descriptor: int, generation: str) -> dict[str, int]:
         raise OSError("short write while initializing process-tree lease")
     os.fsync(descriptor)
     metadata = os.fstat(descriptor)
-    return {"device": metadata.st_dev, "inode": metadata.st_ino}
+    return portable_identity(metadata)
 
 
 def bound_lease_locked(
-    path: Path, generation: str, identity: dict[str, int]
+    path: Path, generation: str, identity: dict[str, object]
 ) -> bool:
     """Observe the exact generation-bound lease named by a status record."""
-    if (
-        set(identity) != {"device", "inode"}
-        or not all(
-            isinstance(value, int) and not isinstance(value, bool) and value >= 0
-            for value in identity.values()
-        )
-    ):
-        raise OSError("process-tree lease identity is invalid")
+    try:
+        validate_identity(identity, "process-tree lease identity")
+    except FilesystemIdentityError as error:
+        raise OSError(str(error)) from error
     flags = os.O_RDONLY | os.O_CLOEXEC
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
@@ -49,10 +52,7 @@ def bound_lease_locked(
         metadata = os.fstat(descriptor)
         if not stat.S_ISREG(metadata.st_mode):
             raise OSError(f"process-tree lease is not a regular file: {path}")
-        if (metadata.st_dev, metadata.st_ino) != (
-            identity["device"],
-            identity["inode"],
-        ):
+        if not identity_matches(identity, metadata):
             raise OSError(f"process-tree lease identity changed: {path}")
         os.lseek(descriptor, 0, os.SEEK_SET)
         if os.read(descriptor, 66) != f"{generation}\n".encode():

--- a/atrinik_workspace/scopes.py
+++ b/atrinik_workspace/scopes.py
@@ -11,6 +11,7 @@ import re
 import secrets
 from typing import Any, TYPE_CHECKING
 
+from .filesystem_identity import pair_matches, portable_device
 from .locking import LockBusyError, exclusive_lock
 from .model import (
     AtomicJsonCommitUncertain,
@@ -571,7 +572,7 @@ class ScopeLifecycle:
         identity = path.stat(follow_symlinks=False)
         return {
             "path": str(path),
-            "device": identity.st_dev,
+            "device": portable_device(identity),
             "inode": identity.st_ino,
         }
 
@@ -810,7 +811,7 @@ class ScopeLifecycle:
             {
                 "status": "created",
                 "common_git_dir": common,
-                "path_device": identity.st_dev,
+                "path_device": portable_device(identity),
                 "path_inode": identity.st_ino,
             }
         )
@@ -889,7 +890,7 @@ class ScopeLifecycle:
                 {
                     "status": "created",
                     "sha256": _file_sha256(profile_path),
-                    "path_device": profile_identity.st_dev,
+                    "path_device": portable_device(profile_identity),
                     "path_inode": profile_identity.st_ino,
                 }
             )
@@ -1063,7 +1064,7 @@ class ScopeLifecycle:
                     {
                         "status": "created",
                         "common_git_dir": common,
-                        "path_device": identity.st_dev,
+                        "path_device": portable_device(identity),
                         "path_inode": identity.st_ino,
                     }
                 )
@@ -1110,7 +1111,7 @@ class ScopeLifecycle:
                 {
                     "status": "created",
                     "sha256": _file_sha256(profile_path),
-                    "path_device": profile_identity.st_dev,
+                    "path_device": portable_device(profile_identity),
                     "path_inode": profile_identity.st_ino,
                 }
             )
@@ -1224,11 +1225,13 @@ class ScopeLifecycle:
                     profile_path.is_file()
                     and not profile_path.is_symlink()
                     and _file_sha256(profile_path) == profile["sha256"]
-                    and (
-                        profile_path.stat(follow_symlinks=False).st_dev,
-                        profile_path.stat(follow_symlinks=False).st_ino,
+                    and pair_matches(
+                        {
+                            "device": profile["path_device"],
+                            "inode": profile["path_inode"],
+                        },
+                        profile_path.stat(follow_symlinks=False),
                     )
-                    == (profile["path_device"], profile["path_inode"])
                 ):
                     profile_path.unlink()
                     self.workspace._remove_physical_reference(profile_path)
@@ -1262,8 +1265,13 @@ class ScopeLifecycle:
                 exact = (
                     path.is_dir()
                     and not path.is_symlink()
-                    and (path.stat(follow_symlinks=False).st_dev, path.stat(follow_symlinks=False).st_ino)
-                    == (row["path_device"], row["path_inode"])
+                    and pair_matches(
+                        {
+                            "device": row["path_device"],
+                            "inode": row["path_inode"],
+                        },
+                        path.stat(follow_symlinks=False),
+                    )
                     and self.workspace._git_common_directory(path, trace=False)
                     == Path(row["common_git_dir"])
                     and git(path, "rev-parse", "HEAD", capture=True, trace=False)
@@ -2050,10 +2058,10 @@ class ScopeLifecycle:
                     clean = records_match and stopped_cleanly and state_disposed
                     if clean:
                         topology_evidence = {
-                            "spec_device": spec_after.st_dev,
+                            "spec_device": portable_device(spec_after),
                             "spec_inode": spec_after.st_ino,
                             "spec_sha256": spec_sha256,
-                            "status_device": status_after.st_dev,
+                            "status_device": portable_device(status_after),
                             "status_inode": status_after.st_ino,
                             "status_sha256": status_sha256,
                         }
@@ -2155,7 +2163,7 @@ class ScopeLifecycle:
                 {
                     "kind": "build",
                     "path": str(root),
-                    "device": identity.st_dev if identity is not None else None,
+                    "device": portable_device(identity) if identity is not None else None,
                     "inode": identity.st_ino if identity is not None else None,
                     "metadata_sha256": metadata_sha256,
                     "marker_sha256": marker_sha256,
@@ -2173,12 +2181,12 @@ class ScopeLifecycle:
                 profile_reasons.append("changed_profile")
             else:
                 profile_identity = profile_path.stat(follow_symlinks=False)
-                if (
-                    profile_identity.st_dev,
-                    profile_identity.st_ino,
-                ) != (
-                    record["profile"]["path_device"],
-                    record["profile"]["path_inode"],
+                if not pair_matches(
+                    {
+                        "device": record["profile"]["path_device"],
+                        "inode": record["profile"]["path_inode"],
+                    },
+                    profile_identity,
                 ):
                     profile_reasons.append("replaced_profile")
             disposition = "protected" if profile_reasons else "eligible"
@@ -2199,8 +2207,12 @@ class ScopeLifecycle:
                 else:
                     try:
                         identity = path.stat(follow_symlinks=False)
-                        if (identity.st_dev, identity.st_ino) != (
-                            row["path_device"], row["path_inode"]
+                        if not pair_matches(
+                            {
+                                "device": row["path_device"],
+                                "inode": row["path_inode"],
+                            },
+                            identity,
                         ):
                             reasons.append("replaced_path")
                         if self.workspace._git_common_directory(path, trace=False) != Path(row["common_git_dir"]):
@@ -2301,6 +2313,7 @@ class ScopeLifecycle:
         from .workspace import (
             BUILD_METADATA,
             _owned_tree_tombstone_path,
+            _portable_tombstone_path,
             git,
             remove_owned_tree,
         )
@@ -2341,7 +2354,8 @@ class ScopeLifecycle:
                     )
                 identity = path.stat(follow_symlinks=False)
                 if (
-                    identity.st_dev != topology_item.get(f"{prefix}_device")
+                    portable_device(identity)
+                    != topology_item.get(f"{prefix}_device")
                     or identity.st_ino != topology_item.get(f"{prefix}_inode")
                     or _file_sha256(path) != topology_item.get(f"{prefix}_sha256")
                 ):
@@ -2545,9 +2559,36 @@ class ScopeLifecycle:
                     "device": item["device"],
                     "inode": item["inode"],
                 }
-                tombstone = _owned_tree_tombstone_path(root, recovery_identity)
-                if root.exists() or root.is_symlink() or tombstone.exists() or tombstone.is_symlink():
-                    remove_owned_tree(root, expected_identity=recovery_identity)
+                tombstone = _portable_tombstone_path(root, recovery_identity)
+                if tombstone is None and (root.exists() or root.is_symlink()):
+                    metadata = root.stat(follow_symlinks=False)
+                    tombstone = _owned_tree_tombstone_path(
+                        root,
+                        {"device": metadata.st_dev, "inode": metadata.st_ino},
+                    )
+                if (
+                    root.exists()
+                    or root.is_symlink()
+                    or tombstone is not None
+                    and (tombstone.exists() or tombstone.is_symlink())
+                ):
+                    target = root if root.exists() or root.is_symlink() else tombstone
+                    if target is None:
+                        raise WorkspaceError(
+                            f"scope build removal evidence disappeared: {root}"
+                        )
+                    metadata = target.stat(follow_symlinks=False)
+                    if not pair_matches(recovery_identity, metadata):
+                        raise WorkspaceError(
+                            f"scope build removal identity changed: {root}"
+                        )
+                    remove_owned_tree(
+                        root,
+                        expected_identity={
+                            "device": metadata.st_dev,
+                            "inode": metadata.st_ino,
+                        },
+                    )
                 finish(action)
                 continue
             if not root.exists() and not root.is_symlink():
@@ -2568,9 +2609,20 @@ class ScopeLifecycle:
                     f"scope build ownership changed during release: {root}"
                 )
             mark_removing(action)
+            root_metadata = root.stat(follow_symlinks=False)
+            if not pair_matches(
+                {"device": item["device"], "inode": item["inode"]},
+                root_metadata,
+            ):
+                raise WorkspaceError(
+                    f"scope build removal identity changed: {root}"
+                )
             remove_owned_tree(
                 root,
-                expected_identity={"device": item["device"], "inode": item["inode"]},
+                expected_identity={
+                    "device": root_metadata.st_dev,
+                    "inode": root_metadata.st_ino,
+                },
             )
             self._maybe_fail(f"release:build-tree:{root.name}")
             finish(action)
@@ -2602,13 +2654,12 @@ class ScopeLifecycle:
                     profile_path.is_symlink()
                     or not profile_path.is_file()
                     or _file_sha256(profile_path) != record["profile"]["sha256"]
-                    or (
-                        profile_path.stat(follow_symlinks=False).st_dev,
-                        profile_path.stat(follow_symlinks=False).st_ino,
-                    )
-                    != (
-                        record["profile"]["path_device"],
-                        record["profile"]["path_inode"],
+                    or not pair_matches(
+                        {
+                            "device": record["profile"]["path_device"],
+                            "inode": record["profile"]["path_inode"],
+                        },
+                        profile_path.stat(follow_symlinks=False),
                     )
                 ):
                     raise WorkspaceError("scope profile changed during release")
@@ -2695,8 +2746,13 @@ class ScopeLifecycle:
                 raise WorkspaceError(f"scope worktree changed during release: {path}")
             identity = path.stat(follow_symlinks=False)
             if (
-                (identity.st_dev, identity.st_ino)
-                != (row["path_device"], row["path_inode"])
+                not pair_matches(
+                    {
+                        "device": row["path_device"],
+                        "inode": row["path_inode"],
+                    },
+                    identity,
+                )
                 or self.workspace._git_common_directory(path, trace=False)
                 != Path(row["common_git_dir"])
                 or git(path, "rev-parse", "HEAD", capture=True, trace=False)

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -16,6 +16,7 @@ import threading
 import time
 from typing import Any, BinaryIO
 
+from .filesystem_identity import FilesystemIdentityError, validate_identity
 from .launch_identity import CLIENT_LAUNCH_LABEL_ENV, client_launch_label
 from .model import durable_atomic_json
 from .process_tree import control_socket_path, holders_exist, signal_holders
@@ -433,13 +434,7 @@ def _open_control(spec: dict[str, Any], topology_root: Path) -> socket.socket | 
         or control["socket"]
         != str(control_socket_path(topology_root, control["generation"]))
         or not isinstance(control.get("lease"), dict)
-        or set(control["lease"]) != {"device", "inode"}
-        or not all(
-            isinstance(value, int)
-            and not isinstance(value, bool)
-            and value >= 0
-            for value in control["lease"].values()
-        )
+        or not _valid_filesystem_identity(control["lease"])
     ):
         raise RuntimeError("topology control identity is invalid")
     endpoint = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -452,6 +447,14 @@ def _open_control(spec: dict[str, Any], topology_root: Path) -> socket.socket | 
         endpoint.close()
         raise
     return endpoint
+
+
+def _valid_filesystem_identity(value: Any) -> bool:
+    try:
+        validate_identity(value)
+    except FilesystemIdentityError:
+        return False
+    return True
 
 
 def _validate_scenario_connect_field(label: str, value: object) -> str:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -14281,10 +14281,13 @@ class Workspace:
                 )
                 try:
                     previous_metadata = os.fstat(previous_fd)
-                    if previous_identity != {
-                        "device": previous_metadata.st_dev,
-                        "inode": previous_metadata.st_ino,
-                    }:
+                    try:
+                        previous_identity_matches = identity_matches(
+                            previous_identity, previous_metadata
+                        )
+                    except FilesystemIdentityError:
+                        previous_identity_matches = False
+                    if not previous_identity_matches:
                         raise WorkspaceError(
                             f"temporary topology state identity changed: {previous_state}"
                         )
@@ -14404,6 +14407,7 @@ class Workspace:
                             finally:
                                 os.close(tmp_fd)
                         staged_metadata = os.fstat(staging_fd)
+                        staged_identity = portable_identity(staged_metadata)
                         policy = {
                             "mode": "temporary",
                             "name": None,
@@ -14415,10 +14419,7 @@ class Workspace:
                             },
                             "lifecycle": "disposable",
                             "created_at": previous_policy["created_at"],
-                            "identity": {
-                                "device": staged_metadata.st_dev,
-                                "inode": staged_metadata.st_ino,
-                            },
+                            "identity": staged_identity,
                             "implementation": implementation,
                             "profile": profile_name,
                             "server": server_coordinate,
@@ -14472,8 +14473,8 @@ class Workspace:
                             follow_symlinks=False,
                         )
                         if (visible.st_dev, visible.st_ino) != (
-                            policy["identity"]["device"],
-                            policy["identity"]["inode"],
+                            staged_metadata.st_dev,
+                            staged_metadata.st_ino,
                         ):
                             raise WorkspaceError(
                                 f"temporary topology state identity changed during clone: {destination}"

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -4333,20 +4333,30 @@ class Workspace:
         git_common_identity = git_common.stat()
         expected_source_identity = state.get("sources", {}).get(component.source)
         if (
-            (checkout_identity.st_dev, checkout_identity.st_ino)
-            != (state.get("device"), state.get("inode"))
-            or str(git_common) != state.get("git_common")
-            or (git_common_identity.st_dev, git_common_identity.st_ino)
-            != (
-                state.get("git_common_device"),
-                state.get("git_common_inode"),
+            not pair_matches(
+                {
+                    "device": state.get("device"),
+                    "inode": state.get("inode"),
+                },
+                checkout_identity,
             )
-            or expected_source_identity
-            != {
-                "path": str(source.resolve()),
-                "device": source_identity.st_dev,
-                "inode": source_identity.st_ino,
-            }
+            or str(git_common) != state.get("git_common")
+            or not pair_matches(
+                {
+                    "device": state.get("git_common_device"),
+                    "inode": state.get("git_common_inode"),
+                },
+                git_common_identity,
+            )
+            or not isinstance(expected_source_identity, dict)
+            or expected_source_identity.get("path") != str(source.resolve())
+            or not pair_matches(
+                {
+                    "device": expected_source_identity.get("device"),
+                    "inode": expected_source_identity.get("inode"),
+                },
+                source_identity,
+            )
         ):
             raise WorkspaceError(
                 f"clean primary source identity changed before materialization: {checkout}"
@@ -4463,23 +4473,27 @@ class Workspace:
             current_source = source.stat()
             current_git_common_identity = current_git_common.stat()
             if (
-                (current_checkout.st_dev, current_checkout.st_ino)
-                != (state["device"], state["inode"])
+                not pair_matches(
+                    {"device": state["device"], "inode": state["inode"]},
+                    current_checkout,
+                )
                 or str(current_git_common) != state["git_common"]
-                or (
-                    current_git_common_identity.st_dev,
-                    current_git_common_identity.st_ino,
+                or not pair_matches(
+                    {
+                        "device": state["git_common_device"],
+                        "inode": state["git_common_inode"],
+                    },
+                    current_git_common_identity,
                 )
-                != (
-                    state["git_common_device"],
-                    state["git_common_inode"],
+                or not pair_matches(
+                    {
+                        "device": state["sources"][component.source]["device"],
+                        "inode": state["sources"][component.source]["inode"],
+                    },
+                    current_source,
                 )
-                or state["sources"][component.source]
-                != {
-                    "path": str(source.resolve()),
-                    "device": current_source.st_dev,
-                    "inode": current_source.st_ino,
-                }
+                or state["sources"][component.source]["path"]
+                != str(source.resolve())
                 or not _is_clean(checkout, trace=False)
                 or git(
                     checkout,
@@ -8866,10 +8880,10 @@ class Workspace:
                 git_common_identity = git_common.stat()
                 state.update(
                     {
-                        "device": identity.st_dev,
+                        "device": portable_device(identity),
                         "inode": identity.st_ino,
                         "git_common": str(git_common),
-                        "git_common_device": git_common_identity.st_dev,
+                        "git_common_device": portable_device(git_common_identity),
                         "git_common_inode": git_common_identity.st_ino,
                         "sources": {},
                     }
@@ -8884,7 +8898,7 @@ class Workspace:
                 identity = source.stat()
                 states[component.checkout_name]["sources"][component.source] = {
                     "path": str(source),
-                    "device": identity.st_dev,
+                    "device": portable_device(identity),
                     "inode": identity.st_ino,
                 }
         return states

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -36,6 +36,16 @@ import zipfile
 
 from .launch_identity import CLIENT_LAUNCH_LABEL_ENV, client_launch_label
 from .content_migration import ContentMigration
+from .filesystem_identity import (
+    FilesystemIdentityError,
+    identity_digest,
+    identity_matches,
+    is_legacy_identity,
+    pair_matches,
+    portable_device,
+    portable_identity,
+    validate_identity,
+)
 from .locking import (
     LeaseRequest,
     LockBusyError,
@@ -353,6 +363,7 @@ CLASSIC_CLIENT_RUNTIME_SOURCE_EXCLUSIONS = frozenset(
     {".git", "build", "sound", MANAGED_MARKER, "shaders"}
 )
 CLASSIC_CLIENT_RUNTIME_BINARY_EXCLUSIONS = frozenset({"src", "shaders"})
+LEASE_NAMESPACE_IDENTITY_SCHEMA_VERSION = 2
 
 
 @dataclass
@@ -816,6 +827,53 @@ def _owned_tree_tombstone_path(
     )
 
 
+def _live_identity_dict(metadata: os.stat_result) -> dict[str, int]:
+    """Project an opened object into the identity used by live fences."""
+
+    return {"device": metadata.st_dev, "inode": metadata.st_ino}
+
+
+def _portable_tombstone_path(
+    path: Path, identity: dict[str, Any]
+) -> Path | None:
+    """Find an owned-tree tombstone without reconstructing a mount device.
+
+    Older tombstones include the old device in their filename.  New durable
+    records do not know that value after a remount, so recovery scans only the
+    exact name-hash family and proves the candidate through its opened
+    metadata.  Ambiguous candidates fail closed.
+    """
+
+    digest = hashlib.sha256(path.name.encode("utf-8")).hexdigest()[:16]
+    candidates: list[Path] = []
+    try:
+        entries = sorted(path.parent.iterdir())
+    except FileNotFoundError:
+        return None
+    except OSError as error:
+        raise WorkspaceError(
+            f"cannot inspect owned-tree tombstones for {path}: {error}"
+        ) from error
+    for candidate in entries:
+        if not re.fullmatch(rf"\.remove-{digest}-[0-9a-f]+-[0-9a-f]+", candidate.name):
+            continue
+        try:
+            metadata = candidate.stat(follow_symlinks=False)
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot inspect owned-tree tombstone {candidate}: {error}"
+            ) from error
+        if (
+            pair_matches(identity, metadata)
+            if set(identity) == {"device", "inode"}
+            else identity_matches(identity, metadata)
+        ):
+            candidates.append(candidate)
+    if len(candidates) > 1:
+        raise WorkspaceError(f"owned-tree tombstones are ambiguous: {path}")
+    return candidates[0] if candidates else None
+
+
 def _fsync_directory(path: Path) -> None:
     descriptor = _open_directory_nofollow(
         path, os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW
@@ -835,7 +893,7 @@ def _remove_owned_tree_contents(
 ) -> None:
     def move_to_tombstone(name: str, child: os.stat_result) -> str:
         tombstone = _owned_tree_tombstone_name(
-            name, child.st_dev, child.st_ino
+            name, portable_device(child), child.st_ino
         )
         rename_no_replace_at(descriptor, name, descriptor, tombstone)
         moved = os.stat(tombstone, dir_fd=descriptor, follow_symlinks=False)
@@ -869,13 +927,19 @@ def _remove_owned_tree_contents(
         tombstone_match = re.fullmatch(
             r"\.remove-[0-9a-f]{16}-([0-9a-f]+)-([0-9a-f]+)", name
         )
-        if tombstone_match and (child.st_dev, child.st_ino) != (
-            int(tombstone_match.group(1), 16),
-            int(tombstone_match.group(2), 16),
-        ):
-            raise WorkspaceError(
-                f"owned removal has an uncertain tombstone: {child_display}"
-            )
+        if tombstone_match:
+            encoded_identity = {
+                "device": int(tombstone_match.group(1), 16),
+                "inode": int(tombstone_match.group(2), 16),
+            }
+            if not (
+                child.st_ino == encoded_identity["inode"]
+                and encoded_identity["device"]
+                in {child.st_dev, portable_device(child)}
+            ):
+                raise WorkspaceError(
+                    f"owned removal has an uncertain tombstone: {child_display}"
+                )
         if child.st_dev != device:
             raise WorkspaceError(
                 f"owned removal encountered a mount: {child_display}"
@@ -914,26 +978,44 @@ def _remove_owned_tree_contents(
 def remove_owned_tree(
     path: Path,
     *,
-    expected_identity: dict[str, int] | None = None,
+    expected_identity: dict[str, Any] | None = None,
     keep_root: bool = False,
     reject_links: bool = False,
     parent_directory_fd: int | None = None,
 ) -> None:
-    if expected_identity is not None and (
-        set(expected_identity) != {"device", "inode"}
-        or any(
-            not isinstance(value, int) or isinstance(value, bool) or value < 0
-            for value in expected_identity.values()
-        )
-    ):
-        raise WorkspaceError(f"owned removal root identity is invalid: {path}")
-    def root_tombstone_name(identity: dict[str, int] | tuple[int, int]) -> str:
-        device, inode = (
-            (identity["device"], identity["inode"])
-            if isinstance(identity, dict)
-            else identity
-        )
-        return _owned_tree_tombstone_name(path.name, device, inode)
+    if expected_identity is not None:
+        try:
+            validate_identity(expected_identity)
+        except FilesystemIdentityError as error:
+            raise WorkspaceError(
+                f"owned removal root identity is invalid: {path}"
+            ) from error
+
+    def find_tombstone() -> tuple[str, os.stat_result]:
+        candidates: list[tuple[str, os.stat_result]] = []
+        for name in sorted(os.listdir(parent_descriptor)):
+            if not re.fullmatch(
+                rf"\.remove-{hashlib.sha256(path.name.encode('utf-8')).hexdigest()[:16]}-[0-9a-f]+-[0-9a-f]+",
+                name,
+            ):
+                continue
+            try:
+                candidate = os.stat(
+                    name, dir_fd=parent_descriptor, follow_symlinks=False
+                )
+            except FileNotFoundError:
+                continue
+            if expected_identity is not None and (
+                pair_matches(expected_identity, candidate)
+                if set(expected_identity) == {"device", "inode"}
+                else identity_matches(expected_identity, candidate)
+            ):
+                candidates.append((name, candidate))
+        if len(candidates) > 1:
+            raise WorkspaceError(f"owned removal roots are ambiguous: {path}")
+        if not candidates:
+            raise FileNotFoundError(path)
+        return candidates[0]
 
     parent_descriptor = (
         os.dup(parent_directory_fd)
@@ -954,11 +1036,8 @@ def remove_owned_tree(
         except FileNotFoundError:
             if expected_identity is None:
                 raise WorkspaceError(f"owned removal root is invalid: {path}")
-            entry_name = root_tombstone_name(expected_identity)
             try:
-                before = os.stat(
-                    entry_name, dir_fd=parent_descriptor, follow_symlinks=False
-                )
+                entry_name, before = find_tombstone()
             except FileNotFoundError as error:
                 raise WorkspaceError(
                     f"owned removal root is invalid: {path}"
@@ -966,9 +1045,10 @@ def remove_owned_tree(
             already_tombstoned = True
         if not stat.S_ISDIR(before.st_mode):
             raise WorkspaceError(f"owned removal root is invalid: {path}")
-        if expected_identity is not None and (before.st_dev, before.st_ino) != (
-            expected_identity["device"],
-            expected_identity["inode"],
+        if expected_identity is not None and not (
+            pair_matches(expected_identity, before)
+            if set(expected_identity) == {"device", "inode"}
+            else identity_matches(expected_identity, before)
         ):
             raise WorkspaceError(f"owned removal root identity changed: {path}")
         parent_mount_id = _descriptor_mount_id(parent_descriptor)
@@ -1014,7 +1094,13 @@ def remove_owned_tree(
         if keep_root:
             os.fsync(parent_descriptor)
             return
-        tombstone = root_tombstone_name(expected)
+        tombstone = (
+            entry_name
+            if already_tombstoned
+            else _owned_tree_tombstone_name(
+                path.name, portable_device(opened), opened.st_ino
+            )
+        )
         if not already_tombstoned:
             rename_no_replace_at(
                 parent_descriptor,
@@ -2407,13 +2493,26 @@ class Workspace:
                 record = load_regular_json(
                     record_path, "physical lease namespace identity"
                 )
+                valid = False
                 if (
-                    not isinstance(record, dict)
-                    or set(record) != {"schema_version", "device", "inode"}
-                    or record.get("schema_version") != 1
-                    or record.get("device") != identity[0]
-                    or record.get("inode") != identity[1]
+                    isinstance(record, dict)
+                    and set(record) == {"schema_version", "device", "inode"}
+                    and record.get("schema_version") == 1
                 ):
+                    valid = record.get("device") == identity[0] and record.get(
+                        "inode"
+                    ) == identity[1]
+                elif (
+                    isinstance(record, dict)
+                    and set(record) == {"schema_version", "identity"}
+                    and record.get("schema_version")
+                    == LEASE_NAMESPACE_IDENTITY_SCHEMA_VERSION
+                ):
+                    try:
+                        valid = identity_matches(record["identity"], visible)
+                    except FilesystemIdentityError:
+                        valid = False
+                if not valid:
                     raise WorkspaceError(
                         "physical lease namespace identity changed; restore the "
                         f"original namespace: {namespace}"
@@ -2422,9 +2521,8 @@ class Workspace:
                 durable_atomic_json(
                     record_path,
                     {
-                        "schema_version": 1,
-                        "device": identity[0],
-                        "inode": identity[1],
+                        "schema_version": LEASE_NAMESPACE_IDENTITY_SCHEMA_VERSION,
+                        "identity": portable_identity(visible),
                     },
                 )
         return identity
@@ -12898,6 +12996,21 @@ class Workspace:
         return {"device": metadata.st_dev, "inode": metadata.st_ino}
 
     @staticmethod
+    def _state_portable_identity(path: Path) -> dict[str, Any]:
+        metadata = path.stat(follow_symlinks=False)
+        if not stat.S_ISDIR(metadata.st_mode):
+            raise WorkspaceError(f"server state is not a directory: {path}")
+        return portable_identity(metadata)
+
+    @staticmethod
+    def _state_identity_matches(path: Path, identity: Any) -> bool:
+        try:
+            metadata = path.stat(follow_symlinks=False)
+            return identity_matches(identity, metadata)
+        except (OSError, FilesystemIdentityError):
+            return False
+
+    @staticmethod
     def _state_implementation(
         stack: str,
         providers: dict[str, str],
@@ -13282,7 +13395,7 @@ class Workspace:
             "path": str(path),
             "owner": owner,
             "lifecycle": lifecycle,
-            "identity": self._state_identity(path),
+            "identity": self._state_portable_identity(path),
             "implementation": implementation,
         }
 
@@ -13398,13 +13511,7 @@ class Workspace:
             or not isinstance(record.get("generation"), str)
             or not re.fullmatch(r"[0-9a-f]{64}", record["generation"])
             or not isinstance(identity, dict)
-            or set(identity) != {"device", "inode"}
-            or not all(
-                isinstance(value, int)
-                and not isinstance(value, bool)
-                and value >= 0
-                for value in identity.values()
-            )
+            or not self._valid_state_identity(identity)
         ):
             raise WorkspaceError(
                 f"promoted state provenance is invalid: {record_path}"
@@ -13415,9 +13522,8 @@ class Workspace:
             raise WorkspaceError(
                 f"promoted state provenance is invalid: {record_path}: {error}"
             ) from error
-        if (
-            not stat.S_ISDIR(visible.st_mode)
-            or {"device": visible.st_dev, "inode": visible.st_ino} != identity
+        if not stat.S_ISDIR(visible.st_mode) or not self._state_identity_matches(
+            path, identity
         ):
             raise WorkspaceError(
                 f"promoted state provenance is invalid: {record_path}"
@@ -13603,6 +13709,12 @@ class Workspace:
                     same_state = isinstance(raw_status, dict) and (
                         raw_status.get("state") == str(path)
                         or (
+                            isinstance(raw_policy, dict)
+                            and self._state_identity_matches(
+                                path, raw_policy.get("identity")
+                            )
+                        )
+                        or (
                             requested_identity is not None
                             and isinstance(raw_policy, dict)
                             and raw_policy.get("identity") == requested_identity
@@ -13630,6 +13742,13 @@ class Workspace:
                     if (
                         (
                             status.get("state") == str(path)
+                            or (
+                                isinstance(status.get("state_policy"), dict)
+                                and self._state_identity_matches(
+                                    path,
+                                    status["state_policy"].get("identity"),
+                                )
+                            )
                             or (
                                 requested_identity is not None
                                 and status.get("state_policy", {}).get("identity")
@@ -13779,10 +13898,11 @@ class Workspace:
                 write_implementation=False,
             )
             staging_metadata = os.fstat(staging_fd)
-            identity = {
+            live_state_identity = {
                 "device": staging_metadata.st_dev,
                 "inode": staging_metadata.st_ino,
             }
+            persistent_state_identity = portable_identity(staging_metadata)
             policy = {
                 "mode": "temporary",
                 "name": None,
@@ -13794,7 +13914,7 @@ class Workspace:
                 },
                 "lifecycle": "disposable",
                 "created_at": created_at,
-                "identity": identity,
+                "identity": persistent_state_identity,
                 "implementation": implementation,
                 "profile": profile_name,
                 "server": server_coordinate,
@@ -13904,7 +14024,7 @@ class Workspace:
                 staging_name, dir_fd=container_fd, follow_symlinks=False
             )
             if (visible_staging.st_dev, visible_staging.st_ino) != (
-                identity["device"], identity["inode"]
+                live_state_identity["device"], live_state_identity["inode"]
             ):
                 raise WorkspaceError(
                     "temporary topology state staging changed before publication"
@@ -13912,7 +14032,7 @@ class Workspace:
             rename_no_replace_at(
                 container_fd, staging_name, container_fd, generation
             )
-            published_identity = identity
+            published_identity = live_state_identity
             if (
                 _tree_digest_descriptor(
                     staging_fd,
@@ -13942,7 +14062,10 @@ class Workspace:
             opened_container = os.fstat(container_fd)
             if (
                 (published.st_dev, published.st_ino)
-                != (identity["device"], identity["inode"])
+                != (
+                    live_state_identity["device"],
+                    live_state_identity["inode"],
+                )
                 or (visible_container.st_dev, visible_container.st_ino)
                 != (opened_container.st_dev, opened_container.st_ino)
             ):
@@ -15661,7 +15784,7 @@ class Workspace:
     @staticmethod
     def _runtime_state_output_identity_at(
         state_directory_fd: int, generation: str
-    ) -> dict[str, int]:
+    ) -> dict[str, Any]:
         flags = os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW
         descriptors: list[int] = []
         state_mount_id = _descriptor_mount_id(state_directory_fd)
@@ -15676,7 +15799,7 @@ class Workspace:
                     )
                 parent = descriptor
             metadata = os.fstat(descriptors[-1])
-            return {"device": metadata.st_dev, "inode": metadata.st_ino}
+            return portable_identity(metadata)
         finally:
             for descriptor in reversed(descriptors):
                 os.close(descriptor)
@@ -15687,7 +15810,7 @@ class Workspace:
         generation: str,
         state_directory_fd: int | None = None,
         cleanup_proof: list[bool] | None = None,
-    ) -> tuple[Path, int, dict[str, int]]:
+    ) -> tuple[Path, int, dict[str, Any]]:
         flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
         descriptors: list[int] = []
         created_generation = False
@@ -15784,10 +15907,7 @@ class Workspace:
                 os.close(marker_fd)
             metadata = os.fstat(generation_fd)
             result_fd = os.dup(generation_fd)
-            return output, result_fd, {
-                "device": metadata.st_dev,
-                "inode": metadata.st_ino,
-            }
+            return output, result_fd, portable_identity(metadata)
         except BaseException as error:
             if created_generation and len(descriptors) >= 4:
                 generation_fd = descriptors[-1]
@@ -15846,7 +15966,7 @@ class Workspace:
         path: Path,
         generation: str,
         state_directory_fd: int | None = None,
-        expected_identity: dict[str, int] | None = None,
+        expected_identity: dict[str, Any] | None = None,
         keep_tombstone: bool = False,
     ) -> None:
         if state_directory_fd is not None:
@@ -15884,28 +16004,41 @@ class Workspace:
                 already_tombstoned = False
                 try:
                     generation_fd = open_exact_directory(parent_fd, entry_name)
-                except FileNotFoundError:
+                except FileNotFoundError as missing:
                     digest = hashlib.sha256(
                         generation.encode("utf-8")
                     ).hexdigest()[:16]
-                    candidates = [
-                        name
-                        for name in os.listdir(parent_fd)
-                        if re.fullmatch(
+                    candidates: list[str] = []
+                    for name in os.listdir(parent_fd):
+                        if not re.fullmatch(
                             rf"\.remove-{digest}-[0-9a-f]+-[0-9a-f]+", name
+                        ):
+                            continue
+                        try:
+                            candidate_metadata = os.stat(
+                                name, dir_fd=parent_fd, follow_symlinks=False
+                            )
+                        except FileNotFoundError:
+                            continue
+                        if expected_identity is not None and identity_matches(
+                            expected_identity, candidate_metadata
+                        ):
+                            candidates.append(name)
+                    if len(candidates) > 1:
+                        raise WorkspaceError(
+                            "server runtime state output tombstones are ambiguous: "
+                            f"{path}"
                         )
-                    ]
-                    if len(candidates) != 1:
-                        raise
+                    if not candidates:
+                        raise missing
                     entry_name = candidates[0]
                     generation_fd = open_exact_directory(parent_fd, entry_name)
                     already_tombstoned = True
                 descriptors.append(generation_fd)
                 metadata = os.fstat(generation_fd)
-                if expected_identity is None or expected_identity != {
-                    "device": metadata.st_dev,
-                    "inode": metadata.st_ino,
-                }:
+                if expected_identity is None or not identity_matches(
+                    expected_identity, metadata
+                ):
                     raise WorkspaceError(
                         f"server runtime state output identity changed: {path}"
                     )
@@ -15914,10 +16047,7 @@ class Workspace:
                         r"\.remove-[0-9a-f]{16}-([0-9a-f]+)-([0-9a-f]+)",
                         entry_name,
                     )
-                    if match is None or (metadata.st_dev, metadata.st_ino) != (
-                        int(match.group(1), 16),
-                        int(match.group(2), 16),
-                    ):
+                    if match is None:
                         raise WorkspaceError(
                             f"server runtime state output tombstone is invalid: {path}"
                         )
@@ -16007,7 +16137,7 @@ class Workspace:
     def _finish_runtime_state_output_tombstone(
         state_directory_fd: int,
         generation: str,
-        expected_identity: dict[str, int],
+        expected_identity: dict[str, Any],
     ) -> bool:
         flags = os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW
         descriptors = [os.dup(state_directory_fd)]
@@ -16027,24 +16157,37 @@ class Workspace:
                     )
                 descriptors.append(descriptor)
             parent_fd = descriptors[-1]
-            tombstone = _owned_tree_tombstone_name(
-                generation,
-                expected_identity["device"],
-                expected_identity["inode"],
-            )
-            try:
-                visible = os.stat(
-                    tombstone, dir_fd=parent_fd, follow_symlinks=False
+            digest = hashlib.sha256(generation.encode("utf-8")).hexdigest()[:16]
+            candidates: list[str] = []
+            for name in os.listdir(parent_fd):
+                if not re.fullmatch(
+                    rf"\.remove-{digest}-[0-9a-f]+-[0-9a-f]+", name
+                ):
+                    continue
+                try:
+                    candidate = os.stat(
+                        name, dir_fd=parent_fd, follow_symlinks=False
+                    )
+                except FileNotFoundError:
+                    continue
+                if identity_matches(expected_identity, candidate):
+                    candidates.append(name)
+            if len(candidates) > 1:
+                raise WorkspaceError(
+                    "server runtime state output tombstones are ambiguous"
                 )
-            except FileNotFoundError:
+            if not candidates:
                 return False
+            tombstone = candidates[0]
+            visible = os.stat(
+                tombstone, dir_fd=parent_fd, follow_symlinks=False
+            )
             descriptor = os.open(tombstone, flags, dir_fd=parent_fd)
             descriptors.append(descriptor)
             opened = os.fstat(descriptor)
             if (
                 not stat.S_ISDIR(visible.st_mode)
-                or (visible.st_dev, visible.st_ino)
-                != (expected_identity["device"], expected_identity["inode"])
+                or not identity_matches(expected_identity, visible)
                 or (opened.st_dev, opened.st_ino)
                 != (visible.st_dev, visible.st_ino)
                 or _descriptor_mount_id(descriptor) != state_mount_id
@@ -16096,16 +16239,11 @@ class Workspace:
 
     @staticmethod
     def _valid_state_identity(value: Any) -> bool:
-        return bool(
-            isinstance(value, dict)
-            and set(value) == {"device", "inode"}
-            and all(
-                isinstance(value[key], int)
-                and not isinstance(value[key], bool)
-                and value[key] >= 0
-                for key in ("device", "inode")
-            )
-        )
+        try:
+            validate_identity(value)
+        except FilesystemIdentityError:
+            return False
+        return True
 
     @staticmethod
     def _clear_runtime_state_output_transaction(topology_root: Path) -> None:
@@ -16183,7 +16321,7 @@ class Workspace:
         output: Path,
         generation: str,
         state_directory_fd: int,
-        output_identity: dict[str, int],
+        output_identity: dict[str, Any],
     ) -> None:
         transaction_path = topology_root / RUNTIME_STATE_OUTPUT_TRANSACTION
         transaction = load_regular_json(
@@ -16556,10 +16694,7 @@ class Workspace:
                             "schema_version": SCHEMA_VERSION,
                             "generation": generation,
                             "state": str(state),
-                            "state_identity": {
-                                "device": state_metadata.st_dev,
-                                "inode": state_metadata.st_ino,
-                            },
+                            "state_identity": portable_identity(state_metadata),
                             "phase": "creating",
                             "output_identity": None,
                         },
@@ -16581,10 +16716,9 @@ class Workspace:
                             "schema_version": SCHEMA_VERSION,
                             "generation": generation,
                             "state": str(state),
-                            "state_identity": {
-                                "device": os.fstat(state_directory_fd).st_dev,
-                                "inode": os.fstat(state_directory_fd).st_ino,
-                            },
+                            "state_identity": portable_identity(
+                                os.fstat(state_directory_fd)
+                            ),
                             "phase": "prepared",
                             "output_identity": state_output_identity,
                         },
@@ -16617,7 +16751,9 @@ class Workspace:
                         state_directory_fd, generation
                     )
                     if state_directory_fd is not None
-                    else self._state_identity(state_output)
+                    else portable_identity(
+                        state_output.stat(follow_symlinks=False)
+                    )
                 )
                 if visible_output_identity != state_output_identity:
                     raise WorkspaceError(
@@ -16675,7 +16811,7 @@ class Workspace:
                 os.O_RDWR | os.O_CREAT,
                 "runtime generation lease",
             )
-            lease_identity = initialize_lease(lease_fd, generation)
+            initialize_lease(lease_fd, generation)
             try:
                 fcntl.flock(lease_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
             except OSError as error:
@@ -16687,6 +16823,7 @@ class Workspace:
                 "runtime generation manifest",
             )
             self._seal_runtime_generation(staging)
+            lease_identity = portable_identity(os.fstat(lease_fd))
             staging.replace(published)
             runtime_record = {
                 "schema_version": RUNTIME_GENERATION_SCHEMA_VERSION,
@@ -17166,8 +17303,17 @@ class Workspace:
                     if isinstance(identities, list):
                         identity = identities[index]
                         if isinstance(identity, dict) and (
-                            _owned_tree_tombstone_path(output, identity).exists()
-                            or _owned_tree_tombstone_path(output, identity).is_symlink()
+                            (
+                                (
+                                    tombstone := (
+                                        _owned_tree_tombstone_path(output, identity)
+                                        if is_legacy_identity(identity)
+                                        else _portable_tombstone_path(output, identity)
+                                    )
+                                )
+                                is not None
+                                and (tombstone.exists() or tombstone.is_symlink())
+                            )
                         ):
                             return "retained_state"
         elif runtime is not None:
@@ -17227,17 +17373,9 @@ class Workspace:
             or not isinstance(policy.get("owner"), dict)
             or not isinstance(policy.get("lifecycle"), str)
             or not isinstance(identity, dict)
-            or set(identity) != {"device", "inode"}
-            or not all(
-                isinstance(value, int) and not isinstance(value, bool) and value >= 0
-                for value in identity.values()
-            )
+            or not self._valid_state_identity(identity)
             or not isinstance(lease_identity, dict)
-            or set(lease_identity) != {"device", "inode"}
-            or not all(
-                isinstance(value, int) and not isinstance(value, bool) and value >= 0
-                for value in lease_identity.values()
-            )
+            or not self._valid_state_identity(lease_identity)
             or not isinstance(implementation, dict)
             or set(implementation) != {"stack", "provider", "repository"}
             or not isinstance(providers, dict)
@@ -17301,7 +17439,7 @@ class Workspace:
                 if (
                     path.is_symlink()
                     or not path.is_dir()
-                    or self._state_identity(path) != identity
+                    or not self._state_identity_matches(path, identity)
                     or marker.is_symlink()
                     or not marker.is_file()
                     or load_json(marker)
@@ -17352,7 +17490,7 @@ class Workspace:
                 or policy.get("owner") != expected_persistent["owner"]
                 or lifecycle != expected_persistent["lifecycle"]
                 or path != self._state_location(expected_name)
-                or self._state_identity(path) != identity
+                or not self._state_identity_matches(path, identity)
             ):
                 raise WorkspaceError(f"persistent topology state policy is invalid: {name}")
             self._validate_state_implementation(path, implementation)
@@ -17516,13 +17654,7 @@ class Workspace:
                     or set(entry) != {"path", "identity", "status"}
                     or not isinstance(entry.get("path"), str)
                     or not isinstance(entry.get("identity"), dict)
-                    or set(entry["identity"]) != {"device", "inode"}
-                    or any(
-                        not isinstance(value, int)
-                        or isinstance(value, bool)
-                        or value < 0
-                        for value in entry["identity"].values()
-                    )
+                    or not self._valid_state_identity(entry["identity"])
                     or entry.get("status") not in {"pending", "complete"}
                     for entry in cleanup_entries
                 )
@@ -17664,13 +17796,7 @@ class Workspace:
             or control.get("socket")
             != str(control_socket_path(root, control["generation"]))
             or not isinstance(control.get("lease"), dict)
-            or set(control["lease"]) != {"device", "inode"}
-            or not all(
-                isinstance(value, int)
-                and not isinstance(value, bool)
-                and value >= 0
-                for value in control["lease"].values()
-            )
+            or not self._valid_state_identity(control["lease"])
         ):
             raise WorkspaceError(f"topology control identity is invalid: {name}")
         process_keys = (
@@ -17746,26 +17872,14 @@ class Workspace:
                     != len(runtime["mutable_state_outputs"])
                     or any(
                         not isinstance(identity, dict)
-                        or set(identity) != {"device", "inode"}
-                        or any(
-                            not isinstance(value, int)
-                            or isinstance(value, bool)
-                            or value < 0
-                            for value in identity.values()
-                        )
+                        or not self._valid_state_identity(identity)
                         for identity in runtime[
                             "mutable_state_output_identities"
                         ]
                     )
                 )
                 or not isinstance(runtime.get("lease"), dict)
-                or set(runtime["lease"]) != {"device", "inode"}
-                or not all(
-                    isinstance(value, int)
-                    and not isinstance(value, bool)
-                    and value >= 0
-                    for value in runtime["lease"].values()
-                )
+                or not self._valid_state_identity(runtime["lease"])
             ):
                 raise WorkspaceError(f"topology runtime identity is invalid: {name}")
             if mutable_state_cleanup is not None and (
@@ -18689,8 +18803,7 @@ class Workspace:
                     state_policy = {
                         **state_policy,
                         "lease_identity": {
-                            "device": lock_metadata.st_dev,
-                            "inode": lock_metadata.st_ino,
+                            **portable_identity(lock_metadata, include_ctime=False),
                         },
                     }
                     try:
@@ -18737,10 +18850,9 @@ class Workspace:
                             else None
                         )
                     state_metadata = os.fstat(state_directory_fd)
-                    if state_policy["identity"] != {
-                        "device": state_metadata.st_dev,
-                        "inode": state_metadata.st_ino,
-                    }:
+                    if not identity_matches(
+                        state_policy["identity"], state_metadata
+                    ):
                         raise WorkspaceError(
                             f"server state identity changed before runtime publication: {state}"
                         )
@@ -19294,9 +19406,10 @@ class Workspace:
             visible = state.stat(follow_symlinks=False)
             identity = policy.get("identity")
             if (
-                {"device": opened.st_dev, "inode": opened.st_ino} != identity
-                or {"device": visible.st_dev, "inode": visible.st_ino}
-                != identity
+                not identity_matches(identity, opened)
+                or not identity_matches(identity, visible)
+                or (opened.st_dev, opened.st_ino)
+                != (visible.st_dev, visible.st_ino)
             ):
                 raise WorkspaceError(
                     f"server state identity changed before runtime cleanup: {state}"
@@ -19455,13 +19568,14 @@ class Workspace:
     def _unlink_temporary_state_lock(
         state: Path,
         state_lease: TextIO,
-        lease_identity: dict[str, int],
+        lease_identity: dict[str, Any],
         parent_directory_fd: int | None = None,
     ) -> None:
         Workspace._validate_temporary_state_lock(
             state, state_lease, lease_identity
         )
         lock = Path(f"{state}.lock")
+        live_lease_identity = _live_identity_dict(os.fstat(state_lease.fileno()))
 
         parent_fd = (
             os.dup(parent_directory_fd)
@@ -19472,9 +19586,10 @@ class Workspace:
             )
         )
         try:
+            durable_device = portable_device(os.fstat(state_lease.fileno()))
             tombstone = (
-                f".{lock.name}.remove-{lease_identity['device']:x}-"
-                f"{lease_identity['inode']:x}"
+                f".{lock.name}.remove-{durable_device:x}-"
+                f"{live_lease_identity['inode']:x}"
             )
             rename_no_replace_at(
                 parent_fd, lock.name, parent_fd, tombstone
@@ -19483,8 +19598,8 @@ class Workspace:
                 tombstone, dir_fd=parent_fd, follow_symlinks=False
             )
             expected = (
-                lease_identity["device"],
-                lease_identity["inode"],
+                live_lease_identity["device"],
+                live_lease_identity["inode"],
             )
             if (moved.st_dev, moved.st_ino) != expected:
                 try:
@@ -19515,6 +19630,7 @@ class Workspace:
                     or (opened.st_dev, opened.st_ino) != expected
                     or (visible.st_dev, visible.st_ino) != expected
                     or visible.st_nlink != 1
+                    or not identity_matches(lease_identity, opened)
                 ):
                     raise WorkspaceError(
                         f"temporary topology state lease changed before removal: {lock}"
@@ -19530,7 +19646,7 @@ class Workspace:
     def _validate_temporary_state_lock(
         state: Path,
         state_lease: TextIO,
-        lease_identity: dict[str, int],
+        lease_identity: dict[str, Any],
     ) -> None:
         lock = Path(f"{state}.lock")
         try:
@@ -19540,12 +19656,13 @@ class Workspace:
                 f"temporary topology state lease is missing: {lock}"
             ) from error
         opened = os.fstat(state_lease.fileno())
-        expected = (lease_identity["device"], lease_identity["inode"])
+        expected = (opened.st_dev, opened.st_ino)
         if (
             not stat.S_ISREG(visible.st_mode)
             or visible.st_nlink != 1
             or (visible.st_dev, visible.st_ino) != expected
             or (opened.st_dev, opened.st_ino) != expected
+            or not identity_matches(lease_identity, opened)
         ):
             raise WorkspaceError(
                 "temporary topology state lease changed before lifecycle "
@@ -19555,14 +19672,24 @@ class Workspace:
     @staticmethod
     def _finish_temporary_state_lock_tombstone(
         state: Path,
-        lease_identity: dict[str, int],
+        lease_identity: dict[str, Any],
         parent_directory_fd: int | None = None,
     ) -> bool:
         lock = Path(f"{state}.lock")
-        tombstone = lock.parent / (
-            f".{lock.name}.remove-{lease_identity['device']:x}-"
-            f"{lease_identity['inode']:x}"
-        )
+        tombstone: Path | None = None
+        for candidate in sorted(lock.parent.glob(f".{lock.name}.remove-*")):
+            try:
+                metadata = candidate.stat(follow_symlinks=False)
+            except FileNotFoundError:
+                continue
+            if identity_matches(lease_identity, metadata):
+                if tombstone is not None:
+                    raise WorkspaceError(
+                        f"temporary topology state lease tombstones are ambiguous: {lock}"
+                    )
+                tombstone = candidate
+        if tombstone is None:
+            return False
         if parent_directory_fd is None:
             if not tombstone.exists() and not tombstone.is_symlink():
                 return False
@@ -19594,13 +19721,13 @@ class Workspace:
                 visible = os.stat(
                     tombstone.name, dir_fd=parent_fd, follow_symlinks=False
                 )
-                expected = (lease_identity["device"], lease_identity["inode"])
                 if (
                     not stat.S_ISREG(metadata.st_mode)
                     or metadata.st_nlink != 1
-                    or (metadata.st_dev, metadata.st_ino) != expected
-                    or (visible.st_dev, visible.st_ino) != expected
+                    or (metadata.st_dev, metadata.st_ino)
+                    != (visible.st_dev, visible.st_ino)
                     or visible.st_nlink != 1
+                    or not identity_matches(lease_identity, metadata)
                 ):
                     raise WorkspaceError(
                         "temporary topology state lease tombstone is invalid: "
@@ -19617,7 +19744,7 @@ class Workspace:
     @staticmethod
     def _lock_state_directory_mutation(
         path: Path,
-        identity: dict[str, int],
+        identity: dict[str, Any],
         description: str = "temporary state",
     ) -> int:
         descriptor = _open_directory_nofollow(
@@ -19626,11 +19753,11 @@ class Workspace:
         try:
             opened = os.fstat(descriptor)
             visible = path.stat(follow_symlinks=False)
-            expected = (identity["device"], identity["inode"])
             if (
                 not stat.S_ISDIR(opened.st_mode)
-                or (opened.st_dev, opened.st_ino) != expected
-                or (visible.st_dev, visible.st_ino) != expected
+                or (opened.st_dev, opened.st_ino)
+                != (visible.st_dev, visible.st_ino)
+                or not identity_matches(identity, opened)
             ):
                 raise WorkspaceError(
                     f"{description} identity changed before mutation: {path}"
@@ -19699,8 +19826,8 @@ class Workspace:
     def _rollback_temporary_state_creation(
         state: Path,
         state_lease: TextIO,
-        state_identity: dict[str, int],
-        lease_identity: dict[str, int],
+        state_identity: dict[str, Any],
+        lease_identity: dict[str, Any],
         state_directory_fd: int | None = None,
         implementation: dict[str, str] | None = None,
     ) -> None:
@@ -19719,9 +19846,14 @@ class Workspace:
             Workspace._validate_temporary_state_integrity(
                 owned_descriptor, state, implementation
             )
+            state_metadata = os.fstat(owned_descriptor)
+            if not identity_matches(state_identity, state_metadata):
+                raise WorkspaceError(
+                    f"temporary state identity changed before rollback: {state}"
+                )
             remove_owned_tree(
                 state,
-                expected_identity=state_identity,
+                expected_identity=_live_identity_dict(state_metadata),
                 reject_links=True,
             )
         finally:
@@ -19773,30 +19905,39 @@ class Workspace:
         if lifecycle == "removal-pending":
             state_present = entry_present(state)
             tombstone_present = entry_present(tombstone)
-            removal_tombstone = _owned_tree_tombstone_path(tombstone, identity)
+            removal_tombstone = _portable_tombstone_path(tombstone, identity)
+            if removal_tombstone is None and state_present:
+                removal_tombstone = _owned_tree_tombstone_path(
+                    tombstone,
+                    _live_identity_dict(
+                        state.stat(follow_symlinks=False)
+                        if state_container_fd is None
+                        else os.stat(
+                            state.name,
+                            dir_fd=state_container_fd,
+                            follow_symlinks=False,
+                        )
+                    ),
+                )
             removal_tombstone_present = (
-                entry_present(removal_tombstone)
+                removal_tombstone is not None
+                and entry_present(removal_tombstone)
             )
             if state_present and tombstone_present:
                 raise WorkspaceError(
                     f"temporary state removal paths conflict: {state}"
                 )
             if state_present:
-                observed_state = (
-                    self._state_identity(state)
+                state_metadata = (
+                    state.stat(follow_symlinks=False)
                     if state_container_fd is None
-                    else {
-                        "device": (
-                            state_metadata := os.stat(
-                                state.name,
-                                dir_fd=state_container_fd,
-                                follow_symlinks=False,
-                            )
-                        ).st_dev,
-                        "inode": state_metadata.st_ino,
-                    }
+                    else os.stat(
+                        state.name,
+                        dir_fd=state_container_fd,
+                        follow_symlinks=False,
+                    )
                 )
-                if observed_state != identity:
+                if not identity_matches(identity, state_metadata):
                     raise WorkspaceError(
                         f"temporary state identity changed before removal: {state}"
                     )
@@ -19830,11 +19971,7 @@ class Workspace:
                 )
                 if (
                     not stat.S_ISDIR(tombstone_metadata.st_mode)
-                    or {
-                        "device": tombstone_metadata.st_dev,
-                        "inode": tombstone_metadata.st_ino,
-                    }
-                    != identity
+                    or not identity_matches(identity, tombstone_metadata)
                 ):
                     raise WorkspaceError(
                         f"temporary state removal identity is invalid: {tombstone}"
@@ -19888,8 +20025,7 @@ class Workspace:
             )
             if (
                 not stat.S_ISDIR(metadata.st_mode)
-                or (metadata.st_dev, metadata.st_ino)
-                != (identity["device"], identity["inode"])
+                or not identity_matches(identity, metadata)
                 or (
                     any(tombstone.iterdir())
                     if tombstone_fd is None
@@ -19977,13 +20113,25 @@ class Workspace:
                 retained = {**policy, "lifecycle": "retained"}
                 return self._write_temporary_state_policy(name, current, retained)
             removal_path = self._temporary_state_removal_path(policy)
-            removal_root_tombstone = _owned_tree_tombstone_path(
+            removal_root_tombstone = _portable_tombstone_path(
                 removal_path, policy["identity"]
             )
+            if removal_root_tombstone is None and (
+                state.exists() or state.is_symlink()
+            ):
+                removal_root_tombstone = _owned_tree_tombstone_path(
+                    removal_path,
+                    _live_identity_dict(state.stat(follow_symlinks=False)),
+                )
             mutation_path = next(
                 (
                     candidate
-                    for candidate in (state, removal_path, removal_root_tombstone)
+                    for candidate in (
+                        state,
+                        removal_path,
+                        removal_root_tombstone,
+                    )
+                    if candidate is not None
                     if candidate.exists() or candidate.is_symlink()
                 ),
                 None,
@@ -20131,11 +20279,12 @@ class Workspace:
                     if (
                         not stat.S_ISDIR(visible_state.st_mode)
                         or self._canonical_state_path(state) != state
-                        or {
-                            "device": opened_state.st_dev,
-                            "inode": opened_state.st_ino,
-                        }
-                        != policy.get("identity")
+                        or not identity_matches(
+                            policy.get("identity"), opened_state
+                        )
+                        or not identity_matches(
+                            policy.get("identity"), visible_state
+                        )
                         or (visible_state.st_dev, visible_state.st_ino)
                         != (opened_state.st_dev, opened_state.st_ino)
                     ):

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -36,6 +36,16 @@ import zipfile
 
 from .launch_identity import CLIENT_LAUNCH_LABEL_ENV, client_launch_label
 from .content_migration import ContentMigration
+from .filesystem_identity import (
+    FilesystemIdentityError,
+    identity_digest,
+    identity_matches,
+    is_legacy_identity,
+    pair_matches,
+    portable_device,
+    portable_identity,
+    validate_identity,
+)
 from .locking import (
     LeaseRequest,
     LockBusyError,
@@ -244,6 +254,7 @@ WORKER_NPM_FILE_CONFIG_KEYS = {
 }
 RUNTIME_INPUT_METADATA = ".atrinik-dependency.json"
 RUNTIME_INPUT_SCHEMA_VERSION = 1
+LEASE_NAMESPACE_IDENTITY_SCHEMA_VERSION = 2
 
 
 @dataclass
@@ -707,6 +718,53 @@ def _owned_tree_tombstone_path(
     )
 
 
+def _live_identity_dict(metadata: os.stat_result) -> dict[str, int]:
+    """Project an opened object into the identity used by live fences."""
+
+    return {"device": metadata.st_dev, "inode": metadata.st_ino}
+
+
+def _portable_tombstone_path(
+    path: Path, identity: dict[str, Any]
+) -> Path | None:
+    """Find an owned-tree tombstone without reconstructing a mount device.
+
+    Older tombstones include the old device in their filename.  New durable
+    records do not know that value after a remount, so recovery scans only the
+    exact name-hash family and proves the candidate through its opened
+    metadata.  Ambiguous candidates fail closed.
+    """
+
+    digest = hashlib.sha256(path.name.encode("utf-8")).hexdigest()[:16]
+    candidates: list[Path] = []
+    try:
+        entries = sorted(path.parent.iterdir())
+    except FileNotFoundError:
+        return None
+    except OSError as error:
+        raise WorkspaceError(
+            f"cannot inspect owned-tree tombstones for {path}: {error}"
+        ) from error
+    for candidate in entries:
+        if not re.fullmatch(rf"\.remove-{digest}-[0-9a-f]+-[0-9a-f]+", candidate.name):
+            continue
+        try:
+            metadata = candidate.stat(follow_symlinks=False)
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot inspect owned-tree tombstone {candidate}: {error}"
+            ) from error
+        if (
+            pair_matches(identity, metadata)
+            if set(identity) == {"device", "inode"}
+            else identity_matches(identity, metadata)
+        ):
+            candidates.append(candidate)
+    if len(candidates) > 1:
+        raise WorkspaceError(f"owned-tree tombstones are ambiguous: {path}")
+    return candidates[0] if candidates else None
+
+
 def _fsync_directory(path: Path) -> None:
     descriptor = _open_directory_nofollow(
         path, os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW
@@ -726,7 +784,7 @@ def _remove_owned_tree_contents(
 ) -> None:
     def move_to_tombstone(name: str, child: os.stat_result) -> str:
         tombstone = _owned_tree_tombstone_name(
-            name, child.st_dev, child.st_ino
+            name, portable_device(child), child.st_ino
         )
         rename_no_replace_at(descriptor, name, descriptor, tombstone)
         moved = os.stat(tombstone, dir_fd=descriptor, follow_symlinks=False)
@@ -760,13 +818,19 @@ def _remove_owned_tree_contents(
         tombstone_match = re.fullmatch(
             r"\.remove-[0-9a-f]{16}-([0-9a-f]+)-([0-9a-f]+)", name
         )
-        if tombstone_match and (child.st_dev, child.st_ino) != (
-            int(tombstone_match.group(1), 16),
-            int(tombstone_match.group(2), 16),
-        ):
-            raise WorkspaceError(
-                f"owned removal has an uncertain tombstone: {child_display}"
-            )
+        if tombstone_match:
+            encoded_identity = {
+                "device": int(tombstone_match.group(1), 16),
+                "inode": int(tombstone_match.group(2), 16),
+            }
+            if not (
+                child.st_ino == encoded_identity["inode"]
+                and encoded_identity["device"]
+                in {child.st_dev, portable_device(child)}
+            ):
+                raise WorkspaceError(
+                    f"owned removal has an uncertain tombstone: {child_display}"
+                )
         if child.st_dev != device:
             raise WorkspaceError(
                 f"owned removal encountered a mount: {child_display}"
@@ -805,26 +869,44 @@ def _remove_owned_tree_contents(
 def remove_owned_tree(
     path: Path,
     *,
-    expected_identity: dict[str, int] | None = None,
+    expected_identity: dict[str, Any] | None = None,
     keep_root: bool = False,
     reject_links: bool = False,
     parent_directory_fd: int | None = None,
 ) -> None:
-    if expected_identity is not None and (
-        set(expected_identity) != {"device", "inode"}
-        or any(
-            not isinstance(value, int) or isinstance(value, bool) or value < 0
-            for value in expected_identity.values()
-        )
-    ):
-        raise WorkspaceError(f"owned removal root identity is invalid: {path}")
-    def root_tombstone_name(identity: dict[str, int] | tuple[int, int]) -> str:
-        device, inode = (
-            (identity["device"], identity["inode"])
-            if isinstance(identity, dict)
-            else identity
-        )
-        return _owned_tree_tombstone_name(path.name, device, inode)
+    if expected_identity is not None:
+        try:
+            validate_identity(expected_identity)
+        except FilesystemIdentityError as error:
+            raise WorkspaceError(
+                f"owned removal root identity is invalid: {path}"
+            ) from error
+
+    def find_tombstone() -> tuple[str, os.stat_result]:
+        candidates: list[tuple[str, os.stat_result]] = []
+        for name in sorted(os.listdir(parent_descriptor)):
+            if not re.fullmatch(
+                rf"\.remove-{hashlib.sha256(path.name.encode('utf-8')).hexdigest()[:16]}-[0-9a-f]+-[0-9a-f]+",
+                name,
+            ):
+                continue
+            try:
+                candidate = os.stat(
+                    name, dir_fd=parent_descriptor, follow_symlinks=False
+                )
+            except FileNotFoundError:
+                continue
+            if expected_identity is not None and (
+                pair_matches(expected_identity, candidate)
+                if set(expected_identity) == {"device", "inode"}
+                else identity_matches(expected_identity, candidate)
+            ):
+                candidates.append((name, candidate))
+        if len(candidates) > 1:
+            raise WorkspaceError(f"owned removal roots are ambiguous: {path}")
+        if not candidates:
+            raise FileNotFoundError(path)
+        return candidates[0]
 
     parent_descriptor = (
         os.dup(parent_directory_fd)
@@ -845,11 +927,8 @@ def remove_owned_tree(
         except FileNotFoundError:
             if expected_identity is None:
                 raise WorkspaceError(f"owned removal root is invalid: {path}")
-            entry_name = root_tombstone_name(expected_identity)
             try:
-                before = os.stat(
-                    entry_name, dir_fd=parent_descriptor, follow_symlinks=False
-                )
+                entry_name, before = find_tombstone()
             except FileNotFoundError as error:
                 raise WorkspaceError(
                     f"owned removal root is invalid: {path}"
@@ -857,9 +936,10 @@ def remove_owned_tree(
             already_tombstoned = True
         if not stat.S_ISDIR(before.st_mode):
             raise WorkspaceError(f"owned removal root is invalid: {path}")
-        if expected_identity is not None and (before.st_dev, before.st_ino) != (
-            expected_identity["device"],
-            expected_identity["inode"],
+        if expected_identity is not None and not (
+            pair_matches(expected_identity, before)
+            if set(expected_identity) == {"device", "inode"}
+            else identity_matches(expected_identity, before)
         ):
             raise WorkspaceError(f"owned removal root identity changed: {path}")
         parent_mount_id = _descriptor_mount_id(parent_descriptor)
@@ -905,7 +985,13 @@ def remove_owned_tree(
         if keep_root:
             os.fsync(parent_descriptor)
             return
-        tombstone = root_tombstone_name(expected)
+        tombstone = (
+            entry_name
+            if already_tombstoned
+            else _owned_tree_tombstone_name(
+                path.name, portable_device(opened), opened.st_ino
+            )
+        )
         if not already_tombstoned:
             rename_no_replace_at(
                 parent_descriptor,
@@ -2298,13 +2384,26 @@ class Workspace:
                 record = load_regular_json(
                     record_path, "physical lease namespace identity"
                 )
+                valid = False
                 if (
-                    not isinstance(record, dict)
-                    or set(record) != {"schema_version", "device", "inode"}
-                    or record.get("schema_version") != 1
-                    or record.get("device") != identity[0]
-                    or record.get("inode") != identity[1]
+                    isinstance(record, dict)
+                    and set(record) == {"schema_version", "device", "inode"}
+                    and record.get("schema_version") == 1
                 ):
+                    valid = record.get("device") == identity[0] and record.get(
+                        "inode"
+                    ) == identity[1]
+                elif (
+                    isinstance(record, dict)
+                    and set(record) == {"schema_version", "identity"}
+                    and record.get("schema_version")
+                    == LEASE_NAMESPACE_IDENTITY_SCHEMA_VERSION
+                ):
+                    try:
+                        valid = identity_matches(record["identity"], visible)
+                    except FilesystemIdentityError:
+                        valid = False
+                if not valid:
                     raise WorkspaceError(
                         "physical lease namespace identity changed; restore the "
                         f"original namespace: {namespace}"
@@ -2313,9 +2412,8 @@ class Workspace:
                 durable_atomic_json(
                     record_path,
                     {
-                        "schema_version": 1,
-                        "device": identity[0],
-                        "inode": identity[1],
+                        "schema_version": LEASE_NAMESPACE_IDENTITY_SCHEMA_VERSION,
+                        "identity": portable_identity(visible),
                     },
                 )
         return identity
@@ -12319,6 +12417,21 @@ class Workspace:
         return {"device": metadata.st_dev, "inode": metadata.st_ino}
 
     @staticmethod
+    def _state_portable_identity(path: Path) -> dict[str, Any]:
+        metadata = path.stat(follow_symlinks=False)
+        if not stat.S_ISDIR(metadata.st_mode):
+            raise WorkspaceError(f"server state is not a directory: {path}")
+        return portable_identity(metadata)
+
+    @staticmethod
+    def _state_identity_matches(path: Path, identity: Any) -> bool:
+        try:
+            metadata = path.stat(follow_symlinks=False)
+            return identity_matches(identity, metadata)
+        except (OSError, FilesystemIdentityError):
+            return False
+
+    @staticmethod
     def _state_implementation(
         stack: str,
         providers: dict[str, str],
@@ -12703,7 +12816,7 @@ class Workspace:
             "path": str(path),
             "owner": owner,
             "lifecycle": lifecycle,
-            "identity": self._state_identity(path),
+            "identity": self._state_portable_identity(path),
             "implementation": implementation,
         }
 
@@ -12819,13 +12932,7 @@ class Workspace:
             or not isinstance(record.get("generation"), str)
             or not re.fullmatch(r"[0-9a-f]{64}", record["generation"])
             or not isinstance(identity, dict)
-            or set(identity) != {"device", "inode"}
-            or not all(
-                isinstance(value, int)
-                and not isinstance(value, bool)
-                and value >= 0
-                for value in identity.values()
-            )
+            or not self._valid_state_identity(identity)
         ):
             raise WorkspaceError(
                 f"promoted state provenance is invalid: {record_path}"
@@ -12836,9 +12943,8 @@ class Workspace:
             raise WorkspaceError(
                 f"promoted state provenance is invalid: {record_path}: {error}"
             ) from error
-        if (
-            not stat.S_ISDIR(visible.st_mode)
-            or {"device": visible.st_dev, "inode": visible.st_ino} != identity
+        if not stat.S_ISDIR(visible.st_mode) or not self._state_identity_matches(
+            path, identity
         ):
             raise WorkspaceError(
                 f"promoted state provenance is invalid: {record_path}"
@@ -13024,6 +13130,12 @@ class Workspace:
                     same_state = isinstance(raw_status, dict) and (
                         raw_status.get("state") == str(path)
                         or (
+                            isinstance(raw_policy, dict)
+                            and self._state_identity_matches(
+                                path, raw_policy.get("identity")
+                            )
+                        )
+                        or (
                             requested_identity is not None
                             and isinstance(raw_policy, dict)
                             and raw_policy.get("identity") == requested_identity
@@ -13051,6 +13163,13 @@ class Workspace:
                     if (
                         (
                             status.get("state") == str(path)
+                            or (
+                                isinstance(status.get("state_policy"), dict)
+                                and self._state_identity_matches(
+                                    path,
+                                    status["state_policy"].get("identity"),
+                                )
+                            )
                             or (
                                 requested_identity is not None
                                 and status.get("state_policy", {}).get("identity")
@@ -13200,10 +13319,11 @@ class Workspace:
                 write_implementation=False,
             )
             staging_metadata = os.fstat(staging_fd)
-            identity = {
+            live_state_identity = {
                 "device": staging_metadata.st_dev,
                 "inode": staging_metadata.st_ino,
             }
+            persistent_state_identity = portable_identity(staging_metadata)
             policy = {
                 "mode": "temporary",
                 "name": None,
@@ -13215,7 +13335,7 @@ class Workspace:
                 },
                 "lifecycle": "disposable",
                 "created_at": created_at,
-                "identity": identity,
+                "identity": persistent_state_identity,
                 "implementation": implementation,
                 "profile": profile_name,
                 "server": server_coordinate,
@@ -13325,7 +13445,7 @@ class Workspace:
                 staging_name, dir_fd=container_fd, follow_symlinks=False
             )
             if (visible_staging.st_dev, visible_staging.st_ino) != (
-                identity["device"], identity["inode"]
+                live_state_identity["device"], live_state_identity["inode"]
             ):
                 raise WorkspaceError(
                     "temporary topology state staging changed before publication"
@@ -13333,7 +13453,7 @@ class Workspace:
             rename_no_replace_at(
                 container_fd, staging_name, container_fd, generation
             )
-            published_identity = identity
+            published_identity = live_state_identity
             if (
                 _tree_digest_descriptor(
                     staging_fd,
@@ -13363,7 +13483,10 @@ class Workspace:
             opened_container = os.fstat(container_fd)
             if (
                 (published.st_dev, published.st_ino)
-                != (identity["device"], identity["inode"])
+                != (
+                    live_state_identity["device"],
+                    live_state_identity["inode"],
+                )
                 or (visible_container.st_dev, visible_container.st_ino)
                 != (opened_container.st_dev, opened_container.st_ino)
             ):
@@ -15082,7 +15205,7 @@ class Workspace:
     @staticmethod
     def _runtime_state_output_identity_at(
         state_directory_fd: int, generation: str
-    ) -> dict[str, int]:
+    ) -> dict[str, Any]:
         flags = os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW
         descriptors: list[int] = []
         state_mount_id = _descriptor_mount_id(state_directory_fd)
@@ -15097,7 +15220,7 @@ class Workspace:
                     )
                 parent = descriptor
             metadata = os.fstat(descriptors[-1])
-            return {"device": metadata.st_dev, "inode": metadata.st_ino}
+            return portable_identity(metadata)
         finally:
             for descriptor in reversed(descriptors):
                 os.close(descriptor)
@@ -15108,7 +15231,7 @@ class Workspace:
         generation: str,
         state_directory_fd: int | None = None,
         cleanup_proof: list[bool] | None = None,
-    ) -> tuple[Path, int, dict[str, int]]:
+    ) -> tuple[Path, int, dict[str, Any]]:
         flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
         descriptors: list[int] = []
         created_generation = False
@@ -15205,10 +15328,7 @@ class Workspace:
                 os.close(marker_fd)
             metadata = os.fstat(generation_fd)
             result_fd = os.dup(generation_fd)
-            return output, result_fd, {
-                "device": metadata.st_dev,
-                "inode": metadata.st_ino,
-            }
+            return output, result_fd, portable_identity(metadata)
         except BaseException as error:
             if created_generation and len(descriptors) >= 4:
                 generation_fd = descriptors[-1]
@@ -15267,7 +15387,7 @@ class Workspace:
         path: Path,
         generation: str,
         state_directory_fd: int | None = None,
-        expected_identity: dict[str, int] | None = None,
+        expected_identity: dict[str, Any] | None = None,
         keep_tombstone: bool = False,
     ) -> None:
         if state_directory_fd is not None:
@@ -15305,28 +15425,41 @@ class Workspace:
                 already_tombstoned = False
                 try:
                     generation_fd = open_exact_directory(parent_fd, entry_name)
-                except FileNotFoundError:
+                except FileNotFoundError as missing:
                     digest = hashlib.sha256(
                         generation.encode("utf-8")
                     ).hexdigest()[:16]
-                    candidates = [
-                        name
-                        for name in os.listdir(parent_fd)
-                        if re.fullmatch(
+                    candidates: list[str] = []
+                    for name in os.listdir(parent_fd):
+                        if not re.fullmatch(
                             rf"\.remove-{digest}-[0-9a-f]+-[0-9a-f]+", name
+                        ):
+                            continue
+                        try:
+                            candidate_metadata = os.stat(
+                                name, dir_fd=parent_fd, follow_symlinks=False
+                            )
+                        except FileNotFoundError:
+                            continue
+                        if expected_identity is not None and identity_matches(
+                            expected_identity, candidate_metadata
+                        ):
+                            candidates.append(name)
+                    if len(candidates) > 1:
+                        raise WorkspaceError(
+                            "server runtime state output tombstones are ambiguous: "
+                            f"{path}"
                         )
-                    ]
-                    if len(candidates) != 1:
-                        raise
+                    if not candidates:
+                        raise missing
                     entry_name = candidates[0]
                     generation_fd = open_exact_directory(parent_fd, entry_name)
                     already_tombstoned = True
                 descriptors.append(generation_fd)
                 metadata = os.fstat(generation_fd)
-                if expected_identity is None or expected_identity != {
-                    "device": metadata.st_dev,
-                    "inode": metadata.st_ino,
-                }:
+                if expected_identity is None or not identity_matches(
+                    expected_identity, metadata
+                ):
                     raise WorkspaceError(
                         f"server runtime state output identity changed: {path}"
                     )
@@ -15335,10 +15468,7 @@ class Workspace:
                         r"\.remove-[0-9a-f]{16}-([0-9a-f]+)-([0-9a-f]+)",
                         entry_name,
                     )
-                    if match is None or (metadata.st_dev, metadata.st_ino) != (
-                        int(match.group(1), 16),
-                        int(match.group(2), 16),
-                    ):
+                    if match is None:
                         raise WorkspaceError(
                             f"server runtime state output tombstone is invalid: {path}"
                         )
@@ -15428,7 +15558,7 @@ class Workspace:
     def _finish_runtime_state_output_tombstone(
         state_directory_fd: int,
         generation: str,
-        expected_identity: dict[str, int],
+        expected_identity: dict[str, Any],
     ) -> bool:
         flags = os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW
         descriptors = [os.dup(state_directory_fd)]
@@ -15448,24 +15578,37 @@ class Workspace:
                     )
                 descriptors.append(descriptor)
             parent_fd = descriptors[-1]
-            tombstone = _owned_tree_tombstone_name(
-                generation,
-                expected_identity["device"],
-                expected_identity["inode"],
-            )
-            try:
-                visible = os.stat(
-                    tombstone, dir_fd=parent_fd, follow_symlinks=False
+            digest = hashlib.sha256(generation.encode("utf-8")).hexdigest()[:16]
+            candidates: list[str] = []
+            for name in os.listdir(parent_fd):
+                if not re.fullmatch(
+                    rf"\.remove-{digest}-[0-9a-f]+-[0-9a-f]+", name
+                ):
+                    continue
+                try:
+                    candidate = os.stat(
+                        name, dir_fd=parent_fd, follow_symlinks=False
+                    )
+                except FileNotFoundError:
+                    continue
+                if identity_matches(expected_identity, candidate):
+                    candidates.append(name)
+            if len(candidates) > 1:
+                raise WorkspaceError(
+                    "server runtime state output tombstones are ambiguous"
                 )
-            except FileNotFoundError:
+            if not candidates:
                 return False
+            tombstone = candidates[0]
+            visible = os.stat(
+                tombstone, dir_fd=parent_fd, follow_symlinks=False
+            )
             descriptor = os.open(tombstone, flags, dir_fd=parent_fd)
             descriptors.append(descriptor)
             opened = os.fstat(descriptor)
             if (
                 not stat.S_ISDIR(visible.st_mode)
-                or (visible.st_dev, visible.st_ino)
-                != (expected_identity["device"], expected_identity["inode"])
+                or not identity_matches(expected_identity, visible)
                 or (opened.st_dev, opened.st_ino)
                 != (visible.st_dev, visible.st_ino)
                 or _descriptor_mount_id(descriptor) != state_mount_id
@@ -15517,16 +15660,11 @@ class Workspace:
 
     @staticmethod
     def _valid_state_identity(value: Any) -> bool:
-        return bool(
-            isinstance(value, dict)
-            and set(value) == {"device", "inode"}
-            and all(
-                isinstance(value[key], int)
-                and not isinstance(value[key], bool)
-                and value[key] >= 0
-                for key in ("device", "inode")
-            )
-        )
+        try:
+            validate_identity(value)
+        except FilesystemIdentityError:
+            return False
+        return True
 
     @staticmethod
     def _clear_runtime_state_output_transaction(topology_root: Path) -> None:
@@ -15604,7 +15742,7 @@ class Workspace:
         output: Path,
         generation: str,
         state_directory_fd: int,
-        output_identity: dict[str, int],
+        output_identity: dict[str, Any],
     ) -> None:
         transaction_path = topology_root / RUNTIME_STATE_OUTPUT_TRANSACTION
         transaction = load_regular_json(
@@ -15977,10 +16115,7 @@ class Workspace:
                             "schema_version": SCHEMA_VERSION,
                             "generation": generation,
                             "state": str(state),
-                            "state_identity": {
-                                "device": state_metadata.st_dev,
-                                "inode": state_metadata.st_ino,
-                            },
+                            "state_identity": portable_identity(state_metadata),
                             "phase": "creating",
                             "output_identity": None,
                         },
@@ -16002,10 +16137,9 @@ class Workspace:
                             "schema_version": SCHEMA_VERSION,
                             "generation": generation,
                             "state": str(state),
-                            "state_identity": {
-                                "device": os.fstat(state_directory_fd).st_dev,
-                                "inode": os.fstat(state_directory_fd).st_ino,
-                            },
+                            "state_identity": portable_identity(
+                                os.fstat(state_directory_fd)
+                            ),
                             "phase": "prepared",
                             "output_identity": state_output_identity,
                         },
@@ -16038,7 +16172,9 @@ class Workspace:
                         state_directory_fd, generation
                     )
                     if state_directory_fd is not None
-                    else self._state_identity(state_output)
+                    else portable_identity(
+                        state_output.stat(follow_symlinks=False)
+                    )
                 )
                 if visible_output_identity != state_output_identity:
                     raise WorkspaceError(
@@ -16096,7 +16232,7 @@ class Workspace:
                 os.O_RDWR | os.O_CREAT,
                 "runtime generation lease",
             )
-            lease_identity = initialize_lease(lease_fd, generation)
+            initialize_lease(lease_fd, generation)
             try:
                 fcntl.flock(lease_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
             except OSError as error:
@@ -16108,6 +16244,7 @@ class Workspace:
                 "runtime generation manifest",
             )
             self._seal_runtime_generation(staging)
+            lease_identity = portable_identity(os.fstat(lease_fd))
             staging.replace(published)
             runtime_record = {
                 "schema_version": RUNTIME_GENERATION_SCHEMA_VERSION,
@@ -16587,8 +16724,17 @@ class Workspace:
                     if isinstance(identities, list):
                         identity = identities[index]
                         if isinstance(identity, dict) and (
-                            _owned_tree_tombstone_path(output, identity).exists()
-                            or _owned_tree_tombstone_path(output, identity).is_symlink()
+                            (
+                                (
+                                    tombstone := (
+                                        _owned_tree_tombstone_path(output, identity)
+                                        if is_legacy_identity(identity)
+                                        else _portable_tombstone_path(output, identity)
+                                    )
+                                )
+                                is not None
+                                and (tombstone.exists() or tombstone.is_symlink())
+                            )
                         ):
                             return "retained_state"
         elif runtime is not None:
@@ -16648,17 +16794,9 @@ class Workspace:
             or not isinstance(policy.get("owner"), dict)
             or not isinstance(policy.get("lifecycle"), str)
             or not isinstance(identity, dict)
-            or set(identity) != {"device", "inode"}
-            or not all(
-                isinstance(value, int) and not isinstance(value, bool) and value >= 0
-                for value in identity.values()
-            )
+            or not self._valid_state_identity(identity)
             or not isinstance(lease_identity, dict)
-            or set(lease_identity) != {"device", "inode"}
-            or not all(
-                isinstance(value, int) and not isinstance(value, bool) and value >= 0
-                for value in lease_identity.values()
-            )
+            or not self._valid_state_identity(lease_identity)
             or not isinstance(implementation, dict)
             or set(implementation) != {"stack", "provider", "repository"}
             or not isinstance(providers, dict)
@@ -16722,7 +16860,7 @@ class Workspace:
                 if (
                     path.is_symlink()
                     or not path.is_dir()
-                    or self._state_identity(path) != identity
+                    or not self._state_identity_matches(path, identity)
                     or marker.is_symlink()
                     or not marker.is_file()
                     or load_json(marker)
@@ -16773,7 +16911,7 @@ class Workspace:
                 or policy.get("owner") != expected_persistent["owner"]
                 or lifecycle != expected_persistent["lifecycle"]
                 or path != self._state_location(expected_name)
-                or self._state_identity(path) != identity
+                or not self._state_identity_matches(path, identity)
             ):
                 raise WorkspaceError(f"persistent topology state policy is invalid: {name}")
             self._validate_state_implementation(path, implementation)
@@ -16937,13 +17075,7 @@ class Workspace:
                     or set(entry) != {"path", "identity", "status"}
                     or not isinstance(entry.get("path"), str)
                     or not isinstance(entry.get("identity"), dict)
-                    or set(entry["identity"]) != {"device", "inode"}
-                    or any(
-                        not isinstance(value, int)
-                        or isinstance(value, bool)
-                        or value < 0
-                        for value in entry["identity"].values()
-                    )
+                    or not self._valid_state_identity(entry["identity"])
                     or entry.get("status") not in {"pending", "complete"}
                     for entry in cleanup_entries
                 )
@@ -17085,13 +17217,7 @@ class Workspace:
             or control.get("socket")
             != str(control_socket_path(root, control["generation"]))
             or not isinstance(control.get("lease"), dict)
-            or set(control["lease"]) != {"device", "inode"}
-            or not all(
-                isinstance(value, int)
-                and not isinstance(value, bool)
-                and value >= 0
-                for value in control["lease"].values()
-            )
+            or not self._valid_state_identity(control["lease"])
         ):
             raise WorkspaceError(f"topology control identity is invalid: {name}")
         process_keys = (
@@ -17167,26 +17293,14 @@ class Workspace:
                     != len(runtime["mutable_state_outputs"])
                     or any(
                         not isinstance(identity, dict)
-                        or set(identity) != {"device", "inode"}
-                        or any(
-                            not isinstance(value, int)
-                            or isinstance(value, bool)
-                            or value < 0
-                            for value in identity.values()
-                        )
+                        or not self._valid_state_identity(identity)
                         for identity in runtime[
                             "mutable_state_output_identities"
                         ]
                     )
                 )
                 or not isinstance(runtime.get("lease"), dict)
-                or set(runtime["lease"]) != {"device", "inode"}
-                or not all(
-                    isinstance(value, int)
-                    and not isinstance(value, bool)
-                    and value >= 0
-                    for value in runtime["lease"].values()
-                )
+                or not self._valid_state_identity(runtime["lease"])
             ):
                 raise WorkspaceError(f"topology runtime identity is invalid: {name}")
             if mutable_state_cleanup is not None and (
@@ -18110,8 +18224,7 @@ class Workspace:
                     state_policy = {
                         **state_policy,
                         "lease_identity": {
-                            "device": lock_metadata.st_dev,
-                            "inode": lock_metadata.st_ino,
+                            **portable_identity(lock_metadata, include_ctime=False),
                         },
                     }
                     try:
@@ -18158,10 +18271,9 @@ class Workspace:
                             else None
                         )
                     state_metadata = os.fstat(state_directory_fd)
-                    if state_policy["identity"] != {
-                        "device": state_metadata.st_dev,
-                        "inode": state_metadata.st_ino,
-                    }:
+                    if not identity_matches(
+                        state_policy["identity"], state_metadata
+                    ):
                         raise WorkspaceError(
                             f"server state identity changed before runtime publication: {state}"
                         )
@@ -18715,9 +18827,10 @@ class Workspace:
             visible = state.stat(follow_symlinks=False)
             identity = policy.get("identity")
             if (
-                {"device": opened.st_dev, "inode": opened.st_ino} != identity
-                or {"device": visible.st_dev, "inode": visible.st_ino}
-                != identity
+                not identity_matches(identity, opened)
+                or not identity_matches(identity, visible)
+                or (opened.st_dev, opened.st_ino)
+                != (visible.st_dev, visible.st_ino)
             ):
                 raise WorkspaceError(
                     f"server state identity changed before runtime cleanup: {state}"
@@ -18876,13 +18989,14 @@ class Workspace:
     def _unlink_temporary_state_lock(
         state: Path,
         state_lease: TextIO,
-        lease_identity: dict[str, int],
+        lease_identity: dict[str, Any],
         parent_directory_fd: int | None = None,
     ) -> None:
         Workspace._validate_temporary_state_lock(
             state, state_lease, lease_identity
         )
         lock = Path(f"{state}.lock")
+        live_lease_identity = _live_identity_dict(os.fstat(state_lease.fileno()))
 
         parent_fd = (
             os.dup(parent_directory_fd)
@@ -18893,9 +19007,10 @@ class Workspace:
             )
         )
         try:
+            durable_device = portable_device(os.fstat(state_lease.fileno()))
             tombstone = (
-                f".{lock.name}.remove-{lease_identity['device']:x}-"
-                f"{lease_identity['inode']:x}"
+                f".{lock.name}.remove-{durable_device:x}-"
+                f"{live_lease_identity['inode']:x}"
             )
             rename_no_replace_at(
                 parent_fd, lock.name, parent_fd, tombstone
@@ -18904,8 +19019,8 @@ class Workspace:
                 tombstone, dir_fd=parent_fd, follow_symlinks=False
             )
             expected = (
-                lease_identity["device"],
-                lease_identity["inode"],
+                live_lease_identity["device"],
+                live_lease_identity["inode"],
             )
             if (moved.st_dev, moved.st_ino) != expected:
                 try:
@@ -18936,6 +19051,7 @@ class Workspace:
                     or (opened.st_dev, opened.st_ino) != expected
                     or (visible.st_dev, visible.st_ino) != expected
                     or visible.st_nlink != 1
+                    or not identity_matches(lease_identity, opened)
                 ):
                     raise WorkspaceError(
                         f"temporary topology state lease changed before removal: {lock}"
@@ -18951,7 +19067,7 @@ class Workspace:
     def _validate_temporary_state_lock(
         state: Path,
         state_lease: TextIO,
-        lease_identity: dict[str, int],
+        lease_identity: dict[str, Any],
     ) -> None:
         lock = Path(f"{state}.lock")
         try:
@@ -18961,12 +19077,13 @@ class Workspace:
                 f"temporary topology state lease is missing: {lock}"
             ) from error
         opened = os.fstat(state_lease.fileno())
-        expected = (lease_identity["device"], lease_identity["inode"])
+        expected = (opened.st_dev, opened.st_ino)
         if (
             not stat.S_ISREG(visible.st_mode)
             or visible.st_nlink != 1
             or (visible.st_dev, visible.st_ino) != expected
             or (opened.st_dev, opened.st_ino) != expected
+            or not identity_matches(lease_identity, opened)
         ):
             raise WorkspaceError(
                 "temporary topology state lease changed before lifecycle "
@@ -18976,14 +19093,24 @@ class Workspace:
     @staticmethod
     def _finish_temporary_state_lock_tombstone(
         state: Path,
-        lease_identity: dict[str, int],
+        lease_identity: dict[str, Any],
         parent_directory_fd: int | None = None,
     ) -> bool:
         lock = Path(f"{state}.lock")
-        tombstone = lock.parent / (
-            f".{lock.name}.remove-{lease_identity['device']:x}-"
-            f"{lease_identity['inode']:x}"
-        )
+        tombstone: Path | None = None
+        for candidate in sorted(lock.parent.glob(f".{lock.name}.remove-*")):
+            try:
+                metadata = candidate.stat(follow_symlinks=False)
+            except FileNotFoundError:
+                continue
+            if identity_matches(lease_identity, metadata):
+                if tombstone is not None:
+                    raise WorkspaceError(
+                        f"temporary topology state lease tombstones are ambiguous: {lock}"
+                    )
+                tombstone = candidate
+        if tombstone is None:
+            return False
         if parent_directory_fd is None:
             if not tombstone.exists() and not tombstone.is_symlink():
                 return False
@@ -19015,13 +19142,13 @@ class Workspace:
                 visible = os.stat(
                     tombstone.name, dir_fd=parent_fd, follow_symlinks=False
                 )
-                expected = (lease_identity["device"], lease_identity["inode"])
                 if (
                     not stat.S_ISREG(metadata.st_mode)
                     or metadata.st_nlink != 1
-                    or (metadata.st_dev, metadata.st_ino) != expected
-                    or (visible.st_dev, visible.st_ino) != expected
+                    or (metadata.st_dev, metadata.st_ino)
+                    != (visible.st_dev, visible.st_ino)
                     or visible.st_nlink != 1
+                    or not identity_matches(lease_identity, metadata)
                 ):
                     raise WorkspaceError(
                         "temporary topology state lease tombstone is invalid: "
@@ -19038,7 +19165,7 @@ class Workspace:
     @staticmethod
     def _lock_state_directory_mutation(
         path: Path,
-        identity: dict[str, int],
+        identity: dict[str, Any],
         description: str = "temporary state",
     ) -> int:
         descriptor = _open_directory_nofollow(
@@ -19047,11 +19174,11 @@ class Workspace:
         try:
             opened = os.fstat(descriptor)
             visible = path.stat(follow_symlinks=False)
-            expected = (identity["device"], identity["inode"])
             if (
                 not stat.S_ISDIR(opened.st_mode)
-                or (opened.st_dev, opened.st_ino) != expected
-                or (visible.st_dev, visible.st_ino) != expected
+                or (opened.st_dev, opened.st_ino)
+                != (visible.st_dev, visible.st_ino)
+                or not identity_matches(identity, opened)
             ):
                 raise WorkspaceError(
                     f"{description} identity changed before mutation: {path}"
@@ -19120,8 +19247,8 @@ class Workspace:
     def _rollback_temporary_state_creation(
         state: Path,
         state_lease: TextIO,
-        state_identity: dict[str, int],
-        lease_identity: dict[str, int],
+        state_identity: dict[str, Any],
+        lease_identity: dict[str, Any],
         state_directory_fd: int | None = None,
         implementation: dict[str, str] | None = None,
     ) -> None:
@@ -19140,9 +19267,14 @@ class Workspace:
             Workspace._validate_temporary_state_integrity(
                 owned_descriptor, state, implementation
             )
+            state_metadata = os.fstat(owned_descriptor)
+            if not identity_matches(state_identity, state_metadata):
+                raise WorkspaceError(
+                    f"temporary state identity changed before rollback: {state}"
+                )
             remove_owned_tree(
                 state,
-                expected_identity=state_identity,
+                expected_identity=_live_identity_dict(state_metadata),
                 reject_links=True,
             )
         finally:
@@ -19194,30 +19326,39 @@ class Workspace:
         if lifecycle == "removal-pending":
             state_present = entry_present(state)
             tombstone_present = entry_present(tombstone)
-            removal_tombstone = _owned_tree_tombstone_path(tombstone, identity)
+            removal_tombstone = _portable_tombstone_path(tombstone, identity)
+            if removal_tombstone is None and state_present:
+                removal_tombstone = _owned_tree_tombstone_path(
+                    tombstone,
+                    _live_identity_dict(
+                        state.stat(follow_symlinks=False)
+                        if state_container_fd is None
+                        else os.stat(
+                            state.name,
+                            dir_fd=state_container_fd,
+                            follow_symlinks=False,
+                        )
+                    ),
+                )
             removal_tombstone_present = (
-                entry_present(removal_tombstone)
+                removal_tombstone is not None
+                and entry_present(removal_tombstone)
             )
             if state_present and tombstone_present:
                 raise WorkspaceError(
                     f"temporary state removal paths conflict: {state}"
                 )
             if state_present:
-                observed_state = (
-                    self._state_identity(state)
+                state_metadata = (
+                    state.stat(follow_symlinks=False)
                     if state_container_fd is None
-                    else {
-                        "device": (
-                            state_metadata := os.stat(
-                                state.name,
-                                dir_fd=state_container_fd,
-                                follow_symlinks=False,
-                            )
-                        ).st_dev,
-                        "inode": state_metadata.st_ino,
-                    }
+                    else os.stat(
+                        state.name,
+                        dir_fd=state_container_fd,
+                        follow_symlinks=False,
+                    )
                 )
-                if observed_state != identity:
+                if not identity_matches(identity, state_metadata):
                     raise WorkspaceError(
                         f"temporary state identity changed before removal: {state}"
                     )
@@ -19251,11 +19392,7 @@ class Workspace:
                 )
                 if (
                     not stat.S_ISDIR(tombstone_metadata.st_mode)
-                    or {
-                        "device": tombstone_metadata.st_dev,
-                        "inode": tombstone_metadata.st_ino,
-                    }
-                    != identity
+                    or not identity_matches(identity, tombstone_metadata)
                 ):
                     raise WorkspaceError(
                         f"temporary state removal identity is invalid: {tombstone}"
@@ -19309,8 +19446,7 @@ class Workspace:
             )
             if (
                 not stat.S_ISDIR(metadata.st_mode)
-                or (metadata.st_dev, metadata.st_ino)
-                != (identity["device"], identity["inode"])
+                or not identity_matches(identity, metadata)
                 or (
                     any(tombstone.iterdir())
                     if tombstone_fd is None
@@ -19398,13 +19534,25 @@ class Workspace:
                 retained = {**policy, "lifecycle": "retained"}
                 return self._write_temporary_state_policy(name, current, retained)
             removal_path = self._temporary_state_removal_path(policy)
-            removal_root_tombstone = _owned_tree_tombstone_path(
+            removal_root_tombstone = _portable_tombstone_path(
                 removal_path, policy["identity"]
             )
+            if removal_root_tombstone is None and (
+                state.exists() or state.is_symlink()
+            ):
+                removal_root_tombstone = _owned_tree_tombstone_path(
+                    removal_path,
+                    _live_identity_dict(state.stat(follow_symlinks=False)),
+                )
             mutation_path = next(
                 (
                     candidate
-                    for candidate in (state, removal_path, removal_root_tombstone)
+                    for candidate in (
+                        state,
+                        removal_path,
+                        removal_root_tombstone,
+                    )
+                    if candidate is not None
                     if candidate.exists() or candidate.is_symlink()
                 ),
                 None,
@@ -19552,11 +19700,12 @@ class Workspace:
                     if (
                         not stat.S_ISDIR(visible_state.st_mode)
                         or self._canonical_state_path(state) != state
-                        or {
-                            "device": opened_state.st_dev,
-                            "inode": opened_state.st_ino,
-                        }
-                        != policy.get("identity")
+                        or not identity_matches(
+                            policy.get("identity"), opened_state
+                        )
+                        or not identity_matches(
+                            policy.get("identity"), visible_state
+                        )
                         or (visible_state.st_dev, visible_state.st_ino)
                         != (opened_state.st_dev, opened_state.st_ino)
                     ):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -152,6 +152,38 @@ workspace/
   cleanup-journals/                  cleanup recovery/delivery receipts
 ~~~
 
+## Durable and ephemeral filesystem identity
+
+The wrapper does not use one filesystem identity for every purpose. Durable
+workspace JSON, topology leases, mutable-state outputs, physical lease
+anchors, scope journals, and delivery-ledger sidecars use the versioned
+portable identity object: object kind, inode, mode, and (for regular files)
+ctime, with an optional content digest. The mount-specific `st_dev` value is
+excluded from that object. Schema-v1 `{ "device", "inode" }` pairs remain
+readable only at compatibility boundaries and are converted by the explicit
+`migrate filesystem` transaction.
+
+Live operations retain the complete descriptor-derived `(st_dev, st_ino)`
+identity and mount identifier where needed for replacement, symlink, hard-link,
+and TOCTOU fencing. A portable identity does not authorize a path-only rebind;
+the live object must still pass the opened-handle check. This keeps a
+devcontainer remount from invalidating durable records without weakening live
+lease, ownership, generation, or content-integrity guarantees.
+Rename-prone lease records use a stable portable projection that omits ctime;
+their opened descriptors, generation tokens, and content checks remain
+ephemeral lifecycle fences.
+
+Filesystem migration snapshots each target before publication, records legacy
+evidence and portable pre/post identities in an atomic journal, and preserves a
+rollback identity after an undo replacement. Resume and audit accept only the
+exact before or after bytes together with their corresponding identity. Missing,
+changed, symlinked, foreign-owned, or ambiguous targets fail closed. The
+transaction covers workspace records, topology recovery records, the physical
+lease anchor, and repository-local delivery-ledger sidecars; cleanup, topology
+shutdown, scope release, and repository migration do not implicitly perform
+this rebind. The complete operator procedure and schema details are in
+[`docs/FILESYSTEM-IDENTITY.md`](FILESYSTEM-IDENTITY.md).
+
 Selected sound repositories may also contain producer-owned
 `build/atrinik-workspace/<20-hex-key>/` playtest trees. They remain outside the
 wrapper build root but are inventoried only by the explicit preview-first

--- a/docs/FILESYSTEM-IDENTITY.md
+++ b/docs/FILESYSTEM-IDENTITY.md
@@ -1,0 +1,57 @@
+# Filesystem identity and remount recovery
+
+The wrapper uses two deliberately different identity classes.
+
+* Durable records use the versioned portable identity object. It contains the
+  object kind, inode, and file mode; regular files also retain ctime and may
+  retain a content digest. It never stores `st_dev`, because that number is
+  assigned by the current mount namespace.
+* Live fencing uses an identity obtained from an opened descriptor. The
+  complete `(st_dev, st_ino)` pair, and the mount identifier where relevant,
+  remains an ephemeral race and replacement check. It is not a durable
+  rebind authority.
+
+This distinction preserves replacement, symlink, hard-link, and TOCTOU
+protections while allowing a remounted workspace to retain its durable
+records. A legacy `{ "device": ..., "inode": ... }` record remains readable,
+but a changed device is never guessed to be a remount by an ordinary command.
+Rename-prone lease records use the same portable kind/inode/mode projection
+without ctime; their opened-descriptor, generation, and content fences remain
+ephemeral and continue to protect the live lifecycle.
+
+## Recovery procedure
+
+Run the commands from the wrapper checkout that owns the records:
+
+```sh
+./atrinik migrate filesystem --dry-run --json
+./atrinik migrate filesystem --apply --confirm-remount
+./atrinik migrate filesystem --audit --json
+```
+
+The dry run inventories legacy records without changing them. It includes the
+physical lease anchor, workspace JSON records (including topology and state
+records), and managed delivery-ledger JSON records and transaction sidecars under
+`build/reviews/`. Apply requires
+the explicit remount confirmation, proves the same inode and safe target for
+each record, and writes a durable transaction journal before publishing any
+replacement. Each pre-image is kept in the journal, along with portable
+pre/post identities and legacy evidence. An interrupted transaction resumes
+only when every record is still exactly its before or after snapshot; otherwise
+it fails closed. A failed transaction rolls back the records it touched and
+retains a rollback identity for the next exact retry. Audit verifies both the
+snapshot digest and the portable identity, so replacing a record with
+byte-identical content does not silently rebind it.
+
+`ATRINIK_WORKSPACE_DIR` is honored for workspace records. The physical lease
+anchor and review sidecars are discovered from the owning wrapper repository.
+Do not edit the JSON or journal by hand, and do not use a path-only or
+inode-only workaround for a missing target. An ambiguous, changed, symlinked,
+foreign-owned, or otherwise unproven target must be repaired or restored and
+then re-audited.
+
+New writers use portable identities. Readers accept the legacy pair only at
+the compatibility boundary, and require this explicit migration before a
+changed mount device can be accepted. The migration is separate from cleanup,
+scope release, repository migration, and topology shutdown; none of those
+commands implicitly rebinds a legacy record.

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1607,6 +1607,43 @@ class CleanupTests(unittest.TestCase):
         self.assertIsNone(observed)
         self.assertIn("loop", error or "")
 
+    def test_text_evidence_rejects_replacement_between_read_and_lstat(self) -> None:
+        path = self.root / "worktree-pointer"
+        path.write_text("gitdir: /tmp/admin\n", encoding="utf-8")
+        real_identity = cleanup_module._regular_text_identity
+
+        def replace_after_read(candidate: Path) -> tuple[str, tuple[int, int, int, int]]:
+            value, identity = real_identity(candidate)
+            replacement = candidate.with_name("worktree-pointer-replacement")
+            replacement.write_text(value, encoding="utf-8")
+            os.replace(replacement, candidate)
+            return value, identity
+
+        with mock.patch.object(
+            cleanup_module,
+            "_regular_text_identity",
+            side_effect=replace_after_read,
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "changed identity"):
+                cleanup_module._text_evidence(path)
+
+        path.write_text("gitdir: /tmp/admin\n", encoding="utf-8")
+        metadata = path.lstat()
+        expected = cleanup_module._portable_text_identity(
+            metadata, path.read_text(encoding="utf-8")
+        )
+        self.assertTrue(cleanup_module._text_evidence_matches(path, expected))
+        old_observed = expected
+        replacement = path.with_name("worktree-pointer-replacement")
+        replacement.write_text("gitdir: /tmp/other-admin\n", encoding="utf-8")
+        os.replace(replacement, path)
+        with mock.patch.object(
+            cleanup_module,
+            "_text_evidence",
+            return_value=("gitdir: /tmp/admin\n", old_observed),
+        ):
+            self.assertFalse(cleanup_module._text_evidence_matches(path, old_observed))
+
     def test_github_query_wraps_process_and_response_failures(self) -> None:
         repository = "atrinik/atrinik"
         head = "a" * 40

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -628,6 +628,34 @@ class ParserTests(unittest.TestCase):
         )
         self.assertEqual(json.loads(output.call_args.args[0]), plan)
 
+    def test_filesystem_migration_dispatches_explicit_remount_confirmation(self) -> None:
+        plan = {
+            "migration": "filesystem-identity-migration-v1",
+            "status": "dry-run",
+            "records": [],
+            "requires_confirm_remount": False,
+        }
+        with mock.patch(
+            "atrinik_workspace.filesystem_migration.migrate_filesystem_records",
+            return_value=plan,
+        ) as migrate:
+            with mock.patch("builtins.print") as output:
+                result = main(
+                    [
+                        "migrate",
+                        "filesystem",
+                        "--apply",
+                        "--confirm-remount",
+                        "--json",
+                    ]
+                )
+
+        self.assertEqual(result, 0)
+        migrate.assert_called_once_with(
+            mock.ANY, "apply", confirm_remount=True
+        )
+        self.assertEqual(json.loads(output.call_args.args[0]), plan)
+
     def test_repository_migration_refusal_returns_failure(self) -> None:
         plan = {
             "migration": "repositories",

--- a/tests/test_filesystem_identity.py
+++ b/tests/test_filesystem_identity.py
@@ -1,20 +1,46 @@
 from __future__ import annotations
 
 import stat
+import tempfile
 from types import SimpleNamespace
 import unittest
+from pathlib import Path
 
 from atrinik_workspace.filesystem_identity import (
+    FilesystemIdentityError,
     FilesystemIdentityMigrationRequired,
+    identity_digest,
     identity_matches,
+    is_legacy_identity,
+    is_portable_identity,
     migrate_legacy_identity,
     pair_matches,
     portable_identity,
+    portable_identity_from_path,
+    portable_device,
+    portable_device_from_components,
     portable_pair,
+    require_identity_match,
+    validate_identity,
 )
 
 
 class FilesystemIdentityTests(unittest.TestCase):
+    @staticmethod
+    def metadata(
+        mode: int,
+        *,
+        inode: int = 1234,
+        device: int = 17,
+        ctime_ns: int = 99,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            st_mode=mode,
+            st_ino=inode,
+            st_dev=device,
+            st_ctime_ns=ctime_ns,
+        )
+
     def test_portable_identity_survives_a_changed_mount_device(self) -> None:
         metadata = SimpleNamespace(
             st_mode=stat.S_IFDIR | 0o700,
@@ -53,12 +79,7 @@ class FilesystemIdentityTests(unittest.TestCase):
         self.assertFalse(identity_matches(portable_identity(original), replaced))
 
     def test_legacy_rebind_requires_explicit_confirmation_and_retains_evidence(self) -> None:
-        metadata = SimpleNamespace(
-            st_mode=stat.S_IFDIR | 0o700,
-            st_ino=1234,
-            st_dev=88,
-            st_ctime_ns=99,
-        )
+        metadata = self.metadata(stat.S_IFDIR | 0o700, device=88)
         legacy = {"device": 17, "inode": 1234}
 
         with self.assertRaises(FilesystemIdentityMigrationRequired):
@@ -72,3 +93,112 @@ class FilesystemIdentityTests(unittest.TestCase):
         self.assertEqual(migrated["inode"], 1234)
         self.assertNotIn("device", migrated)
         self.assertEqual(evidence.json(), legacy)
+
+    def test_validation_and_file_digest_rules_are_explicit(self) -> None:
+        file_metadata = self.metadata(stat.S_IFREG | 0o600)
+        directory_metadata = self.metadata(stat.S_IFDIR | 0o700)
+        digest = "a" * 64
+        identity = portable_identity(file_metadata, content_sha256=digest)
+
+        self.assertTrue(is_portable_identity(identity))
+        self.assertFalse(is_portable_identity({"device": 1, "inode": 2}))
+        self.assertTrue(is_legacy_identity({"device": 1, "inode": 2}))
+        self.assertFalse(is_legacy_identity({"device": True, "inode": 2}))
+        self.assertEqual(identity_digest(identity), identity_digest(dict(identity)))
+        self.assertTrue(identity_matches(identity, file_metadata, content_sha256=digest))
+        self.assertFalse(identity_matches(identity, file_metadata))
+        self.assertFalse(
+            identity_matches(identity, file_metadata, content_sha256="b" * 64)
+        )
+        require_identity_match(
+            identity, file_metadata, "portable file", content_sha256=digest
+        )
+        with self.assertRaisesRegex(FilesystemIdentityError, "portable file changed"):
+            require_identity_match(
+                identity,
+                self.metadata(stat.S_IFREG | 0o600, ctime_ns=100),
+                "portable file",
+                content_sha256=digest,
+            )
+
+        without_ctime = portable_identity(file_metadata, include_ctime=False)
+        self.assertNotIn("ctime_ns", without_ctime)
+        with self.assertRaisesRegex(FilesystemIdentityError, "regular file or directory"):
+            portable_identity(self.metadata(stat.S_IFIFO))
+        with self.assertRaisesRegex(FilesystemIdentityError, "content digest"):
+            portable_identity(file_metadata, content_sha256="not-a-digest")
+        with self.assertRaisesRegex(FilesystemIdentityError, "directory identities"):
+            portable_identity(directory_metadata, content_sha256=digest)
+
+        invalid_values = (
+            None,
+            {"schema_version": 1, "kind": "socket", "inode": 1, "mode": stat.S_IFREG},
+            {"schema_version": 1, "kind": "file", "inode": 1, "mode": stat.S_IFREG, "extra": 1},
+            {"schema_version": 1, "kind": "file", "inode": 1, "mode": 1},
+            {"schema_version": 1, "kind": "file", "inode": 1, "mode": stat.S_IFREG, "ctime_ns": -1},
+            {"schema_version": 1, "kind": "file", "inode": 1, "mode": stat.S_IFREG, "sha256": "bad"},
+            {"schema_version": 1, "kind": "directory", "inode": 1, "mode": stat.S_IFDIR, "sha256": digest},
+        )
+        for value in invalid_values:
+            with self.subTest(value=value), self.assertRaises(FilesystemIdentityError):
+                validate_identity(value, allow_legacy=False)
+
+        for value in (
+            {"device": -1, "inode": 2},
+            {"device": True, "inode": 2},
+            {"device": 1, "inode": -1},
+            {"device": 1, "inode": 2, "extra": 3},
+        ):
+            self.assertFalse(pair_matches(value, file_metadata))
+        self.assertFalse(pair_matches({"device": 1, "inode": 9999}, file_metadata))
+
+    def test_path_and_historical_projection_helpers_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            path = root / "record"
+            path.write_text("record\n", encoding="utf-8")
+            self.assertEqual(portable_identity_from_path(path)["kind"], "file")
+            link = root / "link"
+            link.symlink_to(path)
+            with self.assertRaises(FilesystemIdentityError):
+                portable_identity_from_path(link)
+
+        special = self.metadata(stat.S_IFLNK, inode=55, device=88)
+        self.assertIsInstance(portable_device(special), int)
+        self.assertEqual(
+            portable_device_from_components(55, stat.S_IFREG, "file"),
+            portable_device_from_components(55, stat.S_IFREG, "file"),
+        )
+        for inode, mode, kind in (
+            (-1, stat.S_IFREG, "file"),
+            (1, stat.S_IFREG, "socket"),
+            (1, 1, "file"),
+            (1, stat.S_IFDIR, "file"),
+            (1, stat.S_IFREG, "directory"),
+        ):
+            with self.subTest(inode=inode, mode=mode, kind=kind), self.assertRaises(
+                FilesystemIdentityError
+            ):
+                portable_device_from_components(inode, mode, kind)
+
+    def test_legacy_and_portable_match_require_explicit_migration(self) -> None:
+        metadata = self.metadata(stat.S_IFDIR | 0o700, device=88)
+        legacy = {"device": 17, "inode": 1234}
+        with self.assertRaises(FilesystemIdentityMigrationRequired):
+            require_identity_match(legacy, metadata, "legacy directory")
+        require_identity_match(
+            {"device": 88, "inode": 1234}, metadata, "same-mount directory"
+        )
+
+        migrated, evidence = migrate_legacy_identity(
+            portable_identity(metadata), metadata, "already portable", confirm_remount=False
+        )
+        self.assertEqual(migrated, portable_identity(metadata))
+        self.assertIsNone(evidence)
+        with self.assertRaisesRegex(FilesystemIdentityError, "inode changed"):
+            migrate_legacy_identity(
+                {"device": 17, "inode": 9999},
+                metadata,
+                "changed inode",
+                confirm_remount=True,
+            )

--- a/tests/test_filesystem_identity.py
+++ b/tests/test_filesystem_identity.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import stat
+from types import SimpleNamespace
+import unittest
+
+from atrinik_workspace.filesystem_identity import (
+    FilesystemIdentityMigrationRequired,
+    identity_matches,
+    migrate_legacy_identity,
+    pair_matches,
+    portable_identity,
+    portable_pair,
+)
+
+
+class FilesystemIdentityTests(unittest.TestCase):
+    def test_portable_identity_survives_a_changed_mount_device(self) -> None:
+        metadata = SimpleNamespace(
+            st_mode=stat.S_IFDIR | 0o700,
+            st_ino=1234,
+            st_dev=17,
+            st_ctime_ns=99,
+        )
+        remounted = SimpleNamespace(
+            st_mode=metadata.st_mode,
+            st_ino=metadata.st_ino,
+            st_dev=88,
+            st_ctime_ns=metadata.st_ctime_ns,
+        )
+
+        identity = portable_identity(metadata)
+
+        self.assertNotIn("st_dev", identity)
+        self.assertTrue(identity_matches(identity, remounted))
+        self.assertEqual(portable_pair(metadata), portable_pair(remounted))
+        self.assertTrue(pair_matches(portable_pair(metadata), remounted))
+
+    def test_regular_file_replacement_is_rejected_even_with_same_inode(self) -> None:
+        original = SimpleNamespace(
+            st_mode=stat.S_IFREG | 0o600,
+            st_ino=1234,
+            st_dev=17,
+            st_ctime_ns=99,
+        )
+        replaced = SimpleNamespace(
+            st_mode=original.st_mode,
+            st_ino=original.st_ino,
+            st_dev=88,
+            st_ctime_ns=100,
+        )
+
+        self.assertFalse(identity_matches(portable_identity(original), replaced))
+
+    def test_legacy_rebind_requires_explicit_confirmation_and_retains_evidence(self) -> None:
+        metadata = SimpleNamespace(
+            st_mode=stat.S_IFDIR | 0o700,
+            st_ino=1234,
+            st_dev=88,
+            st_ctime_ns=99,
+        )
+        legacy = {"device": 17, "inode": 1234}
+
+        with self.assertRaises(FilesystemIdentityMigrationRequired):
+            migrate_legacy_identity(
+                legacy, metadata, "test identity", confirm_remount=False
+            )
+        migrated, evidence = migrate_legacy_identity(
+            legacy, metadata, "test identity", confirm_remount=True
+        )
+
+        self.assertEqual(migrated["inode"], 1234)
+        self.assertNotIn("device", migrated)
+        self.assertEqual(evidence.json(), legacy)

--- a/tests/test_filesystem_migration.py
+++ b/tests/test_filesystem_migration.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
+import base64
 import json
 import os
 from pathlib import Path
 import stat
 import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 
 import atrinik_workspace.filesystem_migration as migration
 from atrinik_workspace.filesystem_identity import portable_identity, portable_pair
+from atrinik_workspace.filesystem_migration import FilesystemMigrationError
 
 
 def write_json(path: Path, value: object) -> None:
@@ -299,3 +302,1178 @@ class FilesystemMigrationTests(unittest.TestCase):
         assert transformed is not None
         self.assertEqual(transformed["snapshot"]["inode"], 1234)
         self.assertNotEqual(transformed["snapshot"]["device"], 17)
+
+    def test_modes_namespace_records_and_empty_repository_are_fail_closed(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unsupported filesystem migration mode"):
+            migration.migrate_filesystem_records(self.repository, "convert")
+
+        empty = migration.migrate_filesystem_records(
+            self.repository, "apply", confirm_remount=True
+        )
+        self.assertEqual(empty["status"], "complete")
+        self.assertEqual(empty["records"], [])
+
+        journal = self.workspace / migration.FILESYSTEM_MIGRATION_RECORD
+        namespace = self.repository / ".git" / "atrinik-resource-leases"
+        namespace.mkdir()
+        identity_record = namespace.parent / "atrinik-resource-leases.identity.json"
+        write_json(
+            identity_record,
+            {"schema_version": 1, "device": namespace.stat().st_dev + 1, "inode": namespace.stat().st_ino},
+        )
+
+        plan = migration.migrate_filesystem_records(self.repository, "dry-run")
+        self.assertEqual(plan["records"][0]["path"], str(identity_record))
+        with self.assertRaisesRegex(FilesystemMigrationError, "explicit remount"):
+            migration.migrate_filesystem_records(self.repository, "apply")
+        applied = migration.migrate_filesystem_records(
+            self.repository, "apply", confirm_remount=True
+        )
+        self.assertEqual(applied["status"], "complete")
+        self.assertEqual(
+            migration.migrate_filesystem_records(
+                self.repository, "apply", confirm_remount=True
+            )["status"],
+            "complete",
+        )
+
+        journal.unlink()
+        write_json(
+            identity_record,
+            {
+                "schema_version": 2,
+                "identity": portable_identity(namespace.stat()),
+            },
+        )
+        self.assertEqual(
+            migration.migrate_filesystem_records(self.repository, "dry-run")[
+                "requires_confirm_remount"
+            ],
+            False,
+        )
+
+        write_json(identity_record, {"schema_version": 99})
+        with self.assertRaisesRegex(FilesystemMigrationError, "unsupported schema"):
+            migration.migrate_filesystem_records(self.repository, "dry-run")
+
+        identity_record.unlink()
+        identity_record.mkdir()
+        with self.assertRaisesRegex(FilesystemMigrationError, "not a regular file"):
+            migration.migrate_filesystem_records(self.repository, "dry-run")
+        identity_record.rmdir()
+        target = self.repository / "identity-target.json"
+        target.write_text("{}\n", encoding="utf-8")
+        identity_record.symlink_to(target)
+        with self.assertRaisesRegex(FilesystemMigrationError, "not a regular file"):
+            migration.migrate_filesystem_records(self.repository, "dry-run")
+
+        identity_record.unlink()
+        write_json(
+            identity_record,
+            {"schema_version": 1, "device": namespace.stat().st_dev, "inode": namespace.stat().st_ino + 1},
+        )
+        with self.assertRaisesRegex(FilesystemMigrationError, "inode changed"):
+            migration.migrate_filesystem_records(self.repository, "dry-run")
+
+    def test_unfinished_journal_requires_confirmation_and_planning_is_read_only(self) -> None:
+        record, _state = self.make_state_record("unfinished")
+        original_write = migration._write_json_bytes
+        with mock.patch.object(
+            migration,
+            "_write_json_bytes",
+            side_effect=migration.FilesystemMigrationError("injected unfinished write"),
+        ):
+            with self.assertRaisesRegex(
+                migration.FilesystemMigrationError, "unfinished write"
+            ):
+                migration.migrate_filesystem_records(
+                    self.repository, "apply", confirm_remount=True
+                )
+
+        journal_path = self.workspace / migration.FILESYSTEM_MIGRATION_RECORD
+        before_journal = journal_path.read_bytes()
+        dry_run = migration.migrate_filesystem_records(self.repository, "dry-run")
+        self.assertEqual(dry_run["status"], "dry-run")
+        self.assertEqual(journal_path.read_bytes(), before_journal)
+        with self.assertRaisesRegex(
+            migration.FilesystemMigrationError, "confirm-remount"
+        ):
+            migration.migrate_filesystem_records(self.repository, "apply")
+
+        with mock.patch.object(
+            migration,
+            "_write_json_bytes",
+            side_effect=original_write,
+        ):
+            resumed = migration.migrate_filesystem_records(
+                self.repository, "apply", confirm_remount=True
+            )
+        self.assertEqual(resumed["status"], "complete")
+        self.assertTrue(record.exists())
+
+    def test_record_discovery_and_transformations_cover_context_rules(self) -> None:
+        target = self.workspace / "target"
+        target.mkdir()
+        pair = portable_pair(target.stat())
+        document = self.workspace / "record.json"
+
+        self.assertIsNone(migration._transform_document(document, {"unrelated": True}))
+        with self.assertRaisesRegex(
+            migration.FilesystemMigrationError, "root is not an object"
+        ):
+            migration._transform_document(
+                document,
+                [{"path": str(target), "device": target.stat().st_dev + 1, "inode": target.stat().st_ino}],
+            )
+        same_pair = migration._transform_document(
+            document,
+            {"identity": {"path": str(target), **pair}},
+        )
+        self.assertIsNone(same_pair)
+        ledger = self.workspace / "demo.md.ledger.json"
+        ledger.write_text("{}\n", encoding="utf-8")
+        self.assertIsNone(
+            migration._transform_document(
+                ledger, {"ledger": portable_pair(ledger.stat())}
+            )
+        )
+
+        changed_path = migration._transform_document(
+            document,
+            {
+                "path": str(target),
+                "path_device": target.stat().st_dev + 1,
+                "path_inode": target.stat().st_ino,
+            },
+        )
+        assert changed_path is not None
+        self.assertEqual(changed_path["path_inode"], target.stat().st_ino)
+
+        changed_named = migration._transform_document(
+            document,
+            {
+                "git_common": str(target),
+                "git_common_device": target.stat().st_dev + 1,
+                "git_common_inode": target.stat().st_ino,
+            },
+        )
+        assert changed_named is not None
+        self.assertEqual(changed_named["git_common_inode"], target.stat().st_ino)
+
+        with self.assertRaisesRegex(FilesystemMigrationError, "cannot locate"):
+            migration._transform_document(
+                document, {"identity": {"device": 1, "inode": 2}}
+            )
+        with self.assertRaisesRegex(FilesystemMigrationError, "path identity inode changed"):
+            migration._transform_document(
+                document,
+                {
+                    "path": str(target),
+                    "path_device": target.stat().st_dev,
+                    "path_inode": target.stat().st_ino + 1,
+                },
+            )
+        with self.assertRaisesRegex(FilesystemMigrationError, "git_common_pair inode changed"):
+            migration._transform_document(
+                document,
+                {
+                    "git_common": str(target),
+                    "git_common_device": target.stat().st_dev,
+                    "git_common_inode": target.stat().st_ino + 1,
+                },
+            )
+        with self.assertRaisesRegex(FilesystemMigrationError, "no safe git_common"):
+            migration._transform_document(
+                document,
+                {"git_common": "relative", "git_common_device": 1, "git_common_inode": 2},
+            )
+
+        historical = self.workspace / "historical" / "record"
+        with self.assertRaisesRegex(FilesystemMigrationError, "type evidence"):
+            migration._transform_document(
+                historical,
+                {"archive": {"device": 1, "inode": 2}},
+            )
+        with self.assertRaisesRegex(FilesystemMigrationError, "full live identity"):
+            migration._transform_document(
+                historical,
+                {"identity": {"device": 1, "inode": 2}},
+            )
+        self.assertIsNone(
+            migration._transform_document(
+                historical,
+                {
+                    "archive": {
+                        "device": migration.portable_device_from_components(
+                            2, stat.S_IFREG, "file"
+                        ),
+                        "inode": 2,
+                        "kind": "file",
+                    }
+                },
+            )
+        )
+        with self.assertRaisesRegex(FilesystemMigrationError, "historical path identity"):
+            migration._transform_document(
+                historical,
+                {"path": "/no/such/path", "path_device": 1, "path_inode": 2},
+            )
+        with self.assertRaisesRegex(FilesystemMigrationError, "historical git_common"):
+            migration._transform_document(
+                historical,
+                {
+                    "git_common": "/no/such/path",
+                    "git_common_device": 1,
+                    "git_common_inode": 2,
+                },
+            )
+
+        review_root = self.repository / "build" / "reviews"
+        review_root.mkdir(parents=True)
+        (review_root / "unrelated.json").write_text("{}\n", encoding="utf-8")
+        (review_root / "skip.lock").write_text("{}\n", encoding="utf-8")
+        (review_root / "skip.tmp.json").write_text("{}\n", encoding="utf-8")
+        selected = list(
+            migration._workspace_json_records(
+                review_root, skip={review_root / "skip.lock"}
+            )
+        )
+        self.assertEqual(selected, [])
+        self.assertEqual(list(migration._workspace_json_records(self.workspace / "absent", skip=set())), [])
+        bad_root = self.workspace / "bad-root"
+        bad_root.write_text("not a directory", encoding="utf-8")
+        with self.assertRaisesRegex(FilesystemMigrationError, "not a directory"):
+            list(migration._workspace_json_records(bad_root, skip=set()))
+        symlink = self.workspace / "symlink-root"
+        symlink.symlink_to(self.workspace)
+        with self.assertRaisesRegex(FilesystemMigrationError, "not a directory"):
+            list(migration._workspace_json_records(symlink, skip=set()))
+        candidate_root = self.workspace / "candidate-root"
+        candidate_root.mkdir()
+        candidate = candidate_root / "candidate.json"
+        candidate.symlink_to(target)
+        with self.assertRaisesRegex(FilesystemMigrationError, "is a symlink"):
+            list(migration._workspace_json_records(candidate_root, skip=set()))
+        candidate.unlink()
+        candidate.mkdir()
+        with self.assertRaisesRegex(FilesystemMigrationError, "not a regular file"):
+            list(migration._workspace_json_records(candidate_root, skip=set()))
+
+    def test_identity_target_and_historical_inference_cover_all_record_shapes(self) -> None:
+        document = self.workspace / "record.json"
+        state = self.workspace / "state"
+        state.mkdir()
+        generation = state / "generation"
+        generation.mkdir()
+        output = state / "tmp" / "runtime-assets" / "g1"
+        output.mkdir(parents=True)
+        reservation = self.workspace / "reservation"
+        reservation.mkdir()
+        reservation_lease = reservation / "reservation.lease"
+        reservation_lease.write_text("lease\n", encoding="utf-8")
+        target = self.workspace / "target"
+        target.mkdir()
+
+        target_path, _ = migration._identity_target(
+            document,
+            {"path": str(target)},
+            "identity",
+            (),
+        )
+        self.assertEqual(target_path, target)
+        physical_path, _ = migration._identity_target(
+            document,
+            {"physical_path": str(target)},
+            "identity",
+            (),
+        )
+        self.assertEqual(physical_path, target)
+        self.assertEqual(
+            migration._identity_target(
+                document,
+                {},
+                "directory",
+                (("port_reservation", {"port_reservation": {"path": str(reservation_lease)}}),),
+            ),
+            (reservation, "full"),
+        )
+        self.assertEqual(
+            migration._identity_target(
+                document,
+                {},
+                "lease",
+                (("port_reservation", {"port_reservation": {"path": str(reservation_lease)}}),),
+            ),
+            (reservation_lease, "stable"),
+        )
+        self.assertEqual(
+            migration._identity_target(
+                document,
+                {},
+                "lease",
+                (("runtime", {"runtime": {"path": str(generation)}}),),
+            ),
+            (generation / "generation.lease", "full"),
+        )
+        self.assertEqual(
+            migration._identity_target(
+                document,
+                {},
+                "lease",
+                (("control", {"control": {}}),),
+            ),
+            (self.workspace / "process-tree.lease", "full"),
+        )
+        self.assertEqual(
+            migration._identity_target(
+                document,
+                {},
+                "output_identity",
+                (
+                    ("state", {"state": str(state)}),
+                    ("generation", {"generation": "g1"}),
+                ),
+            ),
+            (output, "full"),
+        )
+        self.assertEqual(
+            migration._identity_target(
+                document,
+                {},
+                "mutable_state_output_identities",
+                ((0, {"mutable_state_outputs": [str(output)]}),),
+            ),
+            (output, "full"),
+        )
+        self.assertEqual(
+            migration._identity_target(
+                document,
+                {},
+                "lease_identity",
+                (("state_policy", {"state_policy": {"path": str(state)}}),),
+            ),
+            (Path(f"{state}.lock"), "stable"),
+        )
+        self.assertEqual(
+            migration._identity_target(
+                document,
+                {},
+                "lease_identity",
+                (("owner", {"path": str(state)}),),
+            ),
+            (Path(f"{state}.lock"), "stable"),
+        )
+        self.assertEqual(
+            migration._identity_target(
+                document,
+                {},
+                "identity",
+                (("owner", {"physical_path": str(target)}),),
+            ),
+            (target, "full"),
+        )
+        self.assertEqual(
+            migration._identity_target(
+                document,
+                {},
+                "mutable_state_output_identities",
+                (),
+            ),
+            (None, "full"),
+        )
+        ledger = self.workspace / "record.md.ledger.json"
+        self.assertEqual(
+            migration._identity_target(ledger, {}, "source", ()),
+            (ledger, "pair"),
+        )
+        self.assertEqual(
+            migration._identity_target(ledger, {}, None, (("device", {}),)),
+            (ledger, "pair"),
+        )
+        self.assertEqual(
+            migration._projection_for("identity", ()),
+            "full",
+        )
+        self.assertEqual(
+            migration._projection_for("mutable_state_output_identities", ()),
+            "full",
+        )
+        self.assertEqual(
+            migration._projection_for(
+                "directory",
+                (("port_reservation", {"port_reservation": {}}),),
+            ),
+            "full",
+        )
+        self.assertEqual(
+            migration._projection_for(
+                "lease", (("control", {"control": {}}),)
+            ),
+            "full",
+        )
+
+        self.assertEqual(
+            migration._historical_pair({"inode": 2}, "lease", (), document)["inode"],
+            2,
+        )
+        self.assertEqual(
+            migration._historical_pair(
+                {"inode": 2, "file_type": "directory"}, None, (), document
+            )["device"],
+            migration.portable_device_from_components(2, stat.S_IFDIR, "directory"),
+        )
+        self.assertEqual(
+            migration._historical_pair(
+                {"inode": 2}, None, (("roots", {}),), document
+            )["inode"],
+            2,
+        )
+        self.assertEqual(
+            migration._historical_pair(
+                {"inode": 2}, None, (("control", {}),), document
+            )["inode"],
+            2,
+        )
+        self.assertEqual(
+            migration._historical_pair(
+                {"inode": 2}, None, (), self.workspace / "record.lock"
+            )["inode"],
+            2,
+        )
+        self.assertIsNone(migration._historical_pair({"inode": -1}, None, (), document))
+        self.assertIsNone(
+            migration._historical_pair(
+                {"inode": 2}, None, (), self.workspace / "record"
+            )
+        )
+        self.assertTrue(migration._is_historical_pair(self.workspace / ".archive-record", {}, ()))
+        self.assertTrue(
+            migration._is_historical_pair(document, {}, (("archive", {}),))
+        )
+        self.assertTrue(
+            migration._is_historical_pair(document, {"raw_base64": "e30="}, ())
+        )
+        self.assertFalse(migration._is_historical_pair(document, {}, ()))
+
+        self.assertEqual(
+            migration._nearby_named_target(
+                document, {"name": str(target)}, ()
+            ),
+            target,
+        )
+        self.assertEqual(
+            migration._nearby_named_target(document, {"name": target.name}, ()),
+            target,
+        )
+        self.assertIsNone(
+            migration._nearby_named_target(
+                document,
+                {"name": "../outside", "target": "bad\x00name"},
+                (),
+            )
+        )
+
+    def test_journal_validation_preserves_snapshots_and_rejects_tampering(self) -> None:
+        target = self.workspace / "journal-target.json"
+        before_value = {"before": True}
+        after_value = {"after": True}
+        write_json(target, before_value)
+        record = migration._plan_record(target, before_value, after_value)
+        journal_path = self.workspace / "manual-journal.json"
+        journal = migration._new_journal([record], confirm_remount=True)
+        write_json(journal_path, journal)
+        normalized = migration._read_journal(journal_path)
+        self.assertEqual(normalized["records"][0]["path"], str(target))
+        self.assertEqual(
+            migration._public_record(normalized["records"][0])["path"],
+            str(target),
+        )
+
+        invalid_top_level = (
+            [],
+            {**journal, "extra": True},
+            {**journal, "schema_version": 2},
+            {**journal, "transaction": "other"},
+            {**journal, "state": "unknown"},
+            {**journal, "created_at": None},
+            {**journal, "confirm_remount": "yes"},
+            {**journal, "records": {}},
+        )
+        for value in invalid_top_level:
+            with self.subTest(value=value), self.assertRaisesRegex(
+                FilesystemMigrationError, "journal is invalid"
+            ):
+                write_json(journal_path, value)
+                migration._read_journal(journal_path)
+
+        for created_at, message in (
+            ("not-a-time", "timestamp is invalid"),
+            ("2026-01-01T00:00:00", "no timezone"),
+        ):
+            value = {**journal, "created_at": created_at}
+            with self.subTest(created_at=created_at), self.assertRaisesRegex(
+                FilesystemMigrationError, message
+            ):
+                write_json(journal_path, value)
+                migration._read_journal(journal_path)
+        for value, message in (
+            ({**journal, "completed_at": 1}, "journal is invalid"),
+            ({**journal, "completed_at": "2026-01-01T00:00:00Z"}, "unfinished state"),
+            ({**journal, "rollback_error": 1}, "journal is invalid"),
+        ):
+            with self.subTest(value=value), self.assertRaisesRegex(
+                FilesystemMigrationError, message
+            ):
+                write_json(journal_path, value)
+                migration._read_journal(journal_path)
+
+        invalid_records = []
+        invalid_records.append({"not": "a record"})
+        self.assertEqual(record["path"], str(target))
+        self.assertTrue(record["before_base64"])
+        for bad_record, message in (
+            (invalid_records[0], "record is invalid"),
+            ({**record, "path": str(journal_path)}, "own control file"),
+            (
+                {**record, "path": str(self.workspace / migration.FILESYSTEM_MIGRATION_LOCK)},
+                "own control file",
+            ),
+            ({**record, "before_sha256": "b" * 64}, "before snapshot is invalid"),
+            ({**record, "after_sha256": "b" * 64}, "after snapshot is invalid"),
+        ):
+            with self.subTest(message=message), self.assertRaisesRegex(
+                FilesystemMigrationError, message
+            ):
+                write_json(journal_path, {**journal, "records": [bad_record]})
+                migration._read_journal(journal_path)
+
+        link_parent = self.workspace / "journal-link"
+        link_parent.symlink_to(self.workspace)
+        with self.assertRaisesRegex(FilesystemMigrationError, "not canonical"):
+            write_json(
+                journal_path,
+                {**journal, "records": [{**record, "path": str(link_parent / target.name)}]},
+            )
+            migration._read_journal(journal_path)
+
+        missing = self.workspace / "missing-target.json"
+        with self.assertRaisesRegex(FilesystemMigrationError, "cannot inspect"):
+            write_json(
+                journal_path,
+                {**journal, "records": [{**record, "path": str(missing)}]},
+            )
+            migration._read_journal(journal_path)
+
+        with self.assertRaisesRegex(FilesystemMigrationError, "identity"):
+            write_json(
+                journal_path,
+                {
+                    **journal,
+                    "records": [{**record, "before_identity": {}}],
+                },
+            )
+            migration._read_journal(journal_path)
+        directory = self.workspace / "journal-directory"
+        directory.mkdir()
+        with self.assertRaisesRegex(FilesystemMigrationError, "not a file"):
+            migration._validate_journal_identity(
+                portable_identity(directory.stat()), target, "before"
+            )
+
+        legacy_record = {
+            key: record[key] for key in migration._LEGACY_JOURNAL_RECORD_KEYS
+        }
+        write_json(journal_path, {**journal, "records": [legacy_record]})
+        legacy_normalized = migration._read_journal(journal_path)
+        self.assertTrue(legacy_normalized["records"][0]["before_identity"])
+
+        second = self.workspace / "second-target.json"
+        write_json(second, before_value)
+        second_record = migration._plan_record(second, before_value, {"other": True})
+        for records in (
+            [record, record],
+            [second_record, record],
+        ):
+            with self.subTest(records=records), self.assertRaisesRegex(
+                FilesystemMigrationError, "unique and ordered"
+            ):
+                write_json(journal_path, {**journal, "records": records})
+                migration._read_journal(journal_path)
+
+    def test_low_level_snapshot_decoding_and_filesystem_guards_fail_closed(self) -> None:
+        target = self.workspace / "snapshot.json"
+        write_json(target, {"value": 1})
+        raw, identity = migration._read_snapshot(target)
+        self.assertEqual(json.loads(raw), {"value": 1})
+        self.assertEqual(identity["kind"], "file")
+        migration._write_json_bytes(target, raw)
+
+        with self.assertRaisesRegex(FilesystemMigrationError, "canonical JSON"):
+            migration._write_json_bytes(target, b'{ "value": 1 }\n')
+        with self.assertRaisesRegex(FilesystemMigrationError, "not JSON"):
+            migration._decode_json(b"\xff", target)
+        with self.assertRaisesRegex(FilesystemMigrationError, "not JSON"):
+            migration._decode_json(b'{"value": 1, "value": 2}', target)
+        with self.assertRaisesRegex(FilesystemMigrationError, "encoding is invalid"):
+            migration._decode_snapshot(None, target)
+        with self.assertRaisesRegex(FilesystemMigrationError, "not valid base64"):
+            migration._decode_snapshot("!", target)
+        noncanonical = base64.b64encode(b'{ "value": 1 }\n').decode("ascii")
+        with self.assertRaisesRegex(FilesystemMigrationError, "canonical JSON"):
+            migration._decode_snapshot(noncanonical, target)
+        with mock.patch.object(migration, "MAX_MIGRATION_SNAPSHOT_BYTES", 1):
+            with self.assertRaisesRegex(FilesystemMigrationError, "too large"):
+                migration._decode_snapshot(base64.b64encode(raw).decode("ascii"), target)
+
+        directory = self.workspace / "snapshot-directory"
+        directory.mkdir()
+        with self.assertRaisesRegex(FilesystemMigrationError, "not an owned regular file"):
+            migration._read_snapshot(directory)
+        with mock.patch.object(migration, "MAX_MIGRATION_SNAPSHOT_BYTES", 0):
+            with self.assertRaisesRegex(FilesystemMigrationError, "too large"):
+                migration._read_snapshot(target)
+        with mock.patch.object(migration.os, "open", side_effect=OSError("open failed")):
+            with self.assertRaisesRegex(FilesystemMigrationError, "cannot read"):
+                migration._read_snapshot(target)
+        with mock.patch.object(migration.os, "read", return_value=b""):
+            with self.assertRaisesRegex(FilesystemMigrationError, "changed while reading"):
+                migration._read_snapshot(target)
+        original_limit = migration.MAX_MIGRATION_SNAPSHOT_BYTES
+        real_read = os.read
+
+        def read_then_shrink(fd: int, size: int) -> bytes:
+            value = real_read(fd, size)
+            migration.MAX_MIGRATION_SNAPSHOT_BYTES = 0
+            return value
+
+        try:
+            with mock.patch.object(migration.os, "read", side_effect=read_then_shrink):
+                with self.assertRaisesRegex(FilesystemMigrationError, "too large"):
+                    migration._read_snapshot(target)
+        finally:
+            migration.MAX_MIGRATION_SNAPSHOT_BYTES = original_limit
+        visible = SimpleNamespace(
+            st_mode=stat.S_IFREG,
+            st_dev=target.stat().st_dev + 1,
+            st_ino=target.stat().st_ino,
+        )
+        with mock.patch.object(Path, "stat", return_value=visible):
+            with self.assertRaisesRegex(FilesystemMigrationError, "was replaced"):
+                migration._read_snapshot(target)
+
+        with self.assertRaisesRegex(FilesystemMigrationError, "unsafe"):
+            migration._assert_safe_path(Path("relative"))
+        with self.assertRaisesRegex(FilesystemMigrationError, "unsafe"):
+            migration._assert_safe_path(Path("/"))
+        parent_link = self.workspace / "parent-link"
+        parent_link.symlink_to(self.workspace)
+        with self.assertRaisesRegex(FilesystemMigrationError, "symlinked parent"):
+            migration._assert_safe_path(parent_link / target.name)
+
+        with self.assertRaisesRegex(FilesystemMigrationError, "cannot inspect"):
+            migration._metadata(self.workspace / "does-not-exist", target)
+        fifo = self.workspace / "snapshot.fifo"
+        os.mkfifo(fifo)
+        with self.assertRaisesRegex(FilesystemMigrationError, "not a file/directory"):
+            migration._metadata(fifo, target)
+        with mock.patch.object(migration.os, "geteuid", return_value=os.geteuid() + 1):
+            with self.assertRaisesRegex(FilesystemMigrationError, "foreign ownership"):
+                migration._metadata(target, target)
+        with self.assertRaises(FilesystemMigrationError):
+            migration._validate_portable_record_identity({}, target)
+
+        self.assertEqual(migration._physical_lease_namespace(self.repository), self.repository / ".git" / "atrinik-resource-leases")
+        fallback = self.repository / "fallback"
+        fallback.mkdir()
+        (fallback / "workspace").mkdir()
+        self.assertEqual(
+            migration._physical_lease_namespace(fallback),
+            fallback / "workspace" / "atrinik-resource-leases",
+        )
+        marker = fallback / ".git"
+        marker.write_text("not-a-gitdir\n", encoding="utf-8")
+        self.assertEqual(
+            migration._physical_lease_namespace(fallback),
+            fallback / "workspace" / "atrinik-resource-leases",
+        )
+        linked = self.repository / "linked"
+        linked.mkdir()
+        gitdir = self.repository / "common" / "worktrees" / "linked"
+        gitdir.mkdir(parents=True)
+        (linked / ".git").write_text("gitdir: ../common/worktrees/linked\n", encoding="utf-8")
+        self.assertEqual(
+            migration._physical_lease_namespace(linked),
+            self.repository / "common" / "atrinik-resource-leases",
+        )
+        with mock.patch.object(Path, "read_text", side_effect=OSError("marker read")):
+            with self.assertRaisesRegex(FilesystemMigrationError, "cannot read Git"):
+                migration._physical_lease_namespace(linked)
+
+    def test_journal_apply_resume_audit_and_rollback_paths_are_durable(self) -> None:
+        def make_record(
+            name: str, before: object, after: object
+        ) -> tuple[Path, dict[str, object]]:
+            target = self.workspace / name
+            write_json(target, before)
+            return target, migration._plan_record(target, before, after)
+
+        target, record = make_record(
+            "already-after.json", {"before": True}, {"after": True}
+        )
+        write_json(target, {"after": True})
+        record["after_identity"] = migration.portable_identity(target.stat())
+        journal_path = self.workspace / "already-after-journal.json"
+        result = migration._apply_journal(
+            journal_path,
+            migration._new_journal([record], confirm_remount=True),
+        )
+        self.assertEqual(result["status"], "complete")
+
+        resume = migration._resume_journal(
+            journal_path,
+            {
+                **migration._new_journal([record], confirm_remount=True),
+                "state": "prepared",
+            },
+        )
+        self.assertEqual(resume["status"], "complete")
+
+        changed_target, changed_record = make_record(
+            "changed-before.json", {"before": True}, {"after": True}
+        )
+        write_json(changed_target, {"unexpected": True})
+        with self.assertRaisesRegex(FilesystemMigrationError, "input changed"):
+            migration._apply_journal(
+                self.workspace / "changed-before-journal.json",
+                migration._new_journal([changed_record], confirm_remount=True),
+            )
+
+        no_op_target, no_op_record = make_record(
+            "no-longer-applies.json", {"unrelated": True}, {"after": True}
+        )
+        with self.assertRaisesRegex(FilesystemMigrationError, "no longer applies"):
+            migration._apply_journal(
+                self.workspace / "no-longer-applies-journal.json",
+                migration._new_journal([no_op_record], confirm_remount=True),
+            )
+        oversize_state = self.workspace / "state-for-oversize"
+        oversize_state.mkdir()
+        oversized_target, oversized_record = make_record(
+            "oversized-after.json",
+            {
+                "identity": {
+                    "path": str(oversize_state),
+                    "device": oversize_state.stat().st_dev + 1,
+                    "inode": oversize_state.stat().st_ino,
+                }
+            },
+            {"after": True},
+        )
+        with mock.patch.object(
+            migration,
+            "MAX_MIGRATION_SNAPSHOT_BYTES",
+            len(oversized_target.read_bytes()),
+        ):
+            # The record must still have a live target so transformation can
+            # reach the post-transform size guard.
+            with self.assertRaisesRegex(FilesystemMigrationError, "too large"):
+                migration._apply_journal(
+                    self.workspace / "oversized-after-journal.json",
+                    migration._new_journal([oversized_record], confirm_remount=True),
+                )
+            self.assertTrue(oversized_target.exists())
+
+        state = self.workspace / "state-for-rewrite"
+        state.mkdir()
+        rewrite_target, rewrite_record = make_record(
+            "rewrite-plan.json",
+            {
+                "identity": {
+                    "path": str(state),
+                    "device": state.stat().st_dev + 1,
+                    "inode": state.stat().st_ino,
+                }
+            },
+            {"placeholder": True},
+        )
+        rewritten = migration._apply_journal(
+            self.workspace / "rewrite-plan-journal.json",
+            migration._new_journal([rewrite_record], confirm_remount=True),
+        )
+        self.assertEqual(rewritten["status"], "complete")
+        self.assertEqual(
+            json.loads(rewrite_target.read_text(encoding="utf-8"))["identity"][
+                "inode"
+            ],
+            state.stat().st_ino,
+        )
+
+        verify_target, verify_record = make_record(
+            "verify-output.json",
+            {
+                "identity": {
+                    "path": str(state),
+                    "device": state.stat().st_dev + 1,
+                    "inode": state.stat().st_ino,
+                }
+            },
+            {"placeholder": True},
+        )
+        def write_wrong_output(path: Path, raw: bytes) -> None:
+            del raw
+            path.write_bytes(b'{"wrong": true}\n')
+
+        with mock.patch.object(
+            migration, "_write_json_bytes", side_effect=write_wrong_output
+        ), mock.patch.object(migration, "_rollback_record", return_value=None):
+            with self.assertRaisesRegex(FilesystemMigrationError, "output could not be verified"):
+                migration._apply_journal(
+                    self.workspace / "verify-output-journal.json",
+                    migration._new_journal([verify_record], confirm_remount=True),
+                )
+        self.assertTrue(verify_target.exists())
+
+        first_target, first_record = make_record(
+            "rollback-failure-first.json",
+            {
+                "identity": {
+                    "path": str(state),
+                    "device": state.stat().st_dev + 1,
+                    "inode": state.stat().st_ino,
+                }
+            },
+            {"after": 1},
+        )
+        second_target, second_record = make_record(
+            "rollback-failure-second.json",
+            {
+                "identity": {
+                    "path": str(state),
+                    "device": state.stat().st_dev + 1,
+                    "inode": state.stat().st_ino,
+                }
+            },
+            {"after": 2},
+        )
+        real_write = migration._write_json_bytes
+
+        def fail_second(path: Path, raw: bytes) -> None:
+            if Path(path) == second_target:
+                raise FilesystemMigrationError("second write failed")
+            real_write(path, raw)
+
+        with mock.patch.object(migration, "_write_json_bytes", side_effect=fail_second), mock.patch.object(
+            migration, "_rollback_record", side_effect=FilesystemMigrationError("rollback failed")
+        ):
+            with self.assertRaisesRegex(FilesystemMigrationError, "rollback is uncertain"):
+                migration._apply_journal(
+                    self.workspace / "rollback-failure-journal.json",
+                    migration._new_journal(
+                        [first_record, second_record], confirm_remount=True
+                    ),
+                )
+        self.assertTrue(first_target.exists())
+
+        persist_target, persist_record = make_record(
+            "journal-persist-failure.json",
+            {
+                "identity": {
+                    "path": str(state),
+                    "device": state.stat().st_dev + 1,
+                    "inode": state.stat().st_ino,
+                }
+            },
+            {"after": True},
+        )
+        real_durable = migration.durable_atomic_json
+
+        def fail_failed_journal(path: Path, value: object) -> None:
+            if isinstance(value, dict) and "rollback_error" in value:
+                raise OSError("journal storage failed")
+            real_durable(path, value)
+
+        with mock.patch.object(
+            migration,
+            "_write_json_bytes",
+            side_effect=FilesystemMigrationError("write failed"),
+        ), mock.patch.object(
+            migration, "durable_atomic_json", side_effect=fail_failed_journal
+        ):
+            with self.assertRaisesRegex(FilesystemMigrationError, "could not be persisted"):
+                migration._apply_journal(
+                    self.workspace / "journal-persist-failure-control.json",
+                    migration._new_journal([persist_record], confirm_remount=True),
+                )
+        self.assertTrue(persist_target.exists())
+
+        ambiguous_target, ambiguous_record = make_record(
+            "ambiguous.json", {"before": True}, {"after": True}
+        )
+        write_json(ambiguous_target, {"ambiguous": True})
+        with self.assertRaisesRegex(FilesystemMigrationError, "ambiguous"):
+            migration._resume_journal(
+                self.workspace / "ambiguous-journal.json",
+                migration._new_journal([ambiguous_record], confirm_remount=True),
+            )
+        audit_target, audit_record = make_record(
+            "legacy-audit.json", {"before": True}, {"after": True}
+        )
+        audit = migration._audit_journal(
+            self.workspace / "audit-journal.json",
+            {
+                **migration._new_journal([audit_record], confirm_remount=True),
+                "state": "prepared",
+            },
+        )
+        self.assertEqual(audit["records"][0]["status"], "legacy")
+        write_json(audit_target, {"changed": True})
+        with self.assertRaisesRegex(FilesystemMigrationError, "record changed"):
+            migration._audit_journal(
+                self.workspace / "audit-journal.json",
+                {
+                    **migration._new_journal([audit_record], confirm_remount=True),
+                    "state": "prepared",
+                },
+            )
+
+        rollback_target, rollback_record = make_record(
+            "rollback-changed.json", {"before": True}, {"after": True}
+        )
+        write_json(rollback_target, {"unexpected": True})
+        with self.assertRaisesRegex(FilesystemMigrationError, "rollback target changed"):
+            migration._rollback_record(rollback_record)
+
+        verify_rollback_target, verify_rollback_record = make_record(
+            "rollback-unverified.json", {"before": True}, {"after": True}
+        )
+        write_json(verify_rollback_target, {"after": True})
+        verify_rollback_record["after_identity"] = migration.portable_identity(
+            verify_rollback_target.stat()
+        )
+
+        def write_wrong_rollback(path: Path, raw: bytes) -> None:
+            del raw
+            path.write_bytes(b'{"not-before": true}\n')
+
+        with mock.patch.object(
+            migration, "_write_json_bytes", side_effect=write_wrong_rollback
+        ):
+            with self.assertRaisesRegex(
+                FilesystemMigrationError, "rollback could not be verified"
+            ):
+                migration._rollback_record(verify_rollback_record)
+
+    def test_remaining_rebind_and_planning_guards_are_exercised(self) -> None:
+        target = self.workspace / "target"
+        target.mkdir()
+        document = self.workspace / "record.json"
+        missing = self.workspace / "missing"
+
+        with self.assertRaisesRegex(FilesystemMigrationError, "cannot locate"):
+            migration._transform_document(
+                document,
+                {"identity": {"path": str(missing), "device": 1, "inode": 2}},
+            )
+        with self.assertRaisesRegex(FilesystemMigrationError, "safe path identity"):
+            migration._transform_document(
+                document,
+                {"path": str(missing), "path_device": 1, "path_inode": 2},
+            )
+        self.assertIsNone(
+            migration._transform_document(
+                document,
+                {
+                    "path": str(target),
+                    "path_device": portable_pair(target.stat())["device"],
+                    "path_inode": target.stat().st_ino,
+                },
+            )
+        )
+        with self.assertRaisesRegex(FilesystemMigrationError, "inode changed"):
+            migration._transform_document(
+                document,
+                {
+                    "identity": {
+                        "path": str(target),
+                        "device": target.stat().st_dev,
+                        "inode": target.stat().st_ino + 1,
+                    }
+                },
+            )
+        historical = self.workspace / "historical" / "record"
+        same_historical_pair = {
+            "device": migration.portable_device_from_components(
+                2, stat.S_IFREG, "file"
+            ),
+            "inode": 2,
+        }
+        self.assertIsNone(
+            migration._transform_document(
+                historical, {"source": same_historical_pair}
+            )
+        )
+        changed_historical_path = migration._transform_document(
+            historical,
+            {
+                "path": str(missing),
+                "path_device": 1,
+                "path_inode": 2,
+                "inode": 2,
+                "kind": "directory",
+            },
+        )
+        assert changed_historical_path is not None
+        self.assertNotEqual(changed_historical_path["path_device"], 1)
+        self.assertIsNone(
+            migration._transform_document(
+                historical,
+                {
+                    "path": str(missing),
+                    "path_device": migration.portable_device_from_components(
+                        2, stat.S_IFDIR, "directory"
+                    ),
+                    "path_inode": 2,
+                    "inode": 2,
+                    "kind": "directory",
+                },
+            )
+        )
+        with self.assertRaisesRegex(FilesystemMigrationError, "inode changed"):
+            migration._transform_document(
+                document,
+                {
+                    "identity": {
+                        "path": str(target),
+                        "device": target.stat().st_dev,
+                        "inode": target.stat().st_ino + 1,
+                    }
+                },
+            )
+        with self.assertRaisesRegex(FilesystemMigrationError, "inode changed"):
+            migration._transform_document(
+                document,
+                {
+                    "git_common": str(target),
+                    "git_common_device": target.stat().st_dev,
+                    "git_common_inode": target.stat().st_ino + 1,
+                },
+            )
+        self.assertIsNone(
+            migration._transform_document(
+                document,
+                {
+                    "git_common": str(target),
+                    "git_common_device": portable_pair(target.stat())["device"],
+                    "git_common_inode": target.stat().st_ino,
+                },
+            )
+        )
+        with self.assertRaisesRegex(FilesystemMigrationError, "target is missing"):
+            migration._transform_document(
+                document,
+                {
+                    "git_common": str(missing),
+                    "git_common_device": 1,
+                    "git_common_inode": 2,
+                },
+            )
+        self.assertIsNotNone(
+            migration._transform_document(
+                self.workspace / "historical" / "record.json",
+                {
+                    "git_common": str(missing),
+                    "git_common_device": 1,
+                    "git_common_inode": 2,
+                    "kind": "file",
+                },
+            )
+        )
+
+        ancestor_path = migration._identity_target(
+            document, {}, "identity", (("bad", "not-a-dict"),)
+        )
+        self.assertEqual(ancestor_path, (None, "full"))
+        self.assertEqual(
+            migration._projection_for(
+                "lease",
+                (("port_reservation", {"port_reservation": {}}),),
+            ),
+            "full",
+        )
+
+        identity_record = self.repository / ".git" / "atrinik-resource-leases.identity.json"
+        namespace = self.repository / ".git" / "atrinik-resource-leases"
+        namespace.mkdir()
+        write_json(
+            identity_record,
+            {
+                "schema_version": 1,
+                "device": namespace.stat().st_dev,
+                "inode": namespace.stat().st_ino + 1,
+            },
+        )
+        with self.assertRaisesRegex(FilesystemMigrationError, "inode changed"):
+            migration._transform_document(
+                identity_record, json.loads(identity_record.read_text(encoding="utf-8"))
+            )
+        identity_record.unlink()
+        namespace.rmdir()
+
+        plan_path = self.workspace / "plan.json"
+        write_json(plan_path, {"unchanged": True})
+        discovered = migration.Paths.discover(self.repository)
+        with mock.patch.object(
+            migration, "_workspace_json_records", return_value=[plan_path]
+        ):
+            self.assertEqual(migration._plan(discovered, confirm_remount=True), [])
+        with mock.patch.object(
+            migration, "_workspace_json_records", return_value=[plan_path, plan_path]
+        ):
+            self.assertEqual(migration._plan(discovered, confirm_remount=True), [])
+        with mock.patch.object(
+            Path, "rglob", side_effect=OSError("enumeration failed")
+        ):
+            with self.assertRaisesRegex(FilesystemMigrationError, "cannot enumerate"):
+                list(migration._workspace_json_records(self.workspace, skip=set()))
+        skip_file = self.workspace / "skip.json"
+        skip_file.write_text("{}\n", encoding="utf-8")
+        self.assertEqual(
+            list(
+                migration._workspace_json_records(
+                    self.workspace, skip={skip_file}
+                )
+            ),
+            [plan_path],
+        )
+        ignored = self.workspace / "ignored.tmp.json"
+        ignored.write_text("{}\n", encoding="utf-8")
+        self.assertNotIn(
+            ignored,
+            migration._workspace_json_records(self.workspace, skip=set()),
+        )
+
+        with self.assertRaisesRegex(FilesystemMigrationError, "too large"):
+            with mock.patch.object(
+                migration,
+                "_read_snapshot",
+                return_value=(b"{}\n", {"kind": "file"}),
+            ), mock.patch.object(migration, "MAX_MIGRATION_SNAPSHOT_BYTES", 1):
+                migration._plan_record(
+                    plan_path, {"unchanged": True}, {"changed": True}
+                )
+        with self.assertRaisesRegex(FilesystemMigrationError, "no change"):
+            migration._plan_record(
+                plan_path, {"unchanged": True}, {"unchanged": True}
+            )
+
+        journal_path = self.workspace / migration.FILESYSTEM_MIGRATION_RECORD
+        journal_path.write_text("{}\n", encoding="utf-8")
+        with mock.patch.object(
+            migration,
+            "_read_journal",
+            return_value={"state": "unsupported", "records": []},
+        ):
+            with self.assertRaisesRegex(FilesystemMigrationError, "unsupported state"):
+                migration.migrate_filesystem_records(
+                    self.repository, "apply", confirm_remount=True
+                )

--- a/tests/test_filesystem_migration.py
+++ b/tests/test_filesystem_migration.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import stat
+import tempfile
+import unittest
+from unittest import mock
+
+import atrinik_workspace.filesystem_migration as migration
+from atrinik_workspace.filesystem_identity import portable_identity, portable_pair
+
+
+def write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+class FilesystemMigrationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.repository = Path(self.temporary.name)
+        (self.repository / ".git").mkdir()
+        self.workspace = self.repository / "workspace"
+        self.workspace.mkdir()
+
+    def make_state_record(self, name: str) -> tuple[Path, Path]:
+        state = self.workspace / f"state-{name}"
+        state.mkdir()
+        record = self.workspace / f"{name}.json"
+        write_json(
+            record,
+            {
+                "state_policy": {
+                    "identity": {
+                        "device": state.stat().st_dev + 1,
+                        "inode": state.stat().st_ino,
+                    },
+                    "path": str(state),
+                }
+            },
+        )
+        return record, state
+
+    def test_dry_run_and_apply_cover_topology_and_delivery_ledger_records(self) -> None:
+        topology = self.workspace / "topologies" / "demo"
+        topology.mkdir(parents=True)
+        process_lease = topology / "process-tree.lease"
+        process_lease.write_text("process\n", encoding="utf-8")
+        generation = topology / "generations" / "g1"
+        generation.mkdir(parents=True)
+        generation_lease = generation / "generation.lease"
+        generation_lease.write_text("generation\n", encoding="utf-8")
+        state = topology / "state"
+        state.mkdir()
+        state_lock = Path(f"{state}.lock")
+        state_lock.write_text("state\n", encoding="utf-8")
+        output = state / "tmp" / "runtime-assets" / "g1"
+        output.mkdir(parents=True)
+        reservation = self.repository / "reservations"
+        reservation.mkdir()
+        reservation_lease = reservation / "demo.lease"
+        reservation_lease.write_text("reservation\n", encoding="utf-8")
+        topology_record = topology / "status.json"
+        old = lambda path: {"device": path.stat().st_dev + 1, "inode": path.stat().st_ino}
+        write_json(
+            topology_record,
+            {
+                "control": {"lease": old(process_lease)},
+                "port_reservation": {
+                    "directory": old(reservation),
+                    "lease": old(reservation_lease),
+                    "path": str(reservation_lease),
+                },
+                "runtime": {
+                    "lease": old(generation_lease),
+                    "mutable_state_output_identities": [old(output)],
+                    "mutable_state_outputs": [str(output)],
+                    "path": str(generation),
+                },
+                "state_policy": {
+                    "identity": old(state),
+                    "lease_identity": old(state_lock),
+                    "path": str(state),
+                },
+            },
+        )
+
+        review = self.repository / "build" / "reviews" / "demo.md.ledger.json"
+        write_json(
+            review,
+            {
+                "artifacts": [
+                    {
+                        "primitive_request": {
+                            "roots": {
+                                "primary": {
+                                    **old(self.repository),
+                                    "path": str(self.repository),
+                                },
+                                "workspace": {
+                                    **old(self.workspace),
+                                    "path": str(self.workspace),
+                                },
+                            }
+                        }
+                    }
+                ]
+            },
+        )
+        review_inode = review.stat().st_ino
+        release = self.repository / "build" / "reviews" / ".demo.md.ledger.json.release.json"
+        write_json(
+            release,
+            {
+                "ledger": {
+                    "name": review.name,
+                    "device": review.stat().st_dev + 1,
+                    "inode": review.stat().st_ino,
+                }
+            },
+        )
+        reclaim_complete = (
+            self.repository
+            / "build"
+            / "reviews"
+            / ".delivery-ledger-reclaim-complete.json"
+        )
+        write_json(
+            reclaim_complete,
+            {
+                "preview": {
+                    "archive": review.name,
+                    "device": review.stat().st_dev + 1,
+                    "inode": review_inode,
+                }
+            },
+        )
+
+        plan = migration.migrate_filesystem_records(self.repository, "dry-run")
+
+        self.assertTrue(plan["requires_confirm_remount"])
+        planned_paths = {item["path"] for item in plan["records"]}
+        self.assertEqual(
+            planned_paths,
+            {str(topology_record), str(review), str(release), str(reclaim_complete)},
+        )
+        self.assertNotIn("before_base64", plan["records"][0])
+
+        result = migration.migrate_filesystem_records(
+            self.repository, "apply", confirm_remount=True
+        )
+
+        self.assertEqual(result["status"], "complete")
+        converted = json.loads(topology_record.read_text(encoding="utf-8"))
+        self.assertEqual(
+            converted["state_policy"]["identity"], portable_identity(state.stat())
+        )
+        ledger = json.loads(review.read_text(encoding="utf-8"))
+        workspace_root = ledger["artifacts"][0]["primitive_request"]["roots"][
+            "workspace"
+        ]
+        self.assertEqual(workspace_root["device"], portable_pair(self.workspace.stat())["device"])
+        self.assertEqual(workspace_root["inode"], self.workspace.stat().st_ino)
+        self.assertEqual(workspace_root["path"], str(self.workspace))
+        release_value = json.loads(release.read_text(encoding="utf-8"))
+        self.assertEqual(
+            release_value["ledger"]["device"], portable_pair(review.stat())["device"]
+        )
+        self.assertEqual(release_value["ledger"]["inode"], review.stat().st_ino)
+        reclaim_value = json.loads(reclaim_complete.read_text(encoding="utf-8"))
+        self.assertEqual(
+            reclaim_value["preview"]["device"],
+            migration.portable_device_from_components(
+                review_inode, stat.S_IFREG, "file"
+            ),
+        )
+        self.assertEqual(reclaim_value["preview"]["inode"], review_inode)
+        journal = json.loads(
+            (self.workspace / migration.FILESYSTEM_MIGRATION_RECORD).read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(journal["state"], "complete")
+        self.assertTrue(all(record["after_identity"] for record in journal["records"]))
+        audit = migration.migrate_filesystem_records(self.repository, "audit")
+        self.assertEqual({row["status"] for row in audit["records"]}, {"converted"})
+
+    def test_changed_same_content_record_fails_audit(self) -> None:
+        record, state = self.make_state_record("changed")
+        migration.migrate_filesystem_records(
+            self.repository, "apply", confirm_remount=True
+        )
+        replacement = record.with_name("replacement.json")
+        replacement.write_bytes(record.read_bytes())
+        os.replace(replacement, record)
+
+        with self.assertRaisesRegex(migration.FilesystemMigrationError, "identity changed"):
+            migration.migrate_filesystem_records(self.repository, "audit")
+        self.assertEqual(
+            json.loads(record.read_text(encoding="utf-8"))["state_policy"]["identity"],
+            portable_identity(state.stat()),
+        )
+
+    def test_path_and_git_common_inode_changes_refuse_rebind(self) -> None:
+        target = self.workspace / "target"
+        target.mkdir()
+        path_record = self.workspace / "path.json"
+        write_json(
+            path_record,
+            {
+                "path": str(target),
+                "path_device": target.stat().st_dev + 1,
+                "path_inode": target.stat().st_ino + 1,
+            },
+        )
+        with self.assertRaisesRegex(
+            migration.FilesystemMigrationError, "path identity inode changed"
+        ):
+            migration.migrate_filesystem_records(self.repository, "dry-run")
+
+        path_record.unlink()
+        common_record = self.workspace / "common.json"
+        write_json(
+            common_record,
+            {
+                "git_common": str(target),
+                "git_common_device": target.stat().st_dev + 1,
+                "git_common_inode": target.stat().st_ino + 1,
+            },
+        )
+        with self.assertRaisesRegex(
+            migration.FilesystemMigrationError, "git_common_pair inode changed"
+        ):
+            migration.migrate_filesystem_records(self.repository, "dry-run")
+
+    def test_failed_apply_rolls_back_and_can_resume(self) -> None:
+        first, _ = self.make_state_record("a")
+        second, _ = self.make_state_record("b")
+        before = {path: path.read_bytes() for path in (first, second)}
+        original_write = migration._write_json_bytes
+        failed = False
+
+        def fail_once(path: Path, raw: bytes) -> None:
+            nonlocal failed
+            if Path(path).name == second.name and not failed:
+                failed = True
+                raise migration.FilesystemMigrationError("injected write failure")
+            original_write(path, raw)
+
+        with mock.patch.object(migration, "_write_json_bytes", side_effect=fail_once):
+            with self.assertRaisesRegex(
+                migration.FilesystemMigrationError, "injected write failure"
+            ):
+                migration.migrate_filesystem_records(
+                    self.repository, "apply", confirm_remount=True
+                )
+
+        self.assertEqual(first.read_bytes(), before[first])
+        self.assertEqual(second.read_bytes(), before[second])
+        journal_path = self.workspace / migration.FILESYSTEM_MIGRATION_RECORD
+        journal = json.loads(journal_path.read_text(encoding="utf-8"))
+        self.assertEqual(journal["state"], "prepared")
+        self.assertTrue(all(record["rollback_identity"] for record in journal["records"]))
+
+        resumed = migration.migrate_filesystem_records(
+            self.repository, "apply", confirm_remount=True
+        )
+        self.assertEqual(resumed["status"], "complete")
+
+    def test_historical_pair_uses_type_evidence_without_guessing_a_live_target(self) -> None:
+        document = self.workspace / "historical.json"
+        value = {
+            "archive": {
+                "device": 17,
+                "inode": 1234,
+                "kind": "file",
+                "raw_base64": "e30=",
+            }
+        }
+
+        transformed = migration._transform_document(document, value)
+
+        assert transformed is not None
+        self.assertEqual(transformed["archive"]["inode"], 1234)
+        self.assertNotEqual(transformed["archive"]["device"], 17)

--- a/tests/test_filesystem_migration.py
+++ b/tests/test_filesystem_migration.py
@@ -288,3 +288,14 @@ class FilesystemMigrationTests(unittest.TestCase):
         assert transformed is not None
         self.assertEqual(transformed["archive"]["inode"], 1234)
         self.assertNotEqual(transformed["archive"]["device"], 17)
+
+    def test_historical_directory_path_is_treated_as_historical_evidence(self) -> None:
+        value = {"snapshot": {"device": 17, "inode": 1234}}
+
+        transformed = migration._transform_document(
+            self.repository / "historical" / "record.json", value
+        )
+
+        assert transformed is not None
+        self.assertEqual(transformed["snapshot"]["inode"], 1234)
+        self.assertNotEqual(transformed["snapshot"]["device"], 17)


### PR DESCRIPTION
## Summary

Make persisted filesystem identities portable across remounts while preserving live replacement, symlink, hard-link, and TOCTOU protections.

## Implementation / behavior

- Separate durable record identity from mount-specific filesystem device values.
- Add an explicit, atomic, auditable recovery path for existing workspace records after a verified remount.
- Preserve ownership, generation, lease-fencing, content-integrity, and fail-closed behavior for ambiguous or changed live state.
- Document the durable/ephemeral identity boundary and backward-compatible recovery procedure.

## Validation

Focused remount/rebind regression tests and the complete required wrapper validation will run against the final committed head, including the documented devcontainer workflow.

## Limitations / follow-up

No game-runtime topology is required for this wrapper workspace feature.

Closes #522
