### PR TITLE
docs(agents): track process improvements

### DIFF
--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -6,13 +6,16 @@ description: Coordinate work across checkouts, profiles, worktrees, cleanup, rel
 
 ## Resolve scope and ownership
 
-1. Read `AGENTS.md`, `components.json`, and relevant README/architecture; see
-   [repository migration](references/repository-migration.md) for pre-split repositories.
+1. Read `AGENTS.md`, `components.json`, relevant README/architecture, and
+   [repository migration](references/repository-migration.md).
 2. Resolve each physical checkout/source root; read its nearest `AGENTS.md`.
-3. Keep code, tests, packages, and releases with their physical owner; keep
-   orchestration/contracts here.
+3. Keep code, tests, packages, and releases with their physical owner;
+   orchestration/contracts stay here. Before repository work or expensive
+   build/package/runtime/remote-mutation work, consult ignored
+   `build/agent-process-improvements.md` when present, update recurring keys,
+   report `Process improvements added: none` or changed keys/issues.
 
-Checkouts are ignored repositories. One `classic` worktree holds all five
+Checkouts are ignored repositories. One `classic` worktree holds five
 `classic-*` components; both stacks share `content@main`. `content-1x` and the
 former 1.x branch are historical migration evidence only, never active
 components or delivery targets.
@@ -26,7 +29,7 @@ Inspect local state before mutation:
 ./atrinik status --json
 ```
 
-Initialize only absent repositories; `init` selects replacement, `--with classic`
+Initialize absent repositories; `init` selects replacement, `--with classic`
 adds classic, and `sync` never clones.
 
 ```sh
@@ -37,13 +40,11 @@ adds classic, and `sync` never clones.
 ./atrinik worktree create COMPONENT LABEL --branch TYPE/TOPIC
 ```
 
-Sync only clean primaries; never replace, move, or remove dirty sources.
+Sync clean primaries only; never replace/move/remove dirty sources.
 Classic selectors create `workspace/worktrees/classic/LABEL`; prefer atomic scopes.
 
-Classic scope selectors have two namespaces: the positional `components`
-arguments may use a logical component such as `classic-client`, while
-`--label`, `--branch`, and `--start-point` overrides are keyed by the physical
-checkout `classic`. For example:
+Classic selectors use logical components positionally; `--label`, `--branch`,
+and `--start-point` overrides use physical checkout `classic`:
 
 ```sh
 ./atrinik scope create classic-client --name REVIEW --from classic \
@@ -57,7 +58,7 @@ publication. Compare `requested_components`, topology, and checkout with the
 ledger request; a failed bind is recoverable only through the helper, never by
 editing or deleting ledger state.
 
-A rolled-back named create after branch-only Git/LFS failure is retried.
+Retry a rolled-back named create after branch-only Git/LFS failure.
 The wrapper proves generation/digest, rows/roots, base/head, and no coordinate
 conflict; drift or uncertainty stops. Then use `scope show`, `scope-observe`,
 and `scope-bind-cas`; never edit either.
@@ -68,8 +69,8 @@ Release with a fresh preview digest:
 ./atrinik scope release REVIEW --apply --plan PLAN_SHA256 --json
 ```
 
-Release never stops topologies or deletes persistent state; interrupted steps
-resume after a fresh preview and uncertainty retains journals.
+Release never stops topologies/deletes persistent state; interrupted steps resume
+after a fresh preview and uncertainty retains journals.
 
 Reclaim review data only through preview-first cleanup:
 
@@ -84,8 +85,8 @@ Repeat with `--apply`. Defaults cover worktrees/builds; caches/history opt in;
 `all` excludes topologies. Remove only stopped, released, exactly owned records;
 uncertainty fails closed. Apply sound-cache before its worktree and retry
 unchanged. Retire receipts only through an explicit `cleanup-journals` preview;
-exact names are required on apply. Pending/unsafe receipts and delivery
-sidecars are never cleanup targets.
+exact names are required on apply. Pending/unsafe receipts/delivery sidecars
+are never cleanup targets.
 
 ## Compose coherent sources
 
@@ -105,15 +106,13 @@ Classic selection is checkout-wide, not per subdirectory. Builds pin snapshots;
 live inputs retain leases and cleanup owns staging.
 
 Lease order is registry, profile, Git-admin, source, topology/scenario, state,
-build, cache. Gate matching coordinates; multi-source writers retry all-or-none.
-Only migration takes the barrier. Published runtimes retain generation,
-process-tree, state, and port leases. Fail closed without sharing; incomplete
-coordinates are inert. Completion is bounded, local, read-only, secret-free,
-and parser-driven before `Workspace`.
+build, cache. Gate matching coordinates; multi-source writers retry all-or-none;
+fail closed on incomplete/shared state. Migration alone takes the barrier. Published runtimes retain
+generation, process-tree, state, and port leases. Completion is bounded, local,
+read-only, secret-free, and parser-driven before `Workspace`.
 
-Verify concurrency with distinct worktrees, observable readiness rendezvous,
-and A live through B's release. Count transitions/conflicts; timeouts bound
-failure, not compiler speed.
+Verify concurrency with distinct worktrees/readiness rendezvous and A live through
+B's release; count transitions/conflicts; timeouts bound failure, not compiler speed.
 
 For classic execution load `atrinik-server-runtime`; add
 `atrinik-test-scenario` for a ready character. Never handcraft saves or expose
@@ -133,17 +132,16 @@ Use wrapper commands:
 ./atrinik down TOPOLOGY
 ```
 
