### PR TITLE
feat(wrapper): register web-platform component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 /sound/
 /tools/
 /website/
+/web-platform/
 *.log
 *.py[cod]
 __pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,8 @@
   `components.json` own profiles, worktrees, builds, runtimes, cleanup,
   migration, and supply-chain reports.
 - `default` selects the MIT replacement stack (Rust, Go, Protobuf, Astro,
-  source-only Observatory) plus source-only `deploy-control`; M1 foundations
+  source-only Observatory, shared `web-platform`, plus source-only
+  `deploy-control`; M1 foundations
   lack wrapper integration. `classic` is playable C17/CMake/Ninja plus MIT
   playtester; never mix providers.
 - Windows supports repository commands; Linux-only commands return stable errors.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,15 +130,18 @@ Do not normalize them as source headers; change one only through deliberate
 repository-owned legal review.
 
 The canonical `server`, `client`, `editor`, `protocol`, `renderer`,
-`content-toolkit`, `website`, and `observatory` repositories form the MIT
-replacement stack. `observatory` is source-only in the wrapper: it has no
-wrapper build adapter or runtime dependency and remains default-cohort only.
+`content-toolkit`, `website`, `observatory`, and `web-platform` repositories
+form the MIT replacement stack. `observatory` is source-only in the wrapper:
+it has no wrapper build adapter or runtime dependency and remains
+default-cohort only.
 The separately authored MIT `atrinik/deploy-control` repository is shared
 organization infrastructure for the Cloudflare Worker, Durable Object,
 protocol, and registered host-agent contracts. Its wrapper registration is
 source-only and default-only; package installation, release/deployment
 outputs, Cloudflare bindings, credentials, agent keys, host state, and mutable
-runtime state remain owned or stored outside this coordinator.
+runtime state remain owned or stored outside this coordinator. The shared
+`atrinik/web-platform` package is source-only and default-cohort only until its
+package consumers and validation contract are established.
 Plain `./atrinik init` is replacement/default-only. Exact
 `./atrinik init --with classic` adds the complete currently playable classic
 cohort: the `atrinik/classic` monorepo checkout, the independent MIT

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ persistent server state safely.
 
 No checkout is a submodule. Primary repositories are ignored, independent Git
 checkouts directly beside this README (`./client`, `./server`, `./classic`,
-`./observatory`, `./deploy-control`, and so on). The `atrinik/classic` checkout at `./classic`
+`./observatory`, `./deploy-control`, `./web-platform`, and so on). The `atrinik/classic` checkout at `./classic`
 contains the logical
 `classic-client`, `classic-server`, `classic-editor`,
 `classic-libatrinik`, and `classic-protocol` source roots. Generated worktrees,
@@ -463,7 +463,7 @@ identity are coordinated here, while installation and tests remain owned by
 
 Checkout entries have explicit local destinations; normally these are direct
 children of the wrapper root such as `./client`, `./classic`, `./content`,
-`./observatory`, and `./deploy-control`.
+`./observatory`, `./deploy-control`, and `./web-platform`.
 Logical components name their owning checkout and a safe source root within
 it. Both stacks map role `content` to that one shared checkout. A local
 `./content-1x` directory may remain as preserved migration history, but it is
@@ -480,11 +480,14 @@ checkouts are reported as optional rather than invalidating status or a
 built-in profile.
 
 The manifest assigns logical roles such as `client`, `server`, `protocol`,
-`libatrinik`, `content`, `playtester`, source-only `observatory`, and shared
-source-only `deploy-control` to providers within each stack. The `observatory`
+`libatrinik`, `content`, `playtester`, source-only `observatory`, shared
+source-only `deploy-control`, and the shared `web-platform` package to
+providers within each stack. The `observatory`
 and `deploy-control` roles are default-only and have no wrapper build adapter
 or runtime dependency; `deploy-control` owns its Worker/agent package and
-deployment workflow boundaries in its own repository. The
+deployment workflow boundaries in its own repository. The shared
+`web-platform` package is default-only and has no wrapper build adapter or
+runtime dependency while its package contract is being established. The
 built-in `default` and `classic` profiles resolve exactly one compatible
 provider for every role they require.
 A runnable service closure cannot combine replacement and classic

--- a/atrinik_workspace/model.py
+++ b/atrinik_workspace/model.py
@@ -127,6 +127,7 @@ LOGICAL_ROLES = {
     "github-settings",
     "observatory",
     "deploy-control",
+    "web-platform",
 }
 IMPLEMENTATION_ROLES = {
     "client",

--- a/components.json
+++ b/components.json
@@ -16,7 +16,8 @@
       "devcontainer",
       "github-settings",
       "observatory",
-      "deploy-control"
+      "deploy-control",
+      "web-platform"
     ],
     "classic": [
       "classic",
@@ -42,7 +43,8 @@
         "devcontainer",
         "github-settings",
         "observatory",
-        "deploy-control"
+        "deploy-control",
+        "web-platform"
       ],
       "providers": {
         "client": "client",
@@ -59,7 +61,8 @@
         "devcontainer": "devcontainer",
         "github-settings": "github-settings",
         "observatory": "observatory",
-        "deploy-control": "deploy-control"
+        "deploy-control": "deploy-control",
+        "web-platform": "web-platform"
       }
     },
     "classic": {
@@ -214,6 +217,14 @@
       "repository": "atrinik/deploy-control",
       "branch": "main",
       "path": "deploy-control",
+      "generation": "shared",
+      "license": "MIT"
+    },
+    {
+      "name": "web-platform",
+      "repository": "atrinik/web-platform",
+      "branch": "main",
+      "path": "web-platform",
       "generation": "shared",
       "license": "MIT"
     },
