### PR TITLE
fix(workspace): preserve historical scope command snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -750,6 +750,11 @@ path, build, topology, log, shutdown, and release commands. Use those returned
 commands rather than reconstructing managed paths. `scope show` and `scope
 list` return the same validated records.
 
+Scope command maps are creation-time snapshots. A later manifest addition
+therefore does not invalidate a completed scope or retroactively add commands
+to its handoff; every retained entry must still be a valid current coordinate
+and exact command, while removed or edited coordinates fail closed.
+
 Creation journals every worktree, profile-reference, profile, and completed
 record publication boundary. A failed transaction removes only exact newly
 created worktrees and profiles that remain clean, unchanged, and unreferenced;

--- a/atrinik_workspace/scopes.py
+++ b/atrinik_workspace/scopes.py
@@ -1531,16 +1531,46 @@ class ScopeLifecycle:
             )
         ):
             raise WorkspaceError(f"scope command coordinates are invalid: {name}")
+        path_commands = commands["paths"]
+        build_commands = commands["builds"]
+        stack_components = {
+            component.name: component
+            for component in self.workspace.manifest.stacks[value["stack"]].components
+        }
+        buildable_components = {
+            component.name
+            for component in stack_components.values()
+            if self.workspace.manifest.effective_build(value["stack"], component) != "none"
+        }
         if (
             not isinstance(commands.get("paths"), dict)
             or not isinstance(commands.get("builds"), dict)
             or not isinstance(commands.get("logs"), dict)
             or set(commands["logs"]) != {"client", "server"}
-            or not all(isinstance(item, str) and item for item in commands["paths"].values())
-            or not all(isinstance(item, str) and item for item in commands["builds"].values())
+            or not all(
+                isinstance(key, str)
+                and key in stack_components
+                and isinstance(item, str)
+                and item
+                for key, item in path_commands.items()
+            )
+            or not all(
+                isinstance(key, str)
+                and key in buildable_components
+                and isinstance(item, str)
+                and item
+                for key, item in build_commands.items()
+            )
             or not all(isinstance(item, str) and item for item in commands["logs"].values())
         ):
             raise WorkspaceError(f"scope command maps are invalid: {name}")
+        selected_components = {
+            component
+            for row in worktrees
+            for component in row["logical_components"]
+        }
+        if not selected_components.issubset(path_commands):
+            raise WorkspaceError(f"scope commands do not match exact coordinates: {name}")
         cleanup = value.get("cleanup")
         if (
             not isinstance(cleanup, dict)
@@ -1581,7 +1611,21 @@ class ScopeLifecycle:
             profile["path_device"],
             profile["path_inode"],
         )
-        if value["commands"] != canonical["commands"]:
+        # Command maps are creation-time handoff snapshots. Compare every
+        # retained entry with its current exact coordinate, but do not require
+        # coordinates added to the manifest after this scope was created.
+        canonical_commands = {
+            **canonical["commands"],
+            "paths": {
+                key: canonical["commands"]["paths"][key]
+                for key in path_commands
+            },
+            "builds": {
+                key: canonical["commands"]["builds"][key]
+                for key in build_commands
+            },
+        }
+        if value["commands"] != canonical_commands:
             raise WorkspaceError(f"scope commands do not match exact coordinates: {name}")
         if value["cleanup"] != canonical["cleanup"]:
             raise WorkspaceError(f"scope cleanup does not match exact coordinates: {name}")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -317,6 +317,12 @@ evidence remains fail-closed. Complete and recoverable scope journals
 contribute exact cleanup references until release journals prove each worktree
 removed.
 
+Scope command maps are persisted creation-time snapshots. Validation keeps
+those snapshots stable when the manifest later gains components: newly added
+coordinates are optional for an existing scope, but every retained command
+must still be recognized by the current stack and match its exact coordinate
+form. Removed, renamed, or edited retained coordinates remain fail-closed.
+
 Release computes a canonical SHA-256 plan over the completed scope generation
 and every observed topology, state, build, profile, worktree, and reference
 disposition. Apply requires that preview digest and recomputes it under the

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -1514,6 +1514,38 @@ class ScopeLifecycleTests(unittest.TestCase):
         with self.assertRaisesRegex(WorkspaceError, "exact coordinates"):
             self.workspace.scope_show("edited-command")
 
+    def test_completed_record_rejects_edited_handoff_command_map(self) -> None:
+        self.make_checkout("client")
+        record = self.workspace.scope_create(["client"], name="edited-command-map")
+        record["commands"]["paths"]["client"] = "./unexpected-command"
+        record_path = (
+            self.workspace_directory / "scopes" / "edited-command-map" / "scope.json"
+        )
+        record_path.write_text(json.dumps(record), encoding="utf-8")
+        with self.assertRaisesRegex(WorkspaceError, "exact coordinates"):
+            self.workspace.scope_show("edited-command-map")
+
+    def test_completed_scope_survives_manifest_component_addition(self) -> None:
+        self.make_checkout("metaserver-worker")
+        record = self.workspace.scope_create(
+            ["metaserver-worker"], name="manifest-component-addition"
+        )
+        # Simulate a record created before deploy-control was registered; the
+        # command handoff is intentionally outside the request digest.
+        record["commands"]["paths"].pop("deploy-control")
+        record_path = (
+            self.workspace_directory
+            / "scopes"
+            / "manifest-component-addition"
+            / "scope.json"
+        )
+        record_path.write_text(json.dumps(record), encoding="utf-8")
+
+        self.assertEqual(
+            self.workspace.scope_show("manifest-component-addition"), record
+        )
+        self.assertEqual(self.workspace.scope_list(), [record])
+
     def test_failure_after_each_publication_boundary_is_journaled(self) -> None:
         self.make_checkout("client")
         for index, boundary in enumerate(


### PR DESCRIPTION
## Summary

Fix scope-registry revalidation for scopes created before the manifest gained a
new component. This restores trusted `scope-observe` and ledger binding for
unrelated existing scopes without rewriting their persisted records.

## Implementation / behavior

- Treat persisted `paths` and `builds` command maps as creation-time snapshots.
- Validate every retained command against the current stack and exact command
  form, while allowing coordinates added by a later manifest revision.
- Continue rejecting unknown, edited, removed, or unselected command
  coordinates, and retain strict validation for scalar handoff commands.
- Add regressions for historical command maps and edited map entries.
- Document the snapshot and fail-closed behavior.

## Validation

- `python3 -B -m unittest -q tests.test_scopes.ScopeLifecycleTests.test_scope_record_schema_rejects_each_identity_family tests.test_scopes.ScopeLifecycleTests.test_completed_record_rejects_edited_handoff_commands tests.test_scopes.ScopeLifecycleTests.test_completed_record_rejects_edited_handoff_command_map tests.test_scopes.ScopeLifecycleTests.test_completed_scope_survives_manifest_component_addition`
- `python3 -B -m unittest -q tests.test_model`
- `python3 -B -m compileall -q atrinik atrinik_workspace tests`
- `python3 -B -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `git diff --check`
- Direct validation of all 11 persisted scope records, including
  `issue-165-directory-ranking-scope`.

## Limitations / follow-up

- The full scope suite has one environment-only failure because this sandbox
  denies UDP port binding.
- The full delivery-ledger suite ran all 94 tests; its only failure was teardown
  detecting ignored helper `__pycache__` debris that cannot be removed because
  `.agents` is mounted read-only here.
- `./atrinik supply-chain validate` and live CLI scope inspection cannot acquire
  the wrapper lease because `.git` is mounted read-only in this environment.
