### PR TITLE
fix(guidance): preserve MCP context headroom

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,8 @@
   Observatory, shared `web-platform`, source-only `deploy-control`; M1
   lacks wrapper integration. `classic` is playable C17/CMake/Ninja plus MIT
   playtester; never mix providers.
-- Windows supports repo commands; delivery-ledger coordination needs a pinned Linux
-  devcontainer; other Linux-only commands return stable errors.
+- Windows supports repository commands; delivery-ledger needs pinned Linux
+  devcontainer; Linux-only commands fail stably.
 
 ## Folder structure and ownership
 


### PR DESCRIPTION
## Summary

Restore the root guidance context budget after the web-platform and coordinator guidance changes were merged together.

## Implementation / behavior

- Keep the authoritative delivery-ledger coordinator requirement.
- Condense the platform-support wording so `AGENTS.md` remains below the 6,450-byte MCP context ceiling.
- Preserve the existing routing and safety meaning.

## Validation

- `python3 -m unittest tests.test_mcp_contract tests.test_agent_guidance`
- `python3 -m atrinik_workspace.guidance_inventory --check`
- `./atrinik manifest validate`
- `git diff --check`

## Limitations / follow-up

This is a documentation-only correction; it does not alter the delivery ledger or coordinator probe.
