### PR TITLE
perf(devcontainer): use named volumes for build and cache I/O

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,12 +23,15 @@
     // Ask Docker Desktop's NVIDIA runtime to make all GPU capabilities visible.
     "--gpus=all"
   ],
-  "initializeCommand": "install -d -m 700 \"${localEnv:HOME}/.codex-atrinik\" && if [ ! -e \"${localEnv:HOME}/.gitconfig\" ]; then install -m 600 /dev/null \"${localEnv:HOME}/.gitconfig\"; fi",
+  "initializeCommand": "install -d -m 700 \"${localWorkspaceFolder}/workspace/build\" && install -d -m 700 \"${localEnv:HOME}/.codex-atrinik\" && if [ ! -e \"${localEnv:HOME}/.gitconfig\" ]; then install -m 600 /dev/null \"${localEnv:HOME}/.gitconfig\"; fi",
   "workspaceFolder": "/workspaces/atrinik",
   "mounts": [
     // Keep Codex state and Git identity local to the host user.
     "source=${localEnv:HOME}/.codex-atrinik,target=/home/ubuntu/.codex,type=bind",
     "source=${localEnv:HOME}/.gitconfig,target=/home/ubuntu/.gitconfig,type=bind,readonly",
+    // Keep high-I/O generated workspace data in a per-container named volume.
+    // initializeCommand pre-creates the nested target's writable parent.
+    "source=atrinik-${devcontainerId}-build-cache,target=/workspaces/atrinik/workspace/build,type=volume,volume-nocopy",
     // WSLg owns the Wayland, X11, runtime, and audio endpoints under this tree.
     "source=/mnt/wslg,target=/mnt/wslg,type=bind,readonly",
     // WSLg's Xwayland socket lives here; expose it at the conventional X11 path.
@@ -48,6 +51,8 @@
     // Resolve WSL's D3D12/NVIDIA user-mode libraries before container libraries.
     "LD_LIBRARY_PATH": "/usr/lib/wsl/lib",
     "CODEX_HOME": "/home/ubuntu/.codex",
+    // The container identity namespaces its named build/cache volumes.
+    "ATRINIK_DOCKER_VOLUME_NAMESPACE": "${devcontainerId}",
     // WSLg currently lacks zwp_text_input_v3; SDL's X11 backend supplies text events.
     "SDL_VIDEODRIVER": "x11",
     "PULSE_SERVER": "unix:/mnt/wslg/PulseServer",
@@ -55,6 +60,8 @@
     // Expose graphics/display as well as compute and utility capabilities.
     "NVIDIA_DRIVER_CAPABILITIES": "compute,utility,graphics,display"
   },
