### PR TITLE
fix(project): reserve retained idle workers through exact CAS

### DIFF
--- a/.agents/skills/atrinik-project-delivery/SKILL.md
+++ b/.agents/skills/atrinik-project-delivery/SKILL.md
@@ -34,6 +34,12 @@ Inspect actual runtime worker capacity and existing open workers; a requested
 16 slots is not proof. Reserve ready disjoint lanes before spawning. Record the
 actual returned worker ID, exact entry mode/coordinate and attempt immediately.
 If spawning fails or its outcome is uncertain, reconcile before retrying.
+After a supported retry/replan, a pending node with its retired attempt may
+reserve its own retained idle direct-child worker through `reserve-existing`.
+Follow the operator protocol's fresh runtime observation and exact snapshot
+requirements. Keep the returned reservation until a live runtime recheck and
+accepted follow-up; then record the exact worker and new attempt as running.
+A lost response preserves the reservation and never authorizes another spawn.
 
 Each writing worker explicitly invokes `$atrinik-issue-delivery` for its one
 selected issue or PR. It completes the existing authenticated genesis,

--- a/.agents/skills/atrinik-project-delivery/references/coordinator.md
+++ b/.agents/skills/atrinik-project-delivery/references/coordinator.md
@@ -113,6 +113,92 @@ If a worker's bound delivery already owns a PR, continue that exact delivery,
 not a second issue-mode claim. If additional independent PR work is needed,
 add a separately authorized type-explicit lane after collision checks.
 
+## Reserve an existing idle worker
+
+Use this operation after `retry` or an eligible `replan` leaves the same leaf
+pending with no bound worker and an exact retained attempt. It does not adopt a
+worker from another leaf or authorize copying patches, credentials or ledgers.
+Ordinary `dispatch` and same-owner `reopen` retain their existing behavior.
+
+```sh
+python3 -m atrinik_workspace.project_delivery --root RETURNED_ROOT --snapshot-output /absolute/private/reserved.json --compact reserve-existing atrinik/atrinik#NUMBER --worker /root/leaf --runtime-observation /absolute/private/runtime.json --heavy-limit 1 --expected /absolute/private/current.json
+```
+
+The observation is a trusted coordinator's attestation, not an authenticated
+runtime credential. This adapter uses the collaboration runtime's whole-thread
+tree: obtain a fresh complete `list_agents` response and the actual exposed
+capacity, including the root coordinator and nested/review/completed handles.
+Do not derive capacity from desired parallelism or decrement the open-worker
+count to make space. Only the root dispatcher's own direct children may be
+selected; nested workers remain with their dispatcher. Use this exact schema,
+replacing every example value with current evidence:
+
+```json
+{
+  "schema_version": 1,
+  "observed_at": "2026-09-12T12:00:00Z",
+  "snapshot": {"generation": 7, "digest": "EXACT_SNAPSHOT_SHA256", "path": "/absolute/project/root/project.json"},
+  "project": {"parent": "atrinik/atrinik#PARENT", "authority": "EXACT_SESSION_AUTHORITY", "actor": "zoeyrose"},
+  "runtime": {
+    "namespace": "/root",
+    "capacity_domain": "whole-thread-tree",
+    "capacity": 2,
+    "complete": true,
+    "agents": [
+      {"agent_name": "/root", "agent_status": "running"},
+      {"agent_name": "/root/leaf", "agent_status": "completed"}
+    ]
+  },
+  "selection": {
+    "worker": "/root/leaf",
+    "coordinate": "atrinik/atrinik#NUMBER",
+    "entry_mode": "issue",
+    "retired_attempt": "EXACT_PENDING_NODE_ATTEMPT",
+    "evidence": "Actual runtime task history matches this leaf and retired attempt; exact leaf ledger/worktree/head checked."
+  }
+}
+```
+
+Retain the actual runtime `agent_name`/`agent_status` rows without rewriting
+statuses. The selected status must be `idle` or `completed`; the inventory
+accepts those plus `running`, and refuses unknown or interrupted states. The
+root must be present and running. `complete`, namespace, capacity, selection,
+session and leaf correlation are coordinator attestations, not fields returned
+or cryptographically verified by the runtime. The helper rejects an absent,
+duplicate or mismatched selected identity; it cannot detect a fabricated whole
+attestation. Obtain the selection evidence from actual runtime history and
+fresh leaf ownership checks; never infer ownership from a convenient name.
+
+Keep the observation in an owned regular no-follow file of at most 128 KiB.
+The CLI reads it inside the locked CAS callback, after validating the expected
+snapshot's generation, digest and canonical path. Its UTC timestamp (optionally
+1–6 fractional digits) must be no more than 60 seconds old and not in the
+future. Project actor/authority/parent and selection coordinate/entry mode/
+retired attempt must match exactly. Stale or mismatched evidence fails without
+changing the project. A worker bound to any other node, including a terminal
+node, is unavailable. A running runtime worker with an inactive project
+reservation is inconsistent and must be reconciled first. Dependencies,
+file/resource conflicts, external reservations and heavy-job limits remain
+required. Existing unbound spawn reservations still reserve future handles;
+reactivation adds no open handle and must fit the active capacity budget.
+
+The result durably binds `reserved`, the existing worker and a fresh attempt,
+including the prior attempt and canonical observation digest in its identity.
+Keep the exact returned snapshot/request. A single trusted dispatcher must
+immediately recheck actual runtime idleness, follow up that exact worker with
+that new attempt and the unchanged leaf delivery authority, and only after the
+runtime accepts the start run `worker COORD --attempt NEW_ATTEMPT --id WORKER`
+with the returned snapshot. Every resumed writing worker still re-proves its
+own issue-delivery ledger, worktree, actor and leases before edits. Runtime
+recheck/follow-up is not atomic with local CAS; no signed runtime or atomic
+activation API is available. Serialize these actions in the owning dispatcher.
+
+Busy, unknown, lost follow-up or lost output preserves the prebound reservation.
+Inspect and reconcile the actual worker/attempt before any further action;
+never automatically retry a follow-up, spawn a replacement, or release its
+resources. `retry` still requires actual non-start/stopped-runtime and exact
+leaf recovery proof. Old-attempt results cannot complete the new reservation.
+
 ## GitHub tracking journal
 
 Plan an operation before applying it:

