### PR TITLE
feat(wrapper): add native Windows support

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -93,19 +93,22 @@ jobs:
       - name: Verify deliberate capability results remain stable
         shell: pwsh
         run: |
-          $errorPath = Join-Path $env:RUNNER_TEMP "atrinik-capability-error.txt"
-          python .\atrinik up 2> $errorPath
-          if ($LASTEXITCODE -ne 1) { throw "native Windows up did not return capability status 1" }
-          $message = Get-Content -Raw $errorPath
-          if ($message -notmatch "unavailable on native Windows") {
-            throw "native Windows capability diagnostic is missing"
+          function Invoke-CapabilityCommand {
+            param(
+              [string]$Label,
+              [string[]]$Arguments
+            )
+            $message = (& python .\atrinik @Arguments 2>&1 | Out-String)
+            $status = $LASTEXITCODE
+            Write-Host "$Label exit status: $status"
+            Write-Host $message
+            if ($status -ne 1) { throw "native Windows $Label did not return capability status 1" }
+            if ($message -notmatch "unavailable on native Windows") {
+              throw "native Windows $Label capability diagnostic is missing"
+            }
           }
-          python .\atrinik build all --profile classic 2> $errorPath
-          if ($LASTEXITCODE -ne 1) { throw "native Windows build did not return capability status 1" }
-          $message = Get-Content -Raw $errorPath
-          if ($message -notmatch "unavailable on native Windows") {
-            throw "native Windows build capability diagnostic is missing"
-          }
+          Invoke-CapabilityCommand "up" @("up")
+          Invoke-CapabilityCommand "build" @("build", "all", "--profile", "classic")
 
   integration:
     name: Integration validation

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -56,6 +56,57 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  native-windows-smoke:
+    name: Native Windows wrapper smoke
+    runs-on: windows-2025
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+          python-version: "3.13"
+      - name: Install coverage tooling
+        run: python -m pip install --requirement requirements-dev.txt
+      - name: Validate native Windows CLI import and manifest
+        shell: pwsh
+        run: |
+          python .\atrinik --help | Out-Null
+          python .\atrinik manifest validate
+      - name: Initialize the complete Classic cohort
+        shell: pwsh
+        run: python .\atrinik init --with classic --jobs 4
+      - name: Validate native Windows status, profile, and worktree paths
+        shell: pwsh
+        run: |
+          $status = python .\atrinik status --json
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $rows = $status | ConvertFrom-Json
+          if (($rows | Where-Object { -not $_.initialized }).Count -ne 0) {
+            throw "native Windows initialization left an uninitialized checkout"
+          }
+          python .\atrinik profile show classic --json | Out-Null
+          python .\atrinik worktree list --wrapper-self --json | Out-Null
+      - name: Verify deliberate capability results remain stable
+        shell: pwsh
+        run: |
+          $errorPath = Join-Path $env:RUNNER_TEMP "atrinik-capability-error.txt"
+          python .\atrinik up 2> $errorPath
+          if ($LASTEXITCODE -ne 1) { throw "native Windows up did not return capability status 1" }
+          $message = Get-Content -Raw $errorPath
+          if ($message -notmatch "unavailable on native Windows") {
+            throw "native Windows capability diagnostic is missing"
+          }
+          python .\atrinik build all --profile classic 2> $errorPath
+          if ($LASTEXITCODE -ne 1) { throw "native Windows build did not return capability status 1" }
+          $message = Get-Content -Raw $errorPath
+          if ($message -notmatch "unavailable on native Windows") {
+            throw "native Windows build capability diagnostic is missing"
+          }
+
   integration:
     name: Integration validation
     if: always()

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -109,6 +109,7 @@ jobs:
           }
           Invoke-CapabilityCommand "up" @("up")
           Invoke-CapabilityCommand "build" @("build", "all", "--profile", "classic")
+          $global:LASTEXITCODE = 0
 
   integration:
     name: Integration validation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,14 +2,16 @@
 
 ## Overview
 
-- This MIT Python 3.11+ repository coordinates Atrinik repositories, not source;
-  `./atrinik` and `components.json` manage profiles, worktrees, builds, runtimes,
-  cleanup, migration, and supply-chain reports.
+- This repository coordinates Atrinik repositories; `./atrinik` and
+  `components.json` manage profiles, worktrees, builds, runtimes, cleanup,
+  migration, supply-chain reports.
 - `default` selects the MIT replacement stack (Rust, Go, Protobuf, Astro, and
   source-only Observatory).
-  Its standalone M1 foundations lack wrapper build/runtime integration.
+  M1 foundations lack wrapper integration.
   `classic` selects playable C17/CMake/Ninja plus the MIT playtester. Never mix
   providers or route unavailable replacement adapters through classic.
+- Native Windows supports repository commands; Linux-only build/runtime commands
+  return stable capability errors.
 
 ## Folder structure and ownership
 
@@ -19,8 +21,8 @@
   `components.json`; machine policy lives in `supply-chain/` and `governance/`.
 - Workflows live in `.agents/skills/`, composition in `.devcontainer/`,
   CI/release in `.github/`, and helpers in `scripts/`.
-- Manifest destinations are independent ignored repositories; `workspace/` and
-  `build/` are ignored generated state, so root status omits them.
+- Manifest destinations are ignored repositories; `workspace/` and `build/` are
+  ignored generated state omitted from root status.
 - Resolve ownership through `components.json` and the checkout's nearest
   `AGENTS.md`; keep implementation, tests, packages, and releases there.
 - `classic/` provides `classic-*`; stacks share `content@main`. `content-1x/`
@@ -32,15 +34,15 @@
 ## Core behaviors and patterns
 
 - Use `atrinik-multi-repo-workspace` for wrapper ownership, profiles, worktrees,
-  migration, cleanup, releases, CLI, or layout; add only applicable specialist
-  skills and use `atrinik-guidance-maintenance` for guidance audits.
+  migration, cleanup, releases, CLI, or layout; add applicable specialist skills
+  and use `atrinik-guidance-maintenance` for guidance audits.
 - Use `atrinik-issue-delivery` only when explicitly invoked for an issue or
   existing PR; it stops before merge.
 - Use `atrinik-program-delivery` only when explicitly invoked for an ordered
   master issue; it composes leaves across merge gates and stops before merge or
   issue closure.
-- Never replace or move a dirty primary checkout, remove a dirty worktree, or
-  overwrite mutable server data. Preserve recoverable migration inputs.
+- Never replace dirty primaries, remove dirty worktrees, or overwrite mutable
+  server data; preserve migration inputs.
 - Cleanup is preview-first; delivery completion grants none. Ledger terminal
   transactions stay separate from `./atrinik cleanup`. Preserve dirty,
   detached, locked, active, referenced, or uncertain targets; history fails

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,16 +2,14 @@
 
 ## Overview
 
-- This MIT Python 3.11+ repository coordinates Atrinik repositories, not source;
-  `./atrinik` and `components.json` manage profiles, worktrees, builds, runtimes,
-  cleanup, migration, and supply-chain reports.
+- This Python 3.11+ wrapper coordinates Atrinik repositories; `./atrinik` and
+  `components.json` own profiles, worktrees, builds, runtimes, cleanup,
+  migration, and supply-chain reports.
 - `default` selects the MIT replacement stack (Rust, Go, Protobuf, Astro,
-  source-only Observatory) plus source-only `deploy-control`.
-  Its standalone M1 foundations lack wrapper build/runtime integration.
-  `classic` selects playable C17/CMake/Ninja plus MIT playtester; never mix
-  providers or route unavailable adapters through Classic.
-- Native Windows supports repository commands; Linux-only build/runtime commands
-  return stable capability errors.
+  source-only Observatory) plus source-only `deploy-control`; M1 foundations
+  lack wrapper integration. `classic` is playable C17/CMake/Ninja plus MIT
+  playtester; never mix providers.
+- Windows supports repository commands; Linux-only commands return stable errors.
 
 ## Folder structure and ownership
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,6 +187,21 @@ and comparable-run method.
 Use [local test execution](docs/LOCAL_TESTING.md) for targeted, serial, or
 process-isolated parallel runs before the complete validation recipe.
 
+Native Windows wrapper changes also require a clean Windows host or runner
+smoke of the supported surface:
+
+~~~powershell
+python .\atrinik --help
+python .\atrinik manifest validate
+python .\atrinik init --with classic
+python .\atrinik status --json
+python .\atrinik profile show classic --json
+~~~
+
+Supervised topology, build-publication, cleanup, migration, state, scenario,
+and direct-run commands must retain their documented capability diagnostic on
+Windows; do not replace it with a weaker lock or process cleanup path.
+
 When changing the repository-local skill, also run the skill validator
 available in the active Codex installation; its exact path is
 environment-specific.

--- a/README.md
+++ b/README.md
@@ -23,12 +23,40 @@ directory.
 
 ## Requirements
 
-- Python 3.11 or newer; supervised topologies require Linux process identity
-  and pidfd support
-- Git and the authenticated GitHub CLI (`gh`)
+- Python 3.11 or newer and Git
+- Native Windows support uses Python's Windows path handling and PowerShell or
+  Command Prompt; WSL and the devcontainer are not required for the supported
+  wrapper surface below
+- The GitHub CLI (`gh`) authenticated for GitHub operations
 - CMake, Ninja, and the dependencies required by the selected component when
   building the classic native stack
 - Node.js 20 or newer when building `metaserver-worker`