+  // Fresh named volumes are root-owned; repair only this volume root once.
+  "onCreateCommand": "owner=$(stat -c %u /workspaces/atrinik/workspace/build) && if [ \"$owner\" != \"$(id -u ubuntu)\" ]; then sudo chown -R --no-dereference ubuntu:ubuntu /workspaces/atrinik/workspace/build; fi",
   "postCreateCommand": "./atrinik init",
   "customizations": {
     "vscode": {

--- a/.devcontainer/windows-cross/devcontainer.json
+++ b/.devcontainer/windows-cross/devcontainer.json
@@ -3,13 +3,20 @@
   "image": "ghcr.io/atrinik/windows-build:1.2.1@sha256:d1f082eb28891600a9cf018a1d4310b9f3e1f985f82139fa48fbd4ac77b623bb",
   "workspaceFolder": "/workspaces/atrinik",
   "remoteUser": "vscode",
-  "initializeCommand": "if [ ! -e \"${localEnv:HOME}/.gitconfig\" ]; then install -m 600 /dev/null \"${localEnv:HOME}/.gitconfig\"; fi",
+  "initializeCommand": "install -d -m 700 \"${localWorkspaceFolder}/workspace/build\" && if [ ! -e \"${localEnv:HOME}/.gitconfig\" ]; then install -m 600 /dev/null \"${localEnv:HOME}/.gitconfig\"; fi",
   "mounts": [
-    "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,readonly"
+    "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,readonly",
+    // Keep Windows cross-build trees and caches in a per-container volume.
+    "source=atrinik-${devcontainerId}-build-cache,target=/workspaces/atrinik/workspace/build,type=volume,volume-nocopy"
   ],
+  "containerEnv": {
+    "ATRINIK_DOCKER_VOLUME_NAMESPACE": "${devcontainerId}"
+  },
   "remoteEnv": {
     "PATH": "/opt/mxe/usr/bin:${containerEnv:PATH}"
   },
+  // Fresh named volumes are root-owned; repair only this volume root once.
+  "onCreateCommand": "owner=$(stat -c %u /workspaces/atrinik/workspace/build) && if [ \"$owner\" != \"$(id -u vscode)\" ]; then sudo chown -R --no-dereference vscode:vscode /workspaces/atrinik/workspace/build; fi",
   "postCreateCommand": "./atrinik manifest validate",
   "customizations": {
     "vscode": {

--- a/README.md
+++ b/README.md
@@ -126,6 +126,48 @@ The wrapper owns these launch configurations because they compose the complete
 development workspace. The standalone `devcontainer` component owns only the
 published Linux and Windows toolchain images they reference.
 
+#### Docker storage topology
+
+The ordinary pinned Linux configuration keeps live source checkouts, registered
+worktrees, `workspace/state`, and the trusted `build/reviews` delivery ledger on
+their Linux-native bind mounts. It mounts `workspace/build` as the named volume
+`atrinik-${devcontainerId}-build-cache` with `volume-nocopy`. The host-side
+`workspace/build` parent is created before the nested mount, and the one-time
+`onCreateCommand` repairs the fresh volume root to the remote user's ownership.
+The wrapper still discovers `workspace/build` through `Paths`, records its normal
+markers and leases there, and applies preview-first cleanup to marker-owned
+contents; the volume itself is never guessed or removed by a broad cleanup.
+
+The Windows cross-build configuration uses the same per-container workspace
+volume. Its Docker package fallback deliberately keeps the private immutable
+source staging root and final package output on bind mounts. It attaches separate
+namespaced named volumes for client/server CMake trees, ccache, and dependency
+downloads, initializes their writable roots before the non-root build, and
+records their exact names in the package build metadata. No source checkout,
+registered worktree, server state, credential, or delivery ledger is copied into
+a cache volume.
+
+Volume names use the Dev Container identity through
+`ATRINIK_DOCKER_VOLUME_NAMESPACE`; parallel containers therefore do not share
+mutable build state. Stop all containers using a volume before removing that
+exact volume. Wrapper cleanup remains preview-first for its marker-owned
+contents, while volume removal is an explicit operator action after the
+container lease is gone.
+
+The repeatable synthetic comparison records environment, pinned image,
+namespace, cold/warm bind and volume timings, interruption/cache-reuse
+observations, host export checksums, and exact cleanup results:
+
+~~~sh
+python3 scripts/benchmark_devcontainer_storage.py \
+  --image ghcr.io/atrinik/windows-build:1.2.1@sha256:d1f082eb28891600a9cf018a1d4310b9f3e1f985f82139fa48fbd4ac77b623bb \
+  --output build/storage/windows-docker.json
+~~~
+
+The helper uses bounded deterministic input and refuses pre-existing benchmark
+volumes. Use `--keep-volumes` only when the exact reported volume is needed for
+manual inspection.
+
 For delivery work on a Windows host, the ordinary configuration is the
 coordinator. Its source/worktree mount, `build/reviews` ledger root, wrapper
 workspace, and `/home/ubuntu/.codex` mount must remain Linux-native or backed

--- a/atrinik_workspace/docker_storage.py
+++ b/atrinik_workspace/docker_storage.py
@@ -1,0 +1,86 @@
+"""Collision-safe Docker volume names and package mount specifications."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import os
+from pathlib import Path
+import re
+
+from .model import WorkspaceError
+
+
+VOLUME_NAMESPACE_ENV = "ATRINIK_DOCKER_VOLUME_NAMESPACE"
+_NAMESPACE_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_.-]{0,62}$")
+_PURPOSE_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}$")
+_MAX_DOCKER_VOLUME_NAME_LENGTH = 255
+
+
+@dataclass(frozen=True)
+class DockerVolumeMount:
+    """One writable named volume attached to a fixed container target."""
+
+    purpose: str
+    name: str
+    target: str
+
+    @property
+    def docker_spec(self) -> str:
+        return f"type=volume,source={self.name},target={self.target},volume-nocopy"
+
+
+WINDOWS_PACKAGE_VOLUME_TARGETS = (
+    ("windows-client-build", "/workspace/client/build"),
+    ("windows-server-build", "/workspace/server/build"),
+    ("windows-compiler-cache", "/workspace/.ccache"),
+    ("windows-dependency-downloads", "/workspace/.dependency-downloads"),
+)
+
+
+def _configured_namespace() -> str | None:
+    value = os.environ.get(VOLUME_NAMESPACE_ENV)
+    if value is None:
+        return None
+    if _NAMESPACE_PATTERN.fullmatch(value) is None:
+        raise WorkspaceError(
+            f"{VOLUME_NAMESPACE_ENV} must be a lowercase Docker-safe namespace"
+        )
+    return value
+
+
+def volume_namespace(repository: Path | str) -> str:
+    """Return the configured or path-derived collision-resistant namespace."""
+
+    configured = _configured_namespace()
+    if configured is not None:
+        return configured
+    resolved = Path(repository).expanduser().resolve(strict=False)
+    digest = hashlib.sha256(os.fsencode(str(resolved))).hexdigest()[:16]
+    return f"path-{digest}"
+
+
+def volume_name(repository: Path | str, purpose: str) -> str:
+    """Return a bounded, collision-safe Docker volume name."""
+
+    if _PURPOSE_PATTERN.fullmatch(purpose) is None:
+        raise WorkspaceError(f"invalid Docker volume purpose: {purpose!r}")
+    name = f"atrinik-{volume_namespace(repository)}-{purpose}"
+    if len(name) > _MAX_DOCKER_VOLUME_NAME_LENGTH:
+        raise WorkspaceError("Docker volume name exceeds the Docker limit")
+    return name
+
+
+def windows_package_volume_mounts(
+    repository: Path | str,
+) -> tuple[DockerVolumeMount, ...]:
+    """Describe isolated writable volumes used by the Windows package build."""
+
+    return tuple(
+        DockerVolumeMount(
+            purpose=purpose,
+            name=volume_name(repository, purpose),
+            target=target,
+        )
+        for purpose, target in WINDOWS_PACKAGE_VOLUME_TARGETS
+    )

--- a/atrinik_workspace/workspace.py
+++ b/atrinik_workspace/workspace.py
@@ -35,6 +35,7 @@ import zipfile
 
 from .launch_identity import CLIENT_LAUNCH_LABEL_ENV, client_launch_label
 from .content_migration import ContentMigration
+from .docker_storage import windows_package_volume_mounts
 from .filesystem_identity import (
     FilesystemIdentityError,
     identity_digest,
@@ -15498,7 +15499,7 @@ class Workspace:
 
     def _build_windows_profile_archives(
         self, staging: Path
-    ) -> tuple[Path, Path, dict[str, str]]:
+    ) -> tuple[Path, Path, dict[str, object]]:
         packages = staging / "packages"
         packages.mkdir()
         local_environment = self._local_windows_build_environment()
@@ -15530,7 +15531,70 @@ class Workspace:
                     "devcontainer toolchain or Docker"
                 )
             image = self._windows_build_image()
+            mounts = windows_package_volume_mounts(self.paths.repository)
+            staging_targets = (
+                staging / "client" / "build",
+                staging / "server" / "build",
+                staging / ".ccache",
+                staging / ".dependency-downloads",
+            )
+            expected_mount_targets = (
+                "/workspace/client/build",
+                "/workspace/server/build",
+                "/workspace/.ccache",
+                "/workspace/.dependency-downloads",
+            )
+            if tuple(mount.target for mount in mounts) != expected_mount_targets:
+                raise WorkspaceError("Windows Docker volume target contract is invalid")
+            for target in staging_targets:
+                try:
+                    assert_no_symlink_components(
+                        target, "Windows Docker volume target"
+                    )
+                except OSError as error:
+                    raise WorkspaceError(str(error)) from error
+                if target.is_symlink() or (
+                    target.exists() and not target.is_dir()
+                ):
+                    raise WorkspaceError(
+                        f"Windows Docker volume target is invalid: {target}"
+                    )
+                target.mkdir(parents=True, exist_ok=True)
+                try:
+                    assert_no_symlink_components(
+                        target, "Windows Docker volume target"
+                    )
+                except OSError as error:
+                    raise WorkspaceError(str(error)) from error
+                target.chmod(0o700)
+
+            volume_mount_arguments = [
+                argument
+                for mount in mounts
+                for argument in ("--mount", mount.docker_spec)
+            ]
+            uid = os.getuid()
+            gid = os.getgid()
+            initialization_lines = ["set -euo pipefail"]
+            for mount in mounts:
+                target = shlex.quote(mount.target)
+                initialization_lines.extend(
+                    [
+                        f"test -d {target}",
+                        f'if [ "$(stat -c %u {target})" != "{uid}" ]; then',
+                        f"  chown -R --no-dereference {uid}:{gid} {target}",
+                        "fi",
+                    ]
+                )
+            initialization_script = "\n".join(initialization_lines) + "\n"
+
             script = staging / ".atrinik-build-windows.sh"
+            if script.is_symlink() or (
+                script.exists() and not script.is_file()
+            ):
+                raise WorkspaceError(
+                    f"Windows Docker build script is invalid: {script}"
+                )
             script.write_text(
                 "#!/usr/bin/env bash\n"
                 "set -euo pipefail\n"
@@ -15541,13 +15605,38 @@ class Workspace:
                 encoding="utf-8",
             )
             script.chmod(0o700)
+
+            source_mount = (
+                f"type=bind,source={staging},target=/workspace,readonly"
+            )
+            package_mount = (
+                f"type=bind,source={packages},target=/workspace/packages"
+            )
             run(
                 [
                     "docker",
                     "run",
                     "--rm",
                     "--user",
-                    f"{os.getuid()}:{os.getgid()}",
+                    "0:0",
+                    "--mount",
+                    source_mount,
+                    "--mount",
+                    package_mount,
+                    *volume_mount_arguments,
+                    image,
+                    "bash",
+                    "-euc",
+                    initialization_script,
+                ]
+            )
+            run(
+                [
+                    "docker",
+                    "run",
+                    "--rm",
+                    "--user",
+                    f"{uid}:{gid}",
                     "--env",
                     f"ATRINIK_PACKAGE_VERSION={WINDOWS_PACKAGE_VERSION}",
                     "--env",
@@ -15558,8 +15647,17 @@ class Workspace:
                     "ATRINIK_PROFILE_CONTENT_DIR=/workspace/server/runtime/content",
                     "--env",
                     "ATRINIK_PROFILE_RESOURCES_DIR=/workspace/server/resources",
-                    "--volume",
-                    f"{staging}:/workspace",
+                    "--env",
+                    "CCACHE_DIR=/workspace/.ccache",
+                    "--env",
+                    "XDG_CACHE_HOME=/workspace/.dependency-downloads",
+                    "--env",
+                    "ATRINIK_DEPENDENCY_DOWNLOADS=/workspace/.dependency-downloads",
+                    "--mount",
+                    source_mount,
+                    "--mount",
+                    package_mount,
+                    *volume_mount_arguments,
                     "--workdir",
                     "/workspace",
                     image,
@@ -15567,7 +15665,11 @@ class Workspace:
                     "/workspace/.atrinik-build-windows.sh",
                 ]
             )
-            build = {"mode": "container", "image": image}
+            build = {
+                "mode": "container",
+                "image": image,
+                "volumes": [mount.name for mount in mounts],
+            }
 
         def one(pattern: str, label: str) -> Path:
             matches = sorted(packages.glob(pattern))
@@ -15788,9 +15890,13 @@ class Workspace:
                     }
                     build_metadata = load_json(build_root / BUILD_METADATA)
 
-            client_archive, server_archive, build = (
-                self._build_windows_profile_archives(staging / "sources")
-            )
+            with exclusive_lock(
+                self.paths.builds / "locks" / "windows-package-volumes.lock",
+                "Windows Docker package volumes",
+            ):
+                client_archive, server_archive, build = (
+                    self._build_windows_profile_archives(staging / "sources")
+                )
             package_root = staging / f"atrinik-{profile_name}-windows-review"
             package_root.mkdir()
             self._extract_portable_windows_package(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -226,18 +226,53 @@ workspace/
   worktrees/<checkout>/<label>/      physical-checkout Git worktrees
   scopes/<name>/                     durable development-scope records/journals
   profiles/<name>.json               logical component -> checkout selectors
-  build/profiles/<name>-<key>/       isolated sources, builds, and runtime
-  build/source-generations/<checkout>/<key>/ immutable primary exports
-  build/npm-cache/                   shared package download cache
-  build/worker-dependencies/<key>/   shared validated Worker installations
-  build/compiler-cache/              bounded shared native compiler cache
-  build/retention.json               optional strict build pin/rollback record
+  build/                             profile/cache root; named Docker volume in
+                                      the pinned devcontainers, native otherwise
+    profiles/<name>-<key>/           isolated sources, builds, and runtime
+    source-generations/<checkout>/<key> immutable primary exports
+    npm-cache/                       shared package download cache
+    worker-dependencies/<key>/       shared validated Worker installations
+    compiler-cache/                  bounded shared native compiler cache
+    retention.json                   optional strict build pin/rollback record
   topologies/<name>/                 supervised process state and rotated logs
     temporary-states/<generation>/   disposable or retained exact state
   state/server/<name>/               persistent mutable server data
   states.json                        named external-state registry
   cleanup-journals/                  cleanup recovery/delivery receipts
 ~~~
+
+## Container storage topology
+
+The pinned ordinary Linux devcontainer mounts only `workspace/build` as the
+per-container named volume
+`atrinik-${devcontainerId}-build-cache`. Source checkouts, managed worktrees,
+`workspace/state`, and the top-level `build/reviews` delivery-ledger root stay
+on the trusted Linux-native source bind. This preserves live editing and
+ledger/worktree identity while moving CMake/Ninja trees, compiler caches, npm
+downloads, and other high-churn generated data away from the slow host bind.
+`volume-nocopy` prevents an accidental image-to-volume copy, and the host
+configuration creates the writable nested parent before Docker attaches the
+volume. The lifecycle ownership hook repairs only a fresh volume root; normal
+wrapper markers, ordered build locks, leases, and preview-first cleanup remain
+the authority for the mounted path.
+
+The Windows Docker package fallback has a separate boundary. Its private
+immutable staging tree is a source bind, and its `packages` result is a host
+export bind. Four exact, namespaced named volumes hold client and server build
+trees, ccache, and dependency-download state. The wrapper pre-creates each
+nested target, rejects symlinks or non-directories, initializes root-owned
+volumes before the non-root build, and records the volume names with the
+package's build metadata. The staging bind is package/provenance input only;
+it is not a replacement for the live source/worktree edit loop.
+
+A volume root is a storage backend for an existing wrapper path, not a second
+workspace ownership model. Cleanup inventories and removes only marker-owned
+entries below the path after its normal leases and mount-boundary checks. It
+does not scan or delete arbitrary Docker volumes. Operators remove an exact
+named volume only after all containers using it are stopped. The bounded
+`scripts/benchmark_devcontainer_storage.py` helper measures bind versus volume
+cold/warm I/O and records interruption, cache reuse, volume removal, and host
+export evidence without mutating source or server state.
 
 ## Durable and ephemeral filesystem identity
 
@@ -1121,9 +1156,13 @@ It then copies only those selected inputs into private temporary staging and
 runs the existing Classic client and server portable-package builders. The
 installed `windows-cross` toolchain is preferred; otherwise the command reads
 the digest-pinned image identity from the devcontainer composition and invokes
-that image through Docker. The two paths use the same package scripts and
-`0.0.0` non-release version, so this command cannot mint a release version or
-asset. Explicit, path-bounded package-script inputs preserve the profile's
+that image through Docker. The Docker fallback keeps the private staging
+root and package export on bind mounts while attaching exact namespaced volumes
+for the client/server build trees, ccache, and dependency downloads. The
+wrapper pre-creates and validates each nested target and initializes fresh
+volume ownership before the non-root package scripts run. The two paths use
+the same `0.0.0` non-release version, so this command cannot mint a release version
+or asset. Explicit, path-bounded package-script inputs preserve the profile's
 staged sound, content, and resources instead of resolving component release
 locks. Before publication, tree digests prove the packaged maps, content
 library, and resources still match those staged profile inputs.

--- a/scripts/benchmark_devcontainer_storage.py
+++ b/scripts/benchmark_devcontainer_storage.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+"""Compare bind-mounted and named-volume Docker I/O for the devcontainer."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import re
+import shutil
+import statistics
+import sys
+import subprocess
+import tempfile
+import time
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from atrinik_workspace.docker_storage import volume_namespace
+from atrinik_workspace.model import WorkspaceError
+DEFAULT_WINDOWS_IMAGE = (
+    "ghcr.io/atrinik/windows-build:1.2.1@sha256:"
+    "d1f082eb28891600a9cf018a1d4310b9f3e1f985f82139fa48fbd4ac77b623bb"
+)
+NAMESPACE_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_.-]{0,62}$")
+RUN_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,30}$")
+PURPOSE_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}$")
+MAX_VOLUME_NAME = 255
+WORKLOAD_SCRIPT = r"""set -euo pipefail
+mkdir -p /output/cache /output/result
+created=0
+reused=0
+for source in /input/input-*.bin; do
+    name=$(basename "$source")
+    target="/output/cache/$name"
+    if [ -f "$target" ]; then
+        reused=$((reused + 1))
+    else
+        cp "$source" "$target"
+        created=$((created + 1))
+    fi
+done
+sha256sum /output/cache/input-*.bin | sort > /output/result/checksums.txt
+tar -cf /output/result/artifact.tar -C /output/cache .
+bytes=$(wc -c < /output/result/artifact.tar)
+digest=$(sha256sum /output/result/artifact.tar | cut -d ' ' -f1)
+printf 'created=%s reused=%s bytes=%s digest=%s\n' \
+    "$created" "$reused" "$bytes" "$digest"
+"""
+EXPORT_SCRIPT = r"""set -euo pipefail
+tar -cf /export/volume.tar -C /input .
+"""
+INTERRUPT_SCRIPT = r"""set -euo pipefail
+printf 'interrupted\n' > /output/interrupted.marker
+sleep 30
+"""
+
+
+class BenchmarkError(RuntimeError):
+    """The benchmark cannot safely continue."""
+
+
+def _validate_image(image: str) -> str:
+    if re.fullmatch(r"[^\s@]+@sha256:[0-9a-f]{64}", image) is None:
+        raise BenchmarkError("image must include a lowercase sha256 digest")
+    return image
+
+
+def _validate_namespace(namespace: str) -> str:
+    if NAMESPACE_PATTERN.fullmatch(namespace) is None:
+        raise BenchmarkError("namespace is not Docker-safe")
+    return namespace
+
+
+def _validate_run_id(run_id: str) -> str:
+    if RUN_ID_PATTERN.fullmatch(run_id) is None:
+        raise BenchmarkError("run id must contain only lowercase Docker-safe characters")
+    return run_id
+
+
+def _volume_name(namespace: str, run_id: str) -> str:
+    purpose = f"benchmark-{run_id}-volume"
+    if PURPOSE_PATTERN.fullmatch(purpose) is None:
+        raise BenchmarkError("benchmark run id produces an invalid volume purpose")
+    name = f"atrinik-{namespace}-{purpose}"
+    if len(name) > MAX_VOLUME_NAME:
+        raise BenchmarkError("benchmark volume name exceeds the Docker limit")
+    return name
+
+
+def _docker(
+    arguments: list[str],
+    *,
+    check: bool = True,
+    timeout: int = 600,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(
+            ["docker", *arguments],
+            check=check,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+        )
+    except FileNotFoundError as error:
+        raise BenchmarkError("Docker CLI is unavailable") from error
+    except subprocess.TimeoutExpired as error:
+        raise BenchmarkError(
+            f"Docker command timed out: {' '.join(arguments[:3])}"
+        ) from error
+    if check and result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        if len(detail) > 2000:
+            detail = detail[-2000:]
+        raise BenchmarkError(
+            f"Docker command failed ({' '.join(arguments[:3])}): {detail}"
+        )
+    return result
+
+
+def _docker_fact(arguments: list[str]) -> str:
+    result = _docker(arguments, check=False, timeout=30)
+    if result.returncode != 0:
+        return "unavailable"
+    return (result.stdout or "").strip() or "unknown"
+
+
+def _create_volume(name: str) -> None:
+    existing = _docker(["volume", "inspect", name], check=False, timeout=30)
+    if existing.returncode == 0:
+        raise BenchmarkError(f"refusing to reuse pre-existing benchmark volume: {name}")
+    _docker(
+        [
+            "volume",
+            "create",
+            "--label",
+            "atrinik.benchmark=devcontainer-storage",
+            name,
+        ],
+        timeout=60,
+    )
+
+
+def _write_inputs(root: Path, file_count: int, file_bytes: int) -> int:
+    root.mkdir(mode=0o700)
+    total = 0
+    for index in range(file_count):
+        seed = hashlib.sha256(
+            f"atrinik-devcontainer-storage:{index}".encode("ascii")
+        ).digest()
+        payload = (seed * ((file_bytes + len(seed) - 1) // len(seed)))[:file_bytes]
+        (root / f"input-{index:04d}.bin").write_bytes(payload)
+        total += len(payload)
+    return total
+
+
+def _reset_bind_output(path: Path) -> None:
+    if path.is_symlink():
+        raise BenchmarkError(f"benchmark bind output is a symlink: {path}")
+    if path.exists():
+        shutil.rmtree(path)
+    path.mkdir(mode=0o700)
+
+
+def _bind_mount(source: Path, target: str, *, readonly: bool = False) -> str:
+    spec = f"type=bind,source={source},target={target}"
+    return f"{spec},readonly" if readonly else spec
+
+
+def _volume_mount(
+    name: str,
+    target: str,
+    *,
+    readonly: bool = False,
+) -> str:
+    spec = f"type=volume,source={name},target={target},volume-nocopy"
+    return f"{spec},readonly" if readonly else spec
+
+
+def _parse_workload_output(stdout: str) -> dict[str, Any]:
+    line = next(
+        (candidate for candidate in reversed(stdout.splitlines()) if candidate),
+        "",
+    )
+    values: dict[str, Any] = {}
+    for item in line.split():
+        key, separator, value = item.partition("=")
+        if not separator:
+            continue
+        if key in {"created", "reused", "bytes"}:
+            try:
+                values[key] = int(value)
+            except ValueError as error:
+                raise BenchmarkError("Docker workload returned invalid counters") from error
+        elif key == "digest":
+            if re.fullmatch(r"[0-9a-f]{64}", value) is None:
+                raise BenchmarkError("Docker workload returned an invalid digest")
+            values[key] = value
+    if set(values) != {"created", "reused", "bytes", "digest"}:
+        raise BenchmarkError("Docker workload returned incomplete evidence")
+    return values
+
+
+def _timed_workload(
+    image: str,
+    inputs: Path,
+    output_mount: str,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    result = _docker(
+        [
+            "run",
+            "--rm",
+            "--user",
+            "0:0",
+            "--mount",
+            _bind_mount(inputs, "/input", readonly=True),
+            "--mount",
+            output_mount,
+            image,
+            "bash",
+            "-euc",
+            WORKLOAD_SCRIPT,
+        ]
+    )
+    elapsed_ms = (time.perf_counter() - started) * 1000
+    evidence = _parse_workload_output(result.stdout or "")
+    evidence["duration_ms"] = round(elapsed_ms, 3)
+    return evidence
+
+
+def _host_artifact(output: Path) -> dict[str, Any]:
+    artifact = output / "result" / "artifact.tar"
+    if artifact.is_symlink() or not artifact.is_file():
+        raise BenchmarkError("bind workload did not produce a regular host artifact")
+    payload = artifact.read_bytes()
+    return {
+        "bytes": len(payload),
+        "sha256": hashlib.sha256(payload).hexdigest(),
+    }
+
+
+def _comparison(
+    bind: dict[str, Any],
+    named: dict[str, Any],
+) -> dict[str, Any]:
+    bind_warm = bind["warm"]
+    named_warm = named["warm"]
+    bind_median = float(
+        statistics.median(entry["duration_ms"] for entry in bind_warm)
+    )
+    named_median = float(
+        statistics.median(entry["duration_ms"] for entry in named_warm)
+    )
+    return {
+        "bind_warm_median_ms": round(bind_median, 3),
+        "named_volume_warm_median_ms": round(named_median, 3),
+        "named_volume_over_bind_ratio": (
+            round(named_median / bind_median, 3)
+            if bind_median
+            else None
+        ),
+        "bind_warm_reused_files": sorted(
+            {entry["reused"] for entry in bind_warm}
+        ),
+        "named_volume_warm_reused_files": sorted(
+            {entry["reused"] for entry in named_warm}
+        ),
+        "named_volume_warm_after_interrupt_reused_files": named[
+            "warm_after_interrupt"
+        ]["reused"],
+    }
+
+
+def _interrupt_container(
+    image: str,
+    volume: str,
+    run_id: str,
+    active_containers: list[str],
+) -> dict[str, Any]:
+    name = f"atrinik-benchmark-{run_id}-interrupt"
+    active_containers.append(name)
+    _docker(
+        [
+            "run",
+            "-d",
+            "--name",
+            name,
+            "--user",
+            "0:0",
+            "--mount",
+            _volume_mount(volume, "/output"),
+            image,
+            "bash",
+            "-euc",
+            INTERRUPT_SCRIPT,
+        ],
+        timeout=60,
+    )
+    time.sleep(0.25)
+    state = _docker(
+        ["inspect", "--format", "{{.State.Running}}", name],
+        timeout=30,
+    )
+    running = (state.stdout or "").strip() == "true"
+    if not running:
+        raise BenchmarkError("interruption container exited before it was stopped")
+    removed = _docker(["rm", "-f", name], check=False, timeout=60)
+    if removed.returncode != 0:
+        raise BenchmarkError("could not stop the exact interruption container")
+    active_containers.remove(name)
+    return {
+        "container": name,
+        "was_running": running,
+        "removed": True,
+    }
+
+
+def _export_volume(
+    image: str,
+    volume: str,
+    export_root: Path,
+) -> dict[str, Any]:
+    export_root.mkdir(mode=0o700)
+    _docker(
+        [
+            "run",
+            "--rm",
+            "--user",
+            "0:0",
+            "--mount",
+            _volume_mount(volume, "/input", readonly=True),
+            "--mount",
+            _bind_mount(export_root, "/export"),
+            image,
+            "bash",
+            "-euc",
+            EXPORT_SCRIPT,
+        ]
+    )
+    archive = export_root / "volume.tar"
+    if archive.is_symlink() or not archive.is_file():
+        raise BenchmarkError("named-volume export did not produce a regular archive")
+    payload = archive.read_bytes()
+    return {
+        "bytes": len(payload),
+        "sha256": hashlib.sha256(payload).hexdigest(),
+    }
+
+
+def _cleanup_containers(
+    names: list[str],
+    observations: list[dict[str, Any]],
+) -> None:
+    for name in reversed(names):
+        try:
+            result = _docker(["rm", "-f", name], check=False, timeout=60)
+        except BenchmarkError as error:
+            observations.append(
+                {"container": name, "removed": False, "error": str(error)}
+            )
+            continue
+        observation: dict[str, Any] = {
+            "container": name,
+            "removed": result.returncode == 0,
+        }
+        if result.returncode != 0:
+            observation["error"] = (result.stderr or "").strip()[-500:]
+        observations.append(observation)
+
+
+def _cleanup_volumes(
+    names: list[str],
+    keep: bool,
+    observations: list[dict[str, Any]],
+) -> None:
+    for name in reversed(names):
+        if keep:
+            observations.append({"volume": name, "removed": False, "retained": True})
+            continue
+        try:
+            result = _docker(["volume", "rm", name], check=False, timeout=60)
+        except BenchmarkError as error:
+            observations.append(
+                {"volume": name, "removed": False, "error": str(error)}
+            )
+            continue
+        observations.append(
+            {
+                "volume": name,
+                "removed": result.returncode == 0,
+                "stderr": (result.stderr or "").strip()[-500:],
+            }
+        )
+
+
+def _output_path(value: str) -> Path:
+    candidate = Path(value)
+    if not candidate.is_absolute():
+        candidate = ROOT / candidate
+    candidate = candidate.resolve(strict=False)
+    build_root = (ROOT / "build").resolve(strict=False)
+    if build_root not in candidate.parents:
+        raise BenchmarkError("benchmark output must remain below the ignored build directory")
+    candidate.parent.mkdir(parents=True, exist_ok=True)
+    return candidate
+
+
+def run_benchmark(
+    *,
+    image: str,
+    namespace: str,
+    run_id: str,
+    iterations: int,
+    file_count: int,
+    file_bytes: int,
+    keep_volumes: bool,
+) -> tuple[dict[str, Any], bool]:
+    volumes: list[str] = []
+    containers: list[str] = []
+    cleanup: list[dict[str, Any]] = []
+    report: dict[str, Any] = {
+        "schema": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "image": image,
+        "namespace": namespace,
+        "run_id": run_id,
+        "environment": {
+            "platform": platform.platform(aliased=True),
+            "machine": platform.machine(),
+            "python": platform.python_version(),
+            "docker_client": _docker_fact(["version", "--format", "{{.Client.Version}}"]),
+            "docker_server": _docker_fact(["version", "--format", "{{.Server.Version}}"]),
+            "docker_driver": _docker_fact(["info", "--format", "{{.Driver}}"]),
+        },
+        "workload": {
+            "files": file_count,
+            "bytes_per_file": file_bytes,
+        },
+        "storage_contract": {
+            "bind": "temporary host directory mounted at /output",
+            "named_volume": "exact Docker volume mounted at /output",
+            "source": "temporary host directory mounted read-only at /input",
+            "export": "named volume archived through a temporary host bind",
+        },
+    }
+    failure: str | None = None
+    try:
+        with tempfile.TemporaryDirectory(
+            prefix="atrinik-devcontainer-storage-"
+        ) as temporary:
+            temporary_root = Path(temporary)
+            inputs = temporary_root / "inputs"
+            total_input_bytes = _write_inputs(inputs, file_count, file_bytes)
+            report["workload"]["total_input_bytes"] = total_input_bytes
+
+            bind_output = temporary_root / "bind-output"
+            _reset_bind_output(bind_output)
+            bind_result: dict[str, Any] = {
+                "cold": _timed_workload(
+                    image,
+                    inputs,
+                    _bind_mount(bind_output, "/output"),
+                ),
+                "warm": [],
+                "host_export": _host_artifact(bind_output),
+            }
+            for _ in range(iterations):
+                bind_result["warm"].append(
+                    _timed_workload(
+                        image,
+                        inputs,
+                        _bind_mount(bind_output, "/output"),
+                    )
+                )
+            bind_result["host_export"] = _host_artifact(bind_output)
+            report["bind"] = bind_result
+
+            named_volume = _volume_name(namespace, run_id)
+            _create_volume(named_volume)
+            volumes.append(named_volume)
+            named_mount = _volume_mount(named_volume, "/output")
+            named_result: dict[str, Any] = {
+                "volume": named_volume,
+                "cold": _timed_workload(image, inputs, named_mount),
+                "warm": [],
+            }
+            for _ in range(iterations):
+                named_result["warm"].append(
+                    _timed_workload(image, inputs, named_mount)
+                )
+            named_result["interrupted_container"] = _interrupt_container(
+                image,
+                named_volume,
+                run_id,
+                containers,
+            )
+            named_result["warm_after_interrupt"] = _timed_workload(
+                image,
+                inputs,
+                named_mount,
+            )
+            named_result["host_export"] = _export_volume(
+                image,
+                named_volume,
+                temporary_root / "volume-export",
+            )
+            report["named_volume"] = named_result
+            report["comparison"] = _comparison(bind_result, named_result)
+    except (BenchmarkError, OSError) as error:
+        failure = str(error)
+        report["error"] = failure
+    finally:
+        _cleanup_containers(containers, cleanup)
+        _cleanup_volumes(volumes, keep_volumes, cleanup)
+        report["cleanup"] = cleanup
+
+    success = failure is None and all(
+        observation.get("removed", True) or observation.get("retained", False)
+        for observation in cleanup
+        if "volume" in observation
+    )
+    report["success"] = success
+    return report, success
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Benchmark bind and named-volume Docker storage for Atrinik."
+    )
+    parser.add_argument("--image", default=DEFAULT_WINDOWS_IMAGE)
+    parser.add_argument("--namespace")
+    parser.add_argument("--run-id")
+    parser.add_argument(
+        "--output",
+        default="build/storage/devcontainer-storage-benchmark.json",
+    )
+    parser.add_argument("--iterations", type=int, default=3)
+    parser.add_argument("--files", type=int, default=32)
+    parser.add_argument("--file-bytes", type=int, default=262144)
+    parser.add_argument(
+        "--keep-volumes",
+        action="store_true",
+        help="retain the exact benchmark volume for manual cache inspection",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        image = _validate_image(args.image)
+        namespace = _validate_namespace(
+            args.namespace
+            if args.namespace is not None
+            else volume_namespace(ROOT)
+        )
+        run_id = _validate_run_id(
+            args.run_id
+            or datetime.now(timezone.utc).strftime("run%Y%m%d%H%M%S")
+            + f"-{os.getpid()}"
+        )
+        if not 1 <= args.iterations <= 20:
+            raise BenchmarkError("iterations must be between 1 and 20")
+        if not 1 <= args.files <= 4096:
+            raise BenchmarkError("files must be between 1 and 4096")
+        if not 1 <= args.file_bytes <= 8 * 1024 * 1024:
+            raise BenchmarkError("file-bytes must be between 1 and 8 MiB")
+        if args.files * args.file_bytes > 128 * 1024 * 1024:
+            raise BenchmarkError("workload is capped at 128 MiB")
+        output = _output_path(args.output)
+        report, success = run_benchmark(
+            image=image,
+            namespace=namespace,
+            run_id=run_id,
+            iterations=args.iterations,
+            file_count=args.files,
+            file_bytes=args.file_bytes,
+            keep_volumes=args.keep_volumes,
+        )
+        output.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    except (BenchmarkError, WorkspaceError) as error:
+        _parser().error(str(error))
+        return 2
+
+    print(f"storage benchmark report: {output}")
+    if args.keep_volumes:
+        print(f"benchmark volume retained: {report.get('named_volume', {}).get('volume', 'none')}")
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_devcontainer.py
+++ b/tests/test_devcontainer.py
@@ -18,6 +18,23 @@ class DevcontainerTests(unittest.TestCase):
 
         self.assertEqual(config["workspaceFolder"], "/workspaces/atrinik")
         self.assertEqual(config["postCreateCommand"], "./atrinik init")
+        self.assertIn(
+            "${localWorkspaceFolder}/workspace/build",
+            config["initializeCommand"],
+        )
+        self.assertIn(
+            "source=atrinik-${devcontainerId}-build-cache,"
+            "target=/workspaces/atrinik/workspace/build,type=volume,volume-nocopy",
+            config["mounts"],
+        )
+        self.assertIn(
+            "sudo chown -R --no-dereference ubuntu:ubuntu",
+            config["onCreateCommand"],
+        )
+        self.assertEqual(
+            config["containerEnv"]["ATRINIK_DOCKER_VOLUME_NAMESPACE"],
+            "${devcontainerId}",
+        )
         self.assertEqual(
             config["image"],
             "ghcr.io/atrinik/linux-build:1.3.0@sha256:"
@@ -33,6 +50,23 @@ class DevcontainerTests(unittest.TestCase):
         self.assertEqual(config["workspaceFolder"], "/workspaces/atrinik")
         self.assertEqual(
             config["postCreateCommand"], "./atrinik manifest validate"
+        )
+        self.assertIn(
+            "${localWorkspaceFolder}/workspace/build",
+            config["initializeCommand"],
+        )
+        self.assertIn(
+            "source=atrinik-${devcontainerId}-build-cache,"
+            "target=/workspaces/atrinik/workspace/build,type=volume,volume-nocopy",
+            config["mounts"],
+        )
+        self.assertIn(
+            "sudo chown -R --no-dereference vscode:vscode",
+            config["onCreateCommand"],
+        )
+        self.assertEqual(
+            config["containerEnv"]["ATRINIK_DOCKER_VOLUME_NAMESPACE"],
+            "${devcontainerId}",
         )
         self.assertEqual(
             config["image"],

--- a/tests/test_docker_storage.py
+++ b/tests/test_docker_storage.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import unittest
+from unittest import mock
+
+from atrinik_workspace.docker_storage import (
+    VOLUME_NAMESPACE_ENV,
+    volume_name,
+    volume_namespace,
+    windows_package_volume_mounts,
+)
+from atrinik_workspace.model import WorkspaceError
+
+
+class DockerStorageTests(unittest.TestCase):
+    def test_windows_package_mounts_are_namespaced_and_no_copy(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {VOLUME_NAMESPACE_ENV: "dev-abc123"},
+            clear=False,
+        ):
+            mounts = windows_package_volume_mounts(Path("/tmp/checkout"))
+
+        self.assertEqual(
+            [mount.name for mount in mounts],
+            [
+                "atrinik-dev-abc123-windows-client-build",
+                "atrinik-dev-abc123-windows-server-build",
+                "atrinik-dev-abc123-windows-compiler-cache",
+                "atrinik-dev-abc123-windows-dependency-downloads",
+            ],
+        )
+        self.assertEqual(
+            [mount.target for mount in mounts],
+            [
+                "/workspace/client/build",
+                "/workspace/server/build",
+                "/workspace/.ccache",
+                "/workspace/.dependency-downloads",
+            ],
+        )
+        self.assertTrue(
+            all("volume-nocopy" in mount.docker_spec for mount in mounts)
+        )
+
+    def test_path_namespace_is_stable_without_environment_override(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            namespace = volume_namespace(Path("/tmp/private-checkout"))
+            mounts = windows_package_volume_mounts(Path("/tmp/private-checkout"))
+
+        self.assertRegex(namespace, r"^path-[0-9a-f]{16}$")
+        self.assertTrue(
+            all("private-checkout" not in mount.name for mount in mounts)
+        )
+
+    def test_invalid_namespace_and_purpose_fail_closed(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {VOLUME_NAMESPACE_ENV: "unsafe namespace"},
+            clear=False,
+        ):
+            with self.assertRaisesRegex(WorkspaceError, "lowercase Docker-safe"):
+                volume_namespace(Path("/tmp/checkout"))
+
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaisesRegex(
+                WorkspaceError, "invalid Docker volume purpose"
+            ):
+                volume_name(Path("/tmp/checkout"), "../build")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_storage_benchmark.py
+++ b/tests/test_storage_benchmark.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.benchmark_devcontainer_storage import (
+    DEFAULT_WINDOWS_IMAGE,
+    WORKLOAD_SCRIPT,
+    _parse_workload_output,
+    _volume_name,
+    BenchmarkError,
+    _validate_image,
+    _validate_run_id,
+)
+
+
+class StorageBenchmarkTests(unittest.TestCase):
+    def test_default_image_is_digest_pinned(self) -> None:
+        self.assertEqual(_validate_image(DEFAULT_WINDOWS_IMAGE), DEFAULT_WINDOWS_IMAGE)
+
+    def test_workload_output_is_bounded_and_typed(self) -> None:
+        parsed = _parse_workload_output(
+            "created=32 reused=0 bytes=123 digest=" + "a" * 64 + "\n"
+        )
+
+        self.assertEqual(parsed["created"], 32)
+        self.assertEqual(parsed["reused"], 0)
+        self.assertEqual(parsed["bytes"], 123)
+        self.assertEqual(parsed["digest"], "a" * 64)
+        self.assertIn("cache", WORKLOAD_SCRIPT)
+        self.assertEqual(
+            _volume_name("dev-abc123", "test123"),
+            "atrinik-dev-abc123-benchmark-test123-volume",
+        )
+
+    def test_run_id_rejects_path_syntax(self) -> None:
+        with self.assertRaisesRegex(BenchmarkError, "Docker-safe"):
+            _validate_run_id("../unsafe")

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -31,6 +31,7 @@ from dataclasses import replace
 from unittest import mock
 
 from atrinik_workspace import workspace as workspace_module
+from atrinik_workspace.docker_storage import windows_package_volume_mounts
 from atrinik_workspace import cleanup as cleanup_module
 from atrinik_workspace import locking as locking_module
 from atrinik_workspace.cleanup import Cleanup
@@ -23278,17 +23279,44 @@ class WorkspaceTests(unittest.TestCase):
         staging = self.root / "windows-sources"
         staging.mkdir()
         image = "ghcr.io/atrinik/windows-build:1@sha256:" + "a" * 64
+        calls: list[list[str]] = []
 
         def synthetic_build(arguments: list[str], **_kwargs: object) -> str:
+            calls.append(arguments)
+            self.assertEqual(arguments[0:2], ["docker", "run"])
+            self.assertIn(image, arguments)
+            self.assertIn(
+                f"type=bind,source={staging},target=/workspace,readonly",
+                arguments,
+            )
+            self.assertIn(
+                f"type=bind,source={staging / 'packages'},target=/workspace/packages",
+                arguments,
+            )
+            expected_mounts = windows_package_volume_mounts(
+                self.workspace.paths.repository
+            )
+            for mount in expected_mounts:
+                self.assertIn(mount.docker_spec, arguments)
+            if "ATRINIK_PROFILE_SOUND_DIR=/workspace/client/sound" not in arguments:
+                self.assertEqual(
+                    arguments[arguments.index("--user") + 1],
+                    "0:0",
+                )
+                self.assertIn(
+                    "chown -R --no-dereference",
+                    arguments[-1],
+                )
+                return ""
+
             packages = staging / "packages"
             for component in ("client", "server"):
                 (packages / (
                     f"atrinik-classic-{component}-0.0.0-windows-x86_64.zip"
                 )).write_bytes(component.encode())
-            self.assertEqual(arguments[0:2], ["docker", "run"])
-            self.assertIn(image, arguments)
-            self.assertIn(
-                "ATRINIK_PROFILE_SOUND_DIR=/workspace/client/sound", arguments
+            self.assertEqual(
+                arguments[arguments.index("--user") + 1],
+                f"{os.getuid()}:{os.getgid()}",
             )
             self.assertIn(
                 "ATRINIK_PROFILE_CONTENT_DIR=/workspace/server/runtime/content",
@@ -23296,6 +23324,15 @@ class WorkspaceTests(unittest.TestCase):
             )
             self.assertIn(
                 "ATRINIK_PROFILE_RESOURCES_DIR=/workspace/server/resources",
+                arguments,
+            )
+            self.assertIn("CCACHE_DIR=/workspace/.ccache", arguments)
+            self.assertIn(
+                "XDG_CACHE_HOME=/workspace/.dependency-downloads",
+                arguments,
+            )
+            self.assertIn(
+                "ATRINIK_DEPENDENCY_DOWNLOADS=/workspace/.dependency-downloads",
                 arguments,
             )
             return ""
@@ -23312,9 +23349,30 @@ class WorkspaceTests(unittest.TestCase):
                 staging
             )
 
+        self.assertEqual(len(calls), 2)
         self.assertEqual(client.name, "atrinik-classic-client-0.0.0-windows-x86_64.zip")
         self.assertEqual(server.name, "atrinik-classic-server-0.0.0-windows-x86_64.zip")
-        self.assertEqual(build, {"mode": "container", "image": image})
+        expected_names = [
+            mount.name
+            for mount in windows_package_volume_mounts(
+                self.workspace.paths.repository
+            )
+        ]
+        self.assertEqual(
+            build,
+            {
+                "mode": "container",
+                "image": image,
+                "volumes": expected_names,
+            },
+        )
+        for target in (
+            staging / "client" / "build",
+            staging / "server" / "build",
+            staging / ".ccache",
+            staging / ".dependency-downloads",
+        ):
+            self.assertTrue(target.is_dir())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Use collision-safe Docker named volumes for high-I/O workspace build data and Windows cross-build caches while keeping live source and exported package results on bind mounts.

Closes #538

## Implementation / behavior

- The ordinary pinned Linux devcontainer mounts `workspace/build` as a named volume keyed by `${devcontainerId}`. The wrapper continues to own that path for CMake/Ninja trees, compiler/npm/dependency caches, review evidence, leases, and preview-first cleanup; `workspace/state`, source checkouts, and worktrees stay outside the build volume.
- Windows Docker packaging keeps its deliberate immutable source staging bind and package export bind, but places client/server build trees and ccache in named volumes with the pinned `windows-cross` image. Fresh nested mount targets are pre-created before Docker starts, and the command fails closed on invalid volume configuration.
- Documentation and a deterministic benchmark/inspection helper describe the bind/volume/export/staging topology, cache reuse, interrupted containers, and safe volume removal.
- No source tree or server state is copied into the ordinary development volume.

## Validation

- Focused unit tests cover the devcontainer mount contract, volume namespace validation, package Docker arguments, and cache/export behavior.
- The full wrapper unittest, compile, manifest, supply-chain, guidance, and diff checks are run before the pull request is marked ready.
- The storage benchmark records environment, image, volume namespace, cold/warm results, and cleanup observations as local ignored evidence.

## Limitations / follow-up

- Windows package timings remain environment-specific; retain the generated benchmark evidence with the delivery report rather than committing machine-specific results.
