### PR TITLE
feat(workspace): register deploy-control as shared infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /content-1x/
 /content-toolkit/
 /devcontainer/
+/deploy-control/
 /editor/
 /github-settings/
 # Historical standalone inputs recognized by `atrinik migrate repositories`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,11 +5,11 @@
 - This MIT Python 3.11+ repository coordinates Atrinik repositories, not source;
   `./atrinik` and `components.json` manage profiles, worktrees, builds, runtimes,
   cleanup, migration, and supply-chain reports.
-- `default` selects the MIT replacement stack (Rust, Go, Protobuf, Astro, and
-  source-only Observatory).
+- `default` selects the MIT replacement stack (Rust, Go, Protobuf, Astro,
+  source-only Observatory) plus source-only `deploy-control`.
   Its standalone M1 foundations lack wrapper build/runtime integration.
-  `classic` selects playable C17/CMake/Ninja plus the MIT playtester. Never mix
-  providers or route unavailable replacement adapters through classic.
+  `classic` selects playable C17/CMake/Ninja plus MIT playtester; never mix
+  providers or route unavailable adapters through Classic.
 
 ## Folder structure and ownership
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,12 @@ The canonical `server`, `client`, `editor`, `protocol`, `renderer`,
 `content-toolkit`, `website`, and `observatory` repositories form the MIT
 replacement stack. `observatory` is source-only in the wrapper: it has no
 wrapper build adapter or runtime dependency and remains default-cohort only.
+The separately authored MIT `atrinik/deploy-control` repository is shared
+organization infrastructure for the Cloudflare Worker, Durable Object,
+protocol, and registered host-agent contracts. Its wrapper registration is
+source-only and default-only; package installation, release/deployment
+outputs, Cloudflare bindings, credentials, agent keys, host state, and mutable
+runtime state remain owned or stored outside this coordinator.
 Plain `./atrinik init` is replacement/default-only. Exact
 `./atrinik init --with classic` adds the complete currently playable classic
 cohort: the `atrinik/classic` monorepo checkout, the independent MIT

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ persistent server state safely.
 
 No checkout is a submodule. Primary repositories are ignored, independent Git
 checkouts directly beside this README (`./client`, `./server`, `./classic`,
-`./observatory`, and so on). The `atrinik/classic` checkout at `./classic`
+`./observatory`, `./deploy-control`, and so on). The `atrinik/classic` checkout at `./classic`
 contains the logical
 `classic-client`, `classic-server`, `classic-editor`,
 `classic-libatrinik`, and `classic-protocol` source roots. Generated worktrees,
@@ -160,7 +160,10 @@ Python dependency. GitHub
 Actions and container images use immutable commits or
 digests with human-readable update hints, and every active repository enables
 weekly Dependabot updates for its supported ecosystems. Git submodules are not
-a supported dependency path.
+a supported dependency path. The shared `deploy-control` checkout owns its
+Worker/agent package lock, action pins, runner contract, and release/deployment
+inputs; the wrapper records those boundaries without copying its implementation,
+credentials, bindings, or mutable host state.
 
 Validate the catalog alone or audit the exact checkouts selected by a complete
 profile. Initialize the replacement stack before its audit; use the additive
@@ -263,8 +266,10 @@ replacement build or runtime dependency.
 With no component arguments, `init` clones only the replacement/default
 initialization cohort. That includes the replacement MIT `server`, `client`,
 `editor`, `protocol`, `renderer`, `content-toolkit`, and `website` repositories;
-`content` from `atrinik/content@main`; compatible shared resources, sound, and
-metaserver code; and required development infrastructure. It does not clone
+`content` from `atrinik/content@main`; compatible shared resources, sound,
+metaserver code; the source-only shared `atrinik/deploy-control` checkout for
+organization infrastructure; and required development infrastructure. It does
+not clone
 `atrinik/classic`, `atrinik/playtester`, or the MIT-by-default `tools`
 repository with its GPL-2.0-or-later `map-checker-qt/` exception, and
 does not touch a retained historical `atrinik/content@1.x` checkout.
