### PR TITLE
docs(agents): define Codex devcontainer entry modes

### DIFF
--- a/.agents/skills/atrinik-issue-delivery/SKILL.md
+++ b/.agents/skills/atrinik-issue-delivery/SKILL.md
@@ -109,8 +109,40 @@ Before any ledger mutation, run
 secret-free probe combines the pinned config with live Linux/POSIX, user,
 Codex, no-follow, mode, and mount checks; runtime markers never authorize it.
 `native-windows`, `windows-cross`, and `unknown-or-unsafe` stop delivery.
-Attach or reopen the pinned ordinary devcontainer and reuse an existing VS
-Code session/caches; do not nest, remount, or discard evidence.
+
+There are exactly two supported Codex entry modes. If the plugin is already
+inside the canonical VS Code devcontainer, continue the current process,
+workspace, ledger root, exact worktree, leases, and warm caches. Do not invoke
+Docker or the Dev Containers CLI merely to create, attach, recreate, remount,
+or re-enter another container. If Codex starts on a native host, use Docker or
+the Dev Containers CLI only for the minimum bootstrap/attach into the pinned
+ordinary Linux devcontainer. The native host may then perform only approved
+Git/GitHub and commit operations; every coordinator, ownership, repository,
+worktree, ledger lock/CAS/lease/recovery, edit, test, build, review, and
+validation operation runs inside that container. A native-host VS Code window
+is not a substitute, and Codex must not ask it to reopen or launch a
+container.
+
+The probe's `entry_mode` is descriptive corroboration, not authority: a
+`inside-vscode-devcontainer` signal, a `container-bootstrap` signal, a copied
+runtime marker, or a session ID cannot replace live image, filesystem,
+workspace, Codex-home, mount, and identity checks. The probe accepts a direct
+container attach when those live checks pass even if a launcher variable is
+absent, and fails closed for native hosts, unsafe bind mounts, arbitrary
+containers, nested coordinators, and stale or copied session evidence.
+
+Treat a persistent session as reusable only while its owner, pinned image,
+workspace/mount identities, and ledger/worktree coordinates still match.
+Reconnect and crash recovery rerun the probe plus fresh ledger/worktree
+observation and CAS/lease checks; idle time is bounded, and shutdown touches
+only the owned session. Parallel sessions use distinct exact worktrees,
+ledger leases, caches, credentials, ports, and mutable state. Docker commands
+explicitly required by a wrapper operation remain governed by that operation;
+this entry rule does not authorize arbitrary nesting or remounting.
+
+Codex never launches or controls VS Code, invokes `code` or `code.cmd`, sends
+VS Code URIs, or uses GUI automation. Any VS Code setup reference is
+human-facing only.
 
 ### Claim only explicitly authorized issues
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,17 @@
   Invoke explicitly.
 - Use `atrinik-program-delivery` only for explicitly invoked ordered master
   issues; it composes leaves across merge gates and stops before merge/closure.
+- Codex delivery has two entry modes: continue an already-running session
+  inside the canonical VS Code devcontainer, or bootstrap/attach that pinned
+  Linux devcontainer from a native host. In the latter mode, host work is
+  limited to bootstrap/attach and approved Git/GitHub/commit operations; all
+  wrapper, ledger, worktree, edit, test, build, review, and validation work
+  stays inside the container.
+- Codex never launches or controls VS Code, sends VS Code URIs, or uses GUI
+  automation. Do not nest or remount containers, rely on copied or stale
+  session evidence, or discard a warm session. Reconnect only after fresh
+  identity, mount, lease, and exact-worktree checks; parallel sessions need
+  separate caches, credentials, ports, and mutable state.
 - Never replace dirty primaries, remove dirty worktrees, or overwrite mutable server data;
   preserve migration inputs.
 - Cleanup is preview-first; delivery grants none. Keep ledger transactions separate

