### PR TITLE
docs(agents): document optional SSH commit signing boundary

### DIFF
--- a/.agents/skills/atrinik-github-governance/SKILL.md
+++ b/.agents/skills/atrinik-github-governance/SKILL.md
@@ -20,6 +20,13 @@ description: Publish Atrinik PRs, govern GitHub policy, or review and explicitly
 5. Keep controls Team-plan compatible; document and review Enterprise-only
    migrations.
 
+## Optional commit-signing guidance
+
+For optional SSH commit-signing setup and the host/container boundary, read
+[the SSH signing reference](references/ssh-signing.md). It keeps personal
+keys and signing configuration out of the repository and does not change
+repository commit-signing policy.
+
 ## Change policy coherently
 
 - Synchronize required workflow jobs with repository rulesets; when workflows

--- a/.agents/skills/atrinik-github-governance/references/ssh-signing.md
+++ b/.agents/skills/atrinik-github-governance/references/ssh-signing.md
@@ -1,0 +1,129 @@
+# Optional SSH commit signing
+
+This reference describes the optional SSH signing path for Atrinik contributors
+and agents. It complements GitHub's [commit signature verification
+guide](https://docs.github.com/en/authentication/managing-commit-signature-verification)
+and keeps signing configuration outside the repository.
+
+## Keep the host/container boundary explicit
+
+- Signing configuration, the passphrase, and the passphrase-protected private
+  key belong to the contributor host and personal account.
+- Native host Git is the default place to create and sign commits. Use the
+  Docker/devcontainer for builds, tests, and other container-owned work.
+- An exceptional container commit may forward the host SSH agent through an
+  explicitly supported `SSH_AUTH_SOCK` path and set only the required public
+  signing metadata. Agent forwarding does not copy the private key.
+- Never copy or bind-mount a private signing key, the private `.ssh` directory,
+  or a personal Git configuration containing signing secrets into a source
+  tree, image, container, generated state directory, or repository.
+- SSH signing is optional. This procedure does not change repository rulesets or
+  create a project-wide signed-commit policy.
+
+## Choose or create a signing key
+
+SSH signature support requires Git 2.34 or later. Check the host Git version
+before changing configuration:
+
+```powershell
+git --version
+```
+
+A dedicated Ed25519 signing key keeps authentication and signing roles easier to
+scope and revoke. Reusing an existing authentication key is also supported, but
+the same public key must be registered with GitHub for signing as well as
+authentication. Both choices are personal account configuration.
+
+On Windows PowerShell, create a dedicated key when needed:
+
+```powershell
+ssh-keygen -t ed25519 -C "Atrinik Git signing" -f "$env:USERPROFILE\.ssh\id_ed25519_atrinik_signing"
+```
+
+Accept a passphrase at the prompt. Do not put a passphrase on the command line
+or in a script, repository file, image, or generated state.
+
+## Load the private key through the Windows OpenSSH agent
+
+The agent holds the private key for the signing operation; the repository only
+needs the public key path. In an elevated PowerShell session when the service
+policy requires it:
+
+```powershell
+Get-Service ssh-agent | Set-Service -StartupType Manual
+Start-Service ssh-agent
+ssh-add "$env:USERPROFILE\.ssh\id_ed25519_atrinik_signing"
+ssh-add -l
+```
+
+The final command should list the key fingerprint without printing private key
+material. Keep the agent and private key on the Windows host.
+
+## Register the public key with GitHub
+
+Print or copy only the public-key file:
+
+```powershell
+Get-Content "$env:USERPROFILE\.ssh\id_ed25519_atrinik_signing.pub"
+```
+
+In GitHub, open **Settings -> SSH and GPG keys -> New SSH key**, select
+**Signing Key**, and paste the `.pub` contents. If the key is also used for
+repository authentication, register the same public key for that use as well.
+Never paste the private key.
+
+GitHub associates a signature with the account and commit author identity. Set
+the commit email to an address verified on that GitHub account; a key comment
+does not replace email verification:
+
+```powershell
+git config --global user.email "your-verified-address@example.com"
+```
+
+## Tell Git to use SSH signatures
+
+Use the public key path when an SSH agent supplies the private key:
+
+```powershell
+git config --global gpg.format ssh
+git config --global user.signingkey "$env:USERPROFILE\.ssh\id_ed25519_atrinik_signing.pub"
+```
+
+Signing can be enabled for all personal repositories:
+
+```powershell
+git config --global commit.gpgsign true
+```
+
+Alternatively, leave that default unset and opt in for an individual commit:
+
+```powershell
+git commit -S -m "docs: update contributor guidance"
+```
+
+These are user-level choices. Do not commit them as repository configuration.
+
+## Verify the local signature and GitHub status separately
+
+After creating a signed commit, inspect the local result:
+
+```powershell
+git show --show-signature --format=fuller -1 HEAD
+git cat-file commit HEAD | Select-String '^gpgsig '
+```
+
+`git show --show-signature` reports the local verification result when the
+host has the relevant verifier configuration. The `gpgsig` header check only
+confirms that the commit object contains a signature block; neither check alone
+proves GitHub will display **Verified**.
+
+Push the commit, open the commit or pull request's **Commits** view on GitHub,
+and inspect the badge beside the commit. **Verified** means GitHub matched and
+verified the signature using the registered public signing key and the
+account's verified author email. If the badge is absent or says **Unverified**,
+check Git version, agent state, signing-key registration, and the author email.
+
+Cryptographic signing is different from a sign-off trailer. `git commit -s`
+adds a `Signed-off-by` line to the message; it does not create an SSH
+signature or make GitHub show **Verified**. `git commit -S` requests the
+cryptographic signature.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,10 @@
   same-coordinate readers; share migration barrier; unbound records inert. Report
   `Tooling issues: none` or stable keys in ignored
   `build/agent-tooling-issues.md`; never commit/publish/copy to product issues.
+- Optional SSH commit signing stays on the host; use
+  `.agents/skills/atrinik-github-governance/references/ssh-signing.md` for the
+  host/container boundary, and never copy or mount private signing keys into a
+  container.
 - On touch, refresh existing Atrinik-owned copyright terminal years and blanket holders per
   `CONTRIBUTING.md`; preserve precise attribution.
 - MIT reuse follows `docs/PROVENANCE.md` and its canonical registry; rights, identity,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,56 @@ remain focused on the manifest, multi-repository workflows, or their tests and
 documentation. Preserve dirty physical checkouts and persistent state during
 manual validation.
 
+## Optional SSH commit signing
+
+SSH commit signing is optional and is configured per user on the host. It does
+not require GPG, change repository rulesets, or put Git configuration in the
+repository. GitHub supports SSH signatures with Git 2.34 or later.
+
+On a Windows host, check Git, create or choose an Ed25519 key, and load its
+private half into the Windows OpenSSH agent. A dedicated signing key keeps
+authentication and signing roles separate; reusing an authentication key is
+fine when its public half is also registered with GitHub as a **Signing Key**.
+
+```powershell
+git --version
+ssh-keygen -t ed25519 -C "Atrinik Git signing" -f "$env:USERPROFILE\.ssh\id_ed25519_atrinik_signing"
+Get-Service ssh-agent | Set-Service -StartupType Manual
+Start-Service ssh-agent
+ssh-add "$env:USERPROFILE\.ssh\id_ed25519_atrinik_signing"
+ssh-add -l
+```
+
+Let `ssh-keygen` prompt for a passphrase; never put the passphrase in a
+command, script, or repository file. In GitHub **Settings -> SSH and GPG keys
+-> New SSH key**, choose **Signing Key** and paste only the
+`id_ed25519_atrinik_signing.pub` contents. If the key is also an
+authentication key, register the same public key for that use too.
+
+Tell Git to use the public key and an email verified on the same GitHub account:
+
+```powershell
+git config --global gpg.format ssh
+git config --global user.signingkey "$env:USERPROFILE\.ssh\id_ed25519_atrinik_signing.pub"
+git config --global user.email "your-verified-address@example.com"
+git config --global commit.gpgsign true
+```
+
+Leave `commit.gpgsign` unset and use `git commit -S` for per-commit opt-in
+if a global default is not wanted. The private key and signing configuration
+stay on the host. Native host Git is the default place to create and sign
+commits; use the Docker/devcontainer for compilation and tests. An exceptional
+container commit may forward `SSH_AUTH_SOCK` when that workflow explicitly
+supports it, but never copy or mount a private key or private `.ssh` directory.
+
+Verify locally with `git show --show-signature -1` and, if useful, inspect the
+commit object's `gpgsig` header with `git cat-file commit HEAD`. After push,
+GitHub's **Verified** badge is a separate remote check that depends on the
+registered public signing key and verified author email. A `Signed-off-by`
+trailer from `git commit -s` is not a cryptographic signature and does not
+produce that badge. See the [agent-facing SSH signing reference](.agents/skills/atrinik-github-governance/references/ssh-signing.md)
+for the full host/container procedure and troubleshooting notes.
+
 Filesystem-identity changes must keep the durable/ephemeral boundary explicit:
 portable identities are the only values written to workspace, topology, lease,
 scope, and delivery-ledger records; raw `st_dev` values are limited to live

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -1516,6 +1516,58 @@ class AgentGuidanceTests(unittest.TestCase):
             with self.subTest(stale=stale):
                 self.assertNotIn(stale, corpus)
 
+    def test_ssh_signing_guidance_is_optional_and_secret_safe(self) -> None:
+        contributing = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+        agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+        skill = (
+            ROOT / ".agents/skills/atrinik-github-governance/SKILL.md"
+        ).read_text(encoding="utf-8")
+        reference = (
+            ROOT
+            / ".agents/skills/atrinik-github-governance/references/ssh-signing.md"
+        ).read_text(encoding="utf-8")
+        corpus = "\n".join((contributing, agents, skill, reference))
+        normalized = " ".join(corpus.split())
+
+        for marker in {
+            "SSH commit signing is optional",
+            "Git 2.34",
+            "Ed25519",
+            "ssh-agent",
+            "gpg.format ssh",
+            "user.signingkey",
+            "commit.gpgsign true",
+            "gpgsig",
+            "**Verified**",
+            "Signed-off-by",
+            "SSH_AUTH_SOCK",
+            "public key",
+            "private signing key",
+            "verified author email",
+            "references/ssh-signing.md",
+        }:
+            with self.subTest(marker=marker):
+                self.assertIn(marker, normalized)
+
+        self.assertNotRegex(
+            corpus, r"-----BEGIN [^-]*PRIVATE KEY-----"
+        )
+        self.assertNotRegex(
+            corpus,
+            r"(?im)^\s*(?:all|every|each)\s+commits?\s+must\s+be\s+signed\b",
+        )
+        self.assertNotRegex(
+            corpus,
+            r"(?i)\b(?:signed commits|commit signing|commit signatures)\s+"
+            r"(?:is|are)\s+(?:required|mandatory)\b",
+        )
+        self.assertNotRegex(
+            corpus,
+            r"(?i)\b(?:repository|project|organization)\s+"
+            r"(?:requires|enforces|mandates)\s+"
+            r"(?:signed commits|commit signing)\b",
+        )
+
     def test_native_pr_stack_governance_is_guarded_and_complete(self) -> None:
         skill = ROOT / ".agents/skills/atrinik-github-governance"
         package = {
@@ -1529,6 +1581,7 @@ class AgentGuidanceTests(unittest.TestCase):
                 "SKILL.md",
                 "agents/openai.yaml",
                 "references/pr-stack-review-and-merge.md",
+                "references/ssh-signing.md",
             },
         )
 


### PR DESCRIPTION
## Summary

Documents optional SSH commit signing for Atrinik contributors and Codex work on native Windows hosts and in the canonical Docker/devcontainer workflow.

## Implementation / behavior

- Adds a contributor recipe for current Git, Ed25519 key creation, the Windows OpenSSH agent, GitHub signing-key registration, the verified author email, and per-user Git settings.
- Adds agent guidance for the host/container signing boundary, including the exceptional agent-forwarding path and the prohibition on copying or mounting private signing keys.
- Explains Git's embedded `gpgsig` header, GitHub's **Verified** status, and the separate `Signed-off-by` sign-off trailer.
- Keeps signing optional and leaves repository rulesets, devcontainer definitions, builds, runtimes, and dependencies unchanged.

## Validation

- Guidance tests cover private-key exclusion, local link resolution, and rejection of accidental mandatory-signature wording.
- The final handoff records the applicable guidance inventory, skill validation, full test suite, compile check, and `git diff --check` results.

## Limitations / follow-up

- A future required-signature ruleset or organization policy remains a separate GitHub governance change.
- Personal Git/GitHub configuration and SSH-agent state remain outside the repository and container; no private key is copied, mounted, committed, or placed in generated state.

Closes #541
