### PR TITLE
build(devcontainer): adopt the Git LFS-enabled Linux image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   // interactive Classic client and the GPU-backed Vulkan shader path.
   "name": "Atrinik 2026 Linux Build",
   // Pin the published toolchain image so rebuilds use an auditable input.
-  "image": "ghcr.io/atrinik/linux-build:1.3.0@sha256:260658d2709e993b41148a9d8f724c2d2f7f1fd93543a139b00d139b10e7f31a",
+  "image": "ghcr.io/atrinik/linux-build:1.10.0@sha256:7904a1802054662b0ede5b55de72e4c92b0112a3c211125f994ed6c62e9ec9d8",
   "features": {
     // The wrapper uses the Docker CLI for isolated runtime topologies.
     "ghcr.io/devcontainers/features/docker-in-docker:4": {

--- a/README.md
+++ b/README.md
@@ -267,6 +267,56 @@ Copied or stale session markers, arbitrary containers, nested coordinators,
 and unsafe bind mounts never grant authority. Keep the `windows-cross` container for
 package/build work and host-bound validation.
 
+#### Linux image upgrades
+
+The ordinary Linux workspace now uses the Git LFS-enabled `linux-build:1.10.0`
+release from devcontainer revision
+`f51d809a2670387833476954ee6cc05692ce6c56`, published by
+[Linux run 34168767678, attempt 2](https://github.com/atrinik/devcontainer/actions/runs/34168767678/attempts/2).
+The immutable pin in `.devcontainer/devcontainer.json` is
+`ghcr.io/atrinik/linux-build:1.10.0@sha256:7904a1802054662b0ede5b55de72e4c92b0112a3c211125f994ed6c62e9ec9d8`.
+The registry's source/revision labels and build provenance match that producer.
+Independently pinned sound, Classic build, and Windows images retain their
+own release contracts.
+
+An existing container keeps its original image after a source update. From the
+native host, inspect the exact owned container before attaching:
+
+~~~sh
+docker inspect "$CONTAINER_ID" --format '{{.Id}} {{.Config.Image}} {{.State.Status}}'
+~~~
+
+Compare that immutable image reference with the checked-out configuration.
+A tag or a previous successful probe does not establish a match. When
+`DEVCONTAINER_IMAGE` is supplied by the terminal launcher, the coordinator
+probe also rejects a stale image and names the required pin; do not change
+that variable to disguise the running image.
+
+Preserve the exact worktree, ledger, mounts, credentials, caches and mutable
+state. Finish active operations before stopping only your owned container.
+For a human editor session, use **Dev Containers: Rebuild Container** for that
+workspace. For terminal bootstrap, pull the exact configuration pin and
+recreate only the stopped owned session using its verified mount and user
+coordinates, then attach as `ubuntu`. Do not replace another worker's
+container, remove volumes, copy a ledger, or recreate managed worktrees.
+Rerun the coordinator probe, worktree inventory and helper ownership/lease
+checks after attaching.
+
+Before initializing LFS-backed repositories in the new terminal or editor
+session, verify the image-provided filters with the fresh user configuration:
+
+~~~sh
+git lfs version
+git config --get filter.lfs.process
+git config --get filter.lfs.required
+./atrinik init
+~~~
+
+The filter process must be `git-lfs filter-process` and required must be
+`true`; no manual package installation is needed. Check materialized payloads
+after clone, checkout and linked-worktree creation. These source checks do
+not establish runtime export or media hydration, which remains separate.
+
 #### Agent-owned persistent sessions
 
 A session is one agent-owned container plus its exact, live identity; it is

--- a/scripts/atrinik_coordinator_context.py
+++ b/scripts/atrinik_coordinator_context.py
@@ -36,8 +36,8 @@ ENTRY_MODE_NATIVE_HOST = "native-host"
 ENTRY_MODE_UNKNOWN = "unknown"
 
 CANONICAL_IMAGE = (
-    "ghcr.io/atrinik/linux-build:1.3.0@sha256:"
-    "260658d2709e993b41148a9d8f724c2d2f7f1fd93543a139b00d139b10e7f31a"
+    "ghcr.io/atrinik/linux-build:1.10.0@sha256:"
+    "7904a1802054662b0ede5b55de72e4c92b0112a3c211125f994ed6c62e9ec9d8"
 )
 WINDOWS_CROSS_IMAGE = (
     "ghcr.io/atrinik/windows-build:1.2.1@sha256:"
@@ -707,12 +707,21 @@ def probe(
     )
 
     if failures:
+        next_action = (
+            "Use the pinned Atrinik Linux devcontainer or the current proven "
+            "in-container session, then rerun this probe before ledger mutation."
+        )
+        if "runtime-image-mismatch" in failures:
+            next_action = (
+                f"Rebuild or attach your owned session using {CANONICAL_IMAGE}; "
+                "follow README.md's Linux image upgrades instructions, preserve "
+                "worktrees and state, and rerun this probe before ledger mutation."
+            )
         return _result(
             UNKNOWN_STATUS,
             False,
             failures,
-            "Use the pinned Atrinik Linux devcontainer or the current proven "
-            "in-container session, then rerun this probe before ledger mutation.",
+            next_action,
             "unknown-or-unsupported-context",
             entry_mode=entry_mode,
         )

--- a/scripts/benchmark_devcontainer_session.py
+++ b/scripts/benchmark_devcontainer_session.py
@@ -28,8 +28,8 @@ from atrinik_workspace.model import WorkspaceError
 
 
 DEFAULT_LINUX_IMAGE = (
-    "ghcr.io/atrinik/linux-build:1.3.0@sha256:"
-    "260658d2709e993b41148a9d8f724c2d2f7f1fd93543a139b00d139b10e7f31a"
+    "ghcr.io/atrinik/linux-build:1.10.0@sha256:"
+    "7904a1802054662b0ede5b55de72e4c92b0112a3c211125f994ed6c62e9ec9d8"
 )
 NAMESPACE_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_.-]{0,62}$")
 RUN_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,30}$")

--- a/supply-chain/inventory.json
+++ b/supply-chain/inventory.json
@@ -1671,25 +1671,25 @@
         "atrinik"
       ],
       "required": true,
-      "version": "1.3.0",
+      "version": "1.10.0",
       "version_source": "Immutable semantic-release image tag",
       "license": "LicenseRef-Atrinik-Image-Contents",
       "source_url": "https://github.com/atrinik/devcontainer/pkgs/container/linux-build",
       "locator": "ghcr.io/atrinik/linux-build",
-      "commit": "b4df04bf5b47a8f5d24e0783efd2c16c5e809f38",
-      "checksum": "sha256:260658d2709e993b41148a9d8f724c2d2f7f1fd93543a139b00d139b10e7f31a",
+      "commit": "f51d809a2670387833476954ee6cc05692ce6c56",
+      "checksum": "sha256:7904a1802054662b0ede5b55de72e4c92b0112a3c211125f994ed6c62e9ec9d8",
       "acquisition": "Dev Containers pulls the release tag and immutable manifest digest",
       "update_cadence_days": 30,
       "update_mechanism": "Weekly audit plus reviewed devcontainer release update",
       "eol_response": "Publish a supported replacement image and update the wrapper atomically",
-      "validation": "Anonymous manifest and provenance inspection, whole-image SBOM, exact non-root gh-stack smoke, devcontainer configuration tests, and complete native build",
+      "validation": "Published manifest and source provenance inspection, whole-image SBOM, fresh non-root terminal bootstrap and Git LFS filter/clone/checkout/linked-worktree payload checks, devcontainer configuration tests, and complete profile supply-chain audits",
       "disposition": "retain",
       "packages": [],
       "evidence": [
         {
           "repository": "atrinik",
           "path": ".devcontainer/devcontainer.json",
-          "contains": "ghcr.io/atrinik/linux-build:1.3.0@sha256:260658d2709e993b41148a9d8f724c2d2f7f1fd93543a139b00d139b10e7f31a"
+          "contains": "ghcr.io/atrinik/linux-build:1.10.0@sha256:7904a1802054662b0ede5b55de72e4c92b0112a3c211125f994ed6c62e9ec9d8"
         }
       ]
     },