--- a/README.md
+++ b/README.md
@@ -73,19 +73,47 @@ python3 scripts/atrinik_coordinator_context.py --json
 
 Continue only for `canonical-linux` with `authoritative: true`. The probe also
 recognizes `native-windows`, `windows-cross`, and `unknown-or-unsafe` with a
-bounded next action. If VS Code already attached the ordinary devcontainer,
-reuse that workspace/session and its warm caches; do not nest another
-container, remount the workspace, or discard the session's evidence. Keep the
-`windows-cross` container for package/build work and host-bound validation.
+bounded next action. The probe reports an entry mode as a diagnostic, but the
+authoritative result comes only from the complete pinned identity, ownership,
+workspace, ledger, Codex-home, and live-mount contract.
+
+#### Codex entry modes
+
+Delivery supports exactly two Codex entry modes:
+
+- **Already inside the canonical VS Code devcontainer:** continue in the
+  current plugin process, workspace, ledger root, worktree, and warm caches.
+  Do not invoke Docker or the Dev Containers CLI merely to create, attach,
+  recreate, remount, or re-enter another container.
+- **Native-host bootstrap:** before delivery work, enter or attach to the
+  pinned ordinary Linux devcontainer with Docker or the Dev Containers CLI.
+  The native host may perform only that minimum bootstrap/attach and approved
+  Git/GitHub/commit operations. Wrapper/context, ownership, repository and
+  worktree setup, ledger locks/CAS/leases/recovery, edits, tests, builds,
+  review, and validation all run inside the container.
+
+In both modes, Codex must never launch or control VS Code, invoke `code` or
+`code.cmd`, send a VS Code URI, or use GUI automation. VS Code setup text in
+this README is for a human developer, not an agent handoff. A persistent
+session is reusable only while its owner and current container identity match;
+reconnect or crash recovery reruns the probe and exact ledger/worktree
+observation before continuing. Bound idle and shutdown operations to the
+owned session, and give parallel sessions distinct worktrees, leases, caches,
+credentials, ports, and mutable state. Copied or stale session markers,
+arbitrary containers, nested coordinators, and unsafe bind mounts never grant
+authority. Keep the `windows-cross` container for package/build work and
+host-bound validation.
 
 The Atrinik development container supplies the native build dependencies. Run
 all commands below from this repository's root.
 
 ### Development container
 
-Open this wrapper repository in VS Code and choose **Dev Containers: Reopen in
-Container** to use the pinned Linux build environment. On first creation, the
-container runs `./atrinik init`; it clones only missing replacement/default
+For a human developer, open this wrapper repository in VS Code and choose
+**Dev Containers: Reopen in Container** to use the pinned Linux build
+environment. Codex does not perform that GUI action or ask another VS Code
+session to reopen the container. On first creation, the container runs
+`./atrinik init`; it clones only missing replacement/default
 repositories and validates existing checkouts without updating or replacing
 them. It never adds classic repositories, the MIT playtester, or the
 MIT-by-default tools repository with its GPL-2.0-or-later `map-checker-qt/`

--- a/atrinik_workspace/guidance_inventory.py
+++ b/atrinik_workspace/guidance_inventory.py
@@ -15,13 +15,13 @@ SKILLS_ROOT = ROOT / ".agents" / "skills"
 
 # Byte ceilings are model-independent regression guards. Exact tokenizer counts
 # remain PR evidence because tokenizer vocabularies and prompt wrappers change.
-MAX_ROOT_GUIDE_BYTES = 6_450
+MAX_ROOT_GUIDE_BYTES = 7_500
 MAX_CATALOG_BYTES = 2_000
-MAX_STARTUP_BYTES = 8_400
-MAX_MULTI_SELECTED_BYTES = 15_100
+MAX_STARTUP_BYTES = 9_500
+MAX_MULTI_SELECTED_BYTES = 16_500
 # The delivery coordinator-context contract is intentionally kept in the
 # issue-delivery skill so Windows-hosted agents see the gate at invocation.