--- a/.agents/skills/atrinik-project-delivery/references/coordinator.md
+++ b/.agents/skills/atrinik-project-delivery/references/coordinator.md
@@ -146,7 +146,7 @@ replacing every example value with current evidence:
     "complete": true,
     "agents": [
       {"agent_name": "/root", "agent_status": "running"},
-      {"agent_name": "/root/leaf", "agent_status": "completed"}
+      {"agent_name": "/root/leaf", "agent_status": {"completed": "Actual retained result text"}}
     ]
   },
   "selection": {
@@ -160,9 +160,13 @@ replacing every example value with current evidence:
 ```
 
 Retain the actual runtime `agent_name`/`agent_status` rows without rewriting
-statuses. The selected status must be `idle` or `completed`; the inventory
-accepts those plus `running`, and refuses unknown or interrupted states. The
-root must be present and running. `complete`, namespace, capacity, selection,
+statuses. A completed worker has the actual tagged status object
+`{"completed": "result text"}`; selected workers accept that exact shape or
+`"idle"`. The inventory also accepts `"running"`, and refuses plain
+`"completed"`, unknown/interrupted states and malformed or ambiguous objects.
+Completion text is bounded with the input, hashed as part of the raw observation
+and never copied into the project record or returned request. The root must be
+present and running. `complete`, namespace, capacity, selection,
 session and leaf correlation are coordinator attestations, not fields returned
 or cryptographically verified by the runtime. The helper rejects an absent,
 duplicate or mismatched selected identity; it cannot detect a fabricated whole

--- a/atrinik_workspace/project_coordinator.py
+++ b/atrinik_workspace/project_coordinator.py
@@ -325,8 +325,16 @@ def reserve_existing(project: dict, ident: str, worker: str, observation: dict,
                 and re.fullmatch(r"/root(?:/[a-z0-9_]+)*", name) is not None,
                 "invalid or foreign runtime worker identity")
         require(name not in agents, "duplicate runtime worker identity")
-        require(isinstance(status, str) and status in {"running", "idle", "completed"},
-                "unknown runtime worker state")
+        if isinstance(status, dict):
+            keys(status, {"completed"}, "completed runtime status")
+            require(isinstance(status["completed"], str) and len(status["completed"]) <= 128 * 1024,
+                    "invalid completed runtime result")
+            # Preserve the actual tagged runtime row in the observation digest;
+            # never copy its potentially private result text into project state.
+            status = "completed"
+        else:
+            require(isinstance(status, str) and status in {"running", "idle"},
+                    "unknown runtime worker state")
         agents[name] = status
     require(agents.get("/root") == "running", "runtime coordinator is missing or inactive")
     require(isinstance(worker, str) and worker in agents and PurePosixPath(worker).parent.as_posix() == "/root",

--- a/atrinik_workspace/project_coordinator.py
+++ b/atrinik_workspace/project_coordinator.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import copy
+from datetime import datetime, timezone
 import hashlib
 import json
 import re
@@ -263,6 +264,116 @@ def reserve(project: dict, capacity: int, heavy_limit: int, open_workers: int = 
                          "instruction": "Use $atrinik-issue-delivery with the exact entry mode and coordinate. "
                          "Complete live ownership/ledger/worktree gates. Do not create a nested goal."})
     return requests
+
+
+def reserve_existing(project: dict, ident: str, worker: str, observation: dict,
+                     expected: dict, heavy_limit: int, *, now: datetime | None = None) -> dict:
+    """Reserve a retained idle handle using a fresh coordinator attestation.
+
+    The runtime cannot authenticate this JSON. The trusted single dispatcher
+    supplies the complete live inventory and correlates its own worker's retired
+    attempt; leaf authority remains with the issue-delivery workflow.
+    """
+    validate_project(project)
+    require(ident in project["nodes"], "unknown leaf")
+    current = project["nodes"][ident]
+    node = next(n for n in project["plan"]["nodes"] if n["id"] == ident)
+    require(not node["external"] and current["state"] == "pending"
+            and current["worker"] is None, "existing worker needs an unbound pending leaf")
+    require(isinstance(current["attempt"], str)
+            and re.fullmatch(r"[0-9a-f]{64}", current["attempt"]) is not None,
+            "existing worker needs an exact retired attempt")
+    require(type(heavy_limit) is int and 0 <= heavy_limit <= MAX_NODES, "invalid heavy limit")
+    keys(observation, {"schema_version", "observed_at", "snapshot", "project", "runtime", "selection"},
+         "runtime observation")
+    require(type(observation["schema_version"]) is int and observation["schema_version"] == 1,
+            "unsupported runtime observation schema")
+    keys(observation["snapshot"], {"generation", "digest", "path"}, "runtime snapshot")
+    require(type(observation["snapshot"]["generation"]) is int
+            and observation["snapshot"] == {k: expected[k] for k in ("generation", "digest", "path")}
+            and expected["generation"] == project["generation"], "stale runtime snapshot")
+    keys(observation["project"], {"parent", "authority", "actor"}, "runtime project")
+    require(observation["project"] == {"parent": project["plan"]["parent"],
+            "authority": project["authority"], "actor": project["actor"]}, "foreign runtime project")
+    timestamp = observation["observed_at"]
+    require(isinstance(timestamp, str) and re.fullmatch(
+        r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,6})?Z", timestamp) is not None,
+        "invalid runtime observation time")
+    try:
+        observed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ProjectError("invalid runtime observation time") from error
+    age = ((now or datetime.now(timezone.utc)) - observed).total_seconds()
+    require(0 <= age <= 60, "runtime observation is stale or from the future")
+
+    runtime = observation["runtime"]
+    keys(runtime, {"namespace", "capacity_domain", "capacity", "complete", "agents"}, "runtime inventory")
+    # This adapter uses the collaboration runtime's whole-thread tree, including
+    # the root coordinator in both inventory and capacity. Nested workers belong
+    # to their own dispatcher and cannot be reassigned by this operation.
+    require(runtime["namespace"] == "/root" and runtime["capacity_domain"] == "whole-thread-tree"
+            and runtime["complete"] is True, "incomplete or foreign runtime namespace")
+    capacity = runtime["capacity"]
+    require(type(capacity) is int and 1 <= capacity <= MAX_NODES, "invalid runtime capacity")
+    require(isinstance(runtime["agents"], list) and 1 <= len(runtime["agents"]) <= capacity,
+            "runtime inventory exceeds capacity or is empty")
+    agents = {}
+    for agent in runtime["agents"]:
+        keys(agent, {"agent_name", "agent_status"}, "runtime agent")
+        name, status = agent["agent_name"], agent["agent_status"]
+        require(isinstance(name, str) and len(name) <= 256
+                and re.fullmatch(r"/root(?:/[a-z0-9_]+)*", name) is not None,
+                "invalid or foreign runtime worker identity")
+        require(name not in agents, "duplicate runtime worker identity")
+        require(isinstance(status, str) and status in {"running", "idle", "completed"},
+                "unknown runtime worker state")
+        agents[name] = status
+    require(agents.get("/root") == "running", "runtime coordinator is missing or inactive")
+    require(isinstance(worker, str) and worker in agents and PurePosixPath(worker).parent.as_posix() == "/root",
+            "selected worker is absent or not owned by this dispatcher")
+    require(agents[worker] in {"idle", "completed"}, "selected worker is active")
+    selection = observation["selection"]
+    keys(selection, {"worker", "coordinate", "entry_mode", "retired_attempt", "evidence"}, "runtime selection")
+    require(all(selection[k] == v for k, v in {
+        "worker": worker, "coordinate": ident, "entry_mode": node["entry_mode"],
+        "retired_attempt": current["attempt"]}.items()), "runtime selection does not match the retired delivery")
+    require(isinstance(selection["evidence"], str) and 0 < len(selection["evidence"].strip()) <= 4096,
+            "runtime history and exact leaf ownership evidence required")
+    require(not any(s["worker"] == worker for key, s in project["nodes"].items() if key != ident),
+            "worker already owns another node")
+
+    active = [s for s in project["nodes"].values() if occupied_attempt(s)]
+    bound = {s["worker"] for s in active if s["worker"] is not None}
+    require(bound <= agents.keys(), "occupied worker missing from runtime inventory")
+    for state in project["nodes"].values():
+        require(agents.get(state["worker"]) != "running" or occupied_attempt(state),
+                "running runtime worker has an inactive project reservation")
+    unbound = sum(s["worker"] is None for s in active)
+    # Open handles do not increase, but prior unbound spawn reservations still
+    # own future handles. Retained idle handles are not active workers.
+    require(len(agents) + unbound <= capacity, "runtime capacity already reserved for spawning")
+    running = {name for name, status in agents.items() if status == "running"}
+    require(len(running | bound | {worker}) + unbound <= capacity, "runtime active capacity exhausted")
+    occupied = [n for n in project["plan"]["nodes"] if n["id"] != ident and occupies_resources(project, n)]
+    require(all(condition_met(project, d["id"], d["condition"]) for d in node["dependencies"]),
+            "existing worker dependency gate")
+    require(not any(conflict(node, other) for other in occupied), "existing worker resource conflict")
+    require(not node["heavy"] or sum(n["heavy"] for n in occupied) < heavy_limit,
+            "existing worker heavy capacity")
+    proof = digest(observation)
+    previous = current["attempt"]
+    attempt = digest({"authority": project["authority"], "generation": project["generation"],
+                      "coordinate": ident, "entry_mode": node["entry_mode"], "worker": worker,
+                      "previous_attempt": previous, "runtime_observation_sha256": proof})
+    require(attempt != previous, "existing worker requires a fresh attempt")
+    current.update(state="reserved", worker=worker, attempt=attempt,
+                   detail=f"Existing worker observation {proof}: {selection['evidence']}")
+    return {"entry_mode": node["entry_mode"], "coordinate": ident, "worker": worker,
+            "attempt": attempt, "previous_attempt": previous, "runtime_observation_sha256": proof,
+            "reads": node["reads"], "writes": node["writes"], "resources": node["resources"],
+            "instruction": "Recheck the actual runtime worker is idle, then follow up this exact worker and attempt. "
+            "Use $atrinik-issue-delivery for this same delivery and reprove leaf ownership/ledger/worktree gates. "
+            "Record worker only after accepted start; preserve an uncertain reservation and do not spawn."}
 
 
 def record_worker(project: dict, ident: str, attempt: str, worker: str) -> None:

--- a/atrinik_workspace/project_delivery.py
+++ b/atrinik_workspace/project_delivery.py
@@ -11,7 +11,7 @@ import sys
 import stat
 
 from .project_coordinator import (ProjectError, attest, digest, new_project, record_worker,
-                                  require, replan, reopen, reserve, retry, schedule, terminal_gaps, worker_result)
+                                  require, replan, reopen, reserve, reserve_existing, retry, schedule, terminal_gaps, worker_result)
 from .project_coordinator_github import GitHub, apply_operation, cancel_operation, prepare_operation, refresh
 from .project_coordinator_store import LIMIT, Store, open_directory, read_input
 from .workspace import durable_atomic_json_at
@@ -82,6 +82,13 @@ def parser() -> argparse.ArgumentParser:
     reopen_cmd.add_argument("--evidence", required=True)
     reopen_cmd.add_argument("--heavy-limit", type=int, default=1)
     reopen_cmd.add_argument("--expected", type=Path, required=True)
+    existing = sub.add_parser("reserve-existing", help="reserve this delivery's verified retained idle worker")
+    existing.add_argument("coordinate")
+    existing.add_argument("--worker", required=True, help="actual retained direct-child runtime worker name")
+    existing.add_argument("--runtime-observation", required=True, type=Path,
+                          help="fresh complete runtime inventory and coordinator attestation")
+    existing.add_argument("--heavy-limit", type=int, default=1)
+    existing.add_argument("--expected", required=True, type=Path)
     for name in ("plan", "dispatch"):
         cmd = sub.add_parser(name)
         cmd.add_argument("--capacity", required=True, type=int)
@@ -153,6 +160,12 @@ def run(args, github=None):
             return retry(project, args.coordinate, args.attempt, args.evidence)
         if args.command == "reopen":
             return reopen(project, args.coordinate, args.attempt, args.evidence, args.heavy_limit)
+        if args.command == "reserve-existing":
+            # Read and check freshness only after Store has locked and accepted
+            # the exact expected snapshot. The JSON is an operator attestation.
+            return reserve_existing(project, args.coordinate, args.worker,
+                                    read_input(args.runtime_observation, 128 * 1024),
+                                    expected, args.heavy_limit)
         if args.command == "dispatch":
             return reserve(project, args.capacity, args.heavy_limit, args.open_workers)
         if args.command == "worker":

--- a/tests/test_project_coordinator.py
+++ b/tests/test_project_coordinator.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import copy
+from datetime import datetime, timedelta, timezone
 import json
 import multiprocessing
 import os
@@ -12,7 +13,7 @@ from unittest.mock import patch
 
 from atrinik_workspace.project_coordinator import (
     ProjectError, attest, conflict, digest, new_project, record_worker, replan, require,
-    reopen, reserve, retry, schedule, terminal_gaps, validate_plan, validate_project, worker_result,
+    reopen, reserve, reserve_existing, retry, schedule, terminal_gaps, validate_plan, validate_project, worker_result,
 )
 from atrinik_workspace.project_coordinator_store import Store, decode, read_input
 from atrinik_workspace.project_coordinator_github import (
@@ -46,6 +47,163 @@ def race(root, expected, queue):
         queue.put("won")
     except (ProjectError, OSError):
         queue.put("lost")
+
+
+def retired_project(nodes=None):
+    p = project(nodes)
+    request = reserve(p, 1, 1)[0]
+    record_worker(p, request["coordinate"], request["attempt"], "/root/leaf")
+    worker_result(p, request["coordinate"], request["attempt"], "ready", "exact leaf checkpoint")
+    retry(p, request["coordinate"], request["attempt"], "runtime completed; exact leaf remains owned")
+    changed = copy.deepcopy(p["plan"])
+    changed["nodes"][0]["writes"] = ["phase-two"]
+    replan(p, changed)
+    return p
+
+
+def runtime_observation(p, expected, capacity=17):
+    agents = {"/root": "running", "/root/leaf": "completed"}
+    for state in p["nodes"].values():
+        if state["worker"] and state["worker"] not in agents:
+            agents[state["worker"]] = "running" if state["state"] == "running" else "completed"
+    for index in range(capacity - len(agents)):
+        agents[f"/root/reviewer_{index}"] = "completed"
+    return {"schema_version": 1, "observed_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "snapshot": {k: expected[k] for k in ("generation", "digest", "path")},
+            "project": {"actor": p["actor"], "authority": p["authority"], "parent": p["plan"]["parent"]},
+            "runtime": {"namespace": "/root", "capacity_domain": "whole-thread-tree", "capacity": capacity,
+                        "complete": True, "agents": [{"agent_name": name, "agent_status": status}
+                                                       for name, status in agents.items()]},
+            "selection": {"worker": "/root/leaf", "coordinate": "atrinik/atrinik#2", "entry_mode": "issue",
+                          "retired_attempt": p["nodes"]["atrinik/atrinik#2"]["attempt"],
+                          "evidence": "Runtime task history matches this retired attempt; exact leaf ledger/head checked."}}
+
+
+class ExistingReservationTests(unittest.TestCase):
+    def reserve(self, p, observation=None, heavy=1):
+        expected = {"generation": p["generation"], "digest": digest(p), "path": "/private/project.json"}
+        observation = observation or runtime_observation(p, expected)
+        return reserve_existing(p, "atrinik/atrinik#2", "/root/leaf", observation, expected, heavy)
+
+    def test_full_capacity_retry_replan_keeps_handle_and_requires_accepted_start(self):
+        p = retired_project()
+        previous = p["nodes"]["atrinik/atrinik#2"]["attempt"]
+        self.assertEqual(reserve(p, 17, 1, 17), [])
+        result = self.reserve(p)
+        self.assertEqual((result["worker"], result["writes"]), ("/root/leaf", ["phase-two"]))
+        self.assertNotEqual(result["attempt"], previous)
+        self.assertEqual(result["previous_attempt"], previous)
+        self.assertEqual(p["nodes"][result["coordinate"]]["state"], "reserved")
+        before = copy.deepcopy(p)
+        for attempt in (previous, result["attempt"]):
+            with self.assertRaises(ProjectError):
+                worker_result(p, result["coordinate"], attempt, "ready", "unstarted or old result")
+        with self.assertRaises(ProjectError):
+            record_worker(p, result["coordinate"], result["attempt"], "/root/other")
+        with self.assertRaises(ProjectError):
+            self.reserve(p)
+        self.assertEqual(p, before)
+        record_worker(p, result["coordinate"], result["attempt"], result["worker"])
+        worker_result(p, result["coordinate"], result["attempt"], "ready", "fresh leaf result")
+        renewed = reopen(p, result["coordinate"], result["attempt"], "same owner; reviewer finding", 1)
+        self.assertNotEqual(renewed["attempt"], result["attempt"])
+
+    def test_pending_requires_retired_attempt_and_no_existing_binding(self):
+        for change in (lambda s: s.update(attempt=None), lambda s: s.update(worker="/root/leaf"),
+                       lambda s: s.update(state="running"), lambda s: s.update(attempt="unknown")):
+            p = retired_project(); change(p["nodes"]["atrinik/atrinik#2"]); before = copy.deepcopy(p)
+            with self.assertRaises(ProjectError): self.reserve(p)
+            self.assertEqual(p, before)
+
+    def test_observation_rejects_stale_foreign_ambiguous_and_unknown_inputs_without_mutation(self):
+        changes = [
+            lambda o: o.update(schema_version=True),
+            lambda o: o["snapshot"].update(generation=99),
+            lambda o: o["snapshot"].update(generation=True),
+            lambda o: o["snapshot"].update(digest="f" * 64),
+            lambda o: o["snapshot"].update(path="/other/project.json"),
+            lambda o: o["project"].update(actor="foreign"),
+            lambda o: o["project"].update(authority="other session"),
+            lambda o: o["project"].update(parent="atrinik/atrinik#99"),
+            lambda o: o["runtime"].update(namespace="/foreign"),
+            lambda o: o["runtime"].update(capacity_domain="children-only"),
+            lambda o: o["runtime"].update(complete=False),
+            lambda o: o["runtime"].update(capacity=True),
+            lambda o: o["runtime"].update(capacity=16),
+            lambda o: o["runtime"]["agents"].pop(0),
+            lambda o: o["runtime"]["agents"].pop(1),
+            lambda o: o["runtime"]["agents"][0].update(agent_status="idle"),
+            lambda o: o["runtime"]["agents"][1].update(agent_status="running"),
+            lambda o: o["runtime"]["agents"][1].update(agent_status="interrupted"),
+            lambda o: o["runtime"]["agents"][2].update(agent_name="/root/leaf"),
+            lambda o: o["runtime"]["agents"][1].update(agent_name="/root/foreign/leaf"),
+            lambda o: o["selection"].update(worker="/root/fabricated"),
+            lambda o: o["selection"].update(coordinate="atrinik/atrinik#3"),
+            lambda o: o["selection"].update(entry_mode="PR"),
+            lambda o: o["selection"].update(retired_attempt="f" * 64),
+            lambda o: o["selection"].update(evidence=" "),
+            lambda o: o.update(observed_at="2026-02-30T00:00:00Z"),
+            lambda o: o.update(observed_at="not UTC"),
+            lambda o: o.update(observed_at=(datetime.now(timezone.utc) - timedelta(seconds=61)).isoformat().replace("+00:00", "Z")),
+            lambda o: o.update(observed_at=(datetime.now(timezone.utc) + timedelta(seconds=1)).isoformat().replace("+00:00", "Z")),
+        ]
+        for index, change in enumerate(changes):
+            with self.subTest(index=index):
+                p = retired_project(); before = copy.deepcopy(p)
+                expected = {"generation": p["generation"], "digest": digest(p), "path": "/private/project.json"}
+                o = runtime_observation(p, expected); change(o)
+                with self.assertRaises(ProjectError): self.reserve(p, o)
+                self.assertEqual(p, before)
+
+    def test_every_other_node_binding_blocks_reuse_even_terminal(self):
+        for state in ("pending", "reserved", "running", "blocked", "ready", "merged", "accepted", "external"):
+            with self.subTest(state=state):
+                p = retired_project(); p["nodes"]["atrinik/atrinik#3"].update(state=state, worker="/root/leaf")
+                with self.assertRaisesRegex(ProjectError, "already owns another node"): self.reserve(p)
+
+    def test_dependency_conditions_and_stale_acceptance_remain_gates(self):
+        for condition in ("ready", "merged", "accepted"):
+            p = retired_project()
+            p["plan"]["nodes"][0]["dependencies"] = [{"id": "atrinik/atrinik#3", "condition": condition}]
+            with self.assertRaisesRegex(ProjectError, "dependency"): self.reserve(p)
+            p["nodes"]["atrinik/atrinik#3"]["state"] = "accepted" if condition == "accepted" else condition
+            if condition == "accepted":
+                with self.assertRaisesRegex(ProjectError, "dependency"): self.reserve(p)
+            else:
+                self.assertEqual(self.reserve(p)["worker"], "/root/leaf")
+
+    def test_conflicts_heavy_and_unbound_spawn_reservations_remain_occupied(self):
+        for kind in ("write", "read", "resource", "external", "heavy", "spawn"):
+            with self.subTest(kind=kind):
+                p = retired_project(); a, b = p["plan"]["nodes"]
+                other = p["nodes"][b["id"]]
+                other.update(state="reserved", worker="/root/other", attempt="a" * 64)
+                if kind == "write": b["writes"] = ["phase-two/child"]
+                if kind == "read": b["reads"] = ["phase-two"]
+                if kind == "resource": a["resources"] = b["resources"] = ["database"]
+                if kind == "external":
+                    b["external"] = True; b["writes"] = ["phase-two"]
+                    other.update(state="external", worker=None, attempt=None)
+                if kind == "heavy": a["heavy"] = b["heavy"] = True
+                if kind == "spawn": other["worker"] = None
+                before = copy.deepcopy(p)
+                with self.assertRaises(ProjectError): self.reserve(p)
+                self.assertEqual(p, before)
+        p = retired_project(); p["plan"]["nodes"][0]["heavy"] = True
+        with self.assertRaisesRegex(ProjectError, "heavy capacity"): self.reserve(p, heavy=0)
+
+    def test_missing_occupied_worker_and_running_terminal_worker_fail_closed(self):
+        for state in ("ready", "merged", "accepted"):
+            p = retired_project(); p["nodes"]["atrinik/atrinik#3"].update(state=state, worker="/root/other")
+            expected = {"generation": p["generation"], "digest": digest(p), "path": "/private/project.json"}
+            observation = runtime_observation(p, expected)
+            next(a for a in observation["runtime"]["agents"] if a["agent_name"] == "/root/other")["agent_status"] = "running"
+            with self.assertRaisesRegex(ProjectError, "inactive project reservation"): self.reserve(p, observation)
+        p = retired_project(); p["nodes"]["atrinik/atrinik#3"].update(state="reserved", worker="/root/other")
+        expected = {"generation": p["generation"], "digest": digest(p), "path": "/private/project.json"}
+        observation = runtime_observation(p, expected)
+        observation["runtime"]["agents"] = [a for a in observation["runtime"]["agents"] if a["agent_name"] != "/root/other"]
+        with self.assertRaisesRegex(ProjectError, "missing from runtime inventory"): self.reserve(p, observation)
 
 
 class SchedulerTests(unittest.TestCase):

--- a/tests/test_project_coordinator.py
+++ b/tests/test_project_coordinator.py
@@ -72,7 +72,7 @@ def runtime_observation(p, expected, capacity=17):
             "snapshot": {k: expected[k] for k in ("generation", "digest", "path")},
             "project": {"actor": p["actor"], "authority": p["authority"], "parent": p["plan"]["parent"]},
             "runtime": {"namespace": "/root", "capacity_domain": "whole-thread-tree", "capacity": capacity,
-                        "complete": True, "agents": [{"agent_name": name, "agent_status": status}
+                        "complete": True, "agents": [{"agent_name": name, "agent_status": {"completed": "Retained runtime result"} if status == "completed" else status}
                                                        for name, status in agents.items()]},
             "selection": {"worker": "/root/leaf", "coordinate": "atrinik/atrinik#2", "entry_mode": "issue",
                           "retired_attempt": p["nodes"]["atrinik/atrinik#2"]["attempt"],
@@ -108,6 +108,18 @@ class ExistingReservationTests(unittest.TestCase):
         renewed = reopen(p, result["coordinate"], result["attempt"], "same owner; reviewer finding", 1)
         self.assertNotEqual(renewed["attempt"], result["attempt"])
 
+    def test_actual_tagged_completed_rows_bind_digest_without_copying_runtime_results(self):
+        p = retired_project()
+        expected = {"generation": p["generation"], "digest": digest(p), "path": "/private/project.json"}
+        observation = runtime_observation(p, expected)
+        private_result = "private runtime completion text must remain outside persisted project"
+        for agent in observation["runtime"]["agents"][1:]:
+            agent["agent_status"] = {"completed": private_result}
+        result = self.reserve(p, observation)
+        self.assertEqual(result["runtime_observation_sha256"], digest(observation))
+        self.assertNotIn(private_result, json.dumps(p))
+        self.assertNotIn(private_result, json.dumps(result))
+
     def test_pending_requires_retired_attempt_and_no_existing_binding(self):
         for change in (lambda s: s.update(attempt=None), lambda s: s.update(worker="/root/leaf"),
                        lambda s: s.update(state="running"), lambda s: s.update(attempt="unknown")):
@@ -135,6 +147,11 @@ class ExistingReservationTests(unittest.TestCase):
             lambda o: o["runtime"]["agents"][0].update(agent_status="idle"),
             lambda o: o["runtime"]["agents"][1].update(agent_status="running"),
             lambda o: o["runtime"]["agents"][1].update(agent_status="interrupted"),
+            lambda o: o["runtime"]["agents"][1].update(agent_status="completed"),
+            lambda o: o["runtime"]["agents"][1].update(agent_status={"completed": None}),
+            lambda o: o["runtime"]["agents"][1].update(agent_status={"completed": [], "running": True}),
+            lambda o: o["runtime"]["agents"][1].update(agent_status={"errored": "unknown result"}),
+            lambda o: o["runtime"]["agents"][2].update(agent_status={"completed": 1}),
             lambda o: o["runtime"]["agents"][2].update(agent_name="/root/leaf"),
             lambda o: o["runtime"]["agents"][1].update(agent_name="/root/foreign/leaf"),
             lambda o: o["selection"].update(worker="/root/fabricated"),

--- a/tests/test_project_delivery_output.py
+++ b/tests/test_project_delivery_output.py
@@ -2,6 +2,7 @@
 from contextlib import redirect_stderr, redirect_stdout
 import io
 import json
+import multiprocessing
 import os
 from pathlib import Path
 import stat
@@ -10,9 +11,9 @@ import unittest
 from unittest.mock import patch
 
 from atrinik_workspace import project_delivery as cli
-from atrinik_workspace.project_coordinator import digest
+from atrinik_workspace.project_coordinator import ProjectError, digest, reserve_existing
 from atrinik_workspace.project_coordinator_store import Store, read_input
-from tests.test_project_coordinator import FakeGitHub, plan, project
+from tests.test_project_coordinator import FakeGitHub, plan, project, retired_project, runtime_observation
 
 
 @unittest.skipUnless(os.name == "posix", "canonical Linux filesystem contract")
@@ -163,6 +164,125 @@ class SnapshotOutputTests(unittest.TestCase):
                 self.assertEqual(response["result"], metadata)
                 self.assertLess(len(json.dumps(response)), 1000)
                 self.assertEqual(read_input(output), snapshot)
+
+
+def race_existing_reservation(root, expected, observation, start, result):
+    start.wait(10)
+    try:
+        snapshot, request = Store(Path(root)).update(expected, lambda p: reserve_existing(
+            p, "atrinik/atrinik#2", "/root/leaf", read_input(Path(observation)), expected, 1))
+        result.put(("reserved", request["attempt"], snapshot["generation"]))
+    except (ProjectError, OSError) as error:
+        result.put(("refused", str(error)))
+
+
+@unittest.skipUnless(os.name == "posix", "canonical Linux filesystem contract")
+class ExistingReservationOutputTests(unittest.TestCase):
+    invoke = SnapshotOutputTests.invoke
+    # Reuse the CLI fixture and invoke helper without inheriting unrelated tests.
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.wrapper = Path(temporary.name)
+        document = retired_project()
+        self.root = self.wrapper / "build" / "project-delivery" / digest({"parent": document["plan"]["parent"]})
+        self.root.mkdir(parents=True, mode=0o700)
+        self.initial = Store(self.root).create(document)
+        for mocked in (patch.object(cli, "context", return_value=self.wrapper),
+                       patch.object(cli, "GitHub", return_value=FakeGitHub())):
+            mocked.start(); self.addCleanup(mocked.stop)
+        self.expected = self.wrapper / "expected.json"
+        self.observation = self.wrapper / "runtime.json"
+        self.invoke(["inspect"], self.expected)
+        self.observation.write_text(json.dumps(runtime_observation(document, self.initial)))
+        self.observation.chmod(0o600)
+        self.command = ["reserve-existing", "atrinik/atrinik#2", "--worker", "/root/leaf",
+                        "--runtime-observation", str(self.observation), "--expected", str(self.expected)]
+
+    def test_reuse_compact_output_is_durable_and_old_snapshot_cannot_reserve_again(self):
+        output = self.wrapper / "reserved.json"
+        code, result, error = self.invoke(self.command, output, True)
+        self.assertEqual((code, error), (0, ""))
+        self.assertEqual(result["result"]["worker"], "/root/leaf")
+        snapshot = read_input(output)
+        self.assertEqual(snapshot, Store(self.root).inspect())
+        state = snapshot["document"]["nodes"]["atrinik/atrinik#2"]
+        self.assertEqual((state["worker"], state["state"]), ("/root/leaf", "reserved"))
+        self.assertEqual(state["attempt"], result["result"]["attempt"])
+        calls = []
+        original = cli.read_input
+        def observed(path, *args):
+            calls.append(path); return original(path, *args)
+        with patch.object(cli, "read_input", side_effect=observed):
+            code, _, error = self.invoke(self.command)
+        self.assertEqual(code, 2); self.assertIn("stale project CAS", error)
+        self.assertNotIn(self.observation, calls)
+        self.assertEqual(Store(self.root).inspect(), snapshot)
+        code, _, error = self.invoke(["worker", "atrinik/atrinik#2", "--attempt", state["attempt"],
+                                     "--id", "/root/other", "--expected", str(output)])
+        self.assertEqual(code, 2); self.assertIn("takeover", error)
+        self.assertEqual(Store(self.root).inspect(), snapshot)
+
+    def test_observation_read_occurs_inside_cas_change_callback(self):
+        original_read, original_update = cli.read_input, Store.update
+        inside = False
+        def update(store, expected, change):
+            def guarded(project):
+                nonlocal inside
+                inside = True
+                try: return change(project)
+                finally: inside = False
+            return original_update(store, expected, guarded)
+        def read(path, *args):
+            if path == self.observation: self.assertTrue(inside)
+            return original_read(path, *args)
+        with patch.object(Store, "update", update), patch.object(cli, "read_input", side_effect=read):
+            self.assertEqual(self.invoke(self.command)[0], 0)
+
+    def test_unsafe_and_oversized_runtime_files_preserve_project(self):
+        link = self.wrapper / "link.json"; link.symlink_to(self.observation)
+        hard = self.wrapper / "hard.json"; os.link(self.observation, hard)
+        fifo = self.wrapper / "pipe.json"; os.mkfifo(fifo, 0o600)
+        huge = self.wrapper / "huge.json"; huge.write_text(" " * (128 * 1024 + 1)); huge.chmod(0o600)
+        duplicate = self.wrapper / "duplicate.json"; duplicate.write_text('{"a":1,"a":2}'); duplicate.chmod(0o600)
+        for path in (link, hard, fifo, huge, duplicate, self.wrapper / "missing.json"):
+            with self.subTest(path=path):
+                command = list(self.command); command[command.index("--runtime-observation") + 1] = str(path)
+                self.assertEqual(self.invoke(command)[0], 2)
+                self.assertEqual(Store(self.root).inspect(), self.initial)
+
+    def test_lost_output_preserves_prebound_reservation_and_requires_reconciliation(self):
+        with patch.object(cli, "publish_result", side_effect=OSError("lost output")):
+            code, result, error = self.invoke(self.command, self.wrapper / "lost.json", True)
+        self.assertEqual(code, 2); self.assertIsNone(result)
+        self.assertIn("command completed", error)
+        self.assertIn("reconcile before any retry", error)
+        current = Store(self.root).inspect()
+        state = current["document"]["nodes"]["atrinik/atrinik#2"]
+        self.assertEqual((state["worker"], state["state"]), ("/root/leaf", "reserved"))
+        self.assertEqual(self.invoke(self.command)[0], 2)
+        self.assertEqual(Store(self.root).inspect(), current)
+
+    def test_concurrent_same_cas_reservations_have_one_winner(self):
+        ctx = multiprocessing.get_context("fork")
+        start, result = ctx.Event(), ctx.Queue()
+        workers = [ctx.Process(target=race_existing_reservation,
+                    args=(str(self.root), self.initial, str(self.observation), start, result)) for _ in range(2)]
+        for worker in workers: worker.start()
+        start.set()
+        try:
+            outcomes = [result.get(timeout=10) for _ in workers]
+            for worker in workers:
+                worker.join(10); self.assertEqual(worker.exitcode, 0)
+            self.assertEqual(sorted(o[0] for o in outcomes), ["refused", "reserved"])
+            current = Store(self.root).inspect()
+            self.assertEqual(current["generation"], self.initial["generation"] + 1)
+            self.assertEqual(current["document"]["nodes"]["atrinik/atrinik#2"]["attempt"],
+                             next(o[1] for o in outcomes if o[0] == "reserved"))
+        finally:
+            for worker in workers:
+                if worker.is_alive(): worker.terminate(); worker.join(10)
+            result.close(); result.join_thread()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Allow project coordination to reserve an existing idle worker for a pending phase without spawning another worker.

## Implementation / behavior

Bind a fresh attempt through exact CAS using a bounded, fresh runtime observation supplied by the trusted coordinator. Preserve dependency, file/resource, active-capacity, heavy-job and unique-worker gates. Runtime observations remain operator attestations, not independently authenticated credentials; leaf ownership is unchanged.

## Validation

Public reservation, retry/replan, concurrent-CAS and failure regressions; complete wrapper validation and independent whole-diff review will be recorded before readiness.

## Limitations / follow-up

The coordinator must recheck runtime idleness immediately before follow-up and preserve uncertain reservations. Existing dispatch and reopen remain supported. This PR does not merge itself or authorize current deliveries through candidate code.

Closes #586

Related: #562.

<!-- atrinik-delivery:body:829b991c84b65553209217caef089dc7d73e0efc549a3b5c26b582223f48f0e7:start -->
## Final validation

Validated commit `f47141c731a0f7910619e54798c38e4375b9ddc6` against base `350aebfcb53035a99568c8014b3447a8aa0bb496`.

- Complete wrapper suite: **1,579 tests passed, seven skipped; 85% coverage** on Python 3.14.4 with coverage 7.15.3 in the pinned Linux coordinator. Skips: Fish unavailable (one), Zsh unavailable (two), native Windows tests (four). The separate Windows CI smoke job passed.
- Final-head compileall, guidance inventory, manifest validation, skill validation and diff whitespace checks passed; focused coordinator/output tests passed (98 tests).
- Independent complete base-to-head review finished with zero actionable findings. The tagged runtime completion-status finding was fixed and independently verified; completion text is retained only through the observation digest.
- Independent public-CLI/real-Store forward tests passed using a **modeled complete 17-handle runtime inventory**, including actual tagged completed-status shapes. They covered retry/replan/reuse/reopen, ordinary dispatch, 22 invalid observations, seven scheduling/ownership gates, a two-process exact-CAS race with one winner, and reservation retention after output publication failure. This is a modeled concurrency test, not a claim that 17 live workers performed a delivery.
- All applicable CI checks passed, including Integration validation, Conventional PR title, three test shards, Windows and CodeQL analyses. The final raw check-run query reports success for all 12 checks, including the CodeQL aggregate and codecov/patch.

The first complete final-head local run exhausted the test process's default 1,024-descriptor limit. Its failure evidence was retained. The successful complete rerun used a process-local soft limit of 65,536, a child-reaping test harness and signing disabled only for temporary fixture commits. An independent 65-test repetition of the new reservation/output tests at the original 1,024 limit passed with stable descriptor counts; this does not diagnose all aggregate fixture descriptor accumulation.

Independent forward evidence SHA-256: `59685c58cdd3a58843a6fbdab067a892aa8bdf072731316ce82cc0ffb41a802a`.
Exact-head/harness attestation SHA-256: `9370ad7311acdf427fcebb25d1bd0712fa61635aad8819b6d07b543c1feb2d83`.

Interactive game/server runtime verification is inapplicable to this coordinator-only change. Runtime inventory is a trusted coordinator attestation, not authenticated runtime proof. The single dispatcher must recheck the selected worker immediately before follow-up and preserve reservations when start or output is uncertain.

<!-- atrinik-delivery:body:829b991c84b65553209217caef089dc7d73e0efc549a3b5c26b582223f48f0e7:end -->