### PR TITLE
fix(supply-chain): make dependency diagnostics optional

### DIFF
--- a/.agents/skills/atrinik-guidance-maintenance/SKILL.md
+++ b/.agents/skills/atrinik-guidance-maintenance/SKILL.md
@@ -48,8 +48,7 @@ git diff --check
 ```
 
 Run the active Codex `skill-creator` validator for changed skills. Add
-ShellCheck, actionlint, profile builds, or supply-chain audits only when
-relevant. Never claim coverage for unread checkouts.
+ShellCheck, actionlint, or builds when relevant; supply-chain is optional. Never claim coverage for unread checkouts.
 
 ## Report
 

--- a/.agents/skills/atrinik-issue-delivery/SKILL.md
+++ b/.agents/skills/atrinik-issue-delivery/SKILL.md
@@ -5,7 +5,7 @@ description: Deliver an Atrinik issue/PR to merge-ready handoff or manage its ex
 
 # Deliver an Atrinik issue or pull request
 
-Choose `ENTRY_MODE=issue` for new work or `PR` for an existing pull request.
+Choose exactly one type-explicit `ENTRY_MODE`: new `issue` or existing `PR`.
 Both stop before merge.
 
 Invocation permits ordinary pushes, selected/delivery-created PR updates,

--- a/.agents/skills/atrinik-issue-delivery/SKILL.md
+++ b/.agents/skills/atrinik-issue-delivery/SKILL.md
@@ -5,8 +5,8 @@ description: Deliver an Atrinik issue/PR to merge-ready handoff or manage its ex
 
 # Deliver an Atrinik issue or pull request
 
-Choose exactly one type-explicit `ENTRY_MODE`: `issue` for new issue-first work
-or `PR` for one existing pull request. Both stop before merge.
+Choose `ENTRY_MODE=issue` for new work or `PR` for an existing pull request.
+Both stop before merge.
 
 Invocation permits ordinary pushes, selected/delivery-created PR updates,
 gated readiness, one coordinate-bound selected-PR comment, and issue-mode draft
@@ -246,14 +246,15 @@ never mounts source, credentials, private keys, or mutable server data.
   validate and miss the candidate; otherwise stop. Retain a complete unreleased
   scope only while its external
   generation, raw digest, identities, absent release journal, and safety match.
-  Released scopes and other references block. Give each physical repository
-  its own worktree, branch, commits, validation, and PR in its owner. In PR mode,
+  Released scopes and other references block. Each physical repository needs
+  its own worktree, branch, commits, validation, and PR. In PR mode,
   this does not authorize a companion PR; another repository needs separate
   type-explicit delivery authority.
 
 ## Implement and publish or update PRs
 
-Implement requirements and owner tests/contracts. Commit/validate coherent
+Implement owner requirements/tests. Supply-chain diagnostics never gate work
+or require inventory updates. Commit/validate coherent
 Conventional checkpoints without rewriting published history. Reprove `origin`,
 then run `git push origin HEAD_BRANCH` in the same scrubbed selector environment;
 reject HTTP, conceal URLs/credentials, and retain credential helpers. In issue

--- a/.agents/skills/atrinik-issue-delivery/references/deep-review-checklist.md
+++ b/.agents/skills/atrinik-issue-delivery/references/deep-review-checklist.md
@@ -250,7 +250,9 @@ applicability; do not turn irrelevant categories into invented findings.
 - Check error paths and observability redact sensitive values without hiding
   actionable context.
 - Review dependency provenance, licenses, pins, hashes, update policy,
-  transitive risk, install scripts, Actions/images, and inventory changes.
+  transitive risk, install scripts, and Actions/images. Aggregate catalog updates
+  and audits are optional diagnostics; neither their absence nor findings block
+  delivery or readiness.
 - Check imported code/assets have complete provenance and compatible licensing.
 - Consider denial of service through size, count, recursion, expensive parsing,
   retries, API use, disk consumption, and log volume.

--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -143,8 +143,8 @@ rendered GitHub-Flavored Markdown with actual line breaks, never literal `\n` se
 `Summary`, `Implementation / behavior`, `Validation`, and applicable `Limitations / follow-up`;
 issue-closing line alone is insufficient. preserve contributor-authored text byte-for-byte; change
 only a delivery-owned section when authorized. Feed multi-section bodies by file/stdin; after
-create/edit verify remote body. Semantic-release owns publication; dependency changes update
-inventory and audit a profile. Follow `docs/PROVENANCE.md`; fail uncertainty.
+create/edit verify remote body. Semantic-release publishes. Supply-chain diagnostics never gate work
+or require inventory updates. Follow `docs/PROVENANCE.md`; fail uncertainty.
 
 ## Maintain guidance
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -163,8 +163,6 @@ jobs:
         run: ./atrinik manifest validate
       - name: Validate provenance registry
         run: ./atrinik provenance validate
-      - name: Validate supply chain
-        run: ./atrinik supply-chain validate
       - name: Upload coverage report
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,16 +1,15 @@
-name: Supply chain
+name: Dependency diagnostics
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "17 5 * * 1"
 
 permissions:
   contents: read
 
 jobs:
   audit:
-    name: Organization dependency audit
+    name: Optional dependency diagnostics
+    continue-on-error: true
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
@@ -22,7 +21,7 @@ jobs:
           python-version: "3.13"
       - name: Initialize complete audit profiles
         run: ./atrinik init --with classic
-      - name: Audit dependency ownership
+      - name: Inspect dependency catalog
         run: |
           ./atrinik supply-chain validate
           ./atrinik supply-chain audit --profile default
@@ -48,8 +47,9 @@ jobs:
             --profile classic \
             --output build/supply-chain/classic/spdx.json
       - name: Upload supply-chain reports
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: atrinik-supply-chain
           path: build/supply-chain
-          if-no-files-found: error
+          if-no-files-found: warn

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 
 - `atrinik` CLI, `atrinik_workspace/` orchestration, `tests/` unittest suite.
 - Checkout/cohort/stack/role/source/build contracts: `components.json`; machine
-  policy: `supply-chain/`, `governance/`.
+  policy: `governance/`; diagnostics: `supply-chain/`.
 - Workflows: `.agents/skills/`; composition: `.devcontainer/`; CI/release:
   `.github/`; helpers: `scripts/`.
 - Manifest destinations are ignored repos; `workspace/` and `build/` are ignored
@@ -62,9 +62,9 @@
   `CONTRIBUTING.md`; preserve precise attribution.
 - MIT reuse follows `docs/PROVENANCE.md` and its registry; rights/identity/temporal/
   authorship/scope uncertainty fails closed.
-- Update `supply-chain/inventory.json` when dependency ownership/validation changes; keep
-  Actions/images immutable, add no submodules, audit a full profile; only aggregate-root
-  workflows and Dependabot are active.
+- Supply-chain inventory, license reports, and audits are optional diagnostics. Never
+  require catalog updates or use findings to block work, PR readiness, or delivery.
+  Keep Actions/images immutable; no submodules. Only root workflows/Dependabot are active.
 - New content/Classic issues name `content@main` and its Classic-target artifact; no live
   1.x branch/checkout/release label/maintenance line/publication target/backport destination
   exists; historical evidence is immutable.
@@ -104,7 +104,6 @@ python3 -m coverage report --show-missing
 python3 -m compileall -q atrinik atrinik_workspace tests
 python3 -m atrinik_workspace.guidance_inventory --check
 ./atrinik manifest validate
-./atrinik supply-chain validate
 git diff --check
 ```
 
