### PR TITLE
fix(agents): make local agent ledgers concurrency-safe

### DIFF
--- a/.agents/skills/atrinik-issue-delivery/SKILL.md
+++ b/.agents/skills/atrinik-issue-delivery/SKILL.md
@@ -87,6 +87,13 @@ owner `AGENTS.md`; do not duplicate procedures.
   artifact, scope, or resource mutation. CAS every result/live refresh through
   the helper; never hand-roll state, locks, markers, or recovery.
 
+  The ignored process-improvement and tooling-issue ledgers have one supported
+  edit path: `./atrinik agent-ledger update --ledger ...`. It resolves the
+  canonical shared root, reads and validates the latest bytes under a stable
+  shared lock, publishes atomically, and returns a digest/CAS result. Never
+  manually edit, overwrite, or truncate either file; follow stale/lock/retry
+  output. Separate filesystems require a coordinator or event handoff.
+
   Planned/absent creates after collision rechecks; planned/exact binds;
   created-or-adopted/exact reuses. Missing, duplicate, mismatched, dirty, or
   unsafe artifacts stop. Attach a bound branch with absent worktree through

--- a/.agents/skills/atrinik-issue-delivery/references/tooling-issues.md
+++ b/.agents/skills/atrinik-issue-delivery/references/tooling-issues.md
@@ -13,8 +13,9 @@ Tooling issues: none
 ```
 
 When a problem was observed, replace `none` with its stable key(s) and a short
-current status. Update the local ledger before the response. Do not omit the
-line because a failure was transient or worked around.
+current status. Update the local ledger before the response through the wrapper
+helper below. Do not omit the line because a failure was transient or worked
+around.
 
 ## Ignored human-readable ledger
 
@@ -22,7 +23,34 @@ Use `build/agent-tooling-issues.md`. The repository's `/build/` ignore rule
 keeps it out of `git status`, release inputs, and package manifests. The file
 is optional local state: never commit, publish, cite, or copy it into an issue,
 PR, delivery report, or other repository evidence. Keep sensitive details out
-of both the file and responses.
+of both the file and responses. The process-improvement ledger uses the same
+facility and the same local-only boundary.
+
+## Supported edit path
+
+never manually edit, overwrite, truncate, or hand-roll either ledger. Use the
+wrapper from the active checkout; it resolves a linked worktree to the shared
+wrapper root, validates the latest bytes, holds `build/.agent-ledgers.lock`
+across merge and publication, and returns the new digest:
+
+```sh
+./atrinik agent-ledger update --ledger tooling-issues \
+  --key 'mechanism=<slug>;remediation=<slug>' --status open \
+  --observation 'generic bounded symptom' --impact 'bounded impact' \
+  --recommended-action 'safe next action' [--expected-digest DIGEST]
+./atrinik agent-ledger update --ledger process-improvements \
+  --key <slug> --status observed --observation 'generic observation' \
+  --expected-benefit 'bounded benefit' --related none \
+  --observed-at 2026-01-01T00:00:00Z [--expected-digest DIGEST]
+```
+
+Pass the prior helper digest for a fail-closed compare-and-swap; use
+`--expected-digest absent` when the target must still be absent. Without a
+digest, the helper merges the named row into the bytes read under its lock.
+Use `--non-blocking` only when the caller will retry after the returned
+contention diagnostic. On a stale digest or uncertain publication, reread the
+latest helper output before retrying. A lock coordinates one shared filesystem;
+separate filesystems need an explicit coordinator/event handoff.
 
 Use this exact table, with one row per stable key:
 

--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -13,7 +13,11 @@ description: Coordinate work across checkouts, profiles, worktrees, cleanup, rel
    orchestration/contracts stay here. Before repository work or expensive
    build/package/runtime/remote-mutation work, consult ignored
    `build/agent-process-improvements.md` when present, update recurring keys,
-   report `Process improvements added: none` or changed keys/issues.
+   report `Process improvements added: none` or changed keys/issues. Use
+   `./atrinik agent-ledger update` for both ignored agent ledgers; never
+   manually edit, overwrite, or truncate their Markdown directly. The helper resolves the
+   canonical shared root and returns the digest/lock/retry result; separate
+   filesystems need a coordinator or event handoff.
 
 Checkouts are ignored repositories. One `classic` worktree holds five
 `classic-*` components; both stacks share `content@main`. `content-1x` and the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,13 +60,10 @@
   rerun exact named create after rollback and bind via helper CAS.
 - Use wrapper paths; never reconstruct managed paths. Isolate topology/state, ports,
   client config; prefer temporary state and local scenario secrets.
-- Before repository or expensive build/package/runtime/remote-mutation work, consult
-  ignored `build/agent-process-improvements.md`; update recurring keys through
-  `./atrinik agent-ledger update`; report `Process improvements added: none` or
-  keys/issues. That command is the only edit path for both ignored ledgers:
-  never manually edit, overwrite, or truncate them; follow its latest digest,
-  lock, and retry output. It locks the canonical shared root; separate filesystems
-  require a coordinator/event handoff.
+- Before repository or expensive build/package/runtime/remote-mutation, consult
+  `build/agent-process-improvements.md`; `./atrinik agent-ledger update` only:
+  never manually edit ledgers. Report `Process improvements added: none` or
+  keys/issues; follow digest/lock/retry; handoff across separate filesystems.
 - Keep completion bounded, parser-driven, and secret-free; lease in order; gate
   same-coordinate readers; share migration barrier; unbound records inert. Report
   `Tooling issues: none` or stable keys in ignored

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,8 +61,12 @@
 - Use wrapper paths; never reconstruct managed paths. Isolate topology/state, ports,
   client config; prefer temporary state and local scenario secrets.
 - Before repository or expensive build/package/runtime/remote-mutation work, consult
-  ignored `build/agent-process-improvements.md`; update recurring keys; report
-  `Process improvements added: none` or keys/issues.
+  ignored `build/agent-process-improvements.md`; update recurring keys through
+  `./atrinik agent-ledger update`; report `Process improvements added: none` or
+  keys/issues. That command is the only edit path for both ignored ledgers:
+  never manually edit, overwrite, or truncate them; follow its latest digest,
+  lock, and retry output. It locks the canonical shared root; separate filesystems
+  require a coordinator/event handoff.
 - Keep completion bounded, parser-driven, and secret-free; lease in order; gate
   same-coordinate readers; share migration barrier; unbound records inert. Report
   `Tooling issues: none` or stable keys in ignored

--- a/README.md
+++ b/README.md
@@ -104,6 +104,27 @@ arbitrary containers, nested coordinators, and unsafe bind mounts never grant
 authority. Keep the `windows-cross` container for package/build work and
 host-bound validation.
 
+### Shared local agent ledgers
+
+The ignored `build/agent-process-improvements.md` and
+`build/agent-tooling-issues.md` files are local, human-readable workspace state.
+Update either one only through the wrapper's schema-aware transaction:
+
+~~~sh
+./atrinik agent-ledger update --ledger tooling-issues \
+  --key 'mechanism=<slug>;remediation=<slug>' --status open \
+  --observation 'generic symptom' --impact 'bounded impact' \
+  --recommended-action 'safe next action'
+~~~
+
+The command finds the shared wrapper root even when invoked from a linked
+worktree, reads and validates the latest bytes under a stable lock, and
+publishes a bounded atomic replacement. Use its returned digest with
+`--expected-digest` for fail-closed stale-writer detection; follow its lock,
+stale, and retry diagnostics. Separate filesystems cannot share that local
+lock and require an explicit coordinator or event handoff. Never copy ledger
+contents into source, CI, release, issue, pull-request, or delivery evidence.
+
 The Atrinik development container supplies the native build dependencies. Run
 all commands below from this repository's root.
 

--- a/atrinik_workspace/agent_ledgers.py
+++ b/atrinik_workspace/agent_ledgers.py
@@ -1,0 +1,904 @@
+"""Concurrency-safe updates for the ignored local agent ledgers.
+
+The two Markdown ledgers are shared workspace state, not repository evidence.
+This module deliberately owns their complete read/validate/merge/publish
+transaction so callers do not have to reproduce the locking and atomic-write
+protocol.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import os
+from pathlib import Path
+import re
+import secrets
+import stat
+import subprocess
+from typing import Iterator, Mapping
+
+from .guidance_inventory import (
+    PROCESS_IMPROVEMENT_LEDGER,
+    PROCESS_KEY,
+    PROCESS_STATUSES,
+    PROCESS_TABLE_HEADER,
+    PROCESS_TIMESTAMP,
+    TOOLING_LEDGER_COLUMNS,
+    TOOLING_LEDGER_MAX_BYTES,
+    TOOLING_LEDGER_RELATIVE,
+    _TOOLING_KEY,
+    _TOOLING_STATUSES,
+    _valid_process_timestamp,
+    validate_process_improvement_ledger_text,
+    validate_tooling_ledger_text,
+)
+from .locking import LockBusyError, exclusive_lock
+from .model import WorkspaceError, _open_directory_nofollow
+from .platform_compat import (
+    IS_WINDOWS,
+    O_BINARY,
+    O_CLOEXEC,
+    assert_no_symlink_components,
+    flush_file,
+)
+
+
+AGENT_LEDGER_LOCK = Path("build/.agent-ledgers.lock")
+AGENT_LEDGER_MAX_BYTES = TOOLING_LEDGER_MAX_BYTES
+ABSENT_DIGEST = "absent"
+_DIGEST = re.compile(r"^[0-9a-f]{64}$")
+
+
+class AgentLedgerError(WorkspaceError):
+    """A requested local agent-ledger transaction cannot be accepted."""
+
+
+class AgentLedgerCommitUncertain(AgentLedgerError):
+    """Publication happened but a durability proof failed afterward."""
+
+
+@dataclass(frozen=True)
+class _LedgerSpec:
+    name: str
+    relative: Path
+    title: str
+    header: str
+    columns: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _Snapshot:
+    data: bytes | None
+
+
+@dataclass(frozen=True)
+class _Table:
+    lines: list[str]
+    row_indexes: dict[str, int]
+    insert_at: int
+
+
+def _spec(ledger: str) -> _LedgerSpec:
+    if ledger == "process-improvements":
+        return _LedgerSpec(
+            name=ledger,
+            relative=PROCESS_IMPROVEMENT_LEDGER,
+            title="# Agent process improvements",
+            header=PROCESS_TABLE_HEADER,
+            columns=(
+                "key",
+                "status",
+                "observation",
+                "expected benefit / proposed action",
+                "related issue / pr",
+                "last observed (utc)",
+            ),
+        )
+    if ledger == "tooling-issues":
+        return _LedgerSpec(
+            name=ledger,
+            relative=TOOLING_LEDGER_RELATIVE,
+            title="# Agent tooling issues",
+            header="| Stable key | Status | Observation | Impact | Recommended action |",
+            columns=TOOLING_LEDGER_COLUMNS,
+        )
+    raise AgentLedgerError(
+        "agent-ledger: ledger must be process-improvements or tooling-issues"
+    )
+
+
+def ledger_path(root: Path, ledger: str) -> Path:
+    """Return the only supported target path for one local ledger."""
+
+    return Path(root) / _spec(ledger).relative
+
+
+def ledger_lock_path(root: Path) -> Path:
+    """Return the stable lock path shared by both replaceable ledger files."""
+
+    return Path(root) / AGENT_LEDGER_LOCK
+
+
+def _git_root_output(repository: Path, argument: str) -> Path:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repository), "rev-parse", argument],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise AgentLedgerError(
+            "agent-ledger: cannot discover the canonical shared workspace root"
+        ) from error
+    if result.returncode or not result.stdout.strip():
+        raise AgentLedgerError(
+            "agent-ledger: canonical shared workspace root is not a Git checkout"
+        )
+    return Path(result.stdout.strip())
+
+
+def resolve_shared_root(repository: Path) -> Path:
+    """Resolve a worktree or primary checkout to its shared wrapper root.
+
+    Linked Git worktrees have a different source top-level but share the
+    repository's common Git directory. Its parent is the only root accepted by
+    the CLI, which keeps both ignored ledgers and the stable lock common to all
+    worktrees of the wrapper repository.
+    """
+
+    candidate = Path(repository)
+    try:
+        assert_no_symlink_components(candidate, "agent-ledger repository")
+        candidate = candidate.resolve(strict=True)
+    except OSError as error:
+        raise AgentLedgerError(
+            f"agent-ledger: cannot inspect repository {repository}: {error}"
+        ) from error
+    if not candidate.is_dir():
+        raise AgentLedgerError(
+            f"agent-ledger: repository is not a directory: {candidate}"
+        )
+
+    top = _git_root_output(candidate, "--show-toplevel")
+    common = _git_root_output(candidate, "--git-common-dir")
+    if not common.is_absolute():
+        common = top / common
+    try:
+        top = top.resolve(strict=True)
+        common = common.resolve(strict=True)
+    except OSError as error:
+        raise AgentLedgerError(
+            "agent-ledger: Git checkout identity could not be resolved"
+        ) from error
+    if not common.is_dir():
+        raise AgentLedgerError(
+            f"agent-ledger: Git common directory is not a directory: {common}"
+        )
+    root = common.parent
+    try:
+        assert_no_symlink_components(root, "agent-ledger shared root")
+    except OSError as error:
+        raise AgentLedgerError(
+            f"agent-ledger: shared root is unsafe: {error}"
+        ) from error
+    wrapper = root / "atrinik"
+    if not (root / "components.json").is_file() or not wrapper.is_file():
+        raise AgentLedgerError(
+            "agent-ledger: Git common root is not the canonical Atrinik wrapper"
+        )
+    if not os.access(wrapper, os.X_OK):
+        raise AgentLedgerError(
+            f"agent-ledger: canonical wrapper is not executable: {wrapper}"
+        )
+    if top == root and not (root / ".git").exists():
+        raise AgentLedgerError(
+            "agent-ledger: canonical wrapper checkout has no Git metadata"
+        )
+    return root
+
+
+def _canonical_root(root: Path) -> Path:
+    candidate = Path(root)
+    try:
+        assert_no_symlink_components(candidate, "agent-ledger root")
+        candidate = candidate.resolve(strict=True)
+    except OSError as error:
+        raise AgentLedgerError(
+            f"agent-ledger: cannot inspect shared root {root}: {error}"
+        ) from error
+    if not candidate.is_dir():
+        raise AgentLedgerError(
+            f"agent-ledger: shared root is not a directory: {candidate}"
+        )
+    return candidate
+
+
+def _verify_local_only(root: Path, spec: _LedgerSpec) -> None:
+    relative = spec.relative.as_posix()
+    try:
+        ignored = subprocess.run(
+            ["git", "check-ignore", "--no-index", "--quiet", "--", relative],
+            cwd=root,
+            capture_output=True,
+            check=False,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise AgentLedgerError(
+            f"agent-ledger: cannot verify that {relative} is ignored"
+        ) from error
+    if ignored.returncode != 0:
+        raise AgentLedgerError(
+            f"agent-ledger: refusing non-ignored ledger path {relative}"
+        )
+
+    try:
+        tracked = subprocess.run(
+            ["git", "ls-files", "--error-unmatch", "--", relative],
+            cwd=root,
+            capture_output=True,
+            check=False,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise AgentLedgerError(
+            f"agent-ledger: cannot verify tracking state for {relative}"
+        ) from error
+    if tracked.returncode == 0:
+        raise AgentLedgerError(
+            f"agent-ledger: refusing tracked ledger path {relative}"
+        )
+    if tracked.returncode != 1:
+        raise AgentLedgerError(
+            f"agent-ledger: cannot verify tracking state for {relative}"
+        )
+
+
+def _ensure_build_directory(root: Path) -> Path:
+    build = root / "build"
+    try:
+        assert_no_symlink_components(build, "agent-ledger build")
+        build.mkdir(parents=True, exist_ok=True)
+        assert_no_symlink_components(build, "agent-ledger build")
+        metadata = build.stat(follow_symlinks=False)
+    except OSError as error:
+        raise AgentLedgerError(
+            f"agent-ledger: cannot establish the shared build directory: {error}"
+        ) from error
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise AgentLedgerError(
+            f"agent-ledger: shared build path is not a directory: {build}"
+        )
+    return build
+
+
+@contextmanager
+def _opened_build_directory(build: Path) -> Iterator[int | None]:
+    if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
+        yield None
+        return
+    flags = os.O_RDONLY | O_CLOEXEC | getattr(os, "O_DIRECTORY", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    descriptor: int | None = None
+    try:
+        descriptor = _open_directory_nofollow(build, flags)
+        _assert_directory_identity(build, descriptor)
+    except (OSError, WorkspaceError) as error:
+        if descriptor is not None:
+            os.close(descriptor)
+        raise AgentLedgerError(
+            f"agent-ledger: shared build directory is unsafe: {build}: {error}"
+        ) from error
+    try:
+        yield descriptor
+    finally:
+        os.close(descriptor)
+
+
+def _assert_directory_identity(build: Path, directory: int) -> None:
+    opened = os.fstat(directory)
+    visible = build.stat(follow_symlinks=False)
+    if (
+        not stat.S_ISDIR(opened.st_mode)
+        or (opened.st_dev, opened.st_ino) != (visible.st_dev, visible.st_ino)
+    ):
+        raise AgentLedgerError(
+            f"agent-ledger: shared build directory changed during publication: {build}"
+        )
+
+
+def _read_limited(stream: object) -> bytes:
+    chunks: list[bytes] = []
+    total = 0
+    while total <= AGENT_LEDGER_MAX_BYTES:
+        if isinstance(stream, int):
+            piece = os.read(stream, AGENT_LEDGER_MAX_BYTES + 1 - total)
+        else:
+            piece = stream.read(AGENT_LEDGER_MAX_BYTES + 1 - total)  # type: ignore[union-attr]
+        if not piece:
+            break
+        chunks.append(piece)
+        total += len(piece)
+        if total > AGENT_LEDGER_MAX_BYTES:
+            raise AgentLedgerError(
+                "agent-ledger: ledger exceeds the 128 KiB size limit"
+            )
+    return b"".join(chunks)
+
+
+def _read_snapshot(path: Path, directory: int | None) -> _Snapshot:
+    if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
+        opened_file = False
+        try:
+            assert_no_symlink_components(path, "agent-ledger")
+            opened_parent = path.parent.stat(follow_symlinks=False)
+            with path.open("rb") as stream:
+                opened_file = True
+                opened = os.fstat(stream.fileno())
+                if not stat.S_ISREG(opened.st_mode):
+                    raise AgentLedgerError(
+                        f"agent-ledger: ledger is not a regular file: {path}"
+                    )
+                data = _read_limited(stream)
+            visible = path.stat(follow_symlinks=False)
+            visible_parent = path.parent.stat(follow_symlinks=False)
+            identity = (opened.st_dev, opened.st_ino)
+            if (
+                not stat.S_ISREG(visible.st_mode)
+                or identity != (visible.st_dev, visible.st_ino)
+                or (opened_parent.st_dev, opened_parent.st_ino)
+                != (visible_parent.st_dev, visible_parent.st_ino)
+                or opened.st_size != len(data)
+            ):
+                raise AgentLedgerError(
+                    f"agent-ledger: ledger changed while being read: {path}"
+                )
+            return _Snapshot(data)
+        except FileNotFoundError:
+            if not opened_file:
+                return _Snapshot(None)
+            raise AgentLedgerError(
+                f"agent-ledger: ledger disappeared while being read: {path}"
+            )
+        except (AgentLedgerError, OSError) as error:
+            if isinstance(error, AgentLedgerError):
+                raise
+            raise AgentLedgerError(
+                f"agent-ledger: cannot read ledger {path}: {error}"
+            ) from error
+
+    if directory is None:  # pragma: no cover - protected by the context manager
+        raise AgentLedgerError("agent-ledger: missing shared directory descriptor")
+    flags = os.O_RDONLY | O_CLOEXEC | getattr(os, "O_NOFOLLOW", 0)
+    descriptor: int | None = None
+    try:
+        try:
+            descriptor = os.open(path.name, flags, dir_fd=directory)
+        except FileNotFoundError:
+            return _Snapshot(None)
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode):
+            raise AgentLedgerError(
+                f"agent-ledger: ledger is not a regular file: {path}"
+            )
+        data = _read_limited(descriptor)
+        visible = os.stat(path.name, dir_fd=directory, follow_symlinks=False)
+        after = os.fstat(descriptor)
+        identity = (opened.st_dev, opened.st_ino)
+        if (
+            not stat.S_ISREG(visible.st_mode)
+            or identity != (visible.st_dev, visible.st_ino)
+            or identity != (after.st_dev, after.st_ino)
+            or after.st_size != len(data)
+        ):
+            raise AgentLedgerError(
+                f"agent-ledger: ledger changed while being read: {path}"
+            )
+        return _Snapshot(data)
+    except AgentLedgerError:
+        raise
+    except OSError as error:
+        if getattr(error, "errno", None) == 2 and descriptor is None:
+            return _Snapshot(None)
+        raise AgentLedgerError(
+            f"agent-ledger: cannot read ledger {path}: {error}"
+        ) from error
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def _digest(data: bytes | None) -> str | None:
+    return None if data is None else hashlib.sha256(data).hexdigest()
+
+
+def _validate_expected_digest(value: str | None) -> None:
+    if value is not None and value != ABSENT_DIGEST and not _DIGEST.fullmatch(value):
+        raise AgentLedgerError(
+            "agent-ledger: expected digest must be a lowercase SHA-256 digest or absent"
+        )
+
+
+def _field(label: str, value: str, *, key: bool = False) -> str:
+    if not isinstance(value, str):
+        raise AgentLedgerError(f"agent-ledger: {label} must be text")
+    cleaned = value.strip()
+    if not cleaned:
+        raise AgentLedgerError(f"agent-ledger: {label} must not be empty")
+    if "\n" in cleaned or "\r" in cleaned or "|" in cleaned:
+        raise AgentLedgerError(
+            f"agent-ledger: {label} must be one Markdown-table line without pipes"
+        )
+    if any((ord(char) < 32 and char != "\t") or ord(char) == 127 for char in cleaned):
+        raise AgentLedgerError(
+            f"agent-ledger: {label} contains a control character"
+        )
+    if key and "`" in cleaned:
+        raise AgentLedgerError(f"agent-ledger: {label} must not contain backticks")
+    return cleaned
+
+
+def _timestamp(value: str | None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace(
+            "+00:00", "Z"
+        )
+    cleaned = _field("observed-at", value)
+    if not PROCESS_TIMESTAMP.fullmatch(cleaned) or not _valid_process_timestamp(cleaned):
+        raise AgentLedgerError(
+            "agent-ledger: observed-at must be a valid UTC timestamp ending in Z"
+        )
+    return cleaned
+
+
+def _row_values(
+    ledger: str,
+    *,
+    key: str,
+    status: str,
+    observation: str,
+    expected_benefit: str | None,
+    related: str,
+    observed_at: str | None,
+    impact: str | None,
+    recommended_action: str | None,
+) -> tuple[str, ...]:
+    clean_key = _field("stable key", key, key=True)
+    clean_status = _field("status", status)
+    clean_observation = _field("observation", observation)
+    if ledger == "process-improvements":
+        if not PROCESS_KEY.fullmatch(clean_key):
+            raise AgentLedgerError("agent-ledger: invalid process-improvement stable key")
+        if clean_status.lower() not in PROCESS_STATUSES:
+            raise AgentLedgerError("agent-ledger: invalid process-improvement status")
+        benefit = _field("expected-benefit", expected_benefit or "")
+        relation = _field("related", related)
+        return (
+            clean_key,
+            clean_status.lower(),
+            clean_observation,
+            benefit,
+            relation,
+            _timestamp(observed_at),
+        )
+
+    if not _TOOLING_KEY.fullmatch(clean_key):
+        raise AgentLedgerError("agent-ledger: invalid tooling-issue stable key")
+    if clean_status not in _TOOLING_STATUSES:
+        raise AgentLedgerError("agent-ledger: invalid tooling-issue status")
+    return (
+        clean_key,
+        clean_status,
+        clean_observation,
+        _field("impact", impact or ""),
+        _field("recommended-action", recommended_action or ""),
+    )
+
+
+def _line_cells(line: str) -> list[str] | None:
+    stripped = line.strip()
+    if not (stripped.startswith("|") and stripped.endswith("|")):
+        return None
+    return [cell.strip() for cell in stripped[1:-1].split("|")]
+
+
+def _unquote(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] == "`":
+        return value[1:-1].strip()
+    return value
+
+
+def _table_for(spec: _LedgerSpec, text: str) -> _Table:
+    lines = text.splitlines(keepends=True)
+    logical = [line.rstrip("\r\n") for line in lines]
+    if spec.name == "process-improvements":
+        header_index = next(
+            (index for index, line in enumerate(logical) if line.strip() == spec.header),
+            None,
+        )
+    else:
+        header_index = next(
+            (
+                index
+                for index, line in enumerate(logical)
+                if (cells := _line_cells(line))
+                and [_unquote(cell).casefold() for cell in cells]
+                == list(spec.columns)
+            ),
+            None,
+        )
+    if header_index is None or header_index + 1 >= len(lines):
+        raise AgentLedgerError("agent-ledger: current ledger table is not canonical")
+    separator = _line_cells(logical[header_index + 1])
+    if separator is None or not all(re.fullmatch(r":?-{3,}:?", cell) for cell in separator):
+        raise AgentLedgerError("agent-ledger: current ledger table separator is invalid")
+
+    row_indexes: dict[str, int] = {}
+    row_seen = False
+    insert_at = len(lines)
+    for index in range(header_index + 2, len(lines)):
+        stripped = logical[index].strip()
+        if not stripped or not stripped.startswith("|"):
+            if row_seen:
+                insert_at = index
+                break
+            continue
+        cells = _line_cells(logical[index])
+        if cells is None or len(cells) != len(spec.columns):
+            raise AgentLedgerError("agent-ledger: current ledger contains a malformed row")
+        key = _unquote(cells[0])
+        if key in row_indexes:
+            raise AgentLedgerError("agent-ledger: current ledger contains duplicate stable keys")
+        row_indexes[key] = index
+        row_seen = True
+    if not row_seen:
+        raise AgentLedgerError("agent-ledger: current ledger contains no rows")
+    return _Table(lines, row_indexes, insert_at)
+
+
+def _row_text(ledger: str, values: tuple[str, ...]) -> str:
+    cells = [f"`{values[0]}`", *values[1:]]
+    return "| " + " | ".join(cells) + " |"
+
+
+def _merge(spec: _LedgerSpec, current: bytes | None, values: tuple[str, ...]) -> tuple[bytes, str]:
+    if current is None:
+        newline = "\n"
+        if spec.name == "process-improvements":
+            separator = "| --- | --- | --- | --- | --- | --- |"
+        else:
+            separator = "| --- | --- | --- | --- | --- |"
+        text = (
+            f"{spec.title}{newline}{newline}"
+            f"{spec.header}{newline}{separator}{newline}"
+            f"{_row_text(spec.name, values)}{newline}"
+        )
+        return text.encode("utf-8"), "added"
+
+    try:
+        text = current.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise AgentLedgerError("agent-ledger: current ledger is not UTF-8") from error
+    table = _table_for(spec, text)
+    newline = "\r\n" if "\r\n" in text else "\n"
+    rendered = _row_text(spec.name, values)
+    key = values[0]
+    operation = "updated" if key in table.row_indexes else "added"
+    if key in table.row_indexes:
+        index = table.row_indexes[key]
+        ending = (
+            "\r\n"
+            if table.lines[index].endswith("\r\n")
+            else "\n"
+            if table.lines[index].endswith("\n")
+            else ""
+        )
+        table.lines[index] = rendered + ending
+    else:
+        index = table.insert_at
+        if index == len(table.lines) and table.lines and not table.lines[-1].endswith(("\n", "\r")):
+            table.lines[-1] += newline
+        table.lines.insert(index, rendered + newline)
+    result = "".join(table.lines).encode("utf-8")
+    return result, operation
+
+
+def _validate_candidate(spec: _LedgerSpec, data: bytes) -> None:
+    if len(data) > AGENT_LEDGER_MAX_BYTES:
+        raise AgentLedgerError("agent-ledger: candidate ledger exceeds the 128 KiB size limit")
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise AgentLedgerError("agent-ledger: candidate ledger is not UTF-8") from error
+    failures = (
+        validate_process_improvement_ledger_text(text)
+        if spec.name == "process-improvements"
+        else validate_tooling_ledger_text(text)
+    )
+    if failures:
+        raise AgentLedgerError(
+            "agent-ledger: candidate rejected: " + "; ".join(failures)
+        )
+
+
+def _atomic_publish(path: Path, directory: int | None, data: bytes) -> None:
+    temporary_name = f".{path.name}.{secrets.token_hex(12)}.tmp"
+    replaced = False
+    descriptor: int | None = None
+    try:
+        if IS_WINDOWS:  # pragma: no cover - exercised by native Windows CI
+            assert_no_symlink_components(path.parent, "agent-ledger")
+            assert_no_symlink_components(path, "agent-ledger")
+            opened_parent = path.parent.stat(follow_symlinks=False)
+            descriptor = os.open(
+                path.with_name(temporary_name),
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | O_CLOEXEC | O_BINARY,
+                0o600,
+            )
+            with os.fdopen(descriptor, "wb") as stream:
+                descriptor = None
+                stream.write(data)
+                stream.flush()
+                flush_file(stream.fileno())
+            visible_parent = path.parent.stat(follow_symlinks=False)
+            if (opened_parent.st_dev, opened_parent.st_ino) != (
+                visible_parent.st_dev,
+                visible_parent.st_ino,
+            ):
+                raise AgentLedgerError(
+                    "agent-ledger: shared build directory changed during publication"
+                )
+            assert_no_symlink_components(path, "agent-ledger")
+            os.replace(path.with_name(temporary_name), path)
+            replaced = True
+            assert_no_symlink_components(path, "agent-ledger")
+            with path.open("r+b") as stream:
+                opened = os.fstat(stream.fileno())
+                visible = path.stat(follow_symlinks=False)
+                if (
+                    not stat.S_ISREG(opened.st_mode)
+                    or (opened.st_dev, opened.st_ino) != (visible.st_dev, visible.st_ino)
+                ):
+                    raise OSError("published ledger identity changed")
+                flush_file(stream.fileno())
+            return
+
+        if directory is None:  # pragma: no cover - protected by the context manager
+            raise AgentLedgerError("agent-ledger: missing shared directory descriptor")
+        flags = (
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | O_CLOEXEC
+            | getattr(os, "O_NOFOLLOW", 0)
+        )
+        descriptor = os.open(temporary_name, flags, 0o600, dir_fd=directory)
+        with os.fdopen(descriptor, "wb") as stream:
+            descriptor = None
+            stream.write(data)
+            stream.flush()
+            flush_file(stream.fileno())
+        _assert_directory_identity(path.parent, directory)
+        os.replace(
+            temporary_name,
+            path.name,
+            src_dir_fd=directory,
+            dst_dir_fd=directory,
+        )
+        replaced = True
+        try:
+            _assert_directory_identity(path.parent, directory)
+            os.fsync(directory)
+        except OSError as error:
+            raise AgentLedgerCommitUncertain(
+                "agent-ledger: publication is visible but directory durability is uncertain; "
+                f"inspect the latest helper output and retry: {path}: {error}"
+            ) from error
+    except AgentLedgerCommitUncertain:
+        raise
+    except BaseException as error:
+        if replaced:
+            raise AgentLedgerCommitUncertain(
+                "agent-ledger: publication is visible but verification is uncertain; "
+                f"inspect the latest helper output and retry: {path}: {error}"
+            ) from error
+        raise
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        if not replaced:
+            try:
+                if IS_WINDOWS:
+                    path.with_name(temporary_name).unlink(missing_ok=True)
+                elif directory is not None:
+                    os.unlink(temporary_name, dir_fd=directory)
+            except FileNotFoundError:
+                pass
+            except OSError:
+                pass
+
+
+def update_agent_ledger(
+    root: Path,
+    ledger: str,
+    *,
+    key: str,
+    status: str,
+    observation: str,
+    expected_benefit: str | None = None,
+    related: str = "none",
+    observed_at: str | None = None,
+    impact: str | None = None,
+    recommended_action: str | None = None,
+    expected_digest: str | None = None,
+    nonblocking: bool = False,
+) -> dict[str, object]:
+    """Add or replace one stable-key row through one serialized transaction.
+
+    With no ``expected_digest`` the operation merges the row into the latest
+    bytes read under the shared lock. Passing a SHA-256 digest (or ``absent``
+    for a missing target) turns the same operation into a stale-writer
+    compare-and-swap that fails closed.
+    """
+
+    spec = _spec(ledger)
+    _validate_expected_digest(expected_digest)
+    values = _row_values(
+        ledger,
+        key=key,
+        status=status,
+        observation=observation,
+        expected_benefit=expected_benefit,
+        related=related,
+        observed_at=observed_at,
+        impact=impact,
+        recommended_action=recommended_action,
+    )
+    canonical_root = _canonical_root(root)
+    _verify_local_only(canonical_root, spec)
+    build = _ensure_build_directory(canonical_root)
+    path = canonical_root / spec.relative
+    lock = ledger_lock_path(canonical_root)
+    if lock == path:
+        raise AgentLedgerError("agent-ledger: stable lock cannot be the replaceable ledger")
+
+    try:
+        with exclusive_lock(
+            lock,
+            "agent ledgers",
+            nonblocking=nonblocking,
+            inherit=False,
+        ):
+            _verify_local_only(canonical_root, spec)
+            with _opened_build_directory(build) as directory:
+                snapshot = _read_snapshot(path, directory)
+                actual_digest = _digest(snapshot.data)
+                actual_display = actual_digest or ABSENT_DIGEST
+                if expected_digest is not None and expected_digest != actual_display:
+                    raise AgentLedgerError(
+                        "agent-ledger: stale digest; expected "
+                        f"{expected_digest}, actual {actual_display}; reread the latest "
+                        "helper output and retry"
+                    )
+                if snapshot.data is not None:
+                    if len(snapshot.data) > AGENT_LEDGER_MAX_BYTES:
+                        raise AgentLedgerError(
+                            "agent-ledger: current ledger exceeds the 128 KiB size limit"
+                        )
+                    try:
+                        current_text = snapshot.data.decode("utf-8")
+                    except UnicodeDecodeError as error:
+                        raise AgentLedgerError(
+                            "agent-ledger: current ledger is not UTF-8; refusing to replace it"
+                        ) from error
+                    failures = (
+                        validate_process_improvement_ledger_text(current_text)
+                        if spec.name == "process-improvements"
+                        else validate_tooling_ledger_text(current_text)
+                    )
+                    if failures:
+                        raise AgentLedgerError(
+                            "agent-ledger: current ledger is malformed; refusing to replace it: "
+                            + "; ".join(failures)
+                        )
+
+                candidate, operation = _merge(spec, snapshot.data, values)
+                _validate_candidate(spec, candidate)
+                candidate_digest = hashlib.sha256(candidate).hexdigest()
+                if candidate == snapshot.data:
+                    return {
+                        "schema_version": 1,
+                        "ledger": spec.name,
+                        "path": spec.relative.as_posix(),
+                        "lock": AGENT_LEDGER_LOCK.as_posix(),
+                        "key": values[0],
+                        "operation": "unchanged",
+                        "previous_digest": actual_digest,
+                        "digest": candidate_digest,
+                        "bytes": len(candidate),
+                    }
+
+                latest = _read_snapshot(path, directory)
+                if _digest(latest.data) != actual_digest:
+                    raise AgentLedgerError(
+                        "agent-ledger: ledger changed while preparing the publication; "
+                        "reread the latest helper output and retry"
+                    )
+                try:
+                    _atomic_publish(path, directory, candidate)
+                except AgentLedgerError:
+                    raise
+                except OSError as error:
+                    raise AgentLedgerError(
+                        "agent-ledger: atomic publication failed; the previous "
+                        "ledger bytes were preserved when possible; inspect the "
+                        "latest helper output and retry"
+                    ) from error
+                return {
+                    "schema_version": 1,
+                    "ledger": spec.name,
+                    "path": spec.relative.as_posix(),
+                    "lock": AGENT_LEDGER_LOCK.as_posix(),
+                    "key": values[0],
+                    "operation": operation,
+                    "previous_digest": actual_digest,
+                    "digest": candidate_digest,
+                    "bytes": len(candidate),
+                }
+    except LockBusyError as error:
+        raise AgentLedgerError(
+            "agent-ledger: shared lock is busy; retry after reading the latest helper output"
+        ) from error
+
+
+def update_from_mapping(
+    root: Path,
+    ledger: str,
+    row: Mapping[str, str],
+    *,
+    expected_digest: str | None = None,
+    nonblocking: bool = False,
+) -> dict[str, object]:
+    """Convenience adapter for callers that already have a named row mapping."""
+
+    allowed = {
+        "key",
+        "status",
+        "observation",
+        "expected_benefit",
+        "related",
+        "observed_at",
+        "impact",
+        "recommended_action",
+    }
+    unknown = set(row) - allowed
+    if unknown:
+        raise AgentLedgerError(
+            "agent-ledger: unsupported row fields: " + ", ".join(sorted(unknown))
+        )
+    required = {"key", "status", "observation"} - set(row)
+    if required:
+        raise AgentLedgerError(
+            "agent-ledger: row is missing required fields: "
+            + ", ".join(sorted(required))
+        )
+    return update_agent_ledger(
+        root,
+        ledger,
+        key=row["key"],
+        status=row["status"],
+        observation=row["observation"],
+        expected_benefit=row.get("expected_benefit"),
+        related=row.get("related", "none"),
+        observed_at=row.get("observed_at"),
+        impact=row.get("impact"),
+        recommended_action=row.get("recommended_action"),
+        expected_digest=expected_digest,
+        nonblocking=nonblocking,
+    )

--- a/atrinik_workspace/agent_ledgers.py
+++ b/atrinik_workspace/agent_ledgers.py
@@ -219,44 +219,45 @@ def _canonical_root(root: Path) -> Path:
 
 
 def _verify_local_only(root: Path, spec: _LedgerSpec) -> None:
-    relative = spec.relative.as_posix()
-    try:
-        ignored = subprocess.run(
-            ["git", "check-ignore", "--no-index", "--quiet", "--", relative],
-            cwd=root,
-            capture_output=True,
-            check=False,
-            timeout=5,
-        )
-    except (OSError, subprocess.TimeoutExpired) as error:
-        raise AgentLedgerError(
-            f"agent-ledger: cannot verify that {relative} is ignored"
-        ) from error
-    if ignored.returncode != 0:
-        raise AgentLedgerError(
-            f"agent-ledger: refusing non-ignored ledger path {relative}"
-        )
+    paths = (spec.relative.as_posix(), AGENT_LEDGER_LOCK.as_posix())
+    for relative in paths:
+        try:
+            ignored = subprocess.run(
+                ["git", "check-ignore", "--no-index", "--quiet", "--", relative],
+                cwd=root,
+                capture_output=True,
+                check=False,
+                timeout=5,
+            )
+        except (OSError, subprocess.TimeoutExpired) as error:
+            raise AgentLedgerError(
+                f"agent-ledger: cannot verify that {relative} is ignored"
+            ) from error
+        if ignored.returncode != 0:
+            raise AgentLedgerError(
+                f"agent-ledger: refusing non-ignored ledger path {relative}"
+            )
 
-    try:
-        tracked = subprocess.run(
-            ["git", "ls-files", "--error-unmatch", "--", relative],
-            cwd=root,
-            capture_output=True,
-            check=False,
-            timeout=5,
-        )
-    except (OSError, subprocess.TimeoutExpired) as error:
-        raise AgentLedgerError(
-            f"agent-ledger: cannot verify tracking state for {relative}"
-        ) from error
-    if tracked.returncode == 0:
-        raise AgentLedgerError(
-            f"agent-ledger: refusing tracked ledger path {relative}"
-        )
-    if tracked.returncode != 1:
-        raise AgentLedgerError(
-            f"agent-ledger: cannot verify tracking state for {relative}"
-        )
+        try:
+            tracked = subprocess.run(
+                ["git", "ls-files", "--error-unmatch", "--", relative],
+                cwd=root,
+                capture_output=True,
+                check=False,
+                timeout=5,
+            )
+        except (OSError, subprocess.TimeoutExpired) as error:
+            raise AgentLedgerError(
+                f"agent-ledger: cannot verify tracking state for {relative}"
+            ) from error
+        if tracked.returncode == 0:
+            raise AgentLedgerError(
+                f"agent-ledger: refusing tracked ledger path {relative}"
+            )
+        if tracked.returncode != 1:
+            raise AgentLedgerError(
+                f"agent-ledger: cannot verify tracking state for {relative}"
+            )
 
 
 def _ensure_build_directory(root: Path) -> Path:
@@ -374,12 +375,14 @@ def _read_snapshot(path: Path, directory: int | None) -> _Snapshot:
 
     if directory is None:  # pragma: no cover - protected by the context manager
         raise AgentLedgerError("agent-ledger: missing shared directory descriptor")
+    _assert_directory_identity(path.parent, directory)
     flags = os.O_RDONLY | O_CLOEXEC | getattr(os, "O_NOFOLLOW", 0)
     descriptor: int | None = None
     try:
         try:
             descriptor = os.open(path.name, flags, dir_fd=directory)
         except FileNotFoundError:
+            _assert_directory_identity(path.parent, directory)
             return _Snapshot(None)
         opened = os.fstat(descriptor)
         if not stat.S_ISREG(opened.st_mode):
@@ -399,6 +402,7 @@ def _read_snapshot(path: Path, directory: int | None) -> _Snapshot:
             raise AgentLedgerError(
                 f"agent-ledger: ledger changed while being read: {path}"
             )
+        _assert_directory_identity(path.parent, directory)
         return _Snapshot(data)
     except AgentLedgerError:
         raise
@@ -769,14 +773,16 @@ def update_agent_ledger(
         raise AgentLedgerError("agent-ledger: stable lock cannot be the replaceable ledger")
 
     try:
-        with exclusive_lock(
-            lock,
-            "agent ledgers",
-            nonblocking=nonblocking,
-            inherit=False,
-        ):
-            _verify_local_only(canonical_root, spec)
-            with _opened_build_directory(build) as directory:
+        with _opened_build_directory(build) as directory:
+            lock_directory = None if IS_WINDOWS else directory
+            with exclusive_lock(
+                lock,
+                "agent ledgers",
+                nonblocking=nonblocking,
+                directory_fd=lock_directory,
+                inherit=False,
+            ):
+                _verify_local_only(canonical_root, spec)
                 snapshot = _read_snapshot(path, directory)
                 actual_digest = _digest(snapshot.data)
                 actual_display = actual_digest or ABSENT_DIGEST

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -161,15 +161,15 @@ def parser() -> argparse.ArgumentParser:
     agent_ledger_update.add_argument(
         "--ledger", choices=["process-improvements", "tooling-issues"], required=True
     )
-    agent_ledger_update.add_argument("--key", required=True)
-    agent_ledger_update.add_argument("--status", required=True)
-    agent_ledger_update.add_argument("--observation", required=True)
-    agent_ledger_update.add_argument("--expected-benefit")
-    agent_ledger_update.add_argument("--related", default="none")
-    agent_ledger_update.add_argument("--observed-at")
-    agent_ledger_update.add_argument("--impact")
-    agent_ledger_update.add_argument("--recommended-action")
-    agent_ledger_update.add_argument("--expected-digest")
+    mark(agent_ledger_update.add_argument("--key", required=True), "none")
+    mark(agent_ledger_update.add_argument("--status", required=True), "none")
+    mark(agent_ledger_update.add_argument("--observation", required=True), "none")
+    mark(agent_ledger_update.add_argument("--expected-benefit"), "none")
+    mark(agent_ledger_update.add_argument("--related", default="none"), "none")
+    mark(agent_ledger_update.add_argument("--observed-at"), "none")
+    mark(agent_ledger_update.add_argument("--impact"), "none")
+    mark(agent_ledger_update.add_argument("--recommended-action"), "none")
+    mark(agent_ledger_update.add_argument("--expected-digest"), "none")
     agent_ledger_update.add_argument(
         "--non-blocking",
         action="store_true",

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -64,6 +64,18 @@ def preflight_provenance_revisions(*arguments: object, **keywords: object) -> ob
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def shared_agent_ledger_root(repository: Path) -> Path:
+    from .agent_ledgers import resolve_shared_root
+
+    return resolve_shared_root(repository)
+
+
+def update_agent_ledger(*arguments: object, **keywords: object) -> object:
+    from .agent_ledgers import update_agent_ledger as implementation
+
+    return implementation(*arguments, **keywords)
+
+
 def _human_bytes(value: int) -> str:
     """Render an exact byte count compactly for human-facing output."""
 
@@ -136,6 +148,34 @@ def parser() -> argparse.ArgumentParser:
     )
     mark(status.add_argument("components", nargs="*"), "component")
     status.add_argument("--json", action="store_true")
+
+    agent_ledger = commands.add_parser(
+        "agent-ledger", help="update one ignored local agent ledger safely"
+    )
+    agent_ledger_commands = agent_ledger.add_subparsers(
+        dest="agent_ledger_command", required=True
+    )
+    agent_ledger_update = agent_ledger_commands.add_parser(
+        "update", help="add or replace one stable-key row"
+    )
+    agent_ledger_update.add_argument(
+        "--ledger", choices=["process-improvements", "tooling-issues"], required=True
+    )
+    agent_ledger_update.add_argument("--key", required=True)
+    agent_ledger_update.add_argument("--status", required=True)
+    agent_ledger_update.add_argument("--observation", required=True)
+    agent_ledger_update.add_argument("--expected-benefit")
+    agent_ledger_update.add_argument("--related", default="none")
+    agent_ledger_update.add_argument("--observed-at")
+    agent_ledger_update.add_argument("--impact")
+    agent_ledger_update.add_argument("--recommended-action")
+    agent_ledger_update.add_argument("--expected-digest")
+    agent_ledger_update.add_argument(
+        "--non-blocking",
+        action="store_true",
+        help="fail immediately with a retry diagnostic if another update holds the lock",
+    )
+    agent_ledger_update.add_argument("--json", action="store_true")
 
     migrate = commands.add_parser(
         "migrate", help="safely migrate an existing workspace layout"
@@ -751,6 +791,32 @@ def main(arguments: list[str] | None = None) -> int:
         if options.command == "manifest":
             manifest = Manifest.load(ROOT / "components.json")
             print(f"components.json: valid ({len(manifest.components)} components)")
+            return 0
+        if options.command == "agent-ledger":
+            if options.agent_ledger_command != "update":
+                raise WorkspaceError("unknown agent-ledger command")
+            result = update_agent_ledger(
+                shared_agent_ledger_root(ROOT),
+                options.ledger,
+                key=options.key,
+                status=options.status,
+                observation=options.observation,
+                expected_benefit=options.expected_benefit,
+                related=options.related,
+                observed_at=options.observed_at,
+                impact=options.impact,
+                recommended_action=options.recommended_action,
+                expected_digest=options.expected_digest,
+                nonblocking=options.non_blocking,
+            )
+            if options.json:
+                print(json.dumps(result, indent=2, sort_keys=True))
+            else:
+                print(
+                    f"agent-ledger\t{result['ledger']}\t"
+                    f"{result['operation']}\t{result['key']}"
+                )
+                print(f"digest\t{result['digest']}")
             return 0
         if options.command == "provenance":
             if options.provenance_command == "preflight":

--- a/atrinik_workspace/guidance_inventory.py
+++ b/atrinik_workspace/guidance_inventory.py
@@ -175,39 +175,12 @@ def _git_check(root: Path, *arguments: str) -> int | None:
         return None
 
 
-def validate_tooling_ledger(root: Path = ROOT) -> list[str]:
-    '''Validate optional local tooling-ledger state without requiring it.'''
+def validate_tooling_ledger_text(
+    text: str, relative: str = TOOLING_LEDGER_RELATIVE.as_posix()
+) -> list[str]:
+    '''Validate tooling-ledger Markdown already decoded as UTF-8.'''
 
-    relative = TOOLING_LEDGER_RELATIVE.as_posix()
     failures: list[str] = []
-    ignored = _git_check(
-        root, 'check-ignore', '--quiet', '--no-index', '--', relative
-    )
-    if ignored != 0:
-        failures.append(f'{relative} is not ignored')
-    tracked = _git_check(root, 'ls-files', '--error-unmatch', '--', relative)
-    if tracked == 0:
-        failures.append(f'{relative} is tracked')
-
-    path = root / TOOLING_LEDGER_RELATIVE
-    if not path.exists() and not path.is_symlink():
-        return failures
-    if path.is_symlink() or not path.is_file():
-        failures.append(f'{relative} is not a regular file')
-        return failures
-    try:
-        raw = path.read_bytes()
-    except OSError:
-        failures.append(f'{relative} could not be read')
-        return failures
-    if len(raw) > TOOLING_LEDGER_MAX_BYTES:
-        failures.append(f'{relative} exceeds the size limit')
-        return failures
-    try:
-        text = raw.decode('utf-8')
-    except UnicodeDecodeError:
-        failures.append(f'{relative} is not UTF-8')
-        return failures
     if '\x00' in text:
         failures.append(f'{relative} contains binary data')
     if _SECRET_VALUE.search(text) or _PRIVATE_HOST_PATH.search(text):
@@ -269,6 +242,42 @@ def validate_tooling_ledger(root: Path = ROOT) -> list[str]:
     return failures
 
 
+def validate_tooling_ledger(root: Path = ROOT) -> list[str]:
+    '''Validate optional local tooling-ledger state without requiring it.'''
+
+    relative = TOOLING_LEDGER_RELATIVE.as_posix()
+    failures: list[str] = []
+    ignored = _git_check(
+        root, 'check-ignore', '--quiet', '--no-index', '--', relative
+    )
+    if ignored != 0:
+        failures.append(f'{relative} is not ignored')
+    tracked = _git_check(root, 'ls-files', '--error-unmatch', '--', relative)
+    if tracked == 0:
+        failures.append(f'{relative} is tracked')
+
+    path = root / TOOLING_LEDGER_RELATIVE
+    if not path.exists() and not path.is_symlink():
+        return failures
+    if path.is_symlink() or not path.is_file():
+        failures.append(f'{relative} is not a regular file')
+        return failures
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        failures.append(f'{relative} could not be read')
+        return failures
+    if len(raw) > TOOLING_LEDGER_MAX_BYTES:
+        failures.append(f'{relative} exceeds the size limit')
+        return failures
+    try:
+        text = raw.decode('utf-8')
+    except UnicodeDecodeError:
+        failures.append(f'{relative} is not UTF-8')
+        return failures
+    return failures + validate_tooling_ledger_text(text, relative)
+
+
 def process_improvement_ledger_path(root: Path | None = None) -> Path:
     return (root or ROOT) / PROCESS_IMPROVEMENT_LEDGER
 
@@ -300,28 +309,10 @@ def _valid_process_timestamp(value: str) -> bool:
     return True
 
 
-def validate_process_improvement_ledger(root: Path | None = None) -> list[str]:
-    root = root or ROOT
-    path = process_improvement_ledger_path(root)
-    if path.is_symlink():
-        return ["process-improvement ledger must not be a symlink"]
-    if not path.exists():
-        return []
-    if not path.is_file():
-        return ["process-improvement ledger must be a regular file"]
+def validate_process_improvement_ledger_text(text: str) -> list[str]:
+    '''Validate process-improvement Markdown already decoded as UTF-8.'''
 
     errors: list[str] = []
-    ignore_error = _process_ledger_ignore_error(root, path)
-    if ignore_error:
-        errors.append(ignore_error)
-    try:
-        raw = path.read_bytes()
-        if len(raw) > 128 * 1024:
-            errors.append("process-improvement ledger exceeds 128 KiB")
-        text = raw.decode("utf-8")
-    except (OSError, UnicodeError):
-        return errors + ["process-improvement ledger must be bounded UTF-8"]
-
     if not text.endswith("\n"):
         errors.append("process-improvement ledger must end with a newline")
     if any(
@@ -387,6 +378,30 @@ def validate_process_improvement_ledger(root: Path | None = None) -> list[str]:
     if row_count == 0:
         errors.append("process-improvement ledger requires at least one row")
     return errors
+
+
+def validate_process_improvement_ledger(root: Path | None = None) -> list[str]:
+    root = root or ROOT
+    path = process_improvement_ledger_path(root)
+    if path.is_symlink():
+        return ["process-improvement ledger must not be a symlink"]
+    if not path.exists():
+        return []
+    if not path.is_file():
+        return ["process-improvement ledger must be a regular file"]
+
+    errors: list[str] = []
+    ignore_error = _process_ledger_ignore_error(root, path)
+    if ignore_error:
+        errors.append(ignore_error)
+    try:
+        raw = path.read_bytes()
+        if len(raw) > 128 * 1024:
+            errors.append("process-improvement ledger exceeds 128 KiB")
+        text = raw.decode("utf-8")
+    except (OSError, UnicodeError):
+        return errors + ["process-improvement ledger must be bounded UTF-8"]
+    return errors + validate_process_improvement_ledger_text(text)
 
 
 def collect_inventory() -> dict[str, object]:

--- a/tests/test_agent_guidance.py
+++ b/tests/test_agent_guidance.py
@@ -626,6 +626,9 @@ class AgentGuidanceTests(unittest.TestCase):
         for text in normalized:
             self.assertIn("build/agent-process-improvements.md", text)
             self.assertIn("Process improvements added: none", text)
+            self.assertIn("./atrinik agent-ledger update", text)
+            self.assertIn("never manually edit", text)
+            self.assertIn("separate filesystems", text)
         self.assertIn(
             "before repository or expensive build/package/runtime/remote-mutation",
             normalized[0].lower(),
@@ -962,6 +965,11 @@ class AgentGuidanceTests(unittest.TestCase):
         for marker in {
             'Tooling issues: none',
             'build/agent-tooling-issues.md',
+            './atrinik agent-ledger update',
+            'build/.agent-ledgers.lock',
+            '--expected-digest absent',
+            'never manually edit',
+            'separate filesystems',
             'mechanism=<slug>;remediation=<slug>',
             'same mechanism and remediation recur',
             'materially different',

--- a/tests/test_agent_ledgers.py
+++ b/tests/test_agent_ledgers.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+from atrinik_workspace import agent_ledgers
+from atrinik_workspace.agent_ledgers import (
+    AgentLedgerCommitUncertain,
+    AgentLedgerError,
+    ledger_lock_path,
+    ledger_path,
+    resolve_shared_root,
+    update_agent_ledger,
+)
+from atrinik_workspace.guidance_inventory import (
+    validate_process_improvement_ledger,
+    validate_tooling_ledger,
+)
+from atrinik_workspace.locking import exclusive_lock
+
+
+class AgentLedgerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        subprocess.run(
+            ["git", "init", "--quiet"],
+            cwd=self.root,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        (self.root / ".gitignore").write_text("/build/\n", encoding="utf-8")
+
+    def _tooling(self, key: str, observation: str = "observed") -> dict[str, object]:
+        return update_agent_ledger(
+            self.root,
+            "tooling-issues",
+            key=key,
+            status="open",
+            observation=observation,
+            impact="the operation needs a bounded retry",
+            recommended_action="reread the latest helper output",
+        )
+
+    def _process(self, key: str, observation: str = "observed") -> dict[str, object]:
+        return update_agent_ledger(
+            self.root,
+            "process-improvements",
+            key=key,
+            status="observed",
+            observation=observation,
+            expected_benefit="keep the shared workflow bounded",
+            related="none",
+            observed_at="2026-09-03T00:00:00Z",
+        )
+
+    def test_each_schema_can_be_created_and_validated(self) -> None:
+        tooling = self._tooling(
+            "mechanism=local-ledger;remediation=shared-lock"
+        )
+        process = self._process("local-ledger")
+
+        self.assertEqual(tooling["operation"], "added")
+        self.assertEqual(process["operation"], "added")
+        self.assertEqual(validate_tooling_ledger(self.root), [])
+        self.assertEqual(validate_process_improvement_ledger(self.root), [])
+        self.assertNotEqual(tooling["digest"], process["digest"])
+        self.assertTrue((self.root / "build/.agent-ledgers.lock").is_file())
+
+    def test_concurrent_different_keys_preserve_every_row(self) -> None:
+        keys = [
+            f"mechanism=worker-{index};remediation=atomic-merge"
+            for index in range(12)
+        ]
+        with ThreadPoolExecutor(max_workers=len(keys)) as workers:
+            results = list(workers.map(self._tooling, keys))
+
+        self.assertEqual(len(results), len(keys))
+        self.assertTrue(all(result["operation"] == "added" for result in results))
+        self.assertEqual(validate_tooling_ledger(self.root), [])
+        text = ledger_path(self.root, "tooling-issues").read_text(encoding="utf-8")
+        for key in keys:
+            self.assertEqual(text.count(f"`{key}`"), 1)
+
+    def test_concurrent_same_key_keeps_one_valid_latest_row(self) -> None:
+        key = "mechanism=same-key;remediation=serialized"
+        observations = [f"writer-{index}" for index in range(10)]
+        with ThreadPoolExecutor(max_workers=len(observations)) as workers:
+            results = list(
+                workers.map(
+                    lambda observation: self._tooling(key, observation), observations
+                )
+            )
+
+        self.assertEqual(len(results), len(observations))
+        self.assertEqual(validate_tooling_ledger(self.root), [])
+        text = ledger_path(self.root, "tooling-issues").read_text(encoding="utf-8")
+        self.assertEqual(text.count(f"`{key}`"), 1)
+        self.assertTrue(any(observation in text for observation in observations))
+
+    def test_stale_digest_fails_closed_for_both_schemas(self) -> None:
+        for ledger in ("tooling-issues", "process-improvements"):
+            with self.subTest(ledger=ledger):
+                if ledger == "tooling-issues":
+                    initial = self._tooling(
+                        "mechanism=stale-cas;remediation=first"
+                    )
+                    self._tooling(
+                        "mechanism=stale-cas;remediation=first",
+                        "newer observation",
+                    )
+                else:
+                    initial = self._process("stale-cas")
+                    self._process("stale-cas", "newer observation")
+                with self.assertRaisesRegex(AgentLedgerError, "stale digest"):
+                    if ledger == "tooling-issues":
+                        update_agent_ledger(
+                            self.root,
+                            ledger,
+                            key="mechanism=stale-cas;remediation=first",
+                            status="open",
+                            observation="stale observation",
+                            impact="the operation needs a bounded retry",
+                            recommended_action="reread the latest helper output",
+                            expected_digest=initial["digest"],
+                        )
+                    else:
+                        update_agent_ledger(
+                            self.root,
+                            ledger,
+                            key="stale-cas",
+                            status="observed",
+                            observation="stale observation",
+                            expected_benefit="keep the shared workflow bounded",
+                            related="none",
+                            observed_at="2026-09-03T00:00:00Z",
+                            expected_digest=initial["digest"],
+                        )
+
+    def test_absent_digest_is_an_explicit_compare_and_swap(self) -> None:
+        result = self._tooling(
+            "mechanism=absent-cas;remediation=explicit", observation="first"
+        )
+        self.assertEqual(result["previous_digest"], None)
+        self.assertEqual(result["operation"], "added")
+
+        with self.assertRaisesRegex(AgentLedgerError, "stale digest"):
+            update_agent_ledger(
+                self.root,
+                "tooling-issues",
+                key="mechanism=absent-cas;remediation=explicit",
+                status="open",
+                observation="first",
+                impact="the operation needs a bounded retry",
+                recommended_action="reread the latest helper output",
+                expected_digest="absent",
+            )
+
+    def test_nonblocking_contention_has_retry_diagnostic(self) -> None:
+        self._tooling("mechanism=lock-test;remediation=retry")
+        with exclusive_lock(ledger_lock_path(self.root), "test ledger holder"):
+            with self.assertRaisesRegex(AgentLedgerError, "lock is busy"):
+                update_agent_ledger(
+                    self.root,
+                    "tooling-issues",
+                    key="mechanism=lock-test;remediation=retry",
+                    status="open",
+                    observation="contended",
+                    impact="the operation needs a bounded retry",
+                    recommended_action="reread the latest helper output",
+                    nonblocking=True,
+                )
+
+    def test_failed_flush_preserves_previous_bytes_and_retry_succeeds(self) -> None:
+        self._tooling("mechanism=flush-failure;remediation=retry", "before")
+        path = ledger_path(self.root, "tooling-issues")
+        before = path.read_bytes()
+        with mock.patch.object(
+            agent_ledgers, "flush_file", side_effect=OSError("simulated crash")
+        ):
+            with self.assertRaisesRegex(AgentLedgerError, "publication failed"):
+                self._tooling("mechanism=flush-failure;remediation=retry", "after")
+        self.assertEqual(path.read_bytes(), before)
+        self.assertEqual(list(path.parent.glob(f".{path.name}.*.tmp")), [])
+        retry = self._tooling("mechanism=flush-failure;remediation=retry", "after")
+        self.assertEqual(retry["operation"], "updated")
+        self.assertEqual(validate_tooling_ledger(self.root), [])
+
+    def test_post_replace_durability_failure_is_explicit_and_retryable(self) -> None:
+        self._tooling("mechanism=directory-sync;remediation=retry", "before")
+        real_fsync = os.fsync
+        calls = 0
+
+        def fail_directory_sync(descriptor: int) -> None:
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise OSError("simulated directory sync failure")
+            real_fsync(descriptor)
+
+        with mock.patch.object(os, "fsync", side_effect=fail_directory_sync):
+            with self.assertRaises(AgentLedgerCommitUncertain):
+                self._tooling("mechanism=directory-sync;remediation=retry", "after")
+        self.assertIn("after", ledger_path(self.root, "tooling-issues").read_text())
+        retry = self._tooling("mechanism=directory-sync;remediation=retry", "after")
+        self.assertEqual(retry["operation"], "unchanged")
+
+    def test_malformed_current_bytes_are_never_replaced(self) -> None:
+        fixtures = {
+            "tooling-issues": (
+                b"# Agent tooling issues\n\n| Stable key | Status |\n",
+                "mechanism=malformed;remediation=tooling",
+            ),
+            "process-improvements": (
+                b"# Agent process improvements\n\n| Key | Status |\n",
+                "malformed-process",
+            ),
+        }
+        for ledger, (malformed, key) in fixtures.items():
+            with self.subTest(ledger=ledger):
+                path = ledger_path(self.root, ledger)
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(malformed)
+                with self.assertRaisesRegex(AgentLedgerError, "malformed"):
+                    if ledger == "tooling-issues":
+                        self._tooling(key)
+                    else:
+                        self._process(key)
+                self.assertEqual(path.read_bytes(), malformed)
+
+    def test_input_and_local_only_guards_fail_closed(self) -> None:
+        with self.assertRaisesRegex(AgentLedgerError, "invalid tooling-issue stable key"):
+            self._tooling("not-a-tooling-key")
+        with self.assertRaisesRegex(AgentLedgerError, "without pipes"):
+            self._tooling("mechanism=pipe;remediation=reject", "bad | row")
+
+        (self.root / ".gitignore").write_text("/other/\n", encoding="utf-8")
+        with self.assertRaisesRegex(AgentLedgerError, "non-ignored"):
+            self._tooling("mechanism=not-ignored;remediation=reject")
+
+    @unittest.skipIf(os.name == "nt", "native Windows has different symlink privileges")
+    def test_symlink_target_is_rejected_without_following_it(self) -> None:
+        outside = self.root / "outside.md"
+        outside.write_text("do not touch\n", encoding="utf-8")
+        path = ledger_path(self.root, "tooling-issues")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.symlink_to(outside)
+        with self.assertRaises(AgentLedgerError):
+            self._tooling("mechanism=symlink;remediation=reject")
+        self.assertEqual(outside.read_text(encoding="utf-8"), "do not touch\n")
+
+    def test_linked_worktree_resolves_to_the_wrapper_root(self) -> None:
+        root = resolve_shared_root(Path(__file__).resolve().parents[1])
+        self.assertEqual(root, Path("/workspaces/atrinik"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_agent_ledgers.py
+++ b/tests/test_agent_ledgers.py
@@ -245,6 +245,36 @@ class AgentLedgerTests(unittest.TestCase):
         with self.assertRaisesRegex(AgentLedgerError, "non-ignored"):
             self._tooling("mechanism=not-ignored;remediation=reject")
 
+    def test_stable_lock_local_only_guard_fails_closed(self) -> None:
+        self._tooling("mechanism=tracked-lock;remediation=reject")
+        lock = ledger_lock_path(self.root)
+        subprocess.run(
+            ["git", "add", "--force", "--", lock.relative_to(self.root).as_posix()],
+            cwd=self.root,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        path = ledger_path(self.root, "tooling-issues")
+        before = path.read_bytes()
+        with self.assertRaisesRegex(AgentLedgerError, "tracked ledger path"):
+            self._tooling("mechanism=tracked-lock;remediation=reject", "blocked")
+        self.assertEqual(path.read_bytes(), before)
+
+    @unittest.skipIf(os.name == "nt", "native Windows has no directory descriptor pin")
+    def test_replaced_build_directory_is_rejected_before_read(self) -> None:
+        self._tooling("mechanism=directory-replacement;remediation=reject")
+        build = self.root / "build"
+        original = self.root / "build-original"
+        path = ledger_path(self.root, "tooling-issues")
+        with agent_ledgers._opened_build_directory(build) as directory:
+            build.rename(original)
+            build.mkdir()
+            with self.assertRaisesRegex(AgentLedgerError, "changed during publication"):
+                agent_ledgers._read_snapshot(path, directory)
+        self.assertTrue((original / path.name).is_file())
+        self.assertFalse(path.exists())
+
     @unittest.skipIf(os.name == "nt", "native Windows has different symlink privileges")
     def test_symlink_target_is_rejected_without_following_it(self) -> None:
         outside = self.root / "outside.md"

--- a/tests/test_agent_ledgers.py
+++ b/tests/test_agent_ledgers.py
@@ -287,8 +287,17 @@ class AgentLedgerTests(unittest.TestCase):
         self.assertEqual(outside.read_text(encoding="utf-8"), "do not touch\n")
 
     def test_linked_worktree_resolves_to_the_wrapper_root(self) -> None:
-        root = resolve_shared_root(Path(__file__).resolve().parents[1])
-        self.assertEqual(root, Path("/workspaces/atrinik"))
+        repository = Path(__file__).resolve().parents[1]
+        root = resolve_shared_root(repository)
+        common = Path(
+            subprocess.check_output(
+                ["git", "-C", str(repository), "rev-parse", "--git-common-dir"],
+                text=True,
+            ).strip()
+        )
+        if not common.is_absolute():
+            common = repository / common
+        self.assertEqual(root, common.resolve().parent)
 
 
 if __name__ == "__main__":

--- a/tests/test_agent_ledgers.py
+++ b/tests/test_agent_ledgers.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
+import errno
+import io
 import os
 from pathlib import Path
 import subprocess
 import tempfile
+from types import SimpleNamespace
 import unittest
 from unittest import mock
 
@@ -285,6 +288,266 @@ class AgentLedgerTests(unittest.TestCase):
         with self.assertRaises(AgentLedgerError):
             self._tooling("mechanism=symlink;remediation=reject")
         self.assertEqual(outside.read_text(encoding="utf-8"), "do not touch\n")
+
+    def test_validation_rejects_bad_inputs_and_mapping_shapes(self) -> None:
+        with self.assertRaisesRegex(AgentLedgerError, "process-improvements or"):
+            agent_ledgers._spec("unsupported")
+        with self.assertRaisesRegex(AgentLedgerError, "lowercase SHA-256"):
+            agent_ledgers._validate_expected_digest("not-a-digest")
+        with self.assertRaisesRegex(AgentLedgerError, "must be text"):
+            agent_ledgers._field(None, None)  # type: ignore[arg-type]
+        with self.assertRaisesRegex(AgentLedgerError, "must not be empty"):
+            agent_ledgers._field("value", " ")
+        with self.assertRaisesRegex(AgentLedgerError, "without pipes"):
+            agent_ledgers._field("value", "bad | value")
+        with self.assertRaisesRegex(AgentLedgerError, "without pipes"):
+            agent_ledgers._field("value", "bad\nvalue")
+        with self.assertRaisesRegex(AgentLedgerError, "control character"):
+            agent_ledgers._field("value", "bad\x01value")
+        with self.assertRaisesRegex(AgentLedgerError, "backticks"):
+            agent_ledgers._field("key", "bad`key", key=True)
+        self.assertRegex(agent_ledgers._timestamp(None), r"Z$")
+        with self.assertRaisesRegex(AgentLedgerError, "valid UTC timestamp"):
+            agent_ledgers._timestamp("2026-09-03")
+
+        with self.assertRaisesRegex(
+            AgentLedgerError, "process-improvement stable key"
+        ):
+            self._process("bad key")
+        with self.assertRaisesRegex(AgentLedgerError, "process-improvement status"):
+            update_agent_ledger(
+                self.root,
+                "process-improvements",
+                key="valid-key",
+                status="invalid",
+                observation="observed",
+                expected_benefit="bounded benefit",
+            )
+        with self.assertRaisesRegex(AgentLedgerError, "tooling-issue status"):
+            update_agent_ledger(
+                self.root,
+                "tooling-issues",
+                key="mechanism=valid;remediation=status",
+                status="invalid",
+                observation="observed",
+                impact="bounded impact",
+                recommended_action="retry safely",
+            )
+        with self.assertRaisesRegex(AgentLedgerError, "unsupported row fields"):
+            agent_ledgers.update_from_mapping(
+                self.root,
+                "tooling-issues",
+                {
+                    "key": "mechanism=mapping;remediation=unknown",
+                    "status": "open",
+                    "observation": "observed",
+                    "unexpected": "reject",
+                },
+            )
+        with self.assertRaisesRegex(AgentLedgerError, "missing required fields"):
+            agent_ledgers.update_from_mapping(
+                self.root,
+                "tooling-issues",
+                {"key": "mechanism=mapping;remediation=missing", "status": "open"},
+            )
+        result = agent_ledgers.update_from_mapping(
+            self.root,
+            "tooling-issues",
+            {
+                "key": "mechanism=mapping;remediation=valid",
+                "status": "open",
+                "observation": "observed",
+                "impact": "bounded impact",
+                "recommended_action": "retry safely",
+            },
+        )
+        self.assertEqual(result["operation"], "added")
+
+    def test_candidate_and_table_validation_rejects_bad_bytes(self) -> None:
+        spec = agent_ledgers._spec("tooling-issues")
+        with self.assertRaisesRegex(AgentLedgerError, "exceeds the 128 KiB"):
+            agent_ledgers._validate_candidate(
+                spec, b"x" * (agent_ledgers.AGENT_LEDGER_MAX_BYTES + 1)
+            )
+        with self.assertRaisesRegex(AgentLedgerError, "not UTF-8"):
+            agent_ledgers._validate_candidate(spec, b"\xff")
+        with mock.patch.object(
+            agent_ledgers, "validate_tooling_ledger_text", return_value=["invalid"]
+        ):
+            with self.assertRaisesRegex(AgentLedgerError, "candidate rejected"):
+                agent_ledgers._validate_candidate(spec, b"candidate")
+
+        header = "| Stable key | Status | Observation | Impact | Recommended action |"
+        separator = "| --- | --- | --- | --- | --- |"
+        row = "| `mechanism=table;remediation=valid` | open | observed | impact | action |"
+        with self.assertRaisesRegex(AgentLedgerError, "table is not canonical"):
+            agent_ledgers._table_for(spec, "# Agent tooling issues\n")
+        with self.assertRaisesRegex(AgentLedgerError, "separator is invalid"):
+            agent_ledgers._table_for(spec, f"{header}\n| bad |\n{row}\n")
+        with self.assertRaisesRegex(AgentLedgerError, "malformed row"):
+            agent_ledgers._table_for(spec, f"{header}\n{separator}\n| bad |\n")
+        with self.assertRaisesRegex(AgentLedgerError, "duplicate stable keys"):
+            agent_ledgers._table_for(spec, f"{header}\n{separator}\n{row}\n{row}\n")
+        with self.assertRaisesRegex(AgentLedgerError, "contains no rows"):
+            agent_ledgers._table_for(spec, f"{header}\n{separator}\n")
+        table = agent_ledgers._table_for(
+            spec, f"{header}\n{separator}\n{row}\n\nnotes\n"
+        )
+        self.assertEqual(table.insert_at, 3)
+        with self.assertRaisesRegex(AgentLedgerError, "not UTF-8"):
+            agent_ledgers._merge(
+                spec,
+                b"\xff",
+                ("mechanism=x;remediation=y", "open", "o", "i", "a"),
+            )
+        no_final_newline = f"# Agent tooling issues\n\n{header}\n{separator}\n{row}"
+        merged, operation = agent_ledgers._merge(
+            spec,
+            no_final_newline.encode("utf-8"),
+            ("mechanism=table;remediation=added", "open", "o", "i", "a"),
+        )
+        self.assertEqual(operation, "added")
+        self.assertTrue(merged.endswith(b"\n"))
+
+    @unittest.skipIf(
+        os.name == "nt", "native Windows has different descriptor semantics"
+    )
+    def test_snapshot_and_directory_guards_fail_closed(self) -> None:
+        build = self.root / "build"
+        build.mkdir()
+        not_a_directory = self.root / "not-a-directory"
+        not_a_directory.write_text("file", encoding="utf-8")
+        with self.assertRaisesRegex(
+            AgentLedgerError, "shared build directory is unsafe"
+        ):
+            with agent_ledgers._opened_build_directory(not_a_directory):
+                pass
+        with agent_ledgers._opened_build_directory(build) as directory:
+            path = build / "not-a-file"
+            path.mkdir()
+            with self.assertRaisesRegex(AgentLedgerError, "not a regular file"):
+                agent_ledgers._read_snapshot(path, directory)
+            with mock.patch.object(
+                agent_ledgers.os,
+                "open",
+                side_effect=OSError(errno.ENOENT, "missing"),
+            ):
+                self.assertIsNone(
+                    agent_ledgers._read_snapshot(build / "missing", directory).data
+                )
+        self.assertEqual(agent_ledgers._read_limited(io.BytesIO(b"bytes")), b"bytes")
+        with self.assertRaisesRegex(AgentLedgerError, "exceeds the 128 KiB"):
+            agent_ledgers._read_limited(
+                io.BytesIO(b"x" * (agent_ledgers.AGENT_LEDGER_MAX_BYTES + 1))
+            )
+
+    @unittest.skipIf(
+        os.name == "nt", "native Windows has different symlink semantics"
+    )
+    def test_repository_and_local_only_discovery_errors(self) -> None:
+        with mock.patch.object(
+            agent_ledgers.subprocess, "run", side_effect=OSError("git unavailable")
+        ):
+            with self.assertRaisesRegex(AgentLedgerError, "cannot discover"):
+                agent_ledgers._git_root_output(self.root, "--show-toplevel")
+        with mock.patch.object(
+            agent_ledgers.subprocess,
+            "run",
+            return_value=SimpleNamespace(returncode=1, stdout=""),
+        ):
+            with self.assertRaisesRegex(AgentLedgerError, "not a Git checkout"):
+                agent_ledgers._git_root_output(self.root, "--show-toplevel")
+        file_path = self.root / "file"
+        file_path.write_text("file", encoding="utf-8")
+        with self.assertRaisesRegex(AgentLedgerError, "not a directory"):
+            agent_ledgers.resolve_shared_root(file_path)
+        with self.assertRaisesRegex(
+            AgentLedgerError, "shared root is not a directory"
+        ):
+            agent_ledgers._canonical_root(file_path)
+        outside = self.root / "outside"
+        outside.mkdir()
+        (self.root / "build").symlink_to(outside, target_is_directory=True)
+        with self.assertRaisesRegex(
+            AgentLedgerError, "establish the shared build directory"
+        ):
+            agent_ledgers._ensure_build_directory(self.root)
+
+        spec = agent_ledgers._spec("tooling-issues")
+        with mock.patch.object(
+            agent_ledgers.subprocess, "run", side_effect=OSError("check failed")
+        ):
+            with self.assertRaisesRegex(AgentLedgerError, "cannot verify"):
+                agent_ledgers._verify_local_only(self.root, spec)
+        with mock.patch.object(
+            agent_ledgers.subprocess,
+            "run",
+            side_effect=[SimpleNamespace(returncode=0), OSError("tracking failed")],
+        ):
+            with self.assertRaisesRegex(AgentLedgerError, "tracking state"):
+                agent_ledgers._verify_local_only(self.root, spec)
+        with mock.patch.object(
+            agent_ledgers.subprocess,
+            "run",
+            side_effect=[SimpleNamespace(returncode=0), SimpleNamespace(returncode=2)],
+        ):
+            with self.assertRaisesRegex(AgentLedgerError, "cannot verify tracking"):
+                agent_ledgers._verify_local_only(self.root, spec)
+
+    def test_publication_and_update_recovery_edges(self) -> None:
+        build = self.root / "build"
+        build.mkdir()
+        path = build / "agent-tooling-issues.md"
+        with agent_ledgers._opened_build_directory(build) as directory:
+            with mock.patch.object(
+                agent_ledgers,
+                "_assert_directory_identity",
+                side_effect=[None, AgentLedgerError("verification failed")],
+            ):
+                with self.assertRaises(AgentLedgerCommitUncertain):
+                    agent_ledgers._atomic_publish(path, directory, b"published\n")
+            self.assertEqual(path.read_bytes(), b"published\n")
+        with self.assertRaisesRegex(AgentLedgerError, "missing shared directory"):
+            agent_ledgers._atomic_publish(path, None, b"data")
+        for failure in (FileNotFoundError(), OSError("cleanup failed")):
+            with agent_ledgers._opened_build_directory(build) as directory:
+                with mock.patch.object(
+                    agent_ledgers, "flush_file", side_effect=OSError("flush failed")
+                ), mock.patch.object(agent_ledgers.os, "unlink", side_effect=failure):
+                    with self.assertRaises(OSError):
+                        agent_ledgers._atomic_publish(path, directory, b"retry\n")
+
+        with mock.patch.object(
+            agent_ledgers, "ledger_lock_path", return_value=ledger_path(self.root, "tooling-issues")
+        ):
+            with self.assertRaisesRegex(AgentLedgerError, "replaceable ledger"):
+                self._tooling("mechanism=lock;remediation=reject")
+        with mock.patch.object(
+            agent_ledgers,
+            "_read_snapshot",
+            return_value=agent_ledgers._Snapshot(
+                b"x" * (agent_ledgers.AGENT_LEDGER_MAX_BYTES + 1)
+            ),
+        ):
+            with self.assertRaisesRegex(AgentLedgerError, "current ledger exceeds"):
+                self._tooling("mechanism=oversized;remediation=reject")
+        with mock.patch.object(
+            agent_ledgers, "_read_snapshot", return_value=agent_ledgers._Snapshot(b"\xff")
+        ):
+            with self.assertRaisesRegex(
+                AgentLedgerError, "current ledger is not UTF-8"
+            ):
+                self._tooling("mechanism=encoding;remediation=reject")
+        with mock.patch.object(
+            agent_ledgers,
+            "_read_snapshot",
+            side_effect=[
+                agent_ledgers._Snapshot(None),
+                agent_ledgers._Snapshot(b"changed"),
+            ],
+        ):
+            with self.assertRaisesRegex(AgentLedgerError, "changed while preparing"):
+                self._tooling("mechanism=latest;remediation=changed")
 
     def test_linked_worktree_resolves_to_the_wrapper_root(self) -> None:
         repository = Path(__file__).resolve().parents[1]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
+import io
 import json
 from pathlib import Path
+from types import SimpleNamespace
 import unittest
 from unittest import mock
 
-from atrinik_workspace.cli import _human_bytes, _parse_services, main, parser
+from atrinik_workspace import agent_ledgers
+from atrinik_workspace.cli import (
+    _human_bytes,
+    _parse_services,
+    main,
+    parser,
+    shared_agent_ledger_root,
+    update_agent_ledger,
+)
 from atrinik_workspace.model import WorkspaceError
 
 
@@ -87,6 +97,81 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(options.command, "agent-ledger")
         self.assertEqual(options.agent_ledger_command, "update")
         self.assertEqual(options.ledger, "process-improvements")
+
+    def test_agent_ledger_lazy_wrappers_load_implementation(self) -> None:
+        root = Path("/shared/wrapper")
+        with mock.patch.object(
+            agent_ledgers, "resolve_shared_root", return_value=root
+        ) as resolve_root:
+            self.assertEqual(shared_agent_ledger_root(Path("/repo")), root)
+        resolve_root.assert_called_once_with(Path("/repo"))
+
+        result = {"ledger": "tooling-issues", "operation": "added"}
+        with mock.patch.object(
+            agent_ledgers, "update_agent_ledger", return_value=result
+        ) as implementation:
+            self.assertIs(
+                update_agent_ledger(
+                    root,
+                    "tooling-issues",
+                    key="mechanism=wrapper;remediation=lazy",
+                    status="open",
+                    observation="observed",
+                    impact="bounded impact",
+                    recommended_action="retry safely",
+                ),
+                result,
+            )
+        implementation.assert_called_once()
+
+    def test_agent_ledger_update_prints_text_output(self) -> None:
+        result = {
+            "ledger": "tooling-issues",
+            "operation": "added",
+            "key": "mechanism=cli;remediation=text",
+            "digest": "c" * 64,
+        }
+        with mock.patch(
+            "atrinik_workspace.cli.shared_agent_ledger_root",
+            return_value=Path("/shared/wrapper"),
+        ), mock.patch(
+            "atrinik_workspace.cli.update_agent_ledger", return_value=result
+        ), mock.patch("atrinik_workspace.cli.Workspace"):
+            with mock.patch("builtins.print") as output:
+                code = main(
+                    [
+                        "agent-ledger",
+                        "update",
+                        "--ledger",
+                        "tooling-issues",
+                        "--key",
+                        "mechanism=cli;remediation=text",
+                        "--status",
+                        "open",
+                        "--observation",
+                        "the helper is used",
+                        "--impact",
+                        "manual replacement is unsafe",
+                        "--recommended-action",
+                        "use the wrapper command",
+                    ]
+                )
+        self.assertEqual(code, 0)
+        output.assert_any_call(
+            "agent-ledger\ttooling-issues\tadded\tmechanism=cli;remediation=text"
+        )
+        output.assert_any_call(f"digest\t{'c' * 64}")
+
+    def test_agent_ledger_unknown_subcommand_is_reported(self) -> None:
+        fake_parser = mock.Mock()
+        fake_parser.parse_args.return_value = SimpleNamespace(
+            command="agent-ledger", agent_ledger_command="unexpected"
+        )
+        with mock.patch("atrinik_workspace.cli.parser", return_value=fake_parser):
+            with mock.patch("sys.stderr", new=io.StringIO()) as stderr:
+                code = main(["agent-ledger"])
+        self.assertEqual(code, 1)
+        self.assertIn("unknown agent-ledger command", stderr.getvalue())
 
     def test_scope_human_output_reports_exact_coordinates(self) -> None:
         record = {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,84 @@ from atrinik_workspace.model import WorkspaceError
 
 
 class ParserTests(unittest.TestCase):
+    def test_agent_ledger_update_dispatches_without_initializing_workspace(self) -> None:
+        result = {
+            "schema_version": 1,
+            "ledger": "tooling-issues",
+            "operation": "updated",
+            "key": "mechanism=cli;remediation=dispatch",
+            "digest": "a" * 64,
+        }
+        shared_root = Path("/shared/wrapper")
+        with mock.patch(
+            "atrinik_workspace.cli.shared_agent_ledger_root",
+            return_value=shared_root,
+        ) as resolve_root, mock.patch(
+            "atrinik_workspace.cli.update_agent_ledger", return_value=result
+        ) as update, mock.patch("atrinik_workspace.cli.Workspace") as workspace_type:
+            with mock.patch("builtins.print") as output:
+                code = main(
+                    [
+                        "agent-ledger",
+                        "update",
+                        "--ledger",
+                        "tooling-issues",
+                        "--key",
+                        "mechanism=cli;remediation=dispatch",
+                        "--status",
+                        "open",
+                        "--observation",
+                        "the helper is used",
+                        "--impact",
+                        "manual replacement is unsafe",
+                        "--recommended-action",
+                        "use the wrapper command",
+                        "--expected-digest",
+                        "b" * 64,
+                        "--json",
+                    ]
+                )
+
+        self.assertEqual(code, 0)
+        resolve_root.assert_called_once()
+        update.assert_called_once_with(
+            shared_root,
+            "tooling-issues",
+            key="mechanism=cli;remediation=dispatch",
+            status="open",
+            observation="the helper is used",
+            expected_benefit=None,
+            related="none",
+            observed_at=None,
+            impact="manual replacement is unsafe",
+            recommended_action="use the wrapper command",
+            expected_digest="b" * 64,
+            nonblocking=False,
+        )
+        workspace_type.assert_not_called()
+        self.assertEqual(json.loads(output.call_args.args[0]), result)
+
+    def test_agent_ledger_parser_requires_one_supported_ledger(self) -> None:
+        options = parser().parse_args(
+            [
+                "agent-ledger",
+                "update",
+                "--ledger",
+                "process-improvements",
+                "--key",
+                "cache-reuse",
+                "--status",
+                "observed",
+                "--observation",
+                "cache is reusable",
+                "--expected-benefit",
+                "keep the cache warm",
+            ]
+        )
+        self.assertEqual(options.command, "agent-ledger")
+        self.assertEqual(options.agent_ledger_command, "update")
+        self.assertEqual(options.ledger, "process-improvements")
+
     def test_scope_human_output_reports_exact_coordinates(self) -> None:
         record = {
             "name": "review",


### PR DESCRIPTION
## Summary

Add a wrapper-owned, concurrency-safe edit path for the ignored process-improvement and tooling-issue ledgers.

## Implementation / behavior

- Add `./atrinik agent-ledger update` with schema-aware row validation for both ledger formats.
- Serialize the latest read, validation, merge, and durable atomic publication under a stable shared-workspace lock.
- Support content-digest compare-and-swap handling with clear stale, contention, retry, and separate-filesystem guidance.
- Add focused concurrency, crash/retry, atomic-publication, malformed-input, and local-only validation coverage.
- Update the canonical agent guidance and delivery reference so the facility is the only supported ledger edit path.

## Validation

- Run focused agent-ledger and guidance tests.
- Run the complete wrapper test, coverage, compilation, guidance, manifest, supply-chain, and diff validation required by the repository.

## Limitations / follow-up

The two ledgers remain ignored, human-readable local state. They are not source, CI, release, issue, pull-request, or delivery evidence. Separate filesystems still require an explicit coordinator or event handoff because a local lock cannot synchronize unrelated mounts.

Closes #552