@@ -393,6 +404,16 @@
       "build": "none",
       "generation": "shared",
       "provides": ["deploy-control"],
+      "requires": [],
+      "license": "MIT"
+    },
+    {
+      "name": "web-platform",
+      "checkout": "web-platform",
+      "source": ".",
+      "build": "none",
+      "generation": "shared",
+      "provides": ["web-platform"],
       "requires": [],
       "license": "MIT"
     },

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -83,6 +83,12 @@ with the deploy-control repository or its workflows. Cloudflare bindings,
 application and agent keys, host/player state, and mutable runtime state stay
 outside this coordinator.
 
+The default-only shared `web-platform` component occupies
+`atrinik/web-platform@main` at `./web-platform` and provides the shared
+presentation-package source. It has no wrapper build adapter or runtime
+dependency while its package and consumer contracts are being established;
+Classic never selects it.
+
 Manifest validation rejects duplicate checkout or component names, duplicate
 local destinations, unsafe or overlapping source roots within one checkout,
 unknown cohorts, checkouts, or roles, generation mismatches, dependency

--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -533,6 +533,28 @@
       "source": "."
     },
     {
+      "audit_ready": false,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "default"
+      ],
+      "license": "MIT",
+      "commit": null,
+      "name": "web-platform",
+      "repository": "atrinik/web-platform",
+      "role": "Shared presentation package for Atrinik web applications",
+      "roles": [
+        "web-platform"
+      ],
+      "stacks": [
+        "default"
+      ],
+      "supported": true,
+      "checkout": "web-platform",
+      "source": "."
+    },
+    {
       "audit_ready": true,
       "audit_mode": "full",
       "branch": "main",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -666,6 +666,7 @@ class ReleaseConfigurationTests(unittest.TestCase):
                 "github-settings",
                 "observatory",
                 "deploy-control",
+                "web-platform",
             },
         )
         self.assertEqual(
@@ -709,6 +710,21 @@ class ReleaseConfigurationTests(unittest.TestCase):
             "none",
         )
         self.assertNotIn("deploy-control", manifest.cohorts["classic"])
+        web_platform = manifest.by_name["web-platform"]
+        self.assertEqual(
+            manifest.by_checkout["web-platform"].repository,
+            "atrinik/web-platform",
+        )
+        self.assertEqual(manifest.by_checkout["web-platform"].path, "web-platform")
+        self.assertEqual(web_platform.generation, "shared")
+        self.assertEqual(web_platform.build, "none")
+        self.assertEqual(web_platform.provides, ("web-platform",))
+        self.assertEqual(web_platform.requires, ())
+        self.assertEqual(
+            manifest.stack("default").providers["web-platform"].name,
+            "web-platform",
+        )
+        self.assertNotIn("web-platform", manifest.cohorts["classic"])
         self.assertEqual(manifest.effective_build("default", "content"), "none")
         self.assertEqual(
             manifest.effective_build("classic", "content"), "classic-content"

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -201,6 +201,14 @@ class InventoryTests(unittest.TestCase):
             inventory.repositories_by_name["deploy-control"].source,
             ".",
         )
+        web_platform = inventory.repositories_by_name["web-platform"]
+        self.assertEqual(web_platform.repository, "atrinik/web-platform")
+        self.assertEqual(web_platform.cohorts, ("default",))
+        self.assertEqual(web_platform.stacks, ("default",))
+        self.assertEqual(web_platform.roles, ("web-platform",))
+        self.assertEqual(web_platform.license, "MIT")
+        self.assertFalse(web_platform.audit_ready)
+        self.assertEqual(web_platform.audit_mode, "full")
         self.assertEqual(
             inventory.repositories_by_name["content"].stacks,
             ("classic", "default"),


### PR DESCRIPTION
## Summary

Register `atrinik/web-platform` as the shared MIT presentation package in the default workspace cohort and supply-chain inventory.

## Implementation / behavior

- Add the checkout and logical source-only component to the default manifest.
- Keep the package out of the Classic cohort and without a wrapper build or runtime adapter while its consumer contract is established.
- Update workspace guidance, architecture, supply-chain ownership, and focused manifest tests.

## Validation

- `./atrinik manifest validate`
- `./atrinik supply-chain validate`
- `python3 -m unittest tests.test_model tests.test_supply_chain`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `python3 -m compileall -q atrinik atrinik_workspace tests`
- `git diff --check`

## Limitations / follow-up

The package remains source-only and `audit_ready` is false until its package consumers and validation contract are established.
