### PR TITLE
fix(delivery): prove the live base ref during PR binding

### DIFF
--- a/.agents/skills/atrinik-issue-delivery/references/delivery-ledger.md
+++ b/.agents/skills/atrinik-issue-delivery/references/delivery-ledger.md
@@ -1594,7 +1594,13 @@ python3 scripts/delivery_ledger.py pr-bind-cas \
 
 `pr-bind-cas` performs the live authenticated-author, same-repository,
 unchanged-target, draft, durable-body, and complete-comment-pagination proof
-itself immediately before the ledger CAS. Ordinary external comments, such as
+itself immediately before the ledger CAS. Each remote observation independently
+resolves the authenticated live `refs/heads/<base>` and verifies the exact
+repository node/name, full branch ref and commit target against the ledger's
+current base. The PR response's stored base SHA is snapshot metadata, not the
+current branch tip; its repository/ref identity and SHA syntax remain checked.
+Initial, repeated, immediate-precommit and completed-retry observations retain
+these proofs, so live base drift still stops binding. Ordinary external comments, such as
 Codecov or reviewer comments, are classified as non-delivery state and remain
 untouched; a malformed or reserved `atrinik-delivery:comment:` marker, invalid
 page, duplicate node, or pagination that cannot reach a bounded final page

--- a/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
+++ b/.agents/skills/atrinik-issue-delivery/scripts/delivery_ledger.py
@@ -8005,6 +8005,47 @@ def _observe_pr_binding_comments(owner: str, name: str, number: int) -> None:
     raise LedgerError("PR binding comment pagination did not reach a bounded final page")
 
 
+def _pr_binding_live_base(target: Mapping[str, Any]) -> str:
+    """Prove the current branch tip independently of the PR's base snapshot."""
+
+    repository = target["repository"]
+    branch = target["base"]["branch"]
+    qualified_ref = f"refs/heads/{branch}"
+    response = _gh_json(
+        (
+            "api", "--hostname", "github.com", "graphql",
+            "-f", "query=query($owner:String!,$name:String!,$ref:String!){"
+            "repository(owner:$owner,name:$name){id nameWithOwner "
+            "ref(qualifiedName:$ref){name prefix target{__typename oid}}}}",
+            "-f", f"owner={repository['owner']}",
+            "-f", f"name={repository['name']}",
+            "-f", f"ref={qualified_ref}",
+        ),
+        "PR binding live base ref",
+    )
+    if not isinstance(response, dict) or response.get("errors"):
+        raise LedgerError("PR binding live base ref response is invalid")
+    data = response.get("data")
+    remote = data.get("repository") if isinstance(data, dict) else None
+    if (
+        not isinstance(remote, dict)
+        or remote.get("id") != repository["node_id"]
+        or remote.get("nameWithOwner") != f"{repository['owner']}/{repository['name']}"
+    ):
+        raise LedgerError("PR binding live base ref repository differs from the exact target")
+    ref = remote.get("ref")
+    if (
+        not isinstance(ref, dict)
+        or ref.get("prefix") != "refs/heads/"
+        or ref.get("name") != branch
+    ):
+        raise LedgerError("PR binding live base ref differs from the exact target branch")
+    commit = ref.get("target")
+    if not isinstance(commit, dict) or commit.get("__typename") != "Commit":
+        raise LedgerError("PR binding live base ref target is not a commit")
+    return _string(commit.get("oid"), "PR binding live base ref SHA", COMMIT_RE)
+
+
 def _pr_binding_remote(
     document: Mapping[str, Any], target: Mapping[str, Any], pr_number: int
 ) -> dict[str, Any]:
