### PR TITLE
feat(devcontainer): share host GitHub authentication with coordinators

### DIFF
--- a/.agents/skills/atrinik-github-governance/SKILL.md
+++ b/.agents/skills/atrinik-github-governance/SKILL.md
@@ -20,6 +20,9 @@ description: Publish Atrinik PRs, govern GitHub policy, or review and explicitly
 5. Keep controls Team-plan compatible; document and review Enterprise-only
    migrations.
 
+Use [shared read-only host auth](../../../docs/COORDINATOR_AUTH.md); verify actor
+and task capabilities. Only the host changes login/scopes; API mutation gates remain.
+
 ## Optional commit-signing guidance
 
 For optional SSH commit-signing setup and the host/container boundary, read

--- a/.agents/skills/atrinik-guidance-maintenance/SKILL.md
+++ b/.agents/skills/atrinik-guidance-maintenance/SKILL.md
@@ -19,7 +19,8 @@ not initialize, sync, clean up, launch, or mutate external state for an audit.
    `AGENTS.md` and relevant skill. Exclude generated/preserved copies below
    `workspace/` and `build/` from the authoritative inventory.
 4. Record path, owner, lines, evidence, and status: current, stale, missing,
-   duplicated, or unverifiable.
+   duplicated, or unverifiable. Include `docs/COORDINATOR_AUTH.md` and its
+   composition/skill consumers when the shared host auth contract changes.
 
 ## Correct ownership and drift
 

--- a/.agents/skills/atrinik-issue-delivery/SKILL.md
+++ b/.agents/skills/atrinik-issue-delivery/SKILL.md
@@ -117,52 +117,36 @@ secret-free probe combines the pinned config with live Linux/POSIX, user,
 Codex, no-follow, mode, and mount checks; runtime markers never authorize it.
 `native-windows`, `windows-cross`, and `unknown-or-unsafe` stop delivery.
 
-There are exactly two supported Codex entry modes. If the plugin is already
-inside the canonical VS Code devcontainer, continue the current process,
-workspace, ledger root, exact worktree, leases, and warm caches. Do not invoke
-Docker or the Dev Containers CLI merely to create, attach, recreate, remount,
-or re-enter another container. If Codex starts on a native host, use Docker or
-the Dev Containers CLI only for the minimum bootstrap/attach into the pinned
-ordinary Linux devcontainer. The native host may then perform only approved
-Git/GitHub and commit operations; every coordinator, ownership, repository,
-worktree, ledger lock/CAS/lease/recovery, edit, test, build, review, and
-validation operation runs inside that container. A native-host VS Code window
-is not a substitute, and Codex must not ask it to reopen or launch a
-container.
+Use exactly two entry modes:
 
-The probe's `entry_mode` is descriptive corroboration, not authority: a
-`inside-vscode-devcontainer` signal, a `container-bootstrap` signal, a copied
-runtime marker, or a session ID cannot replace live image, filesystem,
-workspace, Codex-home, mount, and identity checks. The probe accepts a direct
-container attach when those live checks pass even if a launcher variable is
-absent, and fails closed for native hosts, unsafe bind mounts, arbitrary
-containers, nested coordinators, and stale or copied session evidence.
+- Already in a canonical VS Code devcontainer: retain the current process,
+  workspace, bound worktree, ledger, leases and caches; never bootstrap another.
+- Native host: bootstrap/attach once with Docker or the Dev Containers CLI into
+  the pinned ordinary Linux image. Thereafter the host performs only approved
+  Git/GitHub/commit operations; ownership, ledger, worktree, edit, test, build,
+  review and validation run inside the coordinator.
 
-Treat a persistent session as reusable only while its owner, pinned image,
-workspace/mount identities, and ledger/worktree coordinates still match.
-Reconnect and crash recovery rerun the probe plus fresh ledger/worktree
-observation and CAS/lease checks; idle time is bounded, and shutdown touches
-only the owned session. Parallel sessions use distinct exact worktrees,
-ledger leases, caches, credentials, ports, and mutable state. Docker commands
-explicitly required by a wrapper operation remain governed by that operation;
-this entry rule does not authorize arbitrary nesting or remounting.
-
-Codex never launches or controls VS Code, invokes `code` or `code.cmd`, sends
-VS Code URIs, or uses GUI automation. Any VS Code setup reference is
-human-facing only.
+An `entry_mode` marker, container name or copied session record is corroboration,
+not authority. Codex never launches or controls VS Code; no executable/URI or
+GUI automation, nested containers, live remounts or foreign/stale coordinates.
+Wrapper-required Docker operations retain their own operation contract.
 
 ### Reuse one owned devcontainer session
 