@@ -429,8 +434,8 @@ identity are coordinated here, while installation and tests remain owned by
 `atrinik/playtester`.
 
 Checkout entries have explicit local destinations; normally these are direct
-children of the wrapper root such as `./client`, `./classic`, `./content`, and
-`./observatory`.
+children of the wrapper root such as `./client`, `./classic`, `./content`,
+`./observatory`, and `./deploy-control`.
 Logical components name their owning checkout and a safe source root within
 it. Both stacks map role `content` to that one shared checkout. A local
 `./content-1x` directory may remain as preserved migration history, but it is
@@ -447,9 +452,11 @@ checkouts are reported as optional rather than invalidating status or a
 built-in profile.
 
 The manifest assigns logical roles such as `client`, `server`, `protocol`,
-`libatrinik`, `content`, `playtester`, and source-only `observatory` to
-providers within each stack. The `observatory` role is default-only and has no
-wrapper build adapter or runtime dependency. The
+`libatrinik`, `content`, `playtester`, source-only `observatory`, and shared
+source-only `deploy-control` to providers within each stack. The `observatory`
+and `deploy-control` roles are default-only and have no wrapper build adapter
+or runtime dependency; `deploy-control` owns its Worker/agent package and
+deployment workflow boundaries in its own repository. The
 built-in `default` and `classic` profiles resolve exactly one compatible
 provider for every role they require.
 A runnable service closure cannot combine replacement and classic

