### PR TITLE
fix(delivery): live-prove actor identity before ledger genesis

### DIFF
--- a/.agents/skills/atrinik-issue-delivery/SKILL.md
+++ b/.agents/skills/atrinik-issue-delivery/SKILL.md
@@ -221,6 +221,7 @@ never mounts source, credentials, private keys, or mutable server data.
   comments are expected and remain untouched. Any malformed or reserved
   `atrinik-delivery:comment:` marker, invalid comment page, duplicate node, or
   incomplete/bounded-out pagination fails closed.
+- Issue-mode actor proof precedes genesis; pre-bind changes use audited recovery.
 - In PR mode, set `TARGET_BRANCH`, `BASE_SHA`, `HEAD_BRANCH`, `HEAD_SHA`, and
   `MERGE_BASE` from the live PR. Fetch and verify the exact base/head refs
   without rewriting published history. Create the local head branch at the

--- a/.agents/skills/atrinik-issue-delivery/references/delivery-ledger.md
+++ b/.agents/skills/atrinik-issue-delivery/references/delivery-ledger.md
@@ -13,6 +13,7 @@ the ownership and recovery boundary.
 - [Create a fresh PR ledger](#create-a-fresh-pr-ledger)
 - [Provision a scope-produced worktree](#provision-a-scope-produced-worktree)
 - [Recover one exact live pre-bind topology mismatch](#recover-one-exact-live-pre-bind-topology-mismatch)
+- [Recover one exact pre-bind actor identity change](#recover-one-exact-pre-bind-actor-identity-change)
 - [Create, inspect, and update](#create-inspect-and-update)
 - [Bind a created PR](#bind-a-created-pr)
 - [Plan and recover body updates](#plan-and-recover-body-updates)
@@ -134,6 +135,7 @@ python3 scripts/delivery_ledger.py recover-prebind-scope REVIEW_ROOT LEDGER_NAME
   RECOVERY_AUTHORITY_JSON \
   --expected-generation GENERATION --expected-digest SHA256 \
   --expected-device DEVICE --expected-inode INODE
+python3 scripts/delivery_ledger.py recover-prebind-identity REVIEW_ROOT LEDGER_NAME REPLACEMENT_LEDGER_JSON RECOVERY_AUTHORITY_JSON --expected-generation GENERATION --expected-digest SHA256 --expected-device DEVICE --expected-inode INODE
 python3 scripts/delivery_ledger.py pr-create-payload REVIEW_ROOT LEDGER_NAME SLOT_ID
 python3 scripts/delivery_ledger.py body-check REVIEW_ROOT LEDGER_NAME PR_NODE_ID BODY
 python3 scripts/delivery_ledger.py body-plan REVIEW_ROOT LEDGER_NAME PR_NODE_ID BODY SECTION
@@ -173,6 +175,15 @@ and bound local worktree before its private CAS. Generic `cas` cannot perform
 this initial PR bind. An interrupted PR bind is retried with the identical
 original command and predecessor tuple so the helper can accept only its exact
 receipt.
+
+At issue-mode genesis, `create` obtains the viewer login/node and every target
+repository's ID and push permission in one authenticated GraphQL response
+pinned to `github.com`, then compares the complete `(login, node_id,
+push_repository_node_ids)` tuple with the prepared actor before any local
+staging or delivery mutation. `pr-bind-cas` repeats that complete proof
+immediately before its private CAS. A mixed login/node response, stale actor,
+missing push authority, or changed tuple fails closed; a caller-supplied tuple
+never grants authority by itself.
 
 Before any dynamic `Workspace` import or Python execution, live proof performs
 a bounded component-wise no-follow ownership/mode prevalidation of the complete
@@ -270,6 +281,13 @@ generation, previous_byte_digest, history, migration
 - `actor` has exactly `login`, `node_id`, `push_repository_node_ids`. The list
   exactly equals the nonempty target-repository set; every selected head is in
   that same-repository set.
+
+The actor tuple is live evidence, not an identity assertion supplied by the
+caller. Genesis requires one response covering the viewer login/node and every
+target's push permission; initial PR binding repeats it and compares all three
+fields. This keeps a valid login with a stale node, or a valid node with a
+different login, from authorizing a branch or PR mutation.
+
 - A repository has exactly `owner`, `name`, `node_id`. Every repeated coordinate
   must retain one node ID, and one node ID cannot alias another coordinate.
 - An issue has exactly `repository`, positive integer `number`, `node_id`.
@@ -1392,6 +1410,39 @@ occurs after the ledger rename, rerun the same command with the original
 predecessor tuple; the durable post-rename proof completes the transaction and
 the predecessor digest remains in `history`. Once that receipt is consumed, a
 newer tuple is required and an ordinary retry is rejected.
+
+## Recover one exact pre-bind actor identity change
+
+If the authenticated actor changes after genesis but before the planned
+issue-mode PR is bound, do not edit the sidecar, recreate the branch/worktree,
+or create/adopt a PR. Preserve the exact source `generation/digest/device/inode`
+tuple and the source ledger bytes. The source must still have no selected PR,
+an empty pull-request authority allowlist, exactly one planned PR slot, and one
+already-bound safe worktree for the target branch.
+
+Prepare a generation+1 candidate that changes only the actor and authority,
+apart from the required predecessor digest, history, and generation. Its
+targets and artifacts must be byte-for-byte equivalent in canonical form to
+the source. The explicit recovery authority binds the exact source identity,
+old and new complete actor tuples, canonical target/artifact digests, prior
+authority timestamp, candidate digest, and the replacement `explicit-recovery`
+authority. That authority's objective digest binds the same projection. Run:
+
+```sh
+python3 scripts/delivery_ledger.py recover-prebind-identity REVIEW_ROOT LEDGER_NAME REPLACEMENT_LEDGER_JSON RECOVERY_AUTHORITY_JSON --expected-generation GENERATION --expected-digest SHA256 --expected-device DEVICE --expected-inode INODE
+```
+
+The helper validates the exact predecessor and candidate digests, rejects
+actor/authority or coordinate drift, and proves that the recovery authority
+postdates the prior authority and allows only the target repositories/issues.
+Under the bound worktree lease it then re-proves the new authenticated actor
+tuple and live absence of every PR for the delivery branch immediately before
+the CAS and again as its precommit guard. The transaction changes no remote
+state and never creates a PR. If a crash occurs after rename, rerun the same
+command with the original predecessor tuple; the durable receipt completes
+the exact recovery, preserving the predecessor digest in `history` and every
+delivery artifact. A newer tuple is required after the receipt is consumed;
+generic `cas` cannot change actor or authority.
 
 ## Create, inspect, and update
 

--- a/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
+++ b/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
@@ -13777,9 +13777,11 @@ def _transition(
         "migration",
     }
     for key in immutable:
-        if key in {"actor", "authority"} and (
-            _scope_recovery_capability is not None
-            or _identity_recovery_capability is not None
+        if (
+            key == "authority" and _scope_recovery_capability is not None
+        ) or (
+            key in {"actor", "authority"}
+            and _identity_recovery_capability is not None
         ):
             continue
         if old[key] != new[key]:

--- a/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
+++ b/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
@@ -97,13 +97,13 @@ _CREATE_STAGE_RE = re.compile(
 _MIGRATE_STAGE_RE = re.compile(r"^\.(?P<target>.+\.md\.ledger\.json)\.migrate\.tmp$")
 _UPDATE_STAGE_RE = re.compile(
     r"^\.(?P<target>.+\.md\.ledger\.json)\.update"
-    r"(?P<operation>-refresh-target|-bind-(?:worktree|scope|pr)-[a-z0-9][a-z0-9._-]{0,127}|-recover-scope-[a-z0-9][a-z0-9._-]{0,127})?"
+    r"(?P<operation>-refresh-target|-bind-(?:worktree|scope|pr)-[a-z0-9][a-z0-9._-]{0,127}|-recover-scope-[a-z0-9][a-z0-9._-]{0,127}|-recover-identity)?"
     r"-g(?P<generation>[0-9]+)-"
     r"from-(?P<digest>[0-9a-f]{64})-to-(?P<candidate>[0-9a-f]{64})\.tmp$"
 )
 _UPDATE_RECEIPT_RE = re.compile(
     r"^\.(?P<target>.+\.md\.ledger\.json)\.update-proof"
-    r"(?P<operation>-refresh-target|-bind-(?:worktree|scope|pr)-[a-z0-9][a-z0-9._-]{0,127}|-recover-scope-[a-z0-9][a-z0-9._-]{0,127})?"
+    r"(?P<operation>-refresh-target|-bind-(?:worktree|scope|pr)-[a-z0-9][a-z0-9._-]{0,127}|-recover-scope-[a-z0-9][a-z0-9._-]{0,127}|-recover-identity)?"
     r"-g"
     r"(?P<generation>[0-9]+)-from-(?P<digest>[0-9a-f]{64})-"
     r"d(?P<device>[0-9]+)-i(?P<inode>[0-9]+)-"
@@ -112,7 +112,8 @@ _UPDATE_RECEIPT_RE = re.compile(
 _UPDATE_OPERATION_RE = re.compile(
     r"^(?:|-refresh-target"
     r"|-bind-(?:worktree|scope|pr)-[a-z0-9][a-z0-9._-]{0,127}"
-    r"|-recover-scope-[a-z0-9][a-z0-9._-]{0,127})$"
+    r"|-recover-scope-[a-z0-9][a-z0-9._-]{0,127}"
+    r"|-recover-identity)$"
 )
 _COMPACT_UPDATE_STAGE_RE = re.compile(
     r"^\.delivery-update-stage-(?P<transaction>[0-9a-f]{64})\.tmp$"
@@ -181,6 +182,7 @@ _RECLAIM_COMPLETE_STAGE_RE = re.compile(
 )
 _UNLINK_QUARANTINE = ".delivery-ledger-unlink"
 _GH_EXECUTABLE = "/usr/bin/gh"
+_GH_EXECUTABLE_CANDIDATES = (_GH_EXECUTABLE, "/usr/local/bin/gh")
 _CANONICAL_REPORT_RE = re.compile(
     r"^(?P<owner>[a-z0-9][a-z0-9._-]*)-(?P<repo>[a-z0-9][a-z0-9._-]*)-"
     r"(?P<mode>issue|pr)-(?P<number>[1-9][0-9]*)\.md$"
@@ -275,6 +277,7 @@ class Snapshot:
 _ATOMIC_BIND_TOKEN = object()
 _TARGET_REFRESH_TOKEN = object()
 _SCOPE_RECOVERY_TOKEN = object()
+_IDENTITY_RECOVERY_TOKEN = object()
 
 
 @dataclass(frozen=True)
@@ -301,6 +304,20 @@ class _ScopeRecoveryCapability:
     slot_id: str
     name: str
     before_raw: bytes
+    after_raw: bytes
+    expected_generation: int
+    expected_digest: str
+    expected_device: int
+    expected_inode: int
+
+
+@dataclass(frozen=True)
+class _IdentityRecoveryCapability:
+    """Authorize one explicit pre-bind actor identity recovery."""
+
+    token: object
+    name: str
+    before_raw: bytes | None
     after_raw: bytes
     expected_generation: int
     expected_digest: str
@@ -1190,18 +1207,31 @@ def _release_document(
     return validated
 
 
+def _trusted_gh_executable() -> str:
+    """Return the first protected gh binary from the pinned image contract."""
+
+    for candidate in _GH_EXECUTABLE_CANDIDATES:
+        try:
+            executable = os.stat(candidate, follow_symlinks=False)
+        except FileNotFoundError:
+            continue
+        except OSError as error:
+            raise LedgerError(
+                f"cannot prove GitHub state: trusted gh is unavailable: {error}"
+            ) from error
+        if (
+            not stat.S_ISREG(executable.st_mode)
+            or executable.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+        ):
+            raise LedgerError("trusted gh executable is not a protected regular file")
+        return candidate
+    raise LedgerError("cannot prove GitHub state: trusted gh is unavailable")
+
+
 def _gh_json(arguments: Sequence[str], context: str) -> Any:
     """Run one bounded authenticated GitHub CLI observation."""
 
-    try:
-        executable = os.stat(_GH_EXECUTABLE, follow_symlinks=False)
-    except OSError as error:
-        raise LedgerError(f"cannot prove {context}: trusted gh is unavailable: {error}") from error
-    if (
-        not stat.S_ISREG(executable.st_mode)
-        or executable.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
-    ):
-        raise LedgerError("trusted gh executable is not a protected regular file")
+    executable = _trusted_gh_executable()
     environment = {
         key: os.environ[key]
         for key in (
@@ -1219,7 +1249,7 @@ def _gh_json(arguments: Sequence[str], context: str) -> Any:
     environment.update(LC_ALL="C", LANG="C", GH_PAGER="cat", PAGER="cat", NO_COLOR="1")
     try:
         process = subprocess.run(
-            [_GH_EXECUTABLE, *arguments],
+            [executable, *arguments],
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -1235,6 +1265,97 @@ def _gh_json(arguments: Sequence[str], context: str) -> Any:
         detail = process.stderr.decode("utf-8", "replace").strip()
         raise LedgerError(f"cannot prove {context} through authenticated gh: {detail or process.returncode}")
     return _decode_value(process.stdout, f"{context} gh output")
+
+
+def _authenticated_actor(
+    document: Mapping[str, Any],
+    context: str = "authenticated GitHub actor",
+) -> dict[str, Any]:
+    """Capture viewer identity and target write authority in one response."""
+
+    targets = document.get("targets")
+    if not isinstance(targets, list) or not targets:
+        raise LedgerError(f"{context} requires at least one target repository")
+    variable_defs: list[str] = []
+    variables: list[tuple[str, str, str, str]] = []
+    fields = ["viewer{login id}"]
+    for index, target in enumerate(targets):
+        if not isinstance(target, dict) or not isinstance(target.get("repository"), dict):
+            raise LedgerError(f"{context} target repository is invalid")
+        repository = target["repository"]
+        owner = _string(repository.get("owner"), f"{context} target owner", OWNER_RE)
+        name = _string(repository.get("name"), f"{context} target name", REPOSITORY_RE)
+        owner_variable = f"owner{index}"
+        name_variable = f"name{index}"
+        variable_defs.extend((f"${owner_variable}:String!", f"${name_variable}:String!"))
+        variables.append((owner_variable, name_variable, owner, name))
+        fields.append(
+            f"repository{index}:repository(owner:${owner_variable},name:${name_variable})"
+            "{id viewerPermission}"
+        )
+    query = f"query({','.join(variable_defs)}){{{''.join(fields)}}}"
+    arguments: list[str] = [
+        "api",
+        "--hostname",
+        "github.com",
+        "graphql",
+        "-f",
+        f"query={query}",
+    ]
+    for owner_variable, name_variable, owner, name in variables:
+        arguments.extend(("-f", f"{owner_variable}={owner}", "-f", f"{name_variable}={name}"))
+    response = _gh_json(tuple(arguments), context)
+    if isinstance(response, dict) and {
+        "login",
+        "node_id",
+        "push_repository_node_ids",
+    }.issubset(response):
+        return _actor_identity(
+            {key: response[key] for key in ("login", "node_id", "push_repository_node_ids")},
+            f"{context} response",
+        )
+    if not isinstance(response, dict):
+        raise LedgerError(f"{context} response is not an object")
+    if response.get("errors"):
+        raise LedgerError(f"{context} returned GraphQL errors")
+    data = response.get("data")
+    if not isinstance(data, dict):
+        raise LedgerError(f"{context} response lacks GraphQL data")
+    viewer = data.get("viewer")
+    if not isinstance(viewer, dict):
+        raise LedgerError(f"{context} response lacks viewer identity")
+    push_nodes: list[str] = []
+    for index, target in enumerate(targets):
+        repository = target["repository"]
+        remote = data.get(f"repository{index}")
+        if not isinstance(remote, dict):
+            raise LedgerError(f"{context} response lacks target repository {index}")
+        remote_node = _string(
+            remote.get("id"), f"{context} target repository {index}.id", NODE_RE
+        )
+        if remote_node != repository["node_id"]:
+            raise LedgerError(f"{context} target repository identity differs from the ledger")
+        if remote.get("viewerPermission") not in {"ADMIN", "MAINTAIN", "WRITE", "PUSH"}:
+            raise LedgerError(f"{context} lacks push authority for target repository")
+        push_nodes.append(remote_node)
+    return _actor_identity(
+        {
+            "login": viewer.get("login"),
+            "node_id": viewer.get("id", viewer.get("node_id")),
+            "push_repository_node_ids": sorted(push_nodes),
+        },
+        f"{context} response",
+    )
+
+
+def _require_authenticated_actor(
+    document: Mapping[str, Any], context: str
+) -> dict[str, Any]:
+    expected = _actor_identity(document["actor"], f"{context} ledger actor")
+    observed = _authenticated_actor(document, context)
+    if observed != expected:
+        raise LedgerError(f"{context} differs from the caller-supplied ledger actor")
+    return observed
 
 
 def _prove_release_github(
@@ -5857,6 +5978,28 @@ def _sorted_node_ids(value: Any, context: str, *, allow_empty: bool = True) -> t
     return nodes
 
 
+def _actor_identity(value: Any, context: str) -> dict[str, Any]:
+    item = _exact(
+        value, {"login", "node_id", "push_repository_node_ids"}, context
+    )
+    login = _string(item["login"], f"{context}.login", LOGIN_RE)
+    if login != login.casefold():
+        raise LedgerError(f"{context}.login must be normalized lowercase")
+    node_id = _string(item["node_id"], f"{context}.node_id", NODE_RE)
+    push_repository_node_ids = list(
+        _sorted_node_ids(
+            item["push_repository_node_ids"],
+            f"{context}.push_repository_node_ids",
+            allow_empty=False,
+        )
+    )
+    return {
+        "login": login,
+        "node_id": node_id,
+        "push_repository_node_ids": push_repository_node_ids,
+    }
+
+
 def _authority(value: Any, context: str) -> tuple[Any, ...]:
     item = _exact(
         value,
@@ -6489,18 +6632,10 @@ def validate(document: Any) -> dict[str, Any]:
     mode = item["entry_mode"]
     if mode not in ENTRY_MODES:
         raise LedgerError("ledger.entry_mode must be issue or pr")
-    actor = _exact(
-        item["actor"], {"login", "node_id", "push_repository_node_ids"}, "ledger.actor"
-    )
-    login = _string(actor["login"], "ledger.actor.login", LOGIN_RE)
-    if login != login.casefold():
-        raise LedgerError("ledger.actor.login must be normalized lowercase")
-    actor_node = _string(actor["node_id"], "ledger.actor.node_id", NODE_RE)
-    push_repositories = _sorted_node_ids(
-        actor["push_repository_node_ids"],
-        "ledger.actor.push_repository_node_ids",
-        allow_empty=False,
-    )
+    actor = _actor_identity(item["actor"], "ledger.actor")
+    login = actor["login"]
+    actor_node = actor["node_id"]
+    push_repositories = tuple(actor["push_repository_node_ids"])
     authority = _authority(item["authority"], "ledger.authority")
     if authority[4] != actor_node:
         raise LedgerError("ledger authority actor does not match authenticated actor")
@@ -7843,15 +7978,8 @@ def _pr_binding_remote(
     owner = repository["owner"]
     name = repository["name"]
     full_name = f"{owner}/{name}"
-    actor = _gh_json(
-        ("api", "--hostname", "github.com", "user"),
-        "PR binding authenticated actor",
-    )
-    if not isinstance(actor, dict) or actor.get("node_id") != document["actor"]["node_id"]:
-        raise LedgerError("authenticated GitHub actor differs from PR binding authority")
-    actor_node = _string(
-        actor.get("node_id"), "PR binding authenticated actor.node_id", NODE_RE
-    )
+    actor = _require_authenticated_actor(document, "PR binding authenticated actor")
+    actor_node = actor["node_id"]
     live = _gh_json(
         (
             "api",
@@ -13452,6 +13580,7 @@ def create(
 ) -> Snapshot:
     prepared = prepare(document)
     _require_create_genesis(prepared)
+    _require_authenticated_actor(prepared, "genesis authenticated actor")
     target = canonical_name(prepared)
     raw = canonical_bytes(prepared)
     stage = f".{target}.create-{byte_digest(raw)}.tmp"
@@ -13634,6 +13763,7 @@ def _transition(
     _binding_capability: _AtomicBindingCapability | None = None,
     _target_refresh_capability: _TargetRefreshCapability | None = None,
     _scope_recovery_capability: _ScopeRecoveryCapability | None = None,
+    _identity_recovery_capability: _IdentityRecoveryCapability | None = None,
 ) -> None:
     immutable = {
         "schema_version",
@@ -13647,7 +13777,10 @@ def _transition(
         "migration",
     }
     for key in immutable:
-        if key == "authority" and _scope_recovery_capability is not None:
+        if key in {"actor", "authority"} and (
+            _scope_recovery_capability is not None
+            or _identity_recovery_capability is not None
+        ):
             continue
         if old[key] != new[key]:
             raise LedgerError(f"immutable ledger field changed: {key}")
@@ -14467,6 +14600,7 @@ def cas(
     _binding_capability: _AtomicBindingCapability | None = None,
     _target_refresh_capability: _TargetRefreshCapability | None = None,
     _scope_recovery_capability: _ScopeRecoveryCapability | None = None,
+    _identity_recovery_capability: _IdentityRecoveryCapability | None = None,
     _target_refresh_legacy: bool = False,
 ) -> Snapshot:
     name = _direct_name(name)
@@ -14479,10 +14613,36 @@ def cas(
     _integer(expected_inode, "expected_inode")
     raw = canonical_bytes(prepared)
     operation = ""
+    if _identity_recovery_capability is not None:
+        capability = _identity_recovery_capability
+        if (
+            _binding_capability is not None
+            or _target_refresh_capability is not None
+            or _scope_recovery_capability is not None
+            or not isinstance(capability, _IdentityRecoveryCapability)
+            or capability.token is not _IDENTITY_RECOVERY_TOKEN
+            or capability.name != name
+            or capability.after_raw != raw
+            or (
+                capability.expected_generation,
+                capability.expected_digest,
+                capability.expected_device,
+                capability.expected_inode,
+            )
+            != (
+                expected_generation,
+                expected_digest,
+                expected_device,
+                expected_inode,
+            )
+        ):
+            raise LedgerError("invalid internal identity-recovery capability")
+        operation = "-recover-identity"
     if _scope_recovery_capability is not None:
         capability = _scope_recovery_capability
         if (
             _binding_capability is not None
+            or _identity_recovery_capability is not None
             or _target_refresh_capability is not None
             or not isinstance(capability, _ScopeRecoveryCapability)
             or capability.token is not _SCOPE_RECOVERY_TOKEN
@@ -14513,6 +14673,7 @@ def cas(
             or not SLOT_RE.fullmatch(capability.slot_id)
             or capability.name != name
             or capability.after_raw != raw
+            or _identity_recovery_capability is not None
             or (
                 capability.expected_generation,
                 capability.expected_digest,
@@ -14532,6 +14693,7 @@ def cas(
         capability = _target_refresh_capability
         if (
             _binding_capability is not None
+            or _identity_recovery_capability is not None
             or not isinstance(capability, _TargetRefreshCapability)
             or capability.token is not _TARGET_REFRESH_TOKEN
             or capability.name != name
@@ -14727,6 +14889,13 @@ def cas(
             if _scope_recovery_capability is not None:
                 if _scope_recovery_capability.before_raw != current.raw:
                     raise LedgerError("scope-recovery predecessor bytes changed")
+            if _identity_recovery_capability is not None:
+                if _identity_recovery_capability.before_raw is None:
+                    raise LedgerError(
+                        "identity-recovery candidate is not already installed"
+                    )
+                if _identity_recovery_capability.before_raw != current.raw:
+                    raise LedgerError("identity-recovery predecessor bytes changed")
             _transition(
                 current.document,
                 prepared,
@@ -14734,6 +14903,7 @@ def cas(
                 _binding_capability=_binding_capability,
                 _target_refresh_capability=_target_refresh_capability,
                 _scope_recovery_capability=_scope_recovery_capability,
+                _identity_recovery_capability=_identity_recovery_capability,
             )
             if compact:
                 assert receipt_name is not None
@@ -15050,6 +15220,344 @@ def _scope_recovery_projection(
                 "topology": replacement["topology"],
             }
     return projection
+
+
+def _identity_recovery_authority(value: Any, context: str) -> dict[str, Any]:
+    item = _exact(
+        value,
+        {
+            "transaction",
+            "source",
+            "old_actor",
+            "new_actor",
+            "targets_sha256",
+            "artifacts_sha256",
+            "prior_authority_issued_at",
+            "candidate_sha256",
+            "authority",
+        },
+        context,
+    )
+    if item["transaction"] != "delivery-ledger-recover-prebind-identity-v1":
+        raise LedgerError(f"{context}.transaction is invalid")
+    source = _exact(
+        item["source"],
+        {"name", "ledger_id", "generation", "sha256", "device", "inode"},
+        f"{context}.source",
+    )
+    _direct_name(source["name"], f"{context}.source.name")
+    _string(source["ledger_id"], f"{context}.source.ledger_id", REFERENCE_RE)
+    _integer(source["generation"], f"{context}.source.generation", minimum=2)
+    _string(source["sha256"], f"{context}.source.sha256", SHA256_RE)
+    _integer(source["device"], f"{context}.source.device", minimum=0)
+    _integer(source["inode"], f"{context}.source.inode", minimum=1)
+    old_actor = _actor_identity(item["old_actor"], f"{context}.old_actor")
+    new_actor = _actor_identity(item["new_actor"], f"{context}.new_actor")
+    if old_actor == new_actor:
+        raise LedgerError(f"{context} must record an actor identity change")
+    targets_sha256 = _string(
+        item["targets_sha256"], f"{context}.targets_sha256", SHA256_RE
+    )
+    artifacts_sha256 = _string(
+        item["artifacts_sha256"], f"{context}.artifacts_sha256", SHA256_RE
+    )
+    prior_authority_issued_at = _string(
+        item["prior_authority_issued_at"],
+        f"{context}.prior_authority_issued_at",
+        TIMESTAMP_RE,
+    )
+    _timestamp_key(
+        prior_authority_issued_at,
+        f"{context}.prior_authority_issued_at",
+    )
+    candidate_sha256 = _string(
+        item["candidate_sha256"], f"{context}.candidate_sha256", SHA256_RE
+    )
+    _authority(item["authority"], f"{context}.authority")
+    return {
+        "transaction": item["transaction"],
+        "source": source,
+        "old_actor": old_actor,
+        "new_actor": new_actor,
+        "targets_sha256": targets_sha256,
+        "artifacts_sha256": artifacts_sha256,
+        "prior_authority_issued_at": prior_authority_issued_at,
+        "candidate_sha256": candidate_sha256,
+        "authority": item["authority"],
+    }
+
+
+def _identity_recovery_allowed(document: Mapping[str, Any]) -> dict[str, Any]:
+    issue_nodes = [
+        issue["node_id"] for issue in document["issues"]["explicit"]
+    ]
+    program = document["program"]
+    if program is not None:
+        issue_nodes.extend(
+            (
+                program["master_issue"]["node_id"],
+                program["leaf_issue"]["node_id"],
+            )
+        )
+    return {
+        "repositories": sorted(
+            {target["repository"]["node_id"] for target in document["targets"]}
+        ),
+        "issues": sorted(set(issue_nodes)),
+        "pull_requests": [],
+    }
+
+
+def _identity_recovery_coordinates(
+    document: Mapping[str, Any],
+) -> tuple[
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+]:
+    item = validate(document)
+    if item["entry_mode"] != "issue":
+        raise LedgerError("pre-bind identity recovery requires issue mode")
+    if item["selected_prs"]:
+        raise LedgerError("pre-bind identity recovery requires no selected PR")
+    if item["authority"]["allowed"]["pull_requests"]:
+        raise LedgerError("pre-bind identity recovery requires an empty PR authority")
+    pull_slots = [
+        slot for slot in item["artifacts"] if slot["kind"] == "pull_request"
+    ]
+    if len(pull_slots) != 1:
+        raise LedgerError(
+            "pre-bind identity recovery requires one planned pull-request slot"
+        )
+    pull_slot = pull_slots[0]
+    if (
+        pull_slot["state"] != "planned"
+        or pull_slot["current"] is not None
+        or pull_slot["immutable"]["node_id"] is not None
+        or pull_slot["initial_body_payload"] is None
+    ):
+        raise LedgerError(
+            "pre-bind identity recovery requires one unbound planned pull-request slot"
+        )
+    return _pr_binding_coordinates(item, pull_slot["slot_id"])
+
+
+def _prove_identity_recovery_no_prs(
+    target: Mapping[str, Any], context: str
+) -> None:
+    repository = target["repository"]
+    owner = repository["owner"]
+    name = repository["name"]
+    branch = target["head"]["branch"]
+    page = _gh_json(
+        (
+            "api",
+            "--hostname",
+            "github.com",
+            f"repos/{owner}/{name}/pulls?"
+            f"state=all&head={owner}:{branch}&per_page=100",
+        ),
+        context,
+    )
+    if not isinstance(page, list):
+        raise LedgerError(f"{context} response is not an array")
+    if len(page) > 100:
+        raise LedgerError(f"{context} response exceeds the bounded page size")
+    if page:
+        raise LedgerError(
+            f"{context} found an existing pull request for the delivery branch"
+        )
+
+
+def recover_prebind_identity(
+    root: Path | str,
+    name: str,
+    document: Mapping[str, Any],
+    recovery_raw: bytes,
+    *,
+    expected_generation: int,
+    expected_digest: str,
+    expected_device: int,
+    expected_inode: int,
+    failpoint: Failpoint = None,
+) -> Snapshot:
+    """Recover one audited actor change before the issue-created PR bind."""
+
+    name = _direct_name(name)
+    candidate = prepare(document)
+    recovery = _identity_recovery_authority(
+        _decode(recovery_raw, "pre-bind identity recovery authority"),
+        "pre-bind identity recovery authority",
+    )
+    if recovery_raw != canonical_bytes(recovery):
+        raise LedgerError("pre-bind identity recovery authority is not canonical")
+    snapshot = inspect(root, name)
+    source = recovery["source"]
+    expected_source = (
+        source["generation"],
+        source["sha256"],
+        source["device"],
+        source["inode"],
+    )
+    if (
+        expected_generation,
+        expected_digest,
+        expected_device,
+        expected_inode,
+    ) != expected_source:
+        raise LedgerError("pre-bind identity recovery source does not match CAS tuple")
+    if snapshot.name != source["name"]:
+        raise LedgerError("pre-bind identity recovery source names a different ledger")
+    candidate_raw = canonical_bytes(candidate)
+    if candidate["ledger_id"] != source["ledger_id"]:
+        raise LedgerError("pre-bind identity recovery candidate differs from source ledger")
+    resume = bool(
+        snapshot.raw == candidate_raw
+        and snapshot.document["generation"] == source["generation"] + 1
+        and snapshot.document["previous_byte_digest"] == source["sha256"]
+        and snapshot.document["history"]
+        and snapshot.document["history"][-1] == source["sha256"]
+    )
+    if not resume and (
+        snapshot.document["ledger_id"] != source["ledger_id"]
+        or not _snapshot_matches_identity(
+            snapshot,
+            source["generation"],
+            source["sha256"],
+            source["device"],
+            source["inode"],
+        )
+    ):
+        raise LedgerError("pre-bind identity recovery source snapshot is stale")
+    if byte_digest(candidate_raw) != recovery["candidate_sha256"]:
+        raise LedgerError(
+            "pre-bind identity recovery candidate digest differs from authority"
+        )
+    if candidate["actor"] != recovery["new_actor"]:
+        raise LedgerError("pre-bind identity recovery candidate actor differs from grant")
+    if candidate["authority"] != recovery["authority"]:
+        raise LedgerError(
+            "pre-bind identity recovery candidate authority differs from grant"
+        )
+    if candidate["authority"]["kind"] != "explicit-recovery":
+        raise LedgerError(
+            "pre-bind identity recovery requires explicit-recovery authority"
+        )
+    if candidate["generation"] != source["generation"] + 1:
+        raise LedgerError("pre-bind identity recovery candidate generation is invalid")
+    if candidate["previous_byte_digest"] != source["sha256"]:
+        raise LedgerError(
+            "pre-bind identity recovery candidate predecessor digest is invalid"
+        )
+    if not candidate["history"] or candidate["history"][-1] != source["sha256"]:
+        raise LedgerError(
+            "pre-bind identity recovery candidate history omits its predecessor"
+        )
+    if candidate["authority"]["actor_node_id"] != candidate["actor"]["node_id"]:
+        raise LedgerError("pre-bind identity recovery authority actor differs from candidate")
+    if candidate["authority"]["allowed"] != _identity_recovery_allowed(candidate):
+        raise LedgerError(
+            "pre-bind identity recovery authority scope differs from candidate"
+        )
+    if not _timestamp_is_after(
+        candidate["authority"]["issued_at"],
+        recovery["prior_authority_issued_at"],
+    ):
+        raise LedgerError(
+            "pre-bind identity recovery authority must postdate the prior authority"
+        )
+    expected_objective = canonical_object_digest(
+        {
+            "operation": "recover-prebind-identity",
+            "source": source,
+            "old_actor": recovery["old_actor"],
+            "new_actor": recovery["new_actor"],
+            "targets_sha256": recovery["targets_sha256"],
+            "artifacts_sha256": recovery["artifacts_sha256"],
+        }
+    )
+    if candidate["authority"]["objective_sha256"] != expected_objective:
+        raise LedgerError(
+            "pre-bind identity recovery objective does not bind its projection"
+        )
+    if not resume:
+        _identity_recovery_coordinates(snapshot.document)
+        if snapshot.document["actor"] != recovery["old_actor"]:
+            raise LedgerError(
+                "pre-bind identity recovery source actor differs from authority"
+            )
+        if (
+            snapshot.document["authority"]["issued_at"]
+            != recovery["prior_authority_issued_at"]
+        ):
+            raise LedgerError(
+                "pre-bind identity recovery prior authority timestamp differs"
+            )
+        if (
+            canonical_object_digest(snapshot.document["targets"])
+            != recovery["targets_sha256"]
+            or canonical_object_digest(snapshot.document["artifacts"])
+            != recovery["artifacts_sha256"]
+        ):
+            raise LedgerError(
+                "pre-bind identity recovery source coordinate digest differs"
+            )
+        projected = copy.deepcopy(snapshot.document)
+        projected["actor"] = copy.deepcopy(candidate["actor"])
+        projected["authority"] = copy.deepcopy(candidate["authority"])
+        projected["generation"] = candidate["generation"]
+        projected["previous_byte_digest"] = candidate["previous_byte_digest"]
+        projected["history"] = copy.deepcopy(candidate["history"])
+        if projected != candidate:
+            raise LedgerError(
+                "pre-bind identity recovery changed fields outside actor and authority"
+            )
+    if (
+        canonical_object_digest(candidate["targets"]) != recovery["targets_sha256"]
+        or canonical_object_digest(candidate["artifacts"])
+        != recovery["artifacts_sha256"]
+    ):
+        raise LedgerError(
+            "pre-bind identity recovery candidate coordinate digest differs"
+        )
+    _, pull_slot, target, _, worktree = _identity_recovery_coordinates(candidate)
+    capability = _IdentityRecoveryCapability(
+        _IDENTITY_RECOVERY_TOKEN,
+        name,
+        None if resume else snapshot.raw,
+        candidate_raw,
+        expected_generation,
+        expected_digest,
+        expected_device,
+        expected_inode,
+    )
+    with _pr_binding_live_safety(candidate, target, worktree) as prove_local:
+        def revalidate() -> None:
+            prove_local()
+            _require_authenticated_actor(
+                candidate,
+                "pre-bind identity recovery authenticated actor",
+            )
+            _prove_identity_recovery_no_prs(
+                target,
+                "pre-bind identity recovery pull requests",
+            )
+
+        revalidate()
+        return cas(
+            root,
+            name,
+            candidate,
+            expected_generation=expected_generation,
+            expected_digest=expected_digest,
+            expected_device=expected_device,
+            expected_inode=expected_inode,
+            failpoint=failpoint,
+            _precommit=revalidate,
+            _identity_recovery_capability=capability,
+        )
 
 
 def _scope_prebind_recovery_authority(value: Any, context: str) -> dict[str, Any]:
@@ -16786,6 +17294,21 @@ def parser() -> argparse.ArgumentParser:
     prebind_recovery_parser.add_argument("--expected-digest", required=True)
     prebind_recovery_parser.add_argument("--expected-device", required=True, type=int)
     prebind_recovery_parser.add_argument("--expected-inode", required=True, type=int)
+    identity_recovery_parser = commands.add_parser(
+        "recover-prebind-identity",
+        help="atomically recover one explicitly authorized pre-bind actor identity change",
+    )
+    identity_recovery_parser.add_argument("root", help="initialized review root")
+    identity_recovery_parser.add_argument("name", help="direct canonical ledger filename")
+    identity_recovery_parser.add_argument("input", help="bounded replacement ledger JSON")
+    identity_recovery_parser.add_argument(
+        "recovery", help="exact explicit-recovery authority JSON"
+    )
+    identity_recovery_parser.add_argument("--expected-generation", required=True, type=int)
+    identity_recovery_parser.add_argument("--expected-digest", required=True)
+    identity_recovery_parser.add_argument("--expected-device", required=True, type=int)
+    identity_recovery_parser.add_argument("--expected-inode", required=True, type=int)
+
     correction_parser = commands.add_parser(
         "correct-target-head",
         help="live-prove and supersede one exact nonexistent target-head typo",
@@ -17072,6 +17595,20 @@ def main(argv: Sequence[str] | None = None) -> int:
                     expected_inode=arguments.expected_inode,
                 ).json()
             )
+        elif arguments.command == "recover-prebind-identity":
+            _print(
+                recover_prebind_identity(
+                    arguments.root,
+                    arguments.name,
+                    _read_input(arguments.input),
+                    _read_bytes_input(arguments.recovery),
+                    expected_generation=arguments.expected_generation,
+                    expected_digest=arguments.expected_digest,
+                    expected_device=arguments.expected_device,
+                    expected_inode=arguments.expected_inode,
+                ).json()
+            )
+
         elif arguments.command == "correct-target-head":
             _print(
                 correct_target_head(

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -314,6 +314,11 @@ coordinate crash/retry/concurrency at every publication boundary. Tests may
 apply archive/reclaim only inside temporary test-owned review roots. Delivery
 must never invoke wrapper cleanup, and repository validation remains
 preview-only.
+Genesis and initial PR binding must prove the complete authenticated actor
+tuple (login, node ID, and push-authorized repository node IDs) in one live
+response. An actor change before binding is recoverable only through the
+audited pre-bind identity CAS with an exact predecessor and preservation of
+the delivery artifacts.
 
 For CMake/cache changes, also repeat an unchanged build, exercise
 `--force-reconfigure` and `--no-ccache`, inspect `ccache --show-stats` when the

--- a/README.md
+++ b/README.md
@@ -2076,6 +2076,16 @@ keeps its active coordinates and recovery evidence. After the PR is externally
 merged and selected issues reach their expected states, a separately authorized
 operator prepares exact post-merge evidence and runs:
 
+Actor identity is live evidence for delivery. Issue-mode genesis captures the
+viewer login/node and push authority for every target repository in one live
+authenticated response before generation-1 publication; a mixed or stale
+tuple fails before local staging or any delivery mutation. `pr-bind-cas`
+repeats the complete tuple immediately before its CAS. If the actor changes
+after genesis but before PR binding, use only the helper's
+`recover-prebind-identity` transaction: it preserves the predecessor
+digest/history and exact target/artifact coordinates, and requires an explicit
+recovery authority, a safe bound worktree, live reproof, and no candidate PR.
+
 Target base/head movement is likewise helper-owned: generic ledger CAS rejects
 it. The target-refresh CAS pins the recorded primitive/scope worktree, proves
 descendant commits and the exact live merge base, and rechecks immediately

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -521,6 +521,17 @@ mutable active resources still block. Inventory excludes
 coordinates only after that marker is durable; a candidate stage remains
 active and blocking.
 
+Issue-mode genesis and initial PR binding are actor-gated. Before generation-1
+publication, the helper obtains viewer login/node and each target repository's
+ID and push permission in one live authenticated GitHub response, compares the
+complete tuple, and fails before local staging or remote delivery mutation on
+any mismatch. `pr-bind-cas` repeats the full tuple proof immediately before
+its CAS. A changed actor before PR binding is recoverable only through the
+explicit `recover-prebind-identity` transaction, which preserves the exact
+predecessor digest/history and target/artifact coordinates while requiring a
+new explicit-recovery authority, a safe bound worktree, live reproof, and no
+candidate PR.
+
 Generic ledger CAS cannot author target coordinates. A target-only refresh is a
 separate live transaction that pins its bound primitive/scope worktree, proves
 base/head commits and descendant lineages, computes the exact merge base, and

--- a/tests/test_delivery_ledger.py
+++ b/tests/test_delivery_ledger.py
@@ -41,6 +41,18 @@ finally:
     sys.dont_write_bytecode = _DONT_WRITE_BYTECODE
 
 
+_TEST_CLI_ACTOR_BOOTSTRAP = (
+    "import importlib.util,sys\n"
+    "spec = importlib.util.spec_from_file_location('delivery_ledger_test_child', sys.argv[1])\n"
+    "module = importlib.util.module_from_spec(spec)\n"
+    "sys.modules[spec.name] = module\n"
+    "spec.loader.exec_module(module)\n"
+    "module._authenticated_actor = lambda document, _context=None: document['actor']\n"
+    "script = sys.argv[1]\n"
+    "sys.argv = [script, *sys.argv[2:]]\n"
+    "raise SystemExit(module.main())\n"
+)
+
 SHA_A = "a" * 40
 SHA_B = "b" * 40
 SHA_C = "c" * 40
@@ -1622,6 +1634,146 @@ def next_generation(snapshot: object) -> dict[str, object]:
     return result
 
 
+def install_issue_bound(
+    root: Path,
+    live_base: Path,
+    *,
+    number: int = 419,
+    label: str = "issue-419",
+) -> tuple[dict[str, object], ledger.Snapshot]:
+    roots = live_roots(live_base / label, "atrinik")
+    document = issue_ledger(
+        number=number,
+        issue_node=f"I_{label.replace('-', '_')}",
+        branch=f"fix/{label}",
+        worktree=str(
+            Path(roots["workspace"]["path"])
+            / "worktrees"
+            / "atrinik"
+            / label
+        ),
+    )
+    replace_sha(document, SHA_A, git_head(roots))
+    worktree = next(
+        slot for slot in document["artifacts"] if slot["kind"] == "worktree"
+    )
+    assert worktree["primitive_request"] is not None
+    worktree["primitive_request"]["roots"] = copy.deepcopy(roots)
+    initial = ledger.create(root, document)
+    request = worktree["primitive_request"]
+    assert request is not None
+    worktree_list = worktree_list_bytes(request)
+    safety = safety_observation_bytes(
+        request,
+        worktree_list,
+        producer_kind="primitive",
+        producer_digest=None,
+    )
+    ledger.bind_worktree_cas(
+        root,
+        initial.name,
+        "worktree",
+        worktree_list,
+        safety,
+        **cas_arguments(initial),
+    )
+    return document, ledger.inspect(root, initial.name)
+
+
+def identity_recovery_material(
+    snapshot: object,
+    *,
+    new_login: str = "newactor",
+    new_node: str = "U_new",
+) -> tuple[dict[str, object], bytes]:
+    assert isinstance(snapshot, ledger.Snapshot)
+    candidate = next_generation(snapshot)
+    new_actor = {
+        "login": new_login,
+        "node_id": new_node,
+        "push_repository_node_ids": ["R_repo"],
+    }
+    candidate["actor"] = new_actor
+    candidate["authority"] = {
+        "kind": "explicit-recovery",
+        "reference": f"recovery:{snapshot.name.removesuffix('.md.ledger.json')}",
+        "objective_sha256": "0" * 64,
+        "issued_at": "2026-08-14T18:02:00Z",
+        "actor_node_id": new_node,
+        "allowed": ledger._identity_recovery_allowed(candidate),
+    }
+    source = {
+        "name": snapshot.name,
+        "ledger_id": snapshot.document["ledger_id"],
+        "generation": snapshot.document["generation"],
+        "sha256": snapshot.digest,
+        "device": snapshot.device,
+        "inode": snapshot.inode,
+    }
+    targets_sha256 = ledger.canonical_object_digest(snapshot.document["targets"])
+    artifacts_sha256 = ledger.canonical_object_digest(snapshot.document["artifacts"])
+    objective = ledger.canonical_object_digest(
+        {
+            "operation": "recover-prebind-identity",
+            "source": source,
+            "old_actor": snapshot.document["actor"],
+            "new_actor": new_actor,
+            "targets_sha256": targets_sha256,
+            "artifacts_sha256": artifacts_sha256,
+        }
+    )
+    candidate["authority"]["objective_sha256"] = objective
+    candidate_raw = ledger.canonical_bytes(candidate)
+    recovery = {
+        "transaction": "delivery-ledger-recover-prebind-identity-v1",
+        "source": source,
+        "old_actor": copy.deepcopy(snapshot.document["actor"]),
+        "new_actor": new_actor,
+        "targets_sha256": targets_sha256,
+        "artifacts_sha256": artifacts_sha256,
+        "prior_authority_issued_at": snapshot.document["authority"]["issued_at"],
+        "candidate_sha256": ledger.byte_digest(candidate_raw),
+        "authority": copy.deepcopy(candidate["authority"]),
+    }
+    return candidate, ledger.canonical_bytes(recovery)
+
+
+def live_issue_pr(
+    value: dict[str, object],
+    *,
+    number: int = 500,
+    node: str = "P_issue_created",
+    actor_node: str = "U_actor",
+    body: bytes = INITIAL_PR_BODY,
+) -> dict[str, object]:
+    target = value["targets"][0]
+    repository_value = {
+        "node_id": target["repository"]["node_id"],
+        "full_name": (
+            f"{target['repository']['owner']}/{target['repository']['name']}"
+        ),
+    }
+    return {
+        "node_id": node,
+        "number": number,
+        "state": "open",
+        "draft": True,
+        "user": {"node_id": actor_node},
+        "base": {
+            "ref": target["base"]["branch"],
+            "sha": target["base"]["current_sha"],
+            "repo": copy.deepcopy(repository_value),
+        },
+        "head": {
+            "ref": target["head"]["branch"],
+            "sha": target["head"]["current_sha"],
+            "repo": copy.deepcopy(repository_value),
+        },
+        "body": body.decode("utf-8"),
+        "updated_at": "2026-08-14T18:01:00Z",
+    }
+
+
 def cas_arguments(snapshot: object) -> dict[str, object]:
     assert isinstance(snapshot, ledger.Snapshot)
     return {
@@ -1900,8 +2052,17 @@ class DeliveryLedgerTests(unittest.TestCase):
             ledger, "_release_live_safety", side_effect=lambda _document: nullcontext([])
         )
         self.release_safety.start()
+        self.authenticated_actor = mock.patch.object(
+            ledger,
+            "_authenticated_actor",
+            side_effect=lambda document, _context=None: copy.deepcopy(
+                document["actor"]
+            ),
+        )
+        self.authenticated_actor.start()
 
     def tearDown(self) -> None:
+        self.authenticated_actor.stop()
         self.release_safety.stop()
         self.live_temporary.cleanup()
 
@@ -2067,7 +2228,14 @@ class DeliveryLedgerTests(unittest.TestCase):
                 path = base / f"input-{index}.json"
                 path.write_text(json.dumps(document), encoding="utf-8")
                 return subprocess.Popen(
-                    [sys.executable, "-B", str(SCRIPT), "create", str(review_root), str(path)],
+                    [
+                        sys.executable,
+                        "-B",
+                        "-c",
+                        _TEST_CLI_ACTOR_BOOTSTRAP,
+                        str(SCRIPT),
+                        "create", str(review_root), str(path),
+                    ],
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     text=True,
@@ -3976,6 +4144,8 @@ class DeliveryLedgerTests(unittest.TestCase):
                 [
                     sys.executable,
                     "-B",
+                    "-c",
+                    _TEST_CLI_ACTOR_BOOTSTRAP,
                     str(SCRIPT),
                     "create",
                     str(review_root),
@@ -13678,6 +13848,223 @@ class DeliveryLedgerTests(unittest.TestCase):
             with self.assertRaisesRegex(ledger.LedgerError, "squash merge change differs"):
                 ledger._prove_release_git(document, document["selected_prs"][0], proof)
 
+    def test_genesis_proves_live_actor_tuple_before_any_local_mutation(self) -> None:
+        def graphql_response(
+            *, login: str = "zoeyrose", node_id: str = "U_actor", permission: str = "ADMIN"
+        ) -> dict[str, object]:
+            return {
+                "data": {
+                    "viewer": {"login": login, "id": node_id},
+                    "repository0": {
+                        "id": "R_repo",
+                        "viewerPermission": permission,
+                    },
+                }
+            }
+
+        cases = (
+            (
+                "mixed login and node",
+                graphql_response(login="different", node_id="U_actor"),
+                "differs from the caller-supplied ledger actor",
+            ),
+            (
+                "stale node",
+                graphql_response(login="zoeyrose", node_id="U_stale"),
+                "differs from the caller-supplied ledger actor",
+            ),
+            (
+                "read-only repository",
+                graphql_response(permission="READ"),
+                "lacks push authority",
+            ),
+        )
+        self.authenticated_actor.stop()
+        try:
+            for label, response, message in cases:
+                with self.subTest(rejected=label), tempfile.TemporaryDirectory() as temporary:
+                    root = Path(temporary)
+                    before = directory_snapshot(root)
+                    with mock.patch.object(
+                        ledger, "_gh_json", return_value=response
+                    ) as observer, self.assertRaisesRegex(
+                        ledger.LedgerError, message
+                    ):
+                        ledger.create(root, issue_ledger())
+                    self.assertEqual(directory_snapshot(root), before)
+                    arguments = observer.call_args.args[0]
+                    self.assertEqual(tuple(arguments[:4]), (
+                        "api", "--hostname", "github.com", "graphql"
+                    ))
+                    self.assertIn("viewer{login id}", arguments[5])
+                    self.assertIn("owner0=atrinik", arguments)
+                    self.assertIn("name0=atrinik", arguments)
+
+            with tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                with mock.patch.object(
+                    ledger, "_gh_json", return_value=graphql_response()
+                ):
+                    created = ledger.create(root, issue_ledger())
+                self.assertEqual(created.document["generation"], 1)
+                self.assertEqual(ledger.inventory(root).pending, ())
+        finally:
+            self.authenticated_actor.start()
+
+    def test_pr_binding_reproves_full_actor_tuple_before_cas(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            value, bound = install_issue_bound(root, self.live_base / "pr-actor-reproof")
+            remote = live_issue_pr(value)
+            changed_actor = {
+                "login": "newactor",
+                "node_id": "U_new",
+                "push_repository_node_ids": ["R_repo"],
+            }
+
+            def observe(arguments: object, _context: str) -> object:
+                endpoint = tuple(arguments)[-1]
+                if "/pulls/500" in endpoint:
+                    return copy.deepcopy(remote)
+                if "/comments?" in endpoint:
+                    return []
+                raise AssertionError(f"unexpected gh observation: {arguments}")
+
+            before = directory_snapshot(root)
+            self.authenticated_actor.stop()
+            try:
+                with mock.patch.object(
+                    ledger,
+                    "_authenticated_actor",
+                    side_effect=[
+                        copy.deepcopy(bound.document["actor"]),
+                        changed_actor,
+                    ],
+                ) as actor_proof, mock.patch.object(
+                    ledger, "_gh_json", side_effect=observe
+                ), self.assertRaisesRegex(
+                    ledger.LedgerError,
+                    "differs from the caller-supplied ledger actor",
+                ):
+                    ledger.bind_pr_cas(
+                        root,
+                        bound.name,
+                        "pull-request",
+                        500,
+                        **cas_arguments(bound),
+                    )
+                self.assertEqual(actor_proof.call_count, 2)
+                self.assertEqual(directory_snapshot(root), before)
+            finally:
+                self.authenticated_actor.start()
+
+    def test_prebind_identity_recovery_preserves_exact_artifacts_and_predecessor(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            value, bound = install_issue_bound(
+                root, self.live_base / "identity-recovery-success"
+            )
+            candidate, recovery = identity_recovery_material(bound)
+            self.authenticated_actor.stop()
+            try:
+                with mock.patch.object(
+                    ledger,
+                    "_authenticated_actor",
+                    return_value=candidate["actor"],
+                ) as actor_proof, mock.patch.object(
+                    ledger, "_gh_json", return_value=[]
+                ) as no_prs:
+                    recovered = ledger.recover_prebind_identity(
+                        root,
+                        bound.name,
+                        candidate,
+                        recovery,
+                        **cas_arguments(bound),
+                    )
+                self.assertEqual(
+                    recovered.document["generation"],
+                    bound.document["generation"] + 1,
+                )
+                self.assertEqual(
+                    recovered.document["previous_byte_digest"], bound.digest
+                )
+                self.assertEqual(recovered.document["history"][-1], bound.digest)
+                self.assertEqual(recovered.document["actor"], candidate["actor"])
+                self.assertEqual(
+                    recovered.document["targets"], bound.document["targets"]
+                )
+                self.assertEqual(
+                    recovered.document["artifacts"], bound.document["artifacts"]
+                )
+                self.assertEqual(actor_proof.call_count, 2)
+                self.assertEqual(no_prs.call_count, 2)
+                self.assertEqual(ledger.inventory(root).pending, ())
+            finally:
+                self.authenticated_actor.start()
+
+    def test_prebind_identity_recovery_retry_keeps_exact_cas_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            value, bound = install_issue_bound(
+                root, self.live_base / "identity-recovery-retry"
+            )
+            candidate, recovery = identity_recovery_material(bound)
+            self.authenticated_actor.stop()
+            try:
+                with mock.patch.object(
+                    ledger,
+                    "_authenticated_actor",
+                    return_value=candidate["actor"],
+                ), mock.patch.object(
+                    ledger, "_gh_json", return_value=[]
+                ):
+                    with self.assertRaises(ledger.InjectedCrash):
+                        ledger.recover_prebind_identity(
+                            root,
+                            bound.name,
+                            candidate,
+                            recovery,
+                            failpoint="cas:renamed",
+                            **cas_arguments(bound),
+                        )
+                    installed = ledger.inspect(root, bound.name)
+                    self.assertEqual(installed.raw, ledger.canonical_bytes(candidate))
+                    self.assertTrue(ledger.inventory(root).pending)
+                    retried = ledger.recover_prebind_identity(
+                        root,
+                        bound.name,
+                        candidate,
+                        recovery,
+                        **cas_arguments(bound),
+                    )
+                self.assertEqual(retried.raw, ledger.canonical_bytes(candidate))
+                self.assertEqual(ledger.inventory(root).pending, ())
+            finally:
+                self.authenticated_actor.start()
+
+    def test_prebind_identity_recovery_rejects_coordinate_drift_without_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            value, bound = install_issue_bound(
+                root, self.live_base / "identity-recovery-drift"
+            )
+            candidate, recovery = identity_recovery_material(bound)
+            base = candidate["targets"][0]["base"]
+            base["current_sha"] = SHA_B
+            base["lineage"].append(SHA_B)
+            before = directory_snapshot(root)
+            with self.assertRaisesRegex(
+                ledger.LedgerError, "candidate digest differs"
+            ):
+                ledger.recover_prebind_identity(
+                    root,
+                    bound.name,
+                    candidate,
+                    recovery,
+                    **cas_arguments(bound),
+                )
+            self.assertEqual(directory_snapshot(root), before)
+
     def test_63_github_proof_pins_host_executable_and_environment(self) -> None:
         completed = subprocess.CompletedProcess(
             [ledger._GH_EXECUTABLE], 0, stdout=b'{"node_id":"U_actor"}\n', stderr=b""
@@ -13699,7 +14086,7 @@ class DeliveryLedgerTests(unittest.TestCase):
             )
         arguments = run.call_args.args[0]
         environment = run.call_args.kwargs["env"]
-        self.assertEqual(arguments[0], ledger._GH_EXECUTABLE)
+        self.assertIn(arguments[0], ledger._GH_EXECUTABLE_CANDIDATES)
         self.assertIn("github.com", arguments)
         self.assertTrue(set(hostile).isdisjoint(environment))
 

--- a/tests/test_delivery_ledger.py
+++ b/tests/test_delivery_ledger.py
@@ -13911,6 +13911,42 @@ class DeliveryLedgerTests(unittest.TestCase):
         finally:
             self.authenticated_actor.start()
 
+    def test_scope_recovery_capability_cannot_change_actor(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            _, bound = install_issue_bound(
+                root, self.live_base / "scope-actor-capability"
+            )
+            candidate = next_generation(bound)
+            candidate["actor"] = {
+                "login": "newactor",
+                "node_id": "U_new",
+                "push_repository_node_ids": ["R_repo"],
+            }
+            candidate["authority"] = copy.deepcopy(bound.document["authority"])
+            candidate["authority"]["actor_node_id"] = "U_new"
+            candidate = ledger.prepare(candidate)
+            capability = ledger._ScopeRecoveryCapability(
+                ledger._SCOPE_RECOVERY_TOKEN,
+                "scope",
+                bound.name,
+                bound.raw,
+                ledger.canonical_bytes(candidate),
+                bound.document["generation"],
+                bound.digest,
+                bound.device,
+                bound.inode,
+            )
+            with self.assertRaisesRegex(
+                ledger.LedgerError, "immutable ledger field changed: actor"
+            ):
+                ledger._transition(
+                    bound.document,
+                    candidate,
+                    bound.digest,
+                    _scope_recovery_capability=capability,
+                )
+
     def test_pr_binding_reproves_full_actor_tuple_before_cas(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)


### PR DESCRIPTION
## Summary

Make issue-delivery ledger genesis validate the authenticated GitHub actor immediately before publication, so a stale or mixed login/node identity cannot authorize later delivery work.

## Implementation / behavior

- Live-prove the actor login, node ID, and push-authority repository node IDs from one authenticated GitHub response before a generation-1 ledger is published.
- Reject caller-supplied identity fields that differ from that live response before creating a branch, worktree, or pull request.
- Add a narrowly scoped, auditable pre-bind recovery for an identity mismatch discovered after genesis, preserving the predecessor digest and proving the exact existing delivery artifacts.
- Re-prove the complete actor tuple during PR binding and reject actor changes between genesis and binding.

## Validation

- Add focused coverage for mixed login/node pairs, stale actor identities, push-authority drift, actor changes between genesis and PR binding, and exact pre-bind recovery.
- Run the focused delivery-ledger tests and the repository's required wrapper validation on the final committed head.

## Limitations / follow-up

This delivery leaves issue #559 open and the pull request in draft state for maintainer review.

Fixes #559

<!-- atrinik-delivery:body:9cd5784ff7ce5554bff4497208508b8115a7c64db03c1398578a38b4977e7d2c:start -->
### Current delivery status

The earlier draft-state sentence above is superseded: PR #561 is ready for maintainer review; issue #559 remains open.

<!-- atrinik-delivery:body:9cd5784ff7ce5554bff4497208508b8115a7c64db03c1398578a38b4977e7d2c:end -->