-Use one pinned container per scope and retain an ignored, secret-free record of
-the agent, ledger, worktree, container/mount/volume identities, lifecycle, and
-cleanup owner. It is corroboration only: the live probe, ledger/worktree CAS,
-and leases decide. Bound idle/lifetime to 30 minutes/12 hours; after a
-stop/crash preserve evidence, re-prove coordinates, and reacquire leases.
-Parallel scopes need distinct worktrees, coordinates, profiles/build roots,
-volume namespaces, credentials, ports, topology/state, and mutable caches;
-share only immutable image layers/read-only inputs. The session benchmark uses
-exact run-scoped resources for cold/warm/recovery/parallel measurements and
-never mounts source, credentials, private keys, or mutable server data.
+Retain one pinned container per scope and an ignored, secret-free record of its
+agent, ledger, worktree, image/mount/volume identities, lifecycle and cleanup owner.
+Reconnect/crash recovery re-proves the live probe, exact worktree, ledger CAS and
+leases. Bound idle/lifetime to 30 minutes/12 hours; preserve stopped evidence and
+stop only owned resources. Parallel scopes use distinct coordinates, worktrees,
+profiles/build roots, volumes, Codex homes, caches, ports and topology/state.
+
+Trusted workers share [host GitHub auth read-only](../../../docs/COORDINATOR_AUTH.md).
+The host owns login/refresh/account changes; workers verify actor and required
+repository/Project/package capabilities together before ledger genesis or resume.
+Bundle missing scopes into one host action; do not repeat pending login requests
+or ask again for a task mutation already authorized in the session. Keep
+other mutable credential stores private. Credential availability grants no
+additional task authority. The session benchmark remains credential/source-free.
 
 ### Claim only explicitly authorized issues
 

--- a/.agents/skills/atrinik-issue-delivery/references/delivery-ledger.md
+++ b/.agents/skills/atrinik-issue-delivery/references/delivery-ledger.md
@@ -185,6 +185,12 @@ immediately before its private CAS. A mixed login/node response, stale actor,
 missing push authority, or changed tuple fails closed; a caller-supplied tuple
 never grants authority by itself.
 
+The supported [read-only host auth mount](../../../../docs/COORDINATOR_AUTH.md)
+at ubuntu's standard `~/.config/gh` supplies this container-local protected `gh`
+observation without a worker login. Host-supplied actor JSON is still not proof.
+The helper strips arbitrary `GH_CONFIG_DIR` overrides; retain its environment
+filtering and verify the mounted login through the live helper.
+
 Before any dynamic `Workspace` import or Python execution, live proof performs
 a bounded component-wise no-follow ownership/mode prevalidation of the complete
 importable `atrinik_workspace` source/bytecode tree. It fingerprints every

--- a/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
+++ b/.agents/skills/atrinik-multi-repo-workspace/SKILL.md
@@ -107,7 +107,9 @@ A persistent coordinator session belongs to one agent and exact delivery coordin
 requires matching pinned container, mounts, worktree, profile/build roots, and ledger coordinates.
 Recovery reruns probe, worktree list, ledger inventory/CAS, and leases. Bound idle/lifetime;
 preserve failure evidence; stop only the owned container. Independent sessions need distinct
-worktrees/coordinates, caches, credentials, ports, topology/state names, and mutable state.
+worktrees/coordinates, caches, ports, topology/state names, and mutable state.
+Use [shared read-only host GitHub auth](../../../docs/COORDINATOR_AUTH.md);
+verify actor/capabilities and keep other credential stores private.
 
 Verify concurrency with distinct worktrees and readiness rendezvous; keep A live through B
 release; count transitions/conflicts; timeouts bound failure, not compiler speed.

--- a/.agents/skills/atrinik-program-delivery/SKILL.md
+++ b/.agents/skills/atrinik-program-delivery/SKILL.md
@@ -46,7 +46,9 @@ master comment, child, or link.
 1. Normalize the master as `owner/repository#number`. Inspect the live issue,
    body, comments, native parent/subissue graph, linked PRs, assignees, Project
    item, releases, repository policy, and current branch tips before mutation.