@@ -8052,9 +8093,10 @@ def _pr_binding_remote(
         raise LedgerError("PR binding PR author differs from the authenticated actor")
     base_branch = _branch(live.get("base", {}).get("ref"), "PR binding base branch")
     head_branch = _branch(live.get("head", {}).get("ref"), "PR binding head branch")
-    base_sha = _string(
-        live.get("base", {}).get("sha"), "PR binding base head SHA", COMMIT_RE
+    base_snapshot_sha = _string(
+        live.get("base", {}).get("sha"), "PR binding base snapshot SHA", COMMIT_RE
     )
+    base_sha = _pr_binding_live_base(target)
     head_sha = _string(
         live.get("head", {}).get("sha"), "PR binding PR head SHA", COMMIT_RE
     )
@@ -8106,6 +8148,7 @@ def _pr_binding_remote(
     return {
         "pull": pull,
         "base_sha": base_sha,
+        "base_snapshot_sha": base_snapshot_sha,
         "head_sha": head_sha,
         "body_digest": digest,
     }

--- a/tests/test_delivery_ledger.py
+++ b/tests/test_delivery_ledger.py
@@ -5575,7 +5575,8 @@ class DeliveryLedgerTests(unittest.TestCase):
                 **cas_arguments(predecessor),
             )
             stale = live_pr(refreshed.document)
-            stale["base"]["sha"] = predecessor.document["targets"][0]["base"]["current_sha"]
+            stale["base"]["sha"] = predecessor.document["targets"][0]["base"]["initial_sha"]
+            self.assertNotEqual(stale["base"]["sha"], refreshed.document["targets"][0]["base"]["current_sha"])
             with mock.patch.object(
                 ledger,
                 "_gh_json",

--- a/tests/test_delivery_ledger.py
+++ b/tests/test_delivery_ledger.py
@@ -5119,10 +5119,22 @@ class DeliveryLedgerTests(unittest.TestCase):
                 "updated_at": updated_at,
             }
 
+        def live_base(live: dict[str, object]) -> dict[str, object]:
+            base = live["base"]
+            return {"data": {"repository": {
+                "id": base["repo"]["node_id"],
+                "nameWithOwner": base["repo"]["full_name"],
+                "ref": {"prefix": "refs/heads/", "name": base["ref"],
+                        "target": {"__typename": "Commit", "oid": base["sha"]}},
+            }}}
+
         def gh_observer(
             live: dict[str, object],
             comments: object = None,
             observed_pages: list[int] | None = None,
+            *,
+            base_responses: list[object] | None = None,
+            observed_refs: list[object] | None = None,
         ):
             if comments is None:
                 response_comments: object = {1: []}
@@ -5131,8 +5143,23 @@ class DeliveryLedgerTests(unittest.TestCase):
             else:
                 response_comments = {1: comments}
 
+            ref_reads = 0
+
             def observe(arguments: object, context: str) -> object:
-                del context
+                nonlocal ref_reads
+                if context == "PR binding live base ref":
+                    arguments = tuple(arguments)
+                    self.assertEqual(arguments[:4], ("api", "--hostname", "github.com", "graphql"))
+                    owner, name = live["base"]["repo"]["full_name"].split("/")
+                    self.assertIn(f"owner={owner}", arguments)
+                    self.assertIn(f"name={name}", arguments)
+                    self.assertIn("ref=refs/heads/main", arguments)
+                    responses = [live_base(live)] if base_responses is None else base_responses
+                    result = responses[min(ref_reads, len(responses) - 1)]
+                    ref_reads += 1
+                    if observed_refs is not None:
+                        observed_refs.append(copy.deepcopy(result))
+                    return copy.deepcopy(result)
                 if tuple(arguments)[-1] == "user":
                     return {"node_id": "U_actor"}
                 endpoint = tuple(arguments)[-1]
@@ -5213,7 +5240,11 @@ class DeliveryLedgerTests(unittest.TestCase):
                     root, bound.name, "pull-request", 500, **cas_arguments(predecessor)
                 )
             self.assertEqual(directory_snapshot(root), before)
-            with mock.patch.object(ledger, "_gh_json", side_effect=gh_observer(live_pr(value))):
+            stale_snapshot = live_pr(value)
+            stale_snapshot["base"]["sha"] = SHA_A
+            with mock.patch.object(ledger, "_gh_json", side_effect=gh_observer(
+                stale_snapshot, base_responses=[live_base(live_pr(value))]
+            )):
                 result = ledger.bind_pr_cas(
                     root, bound.name, "pull-request", 500, **cas_arguments(predecessor)
                 )
@@ -5242,7 +5273,8 @@ class DeliveryLedgerTests(unittest.TestCase):
 
                 def observe(arguments: object, context: str) -> object:
                     nonlocal reads
-                    del context
+                    if context == "PR binding live base ref":
+                        return live_base(first)
                     endpoint = tuple(arguments)[-1]
                     if endpoint == "user":
                         return {"node_id": "U_actor"}
@@ -5277,7 +5309,10 @@ class DeliveryLedgerTests(unittest.TestCase):
             with mock.patch.object(
                 ledger,
                 "_gh_json",
-                side_effect=gh_observer(live_pr(value, base_branch="develop")),
+                side_effect=gh_observer(
+                    live_pr(value, base_branch="develop"),
+                    base_responses=[live_base(live_pr(value))],
+                ),
             ), self.assertRaisesRegex(ledger.LedgerError, "base branch differs"):
                 ledger.bind_pr_cas(
                     root,
@@ -5306,7 +5341,8 @@ class DeliveryLedgerTests(unittest.TestCase):
 
             def observe_concurrent(arguments: object, context: str) -> object:
                 nonlocal pull_reads
-                del context
+                if context == "PR binding live base ref":
+                    return live_base(live_pr(value))
                 endpoint = tuple(arguments)[-1]
                 if endpoint == "user":
                     return {"node_id": "U_actor"}
@@ -5456,6 +5492,79 @@ class DeliveryLedgerTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as temporary, tempfile.TemporaryDirectory() as live_temporary:
             root = Path(temporary)
+            value, bound = install_bound(root, Path(live_temporary))
+            live = live_pr(value)
+            good = live_base(live)
+            invalid: list[tuple[str, object]] = [
+                ("non-object", []), ("missing data", {}),
+                ("GraphQL errors", {"errors": [{"message": "unavailable"}], **good}),
+                ("missing repository", {"data": {"repository": None}}),
+            ]
+            for field, replacement in (("id", "R_wrong"), ("nameWithOwner", "foreign/atrinik"),
+                                       ("ref", None), ("ref", [])):
+                bad = copy.deepcopy(good)
+                bad["data"]["repository"][field] = replacement
+                invalid.append((f"repository {field}: {replacement}", bad))
+            for field, replacement in (("prefix", "refs/tags/"), ("name", "develop"),
+                                       ("target", None), ("target", [])):
+                bad = copy.deepcopy(good)
+                bad["data"]["repository"]["ref"][field] = replacement
+                invalid.append((f"ref {field}: {replacement}", bad))
+            for field, replacement in (("__typename", "Tag"), ("oid", "malformed"),
+                                       ("oid", SHA_B)):
+                bad = copy.deepcopy(good)
+                bad["data"]["repository"]["ref"]["target"][field] = replacement
+                invalid.append((f"target {field}: {replacement}", bad))
+            before = directory_snapshot(root)
+            for label, response in invalid:
+                with self.subTest(live_base=label), mock.patch.object(
+                    ledger, "_gh_json", side_effect=gh_observer(live, base_responses=[response])
+                ), self.assertRaises(ledger.LedgerError):
+                    ledger.bind_pr_cas(root, bound.name, "pull-request", 500, **cas_arguments(bound))
+                self.assertEqual(directory_snapshot(root), before)
+            drift = copy.deepcopy(good)
+            drift["data"]["repository"]["ref"]["target"]["oid"] = SHA_B
+            for observation in (2, 3):
+                observed: list[object] = []
+                with self.subTest(drift_observation=observation), mock.patch.object(
+                    ledger, "_gh_json", side_effect=gh_observer(
+                        live, base_responses=[good] * (observation - 1) + [drift],
+                        observed_refs=observed,
+                    )
+                ), self.assertRaisesRegex(ledger.LedgerError, "remote observation changed"):
+                    ledger.bind_pr_cas(root, bound.name, "pull-request", 500, **cas_arguments(bound))
+                self.assertEqual(len(observed), observation)
+                self.assertEqual(directory_snapshot(root), before)
+            # A stale PR snapshot remains valid across interrupted publication and
+            # exact receipt recovery; a changed live branch does not.
+            live["base"]["sha"] = SHA_A
+            with mock.patch.object(ledger, "_gh_json", side_effect=gh_observer(
+                live, base_responses=[good]
+            )), self.assertRaises(ledger.InjectedCrash):
+                ledger.bind_pr_cas(root, bound.name, "pull-request", 500,
+                                   failpoint="cas:renamed", **cas_arguments(bound))
+            pending = directory_snapshot(root)
+            with mock.patch.object(ledger, "_gh_json", side_effect=gh_observer(
+                live, base_responses=[drift]
+            )), self.assertRaises(ledger.LedgerError):
+                ledger.bind_pr_cas(root, bound.name, "pull-request", 500, **cas_arguments(bound))
+            self.assertEqual(directory_snapshot(root), pending)
+            with mock.patch.object(ledger, "_gh_json", side_effect=gh_observer(
+                live, base_responses=[good]
+            )):
+                recovered = ledger.bind_pr_cas(root, bound.name, "pull-request", 500, **cas_arguments(bound))
+            self.assertEqual(recovered["classification"], "bound-match")
+            self.assertEqual(ledger.inventory(root).pending, ())
+            current = ledger.inspect(root, bound.name)
+            before = directory_snapshot(root)
+            with mock.patch.object(ledger, "_gh_json", side_effect=gh_observer(
+                live, base_responses=[drift]
+            )), self.assertRaises(ledger.LedgerError):
+                ledger.bind_pr_cas(root, bound.name, "pull-request", 500, **cas_arguments(current))
+            self.assertEqual(directory_snapshot(root), before)
+
+        with tempfile.TemporaryDirectory() as temporary, tempfile.TemporaryDirectory() as live_temporary:
+            root = Path(temporary)
             predecessor, candidate, _actual_head, _base_head, _live = target_refresh_setup(
                 Path(live_temporary), root, "pr-bind-target-refresh", stale_predecessor=False
             )
@@ -5465,10 +5574,14 @@ class DeliveryLedgerTests(unittest.TestCase):
                 candidate,
                 **cas_arguments(predecessor),
             )
+            stale = live_pr(refreshed.document)
+            stale["base"]["sha"] = predecessor.document["targets"][0]["base"]["current_sha"]
             with mock.patch.object(
                 ledger,
                 "_gh_json",
-                side_effect=gh_observer(live_pr(refreshed.document)),
+                side_effect=gh_observer(
+                    stale, base_responses=[live_base(live_pr(refreshed.document))]
+                ),
             ):
                 result = ledger.bind_pr_cas(
                     root,
@@ -14517,6 +14630,14 @@ class DeliveryLedgerTests(unittest.TestCase):
             }
 
             def observe(arguments: object, _context: str) -> object:
+                if _context == "PR binding live base ref":
+                    target = value["targets"][0]
+                    return {"data": {"repository": {
+                        "id": target["repository"]["node_id"],
+                        "nameWithOwner": "atrinik/atrinik",
+                        "ref": {"name": target["base"]["branch"], "prefix": "refs/heads/",
+                                "target": {"__typename": "Commit", "oid": target["base"]["current_sha"]}},
+                    }}}
                 endpoint = tuple(arguments)[-1]
                 if "/pulls/500" in endpoint:
                     return copy.deepcopy(remote)


### PR DESCRIPTION
## Summary

Fix issue-delivery PR binding when GitHub retains an older base snapshot after the target branch advances.

## Implementation / behavior

Prove the authenticated live base branch independently at every binding observation, while retaining exact repository, head, body, comment and transactional checks. Preserve existing PR snapshot metadata without treating it as the current branch tip.

## Validation

Regression and complete wrapper validation, independent review and final hosted checks are recorded in the delivery-owned final validation section before readiness.

## Limitations / follow-up

Existing deliveries must use this correction only after it merges. This PR does not change their ledgers or source branches.

Closes #588

Related: #562, #565 and #584.

<!-- atrinik-delivery:body:f5020cc1fb413c526d2ea33ff51fa479a24ea834592c061e4491bcb6f0643e75:start -->
## Final validation

- Final reviewed head: `2f99dad8acfdecdbe0054e4937feb785ea688dc6`.
- Complete wrapper suite: 1,516 tests passed, 7 skipped; 85% coverage. Compileall, guidance inventory, manifest validation and diff checks passed.
- Independent whole-diff review: zero actionable findings after correcting the historical-base regression.
- Public binding regressions cover a stale stored snapshot, mixed repository selection, exact live repository/ref identity, malformed responses, concurrent base changes, and interrupted/completed retries with unchanged failure predecessors.
- The exact authenticated GraphQL query was checked against live GitHub. Local tests used isolated fixtures and a private virtual environment; test-only Git configuration and descriptor limits did not alter delivery authority.

The recovery condition was encountered on #584; its ordinary merge from main subsequently allowed binding. This fix supports a valid stale-snapshot bind without requiring that head update. No existing delivery ledger is changed by this PR, and it remains unmerged for maintainer review.

<!-- atrinik-delivery:body:f5020cc1fb413c526d2ea33ff51fa479a24ea834592c061e4491bcb6f0643e75:end -->