--- a/atrinik_workspace/model.py
+++ b/atrinik_workspace/model.py
@@ -58,6 +58,7 @@ REQUIRED_COHORT_CHECKOUTS = {
         "devcontainer",
         "github-settings",
         "observatory",
+        "deploy-control",
     },
     "classic": {
         "classic",
@@ -81,6 +82,7 @@ REQUIRED_STACK_PROVIDERS = {
         "devcontainer": "devcontainer",
         "github-settings": "github-settings",
         "observatory": "observatory",
+        "deploy-control": "deploy-control",
     },
     "classic": {
         "client": "classic-client",
@@ -116,6 +118,7 @@ LOGICAL_ROLES = {
     "devcontainer",
     "github-settings",
     "observatory",
+    "deploy-control",
 }
 IMPLEMENTATION_ROLES = {
     "client",

--- a/components.json
+++ b/components.json
@@ -15,7 +15,8 @@
       "metaserver-worker",
       "devcontainer",
       "github-settings",
-      "observatory"
+      "observatory",
+      "deploy-control"
     ],
     "classic": [
       "classic",
@@ -40,7 +41,8 @@
         "metaserver-worker",
         "devcontainer",
         "github-settings",
-        "observatory"
+        "observatory",
+        "deploy-control"
       ],
       "providers": {
         "client": "client",
@@ -56,7 +58,8 @@
         "metaserver-worker": "metaserver-worker",
         "devcontainer": "devcontainer",
         "github-settings": "github-settings",
-        "observatory": "observatory"
+        "observatory": "observatory",
+        "deploy-control": "deploy-control"
       }
     },
     "classic": {
@@ -204,6 +207,14 @@
       "branch": "main",
       "path": "observatory",
       "generation": "replacement",
+      "license": "MIT"
+    },
+    {
+      "name": "deploy-control",
+      "repository": "atrinik/deploy-control",
+      "branch": "main",
+      "path": "deploy-control",
+      "generation": "shared",
       "license": "MIT"
     },
     {
@@ -372,6 +383,16 @@
       "build": "none",
       "generation": "replacement",
       "provides": ["observatory"],
+      "requires": [],
+      "license": "MIT"
+    },
+    {
+      "name": "deploy-control",
+      "checkout": "deploy-control",
+      "source": ".",
+      "build": "none",
+      "generation": "shared",
+      "provides": ["deploy-control"],
       "requires": [],
       "license": "MIT"
     },

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,6 +44,15 @@ The default-only `observatory` component occupies
 `atrinik/observatory@main` at `./observatory` and provides a source-only
 `observatory` role. It has no wrapper build adapter or runtime dependency;
 Classic never selects it.
+The default-only shared `deploy-control` component occupies
+`atrinik/deploy-control@main` at `./deploy-control` and provides a source-only
+`deploy-control` role. Its root owns the Worker, Durable Object, protocol, and
+registered host-agent contracts; the wrapper provides no build or runtime
+adapter, and Classic never selects it. Package locks, npm caches, Wrangler
+dry-run/deployment output, release artifacts, and generated `dist` output stay
+with the deploy-control repository or its workflows. Cloudflare bindings,
+application and agent keys, host/player state, and mutable runtime state stay
+outside this coordinator.
 
 Manifest validation rejects duplicate checkout or component names, duplicate
 local destinations, unsafe or overlapping source roots within one checkout,
@@ -70,6 +79,10 @@ cohort, stack, role, and license, and mark uninitialized or non-selected commits
 unavailable so repeated coordinates such as `atrinik/content` or shared
 checkouts such as `atrinik/classic` cannot be collapsed into one ambiguous
 input.
+The shared `deploy-control` repository remains the authority for its Worker and
+agent dependency graph, action pins, runner contract, and release/deployment
+inputs. The wrapper inventory records those owned inputs and validation
+boundaries; it does not vendor or reimplement them.
 
 Source provenance is also a cross-repository contract.
 [`PROVENANCE.md`](PROVENANCE.md) is the single exhaustive historical MIT
@@ -91,6 +104,11 @@ separate eligible material, exclude conflicting embedded work, and record the
 exact source, destination, transformation, review, and registry revision. The
 Classic source remains GPL as distributed; later or uncovered contributions,
 dependencies, assets, and surrounding work receive no permission by association.
+Registering `atrinik/deploy-control` asserts only its separately authored MIT
+repository and ownership boundary. It does not copy Classic material, grant a
+new historical provenance permission, or relicense any Classic source; future
+deploy-control provenance remains recorded in that repository's own source and
+release history.
 
 The `supply-chain` command resolves component inputs through the same profile
 selectors as builds, then reads Git-indexed files without mutating a checkout.

--- a/docs/PROVENANCE.md
+++ b/docs/PROVENANCE.md
@@ -21,6 +21,18 @@ material receives additional MIT permission in the recorded destination; no
 surrounding file, dependency, asset, subtree, binary, or repository is
 relicensed.
 
+## Independent shared infrastructure
+
+`atrinik/deploy-control` is a separately authored MIT organization-infrastructure
+repository for the Cloudflare Worker, Durable Object, protocol, and registered
+host-agent contracts. The wrapper registration records its repository, branch,
+source root, license, and dependency/action ownership; it does not copy
+implementation or grant or relicense Classic material. Package locks,
+action pins, release/generated deployment outputs, and future source provenance
+remain owned by `deploy-control`. Cloudflare/application/agent keys, bindings,
+host state, player data, and mutable runtime state remain outside the wrapper.
+No historical MIT grant or provenance reuse is asserted by this registration.
+
 ## Identity evidence gates
 
 Historical identity reconciliation may use the privacy-preserving attestation

--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -232,6 +232,28 @@
       ],
       "license": "MIT",
       "commit": null,
+      "name": "deploy-control",
+      "repository": "atrinik/deploy-control",
+      "role": "Cloudflare control plane and registered host-agent infrastructure",
+      "roles": [
+        "deploy-control"
+      ],
+      "stacks": [
+        "default"
+      ],
+      "supported": true,
+      "checkout": "deploy-control",
+      "source": "."
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "default"
+      ],
+      "license": "MIT",
+      "commit": null,
       "name": "devcontainer",
       "repository": "atrinik/devcontainer",
       "role": "Linux and Windows build images",