-   Use the requested GitHub access path and never expose credentials.
+   Use the requested GitHub access path and never expose credentials. Share
+   [host auth read-only](../../../docs/COORDINATOR_AUTH.md); batch program-required
+   capability checks and request one host setup, not a login for every leaf.
 2. Treat hierarchy as ownership, not sequencing. Derive order only from the
    master's explicit execution plan, dependency statements, and technical
    constraints. Reject cycles, contradictory owners, repository mismatches,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,6 +29,9 @@
     // Keep Codex state and Git identity local to the host user.
     "source=${localEnv:HOME}/.codex-atrinik,target=/home/ubuntu/.codex,type=bind",
     "source=${localEnv:HOME}/.gitconfig,target=/home/ubuntu/.gitconfig,type=bind,readonly",
+    // Host logs in once; trusted workers share this config without changing it.
+    // Complete docs/COORDINATOR_AUTH.md before creating the container.
+    "source=${localEnv:HOME}/.config/gh-atrinik,target=/home/ubuntu/.config/gh,type=bind,readonly",
     // Keep high-I/O generated workspace data in a per-container named volume.
     // initializeCommand pre-creates the nested target's writable parent.
     "source=atrinik-${devcontainerId}-build-cache,target=/workspaces/atrinik/workspace/build,type=volume,volume-nocopy",
@@ -51,6 +54,7 @@
     // Resolve WSL's D3D12/NVIDIA user-mode libraries before container libraries.
     "LD_LIBRARY_PATH": "/usr/lib/wsl/lib",
     "CODEX_HOME": "/home/ubuntu/.codex",
+    "GH_CONFIG_DIR": "/home/ubuntu/.config/gh",
     // The container identity namespaces its named build/cache volumes.
     "ATRINIK_DOCKER_VOLUME_NAMESPACE": "${devcontainerId}",
     // WSLg currently lacks zwp_text_input_v3; SDL's X11 backend supplies text events.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@
 - Native Windows Classic GPU preflight: follow `docs/WINDOWS_GPU_PREFLIGHT.md`; keep Linux coordinator and native results separate.
 - Explicitly invoke `atrinik-program-delivery` for ordered master issues; it composes leaves across merge gates and stops before merge/closure.
 - Codex delivery has two entry modes: continue in the canonical VS Code devcontainer or bootstrap/attach the pinned Linux devcontainer from a native host; host work is limited to bootstrap/attach and approved Git/GitHub/commit operations; wrapper/ledger/worktree/edit/test/build/review/validation stay inside.
-- Codex never launches/controls VS Code, sends VS Code URIs, or uses GUI automation; do not nest/remount or trust copied/stale evidence. Reuse only exact owner/container/image/mount/worktree/ledger coordinates; reconnect reruns probe, worktree, ledger, and lease checks. Bound idle/shutdown to owner; parallel sessions need separate caches, credentials, ports, and mutable state.
+- Codex never launches/controls VS Code; no URIs, GUI automation, nesting or remounting. Reuse exact owner/container/image/mount/worktree/ledger coordinates only; reconnect rechecks probe, worktree, ledger and leases. Bound shutdown to owner. Isolate mutable state; share host GitHub auth read-only per `docs/COORDINATOR_AUTH.md`.
 - Never replace dirty primaries/remove dirty worktrees or overwrite mutable server data; preserve migration inputs.
 - Cleanup is preview-first; delivery grants none. Keep ledger transactions separate from `./atrinik cleanup`; preserve dirty/detached/locked/active/referenced/uncertain targets; history fails closed.
 - Worktrees belong to physical checkouts; `classic`, `classic-*`, and its roles

--- a/README.md
+++ b/README.md
@@ -262,10 +262,22 @@ match. A secret-free session record may make those facts visible, but it never
 grants authority. Reconnect or crash recovery reruns the probe, exact
 worktree/ledger observation, CAS, and leases before continuing. Bound idle and
 shutdown operations to the owned session, and give parallel sessions distinct
