### PR TITLE
fix(delivery): canonically order mixed-repository PR bindings

### DIFF
--- a/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
+++ b/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
@@ -8262,10 +8262,13 @@ def _pr_binding_candidate(
         slot_result if value["slot_id"] == slot_id else value
         for value in candidate["artifacts"]
     ]
-    candidate["selected_prs"] = [
-        *candidate["selected_prs"],
-        copy.deepcopy(remote["pull"]),
-    ]
+    candidate["selected_prs"] = sorted(
+        [*candidate["selected_prs"], copy.deepcopy(remote["pull"])],
+        key=lambda pull: tuple(
+            str(part).casefold()
+            for part in _pull_request(pull, "atomic PR binding selected PR")
+        ),
+    )
     return prepare(candidate)
 
 

--- a/tests/test_delivery_ledger.py
+++ b/tests/test_delivery_ledger.py
@@ -5017,12 +5017,31 @@ class DeliveryLedgerTests(unittest.TestCase):
                 worktree_slot["primitive_request"]["expected_head_sha"] = live_head
             return value
 
-        def install_bound(root: Path, live_base: Path) -> tuple[dict[str, object], object]:
+        def install_bound(
+            root: Path, live_base: Path, *, peer: bool = False
+        ) -> tuple[dict[str, object], object]:
             roots = live_roots(live_base, "atrinik")
             value = document(roots)
+            if peer:
+                peer_roots = live_roots(live_base / "peer", "classic")
+                companion = document(peer_roots)
+                retarget_repository(companion, repository("classic", "R_classic"))
+                for slot in companion["artifacts"]:
+                    slot["slot_id"] = "classic-" + slot["slot_id"]
+                    if slot["kind"] == "worktree":
+                        slot["primitive_request"].update(
+                            component="classic", physical_checkout="classic"
+                        )
+                value["targets"].extend(companion["targets"])
+                value["artifacts"] = sorted(
+                    value["artifacts"] + companion["artifacts"],
+                    key=lambda slot: slot["slot_id"],
+                )
+                value["actor"]["push_repository_node_ids"] = ["R_classic", "R_repo"]
+                value["authority"]["allowed"]["repositories"] = ["R_classic", "R_repo"]
             initial = ledger.create(root, value)
             worktree = next(
-                slot for slot in value["artifacts"] if slot["kind"] == "worktree"
+                slot for slot in value["artifacts"] if slot["slot_id"] == "worktree"
             )
             request = worktree["primitive_request"]
             assert request is not None
@@ -5041,6 +5060,20 @@ class DeliveryLedgerTests(unittest.TestCase):
                 safety,
                 **cas_arguments(initial),
             )
+            if peer:
+                current = ledger.inspect(root, initial.name)
+                request = next(
+                    slot["primitive_request"] for slot in value["artifacts"]
+                    if slot["slot_id"] == "classic-worktree"
+                )
+                worktree_list = worktree_list_bytes(request)
+                safety = safety_observation_bytes(
+                    request, worktree_list, producer_kind="primitive", producer_digest=None
+                )
+                ledger.bind_worktree_cas(
+                    root, current.name, "classic-worktree", worktree_list, safety,
+                    **cas_arguments(current),
+                )
             return value, ledger.inspect(root, initial.name)
 
         def live_pr(
@@ -5051,17 +5084,20 @@ class DeliveryLedgerTests(unittest.TestCase):
             draft: bool = True,
             base_branch: str | None = None,
             updated_at: str = "2026-08-14T18:00:00Z",
+            target_index: int = 0,
+            number: int = 500,
         ) -> dict[str, object]:
+            target = value["targets"][target_index]
+            repo = target["repository"]
             repository_value = {
-                "node_id": "R_repo",
-                "full_name": "atrinik/atrinik",
+                "node_id": repo["node_id"],
+                "full_name": f"{repo['owner']}/{repo['name']}",
             }