@@ -4086,7 +4086,7 @@
       "update_cadence_days": 30,
       "update_mechanism": "Dependabot base-image update and exact installed-version report",
       "eol_response": "Update package names and base image together before Ubuntu support ends",
-      "validation": "Docker build, tool version probes, and complete native workspace build",
+      "validation": "Docker build, tool version probes including Git LFS, isolated Git LFS worktree/payload smoke, and complete native workspace build",
       "disposition": "isolate",
       "packages": [
         "alsa-utils",
@@ -4109,6 +4109,7 @@
         "gdb",
         "gh",
         "git",
+        "git-lfs",
         "iproute2",
         "jq",
         "libasound2-plugins",

--- a/tests/test_coordinator_context.py
+++ b/tests/test_coordinator_context.py
@@ -256,6 +256,18 @@ class CoordinatorContextTests(unittest.TestCase):
         self.assertFalse(result["authoritative"])
         self.assertIn("runtime-user", result["failed_checks"])
 
+    def test_stale_runtime_image_requires_owned_rebuild(self) -> None:
+        result = self._probe(environment={
+            "HOME": "/home/ubuntu",
+            "CODEX_HOME": "/home/ubuntu/.codex",
+            "DEVCONTAINER_IMAGE": "ghcr.io/atrinik/linux-build:old",
+        })
+        self.assertFalse(result["authoritative"])
+        self.assertIn("runtime-image-mismatch", result["failed_checks"])
+        self.assertIn(context.CANONICAL_IMAGE, result["next_action"])
+        self.assertIn("owned session", result["next_action"])
+        self.assertIn("preserve worktrees and state", result["next_action"])
+
     def test_pinned_config_mismatch_fails_closed(self) -> None:
         config_path = self.repository / ".devcontainer/devcontainer.json"
         config = json.loads(

--- a/tests/test_devcontainer.py
+++ b/tests/test_devcontainer.py
@@ -37,8 +37,8 @@ class DevcontainerTests(unittest.TestCase):
         )
         self.assertEqual(
             config["image"],
-            "ghcr.io/atrinik/linux-build:1.3.0@sha256:"
-            "260658d2709e993b41148a9d8f724c2d2f7f1fd93543a139b00d139b10e7f31a",
+            "ghcr.io/atrinik/linux-build:1.10.0@sha256:"
+            "7904a1802054662b0ede5b55de72e4c92b0112a3c211125f994ed6c62e9ec9d8",
         )
         self.assertEqual(config["containerEnv"]["SDL_VIDEODRIVER"], "x11")
 

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -365,14 +365,14 @@ class InventoryTests(unittest.TestCase):
         self.assertIn("playtester", cmake.scope)
         self.assertNotIn("tools", cmake.scope)
         linux_image = inventory.dependencies_by_id["container/linux-build"]
-        self.assertEqual(linux_image.version, "1.3.0")
+        self.assertEqual(linux_image.version, "1.10.0")
         self.assertEqual(
             linux_image.commit,
-            "b4df04bf5b47a8f5d24e0783efd2c16c5e809f38",
+            "f51d809a2670387833476954ee6cc05692ce6c56",
         )
         self.assertEqual(
             linux_image.checksum,
-            "sha256:260658d2709e993b41148a9d8f724c2d2f7f1fd93543a139b00d139b10e7f31a",
+            "sha256:7904a1802054662b0ede5b55de72e4c92b0112a3c211125f994ed6c62e9ec9d8",
         )
         github_cli = inventory.dependencies_by_id["toolchain/github-cli"]
         self.assertEqual(github_cli.owner, "devcontainer")

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -455,14 +455,14 @@ class InventoryTests(unittest.TestCase):
         self.assertIn("playtester", cmake.scope)
         self.assertNotIn("tools", cmake.scope)
         linux_image = inventory.dependencies_by_id["container/linux-build"]
-        self.assertEqual(linux_image.version, "1.10.0")
+        self.assertEqual(linux_image.version, "1.3.0")
         self.assertEqual(
             linux_image.commit,
-            "f51d809a2670387833476954ee6cc05692ce6c56",
+            "b4df04bf5b47a8f5d24e0783efd2c16c5e809f38",
         )
         self.assertEqual(
             linux_image.checksum,
-            "sha256:7904a1802054662b0ede5b55de72e4c92b0112a3c211125f994ed6c62e9ec9d8",
+            "sha256:260658d2709e993b41148a9d8f724c2d2f7f1fd93543a139b00d139b10e7f31a",
         )
         github_cli = inventory.dependencies_by_id["toolchain/github-cli"]
         self.assertEqual(github_cli.owner, "devcontainer")


### PR DESCRIPTION
## Summary

Adopt the published Git LFS-enabled Linux development image for fresh terminal and editor workspaces.

## Implementation / behavior

Coordinate the Linux image pin, regression expectations, supply-chain records and rebuild guidance. Reconcile the preserved Git LFS package inventory candidate.

## Validation

Delivery validation is pending: exact image provenance, fresh non-root bootstrap and LFS payload checks, complete wrapper checks and profile audits.

## Limitations / follow-up

Runtime export and hydration remain owned by #566.

Closes #567

<!-- atrinik-delivery:body:4e66e3c7ff16bc4c6f51dffb40fba3fd1a323e6800c943415ff02a2d9d2e28ba:start -->
## Current delivery status

Validated at `cc3c269f5954c9eb8a4929ff94971d496468aac6` against main `2e21239de948dee433060acca702d8e73d94c3db`. The former inventory readiness gate is removed by the merged optional-diagnostics policy and the requested policy adoption. No delivery blocker remains.

### Implementation / behavior

- Adopt Linux `1.10.0` at `sha256:7904a1802054662b0ede5b55de72e4c92b0112a3c211125f994ed6c62e9ec9d8`, produced from `f51d809a2670387833476954ee6cc05692ce6c56` by [publication attempt 2](https://github.com/atrinik/devcontainer/actions/runs/34168767678/attempts/2).
- Align the devcontainer, coordinator and session-benchmark pins and live regression expectations. Preserve the verified Git LFS package/validation contribution and scoped Linux image inventory record.
- Preserve both image-upgrade and shared-host authentication guidance when integrating main. Frozen diagnostic fixtures retain their historical expectations; live devcontainer tests check the adopted image.
- Stale-image diagnostics and rebuild/attach instructions preserve owned worktrees and mutable state. Independently pinned consumers retain their own release contracts.

### Validation results

- Registry manifest, source/revision labels and SLSA provenance match the release. Whole-image SPDX scan contains 1,929 packages, including `git-lfs` `3.7.1-1`.
- Fresh non-root image supplies all four LFS filters without manual package or local filter installation. Clone, revision checkout and linked-worktree tests verify materialized bytes; LFS fsck and complete Classic source initialization pass.
- Final wrapper suite: 1,473 tests passed in 220.313 seconds, 7 platform/tool skips, 85% coverage. Focused image/coordinator/diagnostic tests pass. Compile, guidance inventory, MCP contract, provenance registry, manifest and whitespace checks pass.
- Fresh independent complete-diff review reports zero actionable findings. All final-head checks pass, including all three test shards, native Windows smoke, Integration validation, CodeQL, PR title and Codecov patch coverage.

### Optional diagnostics / follow-up

The complete Classic dependency diagnostic now exits successfully and reports the remaining Ubuntu base-image inventory mismatch as informational. Under the merged policy, catalog maintenance and diagnostic findings do not gate work or PR readiness. No unrelated consumer image pins were changed to silence it.

Runtime export/hydration remains separately owned by #566. This PR remains unmerged; maintainers control integration.

<!-- atrinik-delivery:body:4e66e3c7ff16bc4c6f51dffb40fba3fd1a323e6800c943415ff02a2d9d2e28ba:end -->