-Record prerequisites, actions, results, cleanup, and applicable handoff
-commands; never replace wrapper operations with internal executables or generated
-paths.
+Record prerequisites/actions/results/cleanup and applicable handoff commands;
+never replace wrapper operations with internal executables or generated paths.
 
 ## Coordinate publication and policy
 
 Use `atrinik-github-governance` for PRs. Titles use
-`type(optional-scope): concise description` by default; add `!` only when a
-reviewer explicitly requests a breaking change, not auto. PR bodies must be
-substantive rendered GitHub-Flavored Markdown with actual line breaks, never
-literal `\n` separators. Include `Summary`, `Implementation / behavior`,
+`type(optional-scope): concise description`; add `!` only when a reviewer
+explicitly requests a breaking change. PR bodies must be substantive rendered
+GitHub-Flavored Markdown with actual line breaks, never literal `\n` separators.
+Include `Summary`, `Implementation / behavior`,
 `Validation`, and applicable `Limitations / follow-up`; an issue-closing line
 alone is insufficient. preserve contributor-authored text byte-for-byte and
 change only a separately delivery-owned section when authorized. Feed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,40 +2,38 @@
 
 ## Overview
 
-- This Python 3.11+ wrapper coordinates Atrinik repositories; `./atrinik` and
-  `components.json` own profiles, worktrees, builds, runtimes, cleanup,
-  migration, and supply-chain reports.
-- `default` selects the MIT replacement stack (Rust, Go, Protobuf, Astro,
-  source-only Observatory, shared `web-platform`, plus source-only
-  `deploy-control`; M1 foundations
-  lack wrapper integration. `classic` is playable C17/CMake/Ninja plus MIT
-  playtester; never mix providers.
+- Python 3.11+ `./atrinik` coordinates Atrinik repos; it and `components.json`
+  own profiles/worktrees/builds/runtimes/cleanup/migration and supply-chain
+  reports.
+- `default` selects MIT replacement: Rust, Go, Protobuf, Astro, source-only
+  Observatory, shared `web-platform`, source-only `deploy-control`; M1
+  foundations lack wrapper integration. `classic` is playable C17/CMake/Ninja
+  plus MIT playtester; never mix providers.
 - Windows supports repository commands; delivery-ledger coordination needs
   pinned Linux devcontainer; other Linux-only commands return stable errors.
 
 ## Folder structure and ownership
 
-- `atrinik` is the CLI, `atrinik_workspace/` owns orchestration, and `tests/`
-  the `unittest` suite.
-- Checkout, cohort, stack, role, source, and build contracts live in
-  `components.json`; machine policy lives in `supply-chain/` and `governance/`.
-- Workflows live in `.agents/skills/`, composition in `.devcontainer/`,
-  CI/release in `.github/`, and helpers in `scripts/`.
+- `atrinik` CLI, `atrinik_workspace/` orchestration, `tests/` unittest suite.
+- Checkout/cohort/stack/role/source/build contracts: `components.json`; machine
+  policy: `supply-chain/`, `governance/`.
+- Workflows: `.agents/skills/`; composition: `.devcontainer/`; CI/release:
+  `.github/`; helpers: `scripts/`.
 - Manifest destinations are ignored repositories; `workspace/` and `build/` are
   ignored generated state omitted from root status.
-- Resolve ownership through `components.json` and the checkout's nearest
-  `AGENTS.md`; keep implementation, tests, packages, and releases there.
-- `classic/` provides `classic-*`; stacks share `content@main`. `content-1x/`
-  and the former 1.x branch are historical only: preserve any local migration
-  evidence, but never select, recreate, or backport delivery to them.
-  `playtester/` is classic-only. `tools/` is MIT-default except GPL-2.0-or-later
+- Resolve ownership via `components.json` and nearest `AGENTS.md`; keep
+  implementation/tests/packages/releases with their physical owner.
+- `classic/` provides `classic-*`; stacks share `content@main`.
+  `content-1x/` and former 1.x branch are historical: preserve migration
+  evidence; never select, recreate, backport, or deliver to them. `playtester/`
+  is classic-only; `tools/` is MIT-default except GPL-2.0-or-later
   `map-checker-qt/` (`LicenseRef-Atrinik-Tools-Mixed`).
 
 ## Core behaviors and patterns
 
 - Use `atrinik-multi-repo-workspace` for wrapper ownership, profiles, worktrees,
-  migration, cleanup, releases, CLI, or layout; add applicable specialist skills
-  and use `atrinik-guidance-maintenance` for guidance audits.
+  migration, cleanup, releases, CLI/layout; add specialists; use
+  `atrinik-guidance-maintenance` for guidance audits.
 - Use `atrinik-issue-delivery` only when explicitly invoked for an issue or
   existing PR; it stops before merge.
 - Use `atrinik-program-delivery` only when explicitly invoked for an ordered
@@ -48,23 +46,25 @@
   detached, locked, active, referenced, or uncertain targets; history fails
   closed.
 - Worktrees belong to physical checkouts. Selecting `classic`, a `classic-*`
-  component, or one of its roles selects one root for all five; profiles append
-  manifest source directories.
+  component, or its roles selects a root for all five; profiles append
+  manifest source dirs.
 - Prefer `scope create`; Classic uses selectors/physical overrides.
   `scope-<name>` is the profile/topology; noncanonical overrides fail
   pre-publication.
   Rerun exact named create after rollback; bind via helper CAS.
-- Use wrapper paths; never reconstruct managed paths. Isolate topology, state,
-  ports, and client config; prefer temporary state and keep scenario secrets local.
-- Keep completion bounded, parser-driven, and secret-free.
-- Lease in order; gate same-coordinate readers; share the migration barrier.
-- Unbound persisted records are historical and inert.
+- Use wrapper paths; never reconstruct managed paths. Isolate topology/state,
+  ports/client config; prefer temporary state; keep scenario secrets local.
+- Before repository or expensive build/package/runtime/remote-mutation work,
+  consult ignored `build/agent-process-improvements.md` if present; update
+  recurring keys; report `Process improvements added: none` or keys/issues.
+- Keep completion bounded/parser-driven/secret-free; lease in order; gate
+  same-coordinate readers; share migration barrier; unbound records are inert.
 - On touch, refresh existing Atrinik-owned copyright terminal years and blanket
   holders per `CONTRIBUTING.md`; preserve precise attribution.
 - MIT reuse follows `docs/PROVENANCE.md` and its canonical identity registry;
   rights, identity, temporal, authorship, or scope uncertainty fails closed.
 - Update `supply-chain/inventory.json` when dependency ownership/validation
-  changes. Keep Actions/images immutable, add no submodules, and audit a full
+  changes. Keep Actions/images immutable, add no submodules, audit a full
   profile; only aggregate-root workflows and Dependabot are active.
 - New content/Classic issues name `content@main` and its Classic-target
   artifact. No live 1.x branch, checkout, release label, maintenance line,
@@ -83,8 +83,8 @@
 
 ## Working agreements and commands
 
-Run from this repository root. Inspect first; `init` clones only missing
-repositories and `sync` never initializes one:
+Run from repository root; inspect first. `init` clones missing repos;
+`sync` never initializes:
 
 ```sh
 ./atrinik manifest validate
@@ -128,6 +128,6 @@ Run ShellCheck for shell changes, actionlint for workflows, and
 `./atrinik supply-chain audit --profile PROFILE` when dependency inputs change.
 Preserve `.coveragerc` and OIDC Codecov boundaries.
 
-Handoffs name exact profiles, worktrees, topologies, services, states,
-scenarios, prerequisites, results, validation, and cleanup. Synchronize this
-guide and affected skills/docs with contract changes; stale guidance is a defect.
+Handoffs name exact profiles, worktrees, topologies, services, states, scenarios,
+prerequisites, results, validation, and cleanup; synchronize this guide and
+affected skills/docs with contract changes; stale guidance is a defect.

--- a/atrinik_workspace/guidance_inventory.py
+++ b/atrinik_workspace/guidance_inventory.py
@@ -4,6 +4,8 @@ import argparse
 from dataclasses import asdict, dataclass
 import json
 from pathlib import Path
+import re
+import subprocess
 import sys
 
 
@@ -19,6 +21,38 @@ MAX_MULTI_SELECTED_BYTES = 15_100
 # The delivery coordinator-context contract is intentionally kept in the
 # issue-delivery skill so Windows-hosted agents see the gate at invocation.
 MAX_ALL_SKILL_BYTES = 54_100
+
+PROCESS_IMPROVEMENT_LEDGER = Path("build/agent-process-improvements.md")
+PROCESS_TABLE_HEADER = (
+    "| Key | Status | Observation | Expected benefit / proposed action | "
+    "Related issue / PR | Last observed (UTC) |"
+)
+PROCESS_STATUSES = frozenset(
+    {"active", "adopted", "deferred", "observed", "proposed", "resolved"}
+)
+PROCESS_KEY = re.compile(r"^[a-z0-9][a-z0-9-]{1,63}$")
+PROCESS_TIMESTAMP = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$"
+)
+PROCESS_SECRET_PATTERNS = (
+    re.compile(r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----"),
+    re.compile(
+        r"\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|"
+        r"glpat-[A-Za-z0-9_-]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|"
+        r"AKIA[0-9A-Z]{16})\b"
+    ),
+    re.compile(
+        r"(?i)\b(?:password|passphrase|secret|token|api(?:[_ -]?key)?|"
+        r"access[_ -]?token|authorization|cookie)\s*[:=]\s*[^\s|`]+"
+    ),
+    re.compile(
+        r"(?i)\b(?:player|account|character)\s+(?:id|name|password)"
+        r"\s*[:=]\s*[^\s|`]+"
+    ),
+    re.compile(r"(?i)(?:^|[\s|])(?:/home|/users)/[^\s|]+"),
+    re.compile(r"(?i)(?:^|[\s|])[a-z]:[\\/]+users[\\/][^\s|]+"),
+    re.compile(r"(?m)(?:^|[\s|])(?:\d{1,3}\.){3}\d{1,3}(?=$|[\s|])"),
+)
 
 
 @dataclass(frozen=True)