-worktrees, leases, caches, credentials, ports, and mutable state.
+worktrees, leases, caches, ports, and mutable state. The supported read-only
+host GitHub auth mount is shared as described in
+[coordinator authentication](docs/COORDINATOR_AUTH.md).
 Copied or stale session markers, arbitrary containers, nested coordinators,
 and unsafe bind mounts never grant authority. Keep the `windows-cross` container for
 package/build work and host-bound validation.
+
+#### Shared host GitHub authentication
+
+Authenticate once on the host, then share its file-backed GitHub CLI config
+read-only with trusted coordinators. The ordinary devcontainer mounts
+`$HOME/.config/gh-atrinik` at `/home/ubuntu/.config/gh` and sets `GH_CONFIG_DIR` there.
+Complete the [one-time host setup and capability preflight](docs/COORDINATOR_AUTH.md)
+before bootstrap. Native Docker coordinators use the same mount; workers never
+run login, refresh, logout or account switching against it. Existing coordinators
+keep their current mounts until their owner performs supported recovery.
 
 #### Agent-owned persistent sessions
 
@@ -314,8 +326,9 @@ immortal. Only the owner may stop an idle session, and an abandoned session
 is retained for fresh liveness and lease checks. Parallel sessions may share
 immutable image layers and read-only inputs, but must use distinct exact
 worktrees, delivery ledgers/coordinates, profiles and build roots, named
-volume namespaces, Codex homes or credentials, topology/state names, ports,
-and mutable caches.
+volume namespaces, Codex homes, topology/state names, ports, and mutable caches.
+The host GitHub auth directory is the supported shared read-only exception;
+other mutable credential stores remain private.
 
 For shutdown, finish or preserve the delivery evidence, then stop only the
 owned exact container:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -115,8 +115,16 @@ policy bounds idle time to 30 minutes and total lifetime to 12 hours; an
 active build lease prevents reclamation during work but does not make a
 session immortal. Parallel sessions may share immutable image layers and
 read-only inputs, but require distinct exact worktrees, delivery coordinates,
-profiles/build roots, named volume namespaces, credentials, ports, topology
-and state names, and mutable caches. Codex never launches or controls VS Code,
+profiles/build roots, named volume namespaces, ports, topology
+and state names, and mutable caches. Trusted sessions may share the host-owned
+GitHub CLI credential directory through the read-only bind and `GH_CONFIG_DIR`
+contract in [coordinator authentication](COORDINATOR_AUTH.md). The host alone
+changes its login, scopes and active account. Worker-private credential stores
+remain separate. Mount access does not change actor/ledger verification, grant
+issue/Project/release authority, or permit credentials in build inputs or images.
+A read-only bind prevents file changes, not use of the credential for API writes.
+Refresh/rotation requires a fresh actor and capability check before more work.
+Codex never launches or controls VS Code,
 uses its executable or URI, or uses GUI automation; launch-configuration
 instructions are for human operators.
 