-            target = value["targets"][0]
             if head_sha is None:
                 head_sha = target["head"]["current_sha"]
             return {
-                "node_id": "P_issue_created",
-                "number": 500,
+                "node_id": "P_issue_created" if number == 500 else "P_classic_created",
+                "number": number,
                 "state": "open",
                 "draft": draft,
                 "user": {"node_id": "U_actor"},
@@ -5100,7 +5136,7 @@ class DeliveryLedgerTests(unittest.TestCase):
                 if tuple(arguments)[-1] == "user":
                     return {"node_id": "U_actor"}
                 endpoint = tuple(arguments)[-1]
-                if "/pulls/500" in endpoint:
+                if f"/pulls/{live['number']}" in endpoint:
                     return copy.deepcopy(live)
                 if "/comments?" in endpoint:
                     page = int(endpoint.rsplit("page=", 1)[1])
@@ -5155,6 +5191,46 @@ class DeliveryLedgerTests(unittest.TestCase):
             self.assertEqual(repeated["classification"], "bound-match")
             self.assertEqual(bound.document["generation"], 3)
             self.assertEqual(bound.document["selected_prs"][0]["node_id"], "P_issue_created")
+
+        with tempfile.TemporaryDirectory() as temporary, tempfile.TemporaryDirectory() as live_temporary:
+            root = Path(temporary)
+            value, bound = install_bound(root, Path(live_temporary), peer=True)
+            with mock.patch.object(
+                ledger, "_gh_json", side_effect=gh_observer(
+                    live_pr(value, target_index=1, number=501)
+                ),
+            ):
+                ledger.bind_pr_cas(
+                    root, bound.name, "classic-pull-request", 501, **cas_arguments(bound)
+                )
+            predecessor = ledger.inspect(root, bound.name)
+            existing = copy.deepcopy(predecessor.document["selected_prs"])
+            before = directory_snapshot(root)
+            with mock.patch.object(
+                ledger, "_gh_json", side_effect=gh_observer(live_pr(value, body=b"wrong body")),
+            ), self.assertRaises(ledger.LedgerError):
+                ledger.bind_pr_cas(
+                    root, bound.name, "pull-request", 500, **cas_arguments(predecessor)
+                )
+            self.assertEqual(directory_snapshot(root), before)
+            with mock.patch.object(ledger, "_gh_json", side_effect=gh_observer(live_pr(value))):
+                result = ledger.bind_pr_cas(
+                    root, bound.name, "pull-request", 500, **cas_arguments(predecessor)
+                )
+                current = ledger.inspect(root, bound.name)
+                after = directory_snapshot(root)
+                repeated = ledger.bind_pr_cas(
+                    root, bound.name, "pull-request", 500, **cas_arguments(current)
+                )
+            self.assertEqual(result["classification"], "bind-exact")
+            self.assertEqual(repeated["classification"], "bound-match")
+            self.assertEqual(directory_snapshot(root), after)
+            self.assertEqual(
+                [pull["repository"]["name"] for pull in current.document["selected_prs"]],
+                ["atrinik", "classic"],
+            )
+            self.assertEqual(current.document["selected_prs"][1:], existing)
+            self.assertEqual(current.document["authority"], predecessor.document["authority"])
 
         def reject_live_drift(label: str, *, head_sha: str | None = None, body: bytes = INITIAL_PR_BODY) -> None:
             with self.subTest(rejected=label), tempfile.TemporaryDirectory() as temporary, tempfile.TemporaryDirectory() as live_temporary:


### PR DESCRIPTION
## Summary

Fix mixed-repository delivery PR binding when a newly created PR sorts before an existing selection.

## Implementation / behavior

Order selected PRs using the canonical validator identity before preparing the binding candidate. Preserve existing selections and authenticated live checks, exact-coordinate CAS, and retry behavior.

## Validation

Regression coverage exercises reverse-arrival mixed-repository binding and retries. Final wrapper validation and independent review are required before readiness.

## Limitations / follow-up

The corrected helper must merge before paused deliveries can use it. This PR does not change their ledgers or PRs.

Closes #585

Related project: #562.

<!-- atrinik-delivery:body:1f9d2cf684cce917643524f49d3aad0a5791b1535f6d7a6eb9ea83d24e5f3cda:start -->
## Final validation

Validated commit `024aa2710062209470ad72a810ef0aacf20df63a`:

- Full wrapper suite: 1,516 tests passed, 7 skips; 85% coverage.
- Compile, guidance inventory, manifest validation and whitespace checks passed.
- Independent whole-diff review: zero actionable findings.
- All 12 hosted checks passed, including Windows smoke, all test shards, integration validation, CodeQL and Codecov patch coverage.

The regression reproduced the original sorting failure before the fix. Local tests used a private Python environment, isolated Git configuration and an increased test-process file-descriptor limit; initial environment failures are preserved in local evidence. Native runtime testing is inapplicable to this helper-only change.

<!-- atrinik-delivery:body:1f9d2cf684cce917643524f49d3aad0a5791b1535f6d7a6eb9ea83d24e5f3cda:end -->