@@ -70,7 +104,120 @@ def skill_frontmatter(path: Path) -> tuple[str, str]:
     return values["name"], values["description"]
 
 
+def process_improvement_ledger_path(root: Path | None = None) -> Path:
+    return (root or ROOT) / PROCESS_IMPROVEMENT_LEDGER
+
+
+def _process_ledger_ignore_error(root: Path, path: Path) -> str | None:
+    relative = path.relative_to(root).as_posix()
+    try:
+        result = subprocess.run(
+            ["git", "check-ignore", "--no-index", "--quiet", "--", relative],
+            cwd=root,
+            capture_output=True,
+            check=False,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return "cannot verify that the process-improvement ledger path is ignored"
+    if result.returncode:
+        return "process-improvement ledger path is not ignored"
+    return None
+
+
+def validate_process_improvement_ledger(root: Path | None = None) -> list[str]:
+    root = root or ROOT
+    path = process_improvement_ledger_path(root)
+    if path.is_symlink():
+        return ["process-improvement ledger must not be a symlink"]
+    if not path.exists():
+        return []
+    if not path.is_file():
+        return ["process-improvement ledger must be a regular file"]
+
+    errors: list[str] = []
+    ignore_error = _process_ledger_ignore_error(root, path)
+    if ignore_error:
+        errors.append(ignore_error)
+    try:
+        raw = path.read_bytes()
+        if len(raw) > 128 * 1024:
+            errors.append("process-improvement ledger exceeds 128 KiB")
+        text = raw.decode("utf-8")
+    except (OSError, UnicodeError):
+        return errors + ["process-improvement ledger must be bounded UTF-8"]
+
+    if not text.endswith("\n"):
+        errors.append("process-improvement ledger must end with a newline")
+    if any(
+        (ord(char) < 32 and char not in "\n\r\t") or ord(char) == 127
+        for char in text
+    ):
+        errors.append("process-improvement ledger contains control characters")
+    if any(pattern.search(text) for pattern in PROCESS_SECRET_PATTERNS):
+        errors.append("process-improvement ledger contains secret-like content")
+
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "# Agent process improvements":
+        errors.append("process-improvement ledger requires its canonical title")
+    try:
+        header_index = next(
+            index for index, line in enumerate(lines) if line.strip() == PROCESS_TABLE_HEADER
+        )
+    except StopIteration:
+        errors.append("process-improvement ledger requires its canonical table")
+        return errors
+
+    if header_index + 1 >= len(lines):
+        errors.append("process-improvement ledger table requires a separator")
+        return errors
+    separator_cells = [
+        cell.strip() for cell in lines[header_index + 1].split("|")[1:-1]
+    ]
+    if len(separator_cells) != 6 or any(
+        not re.fullmatch(r":?-{3,}:?", cell) for cell in separator_cells
+    ):
+        errors.append("process-improvement ledger table separator is invalid")
+
+    keys: set[str] = set()
+    row_count = 0
+    for line in lines[header_index + 2 :]:
+        stripped = line.strip()
+        if not stripped:
+            if row_count:
+                break
+            continue
+        if not stripped.startswith("|"):
+            if row_count:
+                break
+            continue
+        cells = [cell.strip() for cell in stripped.split("|")[1:-1]]
+        if len(cells) != 6:
+            errors.append("process-improvement ledger row must have six fields")
+            continue
+        row_count += 1
+        key = cells[0].strip("`")
+        if not PROCESS_KEY.fullmatch(key):
+            errors.append("process-improvement ledger has an invalid stable key")
+        elif key in keys:
+            errors.append("process-improvement ledger has duplicate stable keys")
+        keys.add(key)
+        if cells[1].strip("`").lower() not in PROCESS_STATUSES:
+            errors.append("process-improvement ledger has an invalid status")
+        if any(not cell for cell in cells[2:5]):
+            errors.append("process-improvement ledger rows require all descriptive fields")
+        if not PROCESS_TIMESTAMP.fullmatch(cells[5].strip("`")):
+            errors.append("process-improvement ledger requires UTC last-observed timestamps")
+
+    if row_count == 0:
+        errors.append("process-improvement ledger requires at least one row")
+    return errors
+
+
 def collect_inventory() -> dict[str, object]:
+    process_errors = validate_process_improvement_ledger()
+    if process_errors:
+        raise ValueError("; ".join(process_errors))
     root_guide = file_metrics(ROOT / "AGENTS.md")
     skills = []
     for path in sorted(SKILLS_ROOT.glob("*/SKILL.md")):
@@ -96,6 +243,10 @@ def collect_inventory() -> dict[str, object]:
 
     return {
         "root_guide": asdict(root_guide),
+        "process_improvements": {
+            "path": PROCESS_IMPROVEMENT_LEDGER.as_posix(),
+            "present": process_improvement_ledger_path().exists(),
+        },
         "skills": [asdict(skill) for skill in skills],
         "summary": {
             "skill_count": len(skills),

--- a/atrinik_workspace/guidance_inventory.py
+++ b/atrinik_workspace/guidance_inventory.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import asdict, dataclass
+from datetime import datetime
 import json
 from pathlib import Path
 import re
@@ -48,6 +49,10 @@ PROCESS_SECRET_PATTERNS = (
     re.compile(
         r"(?i)\b(?:player|account|character)\s+(?:id|name|password)"
         r"\s*[:=]\s*[^\s|`]+"
+    ),
+    re.compile(
+        r"(?i)\b(?:host|hostname|server|private[_ -]?host)\s*[:=]\s*"
+        r"[^\s|`]+"
     ),
     re.compile(r"(?i)(?:^|[\s|])(?:/home|/users)/[^\s|]+"),
     re.compile(r"(?i)(?:^|[\s|])[a-z]:[\\/]+users[\\/][^\s|]+"),
@@ -123,6 +128,16 @@ def _process_ledger_ignore_error(root: Path, path: Path) -> str | None:
     if result.returncode:
         return "process-improvement ledger path is not ignored"
     return None
+
+
+def _valid_process_timestamp(value: str) -> bool:
+    if not PROCESS_TIMESTAMP.fullmatch(value):
+        return False
+    try:
+        datetime.fromisoformat(value[:-1] + "+00:00")
+    except ValueError:
+        return False
+    return True
 
 
 def validate_process_improvement_ledger(root: Path | None = None) -> list[str]:
@@ -206,7 +221,7 @@ def validate_process_improvement_ledger(root: Path | None = None) -> list[str]:
             errors.append("process-improvement ledger has an invalid status")
         if any(not cell for cell in cells[2:5]):
             errors.append("process-improvement ledger rows require all descriptive fields")
-        if not PROCESS_TIMESTAMP.fullmatch(cells[5].strip("`")):
+        if not _valid_process_timestamp(cells[5].strip("`")):
             errors.append("process-improvement ledger requires UTC last-observed timestamps")
 
     if row_count == 0:

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -352,6 +352,7 @@ class AgentGuidanceTests(unittest.TestCase):
                 "text before row": valid.replace(
                     "| `cache-reuse`", "note\n| `cache-reuse`"
                 ),
+                "blank after row": valid + "\n",
                 "text after row": valid + "notes\n",
             }
             expected_errors = {

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -18,6 +18,7 @@ from atrinik_workspace.guidance_inventory import (
     main,
     render_text,
     skill_frontmatter,
+    validate_process_improvement_ledger,
 )
 
 
@@ -182,6 +183,82 @@ class AgentGuidanceTests(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "missing atrinik-multi"):
                     collect_inventory()
 
+    def test_process_improvement_ledger_is_optional_and_fail_closed(self) -> None:
+        valid = """# Agent process improvements
+
+| Key | Status | Observation | Expected benefit / proposed action | Related issue / PR | Last observed (UTC) |
+| --- | --- | --- | --- | --- | --- |
+| `cache-reuse` | observed | A cache can be reused. | Keep the cache warm. | none | 2026-09-02T00:00:00Z |
+"""
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.assertEqual(validate_process_improvement_ledger(root), [])
+
+            ledger = root / guidance_inventory.PROCESS_IMPROVEMENT_LEDGER
+            ledger.parent.mkdir()
+            ledger.write_text(valid, encoding="utf-8")
+            with mock.patch.object(
+                guidance_inventory.subprocess,
+                "run",
+                return_value=mock.Mock(returncode=0),
+            ) as check_ignore:
+                self.assertEqual(validate_process_improvement_ledger(root), [])
+            check_ignore.assert_called_once_with(
+                [
+                    "git",
+                    "check-ignore",
+                    "--no-index",
+                    "--quiet",
+                    "--",
+                    "build/agent-process-improvements.md",
+                ],
+                cwd=root,
+                capture_output=True,
+                check=False,
+                timeout=5,
+            )
+
+            cases = {
+                "duplicate stable keys": valid.replace(
+                    "| `cache-reuse` | observed | A cache can be reused. | Keep the cache warm. | none | 2026-09-02T00:00:00Z |",
+                    "| `cache-reuse` | observed | A cache can be reused. | Keep the cache warm. | none | 2026-09-02T00:00:00Z |\n| `cache-reuse` | observed | A second observation. | Keep the cache warm. | none | 2026-09-02T00:00:00Z |",
+                ),
+                "invalid status": valid.replace("| observed |", "| complete |"),
+                "missing field": valid.replace("| Keep the cache warm. |", "|  |"),
+                "secret-like content": valid.replace(
+                    "A cache can be reused.", "token: do-not-store-this"
+                ),
+            }
+            expected_errors = {
+                "duplicate stable keys": "duplicate stable keys",
+                "invalid status": "invalid status",
+                "missing field": "all descriptive fields",
+                "secret-like content": "secret-like content",
+            }
+            for name, content in cases.items():
+                with self.subTest(name=name):
+                    ledger.write_text(content, encoding="utf-8")
+                    with mock.patch.object(
+                        guidance_inventory.subprocess,
+                        "run",
+                        return_value=mock.Mock(returncode=0),
+                    ):
+                        errors = validate_process_improvement_ledger(root)
+                    self.assertTrue(errors)
+                    self.assertTrue(
+                        any(expected_errors[name] in error for error in errors),
+                        errors,
+                    )
+
+            ledger.write_text(valid, encoding="utf-8")
+            with mock.patch.object(
+                guidance_inventory.subprocess,
+                "run",
+                return_value=mock.Mock(returncode=1),
+            ):
+                errors = validate_process_improvement_ledger(root)
+            self.assertIn("not ignored", " ".join(errors))
+
     def test_command_output_and_failures(self) -> None:
         stdout = io.StringIO()
         with redirect_stdout(stdout):
@@ -193,6 +270,11 @@ class AgentGuidanceTests(unittest.TestCase):
             self.assertEqual(main(["--json"]), 0)
         inventory = json.loads(stdout.getvalue())
         self.assertEqual(inventory["summary"]["skill_count"], 10)
+        self.assertEqual(
+            inventory["process_improvements"]["path"],
+            "build/agent-process-improvements.md",
+        )
+        self.assertIsInstance(inventory["process_improvements"]["present"], bool)
 
         stderr = io.StringIO()
         with mock.patch.object(
@@ -210,6 +292,26 @@ class AgentGuidanceTests(unittest.TestCase):
             self.assertEqual(main([]), 1)
         self.assertIn(
             "guidance inventory failed: invalid guidance", stderr.getvalue()
+        )
+
+    def test_process_improvement_contract_is_guided(self) -> None:
+        guidance = [
+            (ROOT / "AGENTS.md").read_text(encoding="utf-8"),
+            (
+                ROOT / ".agents/skills/atrinik-multi-repo-workspace/SKILL.md"
+            ).read_text(encoding="utf-8"),
+        ]
+        normalized = [" ".join(text.split()) for text in guidance]
+        for text in normalized:
+            self.assertIn("build/agent-process-improvements.md", text)
+            self.assertIn("Process improvements added: none", text)
+        self.assertIn(
+            "before repository or expensive build/package/runtime/remote-mutation",
+            normalized[0].lower(),
+        )
+        self.assertIn(
+            "before repository work or expensive build/package/runtime/remote-mutation",
+            normalized[1].lower(),
         )
 
     def test_local_guidance_links_resolve(self) -> None:

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -228,12 +228,20 @@ class AgentGuidanceTests(unittest.TestCase):
                 "secret-like content": valid.replace(
                     "A cache can be reused.", "token: do-not-store-this"
                 ),
+                "private host content": valid.replace(
+                    "A cache can be reused.", "host: internal.example"
+                ),
+                "invalid timestamp": valid.replace(
+                    "2026-09-02T00:00:00Z", "2026-99-99T00:00:00Z"
+                ),
             }
             expected_errors = {
                 "duplicate stable keys": "duplicate stable keys",
                 "invalid status": "invalid status",
                 "missing field": "all descriptive fields",
                 "secret-like content": "secret-like content",
+                "private host content": "secret-like content",
+                "invalid timestamp": "UTC last-observed timestamps",
             }
             for name, content in cases.items():
                 with self.subTest(name=name):

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -5,7 +5,9 @@ import io
 import json
 from pathlib import Path
 import re
+import runpy
 import subprocess
+import sys
 import tempfile
 import unittest
 from unittest import mock
@@ -266,6 +268,150 @@ class AgentGuidanceTests(unittest.TestCase):
             ):
                 errors = validate_process_improvement_ledger(root)
             self.assertIn("not ignored", " ".join(errors))
+
+    def test_process_improvement_ledger_rejects_structural_and_io_failures(self) -> None:
+        valid = """# Agent process improvements
+
+| Key | Status | Observation | Expected benefit / proposed action | Related issue / PR | Last observed (UTC) |
+| --- | --- | --- | --- | --- | --- |
+| `cache-reuse` | observed | A cache can be reused. | Keep the cache warm. | none | 2026-09-02T00:00:00Z |
+"""
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            ledger = root / guidance_inventory.PROCESS_IMPROVEMENT_LEDGER
+            ledger.parent.mkdir()
+
+            def validate(content: str | bytes, **patch_kwargs: object) -> list[str]:
+                if isinstance(content, bytes):
+                    ledger.write_bytes(content)
+                else:
+                    ledger.write_text(content, encoding="utf-8")
+                with mock.patch.object(
+                    guidance_inventory.subprocess,
+                    "run",
+                    **{"return_value": mock.Mock(returncode=0), **patch_kwargs},
+                ):
+                    return validate_process_improvement_ledger(root)
+
+            self.assertIn(
+                "cannot verify",
+                " ".join(
+                    validate(valid, side_effect=OSError("git unavailable"))
+                ),
+            )
+            self.assertIn(
+                "cannot verify",
+                " ".join(
+                    validate(
+                        valid,
+                        side_effect=subprocess.TimeoutExpired(["git"], 5),
+                    )
+                ),
+            )
+            self.assertIn(
+                "bounded UTF-8",
+                " ".join(validate(b"\xff")),
+            )
+            self.assertIn(
+                "exceeds 128 KiB",
+                " ".join(validate(valid + "x" * (128 * 1024))),
+            )
+
+            cases = {
+                "missing newline": valid.rstrip("\n"),
+                "control character": valid.replace("A cache", "A \x01cache"),
+                "wrong title": valid.replace(
+                    "# Agent process improvements", "# Other improvements"
+                ),
+                "missing table": "# Agent process improvements\n\nNo rows yet.\n",
+                "missing separator": (
+                    "# Agent process improvements\n\n"
+                    + guidance_inventory.PROCESS_TABLE_HEADER
+                    + "\n"
+                ),
+                "invalid separator": valid.replace(
+                    "| --- | --- | --- | --- | --- | --- |",
+                    "| - | --- | --- | --- | --- | --- |",
+                ),
+                "wrong row shape": valid.replace(
+                    "| `cache-reuse` | observed | A cache can be reused. | "
+                    "Keep the cache warm. | none | 2026-09-02T00:00:00Z |",
+                    "| `cache-reuse` | observed | A cache can be reused. | "
+                    "Keep the cache warm. | none |",
+                ),
+                "invalid stable key": valid.replace(
+                    "`cache-reuse`", "`Cache reuse`"
+                ),
+                "invalid timestamp shape": valid.replace(
+                    "2026-09-02T00:00:00Z", "not-a-timestamp"
+                ),
+                "empty ledger": valid.split("| `cache-reuse`", 1)[0],
+                "blank before row": valid.replace(
+                    "| `cache-reuse`", "\n| `cache-reuse`"
+                ),
+                "text before row": valid.replace(
+                    "| `cache-reuse`", "note\n| `cache-reuse`"
+                ),
+                "text after row": valid + "notes\n",
+            }
+            expected_errors = {
+                "missing newline": "end with a newline",
+                "control character": "control characters",
+                "wrong title": "canonical title",
+                "missing table": "canonical table",
+                "missing separator": "requires a separator",
+                "invalid separator": "separator is invalid",
+                "wrong row shape": "six fields",
+                "invalid stable key": "invalid stable key",
+                "invalid timestamp shape": "UTC last-observed timestamps",
+                "empty ledger": "at least one row",
+            }
+            for name, content in cases.items():
+                with self.subTest(name=name):
+                    errors = validate(content)
+                    if name in expected_errors:
+                        self.assertIn(expected_errors[name], " ".join(errors))
+                    else:
+                        self.assertEqual(errors, [])
+
+            directory_root = root / "directory"
+            directory_root.mkdir()
+            directory_ledger = directory_root / guidance_inventory.PROCESS_IMPROVEMENT_LEDGER
+            directory_ledger.mkdir(parents=True)
+            self.assertIn(
+                "regular file",
+                " ".join(validate_process_improvement_ledger(directory_root)),
+            )
+
+            symlink_path = root / "symlink" / guidance_inventory.PROCESS_IMPROVEMENT_LEDGER
+            symlink_path.parent.mkdir(parents=True)
+            with mock.patch.object(
+                type(symlink_path), "is_symlink", return_value=True
+            ):
+                self.assertIn(
+                    "must not be a symlink",
+                    " ".join(validate_process_improvement_ledger(root / "symlink")),
+                )
+
+    def test_process_improvement_inventory_fails_closed_and_script_entrypoint_runs(
+        self,
+    ) -> None:
+        with mock.patch.object(
+            guidance_inventory,
+            "validate_process_improvement_ledger",
+            return_value=["invalid process ledger"],
+        ):
+            with self.assertRaisesRegex(ValueError, "invalid process ledger"):
+                collect_inventory()
+
+        with self.assertRaises(SystemExit) as exit_info:
+            with mock.patch.object(sys, "argv", ["guidance_inventory.py"]):
+                with redirect_stdout(io.StringIO()):
+                    runpy.run_path(
+                        str(ROOT / "atrinik_workspace/guidance_inventory.py"),
+                        run_name="__main__",
+                    )
+        self.assertEqual(exit_info.exception.code, 0)
 
     def test_command_output_and_failures(self) -> None:
         stdout = io.StringIO()


### PR DESCRIPTION
## Summary

Add a second ignored, human-readable ledger for reusable agent process improvements. Keep it separate from the tooling-failure ledger so successful workflow optimizations can be reused without becoming authoritative delivery evidence.

## Implementation / behavior

- Add `build/agent-process-improvements.md` with stable deduplication keys, status, observations, expected benefit or proposed action, related issue or PR, and last-observed information.
- Update the canonical workspace guidance and repository-work skill to consult the ledger before repository work and before expensive build, package, runtime, or remote-mutation sequences, update recurring rows, and report additions at handoff.
- Extend the non-CI guidance inventory check to accept an absent ledger, prove the path is ignored when present, and reject malformed, duplicated, or secret-like content.
- Seed the ledger with the Windows/container, cache-volume, capability-gating, parallel-preflight, evidence-capture, runtime-boundary, and SSH-agent improvements.

## Validation

- Add focused guidance-inventory tests for absent and present ledgers, ignored-path enforcement, required fields, duplicate keys, and secret-like content.
- Run the focused tests, complete wrapper test and coverage validation, Python compilation, guidance inventory, manifest validation, and `git diff --check` on the final head.

## Limitations / follow-up

The process ledger remains local ignored guidance: it is not committed, published, required by CI, or authoritative source or delivery evidence. Future focused implementation work can be linked from its rows without copying host-specific secrets or raw logs.

Closes #542