@@ -669,6 +691,7 @@
         "client",
         "content",
         "content-toolkit",
+        "deploy-control",
         "devcontainer",
         "editor",
         "github-settings",
@@ -716,6 +739,11 @@
         {
           "repository": "content-toolkit",
           "path": ".github/workflows/validate.yml",
+          "contains": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1"
+        },
+        {
+          "repository": "deploy-control",
+          "path": ".github/workflows/check.yml",
           "contains": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1"
         },
         {
@@ -899,6 +927,7 @@
         "client",
         "content",
         "content-toolkit",
+        "deploy-control",
         "devcontainer",
         "editor",
         "github-settings",
@@ -951,6 +980,11 @@
         {
           "repository": "content-toolkit",
           "path": ".github/workflows/release.yml",
+          "contains": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0"
+        },
+        {
+          "repository": "deploy-control",
+          "path": ".github/workflows/check.yml",
           "contains": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0"
         },
         {
@@ -2183,6 +2217,57 @@
       ]
     },
     {
+      "id": "language/deploy-control-npm",
+      "name": "Deploy-control Worker and agent npm dependency graph",
+      "kind": "language-package-set",
+      "owner": "deploy-control",
+      "scope": [
+        "deploy-control"
+      ],
+      "required": true,
+      "version": "lockfileVersion-3",
+      "version_source": "package-lock.json",
+      "license": "NOASSERTION",
+      "source_url": "https://www.npmjs.com/",
+      "locator": "pkg:npm/atrinik-deploy-control@0.1.0",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "npm ci installs the exact package-lock graph",
+      "update_cadence_days": 7,
+      "update_mechanism": "Grouped Dependabot npm development and production updates",
+      "eol_response": "Upgrade incompatible packages on the supported Node line or replace them",
+      "validation": "npm ci, TypeScript checks, Vitest, and Wrangler dry-run validation",
+      "disposition": "retain",
+      "packages": [
+        "@types/node",
+        "typescript",
+        "vitest",
+        "wrangler"
+      ],
+      "evidence": [
+        {
+          "repository": "deploy-control",
+          "path": ".github/dependabot.yml",
+          "contains": "package-ecosystem: npm"
+        },
+        {
+          "repository": "deploy-control",
+          "path": "package-lock.json",
+          "contains": "\"lockfileVersion\": 3"
+        },
+        {
+          "repository": "deploy-control",
+          "path": "package.json",
+          "contains": "\"name\": \"atrinik-deploy-control\""
+        },
+        {
+          "repository": "deploy-control",
+          "path": "package.json",
+          "contains": "\"wrangler\": \"4.123.0\""
+        }
+      ]
+    },
+    {
       "id": "language/metaserver-npm",
       "name": "Metaserver Worker npm dependency graph",
       "kind": "language-package-set",
@@ -2223,6 +2308,11 @@
         },
         {
           "repository": "metaserver-worker",
+          "path": "deployment/review-check/package.json",
+          "contains": "\"private\": true"
+        },
+        {
+          "repository": "metaserver-worker",
           "path": "package-lock.json",
           "contains": "\"lockfileVersion\": 3"
         },
@@ -2234,7 +2324,7 @@
         {
           "repository": "metaserver-worker",
           "path": "package.json",
-          "contains": "\"wrangler\": \"4.119.0\""
+          "contains": "\"wrangler\": \"4.123.0\""
         }
       ]
     },
@@ -4389,6 +4479,7 @@
         "client",
         "content",
         "content-toolkit",
+        "deploy-control",
         "devcontainer",
         "editor",
         "github-settings",
@@ -4441,6 +4532,11 @@
         {
           "repository": "content-toolkit",
           "path": ".github/workflows/validate.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "deploy-control",
+          "path": ".github/workflows/check.yml",
           "contains": "runs-on: ubuntu-24.04"
         },
         {
@@ -4609,6 +4705,7 @@
         "client",
         "content",
         "content-toolkit",
+        "deploy-control",
         "devcontainer",
         "editor",
         "github-settings",
@@ -4624,7 +4721,7 @@
       ],
       "required": true,
       "version": "wrapper release 22; Classic release 24; Worker, playtester, and replacement releases 24.18.1",