@@ -115,8 +114,8 @@ For cleanup changes also run:
 ./atrinik cleanup --scope topologies --older-than 7 --dry-run --json
 ```
 
-Run ShellCheck for shell changes, actionlint for workflows, and
-`./atrinik supply-chain audit --profile PROFILE` when dependency inputs change.
+Run ShellCheck for shell changes and actionlint for workflows.
+Diagnostics: `./atrinik supply-chain audit --profile PROFILE`.
 Preserve `.coveragerc` and OIDC Codecov boundaries.
 
 Handoffs name exact profiles, worktrees, topologies, services, states, scenarios,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,7 +241,6 @@ python3 -m atrinik_workspace.guidance_inventory --check
 python3 -m atrinik_workspace.mcp_contract validate
 ./atrinik manifest validate
 ./atrinik provenance validate
-./atrinik supply-chain validate
 git diff --check
 ~~~
 
@@ -328,6 +327,11 @@ command is installed, and preview shared-cache retention with
 For local-playtest sound staging changes, use a clean sound checkout that owns
 the public playtest-tree builder. Run the focused wrapper sound fixtures, build
 `classic-client` twice from the same Classic-derived local-playtest profile,
-inspect matching build/topology sound records, and run the complete Classic
-supply-chain audit. The generated tree remains ignored, nonpublishable local
+inspect matching build/topology sound records, and optionally inspect Classic
+dependency diagnostics. The generated tree remains ignored, nonpublishable local
 state; never attach, package, upload, or commit it.
+
+Dependency and license diagnostics (`./atrinik supply-chain ...`) are optional.
+Catalog maintenance and diagnostic findings never gate changes, PR readiness,
+or delivery. Update the catalog only when explicitly requested; use component
+lockfiles and actual source notices for current build inputs and licensing.

--- a/README.md
+++ b/README.md
@@ -524,9 +524,16 @@ The benchmark defaults offline and writes sanitized evidence under ignored
 for bounds, threat coverage, capability ownership, optional live-GitHub
 measurement, and downstream consumer gates.
 
-## Dependency and supply-chain ownership
+## Optional dependency and license diagnostics
 
-`supply-chain/inventory.json` records every supported repository and the owned
+Supply-chain commands are optional inspection tools. They never gate builds,
+tests, PR readiness, or delivery, and catalog updates are never required.
+The catalog can be stale: compare reports with current component lockfiles,
+copyright notices and licenses before relying on them. Explicit `validate` and
+`audit` findings are printed as diagnostics with exit status zero; I/O failures
+remain errors. No automatic audit runs as part of integration or on a schedule.
+
+`supply-chain/inventory.json` records known repositories and the owned
 toolchains, actions, images, source archives, system libraries, optional tools,
 vendored sources, licenses, update cadences, EOL responses, and validation
 paths they consume. Repository records distinguish physical checkout, logical
@@ -578,10 +585,10 @@ workspace from silently weakening an aggregate audit. Absolute
 `--repository NAME=PATH` overrides can select review worktrees, but cannot make
 the rest of the profile optional.
 
-Generated reports remain ignored under `build/`. The scheduled organization
-audit uses `./atrinik init --with classic` to materialize the manifest-defined
+Generated reports remain ignored under `build/`. The manually requested diagnostic workflow
+uses `./atrinik init --with classic` to materialize the manifest-defined
 union of both stacks, audits their physical checkout metadata and logical
-component source roots, rejects unowned dependency inputs, movable
+component source roots, reports unowned dependency inputs, movable
 workflow/image references, and submodules, prints exact available tool
 versions, and publishes
 separate deterministic license, CycloneDX, and SPDX artifacts for each stack.

--- a/atrinik_workspace/cli.py
+++ b/atrinik_workspace/cli.py
@@ -595,7 +595,7 @@ def parser() -> argparse.ArgumentParser:
     scenario_reset.add_argument("--json", action="store_true")
 
     supply_chain = commands.add_parser(
-        "supply-chain", help="validate and report dependency ownership"
+        "supply-chain", help="optional dependency and license diagnostics"
     )
     supply_chain_commands = supply_chain.add_subparsers(
         dest="supply_chain_command", required=True
@@ -1648,6 +1648,9 @@ def main(arguments: list[str] | None = None) -> int:
                 )
         return 0
     except (PlatformCapabilityError, WorkspaceError) as error:
+        if options.command == "supply-chain":
+            print(f"diagnostic: {error}", file=sys.stderr)
+            return 0
         print(f"error: {error}", file=sys.stderr)
         return 1
     except OSError as error:

--- a/atrinik_workspace/supply_chain.py
+++ b/atrinik_workspace/supply_chain.py
@@ -433,6 +433,14 @@ class Inventory:
                 raise WorkspaceError(f"audit root is not a directory: {resolved}")
             normalized[name] = resolved
 
+        if "classic" in normalized and (
+            "container/classic-dependencies" in self.dependencies_by_id
+            or (normalized["classic"] / "dependencies.bundle.json").exists()
+        ):
+            _validate_classic_bundle_inventory(
+                normalized["classic"], self.dependencies_by_id
+            )
+
         action_dependencies = {
             dependency.locator: dependency
             for dependency in self.dependencies
@@ -1269,6 +1277,48 @@ def _source_path(value: object, context: str) -> str:
     if text == ".":
         return text
     return _relative_path(text, context)
+
+
+def _validate_classic_bundle_inventory(
+    root: Path, dependencies: dict[str, Dependency]
+) -> None:
+    """Compare active descriptor fields, not incidental matching evidence text."""
+    identifier = "container/classic-dependencies"
+    dependency = dependencies.get(identifier)
+    if dependency is None:
+        raise WorkspaceError(f"{identifier}: required inventory record is missing")
+    path = _safe_repository_path(root, "dependencies.bundle.json")
+    try:
+        descriptor = json.loads(_read_metadata(path))
+    except json.JSONDecodeError as error:
+        raise WorkspaceError(f"{identifier}: invalid bundle descriptor JSON") from error
+    if not isinstance(descriptor, dict) or descriptor.get("schema_version") != 1:
+        raise WorkspaceError(f"{identifier}: unsupported bundle descriptor schema")
+    image = descriptor.get("image")
+    digest = descriptor.get("digest")
+    material = descriptor.get("material_digest")
+    if (
+        image != "ghcr.io/atrinik/classic-dependencies"
+        or not isinstance(digest, str)
+        or CHECKSUM_PATTERN.fullmatch(digest) is None
+        or not isinstance(material, str)
+        or CHECKSUM_PATTERN.fullmatch(material) is None
+    ):
+        raise WorkspaceError(f"{identifier}: invalid bundle descriptor coordinates")
+    tag = "materials-" + material.removeprefix("sha256:")
+    if descriptor.get("tag") != tag:
+        raise WorkspaceError(f"{identifier}: descriptor tag differs from its material digest")
+    for field, actual, expected in (
+        ("kind", dependency.kind, "container-image"),
+        ("version", dependency.version, tag),
+        ("locator", dependency.locator, f"{image}@{digest}"),
+        ("checksum", dependency.checksum, digest),
+    ):
+        if actual != expected:
+            raise WorkspaceError(
+                f"{identifier}: inventory {field} differs from active "
+                f"classic/dependencies.bundle.json: expected {expected}"
+            )
 
 
 def _safe_repository_path(root: Path, relative: str) -> Path:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -161,7 +161,11 @@ completely. Profile and state schemas are likewise strict: duplicate keys,
 missing fields, unknown fields, invalid names, and repository mismatches fail
 before an operation changes data.
 
-Supply-chain ownership is a wrapper-level cross-repository contract.
+Supply-chain reporting is an optional wrapper-level diagnostic facility.
+Its catalog is a historical reference, not a build or delivery contract.
+Inventory updates are never required, and findings never gate implementation,
+CI, PR readiness, or delivery. Explicit diagnostic commands print discrepancies
+without a failure exit status; operational I/O errors can still prevent a report.
 `supply-chain/inventory.json` names every active or archived organization
 repository and records each supported dependency's owner, consumers, version
 source, license, acquisition path, update cadence, EOL response, validation,
@@ -212,8 +216,8 @@ selectors as builds, then reads Git-indexed files without mutating a checkout.
 Before selecting audit-ready roots, it requires every physical checkout and
 logical component in the profile to resolve. Review-worktree overrides replace
 specific roots but never relax that completeness invariant. An unavailable
-member therefore fails the aggregate operation instead of turning it into a
-partial audit.
+member is reported as an incomplete diagnostic; it does not block delivery
+or produce a misleading complete audit.
 The audit requires immutable remote Actions and container images, updater
 hints, an owned catalog entry for every dependency input, weekly GitHub Actions
 update configuration, and no submodules. It discovers npm, Cargo, Go, Buf,

--- a/docs/CI_PERFORMANCE.md
+++ b/docs/CI_PERFORMANCE.md
@@ -45,7 +45,7 @@ manifest, all per-test durations, and parallel coverage data for 14 days.
 The aggregate job fails unless all shard jobs passed, rediscovery matches every
 manifest, and the union contains every test exactly once with no duplicates.
 It then combines branch coverage once, runs compile, guidance, MCP, manifest,
-provenance, and supply-chain validation as visible steps, and performs the sole
+and provenance validation as visible steps, and performs the sole
 Codecov upload. Pull-request-scoped concurrency cancels superseded heads.
 
 ## Local parallel execution

--- a/docs/LOCAL_TESTING.md
+++ b/docs/LOCAL_TESTING.md
@@ -55,7 +55,6 @@ python3 -m atrinik_workspace.mcp_contract validate
 ./atrinik manifest validate
 ./atrinik provenance preflight
 ./atrinik provenance validate
-./atrinik supply-chain validate
 ```
 
 The hosted workflow remains authoritative for the required `Integration

--- a/docs/MCP_INFORMATION_ACCESS.md
+++ b/docs/MCP_INFORMATION_ACCESS.md
@@ -148,8 +148,8 @@ The maintained Python SDK evaluation is
 `modelcontextprotocol/python-sdk@v2.0.0`, immutable commit
 `6f69a3758ebf2ee55ce050f58b470ce11af71133`, MIT. No SDK dependency is added in
 this contract-only phase. Issue #351 owns the production API evaluation and,
-if adopted, the immutable dependency and transitive
-`supply-chain/inventory.json` update. Dependabot and that package owner review
+if adopted, its immutable dependency inputs. An aggregate catalog update is
+optional diagnostic maintenance, never an adoption requirement. Dependabot and that package owner review
 protocol support, changelog, license, and transitive changes.
 
 ## Reproducible measurement

--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -1448,13 +1448,13 @@
         "classic-server"
       ],
       "required": true,
-      "version": "materials-7e2ad179a1d95540820634792e355e2fbf3cf030b41816c3bed9923c9d0a718d",
+      "version": "materials-5d3ac9ea4b5b5fd8a34352cf39aacaab3144a91f99f2de9c15e68007496acb65",
       "version_source": "Classic dependencies.bundle.json material digest",
       "license": "LicenseRef-Atrinik-Image-Contents",
       "source_url": "https://github.com/atrinik/classic/pkgs/container/classic-dependencies",
-      "locator": "ghcr.io/atrinik/classic-dependencies@sha256:60f13a18830552fbdbda314c9e29029323fce84eb0de1defd2a1d3610de78043",
+      "locator": "ghcr.io/atrinik/classic-dependencies@sha256:036fb758e18c7995e3869d391f75c9995e1d643ee167f4a933b1336138fbe58a",
       "commit": null,
-      "checksum": "sha256:60f13a18830552fbdbda314c9e29029323fce84eb0de1defd2a1d3610de78043",
+      "checksum": "sha256:036fb758e18c7995e3869d391f75c9995e1d643ee167f4a933b1336138fbe58a",
       "acquisition": "A trusted current-main workflow builds the deterministic OCI layout through the authoritative Classic fetcher and publishes its exact manifest digest",
       "update_cadence_days": 30,
       "update_mechanism": "Reviewed Classic lock or acquisition-contract update with a regenerated material and OCI descriptor",
@@ -1471,7 +1471,7 @@
         {
           "repository": "classic",
           "path": "dependencies.bundle.json",
-          "contains": "sha256:60f13a18830552fbdbda314c9e29029323fce84eb0de1defd2a1d3610de78043"
+          "contains": "sha256:036fb758e18c7995e3869d391f75c9995e1d643ee167f4a933b1336138fbe58a"
         },
         {
           "repository": "classic",

--- a/tests/fixtures/supply_chain/README.md
+++ b/tests/fixtures/supply_chain/README.md
@@ -1,0 +1,6 @@
+# Dependency diagnostic fixtures
+
+These fixed snapshots exercise parsing, reports, and malformed-input handling.
+They intentionally do not follow the live dependency catalog or component
+manifest. New dependencies, pin changes, or catalog drift require no updates
+here. Change fixtures only when needed to test diagnostic code behavior.

--- a/tests/fixtures/supply_chain/components.json
+++ b/tests/fixtures/supply_chain/components.json
@@ -1,0 +1,493 @@
+{
+  "schema_version": 3,
+  "cohorts": {
+    "default": [
+      "client",
+      "server",
+      "protocol",
+      "editor",
+      "renderer",
+      "content-toolkit",
+      "website",
+      "content",
+      "sound",
+      "resources",
+      "metaserver-worker",
+      "devcontainer",
+      "github-settings",
+      "observatory",
+      "deploy-control",
+      "web-platform"
+    ],
+    "classic": [
+      "classic",
+      "playtester",
+      "tools"
+    ]
+  },
+  "stacks": {
+    "default": {
+      "generation": "replacement",
+      "components": [
+        "client",
+        "server",
+        "protocol",
+        "editor",
+        "renderer",
+        "content-toolkit",
+        "website",
+        "content",
+        "sound",
+        "resources",
+        "metaserver-worker",
+        "devcontainer",
+        "github-settings",
+        "observatory",
+        "deploy-control",
+        "web-platform"
+      ],
+      "providers": {
+        "client": "client",
+        "server": "server",
+        "protocol": "protocol",
+        "editor": "editor",
+        "renderer": "renderer",
+        "content-toolkit": "content-toolkit",
+        "website": "website",
+        "content": "content",
+        "sound": "sound",
+        "resources": "resources",
+        "metaserver-worker": "metaserver-worker",
+        "devcontainer": "devcontainer",
+        "github-settings": "github-settings",
+        "observatory": "observatory",
+        "deploy-control": "deploy-control",
+        "web-platform": "web-platform"
+      }
+    },
+    "classic": {
+      "generation": "classic",
+      "components": [
+        "classic-client",
+        "classic-server",
+        "classic-protocol",
+        "classic-libatrinik",
+        "classic-editor",
+        "content",
+        "playtester",
+        "tools",
+        "sound",
+        "resources",
+        "metaserver-worker",
+        "devcontainer",
+        "github-settings"
+      ],
+      "providers": {
+        "client": "classic-client",
+        "server": "classic-server",
+        "protocol": "classic-protocol",
+        "libatrinik": "classic-libatrinik",
+        "editor": "classic-editor",
+        "content": "content",
+        "playtester": "playtester",
+        "tools": "tools",
+        "sound": "sound",
+        "resources": "resources",
+        "metaserver-worker": "metaserver-worker",
+        "devcontainer": "devcontainer",
+        "github-settings": "github-settings"
+      }
+    }
+  },
+  "checkouts": [
+    {
+      "name": "client",
+      "repository": "atrinik/client",
+      "branch": "main",
+      "path": "client",
+      "generation": "replacement",
+      "license": "MIT"
+    },
+    {
+      "name": "server",
+      "repository": "atrinik/server",
+      "branch": "main",
+      "path": "server",
+      "generation": "replacement",
+      "license": "MIT"
+    },
+    {
+      "name": "protocol",
+      "repository": "atrinik/protocol",
+      "branch": "main",
+      "path": "protocol",
+      "generation": "replacement",
+      "license": "MIT"
+    },
+    {
+      "name": "editor",
+      "repository": "atrinik/editor",
+      "branch": "main",
+      "path": "editor",
+      "generation": "replacement",
+      "license": "MIT"
+    },
+    {
+      "name": "renderer",
+      "repository": "atrinik/renderer",
+      "branch": "main",
+      "path": "renderer",
+      "generation": "replacement",
+      "license": "MIT"
+    },
+    {
+      "name": "content-toolkit",
+      "repository": "atrinik/content-toolkit",
+      "branch": "main",
+      "path": "content-toolkit",
+      "generation": "replacement",
+      "license": "MIT"
+    },
+    {
+      "name": "website",
+      "repository": "atrinik/website",
+      "branch": "main",
+      "path": "website",
+      "generation": "replacement",
+      "license": "MIT"
+    },
+    {
+      "name": "content",
+      "repository": "atrinik/content",
+      "branch": "main",
+      "path": "content",
+      "generation": "shared",
+      "license": "LicenseRef-Atrinik-Content"
+    },
+    {
+      "name": "sound",
+      "repository": "atrinik/sound",
+      "branch": "main",
+      "path": "sound",
+      "generation": "shared",
+      "license": "LicenseRef-Atrinik-Sound"
+    },
+    {
+      "name": "resources",
+      "repository": "atrinik/resources",
+      "branch": "main",
+      "path": "resources",
+      "generation": "shared",
+      "license": "LicenseRef-Atrinik-Resources"
+    },
+    {
+      "name": "metaserver-worker",
+      "repository": "atrinik/metaserver-worker",
+      "branch": "main",
+      "path": "metaserver-worker",
+      "generation": "shared",
+      "license": "MIT"
+    },
+    {
+      "name": "devcontainer",
+      "repository": "atrinik/devcontainer",
+      "branch": "main",
+      "path": "devcontainer",
+      "generation": "shared",
+      "license": "MIT"
+    },
+    {
+      "name": "github-settings",
+      "repository": "atrinik/github-settings",
+      "branch": "main",
+      "path": "github-settings",
+      "generation": "shared",
+      "license": "MIT"
+    },
+    {
+      "name": "observatory",
+      "repository": "atrinik/observatory",
+      "branch": "main",
+      "path": "observatory",
+      "generation": "replacement",
+      "license": "MIT"
+    },
+    {
+      "name": "deploy-control",
+      "repository": "atrinik/deploy-control",
+      "branch": "main",
+      "path": "deploy-control",
+      "generation": "shared",
+      "license": "MIT"
+    },
+    {
+      "name": "web-platform",
+      "repository": "atrinik/web-platform",
+      "branch": "main",
+      "path": "web-platform",
+      "generation": "shared",
+      "license": "MIT"
+    },
+    {
+      "name": "classic",
+      "repository": "atrinik/classic",
+      "branch": "main",
+      "path": "classic",
+      "generation": "classic",
+      "license": "GPL-2.0-or-later"
+    },
+    {
+      "name": "playtester",
+      "repository": "atrinik/playtester",
+      "branch": "main",
+      "path": "playtester",
+      "generation": "classic",
+      "license": "MIT"
+    },
+    {
+      "name": "tools",
+      "repository": "atrinik/tools",
+      "branch": "main",
+      "path": "tools",
+      "generation": "classic",
+      "license": "LicenseRef-Atrinik-Tools-Mixed"
+    }
+  ],
+  "components": [
+    {
+      "name": "client",
+      "checkout": "client",
+      "source": ".",
+      "build": "none",
+      "generation": "replacement",
+      "provides": ["client"],
+      "requires": ["protocol", "renderer", "content", "sound", "resources"],
+      "license": "MIT"
+    },
+    {
+      "name": "server",
+      "checkout": "server",
+      "source": ".",
+      "build": "none",
+      "generation": "replacement",
+      "provides": ["server"],
+      "requires": ["protocol", "content-toolkit", "content", "resources"],
+      "license": "MIT"
+    },
+    {
+      "name": "protocol",
+      "checkout": "protocol",
+      "source": ".",
+      "build": "none",
+      "generation": "replacement",
+      "provides": ["protocol"],
+      "requires": [],
+      "license": "MIT"
+    },
+    {
+      "name": "editor",
+      "checkout": "editor",
+      "source": ".",
+      "build": "none",
+      "generation": "replacement",
+      "provides": ["editor"],
+      "requires": ["renderer", "content-toolkit", "content", "sound", "resources"],
+      "license": "MIT"
+    },
+    {
+      "name": "renderer",
+      "checkout": "renderer",
+      "source": ".",
+      "build": "none",
+      "generation": "replacement",
+      "provides": ["renderer"],
+      "requires": ["resources"],
+      "license": "MIT"
+    },
+    {
+      "name": "content-toolkit",
+      "checkout": "content-toolkit",
+      "source": ".",
+      "build": "none",
+      "generation": "replacement",
+      "provides": ["content-toolkit"],
+      "requires": ["content"],
+      "license": "MIT"
+    },
+    {
+      "name": "website",
+      "checkout": "website",
+      "source": ".",
+      "build": "none",
+      "generation": "replacement",
+      "provides": ["website"],
+      "requires": [],
+      "license": "MIT"
+    },
+    {
+      "name": "content",
+      "checkout": "content",
+      "source": ".",
+      "build": "none",
+      "build_by_stack": {
+        "classic": "classic-content"
+      },
+      "generation": "shared",
+      "provides": ["content"],
+      "requires": [],
+      "license": "LicenseRef-Atrinik-Content"
+    },
+    {
+      "name": "sound",
+      "checkout": "sound",
+      "source": ".",
+      "build": "assets",
+      "generation": "shared",
+      "provides": ["sound"],
+      "requires": [],
+      "license": "LicenseRef-Atrinik-Sound"
+    },
+    {
+      "name": "resources",
+      "checkout": "resources",
+      "source": ".",
+      "build": "assets",
+      "generation": "shared",
+      "provides": ["resources"],
+      "requires": [],
+      "license": "LicenseRef-Atrinik-Resources"
+    },
+    {
+      "name": "metaserver-worker",
+      "checkout": "metaserver-worker",
+      "source": ".",
+      "build": "worker",
+      "generation": "shared",
+      "provides": ["metaserver-worker"],
+      "requires": [],
+      "license": "MIT"
+    },
+    {
+      "name": "devcontainer",
+      "checkout": "devcontainer",
+      "source": ".",
+      "build": "none",
+      "generation": "shared",
+      "provides": ["devcontainer"],
+      "requires": [],
+      "license": "MIT"
+    },
+    {
+      "name": "github-settings",
+      "checkout": "github-settings",
+      "source": ".",
+      "build": "none",
+      "generation": "shared",
+      "provides": ["github-settings"],
+      "requires": [],
+      "license": "MIT"
+    },
+    {
+      "name": "observatory",
+      "checkout": "observatory",
+      "source": ".",
+      "build": "none",
+      "generation": "replacement",
+      "provides": ["observatory"],
+      "requires": [],
+      "license": "MIT"
+    },
+    {
+      "name": "deploy-control",
+      "checkout": "deploy-control",
+      "source": ".",
+      "build": "none",
+      "generation": "shared",
+      "provides": ["deploy-control"],
+      "requires": [],
+      "license": "MIT"
+    },
+    {
+      "name": "web-platform",
+      "checkout": "web-platform",
+      "source": ".",
+      "build": "none",
+      "generation": "shared",
+      "provides": ["web-platform"],
+      "requires": [],
+      "license": "MIT"
+    },
+    {
+      "name": "classic-client",
+      "checkout": "classic",
+      "source": "client",
+      "source_includes": ["cmake", "LICENSE.md", "ATTRIBUTIONS.md"],
+      "build": "classic-client",
+      "generation": "classic",
+      "provides": ["client"],
+      "requires": ["protocol", "libatrinik", "sound"],
+      "license": "GPL-2.0-or-later"
+    },
+    {
+      "name": "classic-server",
+      "checkout": "classic",
+      "source": "server",
+      "source_includes": ["cmake", "LICENSE.md", "ATTRIBUTIONS.md"],
+      "build": "classic-server",
+      "generation": "classic",
+      "provides": ["server"],
+      "requires": ["protocol", "libatrinik", "content", "resources"],
+      "license": "GPL-2.0-or-later"
+    },
+    {
+      "name": "classic-protocol",
+      "checkout": "classic",
+      "source": "protocol",
+      "build": "classic-protocol",
+      "generation": "classic",
+      "provides": ["protocol"],
+      "requires": [],
+      "license": "GPL-2.0-or-later"
+    },
+    {
+      "name": "classic-libatrinik",
+      "checkout": "classic",
+      "source": "libatrinik",
+      "build": "classic-library",
+      "generation": "classic",
+      "provides": ["libatrinik"],
+      "requires": ["protocol"],
+      "license": "GPL-2.0-or-later"
+    },
+    {
+      "name": "classic-editor",
+      "checkout": "classic",
+      "source": "editor",
+      "build": "none",
+      "generation": "classic",
+      "provides": ["editor"],
+      "requires": ["content", "resources"],
+      "license": "GPL-2.0-or-later"
+    },
+    {
+      "name": "playtester",
+      "checkout": "playtester",
+      "source": ".",
+      "build": "none",
+      "generation": "classic",
+      "provides": ["playtester"],
+      "requires": ["content", "libatrinik", "protocol"],
+      "license": "MIT"
+    },
+    {
+      "name": "tools",
+      "checkout": "tools",
+      "source": ".",
+      "build": "none",
+      "generation": "classic",
+      "provides": ["tools"],
+      "requires": ["content"],
+      "license": "LicenseRef-Atrinik-Tools-Mixed"
+    }
+  ]
+}

--- a/tests/fixtures/supply_chain/inventory.json
+++ b/tests/fixtures/supply_chain/inventory.json
@@ -1,0 +1,5055 @@
+{
+  "schema_version": 4,
+  "organization": "atrinik",
+  "created": "2026-08-08T00:00:00Z",
+  "license_references": {
+    "LicenseRef-Atrinik-Tools-Mixed": "MIT applies by default to tracked files outside narrower notices. GPL-2.0-or-later applies to the complete map-checker-qt/ subtree unless a file explicitly states otherwise."
+  },
+  "repositories": [
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [],
+      "license": "MIT",
+      "commit": null,
+      "name": "atrinik",
+      "repository": "atrinik/atrinik",
+      "role": "Workspace orchestration and aggregate supply-chain ownership",
+      "roles": [
+        "workspace"
+      ],
+      "stacks": [],
+      "supported": true,
+      "checkout": "atrinik",
+      "source": "."
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "metadata",
+      "branch": "main",
+      "cohorts": [
+        "classic"
+      ],
+      "license": "GPL-2.0-or-later",
+      "commit": null,
+      "name": "classic",
+      "repository": "atrinik/classic",
+      "role": "Physical classic checkout governance, CI, dependency, and import-history metadata",
+      "roles": [
+        "checkout-metadata"
+      ],
+      "stacks": [
+        "classic"
+      ],
+      "supported": true,
+      "checkout": "classic",
+      "source": "."
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "classic"
+      ],
+      "license": "GPL-2.0-or-later",
+      "commit": null,
+      "name": "classic-client",
+      "repository": "atrinik/classic",
+      "role": "GPL classic SDL3 game client maintained in the classic monorepo",
+      "roles": [
+        "client"
+      ],
+      "stacks": [
+        "classic"
+      ],
+      "supported": true,
+      "checkout": "classic",
+      "source": "client"
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "classic"
+      ],
+      "license": "GPL-2.0-or-later",
+      "commit": null,
+      "name": "classic-editor",
+      "repository": "atrinik/classic",
+      "role": "GPL classic Gridarta packaging utility maintained in the classic monorepo",
+      "roles": [
+        "editor"
+      ],
+      "stacks": [
+        "classic"
+      ],
+      "supported": true,
+      "checkout": "classic",
+      "source": "editor"
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "classic"
+      ],
+      "license": "GPL-2.0-or-later",
+      "commit": null,
+      "name": "classic-libatrinik",
+      "repository": "atrinik/classic",
+      "role": "GPL classic reusable native libraries maintained in the classic monorepo",
+      "roles": [
+        "libatrinik"
+      ],
+      "stacks": [
+        "classic"
+      ],
+      "supported": true,
+      "checkout": "classic",
+      "source": "libatrinik"
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "classic"
+      ],
+      "license": "GPL-2.0-or-later",
+      "commit": null,
+      "name": "classic-protocol",
+      "repository": "atrinik/classic",
+      "role": "GPL classic C protocol schemas and generated bindings maintained in the classic monorepo",
+      "roles": [
+        "protocol"
+      ],
+      "stacks": [
+        "classic"
+      ],
+      "supported": true,
+      "checkout": "classic",
+      "source": "protocol"
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "classic"
+      ],
+      "license": "GPL-2.0-or-later",
+      "commit": null,
+      "name": "classic-server",
+      "repository": "atrinik/classic",
+      "role": "GPL classic authoritative game server maintained in the classic monorepo",
+      "roles": [
+        "server"
+      ],
+      "stacks": [
+        "classic"
+      ],
+      "supported": true,
+      "checkout": "classic",
+      "source": "server"
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "default"
+      ],
+      "license": "MIT",
+      "commit": null,
+      "name": "client",
+      "repository": "atrinik/client",
+      "role": "MIT Rust game client replacement with an independently validated M1 foundation",
+      "roles": [
+        "client"
+      ],
+      "stacks": [
+        "default"
+      ],
+      "supported": true,
+      "checkout": "client",
+      "source": "."
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "default"
+      ],
+      "license": "LicenseRef-Atrinik-Content",
+      "commit": null,
+      "name": "content",
+      "repository": "atrinik/content",
+      "role": "Authored world content and content tooling",
+      "roles": [
+        "content"
+      ],
+      "stacks": [
+        "classic",
+        "default"
+      ],
+      "supported": true,
+      "checkout": "content",
+      "source": "."
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "default"
+      ],
+      "license": "MIT",
+      "commit": null,
+      "name": "content-toolkit",
+      "repository": "atrinik/content-toolkit",
+      "role": "MIT content model, compiler, validator, and migration toolkit with an independently validated M1 foundation",
+      "roles": [
+        "content-toolkit"
+      ],
+      "stacks": [
+        "default"
+      ],
+      "supported": true,
+      "checkout": "content-toolkit",
+      "source": "."
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "default"
+      ],
+      "license": "MIT",
+      "commit": null,
+      "name": "deploy-control",
+      "repository": "atrinik/deploy-control",
+      "role": "Cloudflare control plane and registered host-agent infrastructure",
+      "roles": [
+        "deploy-control"
+      ],
+      "stacks": [
+        "default"
+      ],
+      "supported": true,
+      "checkout": "deploy-control",
+      "source": "."
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "default"
+      ],
+      "license": "MIT",
+      "commit": null,
+      "name": "devcontainer",
+      "repository": "atrinik/devcontainer",
+      "role": "Linux and Windows build images",
+      "roles": [
+        "devcontainer"
+      ],
+      "stacks": [
+        "classic",
+        "default"
+      ],
+      "supported": true,
+      "checkout": "devcontainer",
+      "source": "."
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "default"
+      ],
+      "license": "MIT",
+      "commit": null,
+      "name": "editor",
+      "repository": "atrinik/editor",
+      "role": "MIT Rust content editor replacement with an independently validated M1 foundation",
+      "roles": [
+        "editor"
+      ],
+      "stacks": [
+        "default"
+      ],
+      "supported": true,
+      "checkout": "editor",
+      "source": "."
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "default"
+      ],
+      "license": "MIT",
+      "commit": null,
+      "name": "github-settings",
+      "repository": "atrinik/github-settings",
+      "role": "Organization governance desired state",
+      "roles": [
+        "github-settings"
+      ],
+      "stacks": [
+        "classic",
+        "default"
+      ],
+      "supported": true,
+      "checkout": "github-settings",
+      "source": "."
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "default"
+      ],
+      "license": "MIT",
+      "commit": null,
+      "name": "metaserver-worker",
+      "repository": "atrinik/metaserver-worker",
+      "role": "Cloudflare metaserver and rendezvous Worker",
+      "roles": [
+        "metaserver-worker"
+      ],
+      "stacks": [
+        "classic",
+        "default"
+      ],
+      "supported": true,
+      "checkout": "metaserver-worker",
+      "source": "."
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [],
+      "license": "NOASSERTION",
+      "commit": null,
+      "name": "nawerhals",
+      "repository": "atrinik/nawerhals",
+      "role": "Archived historical source; no supported build or update surface",
+      "roles": [
+        "archive"
+      ],
+      "stacks": [],
+      "supported": false,
+      "checkout": "nawerhals",
+      "source": "."
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "default"
+      ],
+      "license": "MIT",
+      "commit": null,
+      "name": "observatory",
+      "repository": "atrinik/observatory",
+      "role": "Read-only build, release, package, deployment, and public-service status dashboard",
+      "roles": [
+        "observatory"
+      ],
+      "stacks": [
+        "default"
+      ],
+      "supported": true,
+      "checkout": "observatory",
+      "source": "."
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "classic"
+      ],
+      "license": "MIT",
+      "commit": null,
+      "name": "playtester",
+      "repository": "atrinik/playtester",
+      "role": "MIT autonomous end-to-end playtester for the classic game",
+      "roles": [
+        "playtester"
+      ],
+      "stacks": [
+        "classic"
+      ],
+      "supported": true,
+      "checkout": "playtester",
+      "source": "."
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "default"
+      ],
+      "license": "MIT",
+      "commit": null,
+      "name": "protocol",
+      "repository": "atrinik/protocol",
+      "role": "MIT replacement wire schemas and generated Go and Rust bindings with an independently validated M1 foundation",
+      "roles": [
+        "protocol"
+      ],
+      "stacks": [
+        "default"
+      ],
+      "supported": true,
+      "checkout": "protocol",
+      "source": "."
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "default"
+      ],
+      "license": "MIT",
+      "commit": null,
+      "name": "renderer",
+      "repository": "atrinik/renderer",
+      "role": "MIT shared Rust GPU renderer with an independently validated M1 foundation",
+      "roles": [
+        "renderer"
+      ],
+      "stacks": [
+        "default"
+      ],
+      "supported": true,
+      "checkout": "renderer",
+      "source": "."
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "default"
+      ],
+      "license": "LicenseRef-Atrinik-Resources",
+      "commit": null,
+      "name": "resources",
+      "repository": "atrinik/resources",
+      "role": "Server runtime media",
+      "roles": [
+        "resources"
+      ],
+      "stacks": [
+        "classic",
+        "default"
+      ],
+      "supported": true,
+      "checkout": "resources",
+      "source": "."
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "default"
+      ],
+      "license": "MIT",
+      "commit": null,
+      "name": "server",
+      "repository": "atrinik/server",
+      "role": "MIT Go authoritative game server replacement with an independently validated M1 foundation",
+      "roles": [
+        "server"
+      ],
+      "stacks": [
+        "default"
+      ],
+      "supported": true,
+      "checkout": "server",
+      "source": "."
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "default"
+      ],
+      "license": "LicenseRef-Atrinik-Sound",
+      "commit": null,
+      "name": "sound",
+      "repository": "atrinik/sound",
+      "role": "Client music and sound effects",
+      "roles": [
+        "sound"
+      ],
+      "stacks": [
+        "classic",
+        "default"
+      ],
+      "supported": true,
+      "checkout": "sound",
+      "source": "."
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "classic"
+      ],
+      "license": "LicenseRef-Atrinik-Tools-Mixed",
+      "commit": null,
+      "name": "tools",
+      "repository": "atrinik/tools",
+      "role": "Standalone operator and content-inspection tools",
+      "roles": [
+        "tools"
+      ],
+      "stacks": [
+        "classic"
+      ],
+      "supported": true,
+      "checkout": "tools",
+      "source": "."
+    },
+    {
+      "audit_ready": false,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "default"
+      ],
+      "license": "MIT",
+      "commit": null,
+      "name": "web-platform",
+      "repository": "atrinik/web-platform",
+      "role": "Shared presentation package for Atrinik web applications",
+      "roles": [
+        "web-platform"
+      ],
+      "stacks": [
+        "default"
+      ],
+      "supported": true,
+      "checkout": "web-platform",
+      "source": "."
+    },
+    {
+      "audit_ready": true,
+      "audit_mode": "full",
+      "branch": "main",
+      "cohorts": [
+        "default"
+      ],
+      "license": "MIT",
+      "commit": null,
+      "name": "website",
+      "repository": "atrinik/website",
+      "role": "MIT atrinik.org static website with an independently validated M1 foundation",
+      "roles": [
+        "website"
+      ],
+      "stacks": [
+        "default"
+      ],
+      "supported": true,
+      "checkout": "website",
+      "source": "."
+    }
+  ],
+  "dependencies": [
+    {
+      "id": "action/actions-attest",
+      "name": "actions/attest",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "classic"
+      ],
+      "required": true,
+      "version": "v4",
+      "version_source": "Reviewed upstream major release",
+      "license": "MIT",
+      "source_url": "https://github.com/actions/attest",
+      "locator": "actions/attest",
+      "commit": "1e69f48acb82d1966a394da916b4c1698aa569d6",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade artifact provenance and SBOM attestations before the major is retired",
+      "validation": "Actionlint and production release attestation validation",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic",
+          "path": ".github/workflows/package-release.yml",
+          "contains": "actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4"
+        }
+      ]
+    },
+    {
+      "id": "action/actions-cache",
+      "name": "actions/cache",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "classic"
+      ],
+      "required": true,
+      "version": "v6",
+      "version_source": "Reviewed upstream major release",
+      "license": "MIT",
+      "source_url": "https://github.com/actions/cache",
+      "locator": "actions/cache",
+      "commit": "55cc8345863c7cc4c66a329aec7e433d2d1c52a9",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade all cache consumers together or remove the cache step",
+      "validation": "Actionlint plus root Classic client CI cache restore/save coverage",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic",
+          "path": ".github/workflows/check.yml",
+          "contains": "actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6"
+        }
+      ]
+    },
+    {
+      "id": "action/actions-cache-restore",
+      "name": "actions/cache/restore",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "classic"
+      ],
+      "required": true,
+      "version": "v6",
+      "version_source": "Reviewed upstream major release",
+      "license": "MIT",
+      "source_url": "https://github.com/actions/cache",
+      "locator": "actions/cache/restore",
+      "commit": "55cc8345863c7cc4c66a329aec7e433d2d1c52a9",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade all cache consumers together or remove the explicit restore step",
+      "validation": "Actionlint plus complete-key verified dependency cache restore coverage",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic",
+          "path": ".github/workflows/check.yml",
+          "contains": "actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6"
+        }
+      ]
+    },
+    {
+      "id": "action/actions-cache-save",
+      "name": "actions/cache/save",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "classic"
+      ],
+      "required": true,
+      "version": "v6",
+      "version_source": "Reviewed upstream major release",
+      "license": "MIT",
+      "source_url": "https://github.com/actions/cache",
+      "locator": "actions/cache/save",
+      "commit": "55cc8345863c7cc4c66a329aec7e433d2d1c52a9",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade all cache consumers together or remove the explicit save step",
+      "validation": "Actionlint plus repaired-generation-only verified dependency cache save coverage",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic",
+          "path": ".github/workflows/check.yml",
+          "contains": "actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6"
+        }
+      ]
+    },
+    {
+      "id": "action/actions-checkout",
+      "name": "actions/checkout",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "atrinik",
+        "classic",
+        "client",
+        "content",
+        "content-toolkit",
+        "deploy-control",
+        "devcontainer",
+        "editor",
+        "github-settings",
+        "metaserver-worker",
+        "playtester",
+        "protocol",
+        "renderer",
+        "resources",
+        "server",
+        "sound",
+        "tools",
+        "website"
+      ],
+      "required": true,
+      "version": "v7.0.1",
+      "version_source": "Reviewed upstream major release",
+      "license": "MIT",
+      "source_url": "https://github.com/actions/checkout",
+      "locator": "actions/checkout",
+      "commit": "3d3c42e5aac5ba805825da76410c181273ba90b1",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade every repository in one coordinated policy change",
+      "validation": "Organization-wide immutable-reference audit and actionlint",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": ".github/workflows/integration.yml",
+          "contains": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1"
+        },
+        {
+          "repository": "classic",
+          "path": ".github/workflows/check.yml",
+          "contains": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1"
+        },
+        {
+          "repository": "client",
+          "path": ".github/workflows/validate.yml",
+          "contains": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1"
+        },
+        {
+          "repository": "content-toolkit",
+          "path": ".github/workflows/validate.yml",
+          "contains": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1"
+        },
+        {
+          "repository": "deploy-control",
+          "path": ".github/workflows/check.yml",
+          "contains": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1"
+        },
+        {
+          "repository": "editor",
+          "path": ".github/workflows/validate.yml",
+          "contains": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1"
+        },
+        {
+          "repository": "playtester",
+          "path": ".github/workflows/release.yml",
+          "contains": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1"
+        },
+        {
+          "repository": "playtester",
+          "path": ".github/workflows/validate.yml",
+          "contains": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1"
+        },
+        {
+          "repository": "protocol",
+          "path": ".github/workflows/validate.yml",
+          "contains": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1"
+        },
+        {
+          "repository": "renderer",
+          "path": ".github/workflows/validate.yml",
+          "contains": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1"
+        },
+        {
+          "repository": "server",
+          "path": ".github/workflows/validate.yml",
+          "contains": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1"
+        },
+        {
+          "repository": "website",
+          "path": ".github/workflows/validate.yml",
+          "contains": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1"
+        }
+      ]
+    },
+    {
+      "id": "action/actions-create-github-app-token",
+      "name": "actions/create-github-app-token",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "classic"
+      ],
+      "required": true,
+      "version": "v3.2.0",
+      "version_source": "Reviewed signed upstream release",
+      "license": "MIT",
+      "source_url": "https://github.com/actions/create-github-app-token",
+      "locator": "actions/create-github-app-token",
+      "commit": "bcd2ba49218906704ab6c1aa796996da409d3eb1",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade the Classic dependency updater after App-token workflow review or disable its mutation job",
+      "validation": "Actionlint, Classic workflow contract tests, and a manual disposable App-authored lock pull request",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic",
+          "path": ".github/workflows/update-content.yml",
+          "contains": "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0"
+        }
+      ]
+    },
+    {
+      "id": "action/actions-download-artifact",
+      "name": "actions/download-artifact",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "atrinik",
+        "classic",
+        "client",
+        "devcontainer",
+        "editor"
+      ],
+      "required": true,
+      "version": "v8",
+      "version_source": "Reviewed upstream major release",
+      "license": "MIT",
+      "source_url": "https://github.com/actions/download-artifact",
+      "locator": "actions/download-artifact",
+      "commit": "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade package aggregation workflows before the major is retired",
+      "validation": "Actionlint, Classic release artifact aggregation, and native Windows test artifact execution",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": ".github/workflows/integration.yml",
+          "contains": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8"
+        },
+        {
+          "repository": "classic",
+          "path": ".github/workflows/build-release-candidate.yml",
+          "contains": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8"
+        },
+        {
+          "repository": "classic",
+          "path": ".github/workflows/check.yml",
+          "contains": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8"
+        },
+        {
+          "repository": "classic",
+          "path": ".github/workflows/package-release.yml",
+          "contains": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8"
+        },
+        {
+          "repository": "client",
+          "path": ".github/workflows/package-release.yml",
+          "contains": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8"
+        },
+        {
+          "repository": "devcontainer",
+          "path": ".github/workflows/validate.yml",
+          "contains": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8"
+        },
+        {
+          "repository": "editor",
+          "path": ".github/workflows/package-release.yml",
+          "contains": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8"
+        }
+      ]
+    },
+    {
+      "id": "action/actions-setup-go",
+      "name": "actions/setup-go",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "protocol",
+        "server"
+      ],
+      "required": true,
+      "version": "v7.0.0",
+      "version_source": "Reviewed upstream release",
+      "license": "MIT",
+      "source_url": "https://github.com/actions/setup-go",
+      "locator": "actions/setup-go",
+      "commit": "b7ad1dad31e06c5925ef5d2fc7ad053ef454303e",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade the action with the supported Go toolchain or replace it",
+      "validation": "Actionlint plus Linux and Windows server validation",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "protocol",
+          "path": ".github/workflows/validate.yml",
+          "contains": "actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0"
+        },
+        {
+          "repository": "server",
+          "path": ".github/workflows/validate.yml",
+          "contains": "actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0"
+        }
+      ]
+    },
+    {
+      "id": "action/actions-setup-node",
+      "name": "actions/setup-node",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "atrinik",
+        "classic",
+        "client",
+        "content",
+        "content-toolkit",
+        "deploy-control",
+        "devcontainer",
+        "editor",
+        "github-settings",
+        "metaserver-worker",
+        "playtester",
+        "protocol",
+        "renderer",
+        "resources",
+        "server",
+        "sound",
+        "tools",
+        "website"
+      ],
+      "required": true,
+      "version": "v7.0.0",
+      "version_source": "Reviewed upstream major release",
+      "license": "MIT",
+      "source_url": "https://github.com/actions/setup-node",
+      "locator": "actions/setup-node",
+      "commit": "820762786026740c76f36085b0efc47a31fe5020",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Move CI and semantic-release to the next supported Node line",
+      "validation": "Actionlint plus Worker and semantic-release jobs",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": ".github/workflows/release.yml",
+          "contains": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0"
+        },
+        {
+          "repository": "classic",
+          "path": ".github/workflows/release.yml",
+          "contains": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0"
+        },
+        {
+          "repository": "client",
+          "path": ".github/workflows/release.yml",
+          "contains": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0"
+        },
+        {
+          "repository": "content",
+          "path": ".github/workflows/release.yml",
+          "contains": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0"
+        },
+        {
+          "repository": "content-toolkit",
+          "path": ".github/workflows/release.yml",
+          "contains": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0"
+        },
+        {
+          "repository": "deploy-control",
+          "path": ".github/workflows/check.yml",
+          "contains": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0"
+        },
+        {
+          "repository": "devcontainer",
+          "path": ".github/workflows/release.yml",
+          "contains": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0"
+        },
+        {
+          "repository": "editor",
+          "path": ".github/workflows/release.yml",
+          "contains": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0"
+        },
+        {
+          "repository": "github-settings",
+          "path": ".github/workflows/release.yml",
+          "contains": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0"
+        },
+        {
+          "repository": "playtester",
+          "path": ".github/workflows/release.yml",
+          "contains": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0"
+        },
+        {
+          "repository": "protocol",
+          "path": ".github/workflows/release.yml",
+          "contains": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0"
+        },
+        {
+          "repository": "renderer",
+          "path": ".github/workflows/release.yml",
+          "contains": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0"
+        },
+        {
+          "repository": "resources",
+          "path": ".github/workflows/release.yml",
+          "contains": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0"
+        },
+        {
+          "repository": "server",
+          "path": ".github/workflows/release.yml",
+          "contains": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0"
+        },
+        {
+          "repository": "sound",
+          "path": ".github/workflows/release.yml",
+          "contains": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0"
+        },
+        {
+          "repository": "tools",
+          "path": ".github/workflows/release.yml",
+          "contains": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0"
+        },
+        {
+          "repository": "website",
+          "path": ".github/workflows/release.yml",
+          "contains": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0"
+        }
+      ]
+    },
+    {
+      "id": "action/actions-setup-python",
+      "name": "actions/setup-python",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "atrinik",
+        "classic",
+        "content",
+        "playtester"
+      ],
+      "required": true,
+      "version": "v7.0.0",
+      "version_source": "Reviewed upstream major release",
+      "license": "MIT",
+      "source_url": "https://github.com/actions/setup-python",
+      "locator": "actions/setup-python",
+      "commit": "5fda3b95a4ea91299a34e894583c3862153e4b97",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade the action and supported Python matrix together",
+      "validation": "Actionlint plus Python generation, content, Playtester, and workspace tests",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": ".github/workflows/integration.yml",
+          "contains": "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0"
+        },
+        {
+          "repository": "classic",
+          "path": ".github/workflows/check.yml",
+          "contains": "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0"
+        },
+        {
+          "repository": "playtester",
+          "path": ".github/workflows/validate.yml",
+          "contains": "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0"
+        }
+      ]
+    },
+    {
+      "id": "action/actions-upload-artifact",
+      "name": "actions/upload-artifact",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "atrinik",
+        "classic",
+        "client",
+        "devcontainer",
+        "editor"
+      ],
+      "required": true,
+      "version": "v7",
+      "version_source": "Reviewed upstream major release",
+      "license": "MIT",
+      "source_url": "https://github.com/actions/upload-artifact",
+      "locator": "actions/upload-artifact",
+      "commit": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade package producer workflows before the major is retired",
+      "validation": "Actionlint, Classic release artifact round trips, and native Windows test staging",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": ".github/workflows/integration.yml",
+          "contains": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7"
+        },
+        {
+          "repository": "atrinik",
+          "path": ".github/workflows/supply-chain.yml",
+          "contains": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7"
+        },
+        {
+          "repository": "classic",
+          "path": ".github/workflows/build-release-candidate.yml",
+          "contains": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7"
+        },
+        {
+          "repository": "classic",
+          "path": ".github/workflows/check.yml",
+          "contains": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7"
+        },
+        {
+          "repository": "client",
+          "path": ".github/workflows/package-release.yml",
+          "contains": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7"
+        },
+        {
+          "repository": "devcontainer",
+          "path": ".github/workflows/validate.yml",
+          "contains": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7"
+        },
+        {
+          "repository": "editor",
+          "path": ".github/workflows/package-release.yml",
+          "contains": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7"
+        }
+      ]
+    },
+    {
+      "id": "action/codecov",
+      "name": "Codecov Action",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "atrinik",
+        "classic"
+      ],
+      "required": false,
+      "version": "v6",
+      "version_source": "Reviewed upstream major release",
+      "license": "MIT",
+      "source_url": "https://github.com/codecov/codecov-action",
+      "locator": "codecov/codecov-action",
+      "commit": "fb8b3582c8e4def4969c97caa2f19720cb33a72f",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit and authenticates with OIDC",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Retain local coverage reports while replacing or upgrading the uploader",
+      "validation": "Actionlint, selected-action policy, and non-blocking OIDC upload",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": ".github/workflows/integration.yml",
+          "contains": "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6"
+        },
+        {
+          "repository": "classic",
+          "path": ".github/workflows/check.yml",
+          "contains": "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6"
+        }
+      ]
+    },
+    {
+      "id": "action/docker-build-push",
+      "name": "Docker Build Push Action",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "classic",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "v7",
+      "version_source": "Reviewed upstream major release",
+      "license": "Apache-2.0",
+      "source_url": "https://github.com/docker/build-push-action",
+      "locator": "docker/build-push-action",
+      "commit": "53b7df96c91f9c12dcc8a07bcb9ccacbed38856a",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade image build workflows and verify both image families",
+      "validation": "Actionlint, Docker build checks, and image smoke tests",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic",
+          "path": ".github/workflows/build-release-candidate.yml",
+          "contains": "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7"
+        },
+        {
+          "repository": "classic",
+          "path": ".github/workflows/package-release.yml",
+          "contains": "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7"
+        },
+        {
+          "repository": "devcontainer",
+          "path": ".github/workflows/validate.yml",
+          "contains": "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7"
+        }
+      ]
+    },
+    {
+      "id": "action/docker-login",
+      "name": "Docker Login Action",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "classic",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "v4",
+      "version_source": "Reviewed upstream major release",
+      "license": "Apache-2.0",
+      "source_url": "https://github.com/docker/login-action",
+      "locator": "docker/login-action",
+      "commit": "dbcb813823bdd20940b903addbd779551569679f",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade all GHCR publisher jobs before the major is retired",
+      "validation": "Actionlint and least-privilege package publisher or consumer review",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic",
+          "path": ".github/workflows/build-release-candidate.yml",
+          "contains": "docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4"
+        },
+        {
+          "repository": "classic",
+          "path": ".github/workflows/package-release.yml",
+          "contains": "docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4"
+        },
+        {
+          "repository": "devcontainer",
+          "path": ".github/workflows/publish-linux.yml",
+          "contains": "docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4"
+        }
+      ]
+    },
+    {
+      "id": "action/docker-setup-buildx",
+      "name": "Docker Setup Buildx Action",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "classic",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "v4",
+      "version_source": "Reviewed upstream major release",
+      "license": "Apache-2.0",
+      "source_url": "https://github.com/docker/setup-buildx-action",
+      "locator": "docker/setup-buildx-action",
+      "commit": "bb05f3f5519dd87d3ba754cc423b652a5edd6d2c",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade alongside build-push-action and rebuild images",
+      "validation": "Actionlint and BuildKit image validation",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic",
+          "path": ".github/workflows/build-release-candidate.yml",
+          "contains": "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4"
+        },
+        {
+          "repository": "classic",
+          "path": ".github/workflows/package-release.yml",
+          "contains": "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4"
+        },
+        {
+          "repository": "devcontainer",
+          "path": ".github/workflows/validate.yml",
+          "contains": "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4"
+        }
+      ]
+    },
+    {
+      "id": "action/github-codeql-analyze",
+      "name": "GitHub CodeQL Action analyze",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "classic"
+      ],
+      "required": true,
+      "version": "v4.37.6",
+      "version_source": "Reviewed upstream release",
+      "license": "MIT",
+      "source_url": "https://github.com/github/codeql-action",
+      "locator": "github/codeql-action/analyze",
+      "commit": "5595ccaf912efad79be6eef63a5619ff05969be3",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade the advanced CodeQL workflow before the release is retired",
+      "validation": "Actionlint, advanced CodeQL analysis, and code-scanning policy",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic",
+          "path": ".github/workflows/codeql.yml",
+          "contains": "github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6"
+        }
+      ]
+    },
+    {
+      "id": "action/github-codeql-init",
+      "name": "GitHub CodeQL Action init",
+      "kind": "github-action",
+      "owner": "github-settings",
+      "scope": [
+        "classic"
+      ],
+      "required": true,
+      "version": "v4.37.6",
+      "version_source": "Reviewed upstream release",
+      "license": "MIT",
+      "source_url": "https://github.com/github/codeql-action",
+      "locator": "github/codeql-action/init",
+      "commit": "5595ccaf912efad79be6eef63a5619ff05969be3",
+      "checksum": null,
+      "acquisition": "GitHub Actions downloads the immutable reviewed commit",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot GitHub Actions update group",
+      "eol_response": "Upgrade the advanced CodeQL workflow before the release is retired",
+      "validation": "Actionlint, advanced CodeQL analysis, and code-scanning policy",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic",
+          "path": ".github/workflows/codeql.yml",
+          "contains": "github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6"
+        }
+      ]
+    },
+    {
+      "id": "container/classic-build",
+      "name": "Atrinik Classic Linux build image",
+      "kind": "container-image",
+      "owner": "devcontainer",
+      "scope": [
+        "classic",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "1.2.3",
+      "version_source": "Immutable semantic-release image tag and Classic Check digest pin",
+      "license": "LicenseRef-Atrinik-Image-Contents",
+      "source_url": "https://github.com/atrinik/devcontainer/pkgs/container/classic-build",
+      "locator": "ghcr.io/atrinik/classic-build",
+      "commit": "cfd1afd4088f76f6cd327159b0d58b20a6a6b0dd",
+      "checksum": "sha256:d0ec0a31f97fa1d699f62b81bbe697d95b335f44f1c99fde8704dfc528e2102f",
+      "acquisition": "Classic GitHub Actions anonymously pulls the public release tag at its immutable manifest digest",
+      "update_cadence_days": 30,
+      "update_mechanism": "Reviewed devcontainer candidate evidence followed by semantic release, embedded-inventory verification, and an atomic Classic digest update",
+      "eol_response": "Publish and verify a supported replacement image before advancing the Classic Check digest",
+      "validation": "Anonymous manifest inspection, OCI source/revision and embedded-inventory verification, and complete core, client, server, integrated-graph, cold-cache, and restored-cache validation",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic",
+          "path": ".github/workflows/check.yml",
+          "contains": "ghcr.io/atrinik/classic-build:1.2.3@sha256:d0ec0a31f97fa1d699f62b81bbe697d95b335f44f1c99fde8704dfc528e2102f"
+        },
+        {
+          "repository": "devcontainer",
+          "path": "classic-toolchain.json",
+          "contains": "\"repository\": \"atrinik/classic\""
+        }
+      ]
+    },
+    {
+      "id": "container/classic-dependencies",
+      "name": "Atrinik Classic durable dependency bundle",
+      "kind": "container-image",
+      "owner": "classic-server",
+      "scope": [
+        "classic",
+        "classic-client",
+        "classic-server"
+      ],
+      "required": true,
+      "version": "materials-5d3ac9ea4b5b5fd8a34352cf39aacaab3144a91f99f2de9c15e68007496acb65",
+      "version_source": "Classic dependencies.bundle.json material digest",
+      "license": "LicenseRef-Atrinik-Image-Contents",
+      "source_url": "https://github.com/atrinik/classic/pkgs/container/classic-dependencies",
+      "locator": "ghcr.io/atrinik/classic-dependencies@sha256:036fb758e18c7995e3869d391f75c9995e1d643ee167f4a933b1336138fbe58a",
+      "commit": null,
+      "checksum": "sha256:036fb758e18c7995e3869d391f75c9995e1d643ee167f4a933b1336138fbe58a",
+      "acquisition": "A trusted current-main workflow builds the deterministic OCI layout through the authoritative Classic fetcher and publishes its exact manifest digest",
+      "update_cadence_days": 30,
+      "update_mechanism": "Reviewed Classic lock or acquisition-contract update with a regenerated material and OCI descriptor",
+      "eol_response": "Retain every digest referenced by a supported release; publish and pin a verified replacement before retiring a bundle",
+      "validation": "GitHub-signed OCI attestation, outer OCI digest, closed manifest and materials statement, source-lock/material digests, exact archive set, sizes, inner SHA-256 values, offline consumer isolation contracts, and negative corruption tests",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic",
+          "path": ".github/workflows/publish-dependency-bundle.yml",
+          "contains": "Publish exact verified OCI layout"
+        },
+        {
+          "repository": "classic",
+          "path": "dependencies.bundle.json",
+          "contains": "sha256:036fb758e18c7995e3869d391f75c9995e1d643ee167f4a933b1336138fbe58a"
+        },
+        {
+          "repository": "classic",
+          "path": "tools/release/dependency_bundle.py",
+          "contains": "ghcr.io/atrinik/classic-dependencies"
+        }
+      ]
+    },
+    {
+      "id": "container/classic-server",
+      "name": "Atrinik Classic server image",
+      "kind": "container-image",
+      "owner": "classic-server",
+      "scope": [
+        "classic"
+      ],
+      "required": true,
+      "version": "semantic-release version and generated immutable digest",
+      "version_source": "Root Classic release workflows",
+      "license": "LicenseRef-Atrinik-Image-Contents",
+      "source_url": "https://github.com/atrinik/classic/pkgs/container/classic-server",
+      "locator": "ghcr.io/atrinik/classic-server",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "The root release workflow verifies the durable dependency-bundle digest, builds server/Dockerfile offline from its inner archives, and publishes the version tag with provenance and an SBOM",
+      "update_cadence_days": 30,
+      "update_mechanism": "Classic Dockerfile and release-workflow review with every dependency update",
+      "eol_response": "Publish a rebuilt supported image before retiring the current server image line",
+      "validation": "Read-only offline release-candidate image build plus dependency-bundle, production digest, provenance, and SBOM checks",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic",
+          "path": ".github/workflows/build-release-candidate.yml",
+          "contains": "file: server/Dockerfile"
+        },
+        {
+          "repository": "classic",
+          "path": ".github/workflows/package-release.yml",
+          "contains": "tags: ghcr.io/atrinik/classic-server:${{ needs.candidate.outputs.version }}"
+        }
+      ]
+    },
+    {
+      "id": "container/devcontainer-docker-feature",
+      "name": "Dev Container Docker-in-Docker feature",
+      "kind": "container-feature",
+      "owner": "atrinik",
+      "scope": [
+        "atrinik"
+      ],
+      "required": true,
+      "version": "4.0.0",
+      "version_source": ".devcontainer/devcontainer-lock.json",
+      "license": "MIT",
+      "source_url": "https://github.com/devcontainers/features",
+      "locator": "ghcr.io/devcontainers/features/docker-in-docker",
+      "commit": null,
+      "checksum": "sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5",
+      "acquisition": "Dev Containers resolves the checksum-locked OCI feature",
+      "update_cadence_days": 30,
+      "update_mechanism": "devcontainer lock refresh followed by Docker smoke validation",
+      "eol_response": "Upgrade the feature or remove nested Docker support",
+      "validation": "Lock digest audit and devcontainer configuration tests",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": ".devcontainer/devcontainer-lock.json",
+          "contains": "ghcr.io/devcontainers/features/docker-in-docker@sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5"
+        },
+        {
+          "repository": "atrinik",
+          "path": ".devcontainer/devcontainer.json",
+          "contains": "ghcr.io/devcontainers/features/docker-in-docker:4"
+        }
+      ]
+    },
+    {
+      "id": "container/docker-dind",
+      "name": "Docker-in-Docker daemon image",
+      "kind": "container-image",
+      "owner": "devcontainer",
+      "scope": [
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "27.5.1-dind",
+      "version_source": "Docker Official Images manifest",
+      "license": "Apache-2.0",
+      "source_url": "https://github.com/docker-library/docker",
+      "locator": "docker.io/library/docker",
+      "commit": null,
+      "checksum": "sha256:aa3df78ecf320f5fafdce71c659f1629e96e9de0968305fe1de670e0ca9176ce",
+      "acquisition": "The Classic Check measurement harness pulls the immutable manifest and creates one isolated daemon per trial",
+      "update_cadence_days": 30,
+      "update_mechanism": "Weekly inventory audit plus reviewed measurement-harness update",
+      "eol_response": "Advance the harness to a supported stable Docker daemon before upstream support ends",
+      "validation": "Four counterbalanced fresh-daemon pull trials with owned-container and anonymous-volume cleanup checks",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "tools/measure-classic-check-images.sh",
+          "contains": "docker:27.5.1-dind@sha256:aa3df78ecf320f5fafdce71c659f1629e96e9de0968305fe1de670e0ca9176ce"
+        }
+      ]
+    },
+    {
+      "id": "container/docker-registry",
+      "name": "Docker Distribution registry image",
+      "kind": "container-image",
+      "owner": "devcontainer",
+      "scope": [
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "2.8.3",
+      "version_source": "Docker Official Images manifest",
+      "license": "Apache-2.0",
+      "source_url": "https://github.com/distribution/distribution",
+      "locator": "docker.io/library/registry",
+      "commit": null,
+      "checksum": "sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373",
+      "acquisition": "The Classic Check measurement harness pulls the immutable manifest for an invocation-scoped loopback registry",
+      "update_cadence_days": 30,
+      "update_mechanism": "Weekly inventory audit plus reviewed measurement-harness update",
+      "eol_response": "Advance the harness to a supported stable Distribution registry before upstream support ends",
+      "validation": "Four-trial pull measurement with loopback-only exposure and owned-container, tag, network, and volume cleanup checks",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "tools/measure-classic-check-images.sh",
+          "contains": "registry:2.8.3@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373"
+        }
+      ]
+    },
+    {
+      "id": "container/dockerfile-frontend",
+      "name": "Dockerfile frontend",
+      "kind": "container-image",
+      "owner": "devcontainer",
+      "scope": [
+        "classic-server",
+        "devcontainer",
+        "sound"
+      ],
+      "required": true,
+      "version": "1",
+      "version_source": "Docker Hub manifest",
+      "license": "Apache-2.0",
+      "source_url": "https://github.com/moby/buildkit",
+      "locator": "docker.io/docker/dockerfile",
+      "commit": null,
+      "checksum": "sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89",
+      "acquisition": "BuildKit pulls the Dockerfile syntax frontend by immutable manifest digest",
+      "update_cadence_days": 30,
+      "update_mechanism": "Dependabot Docker update with both image validations",
+      "eol_response": "Advance to a supported stable Dockerfile frontend before removing old syntax support",
+      "validation": "Docker build checks plus Linux and Windows image builds",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic-server",
+          "path": "Dockerfile",
+          "contains": "docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89"
+        },
+        {
+          "repository": "devcontainer",
+          "path": "linux/Dockerfile",
+          "contains": "docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89"
+        },
+        {
+          "repository": "devcontainer",
+          "path": "windows/Dockerfile",
+          "contains": "docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89"
+        },
+        {
+          "repository": "sound",
+          "path": "tools/audio/Dockerfile",
+          "contains": "docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89"
+        }
+      ]
+    },
+    {
+      "id": "container/linux-build",
+      "name": "Atrinik Linux build image",
+      "kind": "container-image",
+      "owner": "devcontainer",
+      "scope": [
+        "atrinik"
+      ],
+      "required": true,
+      "version": "1.3.0",
+      "version_source": "Immutable semantic-release image tag",
+      "license": "LicenseRef-Atrinik-Image-Contents",
+      "source_url": "https://github.com/atrinik/devcontainer/pkgs/container/linux-build",
+      "locator": "ghcr.io/atrinik/linux-build",
+      "commit": "b4df04bf5b47a8f5d24e0783efd2c16c5e809f38",
+      "checksum": "sha256:260658d2709e993b41148a9d8f724c2d2f7f1fd93543a139b00d139b10e7f31a",
+      "acquisition": "Dev Containers pulls the release tag and immutable manifest digest",
+      "update_cadence_days": 30,
+      "update_mechanism": "Weekly audit plus reviewed devcontainer release update",
+      "eol_response": "Publish a supported replacement image and update the wrapper atomically",
+      "validation": "Anonymous manifest and provenance inspection, whole-image SBOM, exact non-root gh-stack smoke, devcontainer configuration tests, and complete native build",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": ".devcontainer/devcontainer.json",
+          "contains": "ghcr.io/atrinik/linux-build:1.3.0@sha256:260658d2709e993b41148a9d8f724c2d2f7f1fd93543a139b00d139b10e7f31a"
+        }
+      ]
+    },
+    {
+      "id": "container/linux-build-sound",
+      "name": "Atrinik Linux audio build image",
+      "kind": "container-image",
+      "owner": "devcontainer",
+      "scope": [
+        "sound"
+      ],
+      "required": true,
+      "version": "1.2.0",
+      "version_source": "sound/manifests/audio-toolchain.json",
+      "license": "LicenseRef-Atrinik-Image-Contents",
+      "source_url": "https://github.com/atrinik/devcontainer/pkgs/container/linux-build",
+      "locator": "ghcr.io/atrinik/linux-build",
+      "commit": "66b8508434044ca50822558172c5cef47a888762",
+      "checksum": "sha256:1231b39d40161c1199fd3e45e99e3d826dde02dade79729c030cc0ce3710898f",
+      "acquisition": "The sound pipeline pulls the immutable devcontainer release image by manifest digest",
+      "update_cadence_days": 30,
+      "update_mechanism": "Reviewed audio-toolchain manifest update with deterministic fixture rebuild",
+      "eol_response": "Move the audio pipeline to a supported devcontainer release and rebuild all fixtures",
+      "validation": "Source commit/release/digest manifest validation, image probe, and reproducible sound fixtures",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "sound",
+          "path": "manifests/audio-toolchain.json",
+          "contains": "66b8508434044ca50822558172c5cef47a888762"
+        },
+        {
+          "repository": "sound",
+          "path": "tools/audio/Dockerfile",
+          "contains": "ghcr.io/atrinik/linux-build@sha256:1231b39d40161c1199fd3e45e99e3d826dde02dade79729c030cc0ce3710898f"
+        }
+      ]
+    },
+    {
+      "id": "container/microsoft-devcontainer-base",
+      "name": "Microsoft Dev Containers Debian base",
+      "kind": "container-image",
+      "owner": "devcontainer",
+      "scope": [
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "bookworm",
+      "version_source": "Microsoft Container Registry manifest",
+      "license": "LicenseRef-Microsoft-Dev-Container",
+      "source_url": "https://github.com/devcontainers/images",
+      "locator": "mcr.microsoft.com/devcontainers/base",
+      "commit": null,
+      "checksum": "sha256:73d85a96694a2cadca1ba3fcb5721f2312a64f1d571dd86f6c77e10a708931dc",
+      "acquisition": "BuildKit pulls the named base and immutable manifest digest",
+      "update_cadence_days": 30,
+      "update_mechanism": "Dependabot Docker update with cold MXE build review",
+      "eol_response": "Move the Windows toolchain image to the next supported Debian base",
+      "validation": "Docker build check and Windows image smoke build",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "windows/Dockerfile",
+          "contains": "mcr.microsoft.com/devcontainers/base:bookworm@sha256:73d85a96694a2cadca1ba3fcb5721f2312a64f1d571dd86f6c77e10a708931dc"
+        }
+      ]
+    },
+    {
+      "id": "container/ubuntu-26.04",
+      "name": "Ubuntu 26.04 base image",
+      "kind": "container-image",
+      "owner": "devcontainer",
+      "scope": [
+        "classic-server",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "26.04",
+      "version_source": "Docker Official Images manifest",
+      "license": "LicenseRef-Ubuntu-Archive",
+      "source_url": "https://hub.docker.com/_/ubuntu",
+      "locator": "docker.io/library/ubuntu",
+      "commit": null,
+      "checksum": "sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7a03",
+      "acquisition": "BuildKit pulls the LTS tag and immutable multi-platform manifest digest",
+      "update_cadence_days": 30,
+      "update_mechanism": "Dependabot Docker update followed by Linux and classic server image builds",
+      "eol_response": "Move all consumers to the next supported Ubuntu LTS before standard support ends",
+      "validation": "Docker build checks, native tests, and classic server startup smoke test",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic-server",
+          "path": "Dockerfile",
+          "contains": "ubuntu@sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7a03"
+        },
+        {
+          "repository": "devcontainer",
+          "path": "linux/Dockerfile",
+          "contains": "ubuntu:26.04@sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7a03"
+        }
+      ]
+    },
+    {
+      "id": "container/windows-build",
+      "name": "Atrinik Windows build image",
+      "kind": "container-image",
+      "owner": "devcontainer",
+      "scope": [
+        "atrinik",
+        "classic"
+      ],
+      "required": true,
+      "version": "1.2.1",
+      "version_source": "Immutable semantic-release image tag",
+      "license": "LicenseRef-Atrinik-Image-Contents",
+      "source_url": "https://github.com/atrinik/devcontainer/pkgs/container/windows-build",
+      "locator": "ghcr.io/atrinik/windows-build",
+      "commit": null,
+      "checksum": "sha256:d1f082eb28891600a9cf018a1d4310b9f3e1f985f82139fa48fbd4ac77b623bb",
+      "acquisition": "Dev Containers and GitHub Actions anonymously pull the public release tag and immutable manifest digest",
+      "update_cadence_days": 30,
+      "update_mechanism": "Weekly audit plus reviewed devcontainer release update",
+      "eol_response": "Publish a supported replacement image and update the wrapper atomically",
+      "validation": "Anonymous manifest inspection, devcontainer configuration tests, portable MinGW builds, and cross-built tests executed on native Windows",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": ".devcontainer/windows-cross/devcontainer.json",
+          "contains": "ghcr.io/atrinik/windows-build:1.2.1@sha256:d1f082eb28891600a9cf018a1d4310b9f3e1f985f82139fa48fbd4ac77b623bb"
+        },
+        {
+          "repository": "classic",
+          "path": ".github/workflows/build-release-candidate.yml",
+          "contains": "ghcr.io/atrinik/windows-build:1.2.1@sha256:d1f082eb28891600a9cf018a1d4310b9f3e1f985f82139fa48fbd4ac77b623bb"
+        },
+        {
+          "repository": "classic",
+          "path": ".github/workflows/check.yml",
+          "contains": "ghcr.io/atrinik/windows-build:1.2.1@sha256:d1f082eb28891600a9cf018a1d4310b9f3e1f985f82139fa48fbd4ac77b623bb"
+        }
+      ]
+    },
+    {
+      "id": "external/content-assets",
+      "name": "Authored content asset licenses",
+      "kind": "external-tool",
+      "owner": "content",
+      "scope": [
+        "content"
+      ],
+      "required": true,
+      "version": "per-file",
+      "version_source": "Nearest tracked LICENSE/COPYING file",
+      "license": "LicenseRef-Atrinik-Asset-Per-File",
+      "source_url": "https://github.com/atrinik/content",
+      "locator": "atrinik-content-assets",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Reviewed authored/imported assets retain source-local attribution",
+      "update_cadence_days": 90,
+      "update_mechanism": "Content license validator and review of every imported asset",
+      "eol_response": "Remove assets whose provenance or redistribution grant cannot be maintained",
+      "validation": "arch/license_check.py and deterministic content packaging",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "content",
+          "path": "arch/license_check.py",
+          "contains": "LICENSE"
+        }
+      ]
+    },
+    {
+      "id": "external/crates-io",
+      "name": "crates.io registry publication and distribution",
+      "kind": "external-tool",
+      "owner": "protocol",
+      "scope": ["protocol"],
+      "required": true,
+      "version": "API v1; atrinik-protocol 0.1.0 canonical registry object",
+      "version_source": "Protocol registry/release policies and immutable v1.4.0 release provenance",
+      "license": "NOASSERTION",
+      "source_url": "https://crates.io/",
+      "locator": "pkg:cargo/atrinik-protocol@0.1.0",
+      "commit": null,
+      "checksum": "sha256:413c4da6c1b304d4a622065efe0d36c3f591041972f1a5ee76c538926f3c0b6b",
+      "acquisition": "Consumers acquire the immutable checksummed crate from crates.io; future publication remains disabled until a separately reviewed Trusted Publishing activation",
+      "update_cadence_days": 30,
+      "update_mechanism": "Review a new policy-owned crate release, exact GitHub OIDC identity, protected environment, and short-lived Trusted Publishing workflow before activation",
+      "eol_response": "Stop registry publication and consumer rollout if ownership, integrity, availability, or supported Cargo compatibility cannot be maintained",
+      "validation": "Fail-closed post-bootstrap policy, offline package reproduction, GitHub release provenance and SHA-256 checks, and public crates.io checksum verification",
+      "disposition": "retain",
+      "packages": ["atrinik-protocol"],
+      "evidence": [
+        {
+          "repository": "protocol",
+          "path": "crates/atrinik-protocol/Cargo.toml",
+          "contains": "publish = [\"crates-io\"]"
+        },
+        {
+          "repository": "protocol",
+          "path": "policy/rust-crate-publishing.json",
+          "contains": "413c4da6c1b304d4a622065efe0d36c3f591041972f1a5ee76c538926f3c0b6b"
+        },
+        {
+          "repository": "protocol",
+          "path": "policy/rust-crate-publishing.json",
+          "contains": "disabled-until-reviewed-activation"
+        },
+        {
+          "repository": "protocol",
+          "path": "tools/check-crate-release-policy.py",
+          "contains": "Rust registry publication is not activated"
+        }
+      ]
+    },
+    {
+      "id": "external/gridarta",
+      "name": "Gridarta source checkout",
+      "kind": "external-tool",
+      "owner": "classic-editor",
+      "scope": [
+        "classic-editor"
+      ],
+      "required": false,
+      "version": "operator-supplied-reviewed-checkout",
+      "version_source": "Explicit build.sh positional checkout",
+      "license": "GPL-2.0-only",
+      "source_url": "https://github.com/gridarta/gridarta",
+      "locator": "gridarta",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Operator supplies a separate checkout; Atrinik never downloads or mutates it",
+      "update_cadence_days": 180,
+      "update_mechanism": "Manual compatibility review for the classic editor",
+      "eol_response": "Retire this packaging path through atrinik/content#5 rather than vendoring Gridarta",
+      "validation": "Disposable Gradle fixture and expected AtrinikEditor.jar contract",
+      "disposition": "remove",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic-editor",
+          "path": "build.sh",
+          "contains": "./gradlew clean :src:atrinik:preparePublish"
+        }
+      ]
+    },
+    {
+      "id": "external/pyqt5",
+      "name": "PyQt5",
+      "kind": "external-tool",
+      "owner": "tools",
+      "scope": [
+        "tools"
+      ],
+      "required": false,
+      "version": "5.x operator-supplied",
+      "version_source": "Classic Qt map-checker runtime",
+      "license": "GPL-3.0-only",
+      "source_url": "https://www.riverbankcomputing.com/software/pyqt/",
+      "locator": "pkg:pypi/PyQt5",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Optional operator-managed Python environment",
+      "update_cadence_days": 90,
+      "update_mechanism": "Manual GUI compatibility review pending the atrinik/editor replacement",
+      "eol_response": "Port or retire the GUI rather than pinning an unsupported Python/Qt stack",
+      "validation": "Headless map-checker tests plus explicit GUI smoke test",
+      "disposition": "replace",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "tools",
+          "path": "map-checker-qt/ui/window_main.py",
+          "contains": "from PyQt5"
+        }
+      ]
+    },
+    {
+      "id": "external/resource-assets",
+      "name": "Server resource asset licenses",
+      "kind": "external-tool",
+      "owner": "resources",
+      "scope": [
+        "resources"
+      ],
+      "required": true,
+      "version": "per-file",
+      "version_source": "Nearest tracked LICENSE file",
+      "license": "LicenseRef-Atrinik-Asset-Per-File",
+      "source_url": "https://github.com/atrinik/resources",
+      "locator": "atrinik-resource-assets",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Reviewed assets retain source-local attribution",
+      "update_cadence_days": 90,
+      "update_mechanism": "Release allowlist and license review",
+      "eol_response": "Remove assets whose provenance or redistribution grant cannot be maintained",
+      "validation": "Deterministic resource archive and required license checks",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "resources",
+          "path": "runtime-paths.txt",
+          "contains": "paintings"
+        }
+      ]
+    },
+    {
+      "id": "external/sound-assets",
+      "name": "Music and sound-effect licenses",
+      "kind": "external-tool",
+      "owner": "sound",
+      "scope": [
+        "sound"
+      ],
+      "required": true,
+      "version": "per-file",
+      "version_source": "Nearest tracked LICENSE file",
+      "license": "LicenseRef-Atrinik-Asset-Per-File",
+      "source_url": "https://github.com/atrinik/sound",
+      "locator": "atrinik-sound-assets",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Reviewed audio retains source-local attribution",
+      "update_cadence_days": 90,
+      "update_mechanism": "Release package and license review",
+      "eol_response": "Remove audio whose provenance or redistribution grant cannot be maintained",
+      "validation": "Deterministic sound archive and required license checks",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "sound",
+          "path": "effects/LICENSE",
+          "contains": "GNU GPL 2.0"
+        }
+      ]
+    },
+    {
+      "id": "language/classic-conventional-changelog",
+      "name": "Classic Conventional Commits changelog preset",
+      "kind": "language-package-set",
+      "owner": "atrinik",
+      "scope": [
+        "atrinik",
+        "classic",
+        "playtester"
+      ],
+      "required": true,
+      "version": "9.3.1",
+      "version_source": "Exact npx package arguments in release workflows",
+      "license": "ISC",
+      "source_url": "https://github.com/conventional-changelog/conventional-changelog",
+      "locator": "pkg:npm/conventional-changelog-conventionalcommits@9.3.1",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "npx installs the exact reviewed package version for release analysis",
+      "update_cadence_days": 30,
+      "update_mechanism": "Scheduled release-tool review with exact workflow evidence",
+      "eol_response": "Upgrade or replace the preset before it loses supported Node compatibility",
+      "validation": "Semantic-release dry runs and exact next-version tests",
+      "disposition": "retain",
+      "packages": [
+        "conventional-changelog-conventionalcommits"
+      ],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": ".github/workflows/release.yml",
+          "contains": "--package=conventional-changelog-conventionalcommits@9.3.1"
+        },
+        {
+          "repository": "classic",
+          "path": ".github/workflows/release.yml",
+          "contains": "--package=conventional-changelog-conventionalcommits@9.3.1"
+        },
+        {
+          "repository": "playtester",
+          "path": ".github/workflows/release.yml",
+          "contains": "--package=conventional-changelog-conventionalcommits@9.3.1"
+        }
+      ]
+    },
+    {
+      "id": "language/classic-semantic-release",
+      "name": "Classic semantic-release",
+      "kind": "language-package-set",
+      "owner": "atrinik",
+      "scope": [
+        "atrinik",
+        "classic",
+        "playtester"
+      ],
+      "required": true,
+      "version": "25.0.9",
+      "version_source": "Exact npx package arguments in release workflows",
+      "license": "MIT",
+      "source_url": "https://github.com/semantic-release/semantic-release",
+      "locator": "pkg:npm/semantic-release@25.0.9",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "npx installs the exact reviewed package version for release analysis",
+      "update_cadence_days": 30,
+      "update_mechanism": "Scheduled release-tool review with exact workflow evidence",
+      "eol_response": "Upgrade semantic-release before its Node line or release contract reaches EOL",
+      "validation": "Semantic-release dry runs and exact next-version tests",
+      "disposition": "retain",
+      "packages": [
+        "semantic-release"
+      ],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": ".github/workflows/release.yml",
+          "contains": "--package=semantic-release@25.0.9"
+        },
+        {
+          "repository": "classic",
+          "path": ".github/workflows/release.yml",
+          "contains": "--package=semantic-release@25.0.9"
+        },
+        {
+          "repository": "playtester",
+          "path": ".github/workflows/release.yml",
+          "contains": "--package=semantic-release@25.0.9"
+        },
+        {
+          "repository": "playtester",
+          "path": ".releaserc.json",
+          "contains": "\"@semantic-release/github\""
+        }
+      ]
+    },
+    {
+      "id": "language/classic-semantic-release-commit-analyzer",
+      "name": "Classic semantic-release commit analyzer",
+      "kind": "language-package-set",
+      "owner": "atrinik",
+      "scope": [
+        "classic"
+      ],
+      "required": true,
+      "version": "13.0.1",
+      "version_source": "Exact npx package arguments in Classic release workflows",
+      "license": "MIT",
+      "source_url": "https://github.com/semantic-release/commit-analyzer",
+      "locator": "pkg:npm/%40semantic-release/commit-analyzer@13.0.1",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "npx installs the exact reviewed package version for first-parent release analysis",
+      "update_cadence_days": 30,
+      "update_mechanism": "Scheduled release-tool review with exact workflow evidence",
+      "eol_response": "Upgrade or replace the analyzer before it loses semantic-release compatibility",
+      "validation": "Synthetic side-parent tests and full Classic graph release analysis",
+      "disposition": "retain",
+      "packages": [
+        "@semantic-release/commit-analyzer"
+      ],
+      "evidence": [
+        {
+          "repository": "classic",
+          "path": ".github/workflows/release.yml",
+          "contains": "--package=@semantic-release/commit-analyzer@13.0.1"
+        }
+      ]
+    },
+    {
+      "id": "language/classic-semantic-release-exec",
+      "name": "Classic semantic-release exec plugin",
+      "kind": "language-package-set",
+      "owner": "atrinik",
+      "scope": [
+        "atrinik",
+        "classic"
+      ],
+      "required": true,
+      "version": "7.1.0",
+      "version_source": "Exact npx package arguments in release workflows",
+      "license": "MIT",
+      "source_url": "https://github.com/semantic-release/exec",
+      "locator": "pkg:npm/%40semantic-release/exec@7.1.0",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "npx installs the exact reviewed package version for release execution",
+      "update_cadence_days": 30,
+      "update_mechanism": "Scheduled release-tool review with exact workflow evidence",
+      "eol_response": "Upgrade or replace the exec plugin before it loses semantic-release compatibility",
+      "validation": "Semantic-release dry runs and exact next-version tests",
+      "disposition": "retain",
+      "packages": [
+        "@semantic-release/exec"
+      ],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": ".github/workflows/release.yml",
+          "contains": "--package=@semantic-release/exec@7.1.0"
+        },
+        {
+          "repository": "classic",
+          "path": ".github/workflows/release.yml",
+          "contains": "--package=@semantic-release/exec@7.1.0"
+        }
+      ]
+    },
+    {
+      "id": "language/classic-semantic-release-notes-generator",
+      "name": "Classic semantic-release notes generator",
+      "kind": "language-package-set",
+      "owner": "atrinik",
+      "scope": [
+        "classic"
+      ],
+      "required": true,
+      "version": "14.1.1",
+      "version_source": "Exact npx package arguments in Classic release workflows",
+      "license": "MIT",
+      "source_url": "https://github.com/semantic-release/release-notes-generator",
+      "locator": "pkg:npm/%40semantic-release/release-notes-generator@14.1.1",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "npx installs the exact reviewed package version for automatic and recovery notes",
+      "update_cadence_days": 30,
+      "update_mechanism": "Scheduled release-tool review with exact workflow evidence",
+      "eol_response": "Upgrade or replace the generator before it loses semantic-release compatibility",
+      "validation": "Byte-identical automatic and recovery first-parent release-note tests",
+      "disposition": "retain",
+      "packages": [
+        "@semantic-release/release-notes-generator"
+      ],
+      "evidence": [
+        {
+          "repository": "classic",
+          "path": ".github/workflows/recover-release.yml",
+          "contains": "--package=@semantic-release/release-notes-generator@14.1.1"
+        }
+      ]
+    },
+    {
+      "id": "language/deploy-control-npm",
+      "name": "Deploy-control Worker and agent npm dependency graph",
+      "kind": "language-package-set",
+      "owner": "deploy-control",
+      "scope": [
+        "deploy-control"
+      ],
+      "required": true,
+      "version": "lockfileVersion-3",
+      "version_source": "package-lock.json",
+      "license": "NOASSERTION",
+      "source_url": "https://www.npmjs.com/",
+      "locator": "pkg:npm/atrinik-deploy-control@0.1.0",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "npm ci installs the exact package-lock graph",
+      "update_cadence_days": 7,
+      "update_mechanism": "Grouped Dependabot npm development and production updates",
+      "eol_response": "Upgrade incompatible packages on the supported Node line or replace them",
+      "validation": "npm ci, TypeScript checks, Vitest, and Wrangler dry-run validation",
+      "disposition": "retain",
+      "packages": [
+        "@types/node",
+        "typescript",
+        "vitest",
+        "wrangler"
+      ],
+      "evidence": [
+        {
+          "repository": "deploy-control",
+          "path": ".github/dependabot.yml",
+          "contains": "package-ecosystem: npm"
+        },
+        {
+          "repository": "deploy-control",
+          "path": "package-lock.json",
+          "contains": "\"lockfileVersion\": 3"
+        },
+        {
+          "repository": "deploy-control",
+          "path": "package.json",
+          "contains": "\"name\": \"atrinik-deploy-control\""
+        },
+        {
+          "repository": "deploy-control",
+          "path": "package.json",
+          "contains": "\"wrangler\": \"4.123.0\""
+        }
+      ]
+    },
+    {
+      "id": "language/metaserver-npm",
+      "name": "Metaserver Worker npm dependency graph",
+      "kind": "language-package-set",
+      "owner": "metaserver-worker",
+      "scope": [
+        "metaserver-worker"
+      ],
+      "required": true,
+      "version": "lockfileVersion-3",
+      "version_source": "package-lock.json",
+      "license": "NOASSERTION",
+      "source_url": "https://www.npmjs.com/",
+      "locator": "pkg:npm/atrinik-metaserver@1.0.0",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "npm ci installs the exact package-lock graph",
+      "update_cadence_days": 7,
+      "update_mechanism": "Grouped Dependabot npm development and production updates",
+      "eol_response": "Upgrade incompatible packages on the supported Node line or replace them",
+      "validation": "npm ci, type checks, Vitest, admin tests, and Wrangler dry run",
+      "disposition": "retain",
+      "packages": [
+        "@cloudflare/vitest-pool-workers",
+        "@types/node",
+        "@types/tr46",
+        "punycode",
+        "tr46",
+        "tsx",
+        "typescript",
+        "vitest",
+        "wrangler"
+      ],
+      "evidence": [
+        {
+          "repository": "metaserver-worker",
+          "path": ".github/dependabot.yml",
+          "contains": "dependency-type: production"
+        },
+        {
+          "repository": "metaserver-worker",
+          "path": "deployment/review-check/package.json",
+          "contains": "\"private\": true"
+        },
+        {
+          "repository": "metaserver-worker",
+          "path": "package-lock.json",
+          "contains": "\"lockfileVersion\": 3"
+        },
+        {
+          "repository": "metaserver-worker",
+          "path": "package.json",
+          "contains": "\"tr46\": \"6.0.0\""
+        },
+        {
+          "repository": "metaserver-worker",
+          "path": "package.json",
+          "contains": "\"wrangler\": \"4.123.0\""
+        }
+      ]
+    },
+    {
+      "id": "language/playtester-python",
+      "name": "Playtester Python package graph",
+      "kind": "language-package-set",
+      "owner": "playtester",
+      "scope": ["playtester"],
+      "required": true,
+      "version": "Python>=3.11; scikit-build-core>=0.10; aioquic>=1.2",
+      "version_source": "pyproject.toml",
+      "license": "NOASSERTION",
+      "source_url": "https://pypi.org/",
+      "locator": "pkg:pypi/atrinik-playtester@0.1.0",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Python build isolation and optional operator environment install declared packages",
+      "update_cadence_days": 30,
+      "update_mechanism": "Dependabot pip review and playtester build/test validation",
+      "eol_response": "Upgrade or replace the playtester package dependency before EOL",
+      "validation": "CMake strict build, native/Python tests, compileall, and loopback security checks",
+      "disposition": "retain",
+      "packages": ["aioquic", "atrinik-protocol", "scikit-build-core"],
+      "evidence": [
+        {"repository":"playtester","path":"pyproject.toml","contains":"scikit-build-core>=0.10"}
+      ]
+    },
+    {
+      "id": "language/protocol-python-build",
+      "name": "Protocol Python build toolchain",
+      "kind": "language-package-set",
+      "owner": "classic-protocol",
+      "scope": [
+        "classic",
+        "classic-protocol"
+      ],
+      "required": true,
+      "version": "setuptools>=77; setuptools-scm>=8,<11; build=1.3.0",
+      "version_source": "pyproject.toml and workflows",
+      "license": "MIT",
+      "source_url": "https://pypi.org/project/build/",
+      "locator": "pkg:pypi/build@1.3.0",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "pip build isolation plus an exact wheel frontend version",
+      "update_cadence_days": 30,
+      "update_mechanism": "Dependabot pip updates with wheel reproducibility tests",
+      "eol_response": "Move to supported PyPA build backends before current versions expire",
+      "validation": "Generated-binding check, unit tests, and wheel build",
+      "disposition": "retain",
+      "packages": [
+        "build",
+        "setuptools",
+        "setuptools-scm"
+      ],
+      "evidence": [
+        {
+          "repository": "classic",
+          "path": ".github/workflows/build-release-candidate.yml",
+          "contains": "python3 -m pip install build==1.3.0"
+        },
+        {
+          "repository": "classic-protocol",
+          "path": "pyproject.toml",
+          "contains": "setuptools-scm>=8,<11"
+        }
+      ]
+    },
+    {
+      "id": "language/replacement-client-cargo",
+      "name": "Replacement client Cargo dependency graph",
+      "kind": "language-package-set",
+      "owner": "client",
+      "scope": ["client"],
+      "required": true,
+      "version": "Cargo.lock-v4",
+      "version_source": "Cargo.lock, workspace manifests, and policy/dependencies.json",
+      "license": "NOASSERTION",
+      "source_url": "https://crates.io/",
+      "locator": "pkg:cargo/atrinik-client@0.1.0",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Cargo installs the exact locked graph, including the released Atrinik protocol crate; CI builds SDL from the locked crate source",
+      "update_cadence_days": 7,
+      "update_mechanism": "Grouped Dependabot Cargo updates plus monthly policy review",
+      "eol_response": "Upgrade, replace, or remove unsupported crates before release",
+      "validation": "cargo metadata, locked build/test/Clippy, protocol fixture checks, cargo-deny, Linux/Windows validation, and Syft SBOM",
+      "disposition": "retain",
+      "packages": ["atrinik-protocol", "httpdate", "sdl3", "sha2", "ureq"],
+      "evidence": [
+        {"repository":"client","path":"Cargo.lock","contains":"version = 4"},
+        {"repository":"client","path":"Cargo.toml","contains":"[workspace]"},
+        {"repository":"client","path":"crates/atrinik-actions/Cargo.toml","contains":"name = \"atrinik-actions\""},
+        {"repository":"client","path":"crates/atrinik-client/Cargo.toml","contains":"name = \"atrinik-client\""},
+        {"repository":"client","path":"crates/atrinik-config-cache/Cargo.toml","contains":"name = \"atrinik-config-cache\""},
+        {"repository":"client","path":"crates/atrinik-directory/Cargo.toml","contains":"name = \"atrinik-directory\""},
+        {"repository":"client","path":"crates/atrinik-platform/Cargo.toml","contains":"name = \"atrinik-platform\""},
+        {"repository":"client","path":"crates/atrinik-protocol-adapter/Cargo.toml","contains":"name = \"atrinik-protocol-adapter\""},
+        {"repository":"client","path":"crates/atrinik-scene-adapter/Cargo.toml","contains":"name = \"atrinik-scene-adapter\""},
+        {"repository":"client","path":"crates/atrinik-session/Cargo.toml","contains":"name = \"atrinik-session\""},
+        {"repository":"client","path":"crates/atrinik-testkit/Cargo.toml","contains":"name = \"atrinik-testkit\""},
+        {"repository":"client","path":"crates/atrinik-ui-model/Cargo.toml","contains":"name = \"atrinik-ui-model\""},
+        {"repository":"client","path":"deny.toml","contains":"[licenses]"},
+        {"repository":"client","path":"policy/dependencies.json","contains":"\"owner\": \"client maintainers\""},
+        {"repository":"client","path":"rust-toolchain.toml","contains":"channel = \"1.97.1\""}
+      ]
+    },
+    {
+      "id": "language/replacement-content-toolkit-cargo",
+      "name": "Replacement content-toolkit Cargo dependency graph",
+      "kind": "language-package-set",
+      "owner": "content-toolkit",
+      "scope": ["content-toolkit"],
+      "required": true,
+      "version": "Cargo.lock-v4",
+      "version_source": "Cargo.lock, workspace manifests, and policy/dependencies.json",
+      "license": "NOASSERTION",
+      "source_url": "https://crates.io/",
+      "locator": "pkg:cargo/atrinik-content@0.1.0",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Cargo installs the exact locked graph",
+      "update_cadence_days": 7,
+      "update_mechanism": "Grouped Dependabot Cargo updates plus monthly policy review",
+      "eol_response": "Upgrade, replace, or remove unsupported crates before release",
+      "validation": "cargo metadata, locked build/test/Clippy, provenance checks, Trivy, and Syft SBOM",
+      "disposition": "retain",
+      "packages": ["sha2"],
+      "evidence": [
+        {"repository":"content-toolkit","path":"Cargo.lock","contains":"version = 4"},
+        {"repository":"content-toolkit","path":"Cargo.toml","contains":"[workspace]"},
+        {"repository":"content-toolkit","path":"crates/atrinik-artifact/Cargo.toml","contains":"name = \"atrinik-artifact\""},
+        {"repository":"content-toolkit","path":"crates/atrinik-catalog/Cargo.toml","contains":"name = \"atrinik-catalog\""},
+        {"repository":"content-toolkit","path":"crates/atrinik-content/Cargo.toml","contains":"name = \"atrinik-content\""},
+        {"repository":"content-toolkit","path":"crates/atrinik-diagnostics/Cargo.toml","contains":"name = \"atrinik-diagnostics\""},
+        {"repository":"content-toolkit","path":"crates/atrinik-schema/Cargo.toml","contains":"name = \"atrinik-schema\""},
+        {"repository":"content-toolkit","path":"crates/atrinik-source/Cargo.toml","contains":"name = \"atrinik-source\""},
+        {"repository":"content-toolkit","path":"crates/atrinik-testkit/Cargo.toml","contains":"name = \"atrinik-testkit\""},
+        {"repository":"content-toolkit","path":"crates/atrinik-transaction/Cargo.toml","contains":"name = \"atrinik-transaction\""},
+        {"repository":"content-toolkit","path":"policy/dependencies.json","contains":"\"name\": \"sha2\""},
+        {"repository":"content-toolkit","path":"rust-toolchain.toml","contains":"channel = \"1.97.1\""}
+      ]
+    },
+    {
+      "id": "language/replacement-editor-cargo",
+      "name": "Replacement editor Cargo dependency graph",
+      "kind": "language-package-set",
+      "owner": "editor",
+      "scope": ["editor"],
+      "required": true,
+      "version": "Cargo.lock-v4",
+      "version_source": "Cargo.lock, workspace manifests, and policy/dependencies.json",
+      "license": "NOASSERTION",
+      "source_url": "https://crates.io/",
+      "locator": "pkg:cargo/atrinik-editor@0.1.0",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Cargo installs the exact locked crates.io and immutable released-source graph",
+      "update_cadence_days": 7,
+      "update_mechanism": "Grouped Dependabot Cargo updates plus monthly policy review",
+      "eol_response": "Upgrade, replace, or remove unsupported crates and released Atrinik contracts before release",
+      "validation": "cargo metadata, locked build/test/Clippy, cargo-deny, Linux/Windows packages, and Syft SBOM",
+      "disposition": "retain",
+      "packages": ["atrinik-render-api", "atrinik-render-resources", "atrinik-scene", "atrinik-source", "atrinik-transaction", "sdl3"],
+      "evidence": [
+        {"repository":"editor","path":"Cargo.lock","contains":"version = 4"},
+        {"repository":"editor","path":"Cargo.toml","contains":"[workspace]"},
+        {"repository":"editor","path":"crates/atrinik-editor-app/Cargo.toml","contains":"name = \"atrinik-editor\""},
+        {"repository":"editor","path":"crates/atrinik-editor-commands/Cargo.toml","contains":"name = \"atrinik-editor-commands\""},
+        {"repository":"editor","path":"crates/atrinik-editor-document/Cargo.toml","contains":"name = \"atrinik-editor-document\""},
+        {"repository":"editor","path":"crates/atrinik-editor-preview/Cargo.toml","contains":"name = \"atrinik-editor-preview\""},
+        {"repository":"editor","path":"crates/atrinik-editor-project/Cargo.toml","contains":"name = \"atrinik-editor-project\""},
+        {"repository":"editor","path":"crates/atrinik-editor-testkit/Cargo.toml","contains":"name = \"atrinik-editor-testkit\""},
+        {"repository":"editor","path":"crates/atrinik-editor-ui/Cargo.toml","contains":"name = \"atrinik-editor-ui\""},
+        {"repository":"editor","path":"deny.toml","contains":"[licenses]"},
+        {"repository":"editor","path":"policy/dependencies.json","contains":"\"owner\": \"editor maintainers\""},
+        {"repository":"editor","path":"rust-toolchain.toml","contains":"channel = \"1.97.1\""}
+      ]
+    },
+    {
+      "id": "language/replacement-protocol-graphs",
+      "name": "Replacement protocol Buf, Cargo, and Go dependency graphs",
+      "kind": "language-package-set",
+      "owner": "protocol",
+      "scope": ["protocol"],
+      "required": true,
+      "version": "Buf-v2; Cargo.lock-v4; Go-1.26.0",
+      "version_source": "Buf configuration, Cargo.lock, go.mod, go.sum, and policy/dependencies.json",
+      "license": "NOASSERTION",
+      "source_url": "https://buf.build/",
+      "locator": "pkg:generic/atrinik-protocol-build@1",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Buf and local pinned generators produce bindings; Cargo and Go install exact locked/module graphs",
+      "update_cadence_days": 7,
+      "update_mechanism": "Grouped Dependabot Cargo/Go updates and reviewed Buf generator changes",
+      "eol_response": "Upgrade generators and package graphs together or stop publication before incompatibility",
+      "validation": "Buf lint/breaking checks, generated drift, Go tests/vet, Rust test/Clippy, and Syft SBOM",
+      "disposition": "retain",
+      "packages": ["buf", "bytes", "golang.org/x/net", "google.golang.org/protobuf", "idna", "prost", "protoc-gen-go", "protoc-gen-prost"],
+      "evidence": [
+        {"repository":"protocol","path":"Cargo.lock","contains":"version = 4"},
+        {"repository":"protocol","path":"Cargo.toml","contains":"[workspace]"},
+        {"repository":"protocol","path":"Cargo.toml","contains":"idna = \"=1.1.0\""},
+        {"repository":"protocol","path":"buf.gen.yaml","contains":"version: v2"},
+        {"repository":"protocol","path":"buf.yaml","contains":"version: v2"},
+        {"repository":"protocol","path":"crates/atrinik-protocol/Cargo.toml","contains":"name = \"atrinik-protocol\""},
+        {"repository":"protocol","path":"go.mod","contains":"golang.org/x/net v0.57.0"},
+        {"repository":"protocol","path":"go.mod","contains":"module github.com/atrinik/protocol"},
+        {"repository":"protocol","path":"go.sum","contains":"google.golang.org/protobuf v1.36.11"},
+        {"repository":"protocol","path":"policy/dependencies.json","contains":"\"name\": \"golang.org/x/net\""},
+        {"repository":"protocol","path":"policy/dependencies.json","contains":"\"name\": \"idna\""},
+        {"repository":"protocol","path":"policy/dependencies.json","contains":"\"name\": \"prost\""},
+        {"repository":"protocol","path":"rust-toolchain.toml","contains":"channel = \"1.97.1\""}
+      ]
+    },
+    {
+      "id": "language/replacement-renderer-cargo",
+      "name": "Replacement renderer Cargo dependency graph",
+      "kind": "language-package-set",
+      "owner": "renderer",
+      "scope": ["renderer"],
+      "required": true,
+      "version": "Cargo.lock-v4",
+      "version_source": "Cargo.lock, workspace manifests, and policy/dependencies.json",
+      "license": "NOASSERTION",
+      "source_url": "https://crates.io/",
+      "locator": "pkg:cargo/atrinik-render@0.1.0",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Cargo installs the exact locked graph; CI builds SDL from crate source and uses pinned wgpu/naga APIs",
+      "update_cadence_days": 7,
+      "update_mechanism": "Grouped Dependabot Cargo updates plus monthly GPU/backend policy review",
+      "eol_response": "Upgrade, replace, or remove unsupported crates and GPU backends before release",
+      "validation": "cargo metadata, locked build/test/Clippy, corpus checks, Trivy, and Syft SBOM",
+      "disposition": "retain",
+      "packages": ["bytemuck", "naga", "pollster", "sdl3", "sha2", "tempfile", "wgpu"],
+      "evidence": [
+        {"repository":"renderer","path":"Cargo.lock","contains":"version = 4"},
+        {"repository":"renderer","path":"Cargo.toml","contains":"[workspace]"},
+        {"repository":"renderer","path":"crates/atrinik-render-api/Cargo.toml","contains":"name = \"atrinik-render-api\""},
+        {"repository":"renderer","path":"crates/atrinik-render-resources/Cargo.toml","contains":"name = \"atrinik-render-resources\""},
+        {"repository":"renderer","path":"crates/atrinik-render-sdl3/Cargo.toml","contains":"name = \"atrinik-render-sdl3\""},
+        {"repository":"renderer","path":"crates/atrinik-render-testkit/Cargo.toml","contains":"name = \"atrinik-render-testkit\""},
+        {"repository":"renderer","path":"crates/atrinik-render-ui/Cargo.toml","contains":"name = \"atrinik-render-ui\""},
+        {"repository":"renderer","path":"crates/atrinik-render-wgpu/Cargo.toml","contains":"name = \"atrinik-render-wgpu\""},
+        {"repository":"renderer","path":"crates/atrinik-render/Cargo.toml","contains":"name = \"atrinik-render\""},
+        {"repository":"renderer","path":"crates/atrinik-scene/Cargo.toml","contains":"name = \"atrinik-scene\""},
+        {"repository":"renderer","path":"policy/dependencies.json","contains":"\"name\":\"wgpu\""},
+        {"repository":"renderer","path":"rust-toolchain.toml","contains":"channel = \"1.97.1\""}
+      ]
+    },
+    {
+      "id": "language/replacement-server-go",
+      "name": "Replacement server Go module graph",
+      "kind": "language-package-set",
+      "owner": "server",
+      "scope": ["server"],
+      "required": true,
+      "version": "Go-1.26.6",
+      "version_source": "go.mod, go.sum, and policy/dependencies.json",
+      "license": "NOASSERTION",
+      "source_url": "https://proxy.golang.org/",
+      "locator": "pkg:golang/github.com/atrinik/server@1.0.0",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Go verifies the exact module checksums in go.sum",
+      "update_cadence_days": 7,
+      "update_mechanism": "Grouped Dependabot Go modules updates plus monthly policy review",
+      "eol_response": "Upgrade, replace, or remove unsupported modules before release",
+      "validation": "go mod verify, go list, vet, race tests, govulncheck, go-licenses, and Syft SBOM",
+      "disposition": "retain",
+      "packages": ["github.com/atrinik/protocol", "github.com/cespare/xxhash/v2", "github.com/go-logr/logr", "github.com/go-logr/stdr", "go.opentelemetry.io/auto/sdk", "go.opentelemetry.io/otel", "go.opentelemetry.io/otel/metric", "go.opentelemetry.io/otel/trace", "golang.org/x/net", "golang.org/x/sys", "golang.org/x/text", "google.golang.org/protobuf"],
+      "evidence": [
+        {"repository":"server","path":"go.mod","contains":"github.com/atrinik/protocol v1.3.0"},
+        {"repository":"server","path":"go.mod","contains":"golang.org/x/sys v0.47.0"},
+        {"repository":"server","path":"go.mod","contains":"module github.com/atrinik/server"},
+        {"repository":"server","path":"go.sum","contains":"github.com/cespare/xxhash/v2 v2.3.0"},
+        {"repository":"server","path":"go.sum","contains":"google.golang.org/protobuf v1.36.11"},
+        {"repository":"server","path":"policy/dependencies.json","contains":"\"name\": \"github.com/atrinik/protocol\""},
+        {"repository":"server","path":"policy/dependencies.json","contains":"\"name\": \"go.opentelemetry.io/otel\""}
+      ]
+    },
+    {
+      "id": "language/replacement-website-npm",
+      "name": "Replacement website npm dependency graph",
+      "kind": "language-package-set",
+      "owner": "website",
+      "scope": ["website"],
+      "required": true,
+      "version": "lockfileVersion-3",
+      "version_source": "package-lock.json and policy/dependencies.json",
+      "license": "NOASSERTION",
+      "source_url": "https://www.npmjs.com/",
+      "locator": "pkg:npm/%40atrinik/website@0.0.0-development",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "npm ci installs the exact package-lock graph with denied optional scripts omitted, only the reviewed esbuild install script allowed, and the audited npm security override applied",
+      "update_cadence_days": 7,
+      "update_mechanism": "Grouped Dependabot npm updates constrained by Astro compatibility",
+      "eol_response": "Upgrade compatible packages on the supported Node line or replace them",
+      "validation": "npm ci, Astro/type/format tests, install-script audit, npm audit, deploy dry run, and npm CycloneDX SBOM",
+      "disposition": "retain",
+      "packages": ["@astrojs/check", "@semantic-release/commit-analyzer", "@semantic-release/exec", "@semantic-release/github", "@semantic-release/release-notes-generator", "astro", "conventional-changelog-conventionalcommits", "npm", "prettier", "prettier-plugin-astro", "semantic-release", "typescript"],
+      "evidence": [
+        {"repository":"website","path":"package-lock.json","contains":"\"lockfileVersion\": 3"},
+        {"repository":"website","path":"package.json","contains":"\"name\": \"@atrinik/website\""},
+        {"repository":"website","path":"policy/dependencies.json","contains":"\"name\": \"esbuild\""},
+        {"repository":"website","path":"policy/dependencies.json","contains":"\"name\": \"npm\""}
+      ]
+    },
+    {
+      "id": "language/wrapper-python-development",
+      "name": "Workspace and Classic Python development dependencies",
+      "kind": "language-package-set",
+      "owner": "atrinik",
+      "scope": [
+        "atrinik",
+        "classic"
+      ],
+      "required": false,
+      "version": "coverage=7.15.3",
+      "version_source": "requirements-dev.txt and the Classic Check workflow",
+      "license": "Apache-2.0",
+      "source_url": "https://pypi.org/project/coverage/",
+      "locator": "pkg:pypi/coverage@7.15.3",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "pip installs the exact development or CI requirement",
+      "update_cadence_days": 7,
+      "update_mechanism": "Dependabot pip updates",
+      "eol_response": "Upgrade with the supported Python line or retain stdlib test execution without coverage",
+      "validation": "Complete wrapper and Classic release-tool unittest suites and coverage reports",
+      "disposition": "retain",
+      "packages": [
+        "coverage"
+      ],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": "requirements-dev.txt",
+          "contains": "coverage==7.15.3"
+        },
+        {
+          "repository": "classic",
+          "path": ".github/workflows/check.yml",
+          "contains": "python3 -m pip install coverage==7.15.3"
+        }
+      ]
+    },
+    {
+      "id": "source/atrinik-content-playtester",
+      "name": "Atrinik content source for playtester world planning",
+      "kind": "source-archive",
+      "owner": "content",
+      "scope": [
+        "playtester"
+      ],
+      "required": true,
+      "version": "v2.14.0",
+      "version_source": "dependencies.lock.json content source input",
+      "license": "LicenseRef-Atrinik-Content",
+      "source_url": "https://github.com/atrinik/content/releases/tag/v2.14.0",
+      "locator": "pkg:github/atrinik/content@v2.14.0",
+      "commit": "7dde0c0afe8840fc95dd26f404310e77d9c82621",
+      "checksum": "sha256:bd5aa9acb8dd17c07e16913cb36c58644f7910f28f47e3b0739d00d91936a9e6",
+      "acquisition": "The playtester downloads the bounded source archive, verifies its exact digest and layout, and publishes it in a read-only atomic cache generation",
+      "update_cadence_days": 30,
+      "update_mechanism": "Reviewed content compatibility update with complete playtester regression validation",
+      "eol_response": "Advance to a supported content release before removing the pinned compatibility baseline",
+      "validation": "Lock validation, checksum, safe extraction, atomic/offline cache tests, world-graph compilation, and complete playtester regressions",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "playtester",
+          "path": "dependencies.lock.json",
+          "contains": "bd5aa9acb8dd17c07e16913cb36c58644f7910f28f47e3b0739d00d91936a9e6"
+        }
+      ]
+    },
+    {
+      "id": "source/atrinik-content-playtester-runtime",
+      "name": "Atrinik content runtime archive for Playtester",
+      "kind": "source-archive",
+      "owner": "content",
+      "scope": [
+        "playtester"
+      ],
+      "required": true,
+      "version": "v2.14.0",
+      "version_source": "Playtester dependencies.lock.json content runtime input",
+      "license": "LicenseRef-Atrinik-Asset-Per-File",
+      "source_url": "https://github.com/atrinik/content/releases/tag/v2.14.0",
+      "locator": "pkg:github/atrinik/content@v2.14.0",
+      "commit": "7dde0c0afe8840fc95dd26f404310e77d9c82621",
+      "checksum": "sha256:f4ad326e20e221869897c72f7e33b533c408ce6654038dbfc4352da1c3391261",
+      "acquisition": "Playtester obtains the archive through its verified atomic cache boundary",
+      "update_cadence_days": 30,
+      "update_mechanism": "Reviewed Playtester compatibility update",
+      "eol_response": "Update the Playtester lock to a supported content release or stop Playtester operation",
+      "validation": "Lock validation, checksum, safe extraction, and playtester atomic/offline cache regressions",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "playtester",
+          "path": "dependencies.lock.json",
+          "contains": "f4ad326e20e221869897c72f7e33b533c408ce6654038dbfc4352da1c3391261"
+        }
+      ]
+    },
+    {
+      "id": "source/atrinik-content-runtime",
+      "name": "Atrinik content runtime archive",
+      "kind": "source-archive",
+      "owner": "content",
+      "scope": [
+        "classic-server"
+      ],
+      "required": true,
+      "version": "v6.0.0",
+      "version_source": "Classic server dependencies.lock.json content runtime input",
+      "license": "LicenseRef-Atrinik-Asset-Per-File",
+      "source_url": "https://github.com/atrinik/content/releases/tag/v6.0.0",
+      "locator": "pkg:github/atrinik/content@v6.0.0",
+      "commit": "7a4904172eee99fdd65482450fac219061676e5e",
+      "checksum": "sha256:dad5ef25be949e5874baba854b1ff008881e03ea42eefab0a14c6be38558b23d",
+      "acquisition": "Classic release packaging obtains the archive from the exact durable dependency-bundle digest and rechecks it before safe extraction",
+      "update_cadence_days": 30,
+      "update_mechanism": "Daily fail-closed GitHub App proposal plus reviewed Classic compatibility update",
+      "eol_response": "Update the Classic lock to a supported content release or stop Classic packaging",
+      "validation": "Lock and dependency-bundle validation, checksum, safe extraction, and offline Classic rehearsal/runtime tests",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic-server",
+          "path": "dependencies.lock.json",
+          "contains": "atrinik-content-6.0.0-classic-runtime.tar.gz"
+        }
+      ]
+    },
+    {
+      "id": "source/atrinik-libatrinik-client",
+      "name": "Archived classic libatrinik release source for the classic client",
+      "kind": "source-archive",
+      "owner": "classic-client",
+      "scope": [
+        "classic-client"
+      ],
+      "required": true,
+      "version": "v1.0.3",
+      "version_source": "classic/client CMake dependency lock",
+      "license": "GPL-2.0-or-later",
+      "source_url": "https://github.com/atrinik/legacy-libatrinik/releases/tag/v1.0.3",
+      "locator": "pkg:github/atrinik/legacy-libatrinik@v1.0.3",
+      "commit": "2996df2866eb220d45a1493408f4e54851f72c8e",
+      "checksum": "sha256:6dc6823aca9cf24242bd67f5aed7469da9ca57fe2cdf7ada30e105b908a396d4",
+      "acquisition": "CMake FetchContent downloads the checksum-pinned release archive",
+      "update_cadence_days": 30,
+      "update_mechanism": "Weekly lock drift audit and coordinated downstream update",
+      "eol_response": "Release and consume a supported library version before removing the old release",
+      "validation": "CMake lock validation and classic client native tests",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic-client",
+          "path": "cmake/dependencies.lock.json",
+          "contains": "libatrinik-1.0.3.tar.gz"
+        }
+      ]
+    },
+    {
+      "id": "source/atrinik-libatrinik-playtester",
+      "name": "Archived classic libatrinik release source for the playtester",
+      "kind": "source-archive",
+      "owner": "playtester",
+      "scope": [
+        "playtester"
+      ],
+      "required": true,
+      "version": "v1.1.5",
+      "version_source": "dependencies.lock.json pathfinding input consumed by CMake",
+      "license": "GPL-2.0-or-later",
+      "source_url": "https://github.com/atrinik/legacy-libatrinik/releases/tag/v1.1.5",
+      "locator": "pkg:github/atrinik/legacy-libatrinik@v1.1.5",
+      "commit": "4c3410063972ea22689b66ad7dd8c7949cc1fbff",
+      "checksum": "sha256:3c07b178cc236881f52272df6e38bc2d4186943b782e4cee34b2e733da9c8f9a",
+      "acquisition": "CMake FetchContent downloads the checksum-pinned release archive",
+      "update_cadence_days": 30,
+      "update_mechanism": "Reviewed pathfinding compatibility update and complete playtester regression validation",
+      "eol_response": "Update or replace the pathfinding dependency before its archived release becomes unusable",
+      "validation": "CMake lock validation, native pathfinding tests, and playtester Python regression tests",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "playtester",
+          "path": "dependencies.lock.json",
+          "contains": "3c07b178cc236881f52272df6e38bc2d4186943b782e4cee34b2e733da9c8f9a"
+        },
+        {
+          "repository": "playtester",
+          "path": "dependencies.lock.json",
+          "contains": "libatrinik-1.1.5.tar.gz"
+        }
+      ]
+    },
+    {
+      "id": "source/atrinik-libatrinik-server",
+      "name": "Archived classic libatrinik release source for the classic server",
+      "kind": "source-archive",
+      "owner": "classic-server",
+      "scope": [
+        "classic-server"
+      ],
+      "required": true,
+      "version": "v1.1.5",
+      "version_source": "classic/server CMake dependency lock",
+      "license": "GPL-2.0-or-later",
+      "source_url": "https://github.com/atrinik/legacy-libatrinik/releases/tag/v1.1.5",
+      "locator": "pkg:github/atrinik/legacy-libatrinik@v1.1.5",
+      "commit": "4c3410063972ea22689b66ad7dd8c7949cc1fbff",
+      "checksum": "sha256:3c07b178cc236881f52272df6e38bc2d4186943b782e4cee34b2e733da9c8f9a",
+      "acquisition": "CMake FetchContent downloads the checksum-pinned release archive",
+      "update_cadence_days": 30,
+      "update_mechanism": "Weekly lock drift audit and coordinated downstream update",
+      "eol_response": "Release and consume a supported library version before removing the old release",
+      "validation": "CMake lock validation and classic server native tests",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic-server",
+          "path": "cmake/dependencies.lock.json",
+          "contains": "libatrinik-1.1.5.tar.gz"
+        }
+      ]
+    },
+    {
+      "id": "source/atrinik-protocol-libatrinik",
+      "name": "Atrinik classic protocol release source for classic libatrinik",
+      "kind": "source-archive",
+      "owner": "classic-protocol",
+      "scope": [
+        "classic-libatrinik"
+      ],
+      "required": true,
+      "version": "v1.0.0",
+      "version_source": "classic/libatrinik/dependencies.lock.json",
+      "license": "MIT",
+      "source_url": "https://github.com/atrinik/legacy-protocol/releases/tag/v1.0.0",
+      "locator": "pkg:github/atrinik/legacy-protocol@v1.0.0",
+      "commit": "8be5e46bbf471b108e9ce70d3f929f74a0fb1f8d",
+      "checksum": "sha256:1e37b970bfa47b119b5156fb90178915ee933c1a42ba061766ecd99f1d6640e8",
+      "acquisition": "CMake FetchContent downloads the checksum-pinned release archive",
+      "update_cadence_days": 30,
+      "update_mechanism": "Weekly lock drift audit and library compatibility review",
+      "eol_response": "Update the library release input before the protocol line is unsupported",
+      "validation": "Lock validation, library tests, and installed consumer",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic-libatrinik",
+          "path": "dependencies.lock.json",
+          "contains": "atrinik-protocol-1.0.0.tar.gz"
+        }
+      ]
+    },
+    {
+      "id": "source/atrinik-protocol-playtester",
+      "name": "Atrinik protocol Python wheel for the playtester",
+      "kind": "source-archive",
+      "owner": "playtester",
+      "scope": ["playtester"],
+      "required": true,
+      "version": "v1.0.9",
+      "version_source": "pyproject.toml exact wheel URL and fragment",
+      "license": "MIT",
+      "source_url": "https://github.com/atrinik/legacy-protocol/releases/tag/v1.0.9",
+      "locator": "pkg:pypi/atrinik-protocol@1.0.9",
+      "commit": null,
+      "checksum": "sha256:78954264fa49ac8736dbfc7a72669f619e0202e6ae15445a0b0839aa8f30eb8a",
+      "acquisition": "pip downloads the exact HTTPS release wheel and verifies the URL-fragment digest",
+      "update_cadence_days": 30,
+      "update_mechanism": "Protocol release review and playtester contract tests",
+      "eol_response": "Update to a supported protocol binding or retire direct Classic protocol operation",
+      "validation": "pip hash verification, playtester protocol tests, and migration parity against the client automation API",
+      "disposition": "replace",
+      "packages": [],
+      "evidence": [
+        {"repository":"playtester","path":"dependencies.lock.json","contains":"78954264fa49ac8736dbfc7a72669f619e0202e6ae15445a0b0839aa8f30eb8a"},
+        {"repository":"playtester","path":"pyproject.toml","contains":"atrinik_protocol-1.0.9-py3-none-any.whl#sha256=78954264fa49ac8736dbfc7a72669f619e0202e6ae15445a0b0839aa8f30eb8a"}
+      ]
+    },
+    {
+      "id": "source/atrinik-resources-runtime",
+      "name": "Atrinik classic server resource archive",
+      "kind": "source-archive",
+      "owner": "resources",
+      "scope": [
+        "classic-server"
+      ],
+      "required": true,
+      "version": "v1.0.1",
+      "version_source": "classic/server/dependencies.lock.json",
+      "license": "LicenseRef-Atrinik-Asset-Per-File",
+      "source_url": "https://github.com/atrinik/resources/releases/tag/v1.0.1",
+      "locator": "pkg:github/atrinik/resources@v1.0.1",
+      "commit": "a3bd8c8a2b746d15b397a67d9f641af7d97a6078",
+      "checksum": "sha256:4db9ecdd74aa570bc7e20eccac980844f3aba8d668230502728b22146d3b2c54",
+      "acquisition": "Classic release packaging obtains the archive from the exact durable dependency-bundle digest, rechecks it, and safely extracts it offline",
+      "update_cadence_days": 30,
+      "update_mechanism": "Weekly lock drift audit and reviewed release consumption",
+      "eol_response": "Update the lock to a supported resource release or stop packaging the classic server",
+      "validation": "Lock and dependency-bundle validation, checksum, safe extraction, offline rehearsal, and runtime allowlist",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic-server",
+          "path": "dependencies.lock.json",
+          "contains": "atrinik-resources-1.0.1.tar.gz"
+        }
+      ]
+    },
+    {
+      "id": "source/atrinik-sound-classic-runtime",
+      "name": "Profile-selected Atrinik Classic sound runtime",
+      "kind": "source-archive",
+      "owner": "sound",
+      "scope": [
+        "atrinik",
+        "classic-client"
+      ],
+      "required": false,
+      "version": "profile-selected",
+      "version_source": "Atrinik profile sound_release immutable coordinates",
+      "license": "LicenseRef-Atrinik-Asset-Per-File",
+      "source_url": "https://github.com/atrinik/sound/releases",
+      "locator": "pkg:github/atrinik/sound@profile-selected?product=classic-runtime",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Atrinik wrapper downloads a profile-pinned release asset into a profile-build-owned verified cache",
+      "update_cadence_days": 30,
+      "update_mechanism": "Set reviewed immutable profile coordinates from an atrinik/sound release",
+      "eol_response": "Select a supported publishable runtime release or return the profile to source mode",
+      "validation": "Exact URL and archive checksum, bounded safe extraction, internal checksums, schema and manifest identity, 339-path codec contract, and logical tree checksum",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": "atrinik_workspace/sound.py",
+          "contains": "atrinik-sound-classic-runtime"
+        }
+      ]
+    },
+    {
+      "id": "source/atrinik-sound-runtime",
+      "name": "Atrinik sound archive",
+      "kind": "source-archive",
+      "owner": "sound",
+      "scope": [
+        "classic-client"
+      ],
+      "required": true,
+      "version": "v1.0.3",
+      "version_source": "classic/client/dependencies.lock.json",
+      "license": "LicenseRef-Atrinik-Asset-Per-File",
+      "source_url": "https://github.com/atrinik/sound/releases/tag/v1.0.3",
+      "locator": "pkg:github/atrinik/sound@v1.0.3",
+      "commit": "18234cce19bf641f24d81333d8abcc0f1e34cd08",
+      "checksum": "sha256:5427d2d2b5b73bad30c279ea5b7f012c380fd402249d45d9363b85ea7674e4bb",
+      "acquisition": "Classic release packaging obtains the archive from the exact durable dependency-bundle digest, rechecks it, and safely extracts it offline",
+      "update_cadence_days": 30,
+      "update_mechanism": "Weekly lock drift audit and reviewed release consumption",
+      "eol_response": "Update the lock to a supported sound release or disable packaging",
+      "validation": "Lock and dependency-bundle validation, checksum, safe extraction, offline rehearsal, and classic client package test",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic-client",
+          "path": "dependencies.lock.json",
+          "contains": "atrinik-sound-1.0.3.tar.gz"
+        }
+      ]
+    },
+    {
+      "id": "source/cc-by-3-license-text",
+      "name": "Creative Commons Attribution 3.0 legal code",
+      "kind": "source-archive",
+      "owner": "sound",
+      "scope": [
+        "sound"
+      ],
+      "required": true,
+      "version": "3.0",
+      "version_source": "sound/manifests/audio-toolchain.json",
+      "license": "NOASSERTION",
+      "source_url": "https://creativecommons.org/licenses/by/3.0/legalcode.txt",
+      "locator": "https://creativecommons.org/licenses/by/3.0/legalcode.txt",
+      "commit": null,
+      "checksum": "sha256:e6bc9e9c474700b708f568bac9e5a8a9bcb2b1dad53442f5ba449fcb848b8e76",
+      "acquisition": "The sound image downloads and verifies the exact legal text for release attribution",
+      "update_cadence_days": 365,
+      "update_mechanism": "Reviewed license-corpus checksum update",
+      "eol_response": "Retain the reviewed immutable text required by existing attributed assets",
+      "validation": "Checksum, release license-path allowlist, and archive attribution tests",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "sound",
+          "path": "tools/audio/Dockerfile",
+          "contains": "CC_BY_SHA256=e6bc9e9c474700b708f568bac9e5a8a9bcb2b1dad53442f5ba449fcb848b8e76"
+        }
+      ]
+    },
+    {
+      "id": "source/cc-by-sa-3-license-text",
+      "name": "Creative Commons Attribution-ShareAlike 3.0 legal code",
+      "kind": "source-archive",
+      "owner": "sound",
+      "scope": [
+        "sound"
+      ],
+      "required": true,
+      "version": "3.0",
+      "version_source": "sound/manifests/audio-toolchain.json",
+      "license": "NOASSERTION",
+      "source_url": "https://creativecommons.org/licenses/by-sa/3.0/legalcode.txt",
+      "locator": "https://creativecommons.org/licenses/by-sa/3.0/legalcode.txt",
+      "commit": null,
+      "checksum": "sha256:3f941b3b89cf7b8370ceb83cc76d2120d471b58735d8ca60238a751a48d7f72f",
+      "acquisition": "The sound image downloads and verifies the exact legal text for release attribution",
+      "update_cadence_days": 365,
+      "update_mechanism": "Reviewed license-corpus checksum update",
+      "eol_response": "Retain the reviewed immutable text required by existing share-alike assets",
+      "validation": "Checksum, release license-path allowlist, and archive attribution tests",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "sound",
+          "path": "tools/audio/Dockerfile",
+          "contains": "CC_BY_SA_SHA256=3f941b3b89cf7b8370ceb83cc76d2120d471b58735d8ca60238a751a48d7f72f"
+        }
+      ]
+    },
+    {
+      "id": "source/cc0-1-license-text",
+      "name": "Creative Commons CC0 1.0 legal code",
+      "kind": "source-archive",
+      "owner": "sound",
+      "scope": [
+        "sound"
+      ],
+      "required": true,
+      "version": "1.0",
+      "version_source": "sound/manifests/audio-toolchain.json",
+      "license": "NOASSERTION",
+      "source_url": "https://creativecommons.org/publicdomain/zero/1.0/legalcode.txt",
+      "locator": "https://creativecommons.org/publicdomain/zero/1.0/legalcode.txt",
+      "commit": null,
+      "checksum": "sha256:a2010f343487d3f7618affe54f789f5487602331c0a8d03f49e9a7c547cf0499",
+      "acquisition": "The sound image downloads and verifies the exact legal text for release attribution",
+      "update_cadence_days": 365,
+      "update_mechanism": "Reviewed license-corpus checksum update",
+      "eol_response": "Retain the reviewed immutable text required by existing CC0 assets",
+      "validation": "Checksum, release license-path allowlist, and archive attribution tests",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "sound",
+          "path": "tools/audio/Dockerfile",
+          "contains": "CC0_SHA256=a2010f343487d3f7618affe54f789f5487602331c0a8d03f49e9a7c547cf0499"
+        }
+      ]
+    },
+    {
+      "id": "source/content-catalog",
+      "name": "Content catalog package",
+      "kind": "source-archive",
+      "owner": "content",
+      "scope": [
+        "tools"
+      ],
+      "required": true,
+      "version": "v1.2.0",
+      "version_source": "tools/map-checker-qt/catalog.lock.json",
+      "license": "MIT",
+      "source_url": "https://github.com/atrinik/content/releases/tag/v1.2.0",
+      "locator": "pkg:github/atrinik/content@v1.2.0#tools/content_catalog",
+      "commit": "766cb6e67aa03dd86b1c333c607885df31c3aca5",
+      "checksum": "sha256:c9ad1cfa555e2c9f23e7e814599ce67ea79a2779879787b6ad91f4a0c9e713f1",
+      "acquisition": "Map checker dependency tool safely extracts the catalog subtree",
+      "update_cadence_days": 30,
+      "update_mechanism": "Weekly lock drift audit and catalog parity tests",
+      "eol_response": "Consume a supported content catalog release before removing the old package",
+      "validation": "Checksum, archive-prefix, path, import-origin, and catalog tests",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "tools",
+          "path": "map-checker-qt/catalog.lock.json",
+          "contains": "atrinik-content-1.2.0/tools/content_catalog"
+        }
+      ]
+    },
+    {
+      "id": "source/freepats",
+      "name": "FreePats General MIDI instrument bank",
+      "kind": "source-archive",
+      "owner": "sound",
+      "scope": [
+        "sound"
+      ],
+      "required": true,
+      "version": "20060219",
+      "version_source": "sound/manifests/audio-toolchain.json",
+      "license": "LicenseRef-FreePats-GPL-Exception",
+      "source_url": "https://deb.debian.org/debian/pool/main/f/freepats/freepats_20060219.orig.tar.gz",
+      "locator": "https://deb.debian.org/debian/pool/main/f/freepats/freepats_20060219.orig.tar.gz",
+      "commit": null,
+      "checksum": "sha256:70bf8ca084df3903d6c9de43fe20539fc0a553d95cfba4d525da3fe66fda5f10",
+      "acquisition": "The sound image downloads the Debian source archive, verifies both archive layers, and installs the unmodified instrument bank",
+      "update_cadence_days": 365,
+      "update_mechanism": "Reviewed instrument-bank and license-exception audit",
+      "eol_response": "Replace the renderer input with a reviewed distributable bank before removing this source",
+      "validation": "Outer and inner checksums, installed-tree/config digests, MIDI fixture render, and release exclusion",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "sound",
+          "path": "manifests/audio-toolchain.json",
+          "contains": "0261ea1057b232183fa472432d5cedb0dca33698a5319328cdf193d4b2193c8a"
+        },
+        {
+          "repository": "sound",
+          "path": "tools/audio/Dockerfile",
+          "contains": "FREEPATS_SHA256=70bf8ca084df3903d6c9de43fe20539fc0a553d95cfba4d525da3fe66fda5f10"
+        }
+      ]
+    },
+    {
+      "id": "source/libogg-sdl",
+      "name": "libogg for SDL3_mixer",
+      "kind": "source-archive",
+      "owner": "devcontainer",
+      "scope": [
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "1.3.5",
+      "version_source": "devcontainer/audio-toolchain.json",
+      "license": "BSD-3-Clause",
+      "source_url": "https://github.com/libsdl-org/ogg",
+      "locator": "pkg:github/libsdl-org/ogg@936fdd822a4e4fc963197b3eda931b89b52859a0",
+      "commit": "936fdd822a4e4fc963197b3eda931b89b52859a0",
+      "checksum": "sha256:4e2e1da271f4b7b9902f325a714e07d6412e9df7a0dbe43ca53257901c5d74ff",
+      "acquisition": "Both build images download the checksum-pinned commit archive and link it statically into SDL3_mixer",
+      "update_cadence_days": 30,
+      "update_mechanism": "Scheduled audio-manifest review with complete Linux and Windows image builds",
+      "eol_response": "Advance the reviewed audio cohort or disable Opus explicitly before an unsupported source ships",
+      "validation": "Manifest checksum, nested SPDX record, source build, Linux decoder probe, and Windows import closure",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "audio-toolchain.json",
+          "contains": "936fdd822a4e4fc963197b3eda931b89b52859a0"
+        }
+      ]
+    },
+    {
+      "id": "source/libopus-sdl",
+      "name": "libopus for SDL3_mixer",
+      "kind": "source-archive",
+      "owner": "devcontainer",
+      "scope": [
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "1.4",
+      "version_source": "devcontainer/audio-toolchain.json",
+      "license": "BSD-3-Clause",
+      "source_url": "https://github.com/libsdl-org/opus",
+      "locator": "pkg:github/libsdl-org/opus@ac9f053e1db9cc1c7608b74e029c25ded0254e3e",
+      "commit": "ac9f053e1db9cc1c7608b74e029c25ded0254e3e",
+      "checksum": "sha256:3af32ef61579bc441883a63fce6b28bc9975df194d72b399415db67c61d5c25a",
+      "acquisition": "Both build images download the checksum-pinned commit archive and link it statically into SDL3_mixer",
+      "update_cadence_days": 30,
+      "update_mechanism": "Scheduled audio-manifest review with complete Linux and Windows image builds",
+      "eol_response": "Advance the reviewed audio cohort or disable Opus explicitly before an unsupported source ships",
+      "validation": "Manifest checksum, nested SPDX record, source build, Linux decoder probe, and Windows import closure",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "audio-toolchain.json",
+          "contains": "ac9f053e1db9cc1c7608b74e029c25ded0254e3e"
+        }
+      ]
+    },
+    {
+      "id": "source/libopusfile-sdl",
+      "name": "libopusfile for SDL3_mixer",
+      "kind": "source-archive",
+      "owner": "devcontainer",
+      "scope": [
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "0.12",
+      "version_source": "devcontainer/audio-toolchain.json",
+      "license": "BSD-3-Clause",
+      "source_url": "https://github.com/libsdl-org/opusfile",
+      "locator": "pkg:github/libsdl-org/opusfile@9e5322c62de32d2b2ad88324b3ad311174cec41d",
+      "commit": "9e5322c62de32d2b2ad88324b3ad311174cec41d",
+      "checksum": "sha256:ed9ea07e9e7e9f9b603e793ffac9551218c978cd5021c7d8f9a3a5dfece9a860",
+      "acquisition": "Both build images download the checksum-pinned commit archive and link it statically into SDL3_mixer",
+      "update_cadence_days": 30,
+      "update_mechanism": "Scheduled audio-manifest review with complete Linux and Windows image builds",
+      "eol_response": "Advance the reviewed audio cohort or disable Opus explicitly before an unsupported source ships",
+      "validation": "Manifest checksum, nested SPDX record, source build, Linux decoder probe, and Windows import closure",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "audio-toolchain.json",
+          "contains": "9e5322c62de32d2b2ad88324b3ad311174cec41d"
+        }
+      ]
+    },
+    {
+      "id": "source/libpcpnatpmp",
+      "name": "libpcpnatpmp",
+      "kind": "source-archive",
+      "owner": "classic-server",
+      "scope": [
+        "classic-server"
+      ],
+      "required": true,
+      "version": "866d283da99f5e98eecff702a8df63e2ae57ffca",
+      "version_source": "classic/server/cmake/immutable_sources.lock.json",
+      "license": "BSD-3-Clause",
+      "source_url": "https://github.com/libpcpnatpmp/libpcpnatpmp",
+      "locator": "pkg:github/libpcpnatpmp/libpcpnatpmp@866d283da99f5e98eecff702a8df63e2ae57ffca",
+      "commit": "866d283da99f5e98eecff702a8df63e2ae57ffca",
+      "checksum": "sha256:65ab99547ecc8277434527607d24f8a1b02a2344ed4cea475bed751606e60202",
+      "acquisition": "Classic release packaging obtains the commit archive from the exact durable dependency-bundle digest; CMake rechecks and extracts it offline before applying the reviewed MinGW patch",
+      "update_cadence_days": 90,
+      "update_mechanism": "Scheduled source-pin audit and sanitizer/network smoke review",
+      "eol_response": "Update the isolated source or replace NAT-PMP support without a fallback copy",
+      "validation": "Dependency-bundle and checksum verification, idempotent patch, native tests, offline rehearsal, and Linux/MinGW builds",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic-server",
+          "path": "cmake/immutable_source_cache.cmake",
+          "contains": "atrinik_extract_immutable_source"
+        },
+        {
+          "repository": "classic-server",
+          "path": "cmake/immutable_sources.lock.json",
+          "contains": "866d283da99f5e98eecff702a8df63e2ae57ffca"
+        },
+        {
+          "repository": "classic-server",
+          "path": "cmake/pcpnatpmp.cmake",
+          "contains": "immutable_sources.lock.json"
+        }
+      ]
+    },
+    {
+      "id": "source/miniupnpc",
+      "name": "MiniUPnPc source for MinGW",
+      "kind": "source-archive",
+      "owner": "devcontainer",
+      "scope": [
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "bf4215a7574f88aa55859db9db00e3ae58cf42d6",
+      "version_source": "windows/Dockerfile MINIUPNPC_COMMIT",
+      "license": "BSD-3-Clause",
+      "source_url": "https://github.com/miniupnp/miniupnp",
+      "locator": "pkg:github/miniupnp/miniupnp@bf4215a7574f88aa55859db9db00e3ae58cf42d6",
+      "commit": "bf4215a7574f88aa55859db9db00e3ae58cf42d6",
+      "checksum": null,
+      "acquisition": "The Windows image shallow-clones and checks out the immutable commit",
+      "update_cadence_days": 90,
+      "update_mechanism": "Scheduled commit drift review and full Windows image build",
+      "eol_response": "Update or remove UPnP support if the source line becomes unsupported",
+      "validation": "Exact checkout plus MinGW configure/build/install",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "windows/Dockerfile",
+          "contains": "MINIUPNPC_COMMIT=bf4215a7574f88aa55859db9db00e3ae58cf42d6"
+        }
+      ]
+    },
+    {
+      "id": "source/mxe",
+      "name": "MXE cross-toolchain source",
+      "kind": "toolchain",
+      "owner": "devcontainer",
+      "scope": [
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "8784776b145a8ddd350ce32aa0908ac10977060c",
+      "version_source": "windows/Dockerfile MXE_REF",
+      "license": "MIT",
+      "source_url": "https://github.com/mxe/mxe",
+      "locator": "pkg:github/mxe/mxe@8784776b145a8ddd350ce32aa0908ac10977060c",
+      "commit": "8784776b145a8ddd350ce32aa0908ac10977060c",
+      "checksum": null,
+      "acquisition": "The Windows image shallow-clones and checks out the immutable commit",
+      "update_cadence_days": 30,
+      "update_mechanism": "Scheduled commit review with cold Windows image and classic client/server builds",
+      "eol_response": "Advance MXE and its compiler before existing targets leave support",
+      "validation": "Patched MXE package builds and portable MinGW classic client/server tests",
+      "disposition": "isolate",
+      "packages": [
+        "cmake",
+        "curl",
+        "libxml2",
+        "openssl",
+        "sdl3",
+        "sdl3_image",
+        "sdl3_ttf",
+        "zlib"
+      ],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "windows/Dockerfile",
+          "contains": "MXE_REF=8784776b145a8ddd350ce32aa0908ac10977060c"
+        }
+      ]
+    },
+    {
+      "id": "source/sdl3-mixer-source",
+      "name": "SDL3_mixer source archive",
+      "kind": "source-archive",
+      "owner": "devcontainer",
+      "scope": [
+        "classic-client",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "3.2.4",
+      "version_source": "devcontainer/audio-toolchain.json and classic client CI installer",
+      "license": "Zlib",
+      "source_url": "https://github.com/libsdl-org/SDL_mixer/releases/tag/release-3.2.4",
+      "locator": "pkg:github/libsdl-org/SDL_mixer@release-3.2.4",
+      "commit": null,
+      "checksum": "sha256:182a07c745375e113dc740d43964ff21b0be29f29f59876c4dbc4db3d32f6901",
+      "acquisition": "Checksum-pinned official release source is built with a bounded codec set",
+      "update_cadence_days": 30,
+      "update_mechanism": "Scheduled release drift review and classic client audio tests",
+      "eol_response": "Upgrade with SDL3 or temporarily disable unsupported codecs explicitly",
+      "validation": "Checksum, nested SPDX record, Linux and Windows source builds, decoder/import probes, native classic client build, and sound tests",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic-client",
+          "path": "tools/install-linux-ci-dependencies.sh",
+          "contains": "182a07c745375e113dc740d43964ff21b0be29f29f59876c4dbc4db3d32f6901"
+        },
+        {
+          "repository": "devcontainer",
+          "path": "audio-toolchain.json",
+          "contains": "182a07c745375e113dc740d43964ff21b0be29f29f59876c4dbc4db3d32f6901"
+        }
+      ]
+    },
+    {
+      "id": "system/check",
+      "name": "Check unit-testing framework",
+      "kind": "system-library",
+      "owner": "classic-server",
+      "scope": [
+        "classic-server"
+      ],
+      "required": false,
+      "version": "distribution-provided",
+      "version_source": "Ubuntu 26.04 package set",
+      "license": "LGPL-2.1-or-later",
+      "source_url": "https://libcheck.github.io/check/",
+      "locator": "pkg:generic/check",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "pkg-config resolves the build-image package",
+      "update_cadence_days": 30,
+      "update_mechanism": "Pinned image rebuild and package-version report",
+      "eol_response": "Upgrade the image or migrate focused tests without suppressing them",
+      "validation": "Optional CHECK_PKG discovery and classic server unit suite",
+      "disposition": "retain",
+      "packages": [
+        "check",
+        "libsubunit-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "classic-server",
+          "path": "CMakeLists.txt",
+          "contains": "pkg_check_modules(CHECK_PKG QUIET IMPORTED_TARGET check)"
+        }
+      ]
+    },
+    {
+      "id": "system/client-ci-packages",
+      "name": "Classic client Linux CI package set",
+      "kind": "system-package-set",
+      "owner": "classic-client",
+      "scope": [
+        "classic-client"
+      ],
+      "required": true,
+      "version": "ubuntu-24.04-runner",
+      "version_source": "GitHub-hosted runner package repositories",
+      "license": "NOASSERTION",
+      "source_url": "https://github.com/actions/runner-images",
+      "locator": "ubuntu-client-ci-packages",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "apt installs the declared packages in the ephemeral CI runner",
+      "update_cadence_days": 30,
+      "update_mechanism": "Weekly dependency audit and exact CI version report",
+      "eol_response": "Move the job to a supported runner/image and update package names together",
+      "validation": "Dependency installer, native build, CTest, and coverage",
+      "disposition": "isolate",
+      "packages": [
+        "build-essential",
+        "ca-certificates",
+        "cmake",
+        "curl",
+        "gcovr",
+        "libcurl4-openssl-dev",
+        "libidn2-dev",
+        "libsdl3-dev",
+        "libsdl3-image-dev",
+        "libsdl3-ttf-dev",
+        "libssl-dev",
+        "libxml2-dev",
+        "ninja-build",
+        "pkgconf",
+        "python3",
+        "zlib1g-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "classic-client",
+          "path": "tools/install-linux-ci-dependencies.sh",
+          "contains": "apt-get install -y -qq --no-install-recommends"
+        }
+      ]
+    },
+    {
+      "id": "system/curl",
+      "name": "libcurl",
+      "kind": "system-library",
+      "owner": "classic-libatrinik",
+      "scope": [
+        "classic-client",
+        "classic-libatrinik",
+        "classic-server",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "distribution/MXE-provided",
+      "version_source": "Pinned build images and MXE commit",
+      "license": "LicenseRef-curl",
+      "source_url": "https://curl.se/libcurl/",
+      "locator": "pkg:generic/libcurl",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake imported target from the pinned native or MXE package set",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image rebuild, MXE review, and exact version report",
+      "eol_response": "Upgrade immediately for unsupported or security-affected TLS/HTTP lines",
+      "validation": "CMake discovery, TLS backend check, and classic client/server network tests",
+      "disposition": "retain",
+      "packages": [
+        "libcurl4-openssl-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "classic-libatrinik",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(CURL REQUIRED)"
+        }
+      ]
+    },
+    {
+      "id": "system/flex",
+      "name": "Flex",
+      "kind": "toolchain",
+      "owner": "classic-server",
+      "scope": [
+        "classic-server",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "distribution-provided",
+      "version_source": "Pinned build images",
+      "license": "BSD-2-Clause",
+      "source_url": "https://github.com/westes/flex",
+      "locator": "pkg:generic/flex",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake finds the lexer generator from the build image",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image update and generated-loader parity tests",
+      "eol_response": "Upgrade the image or replace generated loader inputs deliberately",
+      "validation": "CMake FLEX discovery and loader/runtime tests",
+      "disposition": "retain",
+      "packages": [
+        "flex"
+      ],
+      "evidence": [
+        {
+          "repository": "classic-server",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(FLEX REQUIRED)"
+        }
+      ]
+    },
+    {
+      "id": "system/gd",
+      "name": "libgd",
+      "kind": "system-library",
+      "owner": "classic-server",
+      "scope": [
+        "classic-server",
+        "devcontainer"
+      ],
+      "required": false,
+      "version": "distribution-provided",
+      "version_source": "Pinned build images",
+      "license": "NOASSERTION",
+      "source_url": "https://github.com/libgd/libgd",
+      "locator": "pkg:generic/libgd",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake finds the optional world-maker library from the image",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image update and world-maker generation test",
+      "eol_response": "Replace the world-maker dependency through atrinik/client-rendered imagery before removal",
+      "validation": "CMake GD_LIBRARY discovery and isolated world-maker generation",
+      "disposition": "replace",
+      "packages": [
+        "libgd-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "classic-server",
+          "path": "CMakeLists.txt",
+          "contains": "find_library(GD_LIBRARY gd)"
+        }
+      ]
+    },
+    {
+      "id": "system/idn2",
+      "name": "GNU Libidn2",
+      "kind": "system-library",
+      "owner": "classic-libatrinik",
+      "scope": [
+        "classic-client",
+        "classic-libatrinik",
+        "classic-server",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "distribution/MXE-provided",
+      "version_source": "Pinned build images and MXE commit",
+      "license": "LGPL-3.0-or-later",
+      "source_url": "https://gitlab.com/libidn/libidn2",
+      "locator": "pkg:generic/libidn2",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake links the native or MXE library already present in the reviewed package set",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image rebuild, MXE review, and exact version report",
+      "eol_response": "Upgrade promptly for unsupported or security-affected IDNA implementations",
+      "validation": "CMake discovery plus shared hostname positive and adversarial UTS 46 tests",
+      "disposition": "retain",
+      "packages": [
+        "libidn2-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "classic-libatrinik",
+          "path": "CMakeLists.txt",
+          "contains": "pkg_check_modules(IDN2 REQUIRED IMPORTED_TARGET libidn2)"
+        }
+      ]
+    },
+    {
+      "id": "system/libxml2",
+      "name": "libxml2",
+      "kind": "system-library",
+      "owner": "classic-client",
+      "scope": [
+        "classic-client",
+        "classic-server",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "distribution/MXE-provided",
+      "version_source": "Pinned build images and MXE commit",
+      "license": "MIT",
+      "source_url": "https://gitlab.gnome.org/GNOME/libxml2",
+      "locator": "pkg:generic/libxml2",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake imported target from the native or MXE package set",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image rebuild, MXE review, and parser tests",
+      "eol_response": "Upgrade promptly for unsupported or security-affected parser lines",
+      "validation": "CMake discovery and malformed XML fixtures",
+      "disposition": "retain",
+      "packages": [
+        "libxml2-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "classic-client",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(LibXml2 REQUIRED)"
+        }
+      ]
+    },
+    {
+      "id": "system/miniupnpc",
+      "name": "MiniUPnPc",
+      "kind": "system-library",
+      "owner": "classic-server",
+      "scope": [
+        "classic-server",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "distribution/MXE-pinned",
+      "version_source": "Ubuntu image packages and MinGW source commit",
+      "license": "BSD-3-Clause",
+      "source_url": "https://github.com/miniupnp/miniupnp",
+      "locator": "pkg:generic/miniupnpc",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "pkg-config on Linux and isolated static MinGW build",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image/package update plus MinGW source review",
+      "eol_response": "Update or remove automatic port mapping without weakening network defaults",
+      "validation": "Pkg-config discovery, MinGW static library, and network-disabled runtime tests",
+      "disposition": "isolate",
+      "packages": [
+        "libminiupnpc-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "classic-server",
+          "path": "CMakeLists.txt",
+          "contains": "pkg_check_modules(MINIUPNPC REQUIRED IMPORTED_TARGET miniupnpc)"
+        }
+      ]
+    },
+    {
+      "id": "system/openssl",
+      "name": "OpenSSL",
+      "kind": "system-library",
+      "owner": "classic-libatrinik",
+      "scope": [
+        "classic-client",
+        "classic-libatrinik",
+        "classic-server",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "distribution/MXE-provided",
+      "version_source": "Pinned build images and MXE commit",
+      "license": "Apache-2.0",
+      "source_url": "https://www.openssl.org/",
+      "locator": "pkg:generic/openssl",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake imported target from the native or MXE package set",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image/MXE update, security advisory review, and exact version report",
+      "eol_response": "Upgrade before the supported OpenSSL line reaches EOL; security fixes are urgent",
+      "validation": "CMake discovery, crypto known-answer tests, and TLS runtime tests",
+      "disposition": "retain",
+      "packages": [
+        "libssl-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "classic-libatrinik",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(OpenSSL REQUIRED)"
+        }
+      ]
+    },
+    {
+      "id": "system/pkg-config",
+      "name": "pkg-config/pkgconf",
+      "kind": "toolchain",
+      "owner": "classic-server",
+      "scope": [
+        "classic-client",
+        "classic-server",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "distribution-provided",
+      "version_source": "Pinned build images",
+      "license": "LicenseRef-System-Distribution",
+      "source_url": "https://github.com/pkgconf/pkgconf",
+      "locator": "pkg:generic/pkgconf",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake resolves native package metadata from the build image",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image update and exact version report",
+      "eol_response": "Upgrade the image or migrate affected discovery to supported imported targets",
+      "validation": "CMake PkgConfig discovery across Linux and MinGW",
+      "disposition": "retain",
+      "packages": [
+        "pkgconf"
+      ],
+      "evidence": [
+        {
+          "repository": "classic-server",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(PkgConfig REQUIRED)"
+        }
+      ]
+    },
+    {
+      "id": "system/sdl3",
+      "name": "SDL3",
+      "kind": "system-library",
+      "owner": "classic-client",
+      "scope": [
+        "classic-client",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": ">=3.4",
+      "version_source": "Classic client CMake constraint and pinned build images",
+      "license": "Zlib",
+      "source_url": "https://github.com/libsdl-org/SDL",
+      "locator": "pkg:generic/SDL3",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake imported target from Ubuntu or MXE",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image/MXE update and SDL3 classic client test matrix",
+      "eol_response": "Upgrade to a supported SDL3 release without reintroducing SDL2 compatibility",
+      "validation": "CMake version constraint, native tests, and live classic client smoke test",
+      "disposition": "retain",
+      "packages": [
+        "libsdl3-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "classic-client",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(SDL3 3.4 CONFIG REQUIRED)"
+        }
+      ]
+    },
+    {
+      "id": "system/sdl3-image",
+      "name": "SDL3_image",
+      "kind": "system-library",
+      "owner": "classic-client",
+      "scope": [
+        "classic-client",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": ">=3.2",
+      "version_source": "Classic client CMake constraint and pinned build images",
+      "license": "Zlib",
+      "source_url": "https://github.com/libsdl-org/SDL_image",
+      "locator": "pkg:generic/SDL3_image",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake imported target from Ubuntu or patched MXE",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image/MXE update and image-decoder tests",
+      "eol_response": "Upgrade with SDL3 and preserve supported image formats explicitly",
+      "validation": "CMake version constraint, image fixtures, and portable classic client build",
+      "disposition": "retain",
+      "packages": [
+        "libsdl3-image-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "classic-client",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(SDL3_image 3.2 CONFIG REQUIRED)"
+        }
+      ]
+    },
+    {
+      "id": "system/sdl3-mixer",
+      "name": "SDL3_mixer",
+      "kind": "system-library",
+      "owner": "classic-client",
+      "scope": [
+        "classic-client",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": ">=3.2.4",
+      "version_source": "Classic client CMake constraint and checksum-pinned source/SDK",
+      "license": "Zlib",
+      "source_url": "https://github.com/libsdl-org/SDL_mixer",
+      "locator": "pkg:generic/SDL3_mixer",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake imported target built from the reviewed source or SDK",
+      "update_cadence_days": 30,
+      "update_mechanism": "Source/SDK update with codec and import verification",
+      "eol_response": "Upgrade with SDL3 and retain only deliberately supported codecs",
+      "validation": "CMake version constraint, pkg-config version, and audio smoke tests",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic-client",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(SDL3_mixer 3.2.4 CONFIG REQUIRED)"
+        }
+      ]
+    },
+    {
+      "id": "system/sdl3-ttf",
+      "name": "SDL3_ttf",
+      "kind": "system-library",
+      "owner": "classic-client",
+      "scope": [
+        "classic-client",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": ">=3.2",
+      "version_source": "Classic client CMake constraint and pinned build images",
+      "license": "Zlib",
+      "source_url": "https://github.com/libsdl-org/SDL_ttf",
+      "locator": "pkg:generic/SDL3_ttf",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake imported target from Ubuntu or MXE",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image/MXE update and text-rendering tests",
+      "eol_response": "Upgrade with SDL3 and preserve font behavior through fixtures",
+      "validation": "CMake version constraint, text tests, and portable classic client build",
+      "disposition": "retain",
+      "packages": [
+        "libsdl3-ttf-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "classic-client",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(SDL3_ttf 3.2 CONFIG REQUIRED)"
+        }
+      ]
+    },
+    {
+      "id": "system/server-image-packages",
+      "name": "Classic server container package sets",
+      "kind": "system-package-set",
+      "owner": "classic-server",
+      "scope": [
+        "classic-server"
+      ],
+      "required": true,
+      "version": "ubuntu-26.04-digest-locked",
+      "version_source": "Classic server Dockerfile stages",
+      "license": "NOASSERTION",
+      "source_url": "https://packages.ubuntu.com/",
+      "locator": "ubuntu-server-image-packages",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "apt installs declared build/runtime packages from the digest-pinned image",
+      "update_cadence_days": 30,
+      "update_mechanism": "Dependabot base-image update plus exact installed-version report",
+      "eol_response": "Update package names and base image together; never retain an EOL runtime layer",
+      "validation": "Reproducible image build, world-maker run, and startup healthcheck",
+      "disposition": "isolate",
+      "packages": [
+        "build-essential",
+        "ca-certificates",
+        "cmake",
+        "flex",
+        "git",
+        "libcrypt1",
+        "libcurl4-openssl-dev",
+        "libcurl4t64",
+        "libgd-dev",
+        "libgd3",
+        "libidn2-0",
+        "libidn2-dev",
+        "libminiupnpc-dev",
+        "libminiupnpc21",
+        "libpython3.14",
+        "libreadline-dev",
+        "libreadline8t64",
+        "libssl-dev",
+        "libssl3t64",
+        "ninja-build",
+        "pkgconf",
+        "python3",
+        "python3-dev",
+        "zlib1g",
+        "zlib1g-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "classic-server",
+          "path": "Dockerfile",
+          "contains": "libpython3.14 libreadline8t64 libssl3t64 python3 zlib1g"
+        }
+      ]
+    },
+    {
+      "id": "system/sound-audio-image-packages",
+      "name": "Sound conversion image package set",
+      "kind": "system-package-set",
+      "owner": "sound",
+      "scope": [
+        "sound"
+      ],
+      "required": true,
+      "version": "ubuntu-20260810T000000Z",
+      "version_source": "sound/tools/audio/Dockerfile",
+      "license": "NOASSERTION",
+      "source_url": "https://snapshot.ubuntu.com/ubuntu/20260810T000000Z",
+      "locator": "ubuntu-sound-audio-packages-20260810T000000Z",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "apt installs exact versions from the immutable Ubuntu snapshot layered on the digest-pinned build image",
+      "update_cadence_days": 30,
+      "update_mechanism": "Reviewed snapshot/package update with complete deterministic sound fixture rebuild",
+      "eol_response": "Advance the complete conversion toolchain together; never fall back to floating package repositories",
+      "validation": "Snapshot URL and exact package/version checks, installed binary digests, two-build fixture comparison, and decoder probes",
+      "disposition": "isolate",
+      "packages": [
+        "ffmpeg=7:8.0.1-3ubuntu2",
+        "openmpt123=0.8.4-1",
+        "opus-tools=0.2-1build5"
+      ],
+      "evidence": [
+        {
+          "repository": "sound",
+          "path": "manifests/audio-toolchain.json",
+          "contains": "ffmpeg=7:8.0.1-3ubuntu2"
+        },
+        {
+          "repository": "sound",
+          "path": "tools/audio/Dockerfile",
+          "contains": "UBUNTU_SNAPSHOT=https://snapshot.ubuntu.com/ubuntu/20260810T000000Z"
+        }
+      ]
+    },
+    {
+      "id": "system/threads",
+      "name": "CMake Threads",
+      "kind": "system-library",
+      "owner": "classic-libatrinik",
+      "scope": [
+        "classic-libatrinik"
+      ],
+      "required": true,
+      "version": "platform-provided",
+      "version_source": "CMake platform thread discovery",
+      "license": "NOASSERTION",
+      "source_url": "https://cmake.org/cmake/help/latest/module/FindThreads.html",
+      "locator": "pkg:generic/platform-threads",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake maps the portable Threads target to the platform runtime",
+      "update_cadence_days": 90,
+      "update_mechanism": "Compiler/platform image update",
+      "eol_response": "Move supported platforms together rather than carrying obsolete thread shims",
+      "validation": "CMake discovery and native lifecycle tests",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic-libatrinik",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(Threads REQUIRED)"
+        }
+      ]
+    },
+    {
+      "id": "system/ubuntu-linux-image-packages",
+      "name": "Linux build-image apt package set",
+      "kind": "system-package-set",
+      "owner": "devcontainer",
+      "scope": [
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "ubuntu-26.04-digest-locked",
+      "version_source": "linux/Dockerfile",
+      "license": "NOASSERTION",
+      "source_url": "https://packages.ubuntu.com/",
+      "locator": "ubuntu-linux-build-packages",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "apt installs the declared packages from the digest-pinned image",
+      "update_cadence_days": 30,
+      "update_mechanism": "Dependabot base-image update and exact installed-version report",
+      "eol_response": "Update package names and base image together before Ubuntu support ends",
+      "validation": "Docker build, tool version probes, and complete native workspace build",
+      "disposition": "isolate",
+      "packages": [
+        "alsa-utils",
+        "build-essential",
+        "ca-certificates",
+        "ccache",
+        "check",
+        "clang",
+        "clang-format",
+        "clang-tidy",
+        "clangd",
+        "cmake",
+        "cppcheck",
+        "cproto",
+        "curl",
+        "fd-find",
+        "file",
+        "flex",
+        "fzf",
+        "gdb",
+        "gh",
+        "git",
+        "iproute2",
+        "jq",
+        "libasound2-plugins",
+        "libclang-rt-dev",
+        "libcurl4-openssl-dev",
+        "libgd-dev",
+        "libidn2-dev",
+        "libminiupnpc-dev",
+        "libreadline-dev",
+        "libsdl3-dev",
+        "libsdl3-image-dev",
+        "libsdl3-ttf-dev",
+        "libssl-dev",
+        "libsubunit-dev",
+        "libxml2-dev",
+        "libxml2-utils",
+        "llvm",
+        "ninja-build",
+        "nodejs",
+        "npm",
+        "openssh-client",
+        "patch",
+        "pkgconf",
+        "pulseaudio-utils",
+        "python3-dev",
+        "python3-pip",
+        "python3-venv",
+        "ripgrep",
+        "shellcheck",
+        "shfmt",
+        "sudo",
+        "timidity",
+        "tree",
+        "unzip",
+        "valgrind",
+        "zlib1g-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "linux/Dockerfile",
+          "contains": "apt-get install -y --no-install-recommends"
+        }
+      ]
+    },
+    {
+      "id": "system/ubuntu-windows-image-packages",
+      "name": "Windows build-image host package set",
+      "kind": "system-package-set",
+      "owner": "devcontainer",
+      "scope": [
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "debian-bookworm-digest-locked",
+      "version_source": "windows/Dockerfile",
+      "license": "NOASSERTION",
+      "source_url": "https://packages.debian.org/bookworm/",
+      "locator": "debian-windows-build-packages",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "apt installs declared host and native-build packages from the digest-pinned image",
+      "update_cadence_days": 30,
+      "update_mechanism": "Dependabot base-image update and exact installed-version report",
+      "eol_response": "Update package names and base image together before Debian support ends",
+      "validation": "Cold MXE image build and portable classic client/server builds",
+      "disposition": "isolate",
+      "packages": [
+        "autoconf",
+        "automake",
+        "autopoint",
+        "bison",
+        "bzip2",
+        "ca-certificates",
+        "cmake",
+        "flex",
+        "g++",
+        "g++-multilib",
+        "gettext",
+        "git",
+        "gperf",
+        "intltool",
+        "libc6-dev-i386",
+        "libclang-dev",
+        "libcurl4-openssl-dev",
+        "libgd-dev",
+        "libgdk-pixbuf-2.0-dev",
+        "libgl-dev",
+        "libltdl-dev",
+        "libminiupnpc-dev",
+        "libpcre2-dev",
+        "libssl-dev",
+        "libtool-bin",
+        "libxml-parser-perl",
+        "lzip",
+        "make",
+        "mingw-w64-tools",
+        "ninja-build",
+        "openssh-client",
+        "openssl",
+        "p7zip-full",
+        "patch",
+        "perl",
+        "python-is-python3",
+        "python3",
+        "python3-dev",
+        "python3-mako",
+        "python3-packaging",
+        "python3-pkg-resources",
+        "python3-setuptools",
+        "ruby",
+        "sqlite3",
+        "unzip",
+        "wget",
+        "xz-utils",
+        "zip",
+        "zlib1g-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "windows/Dockerfile",
+          "contains": "mingw-w64-tools"
+        }
+      ]
+    },
+    {
+      "id": "system/zlib",
+      "name": "zlib",
+      "kind": "system-library",
+      "owner": "classic-libatrinik",
+      "scope": [
+        "classic-client",
+        "classic-libatrinik",
+        "classic-server",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "distribution/MXE-provided",
+      "version_source": "Pinned build images and MXE commit",
+      "license": "Zlib",
+      "source_url": "https://zlib.net/",
+      "locator": "pkg:generic/zlib",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "CMake imported target from the native or MXE package set",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image/MXE update and exact version report",
+      "eol_response": "Upgrade promptly for unsupported or security-affected compression lines",
+      "validation": "CMake discovery and compression/packet tests",
+      "disposition": "retain",
+      "packages": [
+        "zlib1g-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "classic-libatrinik",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(ZLIB REQUIRED)"
+        }
+      ]
+    },
+    {
+      "id": "toolchain/actionlint",
+      "name": "actionlint",
+      "kind": "toolchain",
+      "owner": "devcontainer",
+      "scope": [
+        "atrinik",
+        "devcontainer",
+        "github-settings"
+      ],
+      "required": true,
+      "version": "1.7.12",
+      "version_source": "linux/Dockerfile",
+      "license": "MIT",
+      "source_url": "https://github.com/rhysd/actionlint/releases/tag/v1.7.12",
+      "locator": "pkg:github/rhysd/actionlint@v1.7.12",
+      "commit": null,
+      "checksum": "sha256:8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8",
+      "acquisition": "Linux image downloads the checksum-pinned official binary",
+      "update_cadence_days": 30,
+      "update_mechanism": "Scheduled release drift review and workflow validation",
+      "eol_response": "Upgrade before new workflow syntax outgrows the validator",
+      "validation": "Checksum, exact version assertion, and all workflow files",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "linux/Dockerfile",
+          "contains": "ACTIONLINT_SHA256=8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+        }
+      ]
+    },
+    {
+      "id": "toolchain/buf",
+      "name": "Buf and Protobuf generation toolchain",
+      "kind": "toolchain",
+      "owner": "protocol",
+      "scope": ["protocol"],
+      "required": true,
+      "version": "Buf 1.72.0; Protobuf 35.0; protoc-gen-go 1.36.11; protoc-gen-prost 0.5.0",
+      "version_source": "Protocol README and tools/generate.sh exact version gates",
+      "license": "Apache-2.0",
+      "source_url": "https://github.com/bufbuild/buf",
+      "locator": "pkg:github/bufbuild/buf@v1.72.0",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Pinned devcontainer toolchain packages and local exact-version gates",
+      "update_cadence_days": 30,
+      "update_mechanism": "Coordinated protocol generator and devcontainer review",
+      "eol_response": "Upgrade schemas, generators, baseline fixtures, and toolchain image together",
+      "validation": "Exact version gates, Buf format/lint/breaking checks, and generated-output drift",
+      "disposition": "retain",
+      "packages": ["buf", "protoc", "protoc-gen-go", "protoc-gen-prost"],
+      "evidence": [
+        {"repository":"protocol","path":"README.md","contains":"Buf 1.72.0"},
+        {"repository":"protocol","path":"tools/generate.sh","contains":"test \"$(buf --version)\" = 1.72.0"}
+      ]
+    },
+    {
+      "id": "toolchain/cmake",
+      "name": "CMake",
+      "kind": "toolchain",
+      "owner": "devcontainer",
+      "scope": [
+        "classic-client",
+        "classic-libatrinik",
+        "classic-protocol",
+        "classic-server",
+        "devcontainer",
+        "playtester"
+      ],
+      "required": true,
+      "version": ">=3.21",
+      "version_source": "Native repository minimums and pinned build images",
+      "license": "BSD-3-Clause",
+      "source_url": "https://cmake.org/",
+      "locator": "pkg:generic/cmake",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Pinned Linux image packages and MXE toolchain package",
+      "update_cadence_days": 30,
+      "update_mechanism": "Image/MXE update and exact version report",
+      "eol_response": "Raise the project minimum only after every supported image supplies it",
+      "validation": "All native configure/build/test presets",
+      "disposition": "retain",
+      "packages": [
+        "cmake"
+      ],
+      "evidence": [
+        {
+          "repository": "classic-client",
+          "path": "CMakeLists.txt",
+          "contains": "cmake_minimum_required(VERSION 3.21)"
+        },
+        {
+          "repository": "classic-libatrinik",
+          "path": "CMakeLists.txt",
+          "contains": "cmake_minimum_required(VERSION 3.21)"
+        },
+        {
+          "repository": "classic-libatrinik",
+          "path": "tests/consumer/CMakeLists.txt",
+          "contains": "find_package(LibAtrinik \"${ATRINIK_CONSUMER_VERSION}\" EXACT CONFIG REQUIRED)"
+        },
+        {
+          "repository": "classic-protocol",
+          "path": "CMakeLists.txt",
+          "contains": "cmake_minimum_required(VERSION 3.21)"
+        },
+        {
+          "repository": "classic-server",
+          "path": "CMakeLists.txt",
+          "contains": "cmake_minimum_required(VERSION 3.21)"
+        },
+        {
+          "repository": "playtester",
+          "path": "CMakeLists.txt",
+          "contains": "cmake_minimum_required(VERSION 3.21)"
+        }
+      ]
+    },
+    {
+      "id": "toolchain/devcontainer-cli",
+      "name": "Dev Container CLI",
+      "kind": "toolchain",
+      "owner": "devcontainer",
+      "scope": [
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "0.88.0",
+      "version_source": "linux/Dockerfile",
+      "license": "MIT",
+      "source_url": "https://github.com/devcontainers/cli",
+      "locator": "pkg:npm/@devcontainers/cli@0.88.0",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "npm installs the exact global package in the Linux image",
+      "update_cadence_days": 30,
+      "update_mechanism": "Scheduled npm release review and devcontainer configuration tests",
+      "eol_response": "Upgrade before supported Dev Container metadata requires a newer CLI",
+      "validation": "Exact version assertion and devcontainer configuration tests",
+      "disposition": "isolate",
+      "packages": [
+        "@devcontainers/cli"
+      ],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "linux/Dockerfile",
+          "contains": "DEVCONTAINER_CLI_VERSION=0.88.0"
+        }
+      ]
+    },
+    {
+      "id": "toolchain/gh-stack",
+      "name": "GitHub PR stack extension",
+      "kind": "toolchain",
+      "owner": "devcontainer",
+      "scope": [
+        "atrinik",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "0.1.0",
+      "version_source": "linux/Dockerfile checksum and pinned extension manifest",
+      "license": "MIT",
+      "source_url": "https://github.com/github/gh-stack/releases/tag/v0.1.0",
+      "locator": "pkg:github/github/gh-stack@v0.1.0",
+      "commit": "a1b4a3d4d0bcde9ec3a78ab99b2d63af121857a9",
+      "checksum": "sha256:358552dd7dce0a46ce153fe196270cec482b84f080947890aad4061a8d44bc0b",
+      "acquisition": "The Linux image installs the v0.1.0 extension for ubuntu and verifies its attested binary digest",
+      "update_cadence_days": 30,
+      "update_mechanism": "Reviewed version, source, checksum, license, and release-attestation update in the devcontainer image",
+      "eol_response": "Replace the extension before its command contract becomes unsupported",
+      "validation": "Pinned manifest, non-root discovery and dispatch, exact version and checksum, and attestation constrained to github/gh-stack, .github/workflows/release.yml, refs/tags/v0.1.0, and the source commit",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "linux/Dockerfile",
+          "contains": "GH_STACK_SHA256_AMD64=358552dd7dce0a46ce153fe196270cec482b84f080947890aad4061a8d44bc0b"
+        }
+      ]
+    },
+    {
+      "id": "toolchain/github-cli",
+      "name": "GitHub CLI",
+      "kind": "toolchain",
+      "owner": "devcontainer",
+      "scope": [
+        "atrinik",
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "2.97.0",
+      "version_source": "linux/Dockerfile",
+      "license": "MIT",
+      "source_url": "https://github.com/cli/cli/releases/tag/v2.97.0",
+      "locator": "pkg:github/cli/cli@v2.97.0",
+      "commit": "55dbb4dc6b7edb10b48e3d7fc5bccd32318d1b55",
+      "checksum": "sha256:a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112",
+      "acquisition": "The Linux image downloads the checksum-pinned official linux-amd64 release archive",
+      "update_cadence_days": 30,
+      "update_mechanism": "Scheduled upstream release review with a reviewed version and checksum update",
+      "eol_response": "Upgrade before the supported GitHub CLI line loses required PR stack behavior",
+      "validation": "Sole executable path, exact non-root version, archive checksum, license, and whole-image SBOM",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": "linux/Dockerfile",
+          "contains": "GH_SHA256=a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112"
+        }
+      ]
+    },
+    {
+      "id": "toolchain/github-hosted-ubuntu-24.04",
+      "name": "GitHub-hosted Ubuntu 24.04 runner",
+      "kind": "toolchain",
+      "owner": "github-settings",
+      "scope": [
+        "atrinik",
+        "classic",
+        "client",
+        "content",
+        "content-toolkit",
+        "deploy-control",
+        "devcontainer",
+        "editor",
+        "github-settings",
+        "metaserver-worker",
+        "playtester",
+        "protocol",
+        "renderer",
+        "resources",
+        "server",
+        "sound",
+        "tools",
+        "website"
+      ],
+      "required": true,
+      "version": "ubuntu-24.04",
+      "version_source": "Explicit GitHub Actions runner label and generated version report",
+      "license": "LicenseRef-GitHub-Hosted-Runner",
+      "source_url": "https://github.com/actions/runner-images",
+      "locator": "github-hosted-runner/ubuntu-24.04",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "GitHub Actions provisions the named runner image for each job",
+      "update_cadence_days": 30,
+      "update_mechanism": "Monthly runner-image review with exact in-job tool version report",
+      "eol_response": "Move every consumer to a supported explicit runner label before removal",
+      "validation": "Actionlint plus required repository checks",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": ".github/workflows/integration.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "classic",
+          "path": ".github/workflows/check.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "client",
+          "path": ".github/workflows/validate.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "content",
+          "path": ".github/workflows/check.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "content-toolkit",
+          "path": ".github/workflows/validate.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "deploy-control",
+          "path": ".github/workflows/check.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "devcontainer",
+          "path": ".github/workflows/pr-title.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "editor",
+          "path": ".github/workflows/validate.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "github-settings",
+          "path": ".github/workflows/check.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "metaserver-worker",
+          "path": ".github/workflows/check.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "playtester",
+          "path": ".github/workflows/release.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "playtester",
+          "path": ".github/workflows/validate.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "protocol",
+          "path": ".github/workflows/validate.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "renderer",
+          "path": ".github/workflows/validate.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "resources",
+          "path": ".github/workflows/check.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "server",
+          "path": ".github/workflows/validate.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "sound",
+          "path": ".github/workflows/check.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "tools",
+          "path": ".github/workflows/check.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        },
+        {
+          "repository": "website",
+          "path": ".github/workflows/validate.yml",
+          "contains": "runs-on: ubuntu-24.04"
+        }
+      ]
+    },
+    {
+      "id": "toolchain/github-hosted-ubuntu-26.04",
+      "name": "GitHub-hosted Ubuntu 26.04 runner",
+      "kind": "toolchain",
+      "owner": "devcontainer",
+      "scope": [
+        "devcontainer"
+      ],
+      "required": true,
+      "version": "ubuntu-26.04",
+      "version_source": "Explicit GitHub Actions runner label and generated version report",
+      "license": "LicenseRef-GitHub-Hosted-Runner",
+      "source_url": "https://github.com/actions/runner-images",
+      "locator": "github-hosted-runner/ubuntu-26.04",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "GitHub Actions provisions the named runner image for image validation",
+      "update_cadence_days": 30,
+      "update_mechanism": "Monthly runner-image review and devcontainer cold-build validation",
+      "eol_response": "Move image validation to a supported explicit runner label before removal",
+      "validation": "Actionlint plus Linux and Windows image builds",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "devcontainer",
+          "path": ".github/workflows/validate.yml",
+          "contains": "runs-on: ubuntu-26.04"
+        }
+      ]
+    },
+    {
+      "id": "toolchain/github-hosted-windows-2025",
+      "name": "GitHub-hosted Windows 2025 runner",
+      "kind": "toolchain",
+      "owner": "github-settings",
+      "scope": ["atrinik", "classic", "client", "content", "devcontainer", "editor", "server", "website"],
+      "required": true,
+      "version": "windows-2025",
+      "version_source": "Explicit GitHub Actions runner label and generated version report",
+      "license": "LicenseRef-GitHub-Hosted-Runner",
+      "source_url": "https://github.com/actions/runner-images",
+      "locator": "github-hosted-runner/windows-2025",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "GitHub Actions provisions the explicit hosted runner image",
+      "update_cadence_days": 7,
+      "update_mechanism": "Scheduled supply-chain audit and runner-image review",
+      "eol_response": "Move all consumers to a supported immutable-label generation before removal",
+      "validation": "Windows validation and packaging jobs plus generated tool version report",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {"repository":"atrinik","path":".github/workflows/integration.yml","contains":"runs-on: windows-2025"},
+        {"repository":"classic","path":".github/workflows/check.yml","contains":"runs-on: windows-2025"},
+        {"repository":"client","path":".github/workflows/validate.yml","contains":"runs-on: windows-2025"},
+        {"repository":"content","path":".github/workflows/check.yml","contains":"- windows-2025"},
+        {"repository":"devcontainer","path":".github/workflows/validate.yml","contains":"runs-on: windows-2025"},
+        {"repository":"editor","path":".github/workflows/validate.yml","contains":"runs-on: windows-2025"},
+        {"repository":"server","path":".github/workflows/validate.yml","contains":"runs-on: windows-2025"},
+        {"repository":"website","path":".github/workflows/validate.yml","contains":"runs-on: windows-2025"}
+      ]
+    },
+    {
+      "id": "toolchain/go",
+      "name": "Go replacement toolchain",
+      "kind": "toolchain",
+      "owner": "server",
+      "scope": ["protocol", "server"],
+      "required": true,
+      "version": "1.26.6",
+      "version_source": "Server .go-version and protocol/server module/tool policy",
+      "license": "BSD-3-Clause",
+      "source_url": "https://go.dev/dl/",
+      "locator": "pkg:generic/go@1.26.6",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Pinned devcontainer image and actions/setup-go module-file resolution",
+      "update_cadence_days": 30,
+      "update_mechanism": "Coordinated devcontainer, module, and workflow update",
+      "eol_response": "Upgrade both replacement consumers before the Go release loses support",
+      "validation": "Exact go directives, setup-go CI, go mod verify, vet, race/fuzz tests, and release metadata",
+      "disposition": "retain",
+      "packages": [],
+      "evidence": [
+        {"repository":"protocol","path":"README.md","contains":"Go 1.26.6"},
+        {"repository":"server","path":".go-version","contains":"1.26.6"}
+      ]
+    },
+    {
+      "id": "toolchain/node",
+      "name": "Node.js",
+      "kind": "toolchain",
+      "owner": "atrinik",
+      "scope": [
+        "atrinik",
+        "classic",
+        "client",
+        "content",
+        "content-toolkit",
+        "deploy-control",
+        "devcontainer",
+        "editor",
+        "github-settings",
+        "metaserver-worker",
+        "playtester",
+        "protocol",
+        "renderer",
+        "resources",
+        "server",
+        "sound",
+        "tools",
+        "website"
+      ],
+      "required": true,
+      "version": "wrapper release 22; Classic release 24; Worker, playtester, and replacement releases 24.18.1",
+      "version_source": "Worker/website/deploy-control package engines and exact release workflow lines",
+      "license": "MIT",
+      "source_url": "https://nodejs.org/",
+      "locator": "pkg:generic/node",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "GitHub setup-node or the digest-pinned Linux image",
+      "update_cadence_days": 30,
+      "update_mechanism": "setup-node Dependabot updates and supported-LTS review",
+      "eol_response": "Advance to a supported Node LTS before the current line reaches EOL",
+      "validation": "Exact version report, npm ci, Worker tests, and semantic-release",
+      "disposition": "retain",
+      "packages": [
+        "nodejs",
+        "npm"
+      ],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": ".github/workflows/release.yml",
+          "contains": "node-version: 22"
+        },
+        {
+          "repository": "classic",
+          "path": ".github/workflows/release.yml",
+          "contains": "node-version: \"24\""
+        },
+        {
+          "repository": "client",
+          "path": ".github/workflows/release.yml",
+          "contains": "node-version: 24.18.1"
+        },
+        {
+          "repository": "content",
+          "path": ".github/workflows/release.yml",
+          "contains": "node-version: 24.18.1"
+        },
+        {
+          "repository": "content-toolkit",
+          "path": ".github/workflows/release.yml",
+          "contains": "node-version: 24.18.1"
+        },
+        {
+          "repository": "deploy-control",
+          "path": "package.json",
+          "contains": "\"node\": \"24.18.1\""
+        },
+        {
+          "repository": "devcontainer",
+          "path": ".github/workflows/release.yml",
+          "contains": "node-version: 24.18.1"
+        },
+        {
+          "repository": "editor",
+          "path": ".github/workflows/release.yml",
+          "contains": "node-version: 24.18.1"
+        },
+        {
+          "repository": "github-settings",
+          "path": ".github/workflows/release.yml",
+          "contains": "node-version: 24.18.1"
+        },
+        {
+          "repository": "metaserver-worker",
+          "path": "package.json",
+          "contains": "\"node\": \"24.18.1\""
+        },
+        {
+          "repository": "playtester",
+          "path": ".github/workflows/release.yml",
+          "contains": "node-version: 24.18.1"
+        },
+        {
+          "repository": "playtester",
+          "path": ".github/workflows/release.yml",
+          "contains": "npx --yes"
+        },
+        {
+          "repository": "protocol",
+          "path": ".github/workflows/release.yml",
+          "contains": "node-version: 24.18.1"
+        },
+        {
+          "repository": "renderer",
+          "path": ".github/workflows/release.yml",
+          "contains": "node-version: 24.18.1"
+        },
+        {
+          "repository": "resources",
+          "path": ".github/workflows/release.yml",
+          "contains": "node-version: 24.18.1"
+        },
+        {
+          "repository": "server",
+          "path": ".github/workflows/release.yml",
+          "contains": "node-version: 24.18.1"
+        },
+        {
+          "repository": "sound",
+          "path": ".github/workflows/release.yml",
+          "contains": "node-version: 24.18.1"
+        },
+        {
+          "repository": "tools",
+          "path": ".github/workflows/release.yml",
+          "contains": "node-version: 24.18.1"
+        },
+        {
+          "repository": "website",
+          "path": "package.json",
+          "contains": "\"node\": \">=24.18.1 <25\""
+        }
+      ]
+    },
+    {
+      "id": "toolchain/oras",
+      "name": "ORAS CLI",
+      "kind": "toolchain",
+      "owner": "classic-server",
+      "scope": [
+        "classic"
+      ],
+      "required": true,
+      "version": "v1.3.3",
+      "version_source": "Classic dependency-bundle publisher workflow",
+      "license": "Apache-2.0",
+      "source_url": "https://github.com/oras-project/oras/releases/tag/v1.3.3",
+      "locator": "pkg:github/oras-project/oras@v1.3.3",
+      "commit": null,
+      "checksum": "sha256:9ce999f8d2de03fc03968b29d743077a58783e545e5eaa53917ca177352d0e59",
+      "acquisition": "The trusted Classic publisher downloads the exact official linux-amd64 release asset through GitHub CLI and verifies its GitHub-published SHA-256 before extraction",
+      "update_cadence_days": 90,
+      "update_mechanism": "Reviewed ORAS release and asset-digest update with deterministic OCI layout copy validation",
+      "eol_response": "Pin and validate a supported ORAS release before the current client loses required OCI distribution behavior",
+      "validation": "Exact archive SHA-256 and version plus digest-preserving OCI layout copy and registry postcondition",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic",
+          "path": ".github/workflows/publish-dependency-bundle.yml",
+          "contains": "9ce999f8d2de03fc03968b29d743077a58783e545e5eaa53917ca177352d0e59"
+        }
+      ]
+    },
+    {
+      "id": "toolchain/python",
+      "name": "Python",
+      "kind": "toolchain",
+      "owner": "atrinik",
+      "scope": [
+        "atrinik",
+        "classic-client",
+        "classic-protocol",
+        "classic-server",
+        "content",
+        "devcontainer",
+        "playtester",
+        "tools"
+      ],
+      "required": true,
+      "version": ">=3.11; Windows runtime 3.14.6",
+      "version_source": "Wrapper requirement, classic/protocol metadata, and Windows image arguments",
+      "license": "PSF-2.0",
+      "source_url": "https://www.python.org/",
+      "locator": "pkg:generic/python",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Pinned build images, setup-python, and checksum-pinned Windows runtime/source archives",
+      "update_cadence_days": 30,
+      "update_mechanism": "Supported-version matrix review and image rebuild",
+      "eol_response": "Advance every maintained tool and embedded runtime before Python EOL",
+      "validation": "Exact version report, compileall, Python tests, plugin tests, and MinGW package smoke test",
+      "disposition": "retain",
+      "packages": [
+        "python3",
+        "python3-dev"
+      ],
+      "evidence": [
+        {
+          "repository": "atrinik",
+          "path": "README.md",
+          "contains": "Python 3.11 or newer"
+        },
+        {
+          "repository": "classic-protocol",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(Python3 REQUIRED COMPONENTS Interpreter)"
+        },
+        {
+          "repository": "classic-server",
+          "path": "CMakeLists.txt",
+          "contains": "find_package(Python3 REQUIRED COMPONENTS Interpreter)"
+        },
+        {
+          "repository": "devcontainer",
+          "path": "windows/Dockerfile",
+          "contains": "PYTHON_VERSION=3.14.6"
+        },
+        {
+          "repository": "playtester",
+          "path": "pyproject.toml",
+          "contains": "requires-python = \">=3.11\""
+        }
+      ]
+    },
+    {
+      "id": "toolchain/rust",
+      "name": "Rust replacement toolchain",
+      "kind": "toolchain",
+      "owner": "renderer",
+      "scope": ["client", "content-toolkit", "editor", "protocol", "renderer"],
+      "required": true,
+      "version": "1.97.1",
+      "version_source": "Repository rust-toolchain.toml files",
+      "license": "Apache-2.0",
+      "source_url": "https://static.rust-lang.org/",
+      "locator": "pkg:generic/rust@1.97.1",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "rustup installs the exact minimal toolchain selected by each repository",
+      "update_cadence_days": 30,
+      "update_mechanism": "Coordinated rust-toolchain, MSRV, devcontainer, and dependency review",
+      "eol_response": "Upgrade all replacement Rust repositories before the toolchain loses support",
+      "validation": "Exact toolchain files, formatting, Clippy warnings-as-errors, tests, and Linux/Windows builds",
+      "disposition": "retain",
+      "packages": ["clippy", "rustfmt"],
+      "evidence": [
+        {"repository":"client","path":"rust-toolchain.toml","contains":"channel = \"1.97.1\""},
+        {"repository":"content-toolkit","path":"rust-toolchain.toml","contains":"channel = \"1.97.1\""},
+        {"repository":"editor","path":"rust-toolchain.toml","contains":"channel = \"1.97.1\""},
+        {"repository":"protocol","path":"rust-toolchain.toml","contains":"channel = \"1.97.1\""},
+        {"repository":"renderer","path":"rust-toolchain.toml","contains":"channel = \"1.97.1\""}
+      ]
+    },
+    {
+      "id": "vendored/sdl-gfx-rotozoom",
+      "name": "SDL_gfx rotozoom implementation",
+      "kind": "vendored-source",
+      "owner": "classic-client",
+      "scope": [
+        "classic-client"
+      ],
+      "required": false,
+      "version": "retired",
+      "version_source": "Classic client source audit",
+      "license": "LGPL-2.1-or-later",
+      "source_url": "https://www.ferzkopp.net/Software/SDL_gfx-2.0/",
+      "locator": "sdl-gfx-rotozoom",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "No external acquisition remains; owned SDL3 surface primitives replaced the vendored implementation",
+      "update_cadence_days": 180,
+      "update_mechanism": "Repository search prevents reintroduction",
+      "eol_response": "Keep the retired source absent and maintain the focused owned API",
+      "validation": "Surface primitive unit tests and repository search for SDL_gfx source",
+      "disposition": "replace",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic-client",
+          "path": "src/gui/toolkit/surface_primitives.c",
+          "contains": "rotozoomSurfaceXY"
+        }
+      ]
+    },
+    {
+      "id": "vendored/uthash-family",
+      "name": "uthash, utarray, and utlist",
+      "kind": "vendored-source",
+      "owner": "classic-libatrinik",
+      "scope": [
+        "classic-libatrinik"
+      ],
+      "required": true,
+      "version": "1.9.4",
+      "version_source": "Embedded version macros",
+      "license": "BSD-1-Clause",
+      "source_url": "https://github.com/troydhanson/uthash",
+      "locator": "pkg:github/troydhanson/uthash@v1.9.4",
+      "commit": null,
+      "checksum": null,
+      "acquisition": "Historical vendored headers retained behind the shared library boundary",
+      "update_cadence_days": 90,
+      "update_mechanism": "Scheduled upstream/security review before any isolated upgrade or replacement",
+      "eol_response": "Replace with owned typed containers or update all three headers together after sanitizer/performance tests",
+      "validation": "Version macro audit, native tests, sanitizers, and downstream builds",
+      "disposition": "isolate",
+      "packages": [],
+      "evidence": [
+        {
+          "repository": "classic-libatrinik",
+          "path": "utarray.h",
+          "contains": "UTARRAY_VERSION 1.9 .4"
+        },
+        {
+          "repository": "classic-libatrinik",
+          "path": "uthash.h",
+          "contains": "UTHASH_VERSION 1.9 .4"
+        },
+        {
+          "repository": "classic-libatrinik",
+          "path": "utlist.h",
+          "contains": "UTLIST_VERSION 1.9 .4"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/supply_chain/schema.json
+++ b/tests/fixtures/supply_chain/schema.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://atrinik.org/schema/supply-chain-inventory-v4.json",
+  "title": "Atrinik supply-chain inventory",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "organization", "created", "license_references", "repositories", "dependencies"],
+  "properties": {
+    "schema_version": {"const": 4},
+    "organization": {"const": "atrinik"},
+    "created": {"type": "string", "format": "date-time"},
+    "license_references": {
+      "type": "object",
+      "propertyNames": {"pattern": "^LicenseRef-[A-Za-z0-9.-]+$"},
+      "additionalProperties": {"type": "string", "minLength": 1}
+    },
+    "repositories": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name", "repository", "branch", "checkout", "source", "cohorts", "stacks", "roles",
+          "license", "commit", "supported", "audit_ready", "audit_mode", "role"
+        ],
+        "properties": {
+          "name": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$"},
+          "repository": {"type": "string", "pattern": "^atrinik/[a-z0-9][a-z0-9._-]*$"},
+          "branch": {"type": "string", "minLength": 1},
+          "checkout": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$"},
+          "source": {
+            "type": "string",
+            "pattern": "^(?:\\.|[a-z0-9][a-z0-9._-]*(?:/[a-z0-9][a-z0-9._-]*)*)$"
+          },
+          "cohorts": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {"enum": ["classic", "default"]}
+          },
+          "stacks": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {"enum": ["classic", "default"]}
+          },
+          "roles": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$"}
+          },
+          "license": {"type": "string", "minLength": 1},
+          "commit": {
+            "type": ["string", "null"],
+            "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64})$"
+          },
+          "supported": {"type": "boolean"},
+          "audit_ready": {"type": "boolean"},
+          "audit_mode": {"enum": ["full", "metadata"]},
+          "role": {"type": "string", "minLength": 1}
+        },
+        "allOf": [
+          {
+            "if": {"properties": {"supported": {"const": true}}},
+            "then": {"properties": {"commit": {"const": null}}}
+          }
+        ]
+      }
+    },
+    "dependencies": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/dependency"}
+    }
+  },
+  "$defs": {
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "path", "contains"],
+      "properties": {
+        "repository": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$"},
+        "path": {"type": "string", "minLength": 1},
+        "contains": {"type": "string", "minLength": 1}
+      }
+    },
+    "dependency": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id", "name", "kind", "owner", "scope", "required", "version",
+        "version_source", "license", "source_url", "locator", "commit",
+        "checksum", "acquisition", "update_cadence_days", "update_mechanism",
+        "eol_response", "validation", "disposition", "packages", "evidence"
+      ],
+      "properties": {
+        "id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._/-]*$"},
+        "name": {"type": "string", "minLength": 1},
+        "kind": {
+          "enum": [
+            "container-feature", "container-image", "external-tool",
+            "github-action", "language-package-set", "source-archive",
+            "system-library", "system-package-set", "toolchain", "vendored-source"
+          ]
+        },
+        "owner": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$"},
+        "scope": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$"}
+        },
+        "required": {"type": "boolean"},
+        "version": {"type": "string", "minLength": 1},
+        "version_source": {"type": "string", "minLength": 1},
+        "license": {"type": "string", "minLength": 1},
+        "source_url": {"type": "string", "format": "uri", "pattern": "^https://"},
+        "locator": {"type": "string", "minLength": 1},
+        "commit": {"type": ["string", "null"], "pattern": "^[0-9a-f]{40}$"},
+        "checksum": {"type": ["string", "null"], "pattern": "^sha256:[0-9a-f]{64}$"},
+        "acquisition": {"type": "string", "minLength": 1},
+        "update_cadence_days": {"type": "integer", "minimum": 1, "maximum": 366},
+        "update_mechanism": {"type": "string", "minLength": 1},
+        "eol_response": {"type": "string", "minLength": 1},
+        "validation": {"type": "string", "minLength": 1},
+        "disposition": {"enum": ["isolate", "remove", "replace", "retain"]},
+        "packages": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "evidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/evidence"}
+        }
+      }
+    }
+  }
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1143,6 +1143,32 @@ class ParserTests(unittest.TestCase):
             output.call_args_list,
         )
 
+    def test_supply_chain_findings_are_diagnostic_only(self) -> None:
+        with (
+            mock.patch("atrinik_workspace.cli.Workspace"),
+            mock.patch("atrinik_workspace.cli.Inventory.load") as load,
+            mock.patch("builtins.print") as output,
+        ):
+            load.side_effect = WorkspaceError("catalog differs from current components")
+            for command in ("validate", "audit", "report", "versions"):
+                with self.subTest(command=command):
+                    self.assertEqual(
+                        main(["supply-chain", command] + (
+                            ["--format", "licenses"] if command == "report" else []
+                        )), 0
+                    )
+            self.assertTrue(any(
+                "diagnostic: catalog differs" in str(call)
+                for call in output.call_args_list
+            ))
+            load.side_effect = None
+            inventory = mock.Mock()
+            inventory.audit.side_effect = WorkspaceError("stale image evidence")
+            load.return_value = inventory
+            with mock.patch("atrinik_workspace.cli.repository_roots", return_value={}):
+                self.assertEqual(main(["supply-chain", "audit"]), 0)
+            inventory.audit.assert_called_once()
+
     def test_supply_chain_commands_dispatch_validated_inventory(self) -> None:
         inventory = mock.Mock()
         inventory.dependencies = [object(), object()]

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -17,7 +17,6 @@ class ReplacementFoundationTests(unittest.TestCase):
     def setUp(self) -> None:
         self.inventory = load_json("governance/replacement-foundations.json")
         self.manifest = load_json("components.json")
-        self.supply_chain = load_json("supply-chain/inventory.json")
 
     def test_every_replacement_component_has_one_complete_record(self) -> None:
         expected = {
@@ -149,19 +148,7 @@ class ReplacementFoundationTests(unittest.TestCase):
             )
         )
 
-    def test_foundation_repositories_are_owned_in_supply_chain(self) -> None:
-        supply_chain = {
-            record["repository"]: record
-            for record in self.supply_chain["repositories"]
-            if record["supported"]
-        }
-        for record in self.inventory["repositories"]:
-            with self.subTest(repository=record["repository"]):
-                self.assertIn(record["repository"], supply_chain)
-                self.assertEqual(supply_chain[record["repository"]]["branch"], "main")
-                self.assertTrue(supply_chain[record["repository"]]["audit_ready"])
-
-    def test_scheduled_audit_initializes_complete_profiles(self) -> None:
+    def test_optional_diagnostics_initialize_complete_profiles(self) -> None:
         workflow = (ROOT / ".github/workflows/supply-chain.yml").read_text(
             encoding="utf-8"
         )
@@ -181,22 +168,6 @@ class ReplacementFoundationTests(unittest.TestCase):
                 )
                 self.assertEqual(checkouts[record["name"]]["branch"], "main")
 
-        dependencies = {
-            dependency["id"]: dependency
-            for dependency in self.supply_chain["dependencies"]
-        }
-        for name in {
-            "client",
-            "content-toolkit",
-            "editor",
-            "protocol",
-            "renderer",
-            "server",
-            "website",
-        }:
-            self.assertTrue(
-                any(name in dependency["scope"] for dependency in dependencies.values())
-            )
 
 
 class ClassicToolsInventoryTests(unittest.TestCase):

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -134,6 +134,68 @@ class InventoryTests(unittest.TestCase):
                     f"build/supply-chain/{profile}/{report}", workflow
                 )
 
+    def test_classic_bundle_audit_compares_active_coordinates(self) -> None:
+        digest = "sha256:" + "a" * 64
+        material = "sha256:" + "b" * 64
+        image = "ghcr.io/atrinik/classic-dependencies"
+        descriptor = {
+            "schema_version": 1,
+            "image": image,
+            "digest": digest,
+            "material_digest": material,
+            "tag": "materials-" + "b" * 64,
+            # An old digest can legitimately remain in provenance fields.
+            "verified_input_bundle_digest": "sha256:" + "c" * 64,
+        }
+        dependency = fixture_dependency(
+            identifier="container/classic-dependencies",
+            kind="container-image",
+            scope=("classic",),
+            version=descriptor["tag"],
+            locator=f"{image}@{digest}",
+            checksum=digest,
+            evidence=(Evidence("classic", "dependencies.bundle.json", image),),
+        )
+        repository = fixture_repository(name="classic", checkout="classic")
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            (root / ".github").mkdir()
+            (root / ".github/dependabot.yml").write_text(
+                "package-ecosystem: github-actions\n", encoding="utf-8"
+            )
+            path = root / "dependencies.bundle.json"
+            path.write_text(json.dumps(descriptor), encoding="utf-8")
+            with mock.patch(
+                "atrinik_workspace.supply_chain._audit_files",
+                return_value=[".github/dependabot.yml"],
+            ):
+                def audit(record: Dependency) -> list[str]:
+                    return Inventory("atrinik", "2026-09-08", [repository], [record]).audit(
+                        {"classic": root}
+                    )
+
+                self.assertTrue(audit(dependency))
+                for field, value in (
+                    ("version", "materials-" + "c" * 64),
+                    ("locator", f"{image}@sha256:" + "c" * 64),
+                    ("checksum", "sha256:" + "c" * 64),
+                ):
+                    with self.subTest(field=field):
+                        with self.assertRaisesRegex(WorkspaceError, f"inventory {field}"):
+                            audit(replace(dependency, **{field: value}))
+                descriptor["digest"] = "sha256:" + "d" * 64
+                descriptor["verified_input_bundle_digest"] = digest
+                path.write_text(json.dumps(descriptor), encoding="utf-8")
+                with self.assertRaisesRegex(WorkspaceError, "inventory locator"):
+                    audit(dependency)
+                descriptor["tag"] = "materials-" + "e" * 64
+                path.write_text(json.dumps(descriptor), encoding="utf-8")
+                with self.assertRaisesRegex(WorkspaceError, "tag differs"):
+                    audit(dependency)
+                path.write_text("[]", encoding="utf-8")
+                with self.assertRaisesRegex(WorkspaceError, "descriptor schema"):
+                    audit(dependency)
+
     def assert_invalid_document(
         self, document: object, expected: str
     ) -> None:

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -49,6 +49,7 @@ from atrinik_workspace.supply_chain import (
 
 
 ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "tests/fixtures/supply_chain"
 
 
 def fixture_dependency(**changes: object) -> Dependency:
@@ -109,18 +110,25 @@ def fixture_repository(**changes: object) -> Repository:
 class InventoryTests(unittest.TestCase):
     def load_inventory(self) -> Inventory:
         return Inventory.load(
-            ROOT / "supply-chain" / "inventory.json", ROOT / "components.json"
+            FIXTURE / "inventory.json", FIXTURE / "components.json"
         )
 
     def inventory_document(self) -> dict[str, object]:
         return json.loads(
-            (ROOT / "supply-chain" / "inventory.json").read_text(encoding="utf-8")
+            (FIXTURE / "inventory.json").read_text(encoding="utf-8")
         )
 
-    def test_scheduled_audit_covers_both_content_lines_and_stacks(self) -> None:
+    def test_optional_diagnostics_cover_both_stacks_without_delivery_gate(self) -> None:
         workflow = (ROOT / ".github/workflows/supply-chain.yml").read_text(
             encoding="utf-8"
         )
+
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertNotIn("schedule:", workflow)
+        self.assertIn("continue-on-error: true", workflow)
+        self.assertIn("if: always()", workflow)
+        integration = (ROOT / ".github/workflows/integration.yml").read_text()
+        self.assertNotIn("./atrinik supply-chain", integration)
 
         initialize = "./atrinik init --with classic"
         self.assertEqual(workflow.count(initialize), 1)
@@ -223,7 +231,7 @@ class InventoryTests(unittest.TestCase):
             path = Path(temporary) / "inventory.json"
             path.write_text(json.dumps(document), encoding="utf-8")
             with self.assertRaisesRegex(WorkspaceError, expected):
-                Inventory.load(path, ROOT / "components.json")
+                Inventory.load(path, FIXTURE / "components.json")
 
     def make_audit_repository(self, root: Path) -> None:
         (root / ".github" / "workflows").mkdir(parents=True)
@@ -259,7 +267,7 @@ class InventoryTests(unittest.TestCase):
 
     def test_inventory_and_schema_validate(self) -> None:
         inventory = self.load_inventory()
-        inventory.validate_schema(ROOT / "supply-chain" / "schema.json")
+        inventory.validate_schema(FIXTURE / "schema.json")
 
         self.assertGreaterEqual(len(inventory.dependencies), 60)
         self.assertIn("nawerhals", inventory.repositories_by_name)
@@ -661,7 +669,7 @@ class InventoryTests(unittest.TestCase):
     def test_schema_contract_rejects_weak_or_unexpected_schema(self) -> None:
         inventory = self.load_inventory()
         schema = json.loads(
-            (ROOT / "supply-chain" / "schema.json").read_text(encoding="utf-8")
+            (FIXTURE / "schema.json").read_text(encoding="utf-8")
         )
         repository_schema = schema["properties"]["repositories"]["items"]
         self.assertFalse(repository_schema["additionalProperties"])
@@ -691,14 +699,6 @@ class InventoryTests(unittest.TestCase):
                     path.write_text(json.dumps(value), encoding="utf-8")
                     with self.assertRaisesRegex(WorkspaceError, expected):
                         inventory.validate_schema(path)
-
-    def test_wrapper_dependency_surface_audits_independently(self) -> None:
-        messages = self.load_inventory().audit(
-            {"atrinik": ROOT}, require_all=False
-        )
-
-        self.assertEqual(len(messages), 1)
-        self.assertIn("action references", messages[0])
 
     def test_minimal_repository_audit_covers_actions_and_runners(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -1718,7 +1718,7 @@ jobs:
                 )
 
     def test_component_source_root_rejects_symlinks(self) -> None:
-        component = Manifest.load(ROOT / "components.json").by_name["classic-server"]
+        component = Manifest.load(FIXTURE / "components.json").by_name["classic-server"]
         with tempfile.TemporaryDirectory() as temporary:
             checkout = Path(temporary)
             (checkout / "client").mkdir()
@@ -1858,7 +1858,7 @@ jobs:
     def test_repository_root_overrides_are_strict_and_identity_checked(self) -> None:
         workspace = mock.Mock()
         default_components = json.loads(
-            (ROOT / "components.json").read_text(encoding="utf-8")
+            (FIXTURE / "components.json").read_text(encoding="utf-8")
         )["stacks"]["default"]["components"]
         workspace.profile_summary.return_value = {
             "name": "profile",
@@ -1976,7 +1976,7 @@ jobs:
     def test_repository_override_accepts_fork_origin_and_canonical_upstream(self) -> None:
         workspace = mock.Mock()
         default_components = json.loads(
-            (ROOT / "components.json").read_text(encoding="utf-8")
+            (FIXTURE / "components.json").read_text(encoding="utf-8")
         )["stacks"]["default"]["components"]
         workspace.profile_summary.return_value = {
             "name": "review",
@@ -2057,7 +2057,7 @@ jobs:
     def test_repository_roots_reject_incomplete_profiles(self) -> None:
         workspace = mock.Mock()
         classic_components = json.loads(
-            (ROOT / "components.json").read_text(encoding="utf-8")
+            (FIXTURE / "components.json").read_text(encoding="utf-8")
         )["stacks"]["classic"]["components"]
         workspace.profile_summary.return_value = {
             "name": "classic-review",
@@ -2084,7 +2084,7 @@ jobs:
     def test_repository_roots_fail_closed_when_shared_content_is_missing(self) -> None:
         workspace = mock.Mock()
         document = json.loads(
-            (ROOT / "components.json").read_text(encoding="utf-8")
+            (FIXTURE / "components.json").read_text(encoding="utf-8")
         )
         classic_components = document["stacks"]["classic"]["components"]
         workspace.profile_summary.return_value = {
@@ -2121,7 +2121,7 @@ jobs:
             repository_roots(ROOT, workspace, "classic")
 
         classic_components = json.loads(
-            (ROOT / "components.json").read_text(encoding="utf-8")
+            (FIXTURE / "components.json").read_text(encoding="utf-8")
         )["stacks"]["classic"]["components"]
         workspace.profile_summary.return_value["components"] = [
             {
@@ -2142,7 +2142,7 @@ jobs:
     def test_repository_roots_add_one_classic_checkout_metadata_root(self) -> None:
         workspace = mock.Mock()
         document = json.loads(
-            (ROOT / "components.json").read_text(encoding="utf-8")
+            (FIXTURE / "components.json").read_text(encoding="utf-8")
         )
         components = {
             component["name"]: component for component in document["components"]
@@ -2180,7 +2180,7 @@ jobs:
     def test_classic_override_resolves_the_logical_source_root(self) -> None:
         workspace = mock.Mock()
         manifest_document = json.loads(
-            (ROOT / "components.json").read_text(encoding="utf-8")
+            (FIXTURE / "components.json").read_text(encoding="utf-8")
         )
         classic_components = manifest_document["stacks"]["classic"]["components"]
         component_documents = {
@@ -2277,7 +2277,7 @@ jobs:
     def test_report_component_commits_resolve_only_initialized_profile_stack(self) -> None:
         workspace = mock.Mock()
         classic_components = json.loads(
-            (ROOT / "components.json").read_text(encoding="utf-8")
+            (FIXTURE / "components.json").read_text(encoding="utf-8")
         )["stacks"]["classic"]["components"]
         content_path = "/workspace/classic-review/content"
         workspace.profile_summary.return_value = {
@@ -2317,7 +2317,7 @@ jobs:
     def test_report_component_commits_deduplicates_the_classic_checkout(self) -> None:
         workspace = mock.Mock()
         document = json.loads(
-            (ROOT / "components.json").read_text(encoding="utf-8")
+            (FIXTURE / "components.json").read_text(encoding="utf-8")
         )
         components = {
             component["name"]: component for component in document["components"]

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -183,6 +183,26 @@ class InventoryTests(unittest.TestCase):
                     with self.subTest(field=field):
                         with self.assertRaisesRegex(WorkspaceError, f"inventory {field}"):
                             audit(replace(dependency, **{field: value}))
+                for field, value in (
+                    ("image", "ghcr.io/unrelated/bundle"),
+                    ("digest", None),
+                    ("digest", "sha256:invalid"),
+                    ("material_digest", None),
+                    ("material_digest", "sha256:invalid"),
+                ):
+                    with self.subTest(descriptor_field=field, value=value):
+                        malformed = {**descriptor, field: value}
+                        path.write_text(json.dumps(malformed), encoding="utf-8")
+                        with self.assertRaisesRegex(WorkspaceError, "descriptor coordinates"):
+                            audit(dependency)
+                path.write_text("{", encoding="utf-8")
+                with self.assertRaisesRegex(WorkspaceError, "descriptor JSON"):
+                    audit(dependency)
+                path.write_text(json.dumps(descriptor), encoding="utf-8")
+                with self.assertRaisesRegex(WorkspaceError, "required inventory record"):
+                    Inventory("atrinik", "2026-09-08", [repository], []).audit(
+                        {"classic": root}
+                    )
                 descriptor["digest"] = "sha256:" + "d" * 64
                 descriptor["verified_input_bundle_digest"] = digest
                 path.write_text(json.dumps(descriptor), encoding="utf-8")


### PR DESCRIPTION
## Summary

Reconcile the Classic dependency bundle inventory for #568.

## Implementation / behavior

Verify the descriptor, published artifact, provenance and locks before updating aggregate coordinates; add producer-consumer drift coverage.

## Validation

Pending implementation, complete Classic profile audit and final-head review.

## Limitations / follow-up

Draft delivery checkpoint; acceptance remains pending.

Closes #568

<!-- atrinik-delivery:body:8e9b96193582ba8e2c6827a81cf0b3fe990faffda3f4a5a8526d2eb9b0da5dfe:start -->
## Current delivery scope

### Summary

Aggregate inventory drift currently forces unrelated dependency updates and blocks delivery. Make the supply-chain catalog, audits and reports optional diagnostics. No catalog maintenance or passing aggregate audit is required for builds, tests, PR readiness or delivery.

### Implementation / behavior

Remove live-catalog validation from Integration. Make the dependency workflow manual-only and non-blocking, retaining available reports even when diagnostics cannot complete. Explicit CLI catalog/audit findings are printed as `diagnostic:` and return zero; operational I/O and ordinary command errors remain errors.

Keep dependency, license, CycloneDX and SPDX reporting. Document that the catalog can be stale and actual lockfiles, copyright notices and licenses are the current sources. Synchronize root/contributor guidance and delivery skills. Keep immutable-input, provenance and no-submodules rules intact.

Decouple mandatory unit tests from the live catalog using fixed test snapshots; remove live-catalog assertions in governance tests. Catalog or dependency changes therefore do not require test-fixture or catalog maintenance. The earlier verified Classic bundle reconciliation remains included, and active-field drift remains visible when an audit is explicitly requested.

### Validation

154 affected CLI, supply-chain, governance and guidance tests pass after integrating current main. Python compilation, manifest validation, workflow actionlint, skill validators, guidance budgets and whitespace checks pass. The real Classic audit reports stale Ubuntu evidence with a successful diagnostic exit status. Fresh independent whole-diff review finds no remaining actionable findings.

Final-head [Integration](https://github.com/atrinik/atrinik/actions/runs/34207451088) passes for `a79672a936ce36dbd5455e0b24f462774d059768`, based on `005eec3017ca33cff438292718149b0e25ab8d04`: all three complete-discovery test shards, aggregate validation and native Windows smoke. CodeQL, title policy and Codecov patch coverage also pass. Independent final whole-diff review has zero actionable findings.

The local full wrapper suite ran 1397 tests with seven skips; a guidance wording failure was fixed and retested, while two existing container process-reaping failures remain recorded. Those supervisor tests pass in final CI.

### Limitations / follow-up

Reports reflect known catalog data and can be stale or incomplete; findings are informational and do not imply current license clearance. An explicitly requested diagnostic can still report missing inputs without producing a complete report. No component lockfiles, checksum verification, actual source licenses or provenance obligations are weakened. No inventory follow-up is required for the previously observed Ubuntu discrepancy.

<!-- atrinik-delivery:body:8e9b96193582ba8e2c6827a81cf0b3fe990faffda3f4a5a8526d2eb9b0da5dfe:end -->