+
+### Native Windows wrapper support
+
+The coordinator can be invoked directly from a native Windows checkout with
+`python .\atrinik ...`. The supported Windows surface includes CLI import and
+help, manifest/provenance/supply-chain validation, replacement or Classic
+initialization and synchronization, repository status, profile inspection and
+publication, path resolution, and worktree inventory. For example:
+
+~~~powershell
+python .\atrinik manifest validate
+python .\atrinik init --with classic
+python .\atrinik status --json
+python .\atrinik profile show classic --json
+~~~
+
+Native Windows locks use the kernel `LockFileEx` API, and child Git processes
+receive the active lock handles. JSON publication uses an atomic replacement
+and `FlushFileBuffers`; path and junction components are rejected. Windows
+does not expose the POSIX descriptor-relative directory and process-identity
+facilities used by the wrapper's supervised topology, build publication,
+cleanup, migration, state, scenario, and direct-run workflows. Those commands
+return a stable capability diagnostic naming Linux/WSL2 or the documented
+Windows package workflow rather than weakening locking, cleanup, or topology
+isolation. The complete support matrix is maintained in
+[`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 
 The Atrinik development container supplies the native build dependencies. Run
 all commands below from this repository's root.

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -4,7 +4,6 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import ExitStack, contextmanager, nullcontext
 from contextvars import copy_context
 from datetime import datetime, timezone
-import fcntl
 import hashlib
 import heapq
 import json
@@ -18,6 +17,7 @@ import sys
 from typing import Any, Callable, Iterable, Iterator
 
 from .locking import LockBusyError, active_lock_fds
+from .platform_compat import fcntl
 from .content_migration import CONTENT_MIGRATION_PENDING, CONTENT_MIGRATION_RECORD
 from .delivery import inventory_active_delivery_evidence
 from .migration import MIGRATION_PENDING, MIGRATION_RECORD, OPERATION_PATHS

--- a/atrinik_workspace/cleanup.py
+++ b/atrinik_workspace/cleanup.py
@@ -17,7 +17,7 @@ import sys
 from typing import Any, Callable, Iterable, Iterator
 
 from .locking import LockBusyError, active_lock_fds
-from .platform_compat import fcntl
+from .platform_compat import fcntl, inherited_subprocess_handles
 from .content_migration import CONTENT_MIGRATION_PENDING, CONTENT_MIGRATION_RECORD
 from .delivery import inventory_active_delivery_evidence
 from .migration import MIGRATION_PENDING, MIGRATION_RECORD, OPERATION_PATHS
@@ -190,13 +190,14 @@ HISTORICAL_PULL_BASE_BOUNDARIES = {
 
 def _command(path: Path, *arguments: str) -> str:
     try:
-        result = subprocess.run(
-            ["git", "-C", str(path), *arguments],
-            check=True,
-            capture_output=True,
-            text=True,
-            pass_fds=active_lock_fds(),
-        )
+        with inherited_subprocess_handles(active_lock_fds()) as inheritance:
+            result = subprocess.run(
+                ["git", "-C", str(path), *arguments],
+                check=True,
+                capture_output=True,
+                text=True,
+                **inheritance,
+            )
     except FileNotFoundError as error:
         raise WorkspaceError("required command not found: git") from error
     except subprocess.CalledProcessError as error:
@@ -4404,24 +4405,25 @@ class Cleanup:
     @staticmethod
     def _github_pulls(repository: str, head: str) -> list[dict[str, Any]]:
         try:
-            result = subprocess.run(
-                [
-                    "gh",
-                    "api",
-                    f"repos/{repository}/commits/{head}/pulls?per_page=100",
-                    "--header",
-                    "Accept: application/vnd.github+json",
-                    "--paginate",
-                    "--jq",
-                    ".[] | {number,state,merged_at,merge_commit_sha,"
-                    "head:{sha:.head.sha},base:{ref:.base.ref,sha:.base.sha},html_url}",
-                ],
-                check=True,
-                capture_output=True,
-                text=True,
-                pass_fds=active_lock_fds(),
-                timeout=30,
-            )
+            with inherited_subprocess_handles(active_lock_fds()) as inheritance:
+                result = subprocess.run(
+                    [
+                        "gh",
+                        "api",
+                        f"repos/{repository}/commits/{head}/pulls?per_page=100",
+                        "--header",
+                        "Accept: application/vnd.github+json",
+                        "--paginate",
+                        "--jq",
+                        ".[] | {number,state,merged_at,merge_commit_sha,"
+                        "head:{sha:.head.sha},base:{ref:.base.ref,sha:.base.sha},html_url}",
+                    ],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                    **inheritance,
+                )
         except FileNotFoundError as error:
             raise WorkspaceError("required command not found: gh") from error
         except subprocess.CalledProcessError as error:

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -704,7 +704,7 @@ def main(arguments: list[str] | None = None) -> int:
     workspace: Any = None
     command_maintenance: Any = None
     try:
-        if IS_WINDOWS and (
+        if IS_WINDOWS and (  # pragma: no cover - exercised by native Windows CI
             options.command
             in {
                 "build",

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from .completion import mark, protocol, protocol_command, shell_script
 from .model import Manifest, WorkspaceError
+from .platform_compat import IS_WINDOWS, PlatformCapabilityError, require_linux_capability
 
 
 # Keep completion startup independent from the heavyweight workspace/runtime module.
@@ -703,6 +704,36 @@ def main(arguments: list[str] | None = None) -> int:
     workspace: Any = None
     command_maintenance: Any = None
     try:
+        if IS_WINDOWS and (
+            options.command
+            in {
+                "build",
+                "cleanup",
+                "down",
+                "logs",
+                "migrate",
+                "package",
+                "ps",
+                "run",
+                "scenario",
+                "scope",
+                "state",
+                "topology",
+                "up",
+            }
+            or (
+                options.command == "dev"
+                and options.dev_command in {"build", "restart", "up"}
+            )
+            or (
+                options.command == "worktree"
+                and options.worktree_command in {"create", "remove"}
+            )
+        ):
+            require_linux_capability(
+                f"the '{options.command}' command",
+                "descriptor-relative filesystem operations or supervised process identity",
+            )
         if options.command == "completion":
             print(shell_script(options.shell), end="")
             return 0
@@ -1504,7 +1535,7 @@ def main(arguments: list[str] | None = None) -> int:
                     options.dry_run,
                 )
         return 0
-    except WorkspaceError as error:
+    except (PlatformCapabilityError, WorkspaceError) as error:
         print(f"error: {error}", file=sys.stderr)
         return 1
     except OSError as error:

--- a/atrinik_workspace/content_migration.py
+++ b/atrinik_workspace/content_migration.py
@@ -34,6 +34,7 @@ from .process_tree import (
     holders_exist,
     lease_locked,
 )
+from .platform_compat import inherited_subprocess_handles
 from .sound import validate_release_coordinates
 from .supervisor import process_matches
 
@@ -88,13 +89,14 @@ def _durable_unlink(path: Path, *, missing_ok: bool = False) -> None:
 
 def _git(path: Path, *arguments: str, check: bool = True) -> str:
     try:
-        result = subprocess.run(
-            ["git", "-C", str(path), *arguments],
-            check=check,
-            capture_output=True,
-            text=True,
-            pass_fds=active_lock_fds(),
-        )
+        with inherited_subprocess_handles(active_lock_fds()) as inheritance:
+            result = subprocess.run(
+                ["git", "-C", str(path), *arguments],
+                check=check,
+                capture_output=True,
+                text=True,
+                **inheritance,
+            )
     except FileNotFoundError as error:
         raise WorkspaceError("required command not found: git") from error
     except subprocess.CalledProcessError as error:
@@ -108,13 +110,14 @@ def _git(path: Path, *arguments: str, check: bool = True) -> str:
 
 def _git_succeeds(path: Path, *arguments: str) -> bool:
     try:
-        return subprocess.run(
-            ["git", "-C", str(path), *arguments],
-            check=False,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            pass_fds=active_lock_fds(),
-        ).returncode == 0
+        with inherited_subprocess_handles(active_lock_fds()) as inheritance:
+            return subprocess.run(
+                ["git", "-C", str(path), *arguments],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                **inheritance,
+            ).returncode == 0
     except FileNotFoundError as error:
         raise WorkspaceError("required command not found: git") from error
 

--- a/atrinik_workspace/delivery.py
+++ b/atrinik_workspace/delivery.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from .locking import active_lock_fds
 from .model import WorkspaceError
+from .platform_compat import inherited_subprocess_handles
 
 
 _INVENTORY_LIMIT = 32 * 1024 * 1024
@@ -88,15 +89,16 @@ def inventory_active_delivery_evidence(wrapper_root: Path) -> ActiveDeliveryEvid
     helper = root / _HELPER_RELATIVE
     _regular_path(helper, "delivery-ledger helper")
     try:
-        result = subprocess.run(
-            [sys.executable, "-B", str(helper), "inventory", str(review_root)],
-            cwd=root,
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=_INVENTORY_TIMEOUT_SECONDS,
-            pass_fds=active_lock_fds(),
-        )
+        with inherited_subprocess_handles(active_lock_fds()) as inheritance:
+            result = subprocess.run(
+                [sys.executable, "-B", str(helper), "inventory", str(review_root)],
+                cwd=root,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=_INVENTORY_TIMEOUT_SECONDS,
+                **inheritance,
+            )
     except (OSError, subprocess.TimeoutExpired) as error:
         raise WorkspaceError(f"delivery-ledger inventory failed: {error}") from error
     if (

--- a/atrinik_workspace/locking.py
+++ b/atrinik_workspace/locking.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from contextlib import ExitStack, contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
-import fcntl
 import hashlib
 import json
 import os
@@ -18,6 +17,12 @@ from datetime import datetime, timezone
 from typing import BinaryIO, Callable, Iterator, TextIO
 
 from .model import WorkspaceError
+from .platform_compat import (
+    IS_WINDOWS,
+    O_CLOEXEC,
+    assert_no_symlink_components,
+    fcntl,
+)
 
 
 LAYOUT_WRITER_INTENT_SUFFIX = ".writer-intent"
@@ -120,7 +125,43 @@ def _open_lock(
     *,
     directory_fd: int | None = None,
 ) -> TextIO:
-    flags = os.O_RDWR | os.O_CREAT | os.O_CLOEXEC
+    if IS_WINDOWS:
+        if directory_fd is not None:
+            raise WorkspaceError(
+                "descriptor-relative lock paths are unavailable on native Windows"
+            )
+        lock: TextIO | None = None
+        try:
+            assert_no_symlink_components(path, "lock")
+            opened_parent = path.parent.stat(follow_symlinks=False)
+            if not stat.S_ISDIR(opened_parent.st_mode):
+                raise OSError(f"lock parent is not a directory: {path.parent}")
+            lock = path.open("a+", encoding="utf-8")
+            opened = os.fstat(lock.fileno())
+            assert_no_symlink_components(path, "lock")
+            visible = path.stat(follow_symlinks=False)
+            visible_parent = path.parent.stat(follow_symlinks=False)
+            if (
+                not stat.S_ISREG(opened.st_mode)
+                or not stat.S_ISREG(visible.st_mode)
+                or (opened.st_dev, opened.st_ino) != (visible.st_dev, visible.st_ino)
+                or (opened_parent.st_dev, opened_parent.st_ino)
+                != (visible_parent.st_dev, visible_parent.st_ino)
+            ):
+                raise WorkspaceError(f"{description} lock identity changed during open: {path}")
+            return lock
+        except WorkspaceError:
+            if lock is not None:
+                lock.close()
+            raise
+        except OSError as error:
+            if lock is not None:
+                lock.close()
+            raise WorkspaceError(
+                f"cannot open {description} lock {path}: {error}"
+            ) from error
+
+    flags = os.O_RDWR | os.O_CREAT | O_CLOEXEC
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
     directory_flags = os.O_RDONLY | os.O_CLOEXEC
@@ -181,6 +222,11 @@ def _advisory_lock(
     directory_fd: int | None = None,
 ) -> Iterator[TextIO]:
     if directory_fd is None:
+        if IS_WINDOWS:
+            try:
+                assert_no_symlink_components(path.parent, "lock")
+            except OSError as error:
+                raise WorkspaceError(str(error)) from error
         path.parent.mkdir(parents=True, exist_ok=True)
     with _open_lock(path, description, directory_fd=directory_fd) as lock:
         try:
@@ -249,6 +295,11 @@ def _reap_staged_resource_owners(
 def _lease_owner_summary(
     path: Path, *, wait_for_transition: bool = True
 ) -> str:
+    if IS_WINDOWS:
+        return (
+            "native Windows lock owner metadata is unavailable; "
+            "the kernel lock itself remains authoritative"
+        )
     owners = path.with_name(f"{path.name}.owners")
     parent_descriptor: int | None = None
     owners_descriptor: int | None = None
@@ -1094,6 +1145,37 @@ def resource_locks(
             request.recovery,
         )
     ordered = sorted(combined.values(), key=lambda request: request.sort_key)
+    if IS_WINDOWS:
+        # Windows has no descriptor-relative directory API.  Use the same
+        # kernel-backed LockFileEx leases and fair layout lock sequence, but do
+        # not publish POSIX owner sidecars whose identity cannot be proven
+        # without directory descriptors.  A held kernel lock is still the
+        # authority for admission and release.
+        with ExitStack() as stack:
+            leases: list[TextIO] = []
+            for request in ordered:
+                request_root = root(request) if callable(root) else root
+                path = resource_lock_path(request_root, request.kind, request.coordinate)
+                description = (
+                    f"resource {request.kind} coordinate {request.coordinate}"
+                )
+                if request.mode == "exclusive":
+                    context = exclusive_layout_lock(
+                        path,
+                        description,
+                        nonblocking,
+                        recovery_action=request.recovery,
+                    )
+                else:
+                    context = shared_layout_lock(
+                        path,
+                        description,
+                        nonblocking,
+                        recovery_action=request.recovery,
+                    )
+                leases.append(stack.enter_context(context))
+            yield tuple(leases)
+        return
     with ExitStack() as stack:
         leases: list[TextIO] = []
         for request in ordered:
@@ -1175,6 +1257,16 @@ def resource_lifetime_reader(
     request: LeaseRequest,
 ) -> Iterator[TextIO]:
     """Hold a fair diagnosed resource reader without subprocess registration."""
+
+    if IS_WINDOWS:
+        path = resource_lock_path(root, request.kind, request.coordinate)
+        with shared_layout_lock(
+            path,
+            f"resource {request.kind} coordinate {request.coordinate}",
+            recovery_action=request.recovery,
+        ) as lease:
+            yield lease
+        return
 
     directory_fd = _ensure_resource_lock_directory(root, request.kind)
     path = resource_lock_path(root, request.kind, request.coordinate)

--- a/atrinik_workspace/locking.py
+++ b/atrinik_workspace/locking.py
@@ -125,7 +125,7 @@ def _open_lock(
     *,
     directory_fd: int | None = None,
 ) -> TextIO:
-    if IS_WINDOWS:
+    if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
         if directory_fd is not None:
             raise WorkspaceError(
                 "descriptor-relative lock paths are unavailable on native Windows"
@@ -222,7 +222,7 @@ def _advisory_lock(
     directory_fd: int | None = None,
 ) -> Iterator[TextIO]:
     if directory_fd is None:
-        if IS_WINDOWS:
+        if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
             try:
                 assert_no_symlink_components(path.parent, "lock")
             except OSError as error:
@@ -295,7 +295,7 @@ def _reap_staged_resource_owners(
 def _lease_owner_summary(
     path: Path, *, wait_for_transition: bool = True
 ) -> str:
-    if IS_WINDOWS:
+    if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
         return (
             "native Windows lock owner metadata is unavailable; "
             "the kernel lock itself remains authoritative"
@@ -1145,7 +1145,7 @@ def resource_locks(
             request.recovery,
         )
     ordered = sorted(combined.values(), key=lambda request: request.sort_key)
-    if IS_WINDOWS:
+    if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
         # Windows has no descriptor-relative directory API.  Use the same
         # kernel-backed LockFileEx leases and fair layout lock sequence, but do
         # not publish POSIX owner sidecars whose identity cannot be proven
@@ -1258,7 +1258,7 @@ def resource_lifetime_reader(
 ) -> Iterator[TextIO]:
     """Hold a fair diagnosed resource reader without subprocess registration."""
 
-    if IS_WINDOWS:
+    if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
         path = resource_lock_path(root, request.kind, request.coordinate)
         with shared_layout_lock(
             path,

--- a/atrinik_workspace/migration.py
+++ b/atrinik_workspace/migration.py
@@ -107,6 +107,27 @@ OPERATION_PATHS = (
 def rename_no_replace(source: Path, destination: Path) -> None:
     """Atomically move *source* without replacing a raced-in destination."""
 
+    if os.name == "nt":
+        if destination.exists() or destination.is_symlink():
+            raise WorkspaceError(
+                f"destination appeared before atomic install: {destination}"
+            )
+        try:
+            # Windows' MoveFileEx path used by os.rename does not replace an
+            # existing destination, so the kernel closes the check/rename race
+            # without requiring POSIX renameat2.
+            os.rename(source, destination)
+        except FileExistsError as error:
+            raise WorkspaceError(
+                f"destination appeared before atomic install: {destination}"
+            ) from error
+        except OSError as error:
+            raise WorkspaceError(
+                f"cannot move path without replacement: {source} -> {destination}: "
+                f"{error}"
+            ) from error
+        return
+
     try:
         renameat2 = ctypes.CDLL(None, use_errno=True).renameat2
     except AttributeError as error:

--- a/atrinik_workspace/migration.py
+++ b/atrinik_workspace/migration.py
@@ -28,6 +28,7 @@ from .model import (
     unlink_validated_json,
 )
 from .process_tree import bound_lease_locked, control_socket_path, lease_locked
+from .platform_compat import inherited_subprocess_handles
 from .sound import validate_release_coordinates
 from .supervisor import process_matches
 
@@ -46,13 +47,14 @@ def physical_repository_lock_path(repository_root: Path) -> Path:
 
     repository = Path(repository_root).resolve()
     try:
-        result = subprocess.run(
-            ["git", "-C", str(repository), "rev-parse", "--git-common-dir"],
-            check=True,
-            capture_output=True,
-            text=True,
-            pass_fds=active_lock_fds(),
-        )
+        with inherited_subprocess_handles(active_lock_fds()) as inheritance:
+            result = subprocess.run(
+                ["git", "-C", str(repository), "rev-parse", "--git-common-dir"],
+                check=True,
+                capture_output=True,
+                text=True,
+                **inheritance,
+            )
     except (OSError, subprocess.CalledProcessError) as error:
         raise WorkspaceError(
             f"cannot derive physical repository maintenance lock: {repository}"
@@ -107,7 +109,7 @@ OPERATION_PATHS = (
 def rename_no_replace(source: Path, destination: Path) -> None:
     """Atomically move *source* without replacing a raced-in destination."""
 
-    if os.name == "nt":
+    if os.name == "nt":  # pragma: no cover - exercised by native Windows CI
         if destination.exists() or destination.is_symlink():
             raise WorkspaceError(
                 f"destination appeared before atomic install: {destination}"
@@ -206,14 +208,15 @@ def classic_lineage(path: Path, canonical: str) -> bool:
 
     def inspect(*arguments: str) -> subprocess.CompletedProcess[bytes]:
         try:
-            return subprocess.run(
-                ["git", "-C", str(path), *arguments],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                check=False,
-                env=environment,
-                pass_fds=active_lock_fds(),
-            )
+            with inherited_subprocess_handles(active_lock_fds()) as inheritance:
+                return subprocess.run(
+                    ["git", "-C", str(path), *arguments],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    check=False,
+                    env=environment,
+                    **inheritance,
+                )
         except OSError as error:
             raise WorkspaceError(f"cannot inspect Git history: {error}") from error
 
@@ -3915,13 +3918,22 @@ class RepositoryMigration:
 
     @staticmethod
     def _is_ancestor(path: Path, ancestor: str, descendant: str) -> bool:
-        process = subprocess.run(
-            ["git", "-C", str(path), "merge-base", "--is-ancestor", ancestor, descendant],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            check=False,
-            pass_fds=active_lock_fds(),
-        )
+        with inherited_subprocess_handles(active_lock_fds()) as inheritance:
+            process = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(path),
+                    "merge-base",
+                    "--is-ancestor",
+                    ancestor,
+                    descendant,
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+                **inheritance,
+            )
         if process.returncode == 0:
             return True
         if process.returncode == 1:
@@ -3934,14 +3946,15 @@ class RepositoryMigration:
         environment["GIT_OPTIONAL_LOCKS"] = "0"
         environment["GIT_NO_REPLACE_OBJECTS"] = "1"
         try:
-            return subprocess.run(
-                ["git", "-C", str(path), *arguments],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                check=False,
-                env=environment,
-                pass_fds=active_lock_fds(),
-            )
+            with inherited_subprocess_handles(active_lock_fds()) as inheritance:
+                return subprocess.run(
+                    ["git", "-C", str(path), *arguments],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    check=False,
+                    env=environment,
+                    **inheritance,
+                )
         except OSError as error:
             raise WorkspaceError(f"cannot run Git: {error}") from error
 
@@ -3976,15 +3989,16 @@ class RepositoryMigration:
         environment = environment.copy()
         environment["GIT_NO_REPLACE_OBJECTS"] = "1"
         try:
-            process = subprocess.run(
-                ["git", "-C", str(path), *arguments],
-                input=input_value,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                check=False,
-                env=environment,
-                pass_fds=active_lock_fds(),
-            )
+            with inherited_subprocess_handles(active_lock_fds()) as inheritance:
+                process = subprocess.run(
+                    ["git", "-C", str(path), *arguments],
+                    input=input_value,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    check=False,
+                    env=environment,
+                    **inheritance,
+                )
         except OSError as error:
             raise WorkspaceError(f"cannot run Git: {error}") from error
         if process.returncode:

--- a/atrinik_workspace/model.py
+++ b/atrinik_workspace/model.py
@@ -190,7 +190,7 @@ def load_json(path: Path) -> Any:
 def unlink_validated_json(path: Path, validate: Callable[[Any], None]) -> None:
     """Validate and unlink the same no-follow JSON inode through a parent dirfd."""
 
-    if IS_WINDOWS:
+    if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
         raise WorkspaceError(
             "validated JSON removal is unavailable on native Windows: "
             "the wrapper cannot prove durable parent-directory unlink semantics"
@@ -259,7 +259,7 @@ def durable_atomic_json(path: Path, value: Any) -> None:
 
 
 def _atomic_json(path: Path, value: Any, *, durable: bool) -> None:
-    if IS_WINDOWS:
+    if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
         _atomic_json_windows(path, value, durable=durable)
         return
 
@@ -406,7 +406,7 @@ def _open_directory_nofollow(
 ) -> int:
     """Open every component of a directory path without following symlinks."""
 
-    if IS_WINDOWS:
+    if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
         raise WorkspaceError(
             "descriptor-relative directory operations are unavailable on native Windows"
         )
@@ -1355,7 +1355,7 @@ class Paths:
     @classmethod
     def discover(cls, repository: Path) -> "Paths":
         repository = Path(repository).expanduser()
-        if IS_WINDOWS:
+        if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
             try:
                 assert_no_symlink_components(repository, "repository")
             except OSError as error:
@@ -1365,7 +1365,7 @@ class Paths:
         workspace = Path(configured).expanduser() if configured else repository / "workspace"
         if not workspace.is_absolute():
             raise WorkspaceError("ATRINIK_WORKSPACE_DIR must be an absolute path")
-        if IS_WINDOWS:
+        if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
             try:
                 assert_no_symlink_components(workspace, "workspace")
             except OSError as error:
@@ -1395,7 +1395,7 @@ class Paths:
             raise WorkspaceError(f"refusing unsafe workspace path: {self.workspace}")
         if self.workspace.exists() and not self.workspace.is_dir():
             raise WorkspaceError(f"workspace path is not a directory: {self.workspace}")
-        if IS_WINDOWS:
+        if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
             try:
                 assert_no_symlink_components(self.workspace, "workspace")
             except OSError as error:
@@ -1415,7 +1415,7 @@ class Paths:
             flags |= os.O_NOFOLLOW
 
         while descriptor is None:
-            if IS_WINDOWS:
+            if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
                 try:
                     assert_no_symlink_components(self.marker, "workspace marker")
                 except OSError as error:
@@ -1457,7 +1457,7 @@ class Paths:
                     f"workspace ownership marker is invalid: {self.marker}: {error}"
                 ) from error
             opened = os.fstat(descriptor)
-            if IS_WINDOWS:
+            if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
                 try:
                     assert_no_symlink_components(self.marker, "workspace marker")
                     visible = self.marker.stat(follow_symlinks=False)
@@ -1491,7 +1491,7 @@ class Paths:
 
         try:
             opened = os.fstat(descriptor)
-            if IS_WINDOWS:
+            if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
                 try:
                     assert_no_symlink_components(self.marker, "workspace marker")
                     visible = self.marker.stat(follow_symlinks=False)

--- a/atrinik_workspace/model.py
+++ b/atrinik_workspace/model.py
@@ -327,7 +327,9 @@ def _atomic_json(path: Path, value: Any, *, durable: bool) -> None:
         os.close(directory)
 
 
-def _atomic_json_windows(path: Path, value: Any, *, durable: bool) -> None:
+def _atomic_json_windows(  # pragma: no cover - exercised by native Windows CI
+    path: Path, value: Any, *, durable: bool
+) -> None:
     """Atomically publish JSON using Windows' replace and flush primitives.
 
     Windows has no portable descriptor-relative directory API equivalent to
@@ -1401,7 +1403,7 @@ class Paths:
             except OSError as error:
                 raise WorkspaceError(str(error)) from error
         self.workspace.mkdir(parents=True, exist_ok=True)
-        if IS_WINDOWS:
+        if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
             try:
                 assert_no_symlink_components(self.workspace, "workspace")
             except OSError as error:

--- a/atrinik_workspace/model.py
+++ b/atrinik_workspace/model.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import fcntl
 import hashlib
 import json
 import os
@@ -11,6 +10,15 @@ import secrets
 import stat
 import time
 from typing import Any, Callable, Iterable
+
+from .platform_compat import (
+    IS_WINDOWS,
+    O_BINARY,
+    O_CLOEXEC,
+    assert_no_symlink_components,
+    fcntl,
+    flush_file,
+)
 
 
 SCHEMA_VERSION = 1
@@ -182,9 +190,15 @@ def load_json(path: Path) -> Any:
 def unlink_validated_json(path: Path, validate: Callable[[Any], None]) -> None:
     """Validate and unlink the same no-follow JSON inode through a parent dirfd."""
 
-    directory_flags = os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_DIRECTORY", 0)
+    if IS_WINDOWS:
+        raise WorkspaceError(
+            "validated JSON removal is unavailable on native Windows: "
+            "the wrapper cannot prove durable parent-directory unlink semantics"
+        )
+
+    directory_flags = os.O_RDONLY | O_CLOEXEC | getattr(os, "O_DIRECTORY", 0)
     directory_flags |= getattr(os, "O_NOFOLLOW", 0)
-    file_flags = os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_NOFOLLOW", 0)
+    file_flags = os.O_RDONLY | O_CLOEXEC | getattr(os, "O_NOFOLLOW", 0)
     directory: int | None = None
     descriptor: int | None = None
     try:
@@ -245,7 +259,11 @@ def durable_atomic_json(path: Path, value: Any) -> None:
 
 
 def _atomic_json(path: Path, value: Any, *, durable: bool) -> None:
-    directory_flags = os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_DIRECTORY", 0)
+    if IS_WINDOWS:
+        _atomic_json_windows(path, value, durable=durable)
+        return
+
+    directory_flags = os.O_RDONLY | O_CLOEXEC | getattr(os, "O_DIRECTORY", 0)
     directory_flags |= getattr(os, "O_NOFOLLOW", 0)
     directory = _open_directory_nofollow(
         path.parent, directory_flags, create=True
@@ -266,7 +284,7 @@ def _atomic_json(path: Path, value: Any, *, durable: bool) -> None:
             os.O_WRONLY
             | os.O_CREAT
             | os.O_EXCL
-            | os.O_CLOEXEC
+            | O_CLOEXEC
             | getattr(os, "O_NOFOLLOW", 0),
             0o600,
             dir_fd=directory,
@@ -309,10 +327,89 @@ def _atomic_json(path: Path, value: Any, *, durable: bool) -> None:
         os.close(directory)
 
 
+def _atomic_json_windows(path: Path, value: Any, *, durable: bool) -> None:
+    """Atomically publish JSON using Windows' replace and flush primitives.
+
+    Windows has no portable descriptor-relative directory API equivalent to
+    the POSIX implementation above.  Existing path components are therefore
+    checked for links/junctions before the uniquely named temporary file is
+    written, and the file contents are flushed before and after replacement.
+    Operations that require durable parent-directory unlink proof remain
+    explicitly unavailable instead of using an unsafe fallback.
+    """
+
+    try:
+        assert_no_symlink_components(path.parent, "JSON")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        assert_no_symlink_components(path, "JSON")
+        opened_parent = path.parent.stat(follow_symlinks=False)
+        if not stat.S_ISDIR(opened_parent.st_mode):
+            raise OSError(f"JSON parent is not a directory: {path.parent}")
+    except OSError as error:
+        raise WorkspaceError(str(error)) from error
+    temporary = path.with_name(f".{path.name}.{secrets.token_hex(12)}.tmp")
+    descriptor: int | None = None
+    replaced = False
+    try:
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | O_BINARY | O_CLOEXEC,
+            0o600,
+        )
+        with os.fdopen(
+            descriptor, "w", encoding="utf-8", newline="\n"
+        ) as stream:
+            descriptor = None
+            json.dump(value, stream, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            flush_file(stream.fileno())
+        assert_no_symlink_components(path, "JSON")
+        visible_parent = path.parent.stat(follow_symlinks=False)
+        if (opened_parent.st_dev, opened_parent.st_ino) != (
+            visible_parent.st_dev,
+            visible_parent.st_ino,
+        ):
+            raise WorkspaceError(f"JSON parent directory was replaced: {path.parent}")
+        os.replace(temporary, path)
+        replaced = True
+        assert_no_symlink_components(path, "JSON")
+        if durable:
+            with path.open("r+b") as stream:
+                opened = os.fstat(stream.fileno())
+                visible = path.stat(follow_symlinks=False)
+                if (
+                    not stat.S_ISREG(opened.st_mode)
+                    or not stat.S_ISREG(visible.st_mode)
+                    or (opened.st_dev, opened.st_ino)
+                    != (visible.st_dev, visible.st_ino)
+                ):
+                    raise WorkspaceError(
+                        f"JSON file identity changed after replacement: {path}"
+                    )
+                flush_file(stream.fileno())
+    except BaseException as error:
+        if replaced:
+            raise AtomicJsonCommitUncertain(
+                "JSON replacement is visible but its Windows post-replacement "
+                f"file verification is uncertain: {path}: {error}"
+            ) from error
+        raise
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        temporary.unlink(missing_ok=True)
+
+
 def _open_directory_nofollow(
     path: Path, flags: int, *, create: bool = False
 ) -> int:
     """Open every component of a directory path without following symlinks."""
+
+    if IS_WINDOWS:
+        raise WorkspaceError(
+            "descriptor-relative directory operations are unavailable on native Windows"
+        )
 
     absolute = Path(os.path.abspath(path))
     descriptor = os.open("/", flags)
@@ -1257,11 +1354,22 @@ class Paths:
 
     @classmethod
     def discover(cls, repository: Path) -> "Paths":
+        repository = Path(repository).expanduser()
+        if IS_WINDOWS:
+            try:
+                assert_no_symlink_components(repository, "repository")
+            except OSError as error:
+                raise WorkspaceError(str(error)) from error
         repository = repository.resolve()
         configured = os.environ.get("ATRINIK_WORKSPACE_DIR")
         workspace = Path(configured).expanduser() if configured else repository / "workspace"
         if not workspace.is_absolute():
             raise WorkspaceError("ATRINIK_WORKSPACE_DIR must be an absolute path")
+        if IS_WINDOWS:
+            try:
+                assert_no_symlink_components(workspace, "workspace")
+            except OSError as error:
+                raise WorkspaceError(str(error)) from error
         workspace = workspace.resolve(strict=False)
         if workspace == repository:
             raise WorkspaceError(
@@ -1287,16 +1395,31 @@ class Paths:
             raise WorkspaceError(f"refusing unsafe workspace path: {self.workspace}")
         if self.workspace.exists() and not self.workspace.is_dir():
             raise WorkspaceError(f"workspace path is not a directory: {self.workspace}")
+        if IS_WINDOWS:
+            try:
+                assert_no_symlink_components(self.workspace, "workspace")
+            except OSError as error:
+                raise WorkspaceError(str(error)) from error
         self.workspace.mkdir(parents=True, exist_ok=True)
+        if IS_WINDOWS:
+            try:
+                assert_no_symlink_components(self.workspace, "workspace")
+            except OSError as error:
+                raise WorkspaceError(str(error)) from error
         expected = {"schema_version": SCHEMA_VERSION}
         created = False
         descriptor: int | None = None
         empty_marker_retries = 0
-        flags = os.O_RDWR | os.O_CLOEXEC
+        flags = os.O_RDWR | O_BINARY | O_CLOEXEC
         if hasattr(os, "O_NOFOLLOW"):
             flags |= os.O_NOFOLLOW
 
         while descriptor is None:
+            if IS_WINDOWS:
+                try:
+                    assert_no_symlink_components(self.marker, "workspace marker")
+                except OSError as error:
+                    raise WorkspaceError(str(error)) from error
             if self.marker.is_symlink():
                 raise WorkspaceError(
                     f"refusing unmanaged non-empty workspace directory: {self.workspace}"
@@ -1333,7 +1456,27 @@ class Paths:
                 raise WorkspaceError(
                     f"workspace ownership marker is invalid: {self.marker}: {error}"
                 ) from error
-            if os.fstat(descriptor).st_size == 0:
+            opened = os.fstat(descriptor)
+            if IS_WINDOWS:
+                try:
+                    assert_no_symlink_components(self.marker, "workspace marker")
+                    visible = self.marker.stat(follow_symlinks=False)
+                except OSError as error:
+                    os.close(descriptor)
+                    descriptor = None
+                    raise WorkspaceError(str(error)) from error
+                if (
+                    not stat.S_ISREG(opened.st_mode)
+                    or not stat.S_ISREG(visible.st_mode)
+                    or (opened.st_dev, opened.st_ino)
+                    != (visible.st_dev, visible.st_ino)
+                ):
+                    os.close(descriptor)
+                    descriptor = None
+                    raise WorkspaceError(
+                        f"workspace ownership marker changed during open: {self.marker}"
+                    )
+            if opened.st_size == 0:
                 # The process that won O_EXCL has not published the complete
                 # marker yet. Do not take its lock first and mistake that
                 # transient empty file for corrupt ownership metadata.
@@ -1347,7 +1490,23 @@ class Paths:
                 time.sleep(0.01)
 
         try:
-            if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            opened = os.fstat(descriptor)
+            if IS_WINDOWS:
+                try:
+                    assert_no_symlink_components(self.marker, "workspace marker")
+                    visible = self.marker.stat(follow_symlinks=False)
+                except OSError as error:
+                    raise WorkspaceError(str(error)) from error
+                if (
+                    not stat.S_ISREG(opened.st_mode)
+                    or not stat.S_ISREG(visible.st_mode)
+                    or (opened.st_dev, opened.st_ino)
+                    != (visible.st_dev, visible.st_ino)
+                ):
+                    raise WorkspaceError(
+                        f"workspace ownership marker changed during open: {self.marker}"
+                    )
+            if not stat.S_ISREG(opened.st_mode):
                 raise WorkspaceError(
                     f"workspace ownership marker is invalid: {self.marker}"
                 )
@@ -1367,7 +1526,7 @@ class Paths:
                     json.dump(expected, stream, indent=2, sort_keys=True)
                     stream.write("\n")
                     stream.flush()
-                    os.fsync(stream.fileno())
+                    flush_file(stream.fileno())
                 else:
                     stream.seek(0)
                     try:

--- a/atrinik_workspace/platform_compat.py
+++ b/atrinik_workspace/platform_compat.py
@@ -1,0 +1,197 @@
+"""Small operating-system adapters used by the workspace boundary.
+
+The wrapper is intentionally conservative about platform differences.  Native
+Windows gets a real kernel byte-range lock and handle inheritance for the
+commands that are supported there; Linux-only process-tree operations remain
+explicitly unavailable instead of being approximated.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import errno
+import os
+from pathlib import Path
+import subprocess
+from types import SimpleNamespace
+from typing import Iterator
+
+
+IS_WINDOWS = os.name == "nt"
+O_CLOEXEC = getattr(os, "O_CLOEXEC", 0)
+O_BINARY = getattr(os, "O_BINARY", 0)
+_WINDOWS_LINK_REPARSE_TAGS = {0xA0000003, 0xA000000C}
+
+
+class PlatformCapabilityError(RuntimeError):
+    """A deliberately unavailable platform capability."""
+
+
+def require_linux_capability(operation: str, capability: str) -> None:
+    """Refuse a Linux-only operation with a stable, actionable diagnostic."""
+
+    if IS_WINDOWS:
+        raise PlatformCapabilityError(
+            f"{operation} is unavailable on native Windows: {capability} "
+            "requires Linux process and filesystem capabilities; use Linux, "
+            "WSL2, or the documented Windows package workflow"
+        )
+
+
+def assert_no_symlink_components(path: Path, description: str) -> None:
+    """Reject symlink/junction components in a native Windows path."""
+
+    absolute = Path(os.path.abspath(path))
+    current = Path(absolute.anchor)
+    for part in absolute.parts[1:]:
+        current /= part
+        try:
+            status = current.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError as error:
+            raise OSError(
+                f"cannot inspect {description} path {current}: {error}"
+            ) from error
+        is_junction = getattr(current, "is_junction", lambda: False)()
+        is_windows_link = getattr(status, "st_reparse_tag", 0) in _WINDOWS_LINK_REPARSE_TAGS
+        if os.path.islink(current) or is_junction or is_windows_link:
+            raise OSError(f"refusing symlinked {description} path: {current}")
+        if current != absolute and not os.path.isdir(current):
+            raise OSError(f"{description} parent is not a directory: {current}")
+        del status
+
+
+if IS_WINDOWS:
+    import ctypes
+    from ctypes import wintypes
+    import msvcrt
+
+    LOCK_SH = 1
+    LOCK_EX = 2
+    LOCK_NB = 4
+    LOCK_UN = 8
+
+    _LOCKFILE_EXCLUSIVE_LOCK = 0x00000002
+    _LOCKFILE_FAIL_IMMEDIATELY = 0x00000001
+    _ERROR_LOCK_VIOLATION = 33
+    _INVALID_HANDLE_VALUE = ctypes.c_void_p(-1).value
+
+    class _Overlapped(ctypes.Structure):
+        _fields_ = [
+            ("Internal", ctypes.c_size_t),
+            ("InternalHigh", ctypes.c_size_t),
+            ("Offset", wintypes.DWORD),
+            ("OffsetHigh", wintypes.DWORD),
+            ("hEvent", wintypes.HANDLE),
+        ]
+
+    _kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    _lock_file_ex = _kernel32.LockFileEx
+    _lock_file_ex.argtypes = [
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.POINTER(_Overlapped),
+    ]
+    _lock_file_ex.restype = wintypes.BOOL
+    _unlock_file_ex = _kernel32.UnlockFileEx
+    _unlock_file_ex.argtypes = [
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.POINTER(_Overlapped),
+    ]
+    _unlock_file_ex.restype = wintypes.BOOL
+    _flush_file_buffers = _kernel32.FlushFileBuffers
+    _flush_file_buffers.argtypes = [wintypes.HANDLE]
+    _flush_file_buffers.restype = wintypes.BOOL
+
+    def _lock_handle(value: object) -> wintypes.HANDLE:
+        descriptor = value if isinstance(value, int) else value.fileno()  # type: ignore[union-attr]
+        handle = msvcrt.get_osfhandle(descriptor)
+        if handle == -1 or handle == _INVALID_HANDLE_VALUE:
+            raise OSError(errno.EBADF, "invalid Windows lock handle")
+        return wintypes.HANDLE(handle)
+
+    def _win_flock(value: object, operation: int) -> None:
+        handle = _lock_handle(value)
+        overlapped = _Overlapped()
+        if operation & LOCK_UN:
+            if not _unlock_file_ex(handle, 0, 0xFFFFFFFF, 0xFFFFFFFF, ctypes.byref(overlapped)):
+                error = ctypes.get_last_error()
+                raise OSError(error, os.strerror(error))
+            return
+        flags = 0
+        if operation & LOCK_EX:
+            flags |= _LOCKFILE_EXCLUSIVE_LOCK
+        if operation & LOCK_NB:
+            flags |= _LOCKFILE_FAIL_IMMEDIATELY
+        if not _lock_file_ex(
+            handle,
+            flags,
+            0,
+            0xFFFFFFFF,
+            0xFFFFFFFF,
+            ctypes.byref(overlapped),
+        ):
+            error = ctypes.get_last_error()
+            if error == _ERROR_LOCK_VIOLATION:
+                raise BlockingIOError(errno.EAGAIN, "Windows file lock is busy")
+            raise OSError(error, os.strerror(error))
+
+    fcntl = SimpleNamespace(
+        LOCK_SH=LOCK_SH,
+        LOCK_EX=LOCK_EX,
+        LOCK_NB=LOCK_NB,
+        LOCK_UN=LOCK_UN,
+        flock=_win_flock,
+    )
+
+    def flush_file(descriptor: int) -> None:
+        handle = _lock_handle(descriptor)
+        if not _flush_file_buffers(handle):
+            error = ctypes.get_last_error()
+            raise OSError(error, os.strerror(error))
+
+    @contextmanager
+    def inherited_subprocess_handles(
+        descriptors: tuple[int, ...],
+    ) -> Iterator[dict[str, object]]:
+        """Pass active lock handles to a Windows child process."""
+
+        handles: list[int] = []
+        previous: list[tuple[int, bool]] = []
+        try:
+            for descriptor in dict.fromkeys(descriptors):
+                handle = msvcrt.get_osfhandle(descriptor)
+                if handle == -1 or handle == _INVALID_HANDLE_VALUE:
+                    raise OSError(errno.EBADF, "invalid inherited Windows handle")
+                inheritable = os.get_handle_inheritable(handle)
+                previous.append((handle, inheritable))
+                os.set_handle_inheritable(handle, True)
+                handles.append(handle)
+            if not handles:
+                yield {"close_fds": True}
+                return
+            startup = subprocess.STARTUPINFO()
+            startup.lpAttributeList = {"handle_list": handles}
+            yield {"close_fds": True, "startupinfo": startup}
+        finally:
+            for handle, inheritable in previous:
+                os.set_handle_inheritable(handle, inheritable)
+
+else:
+    import fcntl
+
+    def flush_file(descriptor: int) -> None:
+        os.fsync(descriptor)
+
+    @contextmanager
+    def inherited_subprocess_handles(
+        descriptors: tuple[int, ...],
+    ) -> Iterator[dict[str, object]]:
+        yield {"pass_fds": descriptors}

--- a/atrinik_workspace/platform_compat.py
+++ b/atrinik_workspace/platform_compat.py
@@ -66,6 +66,7 @@ if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
     import ctypes
     from ctypes import wintypes
     import msvcrt
+    import threading
 
     LOCK_SH = 1
     LOCK_EX = 2
@@ -109,6 +110,7 @@ if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
     _flush_file_buffers = _kernel32.FlushFileBuffers
     _flush_file_buffers.argtypes = [wintypes.HANDLE]
     _flush_file_buffers.restype = wintypes.BOOL
+    _windows_handle_inheritance_lock = threading.Lock()
 
     def _lock_handle(value: object) -> wintypes.HANDLE:
         descriptor = value if isinstance(value, int) else value.fileno()  # type: ignore[union-attr]
@@ -163,26 +165,31 @@ if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
     ) -> Iterator[dict[str, object]]:
         """Pass active lock handles to a Windows child process."""
 
-        handles: list[int] = []
-        previous: list[tuple[int, bool]] = []
-        try:
-            for descriptor in dict.fromkeys(descriptors):
-                handle = msvcrt.get_osfhandle(descriptor)
-                if handle == -1 or handle == _INVALID_HANDLE_VALUE:
-                    raise OSError(errno.EBADF, "invalid inherited Windows handle")
-                inheritable = os.get_handle_inheritable(handle)
-                previous.append((handle, inheritable))
-                os.set_handle_inheritable(handle, True)
-                handles.append(handle)
-            if not handles:
-                yield {"close_fds": True}
-                return
-            startup = subprocess.STARTUPINFO()
-            startup.lpAttributeList = {"handle_list": handles}
-            yield {"close_fds": True, "startupinfo": startup}
-        finally:
-            for handle, inheritable in previous:
-                os.set_handle_inheritable(handle, inheritable)
+        # The active lock handles are shared by parallel initialization
+        # workers.  Keep the inheritable-state transition and CreateProcess
+        # call together so another worker cannot restore the handles halfway
+        # through startup.
+        with _windows_handle_inheritance_lock:
+            handles: list[int] = []
+            previous: list[tuple[int, bool]] = []
+            try:
+                for descriptor in dict.fromkeys(descriptors):
+                    handle = msvcrt.get_osfhandle(descriptor)
+                    if handle == -1 or handle == _INVALID_HANDLE_VALUE:
+                        raise OSError(errno.EBADF, "invalid inherited Windows handle")
+                    inheritable = os.get_handle_inheritable(handle)
+                    previous.append((handle, inheritable))
+                    os.set_handle_inheritable(handle, True)
+                    handles.append(handle)
+                if not handles:
+                    yield {"close_fds": True}
+                    return
+                startup = subprocess.STARTUPINFO()
+                startup.lpAttributeList = {"handle_list": handles}
+                yield {"close_fds": True, "startupinfo": startup}
+            finally:
+                for handle, inheritable in previous:
+                    os.set_handle_inheritable(handle, inheritable)
 
 else:
     import fcntl

--- a/atrinik_workspace/platform_compat.py
+++ b/atrinik_workspace/platform_compat.py
@@ -30,7 +30,7 @@ class PlatformCapabilityError(RuntimeError):
 def require_linux_capability(operation: str, capability: str) -> None:
     """Refuse a Linux-only operation with a stable, actionable diagnostic."""
 
-    if IS_WINDOWS:
+    if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
         raise PlatformCapabilityError(
             f"{operation} is unavailable on native Windows: {capability} "
             "requires Linux process and filesystem capabilities; use Linux, "
@@ -62,7 +62,7 @@ def assert_no_symlink_components(path: Path, description: str) -> None:
         del status
 
 
-if IS_WINDOWS:
+if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
     import ctypes
     from ctypes import wintypes
     import msvcrt

--- a/atrinik_workspace/port_reservation.py
+++ b/atrinik_workspace/port_reservation.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import ctypes
 import errno
-import fcntl
 import json
 import os
 from pathlib import Path
@@ -10,6 +9,8 @@ import re
 import secrets
 import stat
 from typing import Any
+
+from .platform_compat import fcntl
 
 
 PORT_RESERVATION_SCHEMA_VERSION = 1

--- a/atrinik_workspace/process_tree.py
+++ b/atrinik_workspace/process_tree.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-import fcntl
 import os
 from pathlib import Path
 import signal
 import stat
 from typing import Iterable
+
+from .platform_compat import fcntl
 
 
 def control_socket_path(topology_root: Path, generation: str) -> Path:

--- a/atrinik_workspace/supervisor.py
+++ b/atrinik_workspace/supervisor.py
@@ -18,6 +18,7 @@ from typing import Any, BinaryIO
 
 from .launch_identity import CLIENT_LAUNCH_LABEL_ENV, client_launch_label
 from .model import durable_atomic_json
+from .platform_compat import inherited_subprocess_handles
 from .process_tree import control_socket_path, holders_exist, signal_holders
 from .port_reservation import PortReservationError, validate_held
 
@@ -651,16 +652,17 @@ def supervise(
             inherited_locks.append(state_directory_fd)
         if state_output_fd is not None and name == "server":
             inherited_locks.append(state_output_fd)
-        process = subprocess.Popen(
-            command,
-            cwd=service["cwd"],
-            env=environment,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            start_new_session=True,
-            pass_fds=tuple(inherited_locks),
-        )
+        with inherited_subprocess_handles(tuple(inherited_locks)) as inheritance:
+            process = subprocess.Popen(
+                command,
+                cwd=service["cwd"],
+                env=environment,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+                **inheritance,
+            )
         processes[name] = process
         start_time = process_start_time(process.pid)
         if start_time is None:

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -10,7 +10,6 @@ import ctypes
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import errno
-import fcntl
 import hashlib
 import json
 import os
@@ -91,6 +90,14 @@ from .model import (
     profile_key,
     require_keys,
     validate_name,
+)
+from .platform_compat import (
+    IS_WINDOWS,
+    O_CLOEXEC,
+    assert_no_symlink_components,
+    fcntl,
+    flush_file,
+    inherited_subprocess_handles,
 )
 from .migration import (
     MIGRATED_CONTENT_WORKTREE_KIND,
@@ -456,16 +463,17 @@ def run(
         inherited_fds = tuple(
             dict.fromkeys((*active_lock_fds(), *pass_fds))
         )
-        result = subprocess.run(
-            arguments,
-            cwd=cwd,
-            check=True,
-            text=True,
-            capture_output=capture,
-            env=env,
-            stdout=sys.stderr if diagnostics_to_stderr and not capture else None,
-            pass_fds=inherited_fds,
-        )
+        with inherited_subprocess_handles(inherited_fds) as inheritance:
+            result = subprocess.run(
+                arguments,
+                cwd=cwd,
+                check=True,
+                text=True,
+                capture_output=capture,
+                env=env,
+                stdout=sys.stderr if diagnostics_to_stderr and not capture else None,
+                **inheritance,
+            )
     except FileNotFoundError as error:
         raise WorkspaceError(f"required command not found: {arguments[0]}") from error
     except subprocess.CalledProcessError as error:
@@ -1867,6 +1875,42 @@ def _run_wrapper_worktree_inventory(
 ) -> bytes:
     """Capture one Git worktree inventory with live byte and time bounds."""
 
+    if IS_WINDOWS:
+        try:
+            with inherited_subprocess_handles(pass_fds) as inheritance:
+                completed = subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        str(repository),
+                        "worktree",
+                        "list",
+                        "--porcelain",
+                        "-z",
+                    ],
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    timeout=_WORKTREE_INVENTORY_TIMEOUT,
+                    check=False,
+                    **inheritance,
+                )
+        except FileNotFoundError as error:
+            raise WorkspaceError("required command not found: git") from error
+        except subprocess.TimeoutExpired as error:
+            raise WorkspaceError("wrapper worktree inventory timed out") from error
+        except OSError as error:
+            raise WorkspaceError(f"cannot list wrapper worktrees: {error}") from error
+        if len(completed.stdout) > _WORKTREE_INVENTORY_LIMIT:
+            raise WorkspaceError("wrapper worktree inventory output is not bounded")
+        if len(completed.stderr) > _WORKTREE_INVENTORY_ERROR_LIMIT:
+            raise WorkspaceError("wrapper worktree inventory error is not bounded")
+        if completed.returncode:
+            detail = completed.stderr.decode("utf-8", errors="replace").strip()
+            suffix = f": {detail}" if detail else ""
+            raise WorkspaceError(f"cannot list wrapper worktrees{suffix}")
+        return completed.stdout
+
     try:
         process = subprocess.Popen(
             [
@@ -1997,11 +2041,13 @@ def _parse_worktree_porcelain(raw: bytes) -> list[dict[str, str]]:
     seen: set[str] = set()
     for index, record in enumerate(records):
         path = Path(record["worktree"])
+        canonical = os.path.normcase(os.path.normpath(str(path)))
+        reported = os.path.normcase(os.path.normpath(record["worktree"]))
         if (
             not path.is_absolute()
-            or record["worktree"] == "/"
-            or str(path) != record["worktree"]
-            or os.path.normpath(record["worktree"]) != record["worktree"]
+            or path == Path(path.anchor)
+            or any(part in {"", ".", ".."} for part in path.parts)
+            or canonical != reported
         ):
             raise WorkspaceError(
                 f"wrapper worktree inventory record {index} has a non-canonical path"
@@ -2016,16 +2062,39 @@ def _parse_worktree_porcelain(raw: bytes) -> list[dict[str, str]]:
 def open_regular_file(
     path: Path, flags: int, description: str, mode: int = 0o600
 ) -> int:
-    flags |= os.O_CLOEXEC
+    if IS_WINDOWS:
+        try:
+            assert_no_symlink_components(path, description)
+        except OSError as error:
+            raise WorkspaceError(str(error)) from error
+    flags |= O_CLOEXEC
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
+    descriptor: int | None = None
     try:
         descriptor = os.open(path, flags, mode)
-        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
-            os.close(descriptor)
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode):
             raise WorkspaceError(f"{description} is not a regular file: {path}")
-        return descriptor
+        if IS_WINDOWS:
+            assert_no_symlink_components(path, description)
+            visible = path.stat(follow_symlinks=False)
+            if (
+                not stat.S_ISREG(visible.st_mode)
+                or (opened.st_dev, opened.st_ino)
+                != (visible.st_dev, visible.st_ino)
+            ):
+                raise WorkspaceError(f"{description} identity changed during open: {path}")
+        result = descriptor
+        descriptor = None
+        return result
+    except WorkspaceError:
+        if descriptor is not None:
+            os.close(descriptor)
+        raise
     except OSError as error:
+        if descriptor is not None:
+            os.close(descriptor)
         raise WorkspaceError(f"cannot open {description} {path}: {error}") from error
 
 
@@ -2450,9 +2519,16 @@ class Workspace:
 
     def _establish_lease_namespace_identity(self) -> tuple[int, int]:
         namespace = self._lease_namespace
+        if IS_WINDOWS:
+            try:
+                assert_no_symlink_components(namespace, "physical lease namespace")
+            except OSError as error:
+                raise WorkspaceError(str(error)) from error
         namespace.mkdir(mode=0o700, exist_ok=True)
         visible = namespace.stat(follow_symlinks=False)
-        if not stat.S_ISDIR(visible.st_mode) or stat.S_IMODE(visible.st_mode) != 0o700:
+        if not stat.S_ISDIR(visible.st_mode) or (
+            not IS_WINDOWS and stat.S_IMODE(visible.st_mode) != 0o700
+        ):
             raise WorkspaceError(f"physical lease namespace is unsafe: {namespace}")
         identity = (visible.st_dev, visible.st_ino)
         if not (self.paths.repository / ".git").exists():
@@ -2546,8 +2622,14 @@ class Workspace:
             "shared",
             "use wrapper worktree",
         )
+        # The Windows adapter holds the wrapper source lease for the lifetime
+        # of this Workspace.  LockFileEx rejects an overlapping acquisition
+        # through a second handle even in the same process, so that existing
+        # lifetime handle is the wrapper request's admission proof there.
         protected_requests = (
-            (*requests, wrapper_request) if include_wrapper else tuple(requests)
+            (*requests, wrapper_request)
+            if include_wrapper and not IS_WINDOWS
+            else tuple(requests)
         )
         with shared_maintenance_lock(
             self._lease_namespace / "repository-layout.lock"
@@ -5312,6 +5394,11 @@ class Workspace:
     def _ensure_repository(self, value: Checkout | Component) -> Path:
         checkout = self._checkout_identity(value)
         destination = self._primary_path(checkout)
+        if IS_WINDOWS:
+            try:
+                assert_no_symlink_components(destination, "component destination")
+            except OSError as error:
+                raise WorkspaceError(str(error)) from error
         if not destination.exists() and not destination.is_symlink():
             temporary = Path(
                 tempfile.mkdtemp(
@@ -5410,6 +5497,11 @@ class Workspace:
         self, value: Checkout | Component, path: Path, *, trace: bool = True
     ) -> str:
         checkout = self._checkout_identity(value)
+        if IS_WINDOWS:
+            try:
+                assert_no_symlink_components(path, "component checkout")
+            except OSError as error:
+                raise WorkspaceError(str(error)) from error
         if path.is_symlink() or not path.is_dir():
             raise WorkspaceError(f"component checkout is not a directory: {path}")
         try:
@@ -6845,6 +6937,22 @@ class Workspace:
         self, name: str, value: dict[str, Any]
     ) -> None:
         namespace = self._lease_namespace
+        if IS_WINDOWS:
+            registry = namespace / "profile-references"
+            try:
+                assert_no_symlink_components(namespace, "physical lease namespace")
+                assert_no_symlink_components(registry, "physical reference registry")
+                namespace.mkdir(mode=0o700, exist_ok=True)
+                registry.mkdir(mode=0o700, exist_ok=True)
+                assert_no_symlink_components(registry, "physical reference registry")
+                atomic_json(registry / name, value)
+            except (OSError, WorkspaceError) as error:
+                if isinstance(error, WorkspaceError):
+                    raise
+                raise WorkspaceError(
+                    f"cannot publish physical reference {name}: {error}"
+                ) from error
+            return
         flags = os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_DIRECTORY", 0)
         flags |= getattr(os, "O_NOFOLLOW", 0)
         parent_fd = os.open(namespace, flags)
@@ -6918,6 +7026,17 @@ class Workspace:
         *,
         expected_mode: int | None = None,
     ) -> None:
+        if IS_WINDOWS:
+            try:
+                assert_no_symlink_components(path, description)
+                metadata = path.stat(follow_symlinks=False)
+            except OSError as error:
+                raise WorkspaceError(
+                    f"{description} was replaced or is unsafe: {path}: {error}"
+                ) from error
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise WorkspaceError(f"{description} was replaced or is unsafe: {path}")
+            return
         opened = os.fstat(descriptor)
         visible = path.stat(follow_symlinks=False)
         if (
@@ -6936,6 +7055,28 @@ class Workspace:
         self, *, only: str | None = None
     ) -> list[dict[str, Any]]:
         registry = self._lease_namespace / "profile-references"
+        if IS_WINDOWS:
+            try:
+                assert_no_symlink_components(registry, "physical reference registry")
+                if not registry.exists():
+                    return []
+                names = [only] if only is not None else sorted(path.name for path in registry.iterdir())
+                records: list[dict[str, Any]] = []
+                for name in names:
+                    if name is None:
+                        continue
+                    if re.fullmatch(r"\.[0-9a-f]{64}\.json\.[0-9a-f]{24}\.tmp", name):
+                        continue
+                    if not re.fullmatch(r"[0-9a-f]{64}\.json", name):
+                        raise WorkspaceError(
+                            f"cannot prove physical reference registry entry: {name}"
+                        )
+                    records.append(load_regular_json(registry / name, "physical reference registry entry"))
+                return records
+            except (OSError, UnicodeError, ValueError, RecursionError) as error:
+                raise WorkspaceError(
+                    f"cannot read physical reference registry {registry}: {error}"
+                ) from error
         flags = os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_DIRECTORY", 0)
         flags |= getattr(os, "O_NOFOLLOW", 0)
         namespace_fd: int | None = None
@@ -7037,6 +7178,22 @@ class Workspace:
         name = hashlib.sha256(str(authored_path.resolve()).encode()).hexdigest() + ".json"
         namespace = self._lease_namespace
         registry = namespace / "profile-references"
+        if IS_WINDOWS:
+            try:
+                assert_no_symlink_components(registry, "physical reference registry")
+                reference = registry / name
+                if reference.is_symlink():
+                    raise WorkspaceError(
+                        f"refusing symlinked physical reference: {reference}"
+                    )
+                reference.unlink(missing_ok=True)
+            except (OSError, WorkspaceError) as error:
+                if isinstance(error, WorkspaceError):
+                    raise
+                raise WorkspaceError(
+                    f"cannot roll back physical reference {name}: {error}"
+                ) from error
+            return
         flags = os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_DIRECTORY", 0)
         flags |= getattr(os, "O_NOFOLLOW", 0)
         namespace_fd: int | None = None
@@ -7305,6 +7462,11 @@ class Workspace:
         return Path(selector["value"])
 
     def _component_source(self, component: Component, checkout_root: Path) -> Path:
+        if IS_WINDOWS:
+            try:
+                assert_no_symlink_components(checkout_root, "component checkout")
+            except OSError as error:
+                raise WorkspaceError(str(error)) from error
         if checkout_root.is_symlink() or not checkout_root.is_dir():
             raise WorkspaceError(
                 f"component checkout is not a directory: {checkout_root}"
@@ -7328,6 +7490,11 @@ class Workspace:
                 f"component source is not a normal directory: {component.name}: {source}"
             )
         resolved = source.resolve()
+        if IS_WINDOWS:
+            try:
+                assert_no_symlink_components(source, "component source")
+            except OSError as error:
+                raise WorkspaceError(str(error)) from error
         if resolved != root and root not in resolved.parents:
             raise WorkspaceError(
                 f"component source escapes checkout: {component.name}: {source}"

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -1875,7 +1875,7 @@ def _run_wrapper_worktree_inventory(
 ) -> bytes:
     """Capture one Git worktree inventory with live byte and time bounds."""
 
-    if IS_WINDOWS:
+    if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
         try:
             with inherited_subprocess_handles(pass_fds) as inheritance:
                 completed = subprocess.run(
@@ -2062,7 +2062,7 @@ def _parse_worktree_porcelain(raw: bytes) -> list[dict[str, str]]:
 def open_regular_file(
     path: Path, flags: int, description: str, mode: int = 0o600
 ) -> int:
-    if IS_WINDOWS:
+    if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
         try:
             assert_no_symlink_components(path, description)
         except OSError as error:
@@ -2076,7 +2076,7 @@ def open_regular_file(
         opened = os.fstat(descriptor)
         if not stat.S_ISREG(opened.st_mode):
             raise WorkspaceError(f"{description} is not a regular file: {path}")
-        if IS_WINDOWS:
+        if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
             assert_no_symlink_components(path, description)
             visible = path.stat(follow_symlinks=False)
             if (
@@ -2519,7 +2519,7 @@ class Workspace:
 
     def _establish_lease_namespace_identity(self) -> tuple[int, int]:
         namespace = self._lease_namespace
-        if IS_WINDOWS:
+        if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
             try:
                 assert_no_symlink_components(namespace, "physical lease namespace")
             except OSError as error:
@@ -3096,25 +3096,26 @@ class Workspace:
         expected: dict[str, tuple[bytes, bytes, bytes]] = {}
         if kind == b"tree":
             try:
-                result = subprocess.run(
-                    [
-                        "git",
-                        "--no-replace-objects",
-                        "-C",
-                        str(checkout),
-                        "ls-tree",
-                        "-r",
-                        "-t",
-                        "--full-tree",
-                        "-z",
-                        object_id,
-                    ],
-                    check=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    pass_fds=active_lock_fds(),
-                    timeout=30,
-                )
+                with inherited_subprocess_handles(active_lock_fds()) as inheritance:
+                    result = subprocess.run(
+                        [
+                            "git",
+                            "--no-replace-objects",
+                            "-C",
+                            str(checkout),
+                            "ls-tree",
+                            "-r",
+                            "-t",
+                            "--full-tree",
+                            "-z",
+                            object_id,
+                        ],
+                        check=True,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        timeout=30,
+                        **inheritance,
+                    )
             except FileNotFoundError as error:
                 raise WorkspaceError("required command not found: git") from error
             except subprocess.CalledProcessError as error:
@@ -3197,21 +3198,24 @@ class Workspace:
                     payload = tempfile.TemporaryFile()
                     try:
                         try:
-                            subprocess.run(
-                                [
-                                    "git",
-                                    "--no-replace-objects",
-                                    "-C",
-                                    str(checkout),
-                                    "cat-file",
-                                    "blob",
-                                    entry_object.decode(),
-                                ],
-                                check=True,
-                                stdout=payload,
-                                stderr=subprocess.PIPE,
-                                pass_fds=active_lock_fds(),
-                            )
+                            with inherited_subprocess_handles(
+                                active_lock_fds()
+                            ) as inheritance:
+                                subprocess.run(
+                                    [
+                                        "git",
+                                        "--no-replace-objects",
+                                        "-C",
+                                        str(checkout),
+                                        "cat-file",
+                                        "blob",
+                                        entry_object.decode(),
+                                    ],
+                                    check=True,
+                                    stdout=payload,
+                                    stderr=subprocess.PIPE,
+                                    **inheritance,
+                                )
                         except FileNotFoundError as error:
                             raise WorkspaceError(
                                 "required command not found: git"
@@ -3256,24 +3260,25 @@ class Workspace:
         """Return the complete, replacement-free entry inventory for a Git tree."""
 
         try:
-            result = subprocess.run(
-                [
-                    "git",
-                    "--no-replace-objects",
-                    "-C",
-                    str(checkout),
-                    "ls-tree",
-                    "-r",
-                    "-t",
-                    "--full-tree",
-                    "-z",
-                    source_tree,
-                ],
-                check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                pass_fds=active_lock_fds(),
-            )
+            with inherited_subprocess_handles(active_lock_fds()) as inheritance:
+                result = subprocess.run(
+                    [
+                        "git",
+                        "--no-replace-objects",
+                        "-C",
+                        str(checkout),
+                        "ls-tree",
+                        "-r",
+                        "-t",
+                        "--full-tree",
+                        "-z",
+                        source_tree,
+                    ],
+                    check=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    **inheritance,
+                )
         except FileNotFoundError as error:
             raise WorkspaceError("required command not found: git") from error
         except subprocess.CalledProcessError as error:
@@ -4208,23 +4213,24 @@ class Workspace:
         algorithm = hashlib.sha1 if len(root_tree) == 40 else hashlib.sha256
         for include, expected_object in sorted(source_includes.items()):
             try:
-                result = subprocess.run(
-                    [
-                        "git",
-                        "--no-replace-objects",
-                        "-C",
-                        str(checkout),
-                        "ls-tree",
-                        "-z",
-                        root_tree,
-                        "--",
-                        include,
-                    ],
-                    check=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    pass_fds=active_lock_fds(),
-                )
+                with inherited_subprocess_handles(active_lock_fds()) as inheritance:
+                    result = subprocess.run(
+                        [
+                            "git",
+                            "--no-replace-objects",
+                            "-C",
+                            str(checkout),
+                            "ls-tree",
+                            "-z",
+                            root_tree,
+                            "--",
+                            include,
+                        ],
+                        check=True,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        **inheritance,
+                    )
             except FileNotFoundError as error:
                 raise WorkspaceError("required command not found: git") from error
             except subprocess.CalledProcessError as error:
@@ -4674,13 +4680,16 @@ class Workspace:
                             ]
                             if archive_pathspec is not None:
                                 archive_command.extend(["--", archive_pathspec])
-                            subprocess.run(
-                                archive_command,
-                                check=True,
-                                stdout=archive_descriptor,
-                                stderr=subprocess.PIPE,
-                                pass_fds=active_lock_fds(),
-                            )
+                            with inherited_subprocess_handles(
+                                active_lock_fds()
+                            ) as inheritance:
+                                subprocess.run(
+                                    archive_command,
+                                    check=True,
+                                    stdout=archive_descriptor,
+                                    stderr=subprocess.PIPE,
+                                    **inheritance,
+                                )
                         except FileNotFoundError as error:
                             raise WorkspaceError(
                                 "required command not found: git"
@@ -5394,7 +5403,7 @@ class Workspace:
     def _ensure_repository(self, value: Checkout | Component) -> Path:
         checkout = self._checkout_identity(value)
         destination = self._primary_path(checkout)
-        if IS_WINDOWS:
+        if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
             try:
                 assert_no_symlink_components(destination, "component destination")
             except OSError as error:
@@ -5497,7 +5506,7 @@ class Workspace:
         self, value: Checkout | Component, path: Path, *, trace: bool = True
     ) -> str:
         checkout = self._checkout_identity(value)
-        if IS_WINDOWS:
+        if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
             try:
                 assert_no_symlink_components(path, "component checkout")
             except OSError as error:
@@ -6937,7 +6946,7 @@ class Workspace:
         self, name: str, value: dict[str, Any]
     ) -> None:
         namespace = self._lease_namespace
-        if IS_WINDOWS:
+        if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
             registry = namespace / "profile-references"
             try:
                 assert_no_symlink_components(namespace, "physical lease namespace")
@@ -7026,7 +7035,7 @@ class Workspace:
         *,
         expected_mode: int | None = None,
     ) -> None:
-        if IS_WINDOWS:
+        if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
             try:
                 assert_no_symlink_components(path, description)
                 metadata = path.stat(follow_symlinks=False)
@@ -7055,7 +7064,7 @@ class Workspace:
         self, *, only: str | None = None
     ) -> list[dict[str, Any]]:
         registry = self._lease_namespace / "profile-references"
-        if IS_WINDOWS:
+        if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
             try:
                 assert_no_symlink_components(registry, "physical reference registry")
                 if not registry.exists():
@@ -7178,7 +7187,7 @@ class Workspace:
         name = hashlib.sha256(str(authored_path.resolve()).encode()).hexdigest() + ".json"
         namespace = self._lease_namespace
         registry = namespace / "profile-references"
-        if IS_WINDOWS:
+        if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
             try:
                 assert_no_symlink_components(registry, "physical reference registry")
                 reference = registry / name
@@ -7462,7 +7471,7 @@ class Workspace:
         return Path(selector["value"])
 
     def _component_source(self, component: Component, checkout_root: Path) -> Path:
-        if IS_WINDOWS:
+        if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
             try:
                 assert_no_symlink_components(checkout_root, "component checkout")
             except OSError as error:
@@ -7490,7 +7499,7 @@ class Workspace:
                 f"component source is not a normal directory: {component.name}: {source}"
             )
         resolved = source.resolve()
-        if IS_WINDOWS:
+        if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
             try:
                 assert_no_symlink_components(source, "component source")
             except OSError as error:
@@ -10163,22 +10172,23 @@ class Workspace:
             tracked = sorted(set(tracked))
         else:
             try:
-                result = subprocess.run(
-                    [
-                        "git",
-                        "-C",
-                        str(source),
-                        "ls-files",
-                        "-z",
-                        "--cached",
-                        "--",
-                        *runtime_paths,
-                    ],
-                    check=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    pass_fds=active_lock_fds(),
-                )
+                with inherited_subprocess_handles(active_lock_fds()) as inheritance:
+                    result = subprocess.run(
+                        [
+                            "git",
+                            "-C",
+                            str(source),
+                            "ls-files",
+                            "-z",
+                            "--cached",
+                            "--",
+                            *runtime_paths,
+                        ],
+                        check=True,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        **inheritance,
+                    )
             except FileNotFoundError as error:
                 raise WorkspaceError("required command not found: git") from error
             except subprocess.CalledProcessError as error:
@@ -20031,16 +20041,19 @@ class Workspace:
                         if not python_path
                         else source_root + os.pathsep + python_path
                     )
-                    process = subprocess.Popen(
-                        command,
-                        cwd=self.paths.repository,
-                        env=environment,
-                        stdin=subprocess.DEVNULL,
-                        stdout=supervisor_log,
-                        stderr=subprocess.STDOUT,
-                        start_new_session=True,
-                        pass_fds=tuple(inherited_locks),
-                    )
+                    with inherited_subprocess_handles(
+                        tuple(inherited_locks)
+                    ) as inheritance:
+                        process = subprocess.Popen(
+                            command,
+                            cwd=self.paths.repository,
+                            env=environment,
+                            stdin=subprocess.DEVNULL,
+                            stdout=supervisor_log,
+                            stderr=subprocess.STDOUT,
+                            start_new_session=True,
+                            **inheritance,
+                        )
                     published_generation_owner.clear()
                     published_state_output_owner.clear()
                     temporary_state_owner.clear()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,6 +29,35 @@ classic cohorts contain physical checkout identities. The built-in `default`
 and `classic` profiles are coherent stacks of logical components rather than
 aliases for every manifest entry.
 
+## Platform capability matrix
+
+The wrapper has a native Windows path for the repository-management surface.
+From a clean Windows checkout, `python .\atrinik manifest validate`,
+`python .\atrinik init --with classic`, `python .\atrinik status --json`, and
+`python .\atrinik profile show classic --json` use native Windows paths and do
+not require WSL or a devcontainer. `sync`, profile create/set, path resolution,
+provenance and supply-chain validation, and worktree inventory use the same
+surface. Git child processes inherit active Windows lock handles, so a clone
+or status operation cannot silently escape its wrapper lease.
+
+| Capability | Linux | Native Windows |
+| --- | --- | --- |
+| CLI import/help, manifest, provenance, and supply-chain validation | supported | supported |
+| Initialize/synchronize checkouts, status, profile inspection/publication, path resolution, and worktree inventory | supported | supported with `LockFileEx` and native paths |
+| Build publication, cleanup, repository/content migration, scope/state/scenario mutation | supported | deliberate capability result; requires descriptor-relative filesystem proof |
+| Supervised topology build/start/status/log/stop and direct client/server run | supported when host capabilities pass | deliberate capability result; requires Linux process identity, pidfd, signals, or `/proc` |
+| Windows review ZIP | supported through the pinned Windows cross-build workflow | use the package workflow from Linux, WSL2, or the `windows-cross` devcontainer |
+
+The native Windows adapter rejects symlink and junction path components, uses
+kernel shared/exclusive byte-range locks, passes active lock handles to child
+Git processes, and flushes atomically published JSON files with
+`FlushFileBuffers`. Windows ACLs are the host ownership boundary; POSIX uid,
+mode, descriptor-relative directory durability, and `/proc` identity are not
+invented or treated as equivalent. Commands that need those proofs fail before
+mutation with a stable diagnostic. This keeps profile/worktree/state lease
+isolation and fail-closed behavior explicit while preserving the stronger
+descriptor-relative implementation on Linux.
+
 The `atrinik/classic@main` checkout at `./classic` provides five logical
 components: `classic-client` from `client/`, `classic-server` from `server/`,
 `classic-editor` from `editor/`, `classic-libatrinik` from `libatrinik/`, and

--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -4546,7 +4546,7 @@
       "name": "GitHub-hosted Windows 2025 runner",
       "kind": "toolchain",
       "owner": "github-settings",
-      "scope": ["classic", "client", "content", "devcontainer", "editor", "server", "website"],
+      "scope": ["atrinik", "classic", "client", "content", "devcontainer", "editor", "server", "website"],
       "required": true,
       "version": "windows-2025",
       "version_source": "Explicit GitHub Actions runner label and generated version report",
@@ -4563,6 +4563,7 @@
       "disposition": "retain",
       "packages": [],
       "evidence": [
+        {"repository":"atrinik","path":".github/workflows/integration.yml","contains":"runs-on: windows-2025"},
         {"repository":"classic","path":".github/workflows/check.yml","contains":"runs-on: windows-2025"},
         {"repository":"client","path":".github/workflows/validate.yml","contains":"runs-on: windows-2025"},
         {"repository":"content","path":".github/workflows/check.yml","contains":"- windows-2025"},

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -62,6 +62,25 @@ SHARED = (
 
 
 class RepositoryMigrationTests(unittest.TestCase):
+    def test_physical_repository_lock_path_inherits_active_descriptors(self) -> None:
+        completed = mock.MagicMock(returncode=0, stdout=".", stderr="")
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            mock.patch(
+                "atrinik_workspace.migration.subprocess.run",
+                return_value=completed,
+            ) as invoke,
+        ):
+            lock_path = migration_module.physical_repository_lock_path(Path(directory))
+
+        self.assertEqual(
+            lock_path,
+            Path(directory).resolve()
+            / "atrinik-resource-leases"
+            / "repository-layout.lock",
+        )
+        self.assertEqual(invoke.call_args.kwargs["pass_fds"], ())
+
     def test_git_helpers_inherit_all_exclusive_layout_descriptors(self) -> None:
         completed = mock.MagicMock(returncode=0, stdout=b"", stderr=b"")
         with (

--- a/tests/test_platform_compat.py
+++ b/tests/test_platform_compat.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from contextlib import redirect_stderr
 from io import StringIO
+import os
 from pathlib import Path
 import tempfile
 import unittest
@@ -13,9 +14,15 @@ from atrinik_workspace.locking import (
     active_lock_fds,
     resource_lifetime_reader,
 )
-from atrinik_workspace.model import atomic_json, durable_atomic_json, load_json
+from atrinik_workspace.model import (
+    WorkspaceError,
+    atomic_json,
+    durable_atomic_json,
+    load_json,
+)
 from atrinik_workspace.platform_compat import IS_WINDOWS, fcntl
 from atrinik_workspace import platform_compat
+from atrinik_workspace.workspace import open_regular_file
 
 
 class PlatformPathSafetyTests(unittest.TestCase):
@@ -56,6 +63,24 @@ class PlatformPathSafetyTests(unittest.TestCase):
                     platform_compat.assert_no_symlink_components(
                         Path(temporary) / "record.json", "test"
                     )
+
+    def test_open_regular_file_closes_descriptor_after_workspace_error(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary) / "directory"
+            directory.mkdir()
+            with self.assertRaisesRegex(WorkspaceError, "not a regular file"):
+                open_regular_file(directory, os.O_RDONLY, "test file")
+
+    def test_open_regular_file_closes_descriptor_after_os_error(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "record"
+            path.write_text("record", encoding="utf-8")
+            with mock.patch(
+                "atrinik_workspace.workspace.os.fstat",
+                side_effect=OSError("stat failed"),
+            ):
+                with self.assertRaisesRegex(WorkspaceError, "cannot open test file"):
+                    open_regular_file(path, os.O_RDONLY, "test file")
 
 
 @unittest.skipUnless(IS_WINDOWS, "native Windows compatibility coverage")

--- a/tests/test_platform_compat.py
+++ b/tests/test_platform_compat.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from contextlib import redirect_stderr
+from io import StringIO
+from pathlib import Path
+import tempfile
+import unittest
+
+from atrinik_workspace import cli
+from atrinik_workspace.locking import (
+    LeaseRequest,
+    active_lock_fds,
+    resource_lifetime_reader,
+)
+from atrinik_workspace.model import atomic_json, durable_atomic_json, load_json
+from atrinik_workspace.platform_compat import IS_WINDOWS, fcntl
+
+
+@unittest.skipUnless(IS_WINDOWS, "native Windows compatibility coverage")
+class NativeWindowsLockTests(unittest.TestCase):
+    def test_kernel_lock_is_exclusive_across_handles(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "lease.lock"
+            with path.open("a+") as first, path.open("a+") as second:
+                fcntl.flock(first, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                with self.assertRaises(BlockingIOError):
+                    fcntl.flock(second, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                fcntl.flock(first, fcntl.LOCK_UN)
+                fcntl.flock(second, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    def test_atomic_json_round_trip_uses_native_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "nested" / "record.json"
+            atomic_json(path, {"value": 1})
+            durable_atomic_json(path, {"value": 2})
+            self.assertEqual(load_json(path), {"value": 2})
+
+    def test_lifetime_lock_handle_is_inherited_by_child_processes(self) -> None:
+        request = LeaseRequest(
+            "source",
+            "native-windows-wrapper",
+            "shared",
+            "test wrapper inheritance",
+            "retry after the test operation finishes",
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            with resource_lifetime_reader(Path(temporary), request) as lease:
+                self.assertIn(lease.fileno(), active_lock_fds())
+
+    def test_linux_only_cli_command_is_stable_and_actionable(self) -> None:
+        error = StringIO()
+        with redirect_stderr(error):
+            result = cli.main(["up"])
+        self.assertEqual(result, 1)
+        self.assertIn("unavailable on native Windows", error.getvalue())
+        self.assertIn("Linux", error.getvalue())

--- a/tests/test_platform_compat.py
+++ b/tests/test_platform_compat.py
@@ -5,6 +5,7 @@ from io import StringIO
 from pathlib import Path
 import tempfile
 import unittest
+from unittest import mock
 
 from atrinik_workspace import cli
 from atrinik_workspace.locking import (
@@ -14,6 +15,47 @@ from atrinik_workspace.locking import (
 )
 from atrinik_workspace.model import atomic_json, durable_atomic_json, load_json
 from atrinik_workspace.platform_compat import IS_WINDOWS, fcntl
+from atrinik_workspace import platform_compat
+
+
+class PlatformPathSafetyTests(unittest.TestCase):
+    def test_real_and_missing_components_are_accepted(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            nested = root / "nested"
+            nested.mkdir()
+            file_path = nested / "record.json"
+            file_path.write_text("{}", encoding="utf-8")
+
+            platform_compat.assert_no_symlink_components(file_path, "test")
+            platform_compat.assert_no_symlink_components(
+                root / "missing" / "record.json", "test"
+            )
+
+    def test_symlink_components_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            with mock.patch.object(platform_compat.os.path, "islink", return_value=True):
+                with self.assertRaisesRegex(OSError, "refusing symlinked test path"):
+                    platform_compat.assert_no_symlink_components(
+                        Path(temporary) / "record.json", "test"
+                    )
+
+    def test_non_directory_parent_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            (root / "record").write_text("{}", encoding="utf-8")
+            with self.assertRaisesRegex(OSError, "test parent is not a directory"):
+                platform_compat.assert_no_symlink_components(
+                    root / "record" / "child", "test"
+                )
+
+    def test_component_inspection_errors_are_contextualized(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            with mock.patch.object(Path, "lstat", side_effect=OSError("blocked")):
+                with self.assertRaisesRegex(OSError, "cannot inspect test path"):
+                    platform_compat.assert_no_symlink_components(
+                        Path(temporary) / "record.json", "test"
+                    )
 
 
 @unittest.skipUnless(IS_WINDOWS, "native Windows compatibility coverage")


### PR DESCRIPTION
## Summary

Add native Windows support to the Atrinik workspace wrapper for the supported CLI surface described in issue #529.

## Implementation / behavior

- Replace unconditional POSIX-only imports and primitives with platform-aware adapters where equivalent Windows behavior is safe.
- Gate Linux-only process and topology operations with stable, actionable capability diagnostics.
- Preserve locking, worktree/profile/state isolation, fail-closed behavior, and existing Linux behavior.
- Add native Windows smoke coverage and document the support matrix and prerequisites.

## Validation

- Run the wrapper's focused Windows compatibility tests and the full Linux test suite.
- Validate import, help, manifest validation, initialization, status, profile handling, and supported build/runtime capability results on native Windows CI.

## Limitations / follow-up

- Full GPU client end-to-end and performance validation remains dependent on the native Windows environment described in issue #529.

Closes #529