-      "version_source": "Worker/website package engines and exact release workflow lines",
+      "version_source": "Worker/website/deploy-control package engines and exact release workflow lines",
       "license": "MIT",
       "source_url": "https://nodejs.org/",
       "locator": "pkg:generic/node",
@@ -4665,6 +4762,11 @@
           "repository": "content-toolkit",
           "path": ".github/workflows/release.yml",
           "contains": "node-version: 24.18.1"
+        },
+        {
+          "repository": "deploy-control",
+          "path": "package.json",
+          "contains": "\"node\": \"24.18.1\""
         },
         {
           "repository": "devcontainer",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -665,6 +665,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
                 "devcontainer",
                 "github-settings",
                 "observatory",
+                "deploy-control",
             },
         )
         self.assertEqual(
@@ -689,6 +690,25 @@ class ReleaseConfigurationTests(unittest.TestCase):
             "observatory",
         )
         self.assertNotIn("observatory", manifest.cohorts["classic"])
+        deploy_control = manifest.by_name["deploy-control"]
+        self.assertEqual(
+            manifest.by_checkout["deploy-control"].repository,
+            "atrinik/deploy-control",
+        )
+        self.assertEqual(manifest.by_checkout["deploy-control"].path, "deploy-control")
+        self.assertEqual(deploy_control.generation, "shared")
+        self.assertEqual(deploy_control.build, "none")
+        self.assertEqual(deploy_control.provides, ("deploy-control",))
+        self.assertEqual(deploy_control.requires, ())
+        self.assertEqual(
+            manifest.stack("default").providers["deploy-control"].name,
+            "deploy-control",
+        )
+        self.assertEqual(
+            manifest.effective_build("default", "deploy-control"),
+            "none",
+        )
+        self.assertNotIn("deploy-control", manifest.cohorts["classic"])
         self.assertEqual(manifest.effective_build("default", "content"), "none")
         self.assertEqual(
             manifest.effective_build("classic", "content"), "classic-content"

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -190,6 +190,17 @@ class InventoryTests(unittest.TestCase):
         self.assertEqual(observatory.roles, ("observatory",))
         self.assertEqual(observatory.license, "MIT")
         self.assertEqual(observatory.audit_mode, "full")
+        deploy_control = inventory.repositories_by_name["deploy-control"]
+        self.assertEqual(deploy_control.repository, "atrinik/deploy-control")
+        self.assertEqual(deploy_control.cohorts, ("default",))
+        self.assertEqual(deploy_control.stacks, ("default",))
+        self.assertEqual(deploy_control.roles, ("deploy-control",))
+        self.assertEqual(deploy_control.license, "MIT")
+        self.assertEqual(deploy_control.audit_mode, "full")
+        self.assertEqual(
+            inventory.repositories_by_name["deploy-control"].source,
+            ".",
+        )
         self.assertEqual(
             inventory.repositories_by_name["content"].stacks,
             ("classic", "default"),


### PR DESCRIPTION
## Summary

Register `atrinik/deploy-control` as a shared organization-infrastructure checkout for workspace ownership and supply-chain tracking.

## Implementation / behavior

- Add the `deploy-control` physical checkout and source-only logical component to the default cohort and replacement profile.
- Keep it out of the Classic stack and do not add unavailable build or runtime adapters.
- Update the manifest model, workspace guidance, architecture, supply-chain, and provenance boundaries for the Worker and host-agent owner.
- Keep credentials, host state, player data, private keys, and mutable deployment state outside this repository.

## Validation

- `./atrinik manifest validate`
- `./atrinik profile show default --json`
- `./atrinik status --json`
- focused model, guidance, and supply-chain tests
- complete wrapper validation and `git diff --check`

Closes #528