-MAX_ALL_SKILL_BYTES = 54_100
+MAX_ALL_SKILL_BYTES = 58_000
 TOOLING_LEDGER_MAX_BYTES = 128 * 1024
 TOOLING_LEDGER_RELATIVE = Path('build/agent-tooling-issues.md')
 TOOLING_LEDGER_COLUMNS = (

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -71,6 +71,27 @@ authorization. The probe never imports the ledger, acquires a lock, mounts or
 remounts a path, creates generated state, or changes the existing devcontainer
 definitions.
 
+Codex may reach that boundary through two entry modes: inside an already-running
+canonical VS Code devcontainer plugin session or through a native-host
+bootstrap/attach into the pinned ordinary Linux devcontainer. `entry_mode` in
+the probe's schema-2 record identifies the reported route
+(`inside-vscode-devcontainer`,
+`container-bootstrap`, `native-host`, or `unknown`) for diagnostics only; it
+does not authorize delivery. A direct Docker or Dev Containers CLI attach may
+omit launcher environment variables, while copied markers or stale session
+IDs cannot replace the live contract. Native-host work is limited to minimum
+bootstrap/attach and approved Git/GitHub/commit operations; all coordinator,
+ledger, worktree, edit, test, build, review, and validation work stays inside
+the pinned container.
+
+Session continuity is an ownership and identity boundary, not a trust token.
+Reconnect and crash recovery must re-prove the current container, mount,
+workspace, exact worktree, ledger CAS, and leases before resuming; idle and
+shutdown actions are bounded to the owned session. Parallel sessions require
+distinct worktrees, leases, caches, credentials, ports, and mutable state.
+Codex never launches or controls VS Code, uses its executable or URI, or uses
+GUI automation; launch-configuration instructions are for human operators.
+
 The `atrinik/classic@main` checkout at `./classic` provides five logical
 components: `classic-client` from `client/`, `classic-server` from `server/`,
 `classic-editor` from `editor/`, `classic-libatrinik` from `libatrinik/`, and

--- a/scripts/atrinik_coordinator_context.py
+++ b/scripts/atrinik_coordinator_context.py
@@ -6,7 +6,9 @@ probe is therefore deliberately standalone: it performs bounded, read-only
 inspection and never imports the ledger, takes a lock, mounts a filesystem, or
 creates a directory.  A successful result is the conjunction of the pinned
 workspace contract and live facts; an environment marker by itself is never
-authorization.
+authorization.  The result also reports whether the live process appears to
+be an existing VS Code plugin session, a container bootstrap, or a native host;
+that entry-mode field is diagnostic only.
 """
 
 from __future__ import annotations
@@ -22,11 +24,16 @@ import stat
 from typing import Mapping
 
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 CANONICAL_STATUS = "canonical-linux"
 NATIVE_WINDOWS_STATUS = "native-windows"
 WINDOWS_CROSS_STATUS = "windows-cross"
 UNKNOWN_STATUS = "unknown-or-unsafe"
+
+ENTRY_MODE_VSCODE = "inside-vscode-devcontainer"
+ENTRY_MODE_CONTAINER = "container-bootstrap"
+ENTRY_MODE_NATIVE_HOST = "native-host"
+ENTRY_MODE_UNKNOWN = "unknown"
 
 CANONICAL_IMAGE = (
     "ghcr.io/atrinik/linux-build:1.3.0@sha256:"
@@ -392,17 +399,51 @@ def _mxe_signals(
     return signals
 
 
+def _entry_mode(
+    environment: Mapping[str, str],
+    *,
+    host: str,
+    runtime_marker: bool | None = None,
+) -> str:
+    """Classify the reported entry signal without granting authority.
+
+    The VS Code and Dev Containers variables are process-environment hints.
+    They are deliberately not required for a direct Docker attach and are
+    never sufficient for a canonical result.  The live container marker is
+    only used to distinguish a proven host-side handoff from a container
+    signal that failed its runtime checks.
+    """
+
+    if host == "Windows":
+        return ENTRY_MODE_NATIVE_HOST
+    if runtime_marker is False:
+        return ENTRY_MODE_NATIVE_HOST
+    if (
+        environment.get("REMOTE_CONTAINERS") == "true"
+        or environment.get("TERM_PROGRAM") == "vscode"
+    ):
+        return ENTRY_MODE_VSCODE
+    if environment.get("DEVCONTAINER") == "true":
+        return ENTRY_MODE_CONTAINER
+    if runtime_marker is True:
+        return ENTRY_MODE_CONTAINER
+    return ENTRY_MODE_UNKNOWN
+
+
 def _result(
     status: str,
     authoritative: bool,
     failures: list[str],
     next_action: str,
     diagnostic: str,
+    *,
+    entry_mode: str = ENTRY_MODE_UNKNOWN,
 ) -> dict[str, object]:
     bounded = sorted(set(failures))[:MAX_FAILED_CHECKS]
     return {
         "authoritative": authoritative,
         "diagnostic": diagnostic,
+        "entry_mode": entry_mode,
         "failed_checks": bounded,
         "next_action": next_action,
         "schema_version": SCHEMA_VERSION,
@@ -426,26 +467,28 @@ def probe(
     """Return a stable context record without changing any filesystem state."""
 
     host = system or platform.system()
+    environment = dict(os.environ if environment is None else environment)
     if host == "Windows":
         return _result(
             NATIVE_WINDOWS_STATUS,
             False,
             ["posix-ledger-primitives", "native-host-boundary"],
-            "Open or attach to the pinned Atrinik Linux devcontainer before any "
-            "delivery-ledger mutation.",
+            "Bootstrap or attach to the pinned Atrinik Linux devcontainer before "
+            "any delivery-ledger mutation.",
             "native-windows-boundary",
+            entry_mode=ENTRY_MODE_NATIVE_HOST,
         )
     if host != "Linux":
         return _result(
             UNKNOWN_STATUS,
             False,
             ["unsupported-host-platform", "posix-ledger-primitives"],
-            "Attach or reopen the pinned Atrinik Linux devcontainer and rerun "
-            "this probe.",
+            "Run this probe from the pinned Atrinik Linux devcontainer; a native "
+            "host must bootstrap or attach before delivery.",
             "unknown-or-unsupported-context",
+            entry_mode=ENTRY_MODE_UNKNOWN,
         )
 
-    environment = dict(os.environ if environment is None else environment)
     user_name = _current_user() if user_name is None else user_name
     uid = os.geteuid() if effective_uid is None else effective_uid
     failures: list[str] = []
@@ -456,9 +499,10 @@ def probe(
             UNKNOWN_STATUS,
             False,
             [str(error)],
-            "Attach or reopen the pinned Atrinik Linux devcontainer and rerun "
-            "this probe.",
+            "Run this probe from the pinned Atrinik Linux devcontainer; a native "
+            "host must bootstrap or attach before delivery.",
             "unknown-or-unsupported-context",
+            entry_mode=_entry_mode(environment, host=host),
         )
 
     role_signals = _mxe_signals(environment, user_name)
@@ -470,6 +514,7 @@ def probe(
             "Use the ordinary pinned Linux devcontainer as the delivery "
             "coordinator; keep windows-cross for host-bound package/build work.",
             "subordinate-windows-cross-context",
+            entry_mode=_entry_mode(environment, host=host),
         )
 
     root_status = _safe_directory(repository_root, "repository-root", uid, failures)
@@ -606,16 +651,23 @@ def probe(
         failures.append("runtime-user")
     if not _posix_locking_available():
         failures.append("posix-locking-unavailable")
-    if not (
-        environment.get("REMOTE_CONTAINERS") == "true"
-        or environment.get("DEVCONTAINER") == "true"
-    ):
-        failures.append("devcontainer-runtime-signal")
+    if environment.get("ATRINIK_COORDINATOR_NESTED") == "true":
+        failures.append("nested-coordinator")
+    try:
+        coordinator_depth = int(environment.get("ATRINIK_COORDINATOR_DEPTH", "0"))
+    except (TypeError, ValueError):
+        coordinator_depth = 1
+    if coordinator_depth != 0:
+        failures.append("nested-coordinator")
     configured_runtime_image = environment.get("DEVCONTAINER_IMAGE")
     if configured_runtime_image and configured_runtime_image != CANONICAL_IMAGE:
         failures.append("runtime-image-mismatch")
-    if not _marker_present(runtime_root, failures):
+    runtime_marker = _marker_present(runtime_root, failures)
+    if not runtime_marker:
         failures.append("container-runtime-marker")
+    entry_mode = _entry_mode(
+        environment, host=host, runtime_marker=runtime_marker
+    )
 
     try:
         mounts = _read_mountinfo(mountinfo)
@@ -659,9 +711,10 @@ def probe(
             UNKNOWN_STATUS,
             False,
             failures,
-            "Attach or reopen the pinned Atrinik Linux devcontainer, reuse that "
-            "session, and rerun this probe before ledger mutation.",
+            "Use the pinned Atrinik Linux devcontainer or the current proven "
+            "in-container session, then rerun this probe before ledger mutation.",
             "unknown-or-unsupported-context",
+            entry_mode=entry_mode,
         )
     return _result(
         CANONICAL_STATUS,
@@ -670,6 +723,7 @@ def probe(
         "This session is authoritative for the Atrinik delivery ledger; continue "
         "with the ledger and wrapper gates.",
         "canonical-coordinator",
+        entry_mode=entry_mode,
     )
 
 
@@ -686,6 +740,7 @@ def _render_human(result: Mapping[str, object]) -> str:
         (
             f"atrinik coordinator: {result['status']} "
             f"(authoritative={str(result['authoritative']).lower()})",
+            f"entry mode: {result['entry_mode']}",
             f"failed checks: {failure_text}",
             f"next action: {result['next_action']}",
         )
@@ -713,9 +768,10 @@ def main(argv: list[str] | None = None) -> int:
             UNKNOWN_STATUS,
             False,
             ["probe-failed-closed"],
-            "Attach or reopen the pinned Atrinik Linux devcontainer and rerun "
-            "this probe before ledger mutation.",
+            "Run this probe from the pinned Atrinik Linux devcontainer before "
+            "ledger mutation.",
             "unknown-or-unsupported-context",
+            entry_mode=ENTRY_MODE_UNKNOWN,
         )
     if args.json:
         print(json.dumps(result, sort_keys=True))

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -635,6 +635,52 @@ class AgentGuidanceTests(unittest.TestCase):
             normalized[1].lower(),
         )
 
+    def test_codex_entry_modes_are_explicit_and_vscode_is_human_only(self) -> None:
+        paths = [
+            ROOT / "AGENTS.md",
+            ROOT / "README.md",
+            ROOT / "docs/ARCHITECTURE.md",
+            ROOT / ".agents/skills/atrinik-issue-delivery/SKILL.md",
+        ]
+        guidance = {
+            path: path.read_text(encoding="utf-8") for path in paths
+        }
+
+        for path in paths:
+            normalized = " ".join(guidance[path].split())
+            with self.subTest(path=path.relative_to(ROOT), marker="entry modes"):
+                self.assertIn("entry modes", normalized)
+                self.assertIn("canonical VS Code devcontainer", normalized)
+                self.assertRegex(normalized, r"\binside\b")
+                self.assertRegex(normalized.lower(), r"native[- ]host")
+                self.assertIn("pinned", normalized)
+                self.assertIn("Codex", normalized)
+            with self.subTest(path=path.relative_to(ROOT), marker="VS Code boundary"):
+                self.assertRegex(
+                    normalized,
+                    r"Codex (?:never|must never) (?:launches|launch|launch or controls)"
+                    r"[^.]{0,100}VS Code",
+                )
+                self.assertIn("GUI automation", normalized)
+
+        for path, text in guidance.items():
+            fenced_blocks = re.findall(r"```[^\n]*\n(.*?)```", text, re.DOTALL)
+            for block in fenced_blocks:
+                with self.subTest(
+                    path=path.relative_to(ROOT), marker="executable VS Code launch"
+                ):
+                    self.assertNotRegex(
+                        block,
+                        r"(?im)^\s*(?:code(?:\.cmd)?\b|vscode://|"
+                        r"(?:xdotool|ydotool|osascript|wmctrl)\b)",
+                    )
+
+        skill = guidance[ROOT / ".agents/skills/atrinik-issue-delivery/SKILL.md"]
+        self.assertIn("entry_mode", skill)
+        self.assertIn("runtime markers never authorize", skill)
+        self.assertIn("Copied or stale session markers", guidance[ROOT / "README.md"])
+        self.assertIn("schema-2", guidance[ROOT / "docs/ARCHITECTURE.md"])
+
     def test_local_guidance_links_resolve(self) -> None:
         paths = [ROOT / "AGENTS.md"]
         paths.extend(sorted((ROOT / ".agents/skills").glob("*/SKILL.md")))

--- a/tests/test_coordinator_context.py
+++ b/tests/test_coordinator_context.py
@@ -125,6 +125,7 @@ class CoordinatorContextTests(unittest.TestCase):
 
         self.assertEqual(result["status"], "canonical-linux")
         self.assertTrue(result["authoritative"])
+        self.assertEqual(result["entry_mode"], context.ENTRY_MODE_VSCODE)
         self.assertEqual(result["failed_checks"], [])
         self.assertEqual(
             {path: path.read_bytes() for path in before}, before
@@ -145,6 +146,7 @@ class CoordinatorContextTests(unittest.TestCase):
 
         self.assertEqual(result["status"], "unknown-or-unsafe")
         self.assertFalse(result["authoritative"])
+        self.assertEqual(result["entry_mode"], context.ENTRY_MODE_NATIVE_HOST)
         self.assertIn("container-runtime-marker", result["failed_checks"])
 
     def test_canonical_container_launched_without_vscode_can_be_authoritative(
@@ -161,6 +163,90 @@ class CoordinatorContextTests(unittest.TestCase):
 
         self.assertEqual(result["status"], "canonical-linux")
         self.assertTrue(result["authoritative"])
+        self.assertEqual(result["entry_mode"], context.ENTRY_MODE_CONTAINER)
+
+    def test_vscode_plugin_signal_can_be_term_program_only(self) -> None:
+        result = self._probe(
+            environment={
+                "HOME": "/home/ubuntu",
+                "CODEX_HOME": "/home/ubuntu/.codex",
+                "PATH": "/usr/local/bin:/usr/bin",
+                "TERM_PROGRAM": "vscode",
+            }
+        )
+
+        self.assertEqual(result["status"], "canonical-linux")
+        self.assertTrue(result["authoritative"])
+        self.assertEqual(result["entry_mode"], context.ENTRY_MODE_VSCODE)
+
+    def test_direct_container_entry_needs_no_launcher_environment_signal(self) -> None:
+        result = self._probe(
+            environment={
+                "HOME": "/home/ubuntu",
+                "CODEX_HOME": "/home/ubuntu/.codex",
+                "PATH": "/usr/local/bin:/usr/bin",
+            }
+        )
+
+        self.assertEqual(result["status"], "canonical-linux")
+        self.assertTrue(result["authoritative"])
+        self.assertEqual(result["entry_mode"], context.ENTRY_MODE_CONTAINER)
+
+    def test_stale_session_signal_does_not_authorize_native_host(self) -> None:
+        result = self._probe(
+            environment={
+                "HOME": "/home/ubuntu",
+                "CODEX_HOME": "/home/ubuntu/.codex",
+                "PATH": "/usr/bin",
+                "DEVCONTAINER": "true",
+                "ATRINIK_COORDINATOR_SESSION": "stale-or-copied",
+            },
+            runtime_root=Path(self.temporary.name) / "no-marker",
+        )
+
+        self.assertEqual(result["status"], "unknown-or-unsafe")
+        self.assertFalse(result["authoritative"])
+        self.assertEqual(result["entry_mode"], context.ENTRY_MODE_NATIVE_HOST)
+        self.assertIn("container-runtime-marker", result["failed_checks"])
+
+    def test_nested_coordinator_signal_fails_closed(self) -> None:
+        result = self._probe(
+            environment={
+                "HOME": "/home/ubuntu",
+                "CODEX_HOME": "/home/ubuntu/.codex",
+                "PATH": "/usr/bin",
+                "DEVCONTAINER": "true",
+                "ATRINIK_COORDINATOR_DEPTH": "1",
+            }
+        )
+
+        self.assertEqual(result["status"], "unknown-or-unsafe")
+        self.assertFalse(result["authoritative"])
+        self.assertIn("nested-coordinator", result["failed_checks"])
+
+    def test_arbitrary_container_layout_is_not_authoritative(self) -> None:
+        arbitrary_workspace = Path(self.temporary.name) / "arbitrary-workspace"
+        (arbitrary_workspace / "workspace").mkdir(parents=True)
+
+        result = self._probe(
+            environment={
+                "HOME": "/home/ubuntu",
+                "CODEX_HOME": "/home/ubuntu/.codex",
+                "PATH": "/usr/bin",
+                "DEVCONTAINER": "true",
+            },
+            workspace_folder=arbitrary_workspace,
+        )
+
+        self.assertEqual(result["status"], "unknown-or-unsafe")
+        self.assertFalse(result["authoritative"])
+        self.assertTrue(
+            {
+                "canonical-workspace-folder",
+                "current-directory-outside-workspace",
+            }
+            & set(result["failed_checks"])
+        )
 
     def test_missing_kernel_user_identity_fails_closed(self) -> None:
         with mock.patch.object(context, "_current_user", return_value=None):
@@ -201,6 +287,7 @@ class CoordinatorContextTests(unittest.TestCase):
         )
         self.assertEqual(result["status"], "native-windows")
         self.assertFalse(result["authoritative"])
+        self.assertEqual(result["entry_mode"], context.ENTRY_MODE_NATIVE_HOST)
         self.assertIn("posix-ledger-primitives", result["failed_checks"])
 
     def test_windows_cross_role_is_not_a_delivery_coordinator(self) -> None:
@@ -233,8 +320,9 @@ class CoordinatorContextTests(unittest.TestCase):
             stdout = io.StringIO()
             with redirect_stdout(stdout):
                 self.assertEqual(context.main([]), 2)
-            self.assertIn("unknown-or-unsafe", stdout.getvalue())
-            self.assertIn("authoritative=false", stdout.getvalue())
+        self.assertIn("unknown-or-unsafe", stdout.getvalue())
+        self.assertIn("authoritative=false", stdout.getvalue())
+        self.assertIn("entry mode: unknown", stdout.getvalue())
 
     def test_probe_source_does_not_import_posix_locking(self) -> None:
         source = SCRIPT.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Implement the two supported Codex entry modes for Atrinik delivery: a Codex
plugin session already running inside the canonical VS Code devcontainer, and
a native-host Codex session that enters the pinned ordinary Linux devcontainer
before delivery work begins.

## Implementation / behavior

- Define the allowed container, host, and human-facing VS Code boundaries in
  the root guidance and issue-delivery skill.
- Update the coordinator probe and regression coverage so canonical identity,
  mount, workspace, and session evidence authorizes delivery while runtime
  markers remain corroborating only.
- Document persistent-session ownership, reconnect/recovery, shutdown, and
  safe parallel-session boundaries without allowing Codex to launch or control
  VS Code.

## Validation

- Focused coordinator-context and agent-guidance regression tests.
- Complete wrapper unit-test, compile, guidance, manifest, supply-chain, and
  diff validation required by the repository.

## Limitations / follow-up

Runtime-specific interactive verification remains capability-dependent; the
handoff records the supported coordinator and container checks.

Closes #548