--- a/docs/COORDINATOR_AUTH.md
+++ b/docs/COORDINATOR_AUTH.md
@@ -1,0 +1,208 @@
+# Shared host GitHub authentication
+
+Trusted Atrinik coordinators use one host-owned GitHub CLI login through a
+read-only directory bind. Each delivery keeps its own container, worktrees,
+leases, Codex home and mutable caches; it does not need another browser login.
+The target is ubuntu's standard `~/.config/gh`, so the delivery helper's
+protected environment (which strips `GH_CONFIG_DIR` overrides) and ordinary
+`gh` both use this same login through `HOME`. Do not change the target to an
+arbitrary config path or weaken the helper's environment filtering.
+Authentication supplies identity and API capabilities, never authorization for
+an issue mutation, merge, release, governance change or other unrequested action.
+
+## One-time host setup
+
+The ordinary devcontainer uses `$HOME/.config/gh-atrinik`. If the host already
+has a working `gh` login, initialize that private directory once from it. This
+transfers the existing credential only between host stores through stdin; no
+new browser login is needed, and no token is printed:
+
+```bash
+(
+  set -o pipefail
+  umask 077
+  install -d -m 700 "$HOME/.config/gh-atrinik"
+  if [ ! -e "$HOME/.config/gh-atrinik/hosts.yml" ]; then
+    gh auth token --hostname github.com | \
+      GH_CONFIG_DIR="$HOME/.config/gh-atrinik" gh auth login \
+        --hostname github.com --git-protocol https --with-token --insecure-storage
+  fi
+)
+GH_CONFIG_DIR="$HOME/.config/gh-atrinik" gh api user --jq .login
+```
+
+The explicit file-storage option places the credential in this private host
+directory; the original keyring-backed config is not modified. Do not repeatedly
+export it or overwrite an established shared login. Use this same `GH_CONFIG_DIR`
+prefix for subsequent host checks and refreshes. If there is no working host
+login, the host owner authenticates directly into the shared directory once:
+
+```sh
+GH_CONFIG_DIR="$HOME/.config/gh-atrinik" gh auth login \
+  --hostname github.com --git-protocol https --web --insecure-storage \
+  --scopes read:packages,project,workflow
+```
+
+Check all task capabilities before worker bootstrap. If the existing login
+lacks them, request one combined host refresh for the missing scopes, for example:
+
+```sh
+GH_CONFIG_DIR="$HOME/.config/gh-atrinik" gh auth refresh \
+  --hostname github.com --scopes read:packages,project,workflow
+```
+
+GitHub CLI's usual repository/organization-read scopes are requested by login;
+`read:packages` enables private image reads, `project` supports authorized Project
+claims, and `workflow` supports deliveries that update workflow files. Verify the
+selected actor and actual capabilities; scopes cannot exceed the account's
+repository/package access or an organization's approval/SSO policy. Add further
+permissions only for the selected task, not speculative organization administration.
+
+An existing file-backed host `gh` directory can also be used with the native
+Docker mount below. A config that only references a host OS keychain is
+insufficient: the container cannot access that keychain. Do not mount the host's
+keyring service, whole home, `.ssh`, or Docker configuration to work around it.
+Never print `hosts.yml`, tokens or raw authentication headers in tool output.
+Do not pass a token through a Docker environment option, build argument, image
+layer, ledger, Git file or PR body. Workers consume the mounted login directly.
+
+GitHub fine-grained PATs can target one organization and selected repositories,
+but currently lack GitHub Packages support. A classic PAT/OAuth login can cover
+more of this workflow but is not inherently restricted to one organization.
+Mounting it read-only does not limit its API permissions: every trusted worker
+can exercise those permissions. Do not expose this mount to untrusted build
+containers, fork code, runtime services or benchmark containers. Keep privileged
+administrative credentials separate from routine delivery authentication.
+
+## Coordinator bootstrap and reuse
+
+The ordinary `.devcontainer/devcontainer.json` declares:
+
+```text
+source=${localEnv:HOME}/.config/gh-atrinik,target=/home/ubuntu/.config/gh,type=bind,readonly
+GH_CONFIG_DIR=/home/ubuntu/.config/gh
+```
+
+For a newly owned native Docker coordinator, add these options to its supported
+pinned-image bootstrap, preserving all existing source, user, private Codex-home,
+build-cache and lifetime requirements:
+
+```sh
+ATRINIK_HOST_GH_CONFIG="$HOME/.config/gh-atrinik"
+test -d "$ATRINIK_HOST_GH_CONFIG"
+test -r "$ATRINIK_HOST_GH_CONFIG/hosts.yml"
+# Options for docker run, not a standalone container launcher:
+# --mount "type=bind,source=$ATRINIK_HOST_GH_CONFIG,target=/home/ubuntu/.config/gh,readonly"
+# --env GH_CONFIG_DIR=/home/ubuntu/.config/gh
+```
+
+Bind the directory, not only `hosts.yml`, so host-side atomic credential updates
+are visible. Validate that it belongs to the intended host user, its credential
+files are private/readable by the mapped ubuntu UID, and no other host user can
+modify the directory. Do not recursively change host permissions. Inspect the
+exact container's mount metadata: `/home/ubuntu/.config/gh` must be a read-only bind from
+the selected directory. Keep `GH_TOKEN` and `GITHUB_TOKEN` unset in workers:
+these environment variables override the mounted login. Confirm effective
+identity rather than assuming mount presence proves authentication.
+
+Do not remount or replace an existing coordinator just to adopt this setup.
+An already canonical session continues in place; its owner can adopt the mount
+at the next supported bootstrap/recovery, with fresh image/mount, worktree and
+ledger checks. Independent coordinators may share this read-only directory;
+other mutable authentication state remains private. Windows cross-build and
+runtime containers do not inherit the mount from the ordinary coordinator.
+
+## Preflight before delivery or expensive work
+
+Run inside the exact coordinator, without `--show-token` or HTTP debug logging:
+
+```sh
+gh auth status --hostname github.com
+gh api user --jq .login
+gh api repos/atrinik/atrinik --jq '{full_name,permissions}'
+```
+
+Use the actual selected repository for its permissions check. Issue/PR delivery
+still requires the live helper's actor, ownership, Project and ledger preflight;
+these examples do not replace it. For package-consuming work, also test:
+
+```sh
+gh api 'orgs/atrinik/packages/container/linux-build/versions?per_page=1' \
+  --jq '.[0].name'
+```
+
+Verify the exact registry manifest as part of artifact acceptance; package
+metadata alone is not proof of manifest/provenance or runtime behavior. Where a
+registry client needs a bearer token, obtain it from the mounted login within
+the coordinator process and keep it in memory; never log or persist a token
+copy. Do not introduce an authentication proxy. Credential mount access does
+not change any host/container execution or Git sandbox restriction in the task.
+
+## Avoid repeated approval and login prompts
+
+Separate three gates: GitHub authentication (who/capabilities), delivery
+permission (what the user authorized), and Codex execution approval (sandbox).
+A missing scope needs one host refresh; an already-authorized issue/Project
+claim needs no second conversational permission request. Sandbox approval is
+separate and still follows the active tool policy. Report which gate failed
+with the exact capability and command, not a generic request to authorize GitHub.
+
+At startup, batch the selected task's read-only repository, Project and package
+capability checks before implementation or expensive work. Gather all missing
+scopes into one host action. Reuse existing valid authentication and permissions;
+do not request a fresh login per worker or rediscover missing scopes one at a
+time. After requesting a host action, keep it pending, continue independent
+work, and recheck after the user reports completion. Do not reissue the same
+browser-login request on every continuation; a lack of reply is not approval.
+For an ordered program, its coordinator owns the single host-setup request; leaf
+workers report missing capabilities to that owner instead of starting competing
+OAuth flows. Independent workers consume the prepared host directory and report
+a missing prerequisite without launching their own login flow.
+
+Keep the same owned coordinator through the delivery and human authentication
+wait. Thirty minutes is the idle deadline, not an unconditional process timer
+that kills active work; the normal maximum lifetime is twelve hours. Record
+activity/deadlines, honor leases, and stop only owned idle resources. If it stops,
+inspect that exact handle and recover once under the existing contract instead
+of spawning another empty-auth coordinator.
+
+For repeated Codex execution approvals, batch related read-only calls and use
+an already-approved narrow command rule where applicable. Keep read and write
+operations separate so the approval's scope is clear. Agents may propose a
+concrete narrowly scoped rule for the host owner to review; they must not disable
+the sandbox, install blanket `gh`/`docker` allow rules, or change managed policy
+as an authentication workaround. Personal execution settings are not repository
+credentials and do not belong in this PR's composition defaults. See the
+[Codex rules](https://developers.openai.com/codex/rules) and
+[security documentation](https://developers.openai.com/codex/security).
+
+## Host-only maintenance and troubleshooting
+
+Workers never run `gh auth login`, `refresh`, `logout`, `switch`, `setup-git` or
+`gh config set` against the shared directory. The host owner performs needed
+changes. For example, add a missing package-read scope on the host:
+
+```sh
+GH_CONFIG_DIR="$HOME/.config/gh-atrinik" gh auth refresh \
+  --hostname github.com --scopes read:packages
+```
+
+After refresh, expiration recovery or account switching, each active worker
+rechecks the actor and task capabilities before proceeding. A different actor
+requires the delivery helper's supported ownership flow; it never silently
+inherits the old ledger. Coordinate host account switching across live workers.
+If the token is revoked, run the host login command again and repeat preflight.
+
+- Missing directory or unreadable `hosts.yml`: finish host setup and check the
+  exact mount source/UID; do not fall back to a writable mount or worker login.
+- Host works but worker returns 401: check keychain-only storage, expired token,
+  wrong mounted directory, and environment overrides without exposing values.
+- API returns 403: check the exact missing scope, account permissions and SSO;
+  ask the host owner for that capability and rerun the failing read.
+- A refresh/config command returns read-only filesystem: run it on the host.
+
+References: [GitHub CLI login](https://cli.github.com/manual/gh_auth_login),
+[environment precedence and GH_CONFIG_DIR](https://cli.github.com/manual/gh_help_environment),
+[refresh](https://cli.github.com/manual/gh_auth_refresh),
+[PAT capabilities and limitations](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens),
+[GHCR authentication](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).

--- a/tests/test_devcontainer.py
+++ b/tests/test_devcontainer.py
@@ -42,6 +42,29 @@ class DevcontainerTests(unittest.TestCase):
         )
         self.assertEqual(config["containerEnv"]["SDL_VIDEODRIVER"], "x11")
 
+    def test_shared_github_auth_is_read_only_and_coordinator_only(self) -> None:
+        config = self.load_config(".devcontainer/devcontainer.json")
+        auth_dir = config["containerEnv"]["GH_CONFIG_DIR"]
+        mounts = [
+            mount.split(",")
+            for mount in config["mounts"]
+            if f"target={auth_dir}" in mount.split(",")
+        ]
+        self.assertEqual(len(mounts), 1)
+        self.assertIn("type=bind", mounts[0])
+        self.assertIn("readonly", mounts[0])
+        self.assertIn(
+            "source=${localEnv:HOME}/.config/gh-atrinik", mounts[0]
+        )
+        self.assertEqual(auth_dir, f"/home/{config['remoteUser']}/.config/gh")
+        self.assertNotEqual(auth_dir, config["containerEnv"]["CODEX_HOME"])
+        self.assertFalse(
+            {"GH_TOKEN", "GITHUB_TOKEN"} & config["containerEnv"].keys()
+        )
+        windows = self.load_config(".devcontainer/windows-cross/devcontainer.json")
+        self.assertNotIn("GH_CONFIG_DIR", windows.get("containerEnv", {}))
+        self.assertFalse(any("gh-atrinik" in mount for mount in windows["mounts"]))
+
     def test_windows_configuration_validates_component_manifest(self) -> None:
         config = self.load_config(
             ".devcontainer/windows-cross/devcontainer.json"


### PR DESCRIPTION
## Summary

Trusted delivery coordinators now reuse one host-owned GitHub CLI login instead of requiring a browser login for every worker. The ordinary devcontainer mounts the private host config read-only at ubuntu's standard GitHub CLI path, so normal commands and the protected delivery actor proof use the same identity.

## Implementation / behavior

- Add the read-only host auth mount and matching configuration regression coverage; keep Windows cross-build containers credential-free under this composition.
- Document initialization from an existing host keyring credential through stdin, one-time login when needed, combined scope preflight, host-only refresh/account switching, environment precedence, and the limits of organization-scoped tokens.
- Synchronize AGENTS.md, README, architecture, and workspace/delivery/program/governance/guidance skills. Preserve actor/ledger verification, task-specific mutation authority, isolated mutable state, and existing-session recovery rules.
- Batch required repository, Project and package capability checks; keep pending host requests pending and give an ordered program one host-setup owner. Distinguish GitHub login, task authorization, and sandbox approval. Preserve the 30-minute idle / 12-hour lifetime distinction.

## Validation

- Fresh pinned canonical coordinator: protected helper actor proof and private package metadata reads succeeded using the host mount; opening the credential file for writing failed with a read-only-filesystem error.
- Focused configuration/coordinator tests and guidance tests passed; all five changed skills passed the skill validator.
- Guidance budgets, manifest validation, supply-chain validation, compileall, and diff checks passed.
- Full wrapper suite: 1,397 tests passed, seven skipped; 85% coverage. Used `NO_COLOR=1`, a subreaper and a 65,536 descriptor limit for the pinned Python 3.14 container runtime. Final guidance/configuration/coordinator rerun: 47 tests passed.
- Final head `ae666764e699de4c11d7fb160f0ab0a28952c1fa`: all three CI test shards, integration validation, native Windows wrapper smoke, CodeQL analyses and PR title policy passed.

## Limitations / follow-up

The host credential directory must be prepared before creating a coordinator. A read-only mount prevents credential-file changes but still grants the token's API capabilities to trusted workers. Host keyring-only storage cannot be mounted directly; workers never mount the host keyring or receive copied credential files. Existing running containers are not remounted automatically. Consumer image adoption in #567 remains separate; this PR does not change image pins or inventory records. No personal Codex approval settings, organization policy, or private chat transcripts are included.
